### PR TITLE
Vendor gettext macros (20250921)

### DIFF
--- a/app-admin/xdg-user-dirs/autobuild/defines
+++ b/app-admin/xdg-user-dirs/autobuild/defines
@@ -3,3 +3,5 @@ PKGSEC=x11
 PKGDEP="bash"
 BUILDDEP="docbook-xsl"
 PKGDES="Manage user directories like ~/Desktop and ~/Music"
+
+ABTYPE=meson

--- a/app-admin/xdg-user-dirs/autobuild/overrides/etc/xdg/autostart/xdg-user-dirs.desktop
+++ b/app-admin/xdg-user-dirs/autobuild/overrides/etc/xdg/autostart/xdg-user-dirs.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Name=XDG User Directories
-Comment=Initialize XDG specified User Directories
-Exec=xdg-user-dirs-update
-Terminal=false
-Type=Application
-Categories=
-GenericName=
-NoShowIn=

--- a/app-admin/xdg-user-dirs/spec
+++ b/app-admin/xdg-user-dirs/spec
@@ -1,4 +1,4 @@
-VER=0.18
-SRCS="tbl::https://user-dirs.freedesktop.org/releases/xdg-user-dirs-$VER.tar.gz"
-CHKSUMS="sha256::ec6f06d7495cdba37a732039f9b5e1578bcb296576fde0da40edb2f52220df3c"
+VER=0.19
+SRCS="tbl::https://user-dirs.freedesktop.org/releases/xdg-user-dirs-$VER.tar.xz"
+CHKSUMS="sha256::e92deb929c10d4b29329397af8a2585101247f7e6177ac6f1d28e82130ed8c19"
 CHKUPDATE="anitya::id=8637"

--- a/app-i18n/ibus-kkc/autobuild/defines
+++ b/app-i18n/ibus-kkc/autobuild/defines
@@ -4,5 +4,12 @@ PKGDEP="ibus libkkc libkkc-data skk-jisyo"
 BUILDDEP="gnome-common intltool vala"
 PKGDES="IBus wrapper for libkkc"
 
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib/ibus --disable-static"
-ABSHADOW=no
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--libexecdir=/usr/lib/ibus'
+)
+
+# FIXME:
+#
+# error: Package `config' not found in specified Vala API directories or GObject-Introspection GIR directories
+ABSHADOW=0

--- a/app-i18n/ibus-kkc/autobuild/patches/0001-FEDORA-fix-build.patch
+++ b/app-i18n/ibus-kkc/autobuild/patches/0001-FEDORA-fix-build.patch
@@ -1,0 +1,195 @@
+diff --git a/README b/README
+index 6c6765a..5301247 100644
+--- a/README
++++ b/README
+@@ -1 +1,28 @@
+ ibus-kkc -- a Japanese Kana Kanji input engine for IBus
++=======================================================
++
++ibus-kkc makes the Kana Kanji conversion library (libkkc[0]) usable
++through IBus.
++
++
++Custom dictionaries
++-------------------
++
++ibus-kkc will look for a "dictionaries.json" file in a path consisting
++of the user's config directory concatenated with the package name (the
++default template for this file is at src/ibus-kkc-dictionaries.json[1]). By
++default the file will be searched in "$HOME/.config/ibus-kkc/".
++
++The "dictionaries.json" file is in JSON format and contains a list of
++JSON objects describing dictionaries that can be downloaded from here[2]
++(this site is in Japanese). All custom dictionary files mentioned in
++"dictionaries.json" will be searched in "/usr/local/share/skk/".
++
++The assumed default encoding of the dictionaries is "EUC-JP". If your
++dictionary uses a different encoding you can add an "encoding" field
++to the JSON object describing your dictionary. The value of that field
++should be the name of the encoding used in your custom dictionary file.
++
++[0] https://github.com/ueno/libkkc
++[1] https://github.com/ueno/ibus-kkc/blob/master/src/ibus-kkc-dictionaries.json
++[2] http://openlab.ring.gr.jp/skk/wiki/wiki.cgi?page=SKK%BC%AD%BD%F1
+diff --git a/src/dictionary.vala b/src/dictionary.vala
+index 34cc538..d693561 100644
+--- a/src/dictionary.vala
++++ b/src/dictionary.vala
+@@ -125,6 +125,9 @@ public class DictionaryRegistry : Object {
+                          file.get_path (),
+                          e.message);
+             }
++        } else {
++                warning ("Dictionary file at %s could not be found. We will run without any custom dictionaries.",
++                         file.get_path ());
+         }
+     }
+ }
+diff --git a/src/engine.vala b/src/engine.vala
+index ebcf3b5..15bdd85 100644
+--- a/src/engine.vala
++++ b/src/engine.vala
+@@ -201,7 +201,11 @@ class KkcEngine : IBus.Engine {
+                                          context.candidates.page_start);
+             update_lookup_table_fast (lookup_table, true);
+             var candidate = context.candidates.get ();
+-            if (show_annotation && candidate.annotation != null) {
++            if (show_annotation
++                && candidate.annotation != null
++                // SKK-JISYO.* has annotations marked as "?" for
++                // development purposes.
++                && candidate.annotation != "?") {
+                 var text = new IBus.Text.from_string (
+                     candidate.annotation);
+                 update_auxiliary_text (text, true);
+@@ -280,27 +284,45 @@ class KkcEngine : IBus.Engine {
+     }
+ 
+     void update_input_mode () {
++        bool changed;
++
+         // Update the menu item
+         var iter = input_mode_props.map_iterator ();
+         while (iter.next ()) {
+             var input_mode = iter.get_key ();
+             var prop = iter.get_value ();
+-            if (input_mode == context.input_mode)
+-                prop.set_state (IBus.PropState.CHECKED);
+-            else
+-                prop.set_state (IBus.PropState.UNCHECKED);
+-            if (properties_registered)
++
++            changed = false;
++            if (input_mode == context.input_mode) {
++                if (prop.get_state () == IBus.PropState.UNCHECKED) {
++                    prop.set_state (IBus.PropState.CHECKED);
++                    changed = true;
++                }
++            } else {
++                if (prop.get_state () == IBus.PropState.CHECKED) {
++                    prop.set_state (IBus.PropState.UNCHECKED);
++                    changed = true;
++                }
++            }
++            if (changed && properties_registered)
+                 update_property (prop);
+         }
+ 
+         // Update the menu
++        changed = false;
+         var symbol = new IBus.Text.from_string (
+             input_mode_symbols.get (context.input_mode));
+         var label = new IBus.Text.from_string (
+             _("Input Mode (%s)").printf (symbol.text));
+-        input_mode_prop.set_label (label);
+-        input_mode_prop.set_symbol (symbol);
+-        if (properties_registered)
++        if (input_mode_prop.get_symbol () != symbol) {
++            input_mode_prop.set_symbol (symbol);
++            changed = true;
++        }
++        if (input_mode_prop.get_label () != label) {
++            input_mode_prop.set_label (label);
++            changed = true;
++        }
++        if (changed && properties_registered)
+             update_property (input_mode_prop);
+     }
+ 
+@@ -413,8 +435,10 @@ class KkcEngine : IBus.Engine {
+         return prop;
+     }
+ 
+-    string[] LOOKUP_TABLE_LABELS = {"1", "2", "3", "4", "5", "6", "7",
+-                                    "8", "9", "0", "a", "b", "c", "d", "e"};
++    static const string[] LOOKUP_TABLE_LABELS = {
++        "1", "2", "3", "4", "5", "6", "7", "8",
++        "9", "0", "a", "b", "c", "d", "e", "f"
++    };
+ 
+     bool process_lookup_table_key_event (uint keyval,
+                                          uint keycode,
+@@ -664,7 +688,7 @@ class KkcEngine : IBus.Engine {
+                 "org.freedesktop.IBus.KKC",
+                 N_("Kana Kanji"), Config.PACKAGE_VERSION, "GPL",
+                 "Daiki Ueno <ueno@gnu.org>",
+-                "http://code.google.com/p/ibus/",
++                "https://github.com/ueno/ibus-kkc",
+                 "",
+                 "ibus-kkc");
+             var engine = new IBus.EngineDesc (
+diff --git a/src/ibus-1.0.vapi b/src/ibus-1.0.vapi
+index 6c200f9..58e96ae 100644
+--- a/src/ibus-1.0.vapi
++++ b/src/ibus-1.0.vapi
+@@ -439,6 +439,7 @@ namespace IBus {
+ 		public unowned string get_icon ();
+ 		public unowned string get_key ();
+ 		public unowned IBus.Text get_label ();
++		public unowned IBus.Text get_symbol ();
+ 		public IBus.PropType get_prop_type ();
+ 		public bool get_sensitive ();
+ 		public IBus.PropState get_state ();
+diff --git a/src/setup.vala b/src/setup.vala
+index 0ccdd66..df9630b 100644
+--- a/src/setup.vala
++++ b/src/setup.vala
+@@ -402,7 +402,11 @@ class SetupDialog : Gtk.Dialog {
+             } catch (Error e) {
+                 warning ("can't write shortcut: %s", e.message);
+             }
++#if VALA_0_36
++            model.remove (ref iter);
++#else
+             model.remove (iter);
++#endif
+         }
+     }
+ 
+@@ -439,7 +443,11 @@ class SetupDialog : Gtk.Dialog {
+                         continue;
+                     keymap.set (old_event, null);
+                 }
++#if VALA_0_36
++                ((Gtk.ListStore)model).remove (ref iter);
++#else
+                 ((Gtk.ListStore)model).remove (iter);
++#endif
+             }
+         }
+         try {
+@@ -524,8 +532,13 @@ class SetupDialog : Gtk.Dialog {
+         var rows = selection.get_selected_rows (out model);
+         foreach (var row in rows) {
+             Gtk.TreeIter iter;
+-            if (model.get_iter (out iter, row))
++            if (model.get_iter (out iter, row)) {
++#if VALA_0_36
++                ((Gtk.ListStore)model).remove (ref iter);
++#else
+                 ((Gtk.ListStore)model).remove (iter);
++#endif
++            }
+         }
+         save_dictionaries ("system_dictionaries");
+     }

--- a/app-i18n/ibus-kkc/spec
+++ b/app-i18n/ibus-kkc/spec
@@ -1,5 +1,5 @@
 VER=1.5.22
-REL=4
-SRCS="tbl::https://github.com/ueno/ibus-kkc/releases/download/v$VER/ibus-kkc-$VER.tar.gz"
-CHKSUMS="sha256::22fe2552f08a34a751cef7d1ea3c088e8dc0f0af26fd7bba9cdd27ff132347ce"
+REL=5
+SRCS="git::commit=tags/v$VER::https://github.com/ueno/ibus-kkc.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228883"

--- a/app-i18n/kakasi/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/app-i18n/kakasi/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,4366 @@
+From 8a988ea71bfdfc7bfcb1c5320076bf03c030135e Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sat, 20 Sep 2025 23:07:50 +0800
+Subject: [PATCH 1/2] AOSCOS Run gettextize to include gettext macros
+
+---
+ Makefile.am            |   4 +-
+ Makefile.in            |   2 +-
+ configure.in           |   2 +-
+ m4/build-to-host.m4    | 274 ++++++++++++++
+ m4/gettext.m4          | 446 ++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4   | 532 +++++++++++++++++++++++++++
+ m4/iconv.m4            | 324 ++++++++++++++++
+ m4/intlmacosx.m4       |  71 ++++
+ m4/lib-ld.m4           | 170 +++++++++
+ m4/lib-link.m4         | 815 +++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4       | 334 +++++++++++++++++
+ m4/nls.m4              |  33 ++
+ m4/po.m4               | 157 ++++++++
+ m4/progtest.m4         |  93 +++++
+ po/Makefile.in.in      | 580 +++++++++++++++++++++++++++++
+ po/Makevars.template   |  82 +++++
+ po/POTFILES.in         |   1 +
+ po/Rules-quot          |  66 ++++
+ po/boldquot.sed        |  21 ++
+ po/en@boldquot.header  |  35 ++
+ po/en@quot.header      |  32 ++
+ po/insert-header.sed   |  31 ++
+ po/quot.sed            |  17 +
+ po/remove-potcdate.sed |  25 ++
+ 24 files changed, 4144 insertions(+), 3 deletions(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+ create mode 100644 po/Makefile.in.in
+ create mode 100644 po/Makevars.template
+ create mode 100644 po/POTFILES.in
+ create mode 100644 po/Rules-quot
+ create mode 100644 po/boldquot.sed
+ create mode 100644 po/en@boldquot.header
+ create mode 100644 po/en@quot.header
+ create mode 100644 po/insert-header.sed
+ create mode 100644 po/quot.sed
+ create mode 100644 po/remove-potcdate.sed
+
+diff --git a/Makefile.am b/Makefile.am
+index 1278f28..1635481 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -8,7 +8,7 @@ dict_DATA = kanwadict itaijidict
+ 
+ bin_SCRIPTS = kakasi-config
+ 
+-EXTRA_DIST = config.rpath INSTALL-ja README-ja ONEWS maintMakefile \
++EXTRA_DIST = m4/ChangeLog  config.rpath INSTALL-ja README-ja ONEWS maintMakefile \
+ 	     kakasi.spec.in kakasi.spec itaijidict magic-kakasi
+ EXTRA_DIRS = doc
+ SUBDIRS = src lib man tests
+@@ -30,3 +30,5 @@ dist-hook:
+ 
+ ##Bug in automake: Can't use `if MAINTAINER_MODE'
+ @MAINTAINER_MODE_TRUE@include $(srcdir)/maintMakefile
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/Makefile.in b/Makefile.in
+index f6d6620..f8865db 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -325,7 +325,7 @@ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENC
+ $(top_srcdir)/configure: @MAINTAINER_MODE_TRUE@ $(am__configure_deps)
+ 	$(am__cd) $(srcdir) && $(AUTOCONF)
+ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
+-	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
++	$(am__cd) $(srcdir) && $(ACLOCAL) -I m4 $(ACLOCAL_AMFLAGS)
+ $(am__aclocal_m4_deps):
+ 
+ config.h: stamp-h1
+diff --git a/configure.in b/configure.in
+index e865b04..f6799b4 100644
+--- a/configure.in
++++ b/configure.in
+@@ -100,7 +100,7 @@ KAKASI_CHECK_CFLAGS([-pedantic])
+ KAKASI_CHECK_CFLAGS([-Wno-unused-result])
+ 
+ AM_CONFIG_HEADER(config.h)
+-AC_CONFIG_FILES([src/Makefile
++AC_CONFIG_FILES([src/Makefile po/Makefile.in
+ 	   lib/Makefile
+ 	   lib/makefile.msc
+ 	   man/Makefile
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+diff --git a/po/Makefile.in.in b/po/Makefile.in.in
+new file mode 100644
+index 0000000..f7b2cea
+--- /dev/null
++++ b/po/Makefile.in.in
+@@ -0,0 +1,580 @@
++# Makefile for PO directory in any package using GNU gettext.
++# Copyright (C) 1995-2000 Ulrich Drepper <drepper@gnu.ai.mit.edu>
++# Copyright (C) 2000-2025 Free Software Foundation, Inc.
++#
++# Copying and distribution of this file, with or without modification,
++# are permitted in any medium without royalty provided the copyright
++# notice and this notice are preserved.  This file is offered as-is,
++# without any warranty.
++#
++# Origin: gettext-0.26
++GETTEXT_MACRO_VERSION = 0.24
++
++# This Makefile makes use of the variable assignment operator != standardized
++# by POSIX:2024
++# <https://pubs.opengroup.org/onlinepubs/9799919799/utilities/make.html>.
++# It thus requires a 'make' implementation that supports this operator !=.
++# As of 2024, these are: GNU make >= 4.0, FreeBSD make, NetBSD make,
++# OpenBSD make. This means that building on specific platforms requires
++# use of GNU make:
++#   - On macOS, use /opt/homebrew/bin/gmake.
++#   - On Solaris 11 OpenIndiana, use /usr/bin/gmake = /usr/gnu/bin/make.
++#   - On Solaris 11.4, install GNU make yourself.
++#   - On AIX, use /opt/freeware/bin/make.
++
++PACKAGE = @PACKAGE@
++VERSION = @VERSION@
++PACKAGE_BUGREPORT = @PACKAGE_BUGREPORT@
++
++SED = @SED@
++SHELL = /bin/sh
++@SET_MAKE@
++
++srcdir = @srcdir@
++top_srcdir = @top_srcdir@
++VPATH = @srcdir@
++
++prefix = @prefix@
++exec_prefix = @exec_prefix@
++datarootdir = @datarootdir@
++datadir = @datadir@
++localedir = @localedir@
++gettextsrcdir = $(datadir)/gettext/po
++
++INSTALL = @INSTALL@
++INSTALL_DATA = @INSTALL_DATA@
++
++# We use $(mkdir_p).
++# In automake <= 1.9.x, $(mkdir_p) is defined either as "mkdir -p --" or as
++# "$(mkinstalldirs)" or as "$(install_sh) -d". For these automake versions,
++# @install_sh@ does not start with $(SHELL), so we add it.
++# In automake >= 1.10, @mkdir_p@ is derived from ${MKDIR_P}, which is defined
++# either as "/path/to/mkdir -p" or ".../install-sh -c -d". For these automake
++# versions, $(mkinstalldirs) and $(install_sh) are unused.
++mkinstalldirs = $(SHELL) @install_sh@ -d
++install_sh = $(SHELL) @install_sh@
++MKDIR_P = @MKDIR_P@
++mkdir_p = @mkdir_p@
++
++# When building gettext-tools, we prefer to use the built programs
++# rather than installed programs.  However, we can't do that when we
++# are cross compiling.
++CROSS_COMPILING = @CROSS_COMPILING@
++
++GMSGFMT_ = @GMSGFMT@
++GMSGFMT_no = @GMSGFMT@
++GMSGFMT_yes = @GMSGFMT_015@
++GMSGFMT = $(GMSGFMT_$(USE_MSGCTXT))
++XGETTEXT_ = @XGETTEXT@
++XGETTEXT_no = @XGETTEXT@
++XGETTEXT_yes = @XGETTEXT_015@
++XGETTEXT = $(XGETTEXT_$(USE_MSGCTXT))
++MSGMERGE = @MSGMERGE@
++MSGMERGE_UPDATE = @MSGMERGE@ --update
++MSGMERGE_FOR_MSGFMT_OPTION = @MSGMERGE_FOR_MSGFMT_OPTION@
++MSGINIT = msginit
++MSGCONV = msgconv
++MSGFILTER = msgfilter
++
++# The list of files which contain translatable strings.
++POTFILES != sed -e '/^\#/d' < $(srcdir)/POTFILES.in
++# This is computed as $(foreach file, $(POTFILES), $(top_srcdir)/$(file))
++POTFILES_DEPS != for file in $(POTFILES); do echo $(top_srcdir)/$$file; done
++
++# The set of available translations.
++ALL_LINGUAS != if test -f $(srcdir)/LINGUAS; then \
++                 sed -e '/^\#/d' < $(srcdir)/LINGUAS; \
++               else \
++                 echo $(LINGUAS); \
++               fi
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).po)
++POFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.po; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).gmo)
++GMOFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.gmo; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).po-update)
++UPDATEPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.po-update; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).nop)
++DUMMYPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.nop; done
++
++DISTFILES.common = \
++  Makefile.in.in remove-potcdate.sed \
++  $(DISTFILES.common.extra1) $(DISTFILES.common.extra2) \
++  $(DISTFILES.common.extra3) $(DISTFILES.common.extra4) \
++  $(DISTFILES.common.extra5) $(DISTFILES.common.extra6)
++DISTFILES = \
++  $(DISTFILES.common) \
++  Makevars POTFILES.in \
++  $(POFILES) $(GMOFILES) \
++  $(DISTFILES.extra1) $(DISTFILES.extra2) \
++  $(DISTFILES.extra3) $(DISTFILES.extra4) \
++  $(DISTFILES.extra5) $(DISTFILES.extra6)
++
++# The set of desired translations, as specified by the installer or distributor.
++DESIRED_LINGUAS = @DESIRED_LINGUAS@
++# The set of translations to install. This is computed based on $(ALL_LINGUAS)
++# and $(DESIRED_LINGUAS). It is a subset of $(ALL_LINGUAS).
++# We use the presentlang catalog if desiredlang is
++#   a. equal to presentlang, or
++#   b. a variant of presentlang (because in this case, presentlang can be used
++#      as a fallback for messages which are not translated in the desiredlang
++#      catalog).
++INST_LINGUAS != for presentlang in $(ALL_LINGUAS); do \
++                  useit=false; \
++                  for desiredlang in $(DESIRED_LINGUAS); do \
++                    case "$$desiredlang" in \
++                      "$$presentlang" | "$$presentlang"_* | "$$presentlang".* | "$$presentlang"@*) \
++                        useit=true ;; \
++                    esac; \
++                  done; \
++                  if $$useit; then echo $$presentlang; fi; \
++                done
++# This is computed as $(foreach lang, $(INST_LINGUAS), $(lang).gmo)
++CATALOGS != for lang in $(INST_LINGUAS); do echo $$lang.gmo; done
++
++POFILESDEPS_ = $(srcdir)/$(DOMAIN).pot
++POFILESDEPS_yes = $(POFILESDEPS_)
++POFILESDEPS_no =
++POFILESDEPS = $(POFILESDEPS_$(PO_DEPENDS_ON_POT))
++
++DISTFILESDEPS_ = update-po
++DISTFILESDEPS_yes = $(DISTFILESDEPS_)
++DISTFILESDEPS_no =
++DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
++
++# Include the customization of this po/ directory.
++include $(srcdir)/Makevars
++
++all: all-@USE_NLS@
++
++
++.SUFFIXES:
++.SUFFIXES: .po .gmo .nop .po-create .po-update
++
++# The .pot file, stamp-po, .po files, and .gmo files appear in release tarballs.
++# The GNU Coding Standards say in
++# <https://www.gnu.org/prep/standards/html_node/Makefile-Basics.html>:
++#   "GNU distributions usually contain some files which are not source files
++#    ... . Since these files normally appear in the source directory, they
++#    should always appear in the source directory, not in the build directory.
++#    So Makefile rules to update them should put the updated files in the
++#    source directory."
++# Therefore we put these files in the source directory, not the build directory.
++
++# During .po -> .gmo conversion, take into account the most recent changes to
++# the .pot file. This eliminates the need to update the .po files when the
++# .pot file has changed, which would be troublesome if the .po files are put
++# under version control.
++$(GMOFILES): $(srcdir)/$(DOMAIN).pot
++.po.gmo:
++	@lang=`echo $* | sed -e 's,.*/,,'`; \
++	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
++	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
++	echo "$${cdcmd}rm -f $${lang}.gmo && $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) -o $${lang}.1po $${lang}.po $(DOMAIN).pot && $(GMSGFMT) -c --statistics --verbose -o $${lang}.gmo $${lang}.1po && rm -f $${lang}.1po"; \
++	cd $(srcdir) && \
++	rm -f $${lang}.gmo && \
++	$(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) -o $${lang}.1po $${lang}.po $(DOMAIN).pot && \
++	$(GMSGFMT) -c --statistics --verbose -o t-$${lang}.gmo $${lang}.1po && \
++	mv t-$${lang}.gmo $${lang}.gmo && \
++	rm -f $${lang}.1po
++
++
++all-yes: $(srcdir)/stamp-po
++all-no:
++
++# Ensure that the gettext macros and this Makefile.in.in are in sync.
++CHECK_MACRO_VERSION = \
++	test "$(GETTEXT_MACRO_VERSION)" = "@GETTEXT_MACRO_VERSION@" \
++	  || { echo "*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version $(GETTEXT_MACRO_VERSION) but the autoconf macros are from gettext version @GETTEXT_MACRO_VERSION@" 1>&2; \
++	       exit 1; \
++	     }
++
++# $(srcdir)/$(DOMAIN).pot is only created when needed. When xgettext finds no
++# internationalized messages, no $(srcdir)/$(DOMAIN).pot is created (because
++# we don't want to bother translators with empty POT files). We assume that
++# LINGUAS is empty in this case, i.e. $(POFILES) and $(GMOFILES) are empty.
++# In this case, $(srcdir)/stamp-po is a nop (i.e. a phony target).
++
++# $(srcdir)/stamp-po is a timestamp denoting the last time at which the CATALOGS
++# have been loosely updated. Its purpose is that when a developer or translator
++# checks out the package from a version control system, and the $(DOMAIN).pot
++# file is not under version control, "make" will update the $(DOMAIN).pot and
++# the $(CATALOGS), but subsequent invocations of "make" will do nothing. This
++# timestamp would not be necessary if updating the $(CATALOGS) would always
++# touch them; however, the rule for $(POFILES) has been designed to not touch
++# files that don't need to be changed.
++$(srcdir)/stamp-po: $(srcdir)/$(DOMAIN).pot
++	@$(CHECK_MACRO_VERSION)
++	test ! -f $(srcdir)/$(DOMAIN).pot || \
++	  test -z "$(GMOFILES)" || $(MAKE) $(GMOFILES)
++	@test ! -f $(srcdir)/$(DOMAIN).pot || { \
++	  echo "touch $(srcdir)/stamp-po" && \
++	  echo timestamp > $(srcdir)/stamp-poT && \
++	  mv $(srcdir)/stamp-poT $(srcdir)/stamp-po; \
++	}
++
++# This target rebuilds $(DOMAIN).pot; it is an expensive operation.
++# Note that $(DOMAIN).pot is not touched if it doesn't need to be changed.
++# The determination of whether the package xyz is a GNU one is based on the
++# heuristic whether some file in the top level directory mentions "GNU xyz".
++# If GNU 'find' is available, we avoid grepping through monster files.
++$(DOMAIN).pot-update: $(POTFILES_DEPS) $(srcdir)/POTFILES.in
++	package_gnu="$(PACKAGE_GNU)"; \
++	test -n "$$package_gnu" || { \
++	  if { if (LC_ALL=C find --version) 2>/dev/null | grep GNU >/dev/null; then \
++	         LC_ALL=C find -L $(top_srcdir) -maxdepth 1 -type f -size -10000000c -exec grep -i 'GNU @PACKAGE@' /dev/null '{}' ';' 2>/dev/null; \
++	       else \
++	         LC_ALL=C grep -i 'GNU @PACKAGE@' $(top_srcdir)/* 2>/dev/null; \
++	       fi; \
++	     } | grep -v 'libtool:' >/dev/null; then \
++	     package_gnu=yes; \
++	   else \
++	     package_gnu=no; \
++	   fi; \
++	}; \
++	if test "$$package_gnu" = "yes"; then \
++	  package_prefix='GNU '; \
++	else \
++	  package_prefix=''; \
++	fi; \
++	if test -n '$(MSGID_BUGS_ADDRESS)' || test '$(PACKAGE_BUGREPORT)' = '@'PACKAGE_BUGREPORT'@'; then \
++	  msgid_bugs_address='$(MSGID_BUGS_ADDRESS)'; \
++	else \
++	  msgid_bugs_address='$(PACKAGE_BUGREPORT)'; \
++	fi; \
++	case `$(XGETTEXT) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
++	  '' | 0.[0-9] | 0.[0-9].* | 0.1[0-5] | 0.1[0-5].* | 0.16 | 0.16.[0-1]*) \
++	    $(XGETTEXT) --default-domain=$(DOMAIN) --directory=$(top_srcdir) \
++	      --add-comments=TRANSLATORS: \
++	      --files-from=$(srcdir)/POTFILES.in \
++	      --copyright-holder='$(COPYRIGHT_HOLDER)' \
++	      --msgid-bugs-address="$$msgid_bugs_address" \
++	      $(XGETTEXT_OPTIONS) @XGETTEXT_EXTRA_OPTIONS@ \
++	    ;; \
++	  *) \
++	    $(XGETTEXT) --default-domain=$(DOMAIN) --directory=$(top_srcdir) \
++	      --add-comments=TRANSLATORS: \
++	      --files-from=$(srcdir)/POTFILES.in \
++	      --copyright-holder='$(COPYRIGHT_HOLDER)' \
++	      --package-name="$${package_prefix}@PACKAGE@" \
++	      --package-version='@VERSION@' \
++	      --msgid-bugs-address="$$msgid_bugs_address" \
++	      $(XGETTEXT_OPTIONS) @XGETTEXT_EXTRA_OPTIONS@ \
++	    ;; \
++	esac
++	test ! -f $(DOMAIN).po || { \
++	  if test -f $(srcdir)/$(DOMAIN).pot-header; then \
++	    sed -e '1,/^#$$/d' < $(DOMAIN).po > $(DOMAIN).1po && \
++	    cat $(srcdir)/$(DOMAIN).pot-header $(DOMAIN).1po > $(DOMAIN).po && \
++	    rm -f $(DOMAIN).1po \
++	    || exit 1; \
++	  fi; \
++	  if test -f $(srcdir)/$(DOMAIN).pot; then \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
++	    if cmp $(DOMAIN).1po $(DOMAIN).2po >/dev/null 2>&1; then \
++	      rm -f $(DOMAIN).1po $(DOMAIN).2po $(DOMAIN).po; \
++	    else \
++	      rm -f $(DOMAIN).1po $(DOMAIN).2po $(srcdir)/$(DOMAIN).pot && \
++	      mv $(DOMAIN).po $(srcdir)/$(DOMAIN).pot; \
++	    fi; \
++	  else \
++	    mv $(DOMAIN).po $(srcdir)/$(DOMAIN).pot; \
++	  fi; \
++	}
++
++# This rule has no dependencies: we don't need to update $(DOMAIN).pot at
++# every "make" invocation, only create it when it is missing.
++# Only "make $(DOMAIN).pot-update" or "make dist" will force an update.
++$(srcdir)/$(DOMAIN).pot:
++	$(MAKE) $(DOMAIN).pot-update
++
++# This target rebuilds a PO file if $(DOMAIN).pot has changed.
++# Note that a PO file is not touched if it doesn't need to be changed.
++$(POFILES): $(POFILESDEPS)
++	@test -f $(srcdir)/$(DOMAIN).pot || $(MAKE) $(srcdir)/$(DOMAIN).pot
++	@lang=`echo $@ | sed -e 's,.*/,,' -e 's/\.po$$//'`; \
++	if test -f "$(srcdir)/$${lang}.po"; then \
++	  if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
++	  test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
++	  echo "$${cdcmd}$(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) --lang=$${lang} --previous $${lang}.po $(DOMAIN).pot"; \
++	  cd $(srcdir) \
++	    && { case `$(MSGMERGE_UPDATE) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
++	           '' | 0.[0-9] | 0.[0-9].* | 0.10 | 0.10.*) \
++	             $(MSGMERGE_UPDATE) $(MSGMERGE_OPTIONS) $${lang}.po $(DOMAIN).pot;; \
++	           0.1[1-5] | 0.1[1-5].*) \
++	             $(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) $${lang}.po $(DOMAIN).pot;; \
++	           0.1[6-7] | 0.1[6-7].*) \
++	             $(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) --previous $${lang}.po $(DOMAIN).pot;; \
++	           *) \
++	             $(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) --lang=$${lang} --previous $${lang}.po $(DOMAIN).pot;; \
++	         esac; \
++	       }; \
++	else \
++	  $(MAKE) $${lang}.po-create; \
++	fi
++
++
++install: install-exec install-data
++install-exec:
++install-data: install-data-@USE_NLS@
++	if test "$(PACKAGE)" = "gettext-tools"; then \
++	  $(mkdir_p) $(DESTDIR)$(gettextsrcdir); \
++	  for file in $(DISTFILES.common) Makevars.template; do \
++	    $(INSTALL_DATA) $(srcdir)/$$file \
++			    $(DESTDIR)$(gettextsrcdir)/$$file; \
++	  done; \
++	  for file in Makevars; do \
++	    rm -f $(DESTDIR)$(gettextsrcdir)/$$file; \
++	  done; \
++	else \
++	  : ; \
++	fi
++install-data-no: all
++install-data-yes: all
++	@catalogs='$(CATALOGS)'; \
++	for cat in $$catalogs; do \
++	  cat=`basename $$cat`; \
++	  lang=`echo $$cat | sed -e 's/\.gmo$$//'`; \
++	  dir=$(localedir)/$$lang/LC_MESSAGES; \
++	  $(mkdir_p) $(DESTDIR)$$dir; \
++	  if test -r $$cat; then realcat=$$cat; else realcat=$(srcdir)/$$cat; fi; \
++	  $(INSTALL_DATA) $$realcat $(DESTDIR)$$dir/$(DOMAIN).mo; \
++	  echo "installing $$realcat as $(DESTDIR)$$dir/$(DOMAIN).mo"; \
++	  for lc in '' $(EXTRA_LOCALE_CATEGORIES); do \
++	    if test -n "$$lc"; then \
++	      if (cd $(DESTDIR)$(localedir)/$$lang && LC_ALL=C ls -l -d $$lc 2>/dev/null) | grep ' -> ' >/dev/null; then \
++	        link=`cd $(DESTDIR)$(localedir)/$$lang && LC_ALL=C ls -l -d $$lc | sed -e 's/^.* -> //'`; \
++	        mv $(DESTDIR)$(localedir)/$$lang/$$lc $(DESTDIR)$(localedir)/$$lang/$$lc.old; \
++	        mkdir $(DESTDIR)$(localedir)/$$lang/$$lc; \
++	        (cd $(DESTDIR)$(localedir)/$$lang/$$lc.old && \
++	         for file in *; do \
++	           if test -f $$file; then \
++	             ln -s ../$$link/$$file $(DESTDIR)$(localedir)/$$lang/$$lc/$$file; \
++	           fi; \
++	         done); \
++	        rm -f $(DESTDIR)$(localedir)/$$lang/$$lc.old; \
++	      else \
++	        if test -d $(DESTDIR)$(localedir)/$$lang/$$lc; then \
++	          :; \
++	        else \
++	          rm -f $(DESTDIR)$(localedir)/$$lang/$$lc; \
++	          mkdir $(DESTDIR)$(localedir)/$$lang/$$lc; \
++	        fi; \
++	      fi; \
++	      rm -f $(DESTDIR)$(localedir)/$$lang/$$lc/$(DOMAIN).mo; \
++	      ln -s ../LC_MESSAGES/$(DOMAIN).mo $(DESTDIR)$(localedir)/$$lang/$$lc/$(DOMAIN).mo 2>/dev/null || \
++	      ln $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(DOMAIN).mo $(DESTDIR)$(localedir)/$$lang/$$lc/$(DOMAIN).mo 2>/dev/null || \
++	      cp -p $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(DOMAIN).mo $(DESTDIR)$(localedir)/$$lang/$$lc/$(DOMAIN).mo; \
++	      echo "installing $$realcat link as $(DESTDIR)$(localedir)/$$lang/$$lc/$(DOMAIN).mo"; \
++	    fi; \
++	  done; \
++	done
++
++install-strip: install
++
++installdirs: installdirs-exec installdirs-data
++installdirs-exec:
++installdirs-data: installdirs-data-@USE_NLS@
++	if test "$(PACKAGE)" = "gettext-tools"; then \
++	  $(mkdir_p) $(DESTDIR)$(gettextsrcdir); \
++	else \
++	  : ; \
++	fi
++installdirs-data-no:
++installdirs-data-yes:
++	@catalogs='$(CATALOGS)'; \
++	for cat in $$catalogs; do \
++	  cat=`basename $$cat`; \
++	  lang=`echo $$cat | sed -e 's/\.gmo$$//'`; \
++	  dir=$(localedir)/$$lang/LC_MESSAGES; \
++	  $(mkdir_p) $(DESTDIR)$$dir; \
++	  for lc in '' $(EXTRA_LOCALE_CATEGORIES); do \
++	    if test -n "$$lc"; then \
++	      if (cd $(DESTDIR)$(localedir)/$$lang && LC_ALL=C ls -l -d $$lc 2>/dev/null) | grep ' -> ' >/dev/null; then \
++	        link=`cd $(DESTDIR)$(localedir)/$$lang && LC_ALL=C ls -l -d $$lc | sed -e 's/^.* -> //'`; \
++	        mv $(DESTDIR)$(localedir)/$$lang/$$lc $(DESTDIR)$(localedir)/$$lang/$$lc.old; \
++	        mkdir $(DESTDIR)$(localedir)/$$lang/$$lc; \
++	        (cd $(DESTDIR)$(localedir)/$$lang/$$lc.old && \
++	         for file in *; do \
++	           if test -f $$file; then \
++	             ln -s ../$$link/$$file $(DESTDIR)$(localedir)/$$lang/$$lc/$$file; \
++	           fi; \
++	         done); \
++	        rm -f $(DESTDIR)$(localedir)/$$lang/$$lc.old; \
++	      else \
++	        if test -d $(DESTDIR)$(localedir)/$$lang/$$lc; then \
++	          :; \
++	        else \
++	          rm -f $(DESTDIR)$(localedir)/$$lang/$$lc; \
++	          mkdir $(DESTDIR)$(localedir)/$$lang/$$lc; \
++	        fi; \
++	      fi; \
++	    fi; \
++	  done; \
++	done
++
++# Define this as empty until I found a useful application.
++installcheck:
++
++uninstall: uninstall-exec uninstall-data
++uninstall-exec:
++uninstall-data: uninstall-data-@USE_NLS@
++	if test "$(PACKAGE)" = "gettext-tools"; then \
++	  for file in $(DISTFILES.common) Makevars.template; do \
++	    rm -f $(DESTDIR)$(gettextsrcdir)/$$file; \
++	  done; \
++	else \
++	  : ; \
++	fi
++uninstall-data-no:
++uninstall-data-yes:
++	catalogs='$(CATALOGS)'; \
++	for cat in $$catalogs; do \
++	  cat=`basename $$cat`; \
++	  lang=`echo $$cat | sed -e 's/\.gmo$$//'`; \
++	  for lc in LC_MESSAGES $(EXTRA_LOCALE_CATEGORIES); do \
++	    rm -f $(DESTDIR)$(localedir)/$$lang/$$lc/$(DOMAIN).mo; \
++	  done; \
++	done
++
++check: all
++
++info dvi ps pdf html tags TAGS ctags CTAGS ID:
++
++install-dvi install-ps install-pdf install-html:
++
++mostlyclean:
++	rm -f $(srcdir)/stamp-poT
++	rm -f core core.* $(DOMAIN).po $(DOMAIN).1po $(DOMAIN).2po *.new.po
++	rm -fr *.o
++
++clean: mostlyclean
++
++distclean: clean
++	rm -f Makefile Makefile.in
++
++maintainer-clean: distclean
++	@echo "This command is intended for maintainers to use;"
++	@echo "it deletes files that may require special tools to rebuild."
++	rm -f $(srcdir)/$(DOMAIN).pot $(srcdir)/stamp-po $(GMOFILES)
++
++distdir = $(top_builddir)/$(PACKAGE)-$(VERSION)/$(subdir)
++dist distdir:
++	test -z "$(DISTFILESDEPS)" || $(MAKE) $(DISTFILESDEPS)
++	@$(MAKE) dist2
++# This is a separate target because 'update-po' must be executed before.
++dist2: $(srcdir)/stamp-po $(DISTFILES)
++	@dists="$(DISTFILES)"; \
++	if test "$(PACKAGE)" = "gettext-tools"; then \
++	  dists="$$dists Makevars.template"; \
++	fi; \
++	if test -f $(srcdir)/$(DOMAIN).pot; then \
++	  dists="$$dists $(DOMAIN).pot stamp-po"; \
++	else \
++	  case $(XGETTEXT) in \
++	    :) echo "Warning: Creating a tarball without '$(DOMAIN).pot', because a suitable 'xgettext' program was not found in PATH." 1>&2;; \
++	    *) echo "Warning: Creating a tarball without '$(DOMAIN).pot', because 'xgettext' found no strings to extract. Check the contents of the POTFILES.in file and the XGETTEXT_OPTIONS in the Makevars file." 1>&2;; \
++	  esac; \
++	fi; \
++	if test -f $(srcdir)/ChangeLog; then \
++	  dists="$$dists ChangeLog"; \
++	fi; \
++	for i in 0 1 2 3 4 5 6 7 8 9; do \
++	  if test -f $(srcdir)/ChangeLog.$$i; then \
++	    dists="$$dists ChangeLog.$$i"; \
++	  fi; \
++	done; \
++	if test -f $(srcdir)/LINGUAS; then dists="$$dists LINGUAS"; fi; \
++	for file in $$dists; do \
++	  if test -f $$file; then \
++	    cp -p $$file $(distdir) || exit 1; \
++	  else \
++	    cp -p $(srcdir)/$$file $(distdir) || exit 1; \
++	  fi; \
++	done
++
++update-po: Makefile
++	$(MAKE) $(DOMAIN).pot-update
++	test -z "$(UPDATEPOFILES)" || $(MAKE) $(UPDATEPOFILES)
++	$(MAKE) update-gmo
++
++# General rule for creating PO files.
++
++.nop.po-create:
++	@lang=`echo $@ | sed -e 's/\.po-create$$//'`; \
++	echo "File $$lang.po does not exist. If you are a translator, you can create it through 'msginit'." 1>&2; \
++	exit 1
++
++# General rule for updating PO files.
++
++.nop.po-update:
++	@lang=`echo $@ | sed -e 's/\.po-update$$//'`; \
++	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
++	tmpdir=`pwd`; \
++	echo "$$lang:"; \
++	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
++	echo "$${cdcmd}$(MSGMERGE) --quiet $(MSGMERGE_OPTIONS) --lang=$$lang --previous $$lang.po $(DOMAIN).pot -o $$lang.new.po"; \
++	cd $(srcdir); \
++	if { case `$(MSGMERGE) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
++	       '' | 0.[0-9] | 0.[0-9].* | 0.10 | 0.10.*) \
++	         $(MSGMERGE) $(MSGMERGE_OPTIONS) -o $$tmpdir/$$lang.new.po $$lang.po $(DOMAIN).pot;; \
++	       0.1[1-5] | 0.1[1-5].*) \
++	         $(MSGMERGE) --quiet $(MSGMERGE_OPTIONS) -o $$tmpdir/$$lang.new.po $$lang.po $(DOMAIN).pot;; \
++	       0.1[6-7] | 0.1[6-7].*) \
++	         $(MSGMERGE) --quiet $(MSGMERGE_OPTIONS) --previous -o $$tmpdir/$$lang.new.po $$lang.po $(DOMAIN).pot;; \
++	       *) \
++	         $(MSGMERGE) --quiet $(MSGMERGE_OPTIONS) --lang=$$lang --previous -o $$tmpdir/$$lang.new.po $$lang.po $(DOMAIN).pot;; \
++	     esac; \
++	   }; then \
++	  if cmp $$lang.po $$tmpdir/$$lang.new.po >/dev/null 2>&1; then \
++	    rm -f $$tmpdir/$$lang.new.po; \
++	  else \
++	    if mv -f $$tmpdir/$$lang.new.po $$lang.po; then \
++	      :; \
++	    else \
++	      echo "msgmerge for $$lang.po failed: cannot move $$tmpdir/$$lang.new.po to $$lang.po" 1>&2; \
++	      exit 1; \
++	    fi; \
++	  fi; \
++	else \
++	  echo "msgmerge for $$lang.po failed!" 1>&2; \
++	  rm -f $$tmpdir/$$lang.new.po; \
++	fi
++
++$(DUMMYPOFILES):
++
++update-gmo: Makefile $(GMOFILES)
++	@:
++
++# Include all the Rules-* extensions. Documented in
++# <https://www.gnu.org/software/gettext/manual/html_node/po_002fRules_002d_002a.html>
++RULES_FILES != cd $(srcdir) \
++               && for file in Rules-*; do \
++                    if test -f "$$file"; then \
++                      case "$$file" in \
++                        *.orig | *.bak | *~) ;; \
++                        *) echo $(srcdir)/"$$file" ;; \
++                      esac; \
++                    fi; \
++                  done
++include $(RULES_FILES)
++
++# Recreate Makefile by invoking config.status. Explicitly invoke the shell,
++# because execution permission bits may not work on the current file system.
++# Use @SHELL@, which is the shell determined by autoconf for the use by its
++# scripts, not $(SHELL) which is hardwired to /bin/sh and may be deficient.
++Makefile: Makefile.in.in Makevars $(top_builddir)/config.status
++	cd $(top_builddir) \
++	  && @SHELL@ ./config.status $(subdir)/$@.in po-directories
++
++force:
++
++# Tell versions [3.59,3.63) of GNU make not to export all variables.
++# Otherwise a system limit (for SysV at least) may be exceeded.
++.NOEXPORT:
++
++# This Makefile contains rules which don't work with parallel make,
++# namely dist2.
++# See <https://lists.gnu.org/archive/html/bug-gettext/2022-06/msg00022.html>.
++# So, turn off parallel execution in this Makefile.
++.NOTPARALLEL:
+diff --git a/po/Makevars.template b/po/Makevars.template
+new file mode 100644
+index 0000000..d1532a9
+--- /dev/null
++++ b/po/Makevars.template
+@@ -0,0 +1,82 @@
++# Makefile variables for PO directory in any package using GNU gettext.
++#
++# Copyright (C) 2003-2025 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to use, copy, distribute, and modify it.
++
++# Usually the message domain is the same as the package name.
++DOMAIN = $(PACKAGE)
++
++# These two variables depend on the location of this directory.
++subdir = po
++top_builddir = ..
++
++# These options get passed to xgettext.
++XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
++
++# This is the copyright holder that gets inserted into the header of the
++# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
++# package.  (Note that the msgid strings, extracted from the package's
++# sources, belong to the copyright holder of the package.)  Translators are
++# expected to transfer the copyright for their translations to this person
++# or entity, or to disclaim their copyright.  The empty string stands for
++# the public domain; in this case the translators are expected to disclaim
++# their copyright.
++COPYRIGHT_HOLDER = Free Software Foundation, Inc.
++
++# This tells whether or not to prepend "GNU " prefix to the package
++# name that gets inserted into the header of the $(DOMAIN).pot file.
++# Possible values are "yes", "no", or empty.  If it is empty, try to
++# detect it automatically by scanning the files in $(top_srcdir) for
++# "GNU packagename" string.
++PACKAGE_GNU =
++
++# This is the email address or URL to which the translators shall report
++# bugs in the untranslated strings:
++# - Strings which are not entire sentences, see the maintainer guidelines
++#   in the GNU gettext documentation, section 'Preparing Strings'.
++# - Strings which use unclear terms or require additional context to be
++#   understood.
++# - Strings which make invalid assumptions about notation of date, time or
++#   money.
++# - Pluralisation problems.
++# - Incorrect English spelling.
++# - Incorrect formatting.
++# It can be your email address, or a mailing list address where translators
++# can write to without being subscribed, or the URL of a web page through
++# which the translators can contact you.
++MSGID_BUGS_ADDRESS =
++
++# This is the list of locale categories, beyond LC_MESSAGES, for which the
++# message catalogs shall be used.  It is usually empty.
++EXTRA_LOCALE_CATEGORIES =
++
++# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
++# context.  Possible values are "yes" and "no".  Set this to yes if the
++# package uses functions taking also a message context, like pgettext(), or
++# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
++USE_MSGCTXT = no
++
++# These options get passed to msgmerge.
++# Useful options are in particular:
++#   --previous            to keep previous msgids of translated messages,
++#   --quiet               to reduce the verbosity.
++MSGMERGE_OPTIONS =
++
++# These options get passed to msginit.
++# If you want to disable line wrapping when writing PO files, add
++# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
++# MSGINIT_OPTIONS.
++MSGINIT_OPTIONS =
++
++# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
++# has changed.  Possible values are "yes" and "no".  Set this to no if
++# the POT file is checked in the repository and the version control
++# program ignores timestamps.
++PO_DEPENDS_ON_POT = yes
++
++# This tells whether or not to forcibly update $(DOMAIN).pot and
++# regenerate PO files on "make dist".  Possible values are "yes" and
++# "no".  Set this to no if the POT file and PO files are maintained
++# externally.
++DIST_DEPENDS_ON_UPDATE_PO = yes
+diff --git a/po/POTFILES.in b/po/POTFILES.in
+new file mode 100644
+index 0000000..667e27c
+--- /dev/null
++++ b/po/POTFILES.in
+@@ -0,0 +1 @@
++# List of source files which contain translatable strings.
+diff --git a/po/Rules-quot b/po/Rules-quot
+new file mode 100644
+index 0000000..9e13054
+--- /dev/null
++++ b/po/Rules-quot
+@@ -0,0 +1,66 @@
++# Special Makefile rules for English message catalogs with quotation marks.
++#
++# Copyright (C) 2001-2024 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++
++DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sed Rules-quot
++
++.SUFFIXES: .insert-header .po-update-en
++
++en@quot.po-create:
++	$(MAKE) en@quot.po-update
++en@boldquot.po-create:
++	$(MAKE) en@boldquot.po-update
++
++en@quot.po-update: en@quot.po-update-en
++en@boldquot.po-update: en@boldquot.po-update-en
++
++.insert-header.po-update-en:
++	@lang=`echo $@ | sed -e 's/\.po-update-en$$//'`; \
++	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; GETTEXTLIBDIR=`cd $(top_srcdir)/src && pwd`; export GETTEXTLIBDIR; fi; \
++	tmpdir=`pwd`; \
++	echo "$$lang:"; \
++	ll=`echo $$lang | sed -e 's/@.*//'`; \
++	LC_ALL=C; export LC_ALL; \
++	cd $(srcdir); \
++	if $(MSGINIT) $(MSGINIT_OPTIONS) -i $(DOMAIN).pot --no-translator -l $$lang -o - 2>/dev/null \
++	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(SED) -e '/^%%/d' \
++	   | $(MSGCONV) -t UTF-8 | \
++	   { case `$(MSGFILTER) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
++	     '' | 0.[0-9] | 0.[0-9].* | 0.1[0-8] | 0.1[0-8].*) \
++	       $(MSGFILTER) $(SED) -f `echo $$lang | sed -e 's/.*@//'`.sed \
++	       ;; \
++	     *) \
++	       $(MSGFILTER) `echo $$lang | sed -e 's/.*@//'` \
++	       ;; \
++	     esac } 2>/dev/null > $$tmpdir/$$lang.new.po \
++	     ; then \
++	  if cmp $$lang.po $$tmpdir/$$lang.new.po >/dev/null 2>&1; then \
++	    rm -f $$tmpdir/$$lang.new.po; \
++	  else \
++	    if mv -f $$tmpdir/$$lang.new.po $$lang.po; then \
++	      :; \
++	    else \
++	      echo "creation of $$lang.po failed: cannot move $$tmpdir/$$lang.new.po to $$lang.po" 1>&2; \
++	      exit 1; \
++	    fi; \
++	  fi; \
++	else \
++	  echo "creation of $$lang.po failed!" 1>&2; \
++	  rm -f $$tmpdir/$$lang.new.po; \
++	fi
++
++en@quot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sed > en@quot.insert-header
++
++en@boldquot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sed > en@boldquot.insert-header
++
++mostlyclean: mostlyclean-quot
++mostlyclean-quot:
++	rm -f *.insert-header
+diff --git a/po/boldquot.sed b/po/boldquot.sed
+new file mode 100644
+index 0000000..3c1de54
+--- /dev/null
++++ b/po/boldquot.sed
+@@ -0,0 +1,21 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks and highlighting the quotations in bold face.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
++s/"\([^"]*\)"/“\1”/g
++s/`\([^`']*\)'/‘\1’/g
++s/ '\([^`']*\)' / ‘\1’ /g
++s/ '\([^`']*\)'$/ ‘\1’/g
++s/^'\([^`']*\)' /‘\1’ /g
++s/“”/""/g
++s/“/“[1m/g
++s/”/[0m”/g
++s/‘/‘[1m/g
++s/’/[0m’/g
+diff --git a/po/en@boldquot.header b/po/en@boldquot.header
+new file mode 100644
+index 0000000..ac96ad9
+--- /dev/null
++++ b/po/en@boldquot.header
+@@ -0,0 +1,35 @@
++%% A header that gets inserted into message catalogs named en@boldquot.po.
++%%
++%% Copyright (C) 2001 Free Software Foundation, Inc.
++%% This file is free software; the Free Software Foundation
++%% gives unlimited permission to copy and/or distribute it,
++%% with or without modifications, as long as this notice is preserved.
++%% This file is offered as-is, without any warranty.
++%%
++%% Written by Bruno Haible <bruno@clisp.org>, 2001.
++%%
++# All this catalog "translates" are quotation characters.
++# The msgids must be ASCII and therefore cannot contain real quotation
++# characters, only substitutes like grave accent (0x60), apostrophe (0x27)
++# and double quote (0x22). These substitutes look strange; see
++# https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
++#
++# This catalog translates grave accent (0x60) and apostrophe (0x27) to
++# left single quotation mark (U+2018) and right single quotation mark (U+2019).
++# It also translates pairs of apostrophe (0x27) to
++# left single quotation mark (U+2018) and right single quotation mark (U+2019)
++# and pairs of quotation mark (0x22) to
++# left double quotation mark (U+201C) and right double quotation mark (U+201D).
++#
++# When output to an UTF-8 terminal, the quotation characters appear perfectly.
++# When output to an ISO-8859-1 terminal, the single quotation marks are
++# transliterated to apostrophes (by iconv in glibc 2.2 or newer) or to
++# grave/acute accent (by libiconv), and the double quotation marks are
++# transliterated to 0x22.
++# When output to an ASCII terminal, the single quotation marks are
++# transliterated to apostrophes, and the double quotation marks are
++# transliterated to 0x22.
++#
++# This catalog furthermore displays the text between the quotation marks in
++# bold face, assuming the VT100/XTerm escape sequences.
++#
+diff --git a/po/en@quot.header b/po/en@quot.header
+new file mode 100644
+index 0000000..287e2e7
+--- /dev/null
++++ b/po/en@quot.header
+@@ -0,0 +1,32 @@
++%% A header that gets inserted into message catalogs named en@quot.po.
++%%
++%% Copyright (C) 2001 Free Software Foundation, Inc.
++%% This file is free software; the Free Software Foundation
++%% gives unlimited permission to copy and/or distribute it,
++%% with or without modifications, as long as this notice is preserved.
++%% This file is offered as-is, without any warranty.
++%%
++%% Written by Bruno Haible <bruno@clisp.org>, 2001.
++%%
++# All this catalog "translates" are quotation characters.
++# The msgids must be ASCII and therefore cannot contain real quotation
++# characters, only substitutes like grave accent (0x60), apostrophe (0x27)
++# and double quote (0x22). These substitutes look strange; see
++# https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
++#
++# This catalog translates grave accent (0x60) and apostrophe (0x27) to
++# left single quotation mark (U+2018) and right single quotation mark (U+2019).
++# It also translates pairs of apostrophe (0x27) to
++# left single quotation mark (U+2018) and right single quotation mark (U+2019)
++# and pairs of quotation mark (0x22) to
++# left double quotation mark (U+201C) and right double quotation mark (U+201D).
++#
++# When output to an UTF-8 terminal, the quotation characters appear perfectly.
++# When output to an ISO-8859-1 terminal, the single quotation marks are
++# transliterated to apostrophes (by iconv in glibc 2.2 or newer) or to
++# grave/acute accent (by libiconv), and the double quotation marks are
++# transliterated to 0x22.
++# When output to an ASCII terminal, the single quotation marks are
++# transliterated to apostrophes, and the double quotation marks are
++# transliterated to 0x22.
++#
+diff --git a/po/insert-header.sed b/po/insert-header.sed
+new file mode 100644
+index 0000000..f9534e7
+--- /dev/null
++++ b/po/insert-header.sed
+@@ -0,0 +1,31 @@
++# Sed script that inserts the file called HEADER before the header entry.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
++# At each occurrence of a line starting with "msgid ", we execute the following
++# commands. At the first occurrence, insert the file. At the following
++# occurrences, do nothing. The distinction between the first and the following
++# occurrences is achieved by looking at the hold space.
++/^msgid /{
++x
++# Test if the hold space is empty.
++s/m/m/
++ta
++# Yes it was empty. First occurrence. Read the file.
++r HEADER
++# Output the file's contents by reading the next line. But don't lose the
++# current line while doing this.
++g
++N
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+diff --git a/po/quot.sed b/po/quot.sed
+new file mode 100644
+index 0000000..eb0e08d
+--- /dev/null
++++ b/po/quot.sed
+@@ -0,0 +1,17 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
++s/"\([^"]*\)"/“\1”/g
++s/`\([^`']*\)'/‘\1’/g
++s/ '\([^`']*\)' / ‘\1’ /g
++s/ '\([^`']*\)'$/ ‘\1’/g
++s/^'\([^`']*\)' /‘\1’ /g
++s/“”/""/g
+diff --git a/po/remove-potcdate.sed b/po/remove-potcdate.sed
+new file mode 100644
+index 0000000..8c70dfb
+--- /dev/null
++++ b/po/remove-potcdate.sed
+@@ -0,0 +1,25 @@
++# Sed script that removes the POT-Creation-Date line in the header entry
++# from a POT file.
++#
++# Copyright (C) 2002 Free Software Foundation, Inc.
++# Copying and distribution of this file, with or without modification,
++# are permitted in any medium without royalty provided the copyright
++# notice and this notice are preserved.  This file is offered as-is,
++# without any warranty.
++#
++# The distinction between the first and the following occurrences of the
++# pattern is achieved by looking at the hold space.
++/^"POT-Creation-Date: .*"$/{
++x
++# Test if the hold space is empty.
++s/P/P/
++ta
++# Yes it was empty. First occurrence. Remove the line.
++g
++d
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+-- 
+2.51.0
+

--- a/app-i18n/kakasi/autobuild/patches/0002-FEDORA-Fix-configure-c99.patch
+++ b/app-i18n/kakasi/autobuild/patches/0002-FEDORA-Fix-configure-c99.patch
@@ -1,0 +1,25 @@
+From 092af847a900afb844ff7cfa8738cb3e4b7849d2 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sat, 20 Sep 2025 23:09:11 +0800
+Subject: [PATCH 2/2] FEDORA Fix configure c99
+
+---
+ configure.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.in b/configure.in
+index f6799b4..a77169c 100644
+--- a/configure.in
++++ b/configure.in
+@@ -85,7 +85,7 @@ AS_VAR_IF(utf8, "yes",[
+     LIBS="$LIBICONV $LIBS"
+     AC_DEFINE(KAKASI_SUPPORT_UTF8, 1, [KAKASI_SUPPORT_UTF8])
+     AC_RUN_IFELSE([AC_LANG_PROGRAM([#include <iconv.h>],
+-		    [if (iconv_open("EUC-JP", "UTF-8") == -1) exit(1);])],
++		    [if (iconv_open("EUC-JP", "UTF-8") == -1) return 1;])],
+ 	[],
+ 	[AC_MSG_ERROR([can not use EUC-JP or UTF-8 encoding on iconv])])
+ ])
+-- 
+2.51.0
+

--- a/app-i18n/kakasi/spec
+++ b/app-i18n/kakasi/spec
@@ -1,4 +1,6 @@
 VER=2.3.6
+REL=1
+# Upstream's web does not use TLS.
 SRCS="tbl::http://kakasi.namazu.org/stable/kakasi-$VER.tar.gz"
 CHKSUMS="sha256::004276fd5619c003f514822d82d14ae83cd45fb9338e0cb56a44974b44961893"
 CHKUPDATE="anitya::id=1487"

--- a/app-multimedia/dvdauthor/autobuild/defines
+++ b/app-multimedia/dvdauthor/autobuild/defines
@@ -3,6 +3,4 @@ PKGSEC=utils
 PKGDEP="freetype fribidi imagemagick libdvdread libpng libxml2"
 PKGDES="DVD authoring tools"
 
-ABSHADOW=0
-NOPARALLEL=1
-RECONF=1
+ABTYPE=autotools

--- a/app-multimedia/dvdauthor/autobuild/patches/0001-GENTOO-Use-pkg-config-to-find-freetype.patch
+++ b/app-multimedia/dvdauthor/autobuild/patches/0001-GENTOO-Use-pkg-config-to-find-freetype.patch
@@ -1,7 +1,7 @@
-From 259f892fe61f16c26733506d2511eec7ff136dc4 Mon Sep 17 00:00:00 2001
+From 4dbfa4fc074e2f7aea1632dcd8f76962e7240570 Mon Sep 17 00:00:00 2001
 From: Lars Wendler <polynomial-c@gentoo.org>
 Date: Mon, 7 May 2018 09:18:48 +0200
-Subject: [PATCH] Use pkg-config to find freetype
+Subject: [PATCH 1/2] GENTOO: Use pkg-config to find freetype
 
 As of freetype-2.9.1 the freetype-config file no longer gets installed
 by default.
@@ -10,10 +10,10 @@ by default.
  1 file changed, 4 insertions(+), 6 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index c06ac6b..1194059 100644
+index f4b270f..c230382 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -79,10 +79,8 @@ PKG_CHECK_MODULES([FRIBIDI], [fribidi], [AC_DEFINE(HAVE_FRIBIDI, 1, [whether Fri
+@@ -84,10 +84,8 @@ PKG_CHECK_MODULES([FRIBIDI], [fribidi], [AC_DEFINE(HAVE_FRIBIDI, 1, [whether Fri
  AC_SUBST(FRIBIDI_CFLAGS)
  AC_SUBST(FRIBIDI_LIBS)
  
@@ -26,7 +26,7 @@ index c06ac6b..1194059 100644
      AC_DEFINE(HAVE_FREETYPE, 1, [Whether FreeType is available])
  
      ac_save_CPPFLAGS="$CPPFLAGS"
-@@ -91,9 +89,9 @@ if test -n "$FREETYPECONFIG"; then
+@@ -96,9 +94,9 @@ if test -n "$FREETYPECONFIG"; then
      CPPFLAGS="$ac_save_CPPFLAGS"
      AC_SUBST(FREETYPE_CPPFLAGS)
      AC_SUBST(FREETYPE_LIBS)
@@ -39,5 +39,5 @@ index c06ac6b..1194059 100644
  
  AC_ARG_ENABLE([default-video-format],
 -- 
-2.17.0
+2.51.0
 

--- a/app-multimedia/dvdauthor/autobuild/patches/0002-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/app-multimedia/dvdauthor/autobuild/patches/0002-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3359 @@
+From 3684d3d0b71b261aa93688da9f8bb7388d4db364 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 15:33:10 +0800
+Subject: [PATCH 2/2] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am          |   2 +
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 12 files changed, 3251 insertions(+)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index de76fc5..eac15a2 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -15,3 +15,5 @@ dvdauthor.spec: $(srcdir)/dvdauthor.spec.in src/config.h
+ 	$(edit) $(srcdir)/dvdauthor.spec.in > dvdauthor.spec.tmp
+ 	mv dvdauthor.spec.tmp dvdauthor.spec
+ 
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/app-multimedia/dvdauthor/spec
+++ b/app-multimedia/dvdauthor/spec
@@ -1,5 +1,5 @@
 VER=0.7.2
-REL=2
-SRCS="tbl::https://downloads.sourceforge.net/dvdauthor/dvdauthor-$VER.tar.gz"
+REL=3
+SRCS="tbl::https://sourceforge.net/projects/dvdauthor/files/dvdauthor-$VER.tar.gz/download"
 CHKSUMS="sha256::3020a92de9f78eb36f48b6f22d5a001c47107826634a785a62dfcd080f612eb7"
 CHKUPDATE="anitya::id=639"

--- a/app-multimedia/spek-x/autobuild/defines
+++ b/app-multimedia/spek-x/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME="spek-x"
+PKGSEC="sound"
 PKGDES="Acoustic spectrum analyser"
 PKGDEP="wxgtk3 ffmpeg"
 BUILDDEP="intltool"
-PKGSEC="sound"
+
+ABTYPE=autotools

--- a/app-multimedia/spek-x/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/app-multimedia/spek-x/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3373 @@
+From 022db4aea2e2094ebf93118ae5b2878e16208115 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 18:59:16 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am          |   2 +
+ configure.ac         |   2 +-
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 13 files changed, 3252 insertions(+), 1 deletion(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index 23ca704..4e65655 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -28,3 +28,5 @@ DISTCLEANFILES = \
+ 	intltool-extract \
+ 	intltool-merge \
+ 	intltool-update
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/configure.ac b/configure.ac
+index 4627bc9..d20bdf5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -83,7 +83,7 @@ fi
+ GETTEXT_PACKAGE=spek
+ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$GETTEXT_PACKAGE"], [Gettext Package])
+ AC_SUBST(GETTEXT_PACKAGE)
+-AM_GNU_GETTEXT_VERSION([0.18.1])
++AM_GNU_GETTEXT_VERSION([0.26])
+ AM_PO_SUBDIRS
+ 
+ AC_CONFIG_FILES([
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/app-multimedia/spek-x/spec
+++ b/app-multimedia/spek-x/spec
@@ -1,4 +1,5 @@
 VER=0.9.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/MikeWang000000/spek-X"
 CHKSUMS="SKIP"
 CHKUPDATE="antiya::id=377561"

--- a/app-utils/cabextract/autobuild/defines
+++ b/app-utils/cabextract/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=cabextract
-PKGDES="Microsoft cabinet file extractor"
 PKGSEC=utils
-PKGDEP=glibc
+PKGDES="Microsoft cabinet file extractor"
+PKGDEP="glibc"
+
+ABTYPE=autotools

--- a/app-utils/cabextract/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/app-utils/cabextract/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3368 @@
+From 08b4e07b2bceff60d0d8ec72fdd286b532a18045 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 16:37:23 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am          |   4 +-
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 12 files changed, 3252 insertions(+), 1 deletion(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index 7335650..460f424 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -14,7 +14,7 @@ TESTS =                 test/bugs.test test/case-ascii.test test/case-utf8.test
+                         test/split.test test/utf8-stresstest.test \
+                         test/symlinks.test
+ 
+-EXTRA_DIST =            cabextract.spec \
++EXTRA_DIST = m4/ChangeLog             cabextract.spec \
+                         doc/cabextract.1 doc/ja/cabextract.1 \
+                         doc/magic doc/wince_cab_format.html \
+                         fnmatch_.h getopt.h src/cabsplit \
+@@ -36,3 +36,5 @@ noinst_LIBRARIES =      libmscab.a
+ libmscab_a_SOURCES =    $(bundled_mspack)
+ AM_CPPFLAGS =           -I$(srcdir)/mspack -DMSPACK_NO_DEFAULT_SYSTEM
+ endif
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/app-utils/cabextract/spec
+++ b/app-utils/cabextract/spec
@@ -1,4 +1,5 @@
 VER=1.11
+REL=1
 SRCS="tbl::https://www.cabextract.org.uk/cabextract-$VER.tar.gz"
 CHKSUMS="sha256::b5546db1155e4c718ff3d4b278573604f30dd64c3c5bfd4657cd089b823a3ac6"
 CHKUPDATE="anitya::id=245"

--- a/app-utils/xclock/autobuild/defines
+++ b/app-utils/xclock/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=xclock
-PKGDES="X Clock"
-PKGDEP=x11-lib
 PKGSEC=x11
+PKGDES="X Clock"
+PKGDEP="x11-lib"
+
+ABTYPE=autotools

--- a/app-utils/xclock/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/app-utils/xclock/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3359 @@
+From 53005c416b80ed5d64bd8f3278d2624694c5611e Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 18:05:31 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am          |   2 +
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 12 files changed, 3251 insertions(+)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index 3b24cd5..cbd9468 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -59,3 +59,5 @@ ChangeLog:
+ 	$(CHANGELOG_CMD)
+ 
+ dist-hook: ChangeLog INSTALL
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/app-utils/xclock/spec
+++ b/app-utils/xclock/spec
@@ -1,4 +1,5 @@
 VER=1.1.1
+REL=1
 SRCS="tbl::https://ftp.x.org/pub/individual/app/xclock-$VER.tar.xz"
 CHKSUMS="sha256::df7ceabf8f07044a2fde4924d794554996811640a45de40cb12c2cf1f90f742c"
 CHKUPDATE="anitya::id=15032"

--- a/desktop-lxde/libfm/autobuild/beyond
+++ b/desktop-lxde/libfm/autobuild/beyond
@@ -1,3 +1,5 @@
-rm -rf "$PKGDIR"/usr/include/libfm
-mv "$PKGDIR"/usr/include/libfm-1.0/ "$PKGDIR"/usr/include/libfm
+abinfo "Remove symlink from libfm to libfm-1.0 ..."
+rm -v "$PKGDIR"/usr/include/libfm
+mv -v "$PKGDIR"/usr/include/libfm-1.0 \
+    "$PKGDIR"/usr/include/libfm
 

--- a/desktop-lxde/libfm/autobuild/defines
+++ b/desktop-lxde/libfm/autobuild/defines
@@ -1,8 +1,13 @@
 PKGNAME=libfm
 PKGSEC=x11
 PKGDEP="desktop-file-utils libexif dbus-glib gtk-3 menu-cache"
-BUILDDEP="intltool gtk-doc"
+BUILDDEP="intltool gtk-doc vala"
 PKGDES="Library for file management (LXDE)"
 
-AUTOTOOLS_AFTER="--with-gnu-ld --with-gtk=3"
-ABSHADOW=no
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--with-gtk=3'
+)
+
+# FIXME: fatal error: fm-marshal.h: No such file or directory
+ABSHADOW=0

--- a/desktop-lxde/libfm/autobuild/defines.stage2
+++ b/desktop-lxde/libfm/autobuild/defines.stage2
@@ -1,9 +1,15 @@
 PKGNAME=libfm
 PKGSEC=x11
 PKGDEP="desktop-file-utils libexif dbus-glib gtk-3"
-BUILDDEP="intltool"
+BUILDDEP="intltool gtk-doc"
 PKGDES="Library for file management (LXDE)"
 
-AUTOTOOLS_AFTER="--with-gnu-ld --with-gtk=3 --with-extra-only --enable-gtk-doc-html=no"
-ABSHADOW=no
-RECONF=0
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--with-gtk=3'
+    '--with-extra-only'
+    '--disable-old-actions'
+)
+
+# FIXME: fatal error: fm-marshal.h: No such file or directory
+ABSHADOW=0

--- a/desktop-lxde/libfm/spec
+++ b/desktop-lxde/libfm/spec
@@ -1,5 +1,4 @@
-VER=1.3.0.2
-REL=1
-SRCS="tbl::https://downloads.sourceforge.net/pcmanfm/libfm-$VER.tar.xz"
-CHKSUMS="sha256::18d06f7996ce1cf8947df6e106bc0338c6ae0c4138c316f2501f6f6f435c7c72"
+VER=1.4.0
+SRCS="git::commit=tags/$VER::https://github.com/lxde/libfm.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8794"

--- a/desktop-mate/mate-calc/autobuild/defines
+++ b/desktop-mate/mate-calc/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=MATE
 PKGDEP="gtk-3"
 BUILDDEP="intltool itstool mate-common yelp-tools"
 PKGDES="Calculator for MATE Desktop"
-PKGEPOCH=1
+
+ABTYPE=autotools

--- a/desktop-mate/mate-calc/autobuild/patch
+++ b/desktop-mate/mate-calc/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i -E 's/（(_.)）/(\1)/g' po/zh_CN.po

--- a/desktop-mate/mate-calc/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/desktop-mate/mate-calc/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3867 @@
+From 7671a3ab9bd259101d6ceacf782feddf99e62a55 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 11:51:10 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am            |   4 +-
+ Makefile.in            |   2 +-
+ configure.ac           |   2 +-
+ m4/build-to-host.m4    | 274 ++++++++++++++
+ m4/gettext.m4          | 446 ++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4   | 532 +++++++++++++++++++++++++++
+ m4/iconv.m4            | 324 ++++++++++++++++
+ m4/intlmacosx.m4       |  71 ++++
+ m4/lib-ld.m4           | 170 +++++++++
+ m4/lib-link.m4         | 815 +++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4       | 334 +++++++++++++++++
+ m4/nls.m4              |  33 ++
+ m4/po.m4               | 157 ++++++++
+ m4/progtest.m4         |  93 +++++
+ po/Makefile.in.in      | 130 +++++--
+ po/Makevars.template   |  82 +++++
+ po/Rules-quot          |  24 +-
+ po/boldquot.sed        |  11 +
+ po/insert-header.sed   |  31 ++
+ po/remove-potcdate.sed |  25 ++
+ 20 files changed, 3514 insertions(+), 46 deletions(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+ create mode 100644 po/Makevars.template
+ create mode 100644 po/insert-header.sed
+ create mode 100644 po/remove-potcdate.sed
+
+diff --git a/Makefile.am b/Makefile.am
+index fef59d5..75d2ea6 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,7 +1,7 @@
+ SUBDIRS = po src data help
+ 
+ # Temporary fix for JHBuild, see https://bugzilla.gnome.org/show_bug.cgi?id=641652
+-ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
++ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+ 
+ DISTCLEANFILES = \
+ 	Makefile.in \
+@@ -19,7 +19,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
+ 	--enable-compile-warnings=no \
+ 	CFLAGS='-Wno-deprecated-declarations'
+ 
+-EXTRA_DIST = \
++EXTRA_DIST = m4/ChangeLog  \
+ 	autogen.sh \
+ 	README.md
+ 
+diff --git a/Makefile.in b/Makefile.in
+index ec4b17c..5ad4fac 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -401,7 +401,7 @@ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENC
+ $(top_srcdir)/configure: @MAINTAINER_MODE_TRUE@ $(am__configure_deps)
+ 	$(am__cd) $(srcdir) && $(AUTOCONF)
+ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
+-	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
++	$(am__cd) $(srcdir) && $(ACLOCAL) -I m4 $(ACLOCAL_AMFLAGS)
+ $(am__aclocal_m4_deps):
+ 
+ config.h: stamp-h1
+diff --git a/configure.ac b/configure.ac
+index 5e1b579..4a87f12 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -50,7 +50,7 @@ AC_CHECK_LIB(mpc, log, [], [AC_MSG_ERROR(could not find required development lib
+ dnl ###########################################################################
+ dnl Internationalization
+ dnl ###########################################################################
+-AM_GNU_GETTEXT_VERSION([0.19.8])
++AM_GNU_GETTEXT_VERSION([0.26])
+ AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
+ AM_GNU_GETTEXT([external])
+ 
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+diff --git a/po/Makefile.in.in b/po/Makefile.in.in
+index 2b36b11..f7b2cea 100644
+--- a/po/Makefile.in.in
++++ b/po/Makefile.in.in
+@@ -1,14 +1,26 @@
+ # Makefile for PO directory in any package using GNU gettext.
+ # Copyright (C) 1995-2000 Ulrich Drepper <drepper@gnu.ai.mit.edu>
+-# Copyright (C) 2000-2023 Free Software Foundation, Inc.
++# Copyright (C) 2000-2025 Free Software Foundation, Inc.
+ #
+ # Copying and distribution of this file, with or without modification,
+ # are permitted in any medium without royalty provided the copyright
+ # notice and this notice are preserved.  This file is offered as-is,
+ # without any warranty.
+ #
+-# Origin: gettext-0.22
+-GETTEXT_MACRO_VERSION = 0.20
++# Origin: gettext-0.26
++GETTEXT_MACRO_VERSION = 0.24
++
++# This Makefile makes use of the variable assignment operator != standardized
++# by POSIX:2024
++# <https://pubs.opengroup.org/onlinepubs/9799919799/utilities/make.html>.
++# It thus requires a 'make' implementation that supports this operator !=.
++# As of 2024, these are: GNU make >= 4.0, FreeBSD make, NetBSD make,
++# OpenBSD make. This means that building on specific platforms requires
++# use of GNU make:
++#   - On macOS, use /opt/homebrew/bin/gmake.
++#   - On Solaris 11 OpenIndiana, use /usr/bin/gmake = /usr/gnu/bin/make.
++#   - On Solaris 11.4, install GNU make yourself.
++#   - On AIX, use /opt/freeware/bin/make.
+ 
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@
+@@ -64,19 +76,60 @@ MSGINIT = msginit
+ MSGCONV = msgconv
+ MSGFILTER = msgfilter
+ 
+-POFILES = @POFILES@
+-GMOFILES = @GMOFILES@
+-UPDATEPOFILES = @UPDATEPOFILES@
+-DUMMYPOFILES = @DUMMYPOFILES@
+-DISTFILES.common = Makefile.in.in remove-potcdate.sin \
+-$(DISTFILES.common.extra1) $(DISTFILES.common.extra2) $(DISTFILES.common.extra3)
+-DISTFILES = $(DISTFILES.common) Makevars POTFILES.in \
+-$(POFILES) $(GMOFILES) \
+-$(DISTFILES.extra1) $(DISTFILES.extra2) $(DISTFILES.extra3)
+-
+-POTFILES = \
+-
+-CATALOGS = @CATALOGS@
++# The list of files which contain translatable strings.
++POTFILES != sed -e '/^\#/d' < $(srcdir)/POTFILES.in
++# This is computed as $(foreach file, $(POTFILES), $(top_srcdir)/$(file))
++POTFILES_DEPS != for file in $(POTFILES); do echo $(top_srcdir)/$$file; done
++
++# The set of available translations.
++ALL_LINGUAS != if test -f $(srcdir)/LINGUAS; then \
++                 sed -e '/^\#/d' < $(srcdir)/LINGUAS; \
++               else \
++                 echo $(LINGUAS); \
++               fi
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).po)
++POFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.po; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).gmo)
++GMOFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.gmo; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).po-update)
++UPDATEPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.po-update; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).nop)
++DUMMYPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.nop; done
++
++DISTFILES.common = \
++  Makefile.in.in remove-potcdate.sed \
++  $(DISTFILES.common.extra1) $(DISTFILES.common.extra2) \
++  $(DISTFILES.common.extra3) $(DISTFILES.common.extra4) \
++  $(DISTFILES.common.extra5) $(DISTFILES.common.extra6)
++DISTFILES = \
++  $(DISTFILES.common) \
++  Makevars POTFILES.in \
++  $(POFILES) $(GMOFILES) \
++  $(DISTFILES.extra1) $(DISTFILES.extra2) \
++  $(DISTFILES.extra3) $(DISTFILES.extra4) \
++  $(DISTFILES.extra5) $(DISTFILES.extra6)
++
++# The set of desired translations, as specified by the installer or distributor.
++DESIRED_LINGUAS = @DESIRED_LINGUAS@
++# The set of translations to install. This is computed based on $(ALL_LINGUAS)
++# and $(DESIRED_LINGUAS). It is a subset of $(ALL_LINGUAS).
++# We use the presentlang catalog if desiredlang is
++#   a. equal to presentlang, or
++#   b. a variant of presentlang (because in this case, presentlang can be used
++#      as a fallback for messages which are not translated in the desiredlang
++#      catalog).
++INST_LINGUAS != for presentlang in $(ALL_LINGUAS); do \
++                  useit=false; \
++                  for desiredlang in $(DESIRED_LINGUAS); do \
++                    case "$$desiredlang" in \
++                      "$$presentlang" | "$$presentlang"_* | "$$presentlang".* | "$$presentlang"@*) \
++                        useit=true ;; \
++                    esac; \
++                  done; \
++                  if $$useit; then echo $$presentlang; fi; \
++                done
++# This is computed as $(foreach lang, $(INST_LINGUAS), $(lang).gmo)
++CATALOGS != for lang in $(INST_LINGUAS); do echo $$lang.gmo; done
+ 
+ POFILESDEPS_ = $(srcdir)/$(DOMAIN).pot
+ POFILESDEPS_yes = $(POFILESDEPS_)
+@@ -88,13 +141,14 @@ DISTFILESDEPS_yes = $(DISTFILESDEPS_)
+ DISTFILESDEPS_no =
+ DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
+ 
+-# Makevars gets inserted here. (Don't remove this line!)
++# Include the customization of this po/ directory.
++include $(srcdir)/Makevars
+ 
+ all: all-@USE_NLS@
+ 
+ 
+ .SUFFIXES:
+-.SUFFIXES: .po .gmo .sed .sin .nop .po-create .po-update
++.SUFFIXES: .po .gmo .nop .po-create .po-update
+ 
+ # The .pot file, stamp-po, .po files, and .gmo files appear in release tarballs.
+ # The GNU Coding Standards say in
+@@ -113,6 +167,7 @@ all: all-@USE_NLS@
+ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
+ .po.gmo:
+ 	@lang=`echo $* | sed -e 's,.*/,,'`; \
++	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+ 	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
+ 	echo "$${cdcmd}rm -f $${lang}.gmo && $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) -o $${lang}.1po $${lang}.po $(DOMAIN).pot && $(GMSGFMT) -c --statistics --verbose -o $${lang}.gmo $${lang}.1po && rm -f $${lang}.1po"; \
+ 	cd $(srcdir) && \
+@@ -122,10 +177,6 @@ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
+ 	mv t-$${lang}.gmo $${lang}.gmo && \
+ 	rm -f $${lang}.1po
+ 
+-.sin.sed:
+-	sed -e '/^#/d' $< > t-$@
+-	mv t-$@ $@
+-
+ 
+ all-yes: $(srcdir)/stamp-po
+ all-no:
+@@ -161,16 +212,12 @@ $(srcdir)/stamp-po: $(srcdir)/$(DOMAIN).pot
+ 	  mv $(srcdir)/stamp-poT $(srcdir)/stamp-po; \
+ 	}
+ 
+-# Note: Target 'all' must not depend on target '$(DOMAIN).pot-update',
+-# otherwise packages like GCC can not be built if only parts of the source
+-# have been downloaded.
+-
+ # This target rebuilds $(DOMAIN).pot; it is an expensive operation.
+ # Note that $(DOMAIN).pot is not touched if it doesn't need to be changed.
+ # The determination of whether the package xyz is a GNU one is based on the
+ # heuristic whether some file in the top level directory mentions "GNU xyz".
+ # If GNU 'find' is available, we avoid grepping through monster files.
+-$(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
++$(DOMAIN).pot-update: $(POTFILES_DEPS) $(srcdir)/POTFILES.in
+ 	package_gnu="$(PACKAGE_GNU)"; \
+ 	test -n "$$package_gnu" || { \
+ 	  if { if (LC_ALL=C find --version) 2>/dev/null | grep GNU >/dev/null; then \
+@@ -222,8 +269,8 @@ $(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
+ 	    || exit 1; \
+ 	  fi; \
+ 	  if test -f $(srcdir)/$(DOMAIN).pot; then \
+-	    sed -f remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
+-	    sed -f remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
+ 	    if cmp $(DOMAIN).1po $(DOMAIN).2po >/dev/null 2>&1; then \
+ 	      rm -f $(DOMAIN).1po $(DOMAIN).2po $(DOMAIN).po; \
+ 	    else \
+@@ -247,6 +294,7 @@ $(POFILES): $(POFILESDEPS)
+ 	@test -f $(srcdir)/$(DOMAIN).pot || $(MAKE) $(srcdir)/$(DOMAIN).pot
+ 	@lang=`echo $@ | sed -e 's,.*/,,' -e 's/\.po$$//'`; \
+ 	if test -f "$(srcdir)/$${lang}.po"; then \
++	  if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+ 	  test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
+ 	  echo "$${cdcmd}$(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) --lang=$${lang} --previous $${lang}.po $(DOMAIN).pot"; \
+ 	  cd $(srcdir) \
+@@ -396,7 +444,6 @@ info dvi ps pdf html tags TAGS ctags CTAGS ID:
+ install-dvi install-ps install-pdf install-html:
+ 
+ mostlyclean:
+-	rm -f remove-potcdate.sed
+ 	rm -f $(srcdir)/stamp-poT
+ 	rm -f core core.* $(DOMAIN).po $(DOMAIN).1po $(DOMAIN).2po *.new.po
+ 	rm -fr *.o
+@@ -404,7 +451,7 @@ mostlyclean:
+ clean: mostlyclean
+ 
+ distclean: clean
+-	rm -f Makefile Makefile.in POTFILES
++	rm -f Makefile Makefile.in
+ 
+ maintainer-clean: distclean
+ 	@echo "This command is intended for maintainers to use;"
+@@ -499,11 +546,24 @@ $(DUMMYPOFILES):
+ update-gmo: Makefile $(GMOFILES)
+ 	@:
+ 
++# Include all the Rules-* extensions. Documented in
++# <https://www.gnu.org/software/gettext/manual/html_node/po_002fRules_002d_002a.html>
++RULES_FILES != cd $(srcdir) \
++               && for file in Rules-*; do \
++                    if test -f "$$file"; then \
++                      case "$$file" in \
++                        *.orig | *.bak | *~) ;; \
++                        *) echo $(srcdir)/"$$file" ;; \
++                      esac; \
++                    fi; \
++                  done
++include $(RULES_FILES)
++
+ # Recreate Makefile by invoking config.status. Explicitly invoke the shell,
+ # because execution permission bits may not work on the current file system.
+ # Use @SHELL@, which is the shell determined by autoconf for the use by its
+ # scripts, not $(SHELL) which is hardwired to /bin/sh and may be deficient.
+-Makefile: Makefile.in.in Makevars $(top_builddir)/config.status @POMAKEFILEDEPS@
++Makefile: Makefile.in.in Makevars $(top_builddir)/config.status
+ 	cd $(top_builddir) \
+ 	  && @SHELL@ ./config.status $(subdir)/$@.in po-directories
+ 
+@@ -512,3 +572,9 @@ force:
+ # Tell versions [3.59,3.63) of GNU make not to export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:
++
++# This Makefile contains rules which don't work with parallel make,
++# namely dist2.
++# See <https://lists.gnu.org/archive/html/bug-gettext/2022-06/msg00022.html>.
++# So, turn off parallel execution in this Makefile.
++.NOTPARALLEL:
+diff --git a/po/Makevars.template b/po/Makevars.template
+new file mode 100644
+index 0000000..d1532a9
+--- /dev/null
++++ b/po/Makevars.template
+@@ -0,0 +1,82 @@
++# Makefile variables for PO directory in any package using GNU gettext.
++#
++# Copyright (C) 2003-2025 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to use, copy, distribute, and modify it.
++
++# Usually the message domain is the same as the package name.
++DOMAIN = $(PACKAGE)
++
++# These two variables depend on the location of this directory.
++subdir = po
++top_builddir = ..
++
++# These options get passed to xgettext.
++XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
++
++# This is the copyright holder that gets inserted into the header of the
++# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
++# package.  (Note that the msgid strings, extracted from the package's
++# sources, belong to the copyright holder of the package.)  Translators are
++# expected to transfer the copyright for their translations to this person
++# or entity, or to disclaim their copyright.  The empty string stands for
++# the public domain; in this case the translators are expected to disclaim
++# their copyright.
++COPYRIGHT_HOLDER = Free Software Foundation, Inc.
++
++# This tells whether or not to prepend "GNU " prefix to the package
++# name that gets inserted into the header of the $(DOMAIN).pot file.
++# Possible values are "yes", "no", or empty.  If it is empty, try to
++# detect it automatically by scanning the files in $(top_srcdir) for
++# "GNU packagename" string.
++PACKAGE_GNU =
++
++# This is the email address or URL to which the translators shall report
++# bugs in the untranslated strings:
++# - Strings which are not entire sentences, see the maintainer guidelines
++#   in the GNU gettext documentation, section 'Preparing Strings'.
++# - Strings which use unclear terms or require additional context to be
++#   understood.
++# - Strings which make invalid assumptions about notation of date, time or
++#   money.
++# - Pluralisation problems.
++# - Incorrect English spelling.
++# - Incorrect formatting.
++# It can be your email address, or a mailing list address where translators
++# can write to without being subscribed, or the URL of a web page through
++# which the translators can contact you.
++MSGID_BUGS_ADDRESS =
++
++# This is the list of locale categories, beyond LC_MESSAGES, for which the
++# message catalogs shall be used.  It is usually empty.
++EXTRA_LOCALE_CATEGORIES =
++
++# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
++# context.  Possible values are "yes" and "no".  Set this to yes if the
++# package uses functions taking also a message context, like pgettext(), or
++# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
++USE_MSGCTXT = no
++
++# These options get passed to msgmerge.
++# Useful options are in particular:
++#   --previous            to keep previous msgids of translated messages,
++#   --quiet               to reduce the verbosity.
++MSGMERGE_OPTIONS =
++
++# These options get passed to msginit.
++# If you want to disable line wrapping when writing PO files, add
++# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
++# MSGINIT_OPTIONS.
++MSGINIT_OPTIONS =
++
++# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
++# has changed.  Possible values are "yes" and "no".  Set this to no if
++# the POT file is checked in the repository and the version control
++# program ignores timestamps.
++PO_DEPENDS_ON_POT = yes
++
++# This tells whether or not to forcibly update $(DOMAIN).pot and
++# regenerate PO files on "make dist".  Possible values are "yes" and
++# "no".  Set this to no if the POT file and PO files are maintained
++# externally.
++DIST_DEPENDS_ON_UPDATE_PO = yes
+diff --git a/po/Rules-quot b/po/Rules-quot
+index 18c024b..9e13054 100644
+--- a/po/Rules-quot
++++ b/po/Rules-quot
+@@ -1,11 +1,14 @@
+ # Special Makefile rules for English message catalogs with quotation marks.
+ #
+-# Copyright (C) 2001-2017 Free Software Foundation, Inc.
+-# This file, Rules-quot, and its auxiliary files (listed under
+-# DISTFILES.common.extra1) are free software; the Free Software Foundation
+-# gives unlimited permission to use, copy, distribute, and modify them.
++# Copyright (C) 2001-2024 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
+ 
+-DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot
++DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sed Rules-quot
+ 
+ .SUFFIXES: .insert-header .po-update-en
+ 
+@@ -26,7 +29,8 @@ en@boldquot.po-update: en@boldquot.po-update-en
+ 	LC_ALL=C; export LC_ALL; \
+ 	cd $(srcdir); \
+ 	if $(MSGINIT) $(MSGINIT_OPTIONS) -i $(DOMAIN).pot --no-translator -l $$lang -o - 2>/dev/null \
+-	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(MSGCONV) -t UTF-8 | \
++	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(SED) -e '/^%%/d' \
++	   | $(MSGCONV) -t UTF-8 | \
+ 	   { case `$(MSGFILTER) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
+ 	     '' | 0.[0-9] | 0.[0-9].* | 0.1[0-8] | 0.1[0-8].*) \
+ 	       $(MSGFILTER) $(SED) -f `echo $$lang | sed -e 's/.*@//'`.sed \
+@@ -51,11 +55,11 @@ en@boldquot.po-update: en@boldquot.po-update-en
+ 	  rm -f $$tmpdir/$$lang.new.po; \
+ 	fi
+ 
+-en@quot.insert-header: insert-header.sin
+-	sed -e '/^#/d' -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sin > en@quot.insert-header
++en@quot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sed > en@quot.insert-header
+ 
+-en@boldquot.insert-header: insert-header.sin
+-	sed -e '/^#/d' -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sin > en@boldquot.insert-header
++en@boldquot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sed > en@boldquot.insert-header
+ 
+ mostlyclean: mostlyclean-quot
+ mostlyclean-quot:
+diff --git a/po/boldquot.sed b/po/boldquot.sed
+index 4b937aa..3c1de54 100644
+--- a/po/boldquot.sed
++++ b/po/boldquot.sed
+@@ -1,3 +1,14 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks and highlighting the quotations in bold face.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
+ s/"\([^"]*\)"/“\1”/g
+ s/`\([^`']*\)'/‘\1’/g
+ s/ '\([^`']*\)' / ‘\1’ /g
+diff --git a/po/insert-header.sed b/po/insert-header.sed
+new file mode 100644
+index 0000000..f9534e7
+--- /dev/null
++++ b/po/insert-header.sed
+@@ -0,0 +1,31 @@
++# Sed script that inserts the file called HEADER before the header entry.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
++# At each occurrence of a line starting with "msgid ", we execute the following
++# commands. At the first occurrence, insert the file. At the following
++# occurrences, do nothing. The distinction between the first and the following
++# occurrences is achieved by looking at the hold space.
++/^msgid /{
++x
++# Test if the hold space is empty.
++s/m/m/
++ta
++# Yes it was empty. First occurrence. Read the file.
++r HEADER
++# Output the file's contents by reading the next line. But don't lose the
++# current line while doing this.
++g
++N
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+diff --git a/po/remove-potcdate.sed b/po/remove-potcdate.sed
+new file mode 100644
+index 0000000..8c70dfb
+--- /dev/null
++++ b/po/remove-potcdate.sed
+@@ -0,0 +1,25 @@
++# Sed script that removes the POT-Creation-Date line in the header entry
++# from a POT file.
++#
++# Copyright (C) 2002 Free Software Foundation, Inc.
++# Copying and distribution of this file, with or without modification,
++# are permitted in any medium without royalty provided the copyright
++# notice and this notice are preserved.  This file is offered as-is,
++# without any warranty.
++#
++# The distinction between the first and the following occurrences of the
++# pattern is achieved by looking at the hold space.
++/^"POT-Creation-Date: .*"$/{
++x
++# Test if the hold space is empty.
++s/P/P/
++ta
++# Yes it was empty. First occurrence. Remove the line.
++g
++d
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+-- 
+2.51.0
+

--- a/desktop-mate/mate-calc/spec
+++ b/desktop-mate/mate-calc/spec
@@ -1,4 +1,6 @@
 VER=1.28.0
+EPOCH=1
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-calc-$VER.tar.xz"
 CHKSUMS="sha256::804b125d1e2864b1e74af816da9b2ab8b19472b9af974437ee7355ada5e628f5"
 CHKUPDATE="anitya::id=198697"

--- a/desktop-mate/mate-icon-theme/autobuild/beyond
+++ b/desktop-mate/mate-icon-theme/autobuild/beyond
@@ -1,1 +1,0 @@
-rm -f "$PKGDIR"/usr/share/icons/mate/icon-theme.cache

--- a/desktop-mate/mate-icon-theme/autobuild/defines
+++ b/desktop-mate/mate-icon-theme/autobuild/defines
@@ -4,5 +4,5 @@ PKGDEP="hicolor-icon-theme"
 BUILDDEP="icon-naming-utils intltool mate-common"
 PKGDES="Default icon theme for MATE"
 
+ABTYPE=autotools
 ABHOST=noarch
-PKGEPOCH=1

--- a/desktop-mate/mate-icon-theme/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/desktop-mate/mate-icon-theme/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3878 @@
+From abb280bbbbc1e2532a51d693c34909837e12c78e Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 11:55:59 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am            |   4 +-
+ Makefile.in            |   2 +-
+ configure.ac           |   2 +-
+ m4/build-to-host.m4    | 274 ++++++++++++++
+ m4/gettext.m4          | 446 ++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4   | 532 +++++++++++++++++++++++++++
+ m4/iconv.m4            | 324 ++++++++++++++++
+ m4/intlmacosx.m4       |  71 ++++
+ m4/lib-ld.m4           | 170 +++++++++
+ m4/lib-link.m4         | 815 +++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4       | 334 +++++++++++++++++
+ m4/nls.m4              |  33 ++
+ m4/po.m4               | 157 ++++++++
+ m4/progtest.m4         |  93 +++++
+ po/Makefile.in.in      | 130 +++++--
+ po/Makevars.template   |  82 +++++
+ po/Rules-quot          |  24 +-
+ po/boldquot.sed        |  11 +
+ po/insert-header.sed   |  31 ++
+ po/quot.sed~           |   6 +
+ po/remove-potcdate.sed |  25 ++
+ 21 files changed, 3521 insertions(+), 45 deletions(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+ create mode 100644 po/Makevars.template
+ create mode 100644 po/insert-header.sed
+ create mode 100644 po/quot.sed~
+ create mode 100644 po/remove-potcdate.sed
+
+diff --git a/Makefile.am b/Makefile.am
+index 2e8d45b..fa6de4a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -90,7 +90,7 @@ install-data-local:
+ 		touch $(DESTDIR)$(themedir); \
+ 	fi
+ 
+-EXTRA_DIST = \
++EXTRA_DIST = m4/ChangeLog  \
+ 	autogen.sh \
+ 	mate \
+ 	menta \
+@@ -125,3 +125,5 @@ dist: ChangeLog
+ 
+ .PHONY: ChangeLog
+ 
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/Makefile.in b/Makefile.in
+index 70bdd72..93d3820 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -428,7 +428,7 @@ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENC
+ $(top_srcdir)/configure:  $(am__configure_deps)
+ 	$(am__cd) $(srcdir) && $(AUTOCONF)
+ $(ACLOCAL_M4):  $(am__aclocal_m4_deps)
+-	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
++	$(am__cd) $(srcdir) && $(ACLOCAL) -I m4 $(ACLOCAL_AMFLAGS)
+ $(am__aclocal_m4_deps):
+ install-themeDATA: $(theme_DATA)
+ 	@$(NORMAL_INSTALL)
+diff --git a/configure.ac b/configure.ac
+index daeebdd..fad35ac 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -9,7 +9,7 @@ AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz no-dist-gzip foreign check-news])
+ 
+ PKG_PROG_PKG_CONFIG([0.19])
+ 
+-AM_GNU_GETTEXT_VERSION([0.19.8])
++AM_GNU_GETTEXT_VERSION([0.26])
+ AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
+ AM_GNU_GETTEXT([external])
+ 
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+diff --git a/po/Makefile.in.in b/po/Makefile.in.in
+index 2b36b11..f7b2cea 100644
+--- a/po/Makefile.in.in
++++ b/po/Makefile.in.in
+@@ -1,14 +1,26 @@
+ # Makefile for PO directory in any package using GNU gettext.
+ # Copyright (C) 1995-2000 Ulrich Drepper <drepper@gnu.ai.mit.edu>
+-# Copyright (C) 2000-2023 Free Software Foundation, Inc.
++# Copyright (C) 2000-2025 Free Software Foundation, Inc.
+ #
+ # Copying and distribution of this file, with or without modification,
+ # are permitted in any medium without royalty provided the copyright
+ # notice and this notice are preserved.  This file is offered as-is,
+ # without any warranty.
+ #
+-# Origin: gettext-0.22
+-GETTEXT_MACRO_VERSION = 0.20
++# Origin: gettext-0.26
++GETTEXT_MACRO_VERSION = 0.24
++
++# This Makefile makes use of the variable assignment operator != standardized
++# by POSIX:2024
++# <https://pubs.opengroup.org/onlinepubs/9799919799/utilities/make.html>.
++# It thus requires a 'make' implementation that supports this operator !=.
++# As of 2024, these are: GNU make >= 4.0, FreeBSD make, NetBSD make,
++# OpenBSD make. This means that building on specific platforms requires
++# use of GNU make:
++#   - On macOS, use /opt/homebrew/bin/gmake.
++#   - On Solaris 11 OpenIndiana, use /usr/bin/gmake = /usr/gnu/bin/make.
++#   - On Solaris 11.4, install GNU make yourself.
++#   - On AIX, use /opt/freeware/bin/make.
+ 
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@
+@@ -64,19 +76,60 @@ MSGINIT = msginit
+ MSGCONV = msgconv
+ MSGFILTER = msgfilter
+ 
+-POFILES = @POFILES@
+-GMOFILES = @GMOFILES@
+-UPDATEPOFILES = @UPDATEPOFILES@
+-DUMMYPOFILES = @DUMMYPOFILES@
+-DISTFILES.common = Makefile.in.in remove-potcdate.sin \
+-$(DISTFILES.common.extra1) $(DISTFILES.common.extra2) $(DISTFILES.common.extra3)
+-DISTFILES = $(DISTFILES.common) Makevars POTFILES.in \
+-$(POFILES) $(GMOFILES) \
+-$(DISTFILES.extra1) $(DISTFILES.extra2) $(DISTFILES.extra3)
+-
+-POTFILES = \
+-
+-CATALOGS = @CATALOGS@
++# The list of files which contain translatable strings.
++POTFILES != sed -e '/^\#/d' < $(srcdir)/POTFILES.in
++# This is computed as $(foreach file, $(POTFILES), $(top_srcdir)/$(file))
++POTFILES_DEPS != for file in $(POTFILES); do echo $(top_srcdir)/$$file; done
++
++# The set of available translations.
++ALL_LINGUAS != if test -f $(srcdir)/LINGUAS; then \
++                 sed -e '/^\#/d' < $(srcdir)/LINGUAS; \
++               else \
++                 echo $(LINGUAS); \
++               fi
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).po)
++POFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.po; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).gmo)
++GMOFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.gmo; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).po-update)
++UPDATEPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.po-update; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).nop)
++DUMMYPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.nop; done
++
++DISTFILES.common = \
++  Makefile.in.in remove-potcdate.sed \
++  $(DISTFILES.common.extra1) $(DISTFILES.common.extra2) \
++  $(DISTFILES.common.extra3) $(DISTFILES.common.extra4) \
++  $(DISTFILES.common.extra5) $(DISTFILES.common.extra6)
++DISTFILES = \
++  $(DISTFILES.common) \
++  Makevars POTFILES.in \
++  $(POFILES) $(GMOFILES) \
++  $(DISTFILES.extra1) $(DISTFILES.extra2) \
++  $(DISTFILES.extra3) $(DISTFILES.extra4) \
++  $(DISTFILES.extra5) $(DISTFILES.extra6)
++
++# The set of desired translations, as specified by the installer or distributor.
++DESIRED_LINGUAS = @DESIRED_LINGUAS@
++# The set of translations to install. This is computed based on $(ALL_LINGUAS)
++# and $(DESIRED_LINGUAS). It is a subset of $(ALL_LINGUAS).
++# We use the presentlang catalog if desiredlang is
++#   a. equal to presentlang, or
++#   b. a variant of presentlang (because in this case, presentlang can be used
++#      as a fallback for messages which are not translated in the desiredlang
++#      catalog).
++INST_LINGUAS != for presentlang in $(ALL_LINGUAS); do \
++                  useit=false; \
++                  for desiredlang in $(DESIRED_LINGUAS); do \
++                    case "$$desiredlang" in \
++                      "$$presentlang" | "$$presentlang"_* | "$$presentlang".* | "$$presentlang"@*) \
++                        useit=true ;; \
++                    esac; \
++                  done; \
++                  if $$useit; then echo $$presentlang; fi; \
++                done
++# This is computed as $(foreach lang, $(INST_LINGUAS), $(lang).gmo)
++CATALOGS != for lang in $(INST_LINGUAS); do echo $$lang.gmo; done
+ 
+ POFILESDEPS_ = $(srcdir)/$(DOMAIN).pot
+ POFILESDEPS_yes = $(POFILESDEPS_)
+@@ -88,13 +141,14 @@ DISTFILESDEPS_yes = $(DISTFILESDEPS_)
+ DISTFILESDEPS_no =
+ DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
+ 
+-# Makevars gets inserted here. (Don't remove this line!)
++# Include the customization of this po/ directory.
++include $(srcdir)/Makevars
+ 
+ all: all-@USE_NLS@
+ 
+ 
+ .SUFFIXES:
+-.SUFFIXES: .po .gmo .sed .sin .nop .po-create .po-update
++.SUFFIXES: .po .gmo .nop .po-create .po-update
+ 
+ # The .pot file, stamp-po, .po files, and .gmo files appear in release tarballs.
+ # The GNU Coding Standards say in
+@@ -113,6 +167,7 @@ all: all-@USE_NLS@
+ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
+ .po.gmo:
+ 	@lang=`echo $* | sed -e 's,.*/,,'`; \
++	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+ 	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
+ 	echo "$${cdcmd}rm -f $${lang}.gmo && $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) -o $${lang}.1po $${lang}.po $(DOMAIN).pot && $(GMSGFMT) -c --statistics --verbose -o $${lang}.gmo $${lang}.1po && rm -f $${lang}.1po"; \
+ 	cd $(srcdir) && \
+@@ -122,10 +177,6 @@ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
+ 	mv t-$${lang}.gmo $${lang}.gmo && \
+ 	rm -f $${lang}.1po
+ 
+-.sin.sed:
+-	sed -e '/^#/d' $< > t-$@
+-	mv t-$@ $@
+-
+ 
+ all-yes: $(srcdir)/stamp-po
+ all-no:
+@@ -161,16 +212,12 @@ $(srcdir)/stamp-po: $(srcdir)/$(DOMAIN).pot
+ 	  mv $(srcdir)/stamp-poT $(srcdir)/stamp-po; \
+ 	}
+ 
+-# Note: Target 'all' must not depend on target '$(DOMAIN).pot-update',
+-# otherwise packages like GCC can not be built if only parts of the source
+-# have been downloaded.
+-
+ # This target rebuilds $(DOMAIN).pot; it is an expensive operation.
+ # Note that $(DOMAIN).pot is not touched if it doesn't need to be changed.
+ # The determination of whether the package xyz is a GNU one is based on the
+ # heuristic whether some file in the top level directory mentions "GNU xyz".
+ # If GNU 'find' is available, we avoid grepping through monster files.
+-$(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
++$(DOMAIN).pot-update: $(POTFILES_DEPS) $(srcdir)/POTFILES.in
+ 	package_gnu="$(PACKAGE_GNU)"; \
+ 	test -n "$$package_gnu" || { \
+ 	  if { if (LC_ALL=C find --version) 2>/dev/null | grep GNU >/dev/null; then \
+@@ -222,8 +269,8 @@ $(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
+ 	    || exit 1; \
+ 	  fi; \
+ 	  if test -f $(srcdir)/$(DOMAIN).pot; then \
+-	    sed -f remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
+-	    sed -f remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
+ 	    if cmp $(DOMAIN).1po $(DOMAIN).2po >/dev/null 2>&1; then \
+ 	      rm -f $(DOMAIN).1po $(DOMAIN).2po $(DOMAIN).po; \
+ 	    else \
+@@ -247,6 +294,7 @@ $(POFILES): $(POFILESDEPS)
+ 	@test -f $(srcdir)/$(DOMAIN).pot || $(MAKE) $(srcdir)/$(DOMAIN).pot
+ 	@lang=`echo $@ | sed -e 's,.*/,,' -e 's/\.po$$//'`; \
+ 	if test -f "$(srcdir)/$${lang}.po"; then \
++	  if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+ 	  test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
+ 	  echo "$${cdcmd}$(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) --lang=$${lang} --previous $${lang}.po $(DOMAIN).pot"; \
+ 	  cd $(srcdir) \
+@@ -396,7 +444,6 @@ info dvi ps pdf html tags TAGS ctags CTAGS ID:
+ install-dvi install-ps install-pdf install-html:
+ 
+ mostlyclean:
+-	rm -f remove-potcdate.sed
+ 	rm -f $(srcdir)/stamp-poT
+ 	rm -f core core.* $(DOMAIN).po $(DOMAIN).1po $(DOMAIN).2po *.new.po
+ 	rm -fr *.o
+@@ -404,7 +451,7 @@ mostlyclean:
+ clean: mostlyclean
+ 
+ distclean: clean
+-	rm -f Makefile Makefile.in POTFILES
++	rm -f Makefile Makefile.in
+ 
+ maintainer-clean: distclean
+ 	@echo "This command is intended for maintainers to use;"
+@@ -499,11 +546,24 @@ $(DUMMYPOFILES):
+ update-gmo: Makefile $(GMOFILES)
+ 	@:
+ 
++# Include all the Rules-* extensions. Documented in
++# <https://www.gnu.org/software/gettext/manual/html_node/po_002fRules_002d_002a.html>
++RULES_FILES != cd $(srcdir) \
++               && for file in Rules-*; do \
++                    if test -f "$$file"; then \
++                      case "$$file" in \
++                        *.orig | *.bak | *~) ;; \
++                        *) echo $(srcdir)/"$$file" ;; \
++                      esac; \
++                    fi; \
++                  done
++include $(RULES_FILES)
++
+ # Recreate Makefile by invoking config.status. Explicitly invoke the shell,
+ # because execution permission bits may not work on the current file system.
+ # Use @SHELL@, which is the shell determined by autoconf for the use by its
+ # scripts, not $(SHELL) which is hardwired to /bin/sh and may be deficient.
+-Makefile: Makefile.in.in Makevars $(top_builddir)/config.status @POMAKEFILEDEPS@
++Makefile: Makefile.in.in Makevars $(top_builddir)/config.status
+ 	cd $(top_builddir) \
+ 	  && @SHELL@ ./config.status $(subdir)/$@.in po-directories
+ 
+@@ -512,3 +572,9 @@ force:
+ # Tell versions [3.59,3.63) of GNU make not to export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:
++
++# This Makefile contains rules which don't work with parallel make,
++# namely dist2.
++# See <https://lists.gnu.org/archive/html/bug-gettext/2022-06/msg00022.html>.
++# So, turn off parallel execution in this Makefile.
++.NOTPARALLEL:
+diff --git a/po/Makevars.template b/po/Makevars.template
+new file mode 100644
+index 0000000..d1532a9
+--- /dev/null
++++ b/po/Makevars.template
+@@ -0,0 +1,82 @@
++# Makefile variables for PO directory in any package using GNU gettext.
++#
++# Copyright (C) 2003-2025 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to use, copy, distribute, and modify it.
++
++# Usually the message domain is the same as the package name.
++DOMAIN = $(PACKAGE)
++
++# These two variables depend on the location of this directory.
++subdir = po
++top_builddir = ..
++
++# These options get passed to xgettext.
++XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
++
++# This is the copyright holder that gets inserted into the header of the
++# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
++# package.  (Note that the msgid strings, extracted from the package's
++# sources, belong to the copyright holder of the package.)  Translators are
++# expected to transfer the copyright for their translations to this person
++# or entity, or to disclaim their copyright.  The empty string stands for
++# the public domain; in this case the translators are expected to disclaim
++# their copyright.
++COPYRIGHT_HOLDER = Free Software Foundation, Inc.
++
++# This tells whether or not to prepend "GNU " prefix to the package
++# name that gets inserted into the header of the $(DOMAIN).pot file.
++# Possible values are "yes", "no", or empty.  If it is empty, try to
++# detect it automatically by scanning the files in $(top_srcdir) for
++# "GNU packagename" string.
++PACKAGE_GNU =
++
++# This is the email address or URL to which the translators shall report
++# bugs in the untranslated strings:
++# - Strings which are not entire sentences, see the maintainer guidelines
++#   in the GNU gettext documentation, section 'Preparing Strings'.
++# - Strings which use unclear terms or require additional context to be
++#   understood.
++# - Strings which make invalid assumptions about notation of date, time or
++#   money.
++# - Pluralisation problems.
++# - Incorrect English spelling.
++# - Incorrect formatting.
++# It can be your email address, or a mailing list address where translators
++# can write to without being subscribed, or the URL of a web page through
++# which the translators can contact you.
++MSGID_BUGS_ADDRESS =
++
++# This is the list of locale categories, beyond LC_MESSAGES, for which the
++# message catalogs shall be used.  It is usually empty.
++EXTRA_LOCALE_CATEGORIES =
++
++# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
++# context.  Possible values are "yes" and "no".  Set this to yes if the
++# package uses functions taking also a message context, like pgettext(), or
++# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
++USE_MSGCTXT = no
++
++# These options get passed to msgmerge.
++# Useful options are in particular:
++#   --previous            to keep previous msgids of translated messages,
++#   --quiet               to reduce the verbosity.
++MSGMERGE_OPTIONS =
++
++# These options get passed to msginit.
++# If you want to disable line wrapping when writing PO files, add
++# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
++# MSGINIT_OPTIONS.
++MSGINIT_OPTIONS =
++
++# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
++# has changed.  Possible values are "yes" and "no".  Set this to no if
++# the POT file is checked in the repository and the version control
++# program ignores timestamps.
++PO_DEPENDS_ON_POT = yes
++
++# This tells whether or not to forcibly update $(DOMAIN).pot and
++# regenerate PO files on "make dist".  Possible values are "yes" and
++# "no".  Set this to no if the POT file and PO files are maintained
++# externally.
++DIST_DEPENDS_ON_UPDATE_PO = yes
+diff --git a/po/Rules-quot b/po/Rules-quot
+index 18c024b..9e13054 100644
+--- a/po/Rules-quot
++++ b/po/Rules-quot
+@@ -1,11 +1,14 @@
+ # Special Makefile rules for English message catalogs with quotation marks.
+ #
+-# Copyright (C) 2001-2017 Free Software Foundation, Inc.
+-# This file, Rules-quot, and its auxiliary files (listed under
+-# DISTFILES.common.extra1) are free software; the Free Software Foundation
+-# gives unlimited permission to use, copy, distribute, and modify them.
++# Copyright (C) 2001-2024 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
+ 
+-DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot
++DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sed Rules-quot
+ 
+ .SUFFIXES: .insert-header .po-update-en
+ 
+@@ -26,7 +29,8 @@ en@boldquot.po-update: en@boldquot.po-update-en
+ 	LC_ALL=C; export LC_ALL; \
+ 	cd $(srcdir); \
+ 	if $(MSGINIT) $(MSGINIT_OPTIONS) -i $(DOMAIN).pot --no-translator -l $$lang -o - 2>/dev/null \
+-	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(MSGCONV) -t UTF-8 | \
++	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(SED) -e '/^%%/d' \
++	   | $(MSGCONV) -t UTF-8 | \
+ 	   { case `$(MSGFILTER) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
+ 	     '' | 0.[0-9] | 0.[0-9].* | 0.1[0-8] | 0.1[0-8].*) \
+ 	       $(MSGFILTER) $(SED) -f `echo $$lang | sed -e 's/.*@//'`.sed \
+@@ -51,11 +55,11 @@ en@boldquot.po-update: en@boldquot.po-update-en
+ 	  rm -f $$tmpdir/$$lang.new.po; \
+ 	fi
+ 
+-en@quot.insert-header: insert-header.sin
+-	sed -e '/^#/d' -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sin > en@quot.insert-header
++en@quot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sed > en@quot.insert-header
+ 
+-en@boldquot.insert-header: insert-header.sin
+-	sed -e '/^#/d' -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sin > en@boldquot.insert-header
++en@boldquot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sed > en@boldquot.insert-header
+ 
+ mostlyclean: mostlyclean-quot
+ mostlyclean-quot:
+diff --git a/po/boldquot.sed b/po/boldquot.sed
+index 4b937aa..3c1de54 100644
+--- a/po/boldquot.sed
++++ b/po/boldquot.sed
+@@ -1,3 +1,14 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks and highlighting the quotations in bold face.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
+ s/"\([^"]*\)"/“\1”/g
+ s/`\([^`']*\)'/‘\1’/g
+ s/ '\([^`']*\)' / ‘\1’ /g
+diff --git a/po/insert-header.sed b/po/insert-header.sed
+new file mode 100644
+index 0000000..f9534e7
+--- /dev/null
++++ b/po/insert-header.sed
+@@ -0,0 +1,31 @@
++# Sed script that inserts the file called HEADER before the header entry.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
++# At each occurrence of a line starting with "msgid ", we execute the following
++# commands. At the first occurrence, insert the file. At the following
++# occurrences, do nothing. The distinction between the first and the following
++# occurrences is achieved by looking at the hold space.
++/^msgid /{
++x
++# Test if the hold space is empty.
++s/m/m/
++ta
++# Yes it was empty. First occurrence. Read the file.
++r HEADER
++# Output the file's contents by reading the next line. But don't lose the
++# current line while doing this.
++g
++N
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+diff --git a/po/quot.sed~ b/po/quot.sed~
+new file mode 100644
+index 0000000..0122c46
+--- /dev/null
++++ b/po/quot.sed~
+@@ -0,0 +1,6 @@
++s/"\([^"]*\)"/“\1”/g
++s/`\([^`']*\)'/‘\1’/g
++s/ '\([^`']*\)' / ‘\1’ /g
++s/ '\([^`']*\)'$/ ‘\1’/g
++s/^'\([^`']*\)' /‘\1’ /g
++s/“”/""/g
+diff --git a/po/remove-potcdate.sed b/po/remove-potcdate.sed
+new file mode 100644
+index 0000000..8c70dfb
+--- /dev/null
++++ b/po/remove-potcdate.sed
+@@ -0,0 +1,25 @@
++# Sed script that removes the POT-Creation-Date line in the header entry
++# from a POT file.
++#
++# Copyright (C) 2002 Free Software Foundation, Inc.
++# Copying and distribution of this file, with or without modification,
++# are permitted in any medium without royalty provided the copyright
++# notice and this notice are preserved.  This file is offered as-is,
++# without any warranty.
++#
++# The distinction between the first and the following occurrences of the
++# pattern is achieved by looking at the hold space.
++/^"POT-Creation-Date: .*"$/{
++x
++# Test if the hold space is empty.
++s/P/P/
++ta
++# Yes it was empty. First occurrence. Remove the line.
++g
++d
++bb
++:a
++# The hold space was nonempty. Following occurrences. Do nothing.
++x
++:b
++}
+-- 
+2.51.0
+

--- a/desktop-mate/mate-icon-theme/spec
+++ b/desktop-mate/mate-icon-theme/spec
@@ -1,4 +1,6 @@
 VER=1.28.0
+EPOCH=1
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-icon-theme-$VER.tar.xz"
 CHKSUMS="sha256::94d6079060ca5df74542921de4eea38b7d02d07561c919356d95de876f9a6d3a"
 CHKUPDATE="anitya::id=10939"

--- a/desktop-mate/mate-user-guide/autobuild/defines
+++ b/desktop-mate/mate-user-guide/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="yelp"
 BUILDDEP="mate-common yelp-tools"
 PKGDES="MATE user guide"
 
+ABTYPE=autotools
 ABHOST=noarch

--- a/desktop-mate/mate-user-guide/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/desktop-mate/mate-user-guide/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3702 @@
+From 032e496dc01787e916a3f4ff5ebc89e5f4b2c10c Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 11:45:45 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am          |   4 +-
+ Makefile.in          |   2 +-
+ configure.ac         |   2 +-
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ po/Makefile.in.in    | 130 +++++--
+ po/Rules-quot        |  24 +-
+ po/boldquot.sed      |  11 +
+ 17 files changed, 3377 insertions(+), 45 deletions(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index 63fdff6..72ced7a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -17,7 +17,7 @@ endif
+ 
+ CLEANFILES = $(desktop_DATA)
+ 
+-EXTRA_DIST = \
++EXTRA_DIST = m4/ChangeLog  \
+     autogen.sh
+ 
+ # Build ChangeLog from GIT  history
+@@ -29,3 +29,5 @@ ChangeLog:
+ dist: ChangeLog
+ 
+ .PHONY: ChangeLog
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/Makefile.in b/Makefile.in
+index 9e834ea..a5d8361 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -400,7 +400,7 @@ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENC
+ $(top_srcdir)/configure: @MAINTAINER_MODE_TRUE@ $(am__configure_deps)
+ 	$(am__cd) $(srcdir) && $(AUTOCONF)
+ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
+-	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
++	$(am__cd) $(srcdir) && $(ACLOCAL) -I m4 $(ACLOCAL_AMFLAGS)
+ $(am__aclocal_m4_deps):
+ mate-user-guide.desktop.in: $(top_builddir)/config.status $(srcdir)/mate-user-guide.desktop.in.in
+ 	cd $(top_builddir) && $(SHELL) ./config.status $@
+diff --git a/configure.ac b/configure.ac
+index c676055..5bb1c5c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -9,7 +9,7 @@ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [The gettext translation
+ AC_SUBST(GETTEXT_PACKAGE)
+ 
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.19.8])
++AM_GNU_GETTEXT_VERSION([0.26])
+ AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
+ AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
+ 
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+diff --git a/po/Makefile.in.in b/po/Makefile.in.in
+index 2b36b11..f7b2cea 100644
+--- a/po/Makefile.in.in
++++ b/po/Makefile.in.in
+@@ -1,14 +1,26 @@
+ # Makefile for PO directory in any package using GNU gettext.
+ # Copyright (C) 1995-2000 Ulrich Drepper <drepper@gnu.ai.mit.edu>
+-# Copyright (C) 2000-2023 Free Software Foundation, Inc.
++# Copyright (C) 2000-2025 Free Software Foundation, Inc.
+ #
+ # Copying and distribution of this file, with or without modification,
+ # are permitted in any medium without royalty provided the copyright
+ # notice and this notice are preserved.  This file is offered as-is,
+ # without any warranty.
+ #
+-# Origin: gettext-0.22
+-GETTEXT_MACRO_VERSION = 0.20
++# Origin: gettext-0.26
++GETTEXT_MACRO_VERSION = 0.24
++
++# This Makefile makes use of the variable assignment operator != standardized
++# by POSIX:2024
++# <https://pubs.opengroup.org/onlinepubs/9799919799/utilities/make.html>.
++# It thus requires a 'make' implementation that supports this operator !=.
++# As of 2024, these are: GNU make >= 4.0, FreeBSD make, NetBSD make,
++# OpenBSD make. This means that building on specific platforms requires
++# use of GNU make:
++#   - On macOS, use /opt/homebrew/bin/gmake.
++#   - On Solaris 11 OpenIndiana, use /usr/bin/gmake = /usr/gnu/bin/make.
++#   - On Solaris 11.4, install GNU make yourself.
++#   - On AIX, use /opt/freeware/bin/make.
+ 
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@
+@@ -64,19 +76,60 @@ MSGINIT = msginit
+ MSGCONV = msgconv
+ MSGFILTER = msgfilter
+ 
+-POFILES = @POFILES@
+-GMOFILES = @GMOFILES@
+-UPDATEPOFILES = @UPDATEPOFILES@
+-DUMMYPOFILES = @DUMMYPOFILES@
+-DISTFILES.common = Makefile.in.in remove-potcdate.sin \
+-$(DISTFILES.common.extra1) $(DISTFILES.common.extra2) $(DISTFILES.common.extra3)
+-DISTFILES = $(DISTFILES.common) Makevars POTFILES.in \
+-$(POFILES) $(GMOFILES) \
+-$(DISTFILES.extra1) $(DISTFILES.extra2) $(DISTFILES.extra3)
+-
+-POTFILES = \
+-
+-CATALOGS = @CATALOGS@
++# The list of files which contain translatable strings.
++POTFILES != sed -e '/^\#/d' < $(srcdir)/POTFILES.in
++# This is computed as $(foreach file, $(POTFILES), $(top_srcdir)/$(file))
++POTFILES_DEPS != for file in $(POTFILES); do echo $(top_srcdir)/$$file; done
++
++# The set of available translations.
++ALL_LINGUAS != if test -f $(srcdir)/LINGUAS; then \
++                 sed -e '/^\#/d' < $(srcdir)/LINGUAS; \
++               else \
++                 echo $(LINGUAS); \
++               fi
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).po)
++POFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.po; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).gmo)
++GMOFILES != for lang in $(ALL_LINGUAS); do echo $(srcdir)/$$lang.gmo; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).po-update)
++UPDATEPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.po-update; done
++# This is computed as $(foreach lang, $(ALL_LINGUAS), $(lang).nop)
++DUMMYPOFILES != for lang in $(ALL_LINGUAS); do echo $$lang.nop; done
++
++DISTFILES.common = \
++  Makefile.in.in remove-potcdate.sed \
++  $(DISTFILES.common.extra1) $(DISTFILES.common.extra2) \
++  $(DISTFILES.common.extra3) $(DISTFILES.common.extra4) \
++  $(DISTFILES.common.extra5) $(DISTFILES.common.extra6)
++DISTFILES = \
++  $(DISTFILES.common) \
++  Makevars POTFILES.in \
++  $(POFILES) $(GMOFILES) \
++  $(DISTFILES.extra1) $(DISTFILES.extra2) \
++  $(DISTFILES.extra3) $(DISTFILES.extra4) \
++  $(DISTFILES.extra5) $(DISTFILES.extra6)
++
++# The set of desired translations, as specified by the installer or distributor.
++DESIRED_LINGUAS = @DESIRED_LINGUAS@
++# The set of translations to install. This is computed based on $(ALL_LINGUAS)
++# and $(DESIRED_LINGUAS). It is a subset of $(ALL_LINGUAS).
++# We use the presentlang catalog if desiredlang is
++#   a. equal to presentlang, or
++#   b. a variant of presentlang (because in this case, presentlang can be used
++#      as a fallback for messages which are not translated in the desiredlang
++#      catalog).
++INST_LINGUAS != for presentlang in $(ALL_LINGUAS); do \
++                  useit=false; \
++                  for desiredlang in $(DESIRED_LINGUAS); do \
++                    case "$$desiredlang" in \
++                      "$$presentlang" | "$$presentlang"_* | "$$presentlang".* | "$$presentlang"@*) \
++                        useit=true ;; \
++                    esac; \
++                  done; \
++                  if $$useit; then echo $$presentlang; fi; \
++                done
++# This is computed as $(foreach lang, $(INST_LINGUAS), $(lang).gmo)
++CATALOGS != for lang in $(INST_LINGUAS); do echo $$lang.gmo; done
+ 
+ POFILESDEPS_ = $(srcdir)/$(DOMAIN).pot
+ POFILESDEPS_yes = $(POFILESDEPS_)
+@@ -88,13 +141,14 @@ DISTFILESDEPS_yes = $(DISTFILESDEPS_)
+ DISTFILESDEPS_no =
+ DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
+ 
+-# Makevars gets inserted here. (Don't remove this line!)
++# Include the customization of this po/ directory.
++include $(srcdir)/Makevars
+ 
+ all: all-@USE_NLS@
+ 
+ 
+ .SUFFIXES:
+-.SUFFIXES: .po .gmo .sed .sin .nop .po-create .po-update
++.SUFFIXES: .po .gmo .nop .po-create .po-update
+ 
+ # The .pot file, stamp-po, .po files, and .gmo files appear in release tarballs.
+ # The GNU Coding Standards say in
+@@ -113,6 +167,7 @@ all: all-@USE_NLS@
+ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
+ .po.gmo:
+ 	@lang=`echo $* | sed -e 's,.*/,,'`; \
++	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+ 	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
+ 	echo "$${cdcmd}rm -f $${lang}.gmo && $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) -o $${lang}.1po $${lang}.po $(DOMAIN).pot && $(GMSGFMT) -c --statistics --verbose -o $${lang}.gmo $${lang}.1po && rm -f $${lang}.1po"; \
+ 	cd $(srcdir) && \
+@@ -122,10 +177,6 @@ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
+ 	mv t-$${lang}.gmo $${lang}.gmo && \
+ 	rm -f $${lang}.1po
+ 
+-.sin.sed:
+-	sed -e '/^#/d' $< > t-$@
+-	mv t-$@ $@
+-
+ 
+ all-yes: $(srcdir)/stamp-po
+ all-no:
+@@ -161,16 +212,12 @@ $(srcdir)/stamp-po: $(srcdir)/$(DOMAIN).pot
+ 	  mv $(srcdir)/stamp-poT $(srcdir)/stamp-po; \
+ 	}
+ 
+-# Note: Target 'all' must not depend on target '$(DOMAIN).pot-update',
+-# otherwise packages like GCC can not be built if only parts of the source
+-# have been downloaded.
+-
+ # This target rebuilds $(DOMAIN).pot; it is an expensive operation.
+ # Note that $(DOMAIN).pot is not touched if it doesn't need to be changed.
+ # The determination of whether the package xyz is a GNU one is based on the
+ # heuristic whether some file in the top level directory mentions "GNU xyz".
+ # If GNU 'find' is available, we avoid grepping through monster files.
+-$(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
++$(DOMAIN).pot-update: $(POTFILES_DEPS) $(srcdir)/POTFILES.in
+ 	package_gnu="$(PACKAGE_GNU)"; \
+ 	test -n "$$package_gnu" || { \
+ 	  if { if (LC_ALL=C find --version) 2>/dev/null | grep GNU >/dev/null; then \
+@@ -222,8 +269,8 @@ $(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
+ 	    || exit 1; \
+ 	  fi; \
+ 	  if test -f $(srcdir)/$(DOMAIN).pot; then \
+-	    sed -f remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
+-	    sed -f remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
++	    sed -f $(srcdir)/remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
+ 	    if cmp $(DOMAIN).1po $(DOMAIN).2po >/dev/null 2>&1; then \
+ 	      rm -f $(DOMAIN).1po $(DOMAIN).2po $(DOMAIN).po; \
+ 	    else \
+@@ -247,6 +294,7 @@ $(POFILES): $(POFILESDEPS)
+ 	@test -f $(srcdir)/$(DOMAIN).pot || $(MAKE) $(srcdir)/$(DOMAIN).pot
+ 	@lang=`echo $@ | sed -e 's,.*/,,' -e 's/\.po$$//'`; \
+ 	if test -f "$(srcdir)/$${lang}.po"; then \
++	  if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+ 	  test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
+ 	  echo "$${cdcmd}$(MSGMERGE_UPDATE) --quiet $(MSGMERGE_OPTIONS) --lang=$${lang} --previous $${lang}.po $(DOMAIN).pot"; \
+ 	  cd $(srcdir) \
+@@ -396,7 +444,6 @@ info dvi ps pdf html tags TAGS ctags CTAGS ID:
+ install-dvi install-ps install-pdf install-html:
+ 
+ mostlyclean:
+-	rm -f remove-potcdate.sed
+ 	rm -f $(srcdir)/stamp-poT
+ 	rm -f core core.* $(DOMAIN).po $(DOMAIN).1po $(DOMAIN).2po *.new.po
+ 	rm -fr *.o
+@@ -404,7 +451,7 @@ mostlyclean:
+ clean: mostlyclean
+ 
+ distclean: clean
+-	rm -f Makefile Makefile.in POTFILES
++	rm -f Makefile Makefile.in
+ 
+ maintainer-clean: distclean
+ 	@echo "This command is intended for maintainers to use;"
+@@ -499,11 +546,24 @@ $(DUMMYPOFILES):
+ update-gmo: Makefile $(GMOFILES)
+ 	@:
+ 
++# Include all the Rules-* extensions. Documented in
++# <https://www.gnu.org/software/gettext/manual/html_node/po_002fRules_002d_002a.html>
++RULES_FILES != cd $(srcdir) \
++               && for file in Rules-*; do \
++                    if test -f "$$file"; then \
++                      case "$$file" in \
++                        *.orig | *.bak | *~) ;; \
++                        *) echo $(srcdir)/"$$file" ;; \
++                      esac; \
++                    fi; \
++                  done
++include $(RULES_FILES)
++
+ # Recreate Makefile by invoking config.status. Explicitly invoke the shell,
+ # because execution permission bits may not work on the current file system.
+ # Use @SHELL@, which is the shell determined by autoconf for the use by its
+ # scripts, not $(SHELL) which is hardwired to /bin/sh and may be deficient.
+-Makefile: Makefile.in.in Makevars $(top_builddir)/config.status @POMAKEFILEDEPS@
++Makefile: Makefile.in.in Makevars $(top_builddir)/config.status
+ 	cd $(top_builddir) \
+ 	  && @SHELL@ ./config.status $(subdir)/$@.in po-directories
+ 
+@@ -512,3 +572,9 @@ force:
+ # Tell versions [3.59,3.63) of GNU make not to export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+ .NOEXPORT:
++
++# This Makefile contains rules which don't work with parallel make,
++# namely dist2.
++# See <https://lists.gnu.org/archive/html/bug-gettext/2022-06/msg00022.html>.
++# So, turn off parallel execution in this Makefile.
++.NOTPARALLEL:
+diff --git a/po/Rules-quot b/po/Rules-quot
+index 18c024b..9e13054 100644
+--- a/po/Rules-quot
++++ b/po/Rules-quot
+@@ -1,11 +1,14 @@
+ # Special Makefile rules for English message catalogs with quotation marks.
+ #
+-# Copyright (C) 2001-2017 Free Software Foundation, Inc.
+-# This file, Rules-quot, and its auxiliary files (listed under
+-# DISTFILES.common.extra1) are free software; the Free Software Foundation
+-# gives unlimited permission to use, copy, distribute, and modify them.
++# Copyright (C) 2001-2024 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
+ 
+-DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot
++DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sed Rules-quot
+ 
+ .SUFFIXES: .insert-header .po-update-en
+ 
+@@ -26,7 +29,8 @@ en@boldquot.po-update: en@boldquot.po-update-en
+ 	LC_ALL=C; export LC_ALL; \
+ 	cd $(srcdir); \
+ 	if $(MSGINIT) $(MSGINIT_OPTIONS) -i $(DOMAIN).pot --no-translator -l $$lang -o - 2>/dev/null \
+-	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(MSGCONV) -t UTF-8 | \
++	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(SED) -e '/^%%/d' \
++	   | $(MSGCONV) -t UTF-8 | \
+ 	   { case `$(MSGFILTER) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
+ 	     '' | 0.[0-9] | 0.[0-9].* | 0.1[0-8] | 0.1[0-8].*) \
+ 	       $(MSGFILTER) $(SED) -f `echo $$lang | sed -e 's/.*@//'`.sed \
+@@ -51,11 +55,11 @@ en@boldquot.po-update: en@boldquot.po-update-en
+ 	  rm -f $$tmpdir/$$lang.new.po; \
+ 	fi
+ 
+-en@quot.insert-header: insert-header.sin
+-	sed -e '/^#/d' -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sin > en@quot.insert-header
++en@quot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@quot.header/g' $(srcdir)/insert-header.sed > en@quot.insert-header
+ 
+-en@boldquot.insert-header: insert-header.sin
+-	sed -e '/^#/d' -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sin > en@boldquot.insert-header
++en@boldquot.insert-header: insert-header.sed
++	sed -e 's/HEADER/en@boldquot.header/g' $(srcdir)/insert-header.sed > en@boldquot.insert-header
+ 
+ mostlyclean: mostlyclean-quot
+ mostlyclean-quot:
+diff --git a/po/boldquot.sed b/po/boldquot.sed
+index 4b937aa..3c1de54 100644
+--- a/po/boldquot.sed
++++ b/po/boldquot.sed
+@@ -1,3 +1,14 @@
++# Sed script that converts quotations, by replacing ASCII quotation marks
++# with Unicode quotation marks and highlighting the quotations in bold face.
++#
++# Copyright (C) 2001 Free Software Foundation, Inc.
++# This file is free software; the Free Software Foundation
++# gives unlimited permission to copy and/or distribute it,
++# with or without modifications, as long as this notice is preserved.
++# This file is offered as-is, without any warranty.
++#
++# Written by Bruno Haible <bruno@clisp.org>, 2001.
++#
+ s/"\([^"]*\)"/“\1”/g
+ s/`\([^`']*\)'/‘\1’/g
+ s/ '\([^`']*\)' / ‘\1’ /g
+-- 
+2.51.0
+

--- a/desktop-mate/mate-user-guide/spec
+++ b/desktop-mate/mate-user-guide/spec
@@ -1,4 +1,5 @@
 VER=1.28.0
+REL=1
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-user-guide-$VER.tar.xz"
 CHKSUMS="sha256::53ef0814f506544614ed61ab7be5221cc8d3a9f14f7ef9698c90fe7e46014b9e"
 CHKUPDATE="anitya::id=230628"

--- a/desktop-wm/fluxbox/01-fluxbox/beyond
+++ b/desktop-wm/fluxbox/01-fluxbox/beyond
@@ -1,2 +1,3 @@
-abinfo "Removing fbsetbg for split package ..."
-rm -v "$PKGDIR"/usr/bin/fbsetbg
+abinfo "Moving fbsetbg for split package ..."
+mv -v "$PKGDIR"/usr/bin/fbsetbg \
+    "$SRCDIR"/fbsetbg

--- a/desktop-wm/fluxbox/01-fluxbox/defines
+++ b/desktop-wm/fluxbox/01-fluxbox/defines
@@ -3,8 +3,10 @@ PKGSEC=x11
 PKGDEP="x11-lib imlib2 fribidi"
 PKGDES="A lightweight and highly-configurable window manager"
 
-AUTOTOOLS_AFTER="--enable-xft \
-                 --enable-xinerama \
-                 --enable-imlib2 \
-                 --enable-nls"
-ABSHADOW=0
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--enable-xft'
+    '--enable-xinerama'
+    '--enable-imlib2'
+    '--enable-nls'
+)

--- a/desktop-wm/fluxbox/01-fluxbox/patches/0001-support-more-terminal-emulators.patch
+++ b/desktop-wm/fluxbox/01-fluxbox/patches/0001-support-more-terminal-emulators.patch
@@ -1,7 +1,17 @@
-diff -Naur fluxbox-1.3.7/util/fluxbox-generate_menu.in fluxbox-1.3.7-new/util/fluxbox-generate_menu.in
---- fluxbox-1.3.7/util/fluxbox-generate_menu.in	2015-02-08 05:44:45.377187009 -0500
-+++ fluxbox-1.3.7-new/util/fluxbox-generate_menu.in	2018-03-04 20:19:55.734436934 -0500
-@@ -1494,7 +1494,9 @@
+From f85ef7a4e58a11c9847d99eb3f13e564ad9aace5 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 16:46:19 +0800
+Subject: [PATCH 1/3] support more terminal emulators
+
+---
+ util/fluxbox-generate_menu.in | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/util/fluxbox-generate_menu.in b/util/fluxbox-generate_menu.in
+index 085d622..b0a6c31 100755
+--- a/util/fluxbox-generate_menu.in
++++ b/util/fluxbox-generate_menu.in
+@@ -1494,7 +1494,9 @@ if find_it_options $MY_TERM; then
  else
      [ -n "$MY_TERM" ] && echo "Warning: you chose an invalid term." >&2
      #The precise order is up for debate.
@@ -12,3 +22,6 @@ diff -Naur fluxbox-1.3.7/util/fluxbox-generate_menu.in fluxbox-1.3.7-new/util/fl
          if find_it_options $term; then
              DEFAULT_TERM=$term
              break
+-- 
+2.51.0
+

--- a/desktop-wm/fluxbox/01-fluxbox/patches/0002-FEDORA-fix-fluxbox-after-gcc11.patch
+++ b/desktop-wm/fluxbox/01-fluxbox/patches/0002-FEDORA-fix-fluxbox-after-gcc11.patch
@@ -1,3 +1,12 @@
+From 3c856a1da8ba1435ab8cc428f30396c4d3b6d50d Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 16:48:07 +0800
+Subject: [PATCH 2/3] FEDORA: fix fluxbox after gcc11
+
+---
+ util/fluxbox-remote.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/util/fluxbox-remote.cc b/util/fluxbox-remote.cc
 index 59852e6..504015b 100644
 --- a/util/fluxbox-remote.cc
@@ -11,4 +20,6 @@ index 59852e6..504015b 100644
              && text_prop.nitems > 0) {
  
              printf("%s", text_prop.value);
+-- 
+2.51.0
 

--- a/desktop-wm/fluxbox/01-fluxbox/patches/0003-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/desktop-wm/fluxbox/01-fluxbox/patches/0003-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3348 @@
+From 1d475435beef781cf94bb4602ec837c7b6a36ed1 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 16:44:41 +0800
+Subject: [PATCH 3/3] AOSCOS: Run gettextize to include gettext macros
+
+---
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 11 files changed, 3249 insertions(+)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/desktop-wm/fluxbox/02-fbsetbg/build
+++ b/desktop-wm/fluxbox/02-fbsetbg/build
@@ -1,4 +1,3 @@
 abinfo "Installing fbsetbg ..."
-make install DESTDIR="$SRCDIR"/fakeinstall
-install -Dvm755 "$SRCDIR"/fakeinstall/usr/bin/fbsetbg \
+install -Dvm755 "$SRCDIR"/fbsetbg \
     "$PKGDIR"/usr/bin/fbsetbg

--- a/desktop-wm/fluxbox/02-fbsetbg/defines
+++ b/desktop-wm/fluxbox/02-fbsetbg/defines
@@ -4,6 +4,7 @@ PKGDEP="x11-lib imlib2 feh"
 PKGDES="A simple wrapper script to set background for X11 desktop environments"
 
 ABHOST=noarch
+ABTYPE=self
 
 PKGBREAK="fluxbox<=1.3.7-4"
 PKGREP="fluxbox<=1.3.7-4"

--- a/desktop-wm/fluxbox/spec
+++ b/desktop-wm/fluxbox/spec
@@ -1,5 +1,5 @@
 VER=1.3.7
-REL=9
-SRCS="tbl::https://sourceforge.net/projects/fluxbox/files/fluxbox/$VER/fluxbox-$VER.tar.gz"
+REL=10
+SRCS="tbl::https://sourceforge.net/projects/fluxbox/files/fluxbox/$VER/fluxbox-$VER.tar.gz/download"
 CHKSUMS="sha256::c99e2baa06fff1e96342b20415059d12ff1fa2917ade0173c75b2fa570295b9f"
 CHKUPDATE="anitya::id=824"

--- a/runtime-desktop/sound-theme-freedesktop/autobuild/defines
+++ b/runtime-desktop/sound-theme-freedesktop/autobuild/defines
@@ -4,3 +4,4 @@ BUILDDEP="intltool"
 PKGDES="Sound themes from FreeDesktop.org"
 
 ABHOST=noarch
+ABTYPE=autotools

--- a/runtime-desktop/sound-theme-freedesktop/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/runtime-desktop/sound-theme-freedesktop/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3373 @@
+From 5fd8c61fa71b328bfef9690ac50419f78fc32b4c Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Thu, 25 Sep 2025 15:37:51 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ Makefile.am          |   2 +
+ Makefile.in          |   2 +-
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 324 +++++++++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 13 files changed, 3252 insertions(+), 1 deletion(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/Makefile.am b/Makefile.am
+index dd7ec3b..542d073 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -63,3 +63,5 @@ $(srcdir)/ChangeLog:
+ 	fi
+ 
+ .PHONY: ChangeLog $(srcdir)/ChangeLog
++
++ACLOCAL_AMFLAGS = -I m4
+diff --git a/Makefile.in b/Makefile.in
+index 129d4c9..ce2d3b6 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -345,7 +345,7 @@ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENC
+ $(top_srcdir)/configure:  $(am__configure_deps)
+ 	$(am__cd) $(srcdir) && $(AUTOCONF)
+ $(ACLOCAL_M4):  $(am__aclocal_m4_deps)
+-	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
++	$(am__cd) $(srcdir) && $(ACLOCAL) -I m4 $(ACLOCAL_AMFLAGS)
+ $(am__aclocal_m4_deps):
+ install-themeDATA: $(theme_DATA)
+ 	@$(NORMAL_INSTALL)
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+new file mode 100644
+index 0000000..915c45a
+--- /dev/null
++++ b/m4/iconv.m4
+@@ -0,0 +1,324 @@
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      gl_saved_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
++#include <iconv.h>
++#include <string.h>
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
++        if (res == 0)
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$gl_saved_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/runtime-desktop/sound-theme-freedesktop/spec
+++ b/runtime-desktop/sound-theme-freedesktop/spec
@@ -1,5 +1,5 @@
 VER=0.8
-REL=2
+REL=3
 SRCS="tbl::https://people.freedesktop.org/~mccann/dist/sound-theme-freedesktop-$VER.tar.bz2"
 CHKSUMS="sha256::cb518b20eef05ec2e82dda1fa89a292c1760dc023aba91b8aa69bafac85e8a14"
 CHKUPDATE="anitya::id=10152"

--- a/runtime-devices/libmtp/autobuild/beyond
+++ b/runtime-devices/libmtp/autobuild/beyond
@@ -1,1 +1,0 @@
-sed -i "/^Unable to open/d" $PKGDIR/usr/lib/udev/rules.d/69-libmtp.rules

--- a/runtime-devices/libmtp/autobuild/defines
+++ b/runtime-devices/libmtp/autobuild/defines
@@ -3,12 +3,12 @@ PKGSEC=libs
 PKGDEP="libusb libgcrypt"
 PKGDES="Implementation of the Media Transfer Protocol"
 
-AUTOTOOLS_AFTER="--with-udev=/usr/lib/udev"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--with-udev=/usr/lib/udev'
+)
 
-# FIXME: Cannot regenerate configure file with following error:
+# FIXME: autogen.sh contains interactive prompts.
 #
-#  /var/cache/acbs/build/acbs.jljsh_5t/libmtp-1.1.22/configure: line 14347: AC_LIB_PREPARE_PREFIX: command not found
-#  /var/cache/acbs/build/acbs.jljsh_5t/libmtp-1.1.22/configure: line 14348: AC_LIB_RPATH: command not found
-#  /var/cache/acbs/build/acbs.jljsh_5t/libmtp-1.1.22/configure: line 14353: syntax error near unexpected token `iconv'
-#  /var/cache/acbs/build/acbs.jljsh_5t/libmtp-1.1.22/configure: line 14353: ` AC_LIB_LINKFLAGS_BODY(iconv)' 
-RECONF=0
+# Skip `Autoupdate config.sub and config.guess (y/n)?`
+ABNOAUTOGEN=1

--- a/runtime-devices/libmtp/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/runtime-devices/libmtp/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3597 @@
+From 0578d4c4ebecfdd745894b3d914b250f991acfe1 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 21 Sep 2025 15:42:18 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ m4/build-to-host.m4  | 274 +++++++++++++++
+ m4/gettext.m4        | 446 +++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 ++++++++++++++++++++++++++++
+ m4/iconv.m4          | 283 +++++++++++----
+ m4/iconv.m4~         | 195 +++++++++++
+ m4/intlmacosx.m4     |  71 ++++
+ m4/lib-ld.m4         | 170 +++++++++
+ m4/lib-link.m4       | 815 +++++++++++++++++++++++++++++++++++++++++++
+ m4/lib-prefix.m4     | 334 ++++++++++++++++++
+ m4/nls.m4            |  33 ++
+ m4/po.m4             | 157 +++++++++
+ m4/progtest.m4       |  93 +++++
+ 12 files changed, 3326 insertions(+), 77 deletions(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/iconv.m4~
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/lib-ld.m4
+ create mode 100644 m4/lib-link.m4
+ create mode 100644 m4/lib-prefix.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+index ee41742..915c45a 100644
+--- a/m4/iconv.m4
++++ b/m4/iconv.m4
+@@ -1,11 +1,20 @@
+-# iconv.m4 serial 11 (gettext-0.18.1)
+-dnl Copyright (C) 2000-2002, 2007-2010 Free Software Foundation, Inc.
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
+ 
+ dnl From Bruno Haible.
+ 
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
+ AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
+ [
+   dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
+@@ -30,61 +39,148 @@ AC_DEFUN([AM_ICONV_LINK],
+   dnl Add $INCICONV to CPPFLAGS before performing the following checks,
+   dnl because if the user has installed libiconv and not disabled its use
+   dnl via --without-libiconv-prefix, he wants to use it. The first
+-  dnl AC_TRY_LINK will then fail, the second AC_TRY_LINK will succeed.
+-  am_save_CPPFLAGS="$CPPFLAGS"
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
+   AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
+ 
+   AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
+     am_cv_func_iconv="no, consider installing GNU libiconv"
+     am_cv_lib_iconv=no
+-    AC_TRY_LINK([#include <stdlib.h>
+-#include <iconv.h>],
+-      [iconv_t cd = iconv_open("","");
+-       iconv(cd,NULL,NULL,NULL,NULL);
+-       iconv_close(cd);],
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
+       [am_cv_func_iconv=yes])
+     if test "$am_cv_func_iconv" != yes; then
+-      am_save_LIBS="$LIBS"
++      gl_saved_LIBS="$LIBS"
+       LIBS="$LIBS $LIBICONV"
+-      AC_TRY_LINK([#include <stdlib.h>
+-#include <iconv.h>],
+-        [iconv_t cd = iconv_open("","");
+-         iconv(cd,NULL,NULL,NULL,NULL);
+-         iconv_close(cd);],
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
+         [am_cv_lib_iconv=yes]
+         [am_cv_func_iconv=yes])
+-      LIBS="$am_save_LIBS"
++      LIBS="$gl_saved_LIBS"
+     fi
+   ])
+   if test "$am_cv_func_iconv" = yes; then
+     AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
+-      dnl This tests against bugs in AIX 5.1, HP-UX 11.11, Solaris 10.
+-      am_save_LIBS="$LIBS"
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
+       if test $am_cv_lib_iconv = yes; then
+         LIBS="$LIBS $LIBICONV"
+       fi
+-      AC_TRY_RUN([
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
+ #include <iconv.h>
+ #include <string.h>
+-int main ()
+-{
+-  /* Test against AIX 5.1 bug: Failures are not distinguishable from successful
+-     returns.  */
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
+   {
+     iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
+     if (cd_utf8_to_88591 != (iconv_t)(-1))
+       {
+-        static const char input[] = "\342\202\254"; /* EURO SIGN */
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
+         char buf[10];
+-        const char *inptr = input;
++        ICONV_CONST char *inptr = input;
+         size_t inbytesleft = strlen (input);
+         char *outptr = buf;
+         size_t outbytesleft = sizeof (buf);
+         size_t res = iconv (cd_utf8_to_88591,
+-                            (char **) &inptr, &inbytesleft,
++                            &inptr, &inbytesleft,
+                             &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
+         if (res == 0)
+-          return 1;
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
+       }
+   }
+ #if 0 /* This bug could be worked around by the caller.  */
+@@ -93,38 +189,54 @@ int main ()
+     iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
+     if (cd_88591_to_utf8 != (iconv_t)(-1))
+       {
+-        static const char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
+         char buf[50];
+-        const char *inptr = input;
++        ICONV_CONST char *inptr = input;
+         size_t inbytesleft = strlen (input);
+         char *outptr = buf;
+         size_t outbytesleft = sizeof (buf);
+         size_t res = iconv (cd_88591_to_utf8,
+-                            (char **) &inptr, &inbytesleft,
++                            &inptr, &inbytesleft,
+                             &outptr, &outbytesleft);
+         if ((int)res > 0)
+-          return 1;
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
+       }
+   }
+ #endif
+   /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
+      provided.  */
+-  if (/* Try standardized names.  */
+-      iconv_open ("UTF-8", "EUC-JP") == (iconv_t)(-1)
+-      /* Try IRIX, OSF/1 names.  */
+-      && iconv_open ("UTF-8", "eucJP") == (iconv_t)(-1)
+-      /* Try AIX names.  */
+-      && iconv_open ("UTF-8", "IBM-eucJP") == (iconv_t)(-1)
+-      /* Try HP-UX names.  */
+-      && iconv_open ("utf8", "eucJP") == (iconv_t)(-1))
+-    return 1;
+-  return 0;
+-}], [am_cv_func_iconv_works=yes], [am_cv_func_iconv_works=no],
+-        [case "$host_os" in
+-           aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
+-           *)            am_cv_func_iconv_works="guessing yes" ;;
+-         esac])
+-      LIBS="$am_save_LIBS"
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
+     ])
+     case "$am_cv_func_iconv_works" in
+       *no) am_func_iconv=no am_cv_lib_iconv=no ;;
+@@ -143,7 +255,7 @@ int main ()
+   else
+     dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
+     dnl either.
+-    CPPFLAGS="$am_save_CPPFLAGS"
++    CPPFLAGS="$gl_saved_CPPFLAGS"
+     LIBICONV=
+     LTLIBICONV=
+   fi
+@@ -151,45 +263,62 @@ int main ()
+   AC_SUBST([LTLIBICONV])
+ ])
+ 
+-dnl Define AM_ICONV using AC_DEFUN_ONCE for Autoconf >= 2.64, in order to
+-dnl avoid warnings like
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
+ dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
+-dnl This is tricky because of the way 'aclocal' is implemented:
+-dnl - It requires defining an auxiliary macro whose name ends in AC_DEFUN.
+-dnl   Otherwise aclocal's initial scan pass would miss the macro definition.
+-dnl - It requires a line break inside the AC_DEFUN_ONCE and AC_DEFUN expansions.
+-dnl   Otherwise aclocal would emit many "Use of uninitialized value $1"
+-dnl   warnings.
+-m4_define([gl_iconv_AC_DEFUN],
+-  m4_version_prereq([2.64],
+-    [[AC_DEFUN_ONCE(
+-        [$1], [$2])]],
+-    [[AC_DEFUN(
+-        [$1], [$2])]]))
+-gl_iconv_AC_DEFUN([AM_ICONV],
++AC_DEFUN_ONCE([AM_ICONV],
+ [
+   AM_ICONV_LINK
+   if test "$am_cv_func_iconv" = yes; then
+-    AC_MSG_CHECKING([for iconv declaration])
+-    AC_CACHE_VAL([am_cv_proto_iconv], [
+-      AC_TRY_COMPILE([
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
+ #include <stdlib.h>
+ #include <iconv.h>
+ extern
+ #ifdef __cplusplus
+ "C"
+ #endif
+-#if defined(__STDC__) || defined(__cplusplus)
+ size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
+-#else
+-size_t iconv();
+-#endif
+-], [], [am_cv_proto_iconv_arg1=""], [am_cv_proto_iconv_arg1="const"])
+-      am_cv_proto_iconv="extern size_t iconv (iconv_t cd, $am_cv_proto_iconv_arg1 char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);"])
+-    am_cv_proto_iconv=`echo "[$]am_cv_proto_iconv" | tr -s ' ' | sed -e 's/( /(/'`
+-    AC_MSG_RESULT([
+-         $am_cv_proto_iconv])
+-    AC_DEFINE_UNQUOTED([ICONV_CONST], [$am_cv_proto_iconv_arg1],
+-      [Define as const if the declaration of iconv() needs const.])
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
+   fi
+ ])
+diff --git a/m4/iconv.m4~ b/m4/iconv.m4~
+new file mode 100644
+index 0000000..ee41742
+--- /dev/null
++++ b/m4/iconv.m4~
+@@ -0,0 +1,195 @@
++# iconv.m4 serial 11 (gettext-0.18.1)
++dnl Copyright (C) 2000-2002, 2007-2010 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++
++dnl From Bruno Haible.
++
++AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
++[
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([iconv])
++])
++
++AC_DEFUN([AM_ICONV_LINK],
++[
++  dnl Some systems have iconv in libc, some have it in libiconv (OSF/1 and
++  dnl those with the standalone portable GNU libiconv installed).
++  AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
++
++  dnl Search for libiconv and define LIBICONV, LTLIBICONV and INCICONV
++  dnl accordingly.
++  AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++
++  dnl Add $INCICONV to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed libiconv and not disabled its use
++  dnl via --without-libiconv-prefix, he wants to use it. The first
++  dnl AC_TRY_LINK will then fail, the second AC_TRY_LINK will succeed.
++  am_save_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
++
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
++    am_cv_func_iconv="no, consider installing GNU libiconv"
++    am_cv_lib_iconv=no
++    AC_TRY_LINK([#include <stdlib.h>
++#include <iconv.h>],
++      [iconv_t cd = iconv_open("","");
++       iconv(cd,NULL,NULL,NULL,NULL);
++       iconv_close(cd);],
++      [am_cv_func_iconv=yes])
++    if test "$am_cv_func_iconv" != yes; then
++      am_save_LIBS="$LIBS"
++      LIBS="$LIBS $LIBICONV"
++      AC_TRY_LINK([#include <stdlib.h>
++#include <iconv.h>],
++        [iconv_t cd = iconv_open("","");
++         iconv(cd,NULL,NULL,NULL,NULL);
++         iconv_close(cd);],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$am_save_LIBS"
++    fi
++  ])
++  if test "$am_cv_func_iconv" = yes; then
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, HP-UX 11.11, Solaris 10.
++      am_save_LIBS="$LIBS"
++      if test $am_cv_lib_iconv = yes; then
++        LIBS="$LIBS $LIBICONV"
++      fi
++      AC_TRY_RUN([
++#include <iconv.h>
++#include <string.h>
++int main ()
++{
++  /* Test against AIX 5.1 bug: Failures are not distinguishable from successful
++     returns.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static const char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        const char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            (char **) &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          return 1;
++      }
++  }
++#if 0 /* This bug could be worked around by the caller.  */
++  /* Test against HP-UX 11.11 bug: Positive return value instead of 0.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static const char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        char buf[50];
++        const char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_88591_to_utf8,
++                            (char **) &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if ((int)res > 0)
++          return 1;
++      }
++  }
++#endif
++  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
++     provided.  */
++  if (/* Try standardized names.  */
++      iconv_open ("UTF-8", "EUC-JP") == (iconv_t)(-1)
++      /* Try IRIX, OSF/1 names.  */
++      && iconv_open ("UTF-8", "eucJP") == (iconv_t)(-1)
++      /* Try AIX names.  */
++      && iconv_open ("UTF-8", "IBM-eucJP") == (iconv_t)(-1)
++      /* Try HP-UX names.  */
++      && iconv_open ("utf8", "eucJP") == (iconv_t)(-1))
++    return 1;
++  return 0;
++}], [am_cv_func_iconv_works=yes], [am_cv_func_iconv_works=no],
++        [case "$host_os" in
++           aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++           *)            am_cv_func_iconv_works="guessing yes" ;;
++         esac])
++      LIBS="$am_save_LIBS"
++    ])
++    case "$am_cv_func_iconv_works" in
++      *no) am_func_iconv=no am_cv_lib_iconv=no ;;
++      *)   am_func_iconv=yes ;;
++    esac
++  else
++    am_func_iconv=no am_cv_lib_iconv=no
++  fi
++  if test "$am_func_iconv" = yes; then
++    AC_DEFINE([HAVE_ICONV], [1],
++      [Define if you have the iconv() function and it works.])
++  fi
++  if test "$am_cv_lib_iconv" = yes; then
++    AC_MSG_CHECKING([how to link with libiconv])
++    AC_MSG_RESULT([$LIBICONV])
++  else
++    dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
++    dnl either.
++    CPPFLAGS="$am_save_CPPFLAGS"
++    LIBICONV=
++    LTLIBICONV=
++  fi
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
++])
++
++dnl Define AM_ICONV using AC_DEFUN_ONCE for Autoconf >= 2.64, in order to
++dnl avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++dnl This is tricky because of the way 'aclocal' is implemented:
++dnl - It requires defining an auxiliary macro whose name ends in AC_DEFUN.
++dnl   Otherwise aclocal's initial scan pass would miss the macro definition.
++dnl - It requires a line break inside the AC_DEFUN_ONCE and AC_DEFUN expansions.
++dnl   Otherwise aclocal would emit many "Use of uninitialized value $1"
++dnl   warnings.
++m4_define([gl_iconv_AC_DEFUN],
++  m4_version_prereq([2.64],
++    [[AC_DEFUN_ONCE(
++        [$1], [$2])]],
++    [[AC_DEFUN(
++        [$1], [$2])]]))
++gl_iconv_AC_DEFUN([AM_ICONV],
++[
++  AM_ICONV_LINK
++  if test "$am_cv_func_iconv" = yes; then
++    AC_MSG_CHECKING([for iconv declaration])
++    AC_CACHE_VAL([am_cv_proto_iconv], [
++      AC_TRY_COMPILE([
++#include <stdlib.h>
++#include <iconv.h>
++extern
++#ifdef __cplusplus
++"C"
++#endif
++#if defined(__STDC__) || defined(__cplusplus)
++size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
++#else
++size_t iconv();
++#endif
++], [], [am_cv_proto_iconv_arg1=""], [am_cv_proto_iconv_arg1="const"])
++      am_cv_proto_iconv="extern size_t iconv (iconv_t cd, $am_cv_proto_iconv_arg1 char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);"])
++    am_cv_proto_iconv=`echo "[$]am_cv_proto_iconv" | tr -s ' ' | sed -e 's/( /(/'`
++    AC_MSG_RESULT([
++         $am_cv_proto_iconv])
++    AC_DEFINE_UNQUOTED([ICONV_CONST], [$am_cv_proto_iconv_arg1],
++      [Define as const if the declaration of iconv() needs const.])
++  fi
++])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+new file mode 100644
+index 0000000..3714b9c
+--- /dev/null
++++ b/m4/lib-ld.m4
+@@ -0,0 +1,170 @@
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Subroutines of libtool.m4,
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
++
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
++AC_DEFUN([AC_LIB_PROG_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  acl_cv_prog_gnu_ld=yes
++  ;;
++*)
++  acl_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$acl_cv_prog_gnu_ld
++])
++
++dnl From libtool-2.4. Sets the variable LD.
++AC_DEFUN([AC_LIB_PROG_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
++      esac
++    fi
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
++if test -n "$LD"; then
++  AC_MSG_RESULT([$LD])
++else
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
++fi
++AC_LIB_PROG_LD_GNU
++])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+new file mode 100644
+index 0000000..1863f4e
+--- /dev/null
++++ b/m4/lib-link.m4
+@@ -0,0 +1,815 @@
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++AC_PREREQ([2.61])
++
++dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
++dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
++    AC_LIB_LINKFLAGS_BODY([$1], [$2])
++    ac_cv_lib[]Name[]_libs="$LIB[]NAME"
++    ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
++    ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
++  ])
++  LIB[]NAME="$ac_cv_lib[]Name[]_libs"
++  LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
++  INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
++  dnl results of this search when this library appears as a dependency.
++  HAVE_LIB[]NAME=yes
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
++dnl searches for libname and the libraries corresponding to explicit and
++dnl implicit dependencies, together with the specified include files and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
++dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++
++  dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
++  dnl accordingly.
++  AC_LIB_LINKFLAGS_BODY([$1], [$2])
++
++  dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
++  dnl because if the user has installed lib[]Name and not disabled its use
++  dnl via --without-lib[]Name-prefix, he wants to use it.
++  acl_saved_CPPFLAGS="$CPPFLAGS"
++  AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
++
++  AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
++  ])
++  if test "$ac_cv_lib[]Name" = yes; then
++    HAVE_LIB[]NAME=yes
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
++    AC_MSG_CHECKING([how to link with lib[]$1])
++    AC_MSG_RESULT([$LIB[]NAME])
++  else
++    HAVE_LIB[]NAME=no
++    dnl If $LIB[]NAME didn't lead to a usable library, we don't need
++    dnl $INC[]NAME either.
++    CPPFLAGS="$acl_saved_CPPFLAGS"
++    LIB[]NAME=
++    LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
++  fi
++  AC_SUBST([HAVE_LIB]NAME)
++  AC_SUBST([LIB]NAME)
++  AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
++])
++
++dnl Determine the platform dependent parameters needed to use rpath:
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
++AC_DEFUN([AC_LIB_RPATH],
++[
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
++  AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
++  AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
++  AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
++  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
++    CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
++    ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
++    . ./conftest.sh
++    rm -f ./conftest.sh
++    acl_cv_rpath=done
++  ])
++  wl="$acl_cv_wl"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  dnl Determine whether the user wants rpath handling at all.
++  AC_ARG_ENABLE([rpath],
++    [  --disable-rpath         do not hardcode runtime library paths],
++    :, enable_rpath=yes)
++])
++
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
++dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
++dnl the libraries corresponding to explicit and implicit dependencies.
++dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
++AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
++[
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++  ])
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
++      fi
++    fi
++])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
++  dnl Search the library and its dependencies in $additional_libdir and
++  dnl $LDFLAGS. Use breadth-first search.
++  LIB[]NAME=
++  LTLIB[]NAME=
++  INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
++  rpathdirs=
++  ltrpathdirs=
++  names_already_handled=
++  names_next_round='$1 $2'
++  while test -n "$names_next_round"; do
++    names_this_round="$names_next_round"
++    names_next_round=
++    for name in $names_this_round; do
++      already_handled=
++      for n in $names_already_handled; do
++        if test "$n" = "$name"; then
++          already_handled=yes
++          break
++        fi
++      done
++      if test -z "$already_handled"; then
++        names_already_handled="$names_already_handled $name"
++        dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
++        dnl or AC_LIB_HAVE_LINKFLAGS call.
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
++        eval value=\"\$HAVE_LIB$uppername\"
++        if test -n "$value"; then
++          if test "$value" = yes; then
++            eval value=\"\$LIB$uppername\"
++            test -z "$value" || LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$value"
++            eval value=\"\$LTLIB$uppername\"
++            test -z "$value" || LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$value"
++          else
++            dnl An earlier call to AC_LIB_HAVE_LINKFLAGS has determined
++            dnl that this library doesn't exist. So just drop it.
++            :
++          fi
++        else
++          dnl Search the library lib$name in $additional_libdir and $LDFLAGS
++          dnl and the already constructed $LIBNAME/$LTLIBNAME.
++          found_dir=
++          found_la=
++          found_so=
++          found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
++          if test $use_additional = yes; then
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                fi
++              fi
++            done
++          fi
++          if test "X$found_dir" = "X"; then
++            for x in $LDFLAGS $LTLIB[]NAME; do
++              AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++              case "$x" in
++                -L*)
++                  dir=`echo "X$x" | sed -e 's/^X-L//'`
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
++                  ;;
++              esac
++              if test "X$found_dir" != "X"; then
++                break
++              fi
++            done
++          fi
++          if test "X$found_dir" != "X"; then
++            dnl Found the library.
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$found_dir -l$name"
++            if test "X$found_so" != "X"; then
++              dnl Linking with a shared library. We attempt to hardcode its
++              dnl directory into the executable's runpath, unless it's the
++              dnl standard /usr/lib.
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
++                dnl No hardcoding is needed.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++              else
++                dnl Use an explicit option to hardcode DIR into the resulting
++                dnl binary.
++                dnl Potentially add DIR to ltrpathdirs.
++                dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                haveit=
++                for x in $ltrpathdirs; do
++                  if test "X$x" = "X$found_dir"; then
++                    haveit=yes
++                    break
++                  fi
++                done
++                if test -z "$haveit"; then
++                  ltrpathdirs="$ltrpathdirs $found_dir"
++                fi
++                dnl The hardcoding into $LIBNAME is system dependent.
++                if test "$acl_hardcode_direct" = yes; then
++                  dnl Using DIR/libNAME.so during linking hardcodes DIR into the
++                  dnl resulting binary.
++                  LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                else
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++                    dnl Use an explicit option to hardcode DIR into the resulting
++                    dnl binary.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    dnl Potentially add DIR to rpathdirs.
++                    dnl The rpathdirs will be appended to $LIBNAME at the end.
++                    haveit=
++                    for x in $rpathdirs; do
++                      if test "X$x" = "X$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      rpathdirs="$rpathdirs $found_dir"
++                    fi
++                  else
++                    dnl Rely on "-L$found_dir".
++                    dnl But don't add it if it's already contained in the LDFLAGS
++                    dnl or the already constructed $LIBNAME
++                    haveit=
++                    for x in $LDFLAGS $LIB[]NAME; do
++                      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                      if test "X$x" = "X-L$found_dir"; then
++                        haveit=yes
++                        break
++                      fi
++                    done
++                    if test -z "$haveit"; then
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
++                    fi
++                    if test "$acl_hardcode_minus_L" != no; then
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
++                    else
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
++                      dnl here, because this doesn't fit in flags passed to the
++                      dnl compiler. So give up. No hardcoding. This affects only
++                      dnl very old systems.
++                      dnl FIXME: Not sure whether we should use
++                      dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
++                      dnl here.
++                      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++                    fi
++                  fi
++                fi
++              fi
++            else
++              if test "X$found_a" != "X"; then
++                dnl Linking with a static library.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_a"
++              else
++                dnl We shouldn't come here, but anyway it's good to have a
++                dnl fallback.
++                LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir -l$name"
++              fi
++            fi
++            dnl Assume the include files are nearby.
++            additional_includedir=
++            case "$found_dir" in
++              */$acl_libdirstem | */$acl_libdirstem/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++            esac
++            if test "X$additional_includedir" != "X"; then
++              dnl Potentially add $additional_includedir to $INCNAME.
++              dnl But don't add it
++              dnl   1. if it's the standard /usr/include,
++              dnl   2. if it's /usr/local/include and we are using GCC on Linux,
++              dnl   3. if it's already present in $CPPFLAGS or the already
++              dnl      constructed $INCNAME,
++              dnl   4. if it doesn't exist as a directory.
++              if test "X$additional_includedir" != "X/usr/include"; then
++                haveit=
++                if test "X$additional_includedir" = "X/usr/local/include"; then
++                  if test -n "$GCC"; then
++                    case $host_os in
++                      linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                    esac
++                  fi
++                fi
++                if test -z "$haveit"; then
++                  for x in $CPPFLAGS $INC[]NAME; do
++                    AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                    if test "X$x" = "X-I$additional_includedir"; then
++                      haveit=yes
++                      break
++                    fi
++                  done
++                  if test -z "$haveit"; then
++                    if test -d "$additional_includedir"; then
++                      dnl Really add $additional_includedir to $INCNAME.
++                      INC[]NAME="${INC[]NAME}${INC[]NAME:+ }-I$additional_includedir"
++                    fi
++                  fi
++                fi
++              fi
++            fi
++            dnl Look for dependencies.
++            if test -n "$found_la"; then
++              dnl Read the .la file. It defines the variables
++              dnl dlname, library_names, old_library, dependency_libs, current,
++              dnl age, revision, installed, dlopen, dlpreopen, libdir.
++              saved_libdir="$libdir"
++              case "$found_la" in
++                */* | *\\*) . "$found_la" ;;
++                *) . "./$found_la" ;;
++              esac
++              libdir="$saved_libdir"
++              dnl We use only dependency_libs.
++              for dep in $dependency_libs; do
++                case "$dep" in
++                  -L*)
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
++                    dnl But don't add it
++                    dnl   1. if it's the standard /usr/lib,
++                    dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
++                    dnl   3. if it's already present in $LDFLAGS or the already
++                    dnl      constructed $LIBNAME,
++                    dnl   4. if it doesn't exist as a directory.
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
++                      haveit=
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
++                        if test -n "$GCC"; then
++                          case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++                          esac
++                        fi
++                      fi
++                      if test -z "$haveit"; then
++                        haveit=
++                        for x in $LDFLAGS $LIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                        haveit=
++                        for x in $LDFLAGS $LTLIB[]NAME; do
++                          AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++                          if test "X$x" = "X-L$dependency_libdir"; then
++                            haveit=yes
++                            break
++                          fi
++                        done
++                        if test -z "$haveit"; then
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
++                          fi
++                        fi
++                      fi
++                    fi
++                    ;;
++                  -R*)
++                    dir=`echo "X$dep" | sed -e 's/^X-R//'`
++                    if test "$enable_rpath" != no; then
++                      dnl Potentially add DIR to rpathdirs.
++                      dnl The rpathdirs will be appended to $LIBNAME at the end.
++                      haveit=
++                      for x in $rpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        rpathdirs="$rpathdirs $dir"
++                      fi
++                      dnl Potentially add DIR to ltrpathdirs.
++                      dnl The ltrpathdirs will be appended to $LTLIBNAME at the end.
++                      haveit=
++                      for x in $ltrpathdirs; do
++                        if test "X$x" = "X$dir"; then
++                          haveit=yes
++                          break
++                        fi
++                      done
++                      if test -z "$haveit"; then
++                        ltrpathdirs="$ltrpathdirs $dir"
++                      fi
++                    fi
++                    ;;
++                  -l*)
++                    dnl Handle this in the next round.
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
++                    ;;
++                  *.la)
++                    dnl Handle this in the next round. Throw away the .la's
++                    dnl directory; it is already contained in a preceding -L
++                    dnl option.
++                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's,^X.*/,,' -e 's,^lib,,' -e 's,\.la$,,'`
++                    ;;
++                  *)
++                    dnl Most likely an immediate library name.
++                    LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$dep"
++                    LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }$dep"
++                    ;;
++                esac
++              done
++            fi
++          else
++            dnl Didn't find the library; assume it is in the system directories
++            dnl known to the linker and runtime loader. (All the system
++            dnl directories known to the linker should also be known to the
++            dnl runtime loader, otherwise the system is severely misconfigured.)
++            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-l$name"
++            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-l$name"
++          fi
++        fi
++      fi
++    done
++  done
++  if test "X$rpathdirs" != "X"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
++      dnl Weird platform: only the last -rpath option counts, the user must
++      dnl pass all path elements in one option. We can arrange that for a
++      dnl single library, but not when more than one $LIBNAMEs are used.
++      alldirs=
++      for found_dir in $rpathdirs; do
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
++      done
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
++      libdir="$alldirs"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
++      LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++    else
++      dnl The -rpath options are cumulative.
++      for found_dir in $rpathdirs; do
++        acl_saved_libdir="$libdir"
++        libdir="$found_dir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
++        LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
++      done
++    fi
++  fi
++  if test "X$ltrpathdirs" != "X"; then
++    dnl When using libtool, the option that works for both libraries and
++    dnl executables is -R. The -R options are cumulative.
++    for found_dir in $ltrpathdirs; do
++      LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
++    done
++  fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
++])
++
++dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
++dnl unless already present in VAR.
++dnl Works only for CPPFLAGS, not for LIB* variables because that sometimes
++dnl contains two or three consecutive elements that belong together.
++AC_DEFUN([AC_LIB_APPENDTOVAR],
++[
++  for element in [$2]; do
++    haveit=
++    for x in $[$1]; do
++      AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++      if test "X$x" = "X$element"; then
++        haveit=yes
++        break
++      fi
++    done
++    if test -z "$haveit"; then
++      [$1]="${[$1]}${[$1]:+ }$element"
++    fi
++  done
++])
++
++dnl For those cases where a variable contains several -L and -l options
++dnl referring to unknown libraries and directories, this macro determines the
++dnl necessary additional linker options for the runtime path.
++dnl AC_LIB_LINKFLAGS_FROM_LIBS([LDADDVAR], [LIBSVALUE], [USE-LIBTOOL])
++dnl sets LDADDVAR to linker options needed together with LIBSVALUE.
++dnl If USE-LIBTOOL evaluates to non-empty, linking with libtool is assumed,
++dnl otherwise linking without libtool is assumed.
++AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
++[
++  AC_REQUIRE([AC_LIB_RPATH])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  $1=
++  if test "$enable_rpath" != no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
++      dnl Use an explicit option to hardcode directories into the resulting
++      dnl binary.
++      rpathdirs=
++      next=
++      for opt in $2; do
++        if test -n "$next"; then
++          dir="$next"
++          dnl No need to hardcode the standard /usr/lib.
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++            rpathdirs="$rpathdirs $dir"
++          fi
++          next=
++        else
++          case $opt in
++            -L) next=yes ;;
++            -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
++                 dnl No need to hardcode the standard /usr/lib.
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
++                   rpathdirs="$rpathdirs $dir"
++                 fi
++                 next= ;;
++            *) next= ;;
++          esac
++        fi
++      done
++      if test "X$rpathdirs" != "X"; then
++        if test -n ""$3""; then
++          dnl libtool is used for linking. Use -R options.
++          for dir in $rpathdirs; do
++            $1="${$1}${$1:+ }-R$dir"
++          done
++        else
++          dnl The linker is used for linking directly.
++          if test -n "$acl_hardcode_libdir_separator"; then
++            dnl Weird platform: only the last -rpath option counts, the user
++            dnl must pass all path elements in one option.
++            alldirs=
++            for dir in $rpathdirs; do
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
++            done
++            acl_saved_libdir="$libdir"
++            libdir="$alldirs"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
++            $1="$flag"
++          else
++            dnl The -rpath options are cumulative.
++            for dir in $rpathdirs; do
++              acl_saved_libdir="$libdir"
++              libdir="$dir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
++              $1="${$1}${$1:+ }$flag"
++            done
++          fi
++        fi
++      fi
++    fi
++  fi
++  AC_SUBST([$1])
++])
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+new file mode 100644
+index 0000000..2928353
+--- /dev/null
++++ b/m4/lib-prefix.m4
+@@ -0,0 +1,334 @@
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible.
++
++dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
++dnl to access previously installed libraries. The basic assumption is that
++dnl a user will want packages to use other packages he previously installed
++dnl with the same --prefix option.
++dnl This macro is not needed if only AC_LIB_LINKFLAGS is used to locate
++dnl libraries, but is otherwise very convenient.
++AC_DEFUN([AC_LIB_PREFIX],
++[
++  AC_BEFORE([$0], [AC_LIB_LINKFLAGS])
++  AC_REQUIRE([AC_PROG_CC])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  dnl By default, look in $includedir and $libdir.
++  use_additional=yes
++  AC_LIB_WITH_FINAL_PREFIX([
++    eval additional_includedir=\"$includedir\"
++    eval additional_libdir=\"$libdir\"
++  ])
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
++[
++    if test "X$withval" = "Xno"; then
++      use_additional=no
++    else
++      if test "X$withval" = "X"; then
++        AC_LIB_WITH_FINAL_PREFIX([
++          eval additional_includedir=\"$includedir\"
++          eval additional_libdir=\"$libdir\"
++        ])
++      else
++        additional_includedir="$withval/include"
++        additional_libdir="$withval/$acl_libdirstem"
++      fi
++    fi
++])
++  if test $use_additional = yes; then
++    dnl Potentially add $additional_includedir to $CPPFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/include,
++    dnl   2. if it's already present in $CPPFLAGS,
++    dnl   3. if it's /usr/local/include and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_includedir" != "X/usr/include"; then
++      haveit=
++      for x in $CPPFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-I$additional_includedir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_includedir" = "X/usr/local/include"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux* | gnu* | k*bsd*-gnu) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_includedir"; then
++            dnl Really add $additional_includedir to $CPPFLAGS.
++            CPPFLAGS="${CPPFLAGS}${CPPFLAGS:+ }-I$additional_includedir"
++          fi
++        fi
++      fi
++    fi
++    dnl Potentially add $additional_libdir to $LDFLAGS.
++    dnl But don't add it
++    dnl   1. if it's the standard /usr/lib,
++    dnl   2. if it's already present in $LDFLAGS,
++    dnl   3. if it's /usr/local/lib and we are using GCC on Linux,
++    dnl   4. if it doesn't exist as a directory.
++    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++      haveit=
++      for x in $LDFLAGS; do
++        AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
++        if test "X$x" = "X-L$additional_libdir"; then
++          haveit=yes
++          break
++        fi
++      done
++      if test -z "$haveit"; then
++        if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++          if test -n "$GCC"; then
++            case $host_os in
++              linux*) haveit=yes;;
++            esac
++          fi
++        fi
++        if test -z "$haveit"; then
++          if test -d "$additional_libdir"; then
++            dnl Really add $additional_libdir to $LDFLAGS.
++            LDFLAGS="${LDFLAGS}${LDFLAGS:+ }-L$additional_libdir"
++          fi
++        fi
++      fi
++    fi
++  fi
++])
++
++dnl AC_LIB_PREPARE_PREFIX creates variables acl_final_prefix,
++dnl acl_final_exec_prefix, containing the values to which $prefix and
++dnl $exec_prefix will expand at the end of the configure script.
++AC_DEFUN([AC_LIB_PREPARE_PREFIX],
++[
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    acl_final_prefix="$ac_default_prefix"
++  else
++    acl_final_prefix="$prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    acl_final_exec_prefix='${prefix}'
++  else
++    acl_final_exec_prefix="$exec_prefix"
++  fi
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
++dnl variables prefix and exec_prefix bound to the values they will have
++dnl at the end of the configure script.
++AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
++[
++  acl_saved_prefix="$prefix"
++  prefix="$acl_final_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
++  exec_prefix="$acl_final_exec_prefix"
++  $1
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
++])
++
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
++AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
++[
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
++  fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
++])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/runtime-devices/libmtp/spec
+++ b/runtime-devices/libmtp/spec
@@ -1,4 +1,5 @@
 VER=1.1.22
-SRCS="tbl::https://downloads.sourceforge.net/libmtp/libmtp-$VER.tar.gz"
+REL=1
+SRCS="tbl::https://sourceforge.net/projects/libmtp/files/libmtp/$VER/libmtp-$VER.tar.gz/download"
 CHKSUMS="sha256::c3fcf411aea9cb9643590cbc9df99fa5fe30adcac695024442973d76fa5f87bc"
 CHKUPDATE="anitya::id=10017"

--- a/runtime-network/gwenhywfar/autobuild/defines
+++ b/runtime-network/gwenhywfar/autobuild/defines
@@ -5,6 +5,7 @@ BUILDDEP="gtk-2 gtk-3 qt-5"
 PKGSUG="$BUILDDEP"
 PKGDES="Multi-platform helper library for networking and security applications and libraries"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-system-certs'
     '--with-guis=gtk2 gtk3 qt5'

--- a/runtime-network/gwenhywfar/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
+++ b/runtime-network/gwenhywfar/autobuild/patches/0001-AOSCOS-Run-gettextize-to-include-gettext-macros.patch
@@ -1,0 +1,3305 @@
+From d0990c43bb6d50e4e34d8cf4fa47200615c065b5 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Mon, 22 Sep 2025 16:11:44 +0800
+Subject: [PATCH] AOSCOS: Run gettextize to include gettext macros
+
+---
+ m4/Makefile.am       |   2 +-
+ m4/build-to-host.m4  | 274 ++++++++++++++++++++++
+ m4/gettext.m4        | 446 ++++++++++++++++++++++++++++++++++++
+ m4/host-cpu-c-abi.m4 | 532 +++++++++++++++++++++++++++++++++++++++++++
+ m4/iconv.m4          | 286 +++++++++++++++++------
+ m4/intlmacosx.m4     |  71 ++++++
+ m4/lib-ld.m4         | 216 +++++++++++-------
+ m4/lib-link.m4       | 399 +++++++++++++++++++++++---------
+ m4/lib-prefix.m4     | 237 +++++++++++++++----
+ m4/nls.m4            |  33 +++
+ m4/po.m4             | 157 +++++++++++++
+ m4/progtest.m4       |  93 ++++++++
+ 12 files changed, 2445 insertions(+), 301 deletions(-)
+ create mode 100644 m4/build-to-host.m4
+ create mode 100644 m4/gettext.m4
+ create mode 100644 m4/host-cpu-c-abi.m4
+ create mode 100644 m4/intlmacosx.m4
+ create mode 100644 m4/nls.m4
+ create mode 100644 m4/po.m4
+ create mode 100644 m4/progtest.m4
+
+diff --git a/m4/Makefile.am b/m4/Makefile.am
+index ba8fcb5..0ec120d 100644
+--- a/m4/Makefile.am
++++ b/m4/Makefile.am
+@@ -1,5 +1,5 @@
+ 
+-EXTRA_DIST= \
++EXTRA_DIST= build-to-host.m4 gettext.m4 host-cpu-c-abi.m4 intlmacosx.m4 nls.m4 po.m4 progtest.m4 \
+  acx_compile_warn.m4 \
+  ax_pthread.m4 \
+  as-scrub-include.m4 \
+diff --git a/m4/build-to-host.m4 b/m4/build-to-host.m4
+new file mode 100644
+index 0000000..01bff8f
+--- /dev/null
++++ b/m4/build-to-host.m4
+@@ -0,0 +1,274 @@
++# build-to-host.m4
++# serial 5
++dnl Copyright (C) 2023-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl Written by Bruno Haible.
++
++dnl When the build environment ($build_os) is different from the target runtime
++dnl environment ($host_os), file names may need to be converted from the build
++dnl environment syntax to the target runtime environment syntax. This is
++dnl because the Makefiles are executed (mostly) by build environment tools and
++dnl therefore expect file names in build environment syntax, whereas the runtime
++dnl expects file names in target runtime environment syntax.
++dnl
++dnl For example, if $build_os = cygwin and $host_os = mingw32, filenames need
++dnl be converted from Cygwin syntax to native Windows syntax:
++dnl   /cygdrive/c/foo/bar -> C:\foo\bar
++dnl   /usr/local/share    -> C:\cygwin64\usr\local\share
++dnl
++dnl gl_BUILD_TO_HOST([somedir])
++dnl This macro takes as input an AC_SUBSTed variable 'somedir', which must
++dnl already have its final value assigned, and produces two additional
++dnl AC_SUBSTed variables 'somedir_c' and 'somedir_c_make', that designate the
++dnl same file name value, just in different syntax:
++dnl   - somedir_c       is the file name in target runtime environment syntax,
++dnl                     as a C string (starting and ending with a double-quote,
++dnl                     and with escaped backslashes and double-quotes in
++dnl                     between).
++dnl   - somedir_c_make  is the same thing, escaped for use in a Makefile.
++
++AC_DEFUN([gl_BUILD_TO_HOST],
++[
++  AC_REQUIRE([AC_CANONICAL_BUILD])
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_BUILD_TO_HOST_INIT])
++
++  dnl Define somedir_c.
++  gl_final_[$1]="$[$1]"
++  dnl Translate it from build syntax to host syntax.
++  case "$build_os" in
++    cygwin*)
++      case "$host_os" in
++        mingw* | windows*)
++          gl_final_[$1]=`cygpath -w "$gl_final_[$1]"` ;;
++      esac
++      ;;
++  esac
++  dnl Convert it to C string syntax.
++  [$1]_c=`printf '%s\n' "$gl_final_[$1]" | sed -e "$gl_sed_double_backslashes" -e "$gl_sed_escape_doublequotes" | tr -d "$gl_tr_cr"`
++  [$1]_c='"'"$[$1]_c"'"'
++  AC_SUBST([$1_c])
++
++  dnl Define somedir_c_make.
++  [$1]_c_make=`printf '%s\n' "$[$1]_c" | sed -e "$gl_sed_escape_for_make_1" -e "$gl_sed_escape_for_make_2" | tr -d "$gl_tr_cr"`
++  dnl Use the substituted somedir variable, when possible, so that the user
++  dnl may adjust somedir a posteriori when there are no special characters.
++  if test "$[$1]_c_make" = '\"'"${gl_final_[$1]}"'\"'; then
++    [$1]_c_make='\"$([$1])\"'
++  fi
++  AC_SUBST([$1_c_make])
++])
++
++dnl Some initializations for gl_BUILD_TO_HOST.
++AC_DEFUN([gl_BUILD_TO_HOST_INIT],
++[
++  gl_sed_double_backslashes='s/\\/\\\\/g'
++  gl_sed_escape_doublequotes='s/"/\\"/g'
++changequote(,)dnl
++  gl_sed_escape_for_make_1="s,\\([ \"&'();<>\\\\\`|]\\),\\\\\\1,g"
++changequote([,])dnl
++  gl_sed_escape_for_make_2='s,\$,\\$$,g'
++  dnl Find out how to remove carriage returns from output. Solaris /usr/ucb/tr
++  dnl does not understand '\r'.
++  case `echo r | tr -d '\r'` in
++    '') gl_tr_cr='\015' ;;
++    *)  gl_tr_cr='\r' ;;
++  esac
++])
++
++
++dnl The following macros are convenience invocations of gl_BUILD_TO_HOST
++dnl for some of the variables that are defined by Autoconf.
++dnl To do so for _all_ the possible variables, use the module 'configmake'.
++
++dnl Defines bindir_c and bindir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_BINDIR],
++[
++  dnl Find the final value of bindir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_bindir="${bindir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval bindir="$bindir"
++  gl_BUILD_TO_HOST([bindir])
++  bindir="${gl_saved_bindir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines datadir_c and datadir_c_make,
++dnl where datadir = $(datarootdir)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_DATADIR],
++[
++  dnl Find the final value of datadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  gl_BUILD_TO_HOST([datadir])
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libdir_c and libdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBDIR],
++[
++  dnl Find the final value of libdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  gl_BUILD_TO_HOST([libdir])
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines libexecdir_c and libexecdir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LIBEXECDIR],
++[
++  dnl Find the final value of libexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  gl_BUILD_TO_HOST([libexecdir])
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines localedir_c and localedir_c_make.
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_LOCALEDIR],
++[
++  dnl Find the final value of localedir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_localedir="${localedir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval localedir="$localedir"
++  gl_BUILD_TO_HOST([localedir])
++  localedir="${gl_saved_localedir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkgdatadir_c and pkgdatadir_c_make,
++dnl where pkgdatadir = $(datadir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGDATADIR],
++[
++  dnl Find the final value of pkgdatadir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_datarootdir="${datarootdir}"
++  gl_saved_datadir="${datadir}"
++  gl_saved_pkgdatadir="${pkgdatadir}"
++  dnl Unfortunately, prefix gets only finally determined at the end of
++  dnl configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  eval datarootdir="$datarootdir"
++  eval datadir="$datadir"
++  eval pkgdatadir="$pkgdatadir"
++  gl_BUILD_TO_HOST([pkgdatadir])
++  pkgdatadir="${gl_saved_pkgdatadir}"
++  datadir="${gl_saved_datadir}"
++  datarootdir="${gl_saved_datarootdir}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibdir_c and pkglibdir_c_make,
++dnl where pkglibdir = $(libdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBDIR],
++[
++  dnl Find the final value of pkglibdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libdir="${libdir}"
++  gl_saved_pkglibdir="${pkglibdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libdir="$libdir"
++  eval pkglibdir="$pkglibdir"
++  gl_BUILD_TO_HOST([pkglibdir])
++  pkglibdir="${gl_saved_pkglibdir}"
++  libdir="${gl_saved_libdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
++
++dnl Defines pkglibexecdir_c and pkglibexecdir_c_make,
++dnl where pkglibexecdir = $(libexecdir)/$(PACKAGE)
++AC_DEFUN_ONCE([gl_BUILD_TO_HOST_PKGLIBEXECDIR],
++[
++  dnl Find the final value of pkglibexecdir.
++  gl_saved_prefix="${prefix}"
++  gl_saved_exec_prefix="${exec_prefix}"
++  gl_saved_libexecdir="${libexecdir}"
++  gl_saved_pkglibexecdir="${pkglibexecdir}"
++  dnl Unfortunately, prefix and exec_prefix get only finally determined
++  dnl at the end of configure.
++  if test "X$prefix" = "XNONE"; then
++    prefix="$ac_default_prefix"
++  fi
++  if test "X$exec_prefix" = "XNONE"; then
++    exec_prefix='${prefix}'
++  fi
++  eval exec_prefix="$exec_prefix"
++  eval libexecdir="$libexecdir"
++  eval pkglibexecdir="$pkglibexecdir"
++  gl_BUILD_TO_HOST([pkglibexecdir])
++  pkglibexecdir="${gl_saved_pkglibexecdir}"
++  libexecdir="${gl_saved_libexecdir}"
++  exec_prefix="${gl_saved_exec_prefix}"
++  prefix="${gl_saved_prefix}"
++])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+new file mode 100644
+index 0000000..67b6d4e
+--- /dev/null
++++ b/m4/gettext.m4
+@@ -0,0 +1,446 @@
++# gettext.m4
++# serial 83 (gettext-0.26)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++dnl Macro to add for using GNU gettext.
++
++dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
++dnl INTLSYMBOL must be one of 'external', 'use-libtool', 'here'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext.
++dnl    It should be 'use-libtool' for the packages 'gettext-runtime' and
++dnl    'gettext-tools'.
++dnl    It should be 'here' for the package 'gettext-runtime/intl'.
++dnl    If INTLSYMBOL is 'here', then a libtool library
++dnl    $(top_builddir)/libintl.la will be created (shared and/or static,
++dnl    depending on --{enable,disable}-{shared,static} and on the presence of
++dnl    AM-DISABLE-SHARED).
++dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
++dnl    implementations (in libc or libintl) without the ngettext() function
++dnl    will be ignored.  If NEEDSYMBOL is specified and is
++dnl    'need-formatstring-macros', then GNU gettext implementations that don't
++dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
++dnl INTLDIR is used to find the intl libraries.  If empty,
++dnl    the value '$(top_builddir)/intl/' is used.
++dnl
++dnl The result of the configuration is one of three cases:
++dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
++dnl    and used.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 2) GNU gettext has been found in the system's C library.
++dnl    Catalog format: GNU --> install in $(datadir)
++dnl    Catalog extension: .mo after installation, .gmo in source tree
++dnl 3) No internationalization, always use English msgid.
++dnl    Catalog format: none
++dnl    Catalog extension: none
++dnl If INTLSYMBOL is 'external', only cases 2 and 3 can occur.
++dnl The use of .gmo is historical (it was needed to avoid overwriting the
++dnl GNU format catalogs when building on a platform with an X/Open gettext),
++dnl but we keep it in order not to force irrelevant filename changes on the
++dnl maintainers.
++dnl
++AC_DEFUN([AM_GNU_GETTEXT],
++[
++  dnl Argument checking.
++  m4_if([$1], [], , [m4_if([$1], [external], , [m4_if([$1], [use-libtool], , [m4_if([$1], [here], ,
++    [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
++])])])])])
++  m4_if(m4_if([$1], [], [old])[]m4_if([$1], [no-libtool], [old]), [old],
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
++  m4_if([$2], [], , [m4_if([$2], [need-ngettext], , [m4_if([$2], [need-formatstring-macros], ,
++    [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
++])])])])
++  define([gt_building_libintl_in_same_build_tree],
++    m4_if([$1], [use-libtool], [yes], [m4_if([$1], [here], [yes], [no])]))
++  gt_NEEDS_INIT
++  AM_GNU_GETTEXT_NEED([$2])
++
++  AC_REQUIRE([AM_PO_SUBDIRS])dnl
++
++  dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
++  AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
++  AC_REQUIRE([AC_LIB_RPATH])
++
++  dnl Sometimes libintl requires libiconv, so first search for libiconv.
++  dnl Ideally we would do this search only after the
++  dnl      if test "$USE_NLS" = "yes"; then
++  dnl        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++  dnl tests. But if configure.ac invokes AM_ICONV after AM_GNU_GETTEXT
++  dnl the configure script would need to contain the same shell code
++  dnl again, outside any 'if'. There are two solutions:
++  dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
++  dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
++  m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++    AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
++  ])
++
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
++  gt_INTL_MACOSX
++
++  dnl Set USE_NLS.
++  AC_REQUIRE([AM_NLS])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    USE_INCLUDED_LIBINTL=no
++  ])
++  LIBINTL=
++  LTLIBINTL=
++  POSUB=
++
++  dnl Add a version number to the cache macros.
++  case " $gt_needs " in
++    *" need-formatstring-macros "*) gt_api_version=3 ;;
++    *" need-ngettext "*) gt_api_version=2 ;;
++    *) gt_api_version=1 ;;
++  esac
++  gt_func_gnugettext_libc="gt_cv_func_gnugettext${gt_api_version}_libc"
++  gt_func_gnugettext_libintl="gt_cv_func_gnugettext${gt_api_version}_libintl"
++
++  dnl If we use NLS figure out what method
++  if test "$USE_NLS" = "yes"; then
++    gt_use_preinstalled_gnugettext=no
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++      AC_MSG_CHECKING([whether included gettext is requested])
++      AC_ARG_WITH([included-gettext],
++        [  --with-included-gettext use the GNU gettext library included here],
++        nls_cv_force_use_gnu_gettext=$withval,
++        nls_cv_force_use_gnu_gettext=no)
++      AC_MSG_RESULT([$nls_cv_force_use_gnu_gettext])
++
++      nls_cv_use_gnu_gettext="$nls_cv_force_use_gnu_gettext"
++      if test "$nls_cv_force_use_gnu_gettext" != "yes"; then
++    ])
++        dnl User does not insist on using GNU NLS library.  Figure out what
++        dnl to use.  If GNU gettext is available we use this.  Else we have
++        dnl to fall back to GNU NLS library.
++
++        if test $gt_api_version -ge 3; then
++          gt_revision_test_code='
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#define __GNU_GETTEXT_SUPPORTED_REVISION(major) ((major) == 0 ? 0 : -1)
++#endif
++changequote(,)dnl
++typedef int array [2 * (__GNU_GETTEXT_SUPPORTED_REVISION(0) >= 1) - 1];
++changequote([,])dnl
++'
++        else
++          gt_revision_test_code=
++        fi
++        if test $gt_api_version -ge 2; then
++          gt_expression_test_code=' + * ngettext ("", "", 0)'
++        else
++          gt_expression_test_code=
++        fi
++
++        dnl In the test code below:
++        dnl * We test for the presence of _nl_msg_cat_cntr because GNU libc and
++        dnl   libintl define this variable, whereas Solaris 10 libc/libintl
++        dnl   (which we don't want to use, as it does not support GNU .mo files)
++        dnl   does not define it.
++        dnl * We don't test for _nl_msg_cat_cntr on MSVC, because the use of a
++        dnl   variable under MSVC depends on whether it is exported by a shared
++        dnl   library or a static library: If libintl is a shared library, we
++        dnl   would have to declare it with __declspec(dllimport), whereas if it
++        dnl   is a static library, we would have to declare it without such a
++        dnl   __declspec. But libintl comes with just one header file,
++        dnl   <libintl.h>, that does not declare _nl_msg_cat_cntr and that does
++        dnl   not tell us whether the library was built shared or static.
++        dnl * We test for the presence of _nl_domain_bindings because GNU libc
++        dnl   defines this variable, whereas NetBSD libc (which we don't want to
++        dnl   use, as it was broken at least in 2002) does not define it.
++        dnl * We test for the presence of _nl_expand_alias because GNU libintl
++        dnl   defines this function, whereas NetBSD libintl (which we don't want
++        dnl   to use, as it was broken at least in 2002) does not define it.
++
++        AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
++            [dnl Solaris 11.[0-3] doesn't strip the CODESET part from the locale name,
++             dnl when looking for a message catalog. E.g. when the locale is fr_FR.UTF-8,
++             dnl on Solaris 11.[0-3] it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Similarly, on Solaris 11 OpenIndiana and Solaris 11 OmniOS it looks only for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl Reported at <https://www.illumos.org/issues/13423>.
++             dnl On Solaris 11.4 this is fixed: it looks for
++             dnl   <LOCALEDIR>/fr_FR.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr.UTF-8/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr_FR/LC_MESSAGES/<domain>.mo
++             dnl   <LOCALEDIR>/fr/LC_MESSAGES/<domain>.mo
++             if test "`uname -sr`" = 'SunOS 5.11'; then
++               case `uname -v` in
++                 11.4 | 11.4.*) eval "$gt_func_gnugettext_libc=yes" ;;
++                 *)             eval "$gt_func_gnugettext_libc=no" ;;
++               esac
++             else
++               eval "$gt_func_gnugettext_libc=yes"
++             fi
++            ],
++            [eval "$gt_func_gnugettext_libc=no"])])
++
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" != "yes"; }; then
++          dnl Sometimes libintl requires libiconv, so first search for libiconv.
++          m4_if(gt_building_libintl_in_same_build_tree, yes, , [
++            AM_ICONV_LINK
++          ])
++          dnl Search for libintl and define LIBINTL, LTLIBINTL and INCINTL
++          dnl accordingly. Don't use AC_LIB_LINKFLAGS_BODY([intl],[iconv])
++          dnl because that would add "-liconv" to LIBINTL and LTLIBINTL
++          dnl even if libiconv doesn't exist.
++          AC_LIB_LINKFLAGS_BODY([intl])
++          AC_CACHE_CHECK([for GNU gettext in libintl],
++            [$gt_func_gnugettext_libintl],
++           [gt_saved_CPPFLAGS="$CPPFLAGS"
++            CPPFLAGS="$CPPFLAGS $INCINTL"
++            gt_saved_LIBS="$LIBS"
++            LIBS="$LIBS $LIBINTL"
++            dnl Now see whether libintl exists and does not depend on libiconv.
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
++              [eval "$gt_func_gnugettext_libintl=yes"],
++              [eval "$gt_func_gnugettext_libintl=no"])
++            dnl Now see whether libintl exists and depends on libiconv or other
++            dnl OS dependent libraries, specifically on macOS and AIX.
++            gt_LIBINTL_EXTRA="$INTL_MACOSX_LIBS"
++            AC_REQUIRE([AC_CANONICAL_HOST])
++            case "$host_os" in
++              aix*) gt_LIBINTL_EXTRA="-lpthread" ;;
++            esac
++            if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } \
++               && { test -n "$LIBICONV" || test -n "$gt_LIBINTL_EXTRA"; }; then
++              LIBS="$LIBS $LIBICONV $gt_LIBINTL_EXTRA"
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
++#if defined _MSC_VER
++#define _nl_msg_cat_cntr 0
++#else
++extern int _nl_msg_cat_cntr;
++#endif
++extern
++#ifdef __cplusplus
++"C"
++#endif
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV $gt_LIBINTL_EXTRA"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV $gt_LIBINTL_EXTRA"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
++            fi
++            CPPFLAGS="$gt_saved_CPPFLAGS"
++            LIBS="$gt_saved_LIBS"])
++        fi
++
++        dnl If an already present or preinstalled GNU gettext() is found,
++        dnl use it.  But if this macro is used in GNU gettext, and GNU
++        dnl gettext is already preinstalled in libintl, we update this
++        dnl libintl.  (Cf. the install rule in intl/Makefile.in.)
++        if { eval "gt_val=\$$gt_func_gnugettext_libc"; test "$gt_val" = "yes"; } \
++           || { { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; } \
++                && test "$PACKAGE" != gettext-runtime \
++                && test "$PACKAGE" != gettext-tools \
++                && test "$PACKAGE" != libintl; }; then
++          gt_use_preinstalled_gnugettext=yes
++        else
++          dnl Reset the values set by searching for libintl.
++          LIBINTL=
++          LTLIBINTL=
++          INCINTL=
++        fi
++
++    m4_if(gt_building_libintl_in_same_build_tree, yes, [
++        if test "$gt_use_preinstalled_gnugettext" != "yes"; then
++          dnl GNU gettext is not found in the C library.
++          dnl Fall back on included GNU gettext library.
++          nls_cv_use_gnu_gettext=yes
++        fi
++      fi
++
++      if test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions used to generate GNU NLS library.
++        USE_INCLUDED_LIBINTL=yes
++        LIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="m4_if([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
++        LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
++      fi
++
++      CATOBJEXT=
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Mark actions to use GNU gettext tools.
++        CATOBJEXT=.gmo
++      fi
++    ])
++
++    if test -n "$INTL_MACOSX_LIBS"; then
++      if test "$gt_use_preinstalled_gnugettext" = "yes" \
++         || test "$nls_cv_use_gnu_gettext" = "yes"; then
++        dnl Some extra flags are needed during linking.
++        LIBINTL="$LIBINTL $INTL_MACOSX_LIBS"
++        LTLIBINTL="$LTLIBINTL $INTL_MACOSX_LIBS"
++      fi
++    fi
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes" \
++       || test "$nls_cv_use_gnu_gettext" = "yes"; then
++      AC_DEFINE([ENABLE_NLS], [1],
++        [Define to 1 if translation of program messages to the user's native language
++   is requested.])
++    else
++      USE_NLS=no
++    fi
++  fi
++
++  AC_MSG_CHECKING([whether to use NLS])
++  AC_MSG_RESULT([$USE_NLS])
++  if test "$USE_NLS" = "yes"; then
++    AC_MSG_CHECKING([where the gettext function comes from])
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        gt_source="external libintl"
++      else
++        gt_source="libc"
++      fi
++    else
++      gt_source="included intl directory"
++    fi
++    AC_MSG_RESULT([$gt_source])
++  fi
++
++  if test "$USE_NLS" = "yes"; then
++
++    if test "$gt_use_preinstalled_gnugettext" = "yes"; then
++      if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
++        AC_MSG_CHECKING([how to link with libintl])
++        AC_MSG_RESULT([$LIBINTL])
++        AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
++      fi
++
++      dnl For backward compatibility. Some packages may be using this.
++      AC_DEFINE([HAVE_GETTEXT], [1],
++       [Define if the GNU gettext() function is already present or preinstalled.])
++      AC_DEFINE([HAVE_DCGETTEXT], [1],
++       [Define if the GNU dcgettext() function is already present or preinstalled.])
++    fi
++
++    dnl We need to process the po/ directory.
++    POSUB=po
++  fi
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [
++    dnl Make all variables we use known to autoconf.
++    AC_SUBST([USE_INCLUDED_LIBINTL])
++    AC_SUBST([CATOBJEXT])
++  ])
++
++  m4_if(gt_building_libintl_in_same_build_tree, yes, [], [
++    dnl For backward compatibility. Some Makefiles may be using this.
++    INTLLIBS="$LIBINTL"
++    AC_SUBST([INTLLIBS])
++  ])
++
++  dnl Make all documented variables known to autoconf.
++  AC_SUBST([LIBINTL])
++  AC_SUBST([LTLIBINTL])
++  AC_SUBST([POSUB])
++
++  dnl Define localedir_c and localedir_c_make.
++  gl_BUILD_TO_HOST_LOCALEDIR
++])
++
++
++dnl gt_NEEDS_INIT ensures that the gt_needs variable is initialized.
++m4_define([gt_NEEDS_INIT],
++[
++  m4_divert_text([DEFAULTS], [gt_needs=])
++  m4_define([gt_NEEDS_INIT], [])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_NEED([NEEDSYMBOL])
++AC_DEFUN([AM_GNU_GETTEXT_NEED],
++[
++  m4_divert_text([INIT_PREPARE], [gt_needs="$gt_needs $1"])
++])
++
++
++dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/host-cpu-c-abi.m4 b/m4/host-cpu-c-abi.m4
+new file mode 100644
+index 0000000..6ca7721
+--- /dev/null
++++ b/m4/host-cpu-c-abi.m4
+@@ -0,0 +1,532 @@
++# host-cpu-c-abi.m4
++# serial 20
++dnl Copyright (C) 2002-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++
++dnl From Bruno Haible and Sam Steingold.
++
++dnl Sets the HOST_CPU variable to the canonical name of the CPU.
++dnl Sets the HOST_CPU_C_ABI variable to the canonical name of the CPU with its
++dnl C language ABI (application binary interface).
++dnl Also defines __${HOST_CPU}__ and __${HOST_CPU_C_ABI}__ as C macros in
++dnl config.h.
++dnl
++dnl This canonical name can be used to select a particular assembly language
++dnl source file that will interoperate with C code on the given host.
++dnl
++dnl For example:
++dnl * 'i386' and 'sparc' are different canonical names, because code for i386
++dnl   will not run on SPARC CPUs and vice versa. They have different
++dnl   instruction sets.
++dnl * 'sparc' and 'sparc64' are different canonical names, because code for
++dnl   'sparc' and code for 'sparc64' cannot be linked together: 'sparc' code
++dnl   contains 32-bit instructions, whereas 'sparc64' code contains 64-bit
++dnl   instructions. A process on a SPARC CPU can be in 32-bit mode or in 64-bit
++dnl   mode, but not both.
++dnl * 'mips' and 'mipsn32' are different canonical names, because they use
++dnl   different argument passing and return conventions for C functions, and
++dnl   although the instruction set of 'mips' is a large subset of the
++dnl   instruction set of 'mipsn32'.
++dnl * 'mipsn32' and 'mips64' are different canonical names, because they use
++dnl   different sizes for the C types like 'int' and 'void *', and although
++dnl   the instruction sets of 'mipsn32' and 'mips64' are the same.
++dnl * The same canonical name is used for different endiannesses. You can
++dnl   determine the endianness through preprocessor symbols:
++dnl   - 'arm': test __ARMEL__.
++dnl   - 'mips', 'mipsn32', 'mips64': test _MIPSEB vs. _MIPSEL.
++dnl   - 'powerpc64': test __BIG_ENDIAN__ vs. __LITTLE_ENDIAN__.
++dnl * The same name 'i386' is used for CPUs of type i386, i486, i586
++dnl   (Pentium), AMD K7, Pentium II, Pentium IV, etc., because
++dnl   - Instructions that do not exist on all of these CPUs (cmpxchg,
++dnl     MMX, SSE, SSE2, 3DNow! etc.) are not frequently used. If your
++dnl     assembly language source files use such instructions, you will
++dnl     need to make the distinction.
++dnl   - Speed of execution of the common instruction set is reasonable across
++dnl     the entire family of CPUs. If you have assembly language source files
++dnl     that are optimized for particular CPU types (like GNU gmp has), you
++dnl     will need to make the distinction.
++dnl   See <https://en.wikipedia.org/wiki/X86_instruction_listings>.
++AC_DEFUN([gl_HOST_CPU_C_ABI],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_C_ASM])
++  AC_CACHE_CHECK([host CPU and C ABI], [gl_cv_host_cpu_c_abi],
++    [case "$host_cpu" in
++
++changequote(,)dnl
++       i[34567]86 )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=i386
++         ;;
++
++       x86_64 )
++         # On x86_64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - 64-bit instruction set, 64-bit pointers, 64-bit 'long': x86_64.
++         # - 64-bit instruction set, 64-bit pointers, 32-bit 'long': x86_64
++         #   with native Windows (mingw, MSVC).
++         # - 64-bit instruction set, 32-bit pointers, 32-bit 'long': x86_64-x32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': i386.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if (defined __x86_64__ || defined __amd64__ \
++                     || defined _M_X64 || defined _M_AMD64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __ILP32__ || defined _ILP32
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=x86_64-x32],
++              [gl_cv_host_cpu_c_abi=x86_64])],
++           [gl_cv_host_cpu_c_abi=i386])
++         ;;
++
++changequote(,)dnl
++       alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi=alpha
++         ;;
++
++       arm* | aarch64 )
++         # Assume arm with EABI.
++         # On arm64 systems, the C compiler may be generating code in one of
++         # these ABIs:
++         # - aarch64 instruction set, 64-bit pointers, 64-bit 'long': arm64.
++         # - aarch64 instruction set, 32-bit pointers, 32-bit 'long': arm64-ilp32.
++         # - 32-bit instruction set, 32-bit pointers, 32-bit 'long': arm or armhf.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __aarch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                [[#if defined __ILP32__ || defined _ILP32
++                   int ok;
++                  #else
++                   error fail
++                  #endif
++                ]])],
++              [gl_cv_host_cpu_c_abi=arm64-ilp32],
++              [gl_cv_host_cpu_c_abi=arm64])],
++           [# Don't distinguish little-endian and big-endian arm, since they
++            # don't require different machine code for simple operations and
++            # since the user can distinguish them through the preprocessor
++            # defines __ARMEL__ vs. __ARMEB__.
++            # But distinguish arm which passes floating-point arguments and
++            # return values in integer registers (r0, r1, ...) - this is
++            # gcc -mfloat-abi=soft or gcc -mfloat-abi=softfp - from arm which
++            # passes them in float registers (s0, s1, ...) and double registers
++            # (d0, d1, ...) - this is gcc -mfloat-abi=hard. GCC 4.6 or newer
++            # sets the preprocessor defines __ARM_PCS (for the first case) and
++            # __ARM_PCS_VFP (for the second case), but older GCC does not.
++            echo 'double ddd; void func (double dd) { ddd = dd; }' > conftest.c
++            # Look for a reference to the register d0 in the .s file.
++            AC_TRY_COMMAND(${CC-cc} $CFLAGS $CPPFLAGS $gl_c_asm_opt conftest.c) >/dev/null 2>&1
++            if LC_ALL=C grep 'd0,' conftest.$gl_asmext >/dev/null; then
++              gl_cv_host_cpu_c_abi=armhf
++            else
++              gl_cv_host_cpu_c_abi=arm
++            fi
++            rm -fr conftest*
++           ])
++         ;;
++
++       hppa1.0 | hppa1.1 | hppa2.0* | hppa64 )
++         # On hppa, the C compiler may be generating 32-bit code or 64-bit
++         # code. In the latter case, it defines _LP64 and __LP64__.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=hppa64],
++           [gl_cv_host_cpu_c_abi=hppa])
++         ;;
++
++       ia64* )
++         # On ia64 on HP-UX, the C compiler may be generating 64-bit code or
++         # 32-bit code. In the latter case, it defines _ILP32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#ifdef _ILP32
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=ia64-ilp32],
++           [gl_cv_host_cpu_c_abi=ia64])
++         ;;
++
++       mips* )
++         # We should also check for (_MIPS_SZPTR == 64), but gcc keeps this
++         # at 32.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined _MIPS_SZLONG && (_MIPS_SZLONG == 64)
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=mips64],
++           [# In the n32 ABI, _ABIN32 is defined, _ABIO32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIN32.
++            # In the 32 ABI, _ABIO32 is defined, _ABIN32 is not defined (but
++            # may later get defined by <sgidefs.h>), and _MIPS_SIM == _ABIO32.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if (_MIPS_SIM == _ABIN32)
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=mipsn32],
++              [gl_cv_host_cpu_c_abi=mips])])
++         ;;
++
++       powerpc* )
++         # Different ABIs are in use on AIX vs. Mac OS X vs. Linux,*BSD.
++         # No need to distinguish them here; the caller may distinguish
++         # them based on the OS.
++         # On powerpc64 systems, the C compiler may still be generating
++         # 32-bit code. And on powerpc-ibm-aix systems, the C compiler may
++         # be generating 64-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __powerpc64__ || defined __LP64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [# On powerpc64, there are two ABIs on Linux: The AIX compatible
++            # one and the ELFv2 one. The latter defines _CALL_ELF=2.
++            AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined _CALL_ELF && _CALL_ELF == 2
++                    int ok;
++                   #else
++                    error fail
++                   #endif
++                 ]])],
++              [gl_cv_host_cpu_c_abi=powerpc64-elfv2],
++              [gl_cv_host_cpu_c_abi=powerpc64])
++           ],
++           [gl_cv_host_cpu_c_abi=powerpc])
++         ;;
++
++       rs6000 )
++         gl_cv_host_cpu_c_abi=powerpc
++         ;;
++
++       riscv32 | riscv64 )
++         # There are 2 architectures (with variants): rv32* and rv64*.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if __riscv_xlen == 64
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [cpu=riscv64],
++           [cpu=riscv32])
++         # There are 6 ABIs: ilp32, ilp32f, ilp32d, lp64, lp64f, lp64d.
++         # Size of 'long' and 'void *':
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [main_abi=lp64],
++           [main_abi=ilp32])
++         # Float ABIs:
++         # __riscv_float_abi_double:
++         #   'float' and 'double' are passed in floating-point registers.
++         # __riscv_float_abi_single:
++         #   'float' are passed in floating-point registers.
++         # __riscv_float_abi_soft:
++         #   No values are passed in floating-point registers.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __riscv_float_abi_double
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [float_abi=d],
++           [AC_COMPILE_IFELSE(
++              [AC_LANG_SOURCE(
++                 [[#if defined __riscv_float_abi_single
++                     int ok;
++                   #else
++                     error fail
++                   #endif
++                 ]])],
++              [float_abi=f],
++              [float_abi=''])
++           ])
++         gl_cv_host_cpu_c_abi="${cpu}-${main_abi}${float_abi}"
++         ;;
++
++       s390* )
++         # On s390x, the C compiler may be generating 64-bit (= s390x) code
++         # or 31-bit (= s390) code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __LP64__ || defined __s390x__
++                  int ok;
++                #else
++                  error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=s390x],
++           [gl_cv_host_cpu_c_abi=s390])
++         ;;
++
++       sparc | sparc64 )
++         # UltraSPARCs running Linux have `uname -m` = "sparc64", but the
++         # C compiler still generates 32-bit code.
++         AC_COMPILE_IFELSE(
++           [AC_LANG_SOURCE(
++              [[#if defined __sparcv9 || defined __arch64__
++                 int ok;
++                #else
++                 error fail
++                #endif
++              ]])],
++           [gl_cv_host_cpu_c_abi=sparc64],
++           [gl_cv_host_cpu_c_abi=sparc])
++         ;;
++
++       *)
++         gl_cv_host_cpu_c_abi="$host_cpu"
++         ;;
++     esac
++    ])
++
++  dnl In most cases, $HOST_CPU and $HOST_CPU_C_ABI are the same.
++  HOST_CPU=`echo "$gl_cv_host_cpu_c_abi" | sed -e 's/-.*//'`
++  HOST_CPU_C_ABI="$gl_cv_host_cpu_c_abi"
++  AC_SUBST([HOST_CPU])
++  AC_SUBST([HOST_CPU_C_ABI])
++
++  # This was
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU}__])
++  #   AC_DEFINE_UNQUOTED([__${HOST_CPU_C_ABI}__])
++  # earlier, but KAI C++ 3.2d doesn't like this.
++  sed -e 's/-/_/g' >> confdefs.h <<EOF
++#ifndef __${HOST_CPU}__
++#define __${HOST_CPU}__ 1
++#endif
++#ifndef __${HOST_CPU_C_ABI}__
++#define __${HOST_CPU_C_ABI}__ 1
++#endif
++EOF
++  AH_TOP([/* CPU and C ABI indicator */
++#ifndef __i386__
++#undef __i386__
++#endif
++#ifndef __x86_64_x32__
++#undef __x86_64_x32__
++#endif
++#ifndef __x86_64__
++#undef __x86_64__
++#endif
++#ifndef __alpha__
++#undef __alpha__
++#endif
++#ifndef __arm__
++#undef __arm__
++#endif
++#ifndef __armhf__
++#undef __armhf__
++#endif
++#ifndef __arm64_ilp32__
++#undef __arm64_ilp32__
++#endif
++#ifndef __arm64__
++#undef __arm64__
++#endif
++#ifndef __hppa__
++#undef __hppa__
++#endif
++#ifndef __hppa64__
++#undef __hppa64__
++#endif
++#ifndef __ia64_ilp32__
++#undef __ia64_ilp32__
++#endif
++#ifndef __ia64__
++#undef __ia64__
++#endif
++#ifndef __loongarch32__
++#undef __loongarch32__
++#endif
++#ifndef __loongarch64__
++#undef __loongarch64__
++#endif
++#ifndef __m68k__
++#undef __m68k__
++#endif
++#ifndef __mips__
++#undef __mips__
++#endif
++#ifndef __mipsn32__
++#undef __mipsn32__
++#endif
++#ifndef __mips64__
++#undef __mips64__
++#endif
++#ifndef __powerpc__
++#undef __powerpc__
++#endif
++#ifndef __powerpc64__
++#undef __powerpc64__
++#endif
++#ifndef __powerpc64_elfv2__
++#undef __powerpc64_elfv2__
++#endif
++#ifndef __riscv32__
++#undef __riscv32__
++#endif
++#ifndef __riscv64__
++#undef __riscv64__
++#endif
++#ifndef __riscv32_ilp32__
++#undef __riscv32_ilp32__
++#endif
++#ifndef __riscv32_ilp32f__
++#undef __riscv32_ilp32f__
++#endif
++#ifndef __riscv32_ilp32d__
++#undef __riscv32_ilp32d__
++#endif
++#ifndef __riscv64_ilp32__
++#undef __riscv64_ilp32__
++#endif
++#ifndef __riscv64_ilp32f__
++#undef __riscv64_ilp32f__
++#endif
++#ifndef __riscv64_ilp32d__
++#undef __riscv64_ilp32d__
++#endif
++#ifndef __riscv64_lp64__
++#undef __riscv64_lp64__
++#endif
++#ifndef __riscv64_lp64f__
++#undef __riscv64_lp64f__
++#endif
++#ifndef __riscv64_lp64d__
++#undef __riscv64_lp64d__
++#endif
++#ifndef __s390__
++#undef __s390__
++#endif
++#ifndef __s390x__
++#undef __s390x__
++#endif
++#ifndef __sh__
++#undef __sh__
++#endif
++#ifndef __sparc__
++#undef __sparc__
++#endif
++#ifndef __sparc64__
++#undef __sparc64__
++#endif
++])
++
++])
++
++
++dnl Sets the HOST_CPU_C_ABI_32BIT variable to 'yes' if the C language ABI
++dnl (application binary interface) is a 32-bit one, to 'no' if it is a 64-bit
++dnl one.
++dnl This is a simplified variant of gl_HOST_CPU_C_ABI.
++AC_DEFUN([gl_HOST_CPU_C_ABI_32BIT],
++[
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_CACHE_CHECK([32-bit host C ABI], [gl_cv_host_cpu_c_abi_32bit],
++    [case "$host_cpu" in
++
++       # CPUs that only support a 32-bit ABI.
++       arc \
++       | bfin \
++       | cris* \
++       | csky \
++       | epiphany \
++       | ft32 \
++       | h8300 \
++       | m68k \
++       | microblaze | microblazeel \
++       | nds32 | nds32le | nds32be \
++       | nios2 | nios2eb | nios2el \
++       | or1k* \
++       | or32 \
++       | sh | sh[1234] | sh[1234]e[lb] \
++       | tic6x \
++       | xtensa* )
++         gl_cv_host_cpu_c_abi_32bit=yes
++         ;;
++
++       # CPUs that only support a 64-bit ABI.
++changequote(,)dnl
++       alpha | alphaev[4-8] | alphaev56 | alphapca5[67] | alphaev6[78] \
++       | mmix )
++changequote([,])dnl
++         gl_cv_host_cpu_c_abi_32bit=no
++         ;;
++
++       *)
++         if test -n "$gl_cv_host_cpu_c_abi"; then
++           dnl gl_HOST_CPU_C_ABI has already been run. Use its result.
++           case "$gl_cv_host_cpu_c_abi" in
++             i386 | x86_64-x32 | arm | armhf | arm64-ilp32 | hppa | ia64-ilp32 | loongarch32 | mips | mipsn32 | powerpc | riscv*-ilp32* | s390 | sparc)
++               gl_cv_host_cpu_c_abi_32bit=yes ;;
++             x86_64 | alpha | arm64 | aarch64c | hppa64 | ia64 | loongarch64 | mips64 | powerpc64 | powerpc64-elfv2 | riscv*-lp64* | s390x | sparc64 )
++               gl_cv_host_cpu_c_abi_32bit=no ;;
++             *)
++               gl_cv_host_cpu_c_abi_32bit=unknown ;;
++           esac
++         else
++           gl_cv_host_cpu_c_abi_32bit=unknown
++         fi
++         if test $gl_cv_host_cpu_c_abi_32bit = unknown; then
++           AC_COMPILE_IFELSE(
++             [AC_LANG_SOURCE(
++                [[int test_pointer_size[sizeof (void *) - 5];
++                ]])],
++             [gl_cv_host_cpu_c_abi_32bit=no],
++             [gl_cv_host_cpu_c_abi_32bit=yes])
++         fi
++         ;;
++     esac
++    ])
++
++  HOST_CPU_C_ABI_32BIT="$gl_cv_host_cpu_c_abi_32bit"
++])
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+index 8e36b52..915c45a 100644
+--- a/m4/iconv.m4
++++ b/m4/iconv.m4
+@@ -1,11 +1,20 @@
+-# iconv.m4 serial AM6 (gettext-0.16.2)
+-dnl Copyright (C) 2000-2002, 2007 Free Software Foundation, Inc.
++# iconv.m4
++# serial 30
++dnl Copyright (C) 2000-2002, 2007-2014, 2016-2025 Free Software Foundation,
++dnl Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
+ 
+ dnl From Bruno Haible.
+ 
++AC_PREREQ([2.64])
++
++dnl Note: AM_ICONV is documented in the GNU gettext manual
++dnl <https://www.gnu.org/software/gettext/manual/html_node/AM_005fICONV.html>.
++dnl Don't make changes that are incompatible with that documentation!
++
+ AC_DEFUN([AM_ICONV_LINKFLAGS_BODY],
+ [
+   dnl Prerequisites of AC_LIB_LINKFLAGS_BODY.
+@@ -30,61 +39,148 @@ AC_DEFUN([AM_ICONV_LINK],
+   dnl Add $INCICONV to CPPFLAGS before performing the following checks,
+   dnl because if the user has installed libiconv and not disabled its use
+   dnl via --without-libiconv-prefix, he wants to use it. The first
+-  dnl AC_TRY_LINK will then fail, the second AC_TRY_LINK will succeed.
+-  am_save_CPPFLAGS="$CPPFLAGS"
++  dnl AC_LINK_IFELSE will then fail, the second AC_LINK_IFELSE will succeed.
++  gl_saved_CPPFLAGS="$CPPFLAGS"
+   AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCICONV])
+ 
+-  AC_CACHE_CHECK([for iconv], am_cv_func_iconv, [
++  AC_CACHE_CHECK([for iconv], [am_cv_func_iconv], [
+     am_cv_func_iconv="no, consider installing GNU libiconv"
+     am_cv_lib_iconv=no
+-    AC_TRY_LINK([#include <stdlib.h>
+-#include <iconv.h>],
+-      [iconv_t cd = iconv_open("","");
+-       iconv(cd,NULL,NULL,NULL,NULL);
+-       iconv_close(cd);],
+-      am_cv_func_iconv=yes)
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM(
++         [[
++#include <stdlib.h>
++#include <iconv.h>
++         ]],
++         [[iconv_t cd = iconv_open("","");
++           iconv(cd,NULL,NULL,NULL,NULL);
++           iconv_close(cd);]])],
++      [am_cv_func_iconv=yes])
+     if test "$am_cv_func_iconv" != yes; then
+-      am_save_LIBS="$LIBS"
++      gl_saved_LIBS="$LIBS"
+       LIBS="$LIBS $LIBICONV"
+-      AC_TRY_LINK([#include <stdlib.h>
+-#include <iconv.h>],
+-        [iconv_t cd = iconv_open("","");
+-         iconv(cd,NULL,NULL,NULL,NULL);
+-         iconv_close(cd);],
+-        am_cv_lib_iconv=yes
+-        am_cv_func_iconv=yes)
+-      LIBS="$am_save_LIBS"
++      AC_LINK_IFELSE(
++        [AC_LANG_PROGRAM(
++           [[
++#include <stdlib.h>
++#include <iconv.h>
++           ]],
++           [[iconv_t cd = iconv_open("","");
++             iconv(cd,NULL,NULL,NULL,NULL);
++             iconv_close(cd);]])],
++        [am_cv_lib_iconv=yes]
++        [am_cv_func_iconv=yes])
++      LIBS="$gl_saved_LIBS"
+     fi
+   ])
+   if test "$am_cv_func_iconv" = yes; then
+-    AC_CACHE_CHECK([for working iconv], am_cv_func_iconv_works, [
+-      dnl This tests against bugs in AIX 5.1 and HP-UX 11.11.
+-      am_save_LIBS="$LIBS"
++    AC_CACHE_CHECK([for working iconv], [am_cv_func_iconv_works], [
++      dnl This tests against bugs in AIX 5.1, AIX 6.1..7.1, HP-UX 11.11,
++      dnl Solaris 10, macOS 14.4.
++      gl_saved_LIBS="$LIBS"
+       if test $am_cv_lib_iconv = yes; then
+         LIBS="$LIBS $LIBICONV"
+       fi
+-      AC_TRY_RUN([
++      am_cv_func_iconv_works=no
++      for ac_iconv_const in '' 'const'; do
++        AC_RUN_IFELSE(
++          [AC_LANG_PROGRAM(
++             [[
+ #include <iconv.h>
+ #include <string.h>
+-int main ()
+-{
+-  /* Test against AIX 5.1 bug: Failures are not distinguishable from successful
+-     returns.  */
++
++#ifndef ICONV_CONST
++# define ICONV_CONST $ac_iconv_const
++#endif
++             ]],
++             [[int result = 0;
++  /* Test against AIX 5.1...7.2 bug: Failures are not distinguishable from
++     successful returns.  This is even documented in
++     <https://www.ibm.com/support/knowledgecenter/ssw_aix_72/i_bostechref/iconv.html> */
+   {
+     iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
+     if (cd_utf8_to_88591 != (iconv_t)(-1))
+       {
+-        static const char input[] = "\342\202\254"; /* EURO SIGN */
++        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_utf8_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 1;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against macOS 14.4 bug: Failures are not distinguishable from
++     successful returns.
++     POSIX:2018 says: "The iconv() function shall ... return the number of
++     non-identical conversions performed."
++     But here, the conversion always does transliteration (the suffixes
++     "//TRANSLIT" and "//IGNORE" have no effect, nor does iconvctl()) and
++     does not report when it does a non-identical conversion.  */
++  {
++    iconv_t cd_utf8_to_88591 = iconv_open ("ISO-8859-1", "UTF-8");
++    if (cd_utf8_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\305\202"; /* LATIN SMALL LETTER L WITH STROKE */
+         char buf[10];
+-        const char *inptr = input;
++        ICONV_CONST char *inptr = input;
+         size_t inbytesleft = strlen (input);
+         char *outptr = buf;
+         size_t outbytesleft = sizeof (buf);
+         size_t res = iconv (cd_utf8_to_88591,
+-                            (char **) &inptr, &inbytesleft,
++                            &inptr, &inbytesleft,
+                             &outptr, &outbytesleft);
++        /* Here:
++           With glibc, GNU libiconv (including macOS up to 13): res == (size_t)-1, errno == EILSEQ.
++           With musl libc, NetBSD 10, Solaris 11: res == 1.
++           With macOS 14.4: res == 0, output is "l".  */
+         if (res == 0)
+-          return 1;
++          result |= 2;
++        iconv_close (cd_utf8_to_88591);
++      }
++  }
++  /* Test against Solaris 10 bug: Failures are not distinguishable from
++     successful returns.  */
++  {
++    iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
++    if (cd_ascii_to_88591 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\263";
++        char buf[10];
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = strlen (input);
++        char *outptr = buf;
++        size_t outbytesleft = sizeof (buf);
++        size_t res = iconv (cd_ascii_to_88591,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res == 0)
++          result |= 4;
++        iconv_close (cd_ascii_to_88591);
++      }
++  }
++  /* Test against AIX 6.1..7.1 bug: Buffer overrun.  */
++  {
++    iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
++    if (cd_88591_to_utf8 != (iconv_t)(-1))
++      {
++        static ICONV_CONST char input[] = "\304";
++        static char buf[2] = { (char)0xDE, (char)0xAD };
++        ICONV_CONST char *inptr = input;
++        size_t inbytesleft = 1;
++        char *outptr = buf;
++        size_t outbytesleft = 1;
++        size_t res = iconv (cd_88591_to_utf8,
++                            &inptr, &inbytesleft,
++                            &outptr, &outbytesleft);
++        if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
++          result |= 8;
++        iconv_close (cd_88591_to_utf8);
+       }
+   }
+ #if 0 /* This bug could be worked around by the caller.  */
+@@ -93,38 +189,54 @@ int main ()
+     iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
+     if (cd_88591_to_utf8 != (iconv_t)(-1))
+       {
+-        static const char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
++        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
+         char buf[50];
+-        const char *inptr = input;
++        ICONV_CONST char *inptr = input;
+         size_t inbytesleft = strlen (input);
+         char *outptr = buf;
+         size_t outbytesleft = sizeof (buf);
+         size_t res = iconv (cd_88591_to_utf8,
+-                            (char **) &inptr, &inbytesleft,
++                            &inptr, &inbytesleft,
+                             &outptr, &outbytesleft);
+         if ((int)res > 0)
+-          return 1;
++          result |= 16;
++        iconv_close (cd_88591_to_utf8);
+       }
+   }
+ #endif
+   /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
+      provided.  */
+-  if (/* Try standardized names.  */
+-      iconv_open ("UTF-8", "EUC-JP") == (iconv_t)(-1)
+-      /* Try IRIX, OSF/1 names.  */
+-      && iconv_open ("UTF-8", "eucJP") == (iconv_t)(-1)
+-      /* Try AIX names.  */
+-      && iconv_open ("UTF-8", "IBM-eucJP") == (iconv_t)(-1)
+-      /* Try HP-UX names.  */
+-      && iconv_open ("utf8", "eucJP") == (iconv_t)(-1))
+-    return 1;
+-  return 0;
+-}], [am_cv_func_iconv_works=yes], [am_cv_func_iconv_works=no],
+-        [case "$host_os" in
+-           aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
+-           *)            am_cv_func_iconv_works="guessing yes" ;;
+-         esac])
+-      LIBS="$am_save_LIBS"
++  {
++    /* Try standardized names.  */
++    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
++    /* Try IRIX, OSF/1 names.  */
++    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
++    /* Try AIX names.  */
++    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
++    /* Try HP-UX names.  */
++    iconv_t cd4 = iconv_open ("utf8", "eucJP");
++    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
++        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
++      result |= 32;
++    if (cd1 != (iconv_t)(-1))
++      iconv_close (cd1);
++    if (cd2 != (iconv_t)(-1))
++      iconv_close (cd2);
++    if (cd3 != (iconv_t)(-1))
++      iconv_close (cd3);
++    if (cd4 != (iconv_t)(-1))
++      iconv_close (cd4);
++  }
++  return result;
++]])],
++          [am_cv_func_iconv_works=yes], ,
++          [case "$host_os" in
++             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
++             *)            am_cv_func_iconv_works="guessing yes" ;;
++           esac])
++        test "$am_cv_func_iconv_works" = no || break
++      done
++      LIBS="$gl_saved_LIBS"
+     ])
+     case "$am_cv_func_iconv_works" in
+       *no) am_func_iconv=no am_cv_lib_iconv=no ;;
+@@ -134,7 +246,7 @@ int main ()
+     am_func_iconv=no am_cv_lib_iconv=no
+   fi
+   if test "$am_func_iconv" = yes; then
+-    AC_DEFINE(HAVE_ICONV, 1,
++    AC_DEFINE([HAVE_ICONV], [1],
+       [Define if you have the iconv() function and it works.])
+   fi
+   if test "$am_cv_lib_iconv" = yes; then
+@@ -143,38 +255,70 @@ int main ()
+   else
+     dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV
+     dnl either.
+-    CPPFLAGS="$am_save_CPPFLAGS"
++    CPPFLAGS="$gl_saved_CPPFLAGS"
+     LIBICONV=
+     LTLIBICONV=
+   fi
+-  AC_SUBST(LIBICONV)
+-  AC_SUBST(LTLIBICONV)
++  AC_SUBST([LIBICONV])
++  AC_SUBST([LTLIBICONV])
+ ])
+ 
+-AC_DEFUN([AM_ICONV],
++dnl Define AM_ICONV using AC_DEFUN_ONCE, in order to avoid warnings like
++dnl "warning: AC_REQUIRE: `AM_ICONV' was expanded before it was required".
++AC_DEFUN_ONCE([AM_ICONV],
+ [
+   AM_ICONV_LINK
+   if test "$am_cv_func_iconv" = yes; then
+-    AC_MSG_CHECKING([for iconv declaration])
+-    AC_CACHE_VAL(am_cv_proto_iconv, [
+-      AC_TRY_COMPILE([
++    AC_CACHE_CHECK([whether iconv is compatible with its POSIX signature],
++      [gl_cv_iconv_nonconst],
++      [AC_COMPILE_IFELSE(
++         [AC_LANG_PROGRAM(
++            [[
+ #include <stdlib.h>
+ #include <iconv.h>
+ extern
+ #ifdef __cplusplus
+ "C"
+ #endif
+-#if defined(__STDC__) || defined(__cplusplus)
+ size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
+-#else
+-size_t iconv();
+-#endif
+-], [], am_cv_proto_iconv_arg1="", am_cv_proto_iconv_arg1="const")
+-      am_cv_proto_iconv="extern size_t iconv (iconv_t cd, $am_cv_proto_iconv_arg1 char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);"])
+-    am_cv_proto_iconv=`echo "[$]am_cv_proto_iconv" | tr -s ' ' | sed -e 's/( /(/'`
+-    AC_MSG_RESULT([$]{ac_t:-
+-         }[$]am_cv_proto_iconv)
+-    AC_DEFINE_UNQUOTED(ICONV_CONST, $am_cv_proto_iconv_arg1,
+-      [Define as const if the declaration of iconv() needs const.])
++            ]],
++            [[]])],
++         [gl_cv_iconv_nonconst=yes],
++         [gl_cv_iconv_nonconst=no])
++      ])
++  else
++    dnl When compiling GNU libiconv on a system that does not have iconv yet,
++    dnl pick the POSIX compliant declaration without 'const'.
++    gl_cv_iconv_nonconst=yes
++  fi
++  if test $gl_cv_iconv_nonconst = yes; then
++    iconv_arg1=""
++  else
++    iconv_arg1="const"
++  fi
++  AC_DEFINE_UNQUOTED([ICONV_CONST], [$iconv_arg1],
++    [Define as const if the declaration of iconv() needs const.])
++  dnl Also substitute ICONV_CONST in the gnulib generated <iconv.h>.
++  m4_ifdef([gl_ICONV_H_DEFAULTS],
++    [AC_REQUIRE([gl_ICONV_H_DEFAULTS])
++     if test $gl_cv_iconv_nonconst != yes; then
++       ICONV_CONST="const"
++     fi
++    ])
++
++  dnl A summary result, for those packages which want to print a summary at the
++  dnl end of the configuration.
++  if test "$am_func_iconv" = yes; then
++    if test -n "$LIBICONV"; then
++      am_cv_func_iconv_summary='yes, in libiconv'
++    else
++      am_cv_func_iconv_summary='yes, in libc'
++    fi
++  else
++    if test "$am_cv_func_iconv" = yes; then
++      am_cv_func_iconv_summary='not working, consider installing GNU libiconv'
++    else
++      am_cv_func_iconv_summary='no, consider installing GNU libiconv'
++    fi
+   fi
+ ])
+diff --git a/m4/intlmacosx.m4 b/m4/intlmacosx.m4
+new file mode 100644
+index 0000000..f0920d0
+--- /dev/null
++++ b/m4/intlmacosx.m4
+@@ -0,0 +1,71 @@
++# intlmacosx.m4
++# serial 10 (gettext-0.23)
++dnl Copyright (C) 2004-2014, 2016, 2019-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Checks for special options needed on Mac OS X.
++dnl Defines INTL_MACOSX_LIBS.
++AC_DEFUN([gt_INTL_MACOSX],
++[
++  dnl Check for API introduced in Mac OS X 10.4.
++  AC_CACHE_CHECK([for CFPreferencesCopyAppValue],
++    [gt_cv_func_CFPreferencesCopyAppValue],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFPreferences.h>]],
++          [[CFPreferencesCopyAppValue(NULL, NULL)]])],
++       [gt_cv_func_CFPreferencesCopyAppValue=yes],
++       [gt_cv_func_CFPreferencesCopyAppValue=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes; then
++    AC_DEFINE([HAVE_CFPREFERENCESCOPYAPPVALUE], [1],
++      [Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in the CoreFoundation framework.])
++  fi
++  dnl Don't check for the API introduced in Mac OS X 10.5, CFLocaleCopyCurrent,
++  dnl because in macOS 10.13.4 it has the following behaviour:
++  dnl When two or more languages are specified in the
++  dnl "System Preferences > Language & Region > Preferred Languages" panel,
++  dnl it returns en_CC where CC is the territory (even when English is not among
++  dnl the preferred languages!).  What we want instead is what
++  dnl CFLocaleCopyCurrent returned in earlier macOS releases and what
++  dnl CFPreferencesCopyAppValue still returns, namely ll_CC where ll is the
++  dnl first among the preferred languages and CC is the territory.
++  AC_CACHE_CHECK([for CFLocaleCopyPreferredLanguages], [gt_cv_func_CFLocaleCopyPreferredLanguages],
++    [gt_saved_LIBS="$LIBS"
++     LIBS="$LIBS -Wl,-framework -Wl,CoreFoundation"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM(
++          [[#include <CoreFoundation/CFLocale.h>]],
++          [[CFLocaleCopyPreferredLanguages();]])],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=yes],
++       [gt_cv_func_CFLocaleCopyPreferredLanguages=no])
++     LIBS="$gt_saved_LIBS"])
++  if test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    AC_DEFINE([HAVE_CFLOCALECOPYPREFERREDLANGUAGES], [1],
++      [Define to 1 if you have the Mac OS X function CFLocaleCopyPreferredLanguages in the CoreFoundation framework.])
++  fi
++  INTL_MACOSX_LIBS=
++  if test $gt_cv_func_CFPreferencesCopyAppValue = yes \
++     || test $gt_cv_func_CFLocaleCopyPreferredLanguages = yes; then
++    dnl Starting with macOS version 14, CoreFoundation relies on CoreServices,
++    dnl and we have to link it in explicitly, otherwise an exception
++    dnl NSInvalidArgumentException "unrecognized selector sent to instance"
++    dnl occurs.
++    INTL_MACOSX_LIBS="-Wl,-framework -Wl,CoreFoundation -Wl,-framework -Wl,CoreServices"
++  fi
++  AC_SUBST([INTL_MACOSX_LIBS])
++])
+diff --git a/m4/lib-ld.m4 b/m4/lib-ld.m4
+index 96c4e2c..3714b9c 100644
+--- a/m4/lib-ld.m4
++++ b/m4/lib-ld.m4
+@@ -1,110 +1,170 @@
+-# lib-ld.m4 serial 3 (gettext-0.13)
+-dnl Copyright (C) 1996-2003 Free Software Foundation, Inc.
++# lib-ld.m4
++# serial 13
++dnl Copyright (C) 1996-2003, 2009-2025 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
+ 
+ dnl Subroutines of libtool.m4,
+-dnl with replacements s/AC_/AC_LIB/ and s/lt_cv/acl_cv/ to avoid collision
+-dnl with libtool.m4.
++dnl with replacements s/_*LT_PATH/AC_LIB_PROG/ and s/lt_/acl_/ to avoid
++dnl collision with libtool.m4.
+ 
+-dnl From libtool-1.4. Sets the variable with_gnu_ld to yes or no.
++dnl From libtool-2.4. Sets the variable with_gnu_ld to yes or no.
+ AC_DEFUN([AC_LIB_PROG_LD_GNU],
+-[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], acl_cv_prog_gnu_ld,
+-[# I'd rather use --version here, but apparently some GNU ld's only accept -v.
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], [acl_cv_prog_gnu_ld],
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
+ case `$LD -v 2>&1 </dev/null` in
+ *GNU* | *'with BFD'*)
+-  acl_cv_prog_gnu_ld=yes ;;
++  acl_cv_prog_gnu_ld=yes
++  ;;
+ *)
+-  acl_cv_prog_gnu_ld=no ;;
++  acl_cv_prog_gnu_ld=no
++  ;;
+ esac])
+ with_gnu_ld=$acl_cv_prog_gnu_ld
+ ])
+ 
+-dnl From libtool-1.4. Sets the variable LD.
++dnl From libtool-2.4. Sets the variable LD.
+ AC_DEFUN([AC_LIB_PROG_LD],
+-[AC_ARG_WITH(gnu-ld,
+-[  --with-gnu-ld           assume the C compiler uses GNU ld [default=no]],
+-test "$withval" = no || with_gnu_ld=yes, with_gnu_ld=no)
+-AC_REQUIRE([AC_PROG_CC])dnl
++[AC_REQUIRE([AC_PROG_CC])dnl
+ AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([[--with-gnu-ld]],
++        [assume the C compiler uses GNU ld [default=no]])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
+ # Prepare PATH_SEPARATOR.
+ # The user is always right.
+ if test "${PATH_SEPARATOR+set}" != set; then
+-  echo "#! /bin/sh" >conf$$.sh
+-  echo  "exit 0"   >>conf$$.sh
+-  chmod +x conf$$.sh
+-  if (PATH="/nonexistent;."; conf$$.sh) >/dev/null 2>&1; then
+-    PATH_SEPARATOR=';'
+-  else
+-    PATH_SEPARATOR=:
+-  fi
+-  rm -f conf$$.sh
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
+ fi
+-ac_prog=ld
+-if test "$GCC" = yes; then
+-  # Check if gcc -print-prog-name=ld gives a path.
+-  AC_MSG_CHECKING([for ld used by GCC])
+-  case $host in
+-  *-*-mingw*)
+-    # gcc leaves a trailing carriage return which upsets mingw
+-    ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
+-  *)
+-    ac_prog=`($CC -print-prog-name=ld) 2>&5` ;;
+-  esac
+-  case $ac_prog in
+-    # Accept absolute paths.
+-    [[\\/]* | [A-Za-z]:[\\/]*)]
+-      [re_direlt='/[^/][^/]*/\.\./']
+-      # Canonicalize the path of ld
+-      ac_prog=`echo $ac_prog| sed 's%\\\\%/%g'`
+-      while echo $ac_prog | grep "$re_direlt" > /dev/null 2>&1; do
+-	ac_prog=`echo $ac_prog| sed "s%$re_direlt%/%"`
+-      done
+-      test -z "$LD" && LD="$ac_prog"
+-      ;;
+-  "")
+-    # If it fails, then pretend we aren't using GCC.
+-    ac_prog=ld
+-    ;;
+-  *)
+-    # If it is relative, then search for the first ld in PATH.
+-    with_gnu_ld=unknown
+-    ;;
+-  esac
++
++if test -n "$LD"; then
++  AC_MSG_CHECKING([for ld])
++elif test "$GCC" = yes; then
++  AC_MSG_CHECKING([for ld used by $CC])
+ elif test "$with_gnu_ld" = yes; then
+   AC_MSG_CHECKING([for GNU ld])
+ else
+   AC_MSG_CHECKING([for non-GNU ld])
+ fi
+-AC_CACHE_VAL(acl_cv_path_LD,
+-[if test -z "$LD"; then
+-  IFS="${IFS= 	}"; ac_save_ifs="$IFS"; IFS="${IFS}${PATH_SEPARATOR-:}"
+-  for ac_dir in $PATH; do
+-    test -z "$ac_dir" && ac_dir=.
+-    if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
+-      acl_cv_path_LD="$ac_dir/$ac_prog"
+-      # Check to see if the program is GNU ld.  I'd rather use --version,
+-      # but apparently some GNU ld's only accept -v.
+-      # Break only if it was the GNU/non-GNU ld that we prefer.
+-      case `"$acl_cv_path_LD" -v 2>&1 < /dev/null` in
+-      *GNU* | *'with BFD'*)
+-	test "$with_gnu_ld" != no && break ;;
+-      *)
+-	test "$with_gnu_ld" != yes && break ;;
++if test -n "$LD"; then
++  # Let the user override the test with a path.
++  :
++else
++  AC_CACHE_VAL([acl_cv_path_LD],
++  [
++    acl_cv_path_LD= # Final result of this test
++    ac_prog=ld # Program to search in $PATH
++    if test "$GCC" = yes; then
++      # Check if gcc -print-prog-name=ld gives a path.
++      case $host in
++        *-*-mingw* | windows*)
++          # gcc leaves a trailing carriage return which upsets mingw
++          acl_output=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++        *)
++          acl_output=`($CC -print-prog-name=ld) 2>&5` ;;
++      esac
++      case $acl_output in
++        # Accept absolute paths.
++        [[\\/]]* | ?:[[\\/]]*)
++          re_direlt='/[[^/]][[^/]]*/\.\./'
++          # Canonicalize the pathname of ld
++          acl_output=`echo "$acl_output" | sed 's%\\\\%/%g'`
++          while echo "$acl_output" | grep "$re_direlt" > /dev/null 2>&1; do
++            acl_output=`echo $acl_output | sed "s%$re_direlt%/%"`
++          done
++          # Got the pathname. No search in PATH is needed.
++          acl_cv_path_LD="$acl_output"
++          ac_prog=
++          ;;
++        "")
++          # If it fails, then pretend we aren't using GCC.
++          ;;
++        *)
++          # If it is relative, then search for the first ld in PATH.
++          with_gnu_ld=unknown
++          ;;
+       esac
+     fi
+-  done
+-  IFS="$ac_save_ifs"
+-else
+-  acl_cv_path_LD="$LD" # Let the user override the test with a path.
+-fi])
+-LD="$acl_cv_path_LD"
++    if test -n "$ac_prog"; then
++      # Search for $ac_prog in $PATH.
++      acl_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++      for ac_dir in $PATH; do
++        IFS="$acl_saved_IFS"
++        test -z "$ac_dir" && ac_dir=.
++        if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++          acl_cv_path_LD="$ac_dir/$ac_prog"
++          # Check to see if the program is GNU ld.  I'd rather use --version,
++          # but apparently some variants of GNU ld only accept -v.
++          # Break only if it was the GNU/non-GNU ld that we prefer.
++          case `"$acl_cv_path_LD" -v 2>&1 </dev/null` in
++            *GNU* | *'with BFD'*)
++              test "$with_gnu_ld" != no && break
++              ;;
++            *)
++              test "$with_gnu_ld" != yes && break
++              ;;
++          esac
++        fi
++      done
++      IFS="$acl_saved_IFS"
++    fi
++    case $host in
++      *-*-aix*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __powerpc64__ || defined __LP64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [# The compiler produces 64-bit code. Add option '-b64' so that the
++           # linker groks 64-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -b64 "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -b64" ;;
++           esac
++          ], [])
++        ;;
++      sparc64-*-netbsd*)
++        AC_COMPILE_IFELSE(
++          [AC_LANG_SOURCE(
++             [[#if defined __sparcv9 || defined __arch64__
++                int ok;
++               #else
++                error fail
++               #endif
++             ]])],
++          [],
++          [# The compiler produces 32-bit code. Add option '-m elf32_sparc'
++           # so that the linker groks 32-bit object files.
++           case "$acl_cv_path_LD " in
++             *" -m elf32_sparc "*) ;;
++             *) acl_cv_path_LD="$acl_cv_path_LD -m elf32_sparc" ;;
++           esac
++          ])
++        ;;
++    esac
++  ])
++  LD="$acl_cv_path_LD"
++fi
+ if test -n "$LD"; then
+-  AC_MSG_RESULT($LD)
++  AC_MSG_RESULT([$LD])
+ else
+-  AC_MSG_RESULT(no)
++  AC_MSG_RESULT([no])
++  AC_MSG_ERROR([no acceptable ld found in \$PATH])
+ fi
+-test -z "$LD" && AC_MSG_ERROR([no acceptable ld found in \$PATH])
+ AC_LIB_PROG_LD_GNU
+ ])
+diff --git a/m4/lib-link.m4 b/m4/lib-link.m4
+index 9292919..1863f4e 100644
+--- a/m4/lib-link.m4
++++ b/m4/lib-link.m4
+@@ -1,58 +1,68 @@
+-# lib-link.m4 serial 8 (gettext-0.15)
+-dnl Copyright (C) 2001-2006 Free Software Foundation, Inc.
++# lib-link.m4
++# serial 35
++dnl Copyright (C) 2001-2025 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
+ 
+ dnl From Bruno Haible.
+ 
+-AC_PREREQ(2.50)
++AC_PREREQ([2.61])
+ 
+ dnl AC_LIB_LINKFLAGS(name [, dependencies]) searches for libname and
+ dnl the libraries corresponding to explicit and implicit dependencies.
+ dnl Sets and AC_SUBSTs the LIB${NAME} and LTLIB${NAME} variables and
+ dnl augments the CPPFLAGS variable.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
+ AC_DEFUN([AC_LIB_LINKFLAGS],
+ [
+   AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
+   AC_REQUIRE([AC_LIB_RPATH])
+-  define([Name],[translit([$1],[./-], [___])])
+-  define([NAME],[translit([$1],[abcdefghijklmnopqrstuvwxyz./-],
+-                               [ABCDEFGHIJKLMNOPQRSTUVWXYZ___])])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
+   AC_CACHE_CHECK([how to link with lib[]$1], [ac_cv_lib[]Name[]_libs], [
+     AC_LIB_LINKFLAGS_BODY([$1], [$2])
+     ac_cv_lib[]Name[]_libs="$LIB[]NAME"
+     ac_cv_lib[]Name[]_ltlibs="$LTLIB[]NAME"
+     ac_cv_lib[]Name[]_cppflags="$INC[]NAME"
++    ac_cv_lib[]Name[]_prefix="$LIB[]NAME[]_PREFIX"
+   ])
+   LIB[]NAME="$ac_cv_lib[]Name[]_libs"
+   LTLIB[]NAME="$ac_cv_lib[]Name[]_ltlibs"
+   INC[]NAME="$ac_cv_lib[]Name[]_cppflags"
++  LIB[]NAME[]_PREFIX="$ac_cv_lib[]Name[]_prefix"
+   AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
+   AC_SUBST([LIB]NAME)
+   AC_SUBST([LTLIB]NAME)
++  AC_SUBST([LIB]NAME[_PREFIX])
+   dnl Also set HAVE_LIB[]NAME so that AC_LIB_HAVE_LINKFLAGS can reuse the
+   dnl results of this search when this library appears as a dependency.
+   HAVE_LIB[]NAME=yes
+-  undefine([Name])
+-  undefine([NAME])
++  popdef([NAME])
++  popdef([Name])
+ ])
+ 
+-dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode)
++dnl AC_LIB_HAVE_LINKFLAGS(name, dependencies, includes, testcode, [missing-message])
+ dnl searches for libname and the libraries corresponding to explicit and
+ dnl implicit dependencies, together with the specified include files and
+-dnl the ability to compile and link the specified testcode. If found, it
+-dnl sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME} and
+-dnl LTLIB${NAME} variables and augments the CPPFLAGS variable, and
++dnl the ability to compile and link the specified testcode. The missing-message
++dnl defaults to 'no' and may contain additional hints for the user.
++dnl If found, it sets and AC_SUBSTs HAVE_LIB${NAME}=yes and the LIB${NAME}
++dnl and LTLIB${NAME} variables and augments the CPPFLAGS variable, and
+ dnl #defines HAVE_LIB${NAME} to 1. Otherwise, it sets and AC_SUBSTs
+ dnl HAVE_LIB${NAME}=no and LIB${NAME} and LTLIB${NAME} to empty.
++dnl Sets and AC_SUBSTs the LIB${NAME}_PREFIX variable to nonempty if libname
++dnl was found in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
+ AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
+ [
+   AC_REQUIRE([AC_LIB_PREPARE_PREFIX])
+   AC_REQUIRE([AC_LIB_RPATH])
+-  define([Name],[translit([$1],[./-], [___])])
+-  define([NAME],[translit([$1],[abcdefghijklmnopqrstuvwxyz./-],
+-                               [ABCDEFGHIJKLMNOPQRSTUVWXYZ___])])
++  pushdef([Name],[m4_translit([$1],[./+-], [____])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
+ 
+   dnl Search for lib[]Name and define LIB[]NAME, LTLIB[]NAME and INC[]NAME
+   dnl accordingly.
+@@ -61,47 +71,68 @@ AC_DEFUN([AC_LIB_HAVE_LINKFLAGS],
+   dnl Add $INC[]NAME to CPPFLAGS before performing the following checks,
+   dnl because if the user has installed lib[]Name and not disabled its use
+   dnl via --without-lib[]Name-prefix, he wants to use it.
+-  ac_save_CPPFLAGS="$CPPFLAGS"
++  acl_saved_CPPFLAGS="$CPPFLAGS"
+   AC_LIB_APPENDTOVAR([CPPFLAGS], [$INC]NAME)
+ 
+   AC_CACHE_CHECK([for lib[]$1], [ac_cv_lib[]Name], [
+-    ac_save_LIBS="$LIBS"
+-    LIBS="$LIBS $LIB[]NAME"
+-    AC_TRY_LINK([$3], [$4], [ac_cv_lib[]Name=yes], [ac_cv_lib[]Name=no])
+-    LIBS="$ac_save_LIBS"
++    acl_saved_LIBS="$LIBS"
++    dnl If $LIB[]NAME contains some -l options, add it to the end of LIBS,
++    dnl because these -l options might require -L options that are present in
++    dnl LIBS. -l options benefit only from the -L options listed before it.
++    dnl Otherwise, add it to the front of LIBS, because it may be a static
++    dnl library that depends on another static library that is present in LIBS.
++    dnl Static libraries benefit only from the static libraries listed after
++    dnl it.
++    case " $LIB[]NAME" in
++      *" -l"*) LIBS="$LIBS $LIB[]NAME" ;;
++      *)       LIBS="$LIB[]NAME $LIBS" ;;
++    esac
++    AC_LINK_IFELSE(
++      [AC_LANG_PROGRAM([[$3]], [[$4]])],
++      [ac_cv_lib[]Name=yes],
++      [ac_cv_lib[]Name='m4_if([$5], [], [no], [[$5]])'])
++    LIBS="$acl_saved_LIBS"
+   ])
+   if test "$ac_cv_lib[]Name" = yes; then
+     HAVE_LIB[]NAME=yes
+-    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the $1 library.])
++    AC_DEFINE([HAVE_LIB]NAME, 1, [Define if you have the lib][$1 library.])
+     AC_MSG_CHECKING([how to link with lib[]$1])
+     AC_MSG_RESULT([$LIB[]NAME])
+   else
+     HAVE_LIB[]NAME=no
+     dnl If $LIB[]NAME didn't lead to a usable library, we don't need
+     dnl $INC[]NAME either.
+-    CPPFLAGS="$ac_save_CPPFLAGS"
++    CPPFLAGS="$acl_saved_CPPFLAGS"
+     LIB[]NAME=
+     LTLIB[]NAME=
++    LIB[]NAME[]_PREFIX=
+   fi
+   AC_SUBST([HAVE_LIB]NAME)
+   AC_SUBST([LIB]NAME)
+   AC_SUBST([LTLIB]NAME)
+-  undefine([Name])
+-  undefine([NAME])
++  AC_SUBST([LIB]NAME[_PREFIX])
++  popdef([NAME])
++  popdef([Name])
+ ])
+ 
+ dnl Determine the platform dependent parameters needed to use rpath:
+-dnl libext, shlibext, hardcode_libdir_flag_spec, hardcode_libdir_separator,
+-dnl hardcode_direct, hardcode_minus_L.
++dnl   acl_libext,
++dnl   acl_shlibext,
++dnl   acl_libname_spec,
++dnl   acl_library_names_spec,
++dnl   acl_hardcode_libdir_flag_spec,
++dnl   acl_hardcode_libdir_separator,
++dnl   acl_hardcode_direct,
++dnl   acl_hardcode_minus_L.
+ AC_DEFUN([AC_LIB_RPATH],
+ [
+-  dnl Tell automake >= 1.10 to complain if config.rpath is missing.
+-  m4_ifdef([AC_REQUIRE_AUX_FILE], [AC_REQUIRE_AUX_FILE([config.rpath])])
++  dnl Complain if config.rpath is missing.
++  AC_REQUIRE_AUX_FILE([config.rpath])
+   AC_REQUIRE([AC_PROG_CC])                dnl we use $CC, $GCC, $LDFLAGS
+   AC_REQUIRE([AC_LIB_PROG_LD])            dnl we use $LD, $with_gnu_ld
+   AC_REQUIRE([AC_CANONICAL_HOST])         dnl we use $host
+   AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT]) dnl we use $ac_aux_dir
+-  AC_CACHE_CHECK([for shared library run path origin], acl_cv_rpath, [
++  AC_CACHE_CHECK([for shared library run path origin], [acl_cv_rpath], [
+     CC="$CC" GCC="$GCC" LDFLAGS="$LDFLAGS" LD="$LD" with_gnu_ld="$with_gnu_ld" \
+     ${CONFIG_SHELL-/bin/sh} "$ac_aux_dir/config.rpath" "$host" > conftest.sh
+     . ./conftest.sh
+@@ -109,35 +140,66 @@ AC_DEFUN([AC_LIB_RPATH],
+     acl_cv_rpath=done
+   ])
+   wl="$acl_cv_wl"
+-  libext="$acl_cv_libext"
+-  shlibext="$acl_cv_shlibext"
+-  hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
+-  hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
+-  hardcode_direct="$acl_cv_hardcode_direct"
+-  hardcode_minus_L="$acl_cv_hardcode_minus_L"
++  acl_libext="$acl_cv_libext"
++  acl_shlibext="$acl_cv_shlibext"
++  acl_libname_spec="$acl_cv_libname_spec"
++  acl_library_names_spec="$acl_cv_library_names_spec"
++  acl_hardcode_libdir_flag_spec="$acl_cv_hardcode_libdir_flag_spec"
++  acl_hardcode_libdir_separator="$acl_cv_hardcode_libdir_separator"
++  acl_hardcode_direct="$acl_cv_hardcode_direct"
++  acl_hardcode_minus_L="$acl_cv_hardcode_minus_L"
+   dnl Determine whether the user wants rpath handling at all.
+-  AC_ARG_ENABLE(rpath,
++  AC_ARG_ENABLE([rpath],
+     [  --disable-rpath         do not hardcode runtime library paths],
+     :, enable_rpath=yes)
+ ])
+ 
++dnl AC_LIB_FROMPACKAGE(name, package)
++dnl declares that libname comes from the given package. The configure file
++dnl will then not have a --with-libname-prefix option but a
++dnl --with-package-prefix option. Several libraries can come from the same
++dnl package. This declaration must occur before an AC_LIB_LINKFLAGS or similar
++dnl macro call that searches for libname.
++AC_DEFUN([AC_LIB_FROMPACKAGE],
++[
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_frompackage_]NAME, [$2])
++  popdef([NAME])
++  pushdef([PACK],[$2])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  define([acl_libsinpackage_]PACKUP,
++    m4_ifdef([acl_libsinpackage_]PACKUP, [m4_defn([acl_libsinpackage_]PACKUP)[[, ]]],)[lib$1])
++  popdef([PACKUP])
++  popdef([PACK])
++])
++
+ dnl AC_LIB_LINKFLAGS_BODY(name [, dependencies]) searches for libname and
+ dnl the libraries corresponding to explicit and implicit dependencies.
+ dnl Sets the LIB${NAME}, LTLIB${NAME} and INC${NAME} variables.
++dnl Also, sets the LIB${NAME}_PREFIX variable to nonempty if libname was found
++dnl in ${LIB${NAME}_PREFIX}/$acl_libdirstem.
+ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+ [
+   AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
+-  define([NAME],[translit([$1],[abcdefghijklmnopqrstuvwxyz./-],
+-                               [ABCDEFGHIJKLMNOPQRSTUVWXYZ___])])
++  pushdef([NAME],[m4_translit([$1],[abcdefghijklmnopqrstuvwxyz./+-],
++                                   [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACK],[m4_ifdef([acl_frompackage_]NAME, [acl_frompackage_]NAME, lib[$1])])
++  pushdef([PACKUP],[m4_translit(PACK,[abcdefghijklmnopqrstuvwxyz./+-],
++                                     [ABCDEFGHIJKLMNOPQRSTUVWXYZ____])])
++  pushdef([PACKLIBS],[m4_ifdef([acl_frompackage_]NAME, [acl_libsinpackage_]PACKUP, lib[$1])])
+   dnl By default, look in $includedir and $libdir.
+   use_additional=yes
+   AC_LIB_WITH_FINAL_PREFIX([
+     eval additional_includedir=\"$includedir\"
+     eval additional_libdir=\"$libdir\"
++    eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++    eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
+   ])
+-  AC_LIB_ARG_WITH([lib$1-prefix],
+-[  --with-lib$1-prefix[=DIR]  search for lib$1 in DIR/include and DIR/lib
+-  --without-lib$1-prefix     don't search for lib$1 in includedir and libdir],
++  AC_ARG_WITH(PACK[-prefix],
++[[  --with-]]PACK[[-prefix[=DIR]  search for ]]PACKLIBS[[ in DIR/include and DIR/lib
++  --without-]]PACK[[-prefix     don't search for ]]PACKLIBS[[ in includedir and libdir]],
+ [
+     if test "X$withval" = "Xno"; then
+       use_additional=no
+@@ -146,18 +208,32 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+         AC_LIB_WITH_FINAL_PREFIX([
+           eval additional_includedir=\"$includedir\"
+           eval additional_libdir=\"$libdir\"
++          eval additional_libdir2=\"$exec_prefix/$acl_libdirstem2\"
++          eval additional_libdir3=\"$exec_prefix/$acl_libdirstem3\"
+         ])
+       else
+         additional_includedir="$withval/include"
+         additional_libdir="$withval/$acl_libdirstem"
++        additional_libdir2="$withval/$acl_libdirstem2"
++        additional_libdir3="$withval/$acl_libdirstem3"
+       fi
+     fi
+ ])
++  if test "X$additional_libdir2" = "X$additional_libdir"; then
++    additional_libdir2=
++  fi
++  if test "X$additional_libdir3" = "X$additional_libdir"; then
++    additional_libdir3=
++  fi
+   dnl Search the library and its dependencies in $additional_libdir and
+-  dnl $LDFLAGS. Using breadth-first-seach.
++  dnl $LDFLAGS. Use breadth-first search.
+   LIB[]NAME=
+   LTLIB[]NAME=
+   INC[]NAME=
++  LIB[]NAME[]_PREFIX=
++  dnl HAVE_LIB${NAME} is an indicator that LIB${NAME}, LTLIB${NAME} have been
++  dnl computed. So it has to be reset here.
++  HAVE_LIB[]NAME=
+   rpathdirs=
+   ltrpathdirs=
+   names_already_handled=
+@@ -177,7 +253,7 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+         names_already_handled="$names_already_handled $name"
+         dnl See if it was already located by an earlier AC_LIB_LINKFLAGS
+         dnl or AC_LIB_HAVE_LINKFLAGS call.
+-        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./-|ABCDEFGHIJKLMNOPQRSTUVWXYZ___|'`
++        uppername=`echo "$name" | sed -e 'y|abcdefghijklmnopqrstuvwxyz./+-|ABCDEFGHIJKLMNOPQRSTUVWXYZ____|'`
+         eval value=\"\$HAVE_LIB$uppername\"
+         if test -n "$value"; then
+           if test "$value" = yes; then
+@@ -197,22 +273,61 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+           found_la=
+           found_so=
+           found_a=
++          eval libname=\"$acl_libname_spec\"    # typically: libname=lib$name
++          if test -n "$acl_shlibext"; then
++            shrext=".$acl_shlibext"             # typically: shrext=.so
++          else
++            shrext=
++          fi
+           if test $use_additional = yes; then
+-            if test -n "$shlibext" && test -f "$additional_libdir/lib$name.$shlibext"; then
+-              found_dir="$additional_libdir"
+-              found_so="$additional_libdir/lib$name.$shlibext"
+-              if test -f "$additional_libdir/lib$name.la"; then
+-                found_la="$additional_libdir/lib$name.la"
+-              fi
+-            else
+-              if test -f "$additional_libdir/lib$name.$libext"; then
+-                found_dir="$additional_libdir"
+-                found_a="$additional_libdir/lib$name.$libext"
+-                if test -f "$additional_libdir/lib$name.la"; then
+-                  found_la="$additional_libdir/lib$name.la"
++            for additional_libdir_variable in additional_libdir additional_libdir2 additional_libdir3; do
++              if test "X$found_dir" = "X"; then
++                eval dir=\$$additional_libdir_variable
++                if test -n "$dir"; then
++                  dnl The same code as in the loop below:
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
++                      found_dir="$dir"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
++                      fi
++                    fi
++                  fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
+                 fi
+               fi
+-            fi
++            done
+           fi
+           if test "X$found_dir" = "X"; then
+             for x in $LDFLAGS $LTLIB[]NAME; do
+@@ -220,21 +335,46 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+               case "$x" in
+                 -L*)
+                   dir=`echo "X$x" | sed -e 's/^X-L//'`
+-                  if test -n "$shlibext" && test -f "$dir/lib$name.$shlibext"; then
+-                    found_dir="$dir"
+-                    found_so="$dir/lib$name.$shlibext"
+-                    if test -f "$dir/lib$name.la"; then
+-                      found_la="$dir/lib$name.la"
+-                    fi
+-                  else
+-                    if test -f "$dir/lib$name.$libext"; then
++                  dnl First look for a shared library.
++                  if test -n "$acl_shlibext"; then
++                    if test -f "$dir/$libname$shrext" && acl_is_expected_elfclass < "$dir/$libname$shrext"; then
+                       found_dir="$dir"
+-                      found_a="$dir/lib$name.$libext"
+-                      if test -f "$dir/lib$name.la"; then
+-                        found_la="$dir/lib$name.la"
++                      found_so="$dir/$libname$shrext"
++                    else
++                      if test "$acl_library_names_spec" = '$libname$shrext$versuffix'; then
++                        ver=`(cd "$dir" && \
++                              for f in "$libname$shrext".*; do echo "$f"; done \
++                              | sed -e "s,^$libname$shrext\\\\.,," \
++                              | sort -t '.' -n -r -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 \
++                              | sed 1q ) 2>/dev/null`
++                        if test -n "$ver" && test -f "$dir/$libname$shrext.$ver" && acl_is_expected_elfclass < "$dir/$libname$shrext.$ver"; then
++                          found_dir="$dir"
++                          found_so="$dir/$libname$shrext.$ver"
++                        fi
++                      else
++                        eval library_names=\"$acl_library_names_spec\"
++                        for f in $library_names; do
++                          if test -f "$dir/$f" && acl_is_expected_elfclass < "$dir/$f"; then
++                            found_dir="$dir"
++                            found_so="$dir/$f"
++                            break
++                          fi
++                        done
+                       fi
+                     fi
+                   fi
++                  dnl Then look for a static library.
++                  if test "X$found_dir" = "X"; then
++                    if test -f "$dir/$libname.$acl_libext" && ${AR-ar} -p "$dir/$libname.$acl_libext" | acl_is_expected_elfclass; then
++                      found_dir="$dir"
++                      found_a="$dir/$libname.$acl_libext"
++                    fi
++                  fi
++                  if test "X$found_dir" != "X"; then
++                    if test -f "$dir/$libname.la"; then
++                      found_la="$dir/$libname.la"
++                    fi
++                  fi
+                   ;;
+               esac
+               if test "X$found_dir" != "X"; then
+@@ -249,7 +389,10 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+               dnl Linking with a shared library. We attempt to hardcode its
+               dnl directory into the executable's runpath, unless it's the
+               dnl standard /usr/lib.
+-              if test "$enable_rpath" = no || test "X$found_dir" = "X/usr/$acl_libdirstem"; then
++              if test "$enable_rpath" = no \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem2" \
++                 || test "X$found_dir" = "X/usr/$acl_libdirstem3"; then
+                 dnl No hardcoding is needed.
+                 LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
+               else
+@@ -268,12 +411,12 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+                   ltrpathdirs="$ltrpathdirs $found_dir"
+                 fi
+                 dnl The hardcoding into $LIBNAME is system dependent.
+-                if test "$hardcode_direct" = yes; then
++                if test "$acl_hardcode_direct" = yes; then
+                   dnl Using DIR/libNAME.so during linking hardcodes DIR into the
+                   dnl resulting binary.
+                   LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
+                 else
+-                  if test -n "$hardcode_libdir_flag_spec" && test "$hardcode_minus_L" = no; then
++                  if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
+                     dnl Use an explicit option to hardcode DIR into the resulting
+                     dnl binary.
+                     LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
+@@ -304,13 +447,13 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+                     if test -z "$haveit"; then
+                       LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$found_dir"
+                     fi
+-                    if test "$hardcode_minus_L" != no; then
++                    if test "$acl_hardcode_minus_L" != no; then
+                       dnl FIXME: Not sure whether we should use
+                       dnl "-L$found_dir -l$name" or "-L$found_dir $found_so"
+                       dnl here.
+                       LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$found_so"
+                     else
+-                      dnl We cannot use $hardcode_runpath_var and LD_RUN_PATH
++                      dnl We cannot use $acl_hardcode_runpath_var and LD_RUN_PATH
+                       dnl here, because this doesn't fit in flags passed to the
+                       dnl compiler. So give up. No hardcoding. This affects only
+                       dnl very old systems.
+@@ -337,6 +480,23 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+             case "$found_dir" in
+               */$acl_libdirstem | */$acl_libdirstem/)
+                 basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem2 | */$acl_libdirstem2/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem2/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
++                additional_includedir="$basedir/include"
++                ;;
++              */$acl_libdirstem3 | */$acl_libdirstem3/)
++                basedir=`echo "X$found_dir" | sed -e 's,^X,,' -e "s,/$acl_libdirstem3/"'*$,,'`
++                if test "$name" = '$1'; then
++                  LIB[]NAME[]_PREFIX="$basedir"
++                fi
+                 additional_includedir="$basedir/include"
+                 ;;
+             esac
+@@ -379,27 +539,31 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+               dnl Read the .la file. It defines the variables
+               dnl dlname, library_names, old_library, dependency_libs, current,
+               dnl age, revision, installed, dlopen, dlpreopen, libdir.
+-              save_libdir="$libdir"
++              saved_libdir="$libdir"
+               case "$found_la" in
+                 */* | *\\*) . "$found_la" ;;
+                 *) . "./$found_la" ;;
+               esac
+-              libdir="$save_libdir"
++              libdir="$saved_libdir"
+               dnl We use only dependency_libs.
+               for dep in $dependency_libs; do
+                 case "$dep" in
+                   -L*)
+-                    additional_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
+-                    dnl Potentially add $additional_libdir to $LIBNAME and $LTLIBNAME.
++                    dependency_libdir=`echo "X$dep" | sed -e 's/^X-L//'`
++                    dnl Potentially add $dependency_libdir to $LIBNAME and $LTLIBNAME.
+                     dnl But don't add it
+                     dnl   1. if it's the standard /usr/lib,
+                     dnl   2. if it's /usr/local/lib and we are using GCC on Linux,
+                     dnl   3. if it's already present in $LDFLAGS or the already
+                     dnl      constructed $LIBNAME,
+                     dnl   4. if it doesn't exist as a directory.
+-                    if test "X$additional_libdir" != "X/usr/$acl_libdirstem"; then
++                    if test "X$dependency_libdir" != "X/usr/$acl_libdirstem" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem2" \
++                       && test "X$dependency_libdir" != "X/usr/$acl_libdirstem3"; then
+                       haveit=
+-                      if test "X$additional_libdir" = "X/usr/local/$acl_libdirstem"; then
++                      if test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem2" \
++                         || test "X$dependency_libdir" = "X/usr/local/$acl_libdirstem3"; then
+                         if test -n "$GCC"; then
+                           case $host_os in
+                             linux* | gnu* | k*bsd*-gnu) haveit=yes;;
+@@ -410,29 +574,29 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+                         haveit=
+                         for x in $LDFLAGS $LIB[]NAME; do
+                           AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
+-                          if test "X$x" = "X-L$additional_libdir"; then
++                          if test "X$x" = "X-L$dependency_libdir"; then
+                             haveit=yes
+                             break
+                           fi
+                         done
+                         if test -z "$haveit"; then
+-                          if test -d "$additional_libdir"; then
+-                            dnl Really add $additional_libdir to $LIBNAME.
+-                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$additional_libdir"
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LIBNAME.
++                            LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }-L$dependency_libdir"
+                           fi
+                         fi
+                         haveit=
+                         for x in $LDFLAGS $LTLIB[]NAME; do
+                           AC_LIB_WITH_FINAL_PREFIX([eval x=\"$x\"])
+-                          if test "X$x" = "X-L$additional_libdir"; then
++                          if test "X$x" = "X-L$dependency_libdir"; then
+                             haveit=yes
+                             break
+                           fi
+                         done
+                         if test -z "$haveit"; then
+-                          if test -d "$additional_libdir"; then
+-                            dnl Really add $additional_libdir to $LTLIBNAME.
+-                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$additional_libdir"
++                          if test -d "$dependency_libdir"; then
++                            dnl Really add $dependency_libdir to $LTLIBNAME.
++                            LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-L$dependency_libdir"
+                           fi
+                         fi
+                       fi
+@@ -469,7 +633,20 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+                     ;;
+                   -l*)
+                     dnl Handle this in the next round.
+-                    names_next_round="$names_next_round "`echo "X$dep" | sed -e 's/^X-l//'`
++                    dnl But on GNU systems, ignore -lc options, because
++                    dnl   - linking with libc is the default anyway,
++                    dnl   - linking with libc.a may produce an error
++                    dnl     "/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie"
++                    dnl     or may produce an executable that always crashes, see
++                    dnl     <https://lists.gnu.org/archive/html/grep-devel/2020-09/msg00052.html>.
++                    dep=`echo "X$dep" | sed -e 's/^X-l//'`
++                    if test "X$dep" != Xc \
++                       || case $host_os in
++                            linux* | gnu* | k*bsd*-gnu) false ;;
++                            *)                          true ;;
++                          esac; then
++                      names_next_round="$names_next_round $dep"
++                    fi
+                     ;;
+                   *.la)
+                     dnl Handle this in the next round. Throw away the .la's
+@@ -498,27 +675,27 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+     done
+   done
+   if test "X$rpathdirs" != "X"; then
+-    if test -n "$hardcode_libdir_separator"; then
++    if test -n "$acl_hardcode_libdir_separator"; then
+       dnl Weird platform: only the last -rpath option counts, the user must
+       dnl pass all path elements in one option. We can arrange that for a
+       dnl single library, but not when more than one $LIBNAMEs are used.
+       alldirs=
+       for found_dir in $rpathdirs; do
+-        alldirs="${alldirs}${alldirs:+$hardcode_libdir_separator}$found_dir"
++        alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$found_dir"
+       done
+-      dnl Note: hardcode_libdir_flag_spec uses $libdir and $wl.
+-      acl_save_libdir="$libdir"
++      dnl Note: acl_hardcode_libdir_flag_spec uses $libdir and $wl.
++      acl_saved_libdir="$libdir"
+       libdir="$alldirs"
+-      eval flag=\"$hardcode_libdir_flag_spec\"
+-      libdir="$acl_save_libdir"
++      eval flag=\"$acl_hardcode_libdir_flag_spec\"
++      libdir="$acl_saved_libdir"
+       LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
+     else
+       dnl The -rpath options are cumulative.
+       for found_dir in $rpathdirs; do
+-        acl_save_libdir="$libdir"
++        acl_saved_libdir="$libdir"
+         libdir="$found_dir"
+-        eval flag=\"$hardcode_libdir_flag_spec\"
+-        libdir="$acl_save_libdir"
++        eval flag=\"$acl_hardcode_libdir_flag_spec\"
++        libdir="$acl_saved_libdir"
+         LIB[]NAME="${LIB[]NAME}${LIB[]NAME:+ }$flag"
+       done
+     fi
+@@ -530,6 +707,10 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
+       LTLIB[]NAME="${LTLIB[]NAME}${LTLIB[]NAME:+ }-R$found_dir"
+     done
+   fi
++  popdef([PACKLIBS])
++  popdef([PACKUP])
++  popdef([PACK])
++  popdef([NAME])
+ ])
+ 
+ dnl AC_LIB_APPENDTOVAR(VAR, CONTENTS) appends the elements of CONTENTS to VAR,
+@@ -566,7 +747,7 @@ AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
+   AC_REQUIRE([AC_LIB_PREPARE_MULTILIB])
+   $1=
+   if test "$enable_rpath" != no; then
+-    if test -n "$hardcode_libdir_flag_spec" && test "$hardcode_minus_L" = no; then
++    if test -n "$acl_hardcode_libdir_flag_spec" && test "$acl_hardcode_minus_L" = no; then
+       dnl Use an explicit option to hardcode directories into the resulting
+       dnl binary.
+       rpathdirs=
+@@ -575,7 +756,9 @@ AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
+         if test -n "$next"; then
+           dir="$next"
+           dnl No need to hardcode the standard /usr/lib.
+-          if test "X$dir" != "X/usr/$acl_libdirstem"; then
++          if test "X$dir" != "X/usr/$acl_libdirstem" \
++             && test "X$dir" != "X/usr/$acl_libdirstem2" \
++             && test "X$dir" != "X/usr/$acl_libdirstem3"; then
+             rpathdirs="$rpathdirs $dir"
+           fi
+           next=
+@@ -584,7 +767,9 @@ AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
+             -L) next=yes ;;
+             -L*) dir=`echo "X$opt" | sed -e 's,^X-L,,'`
+                  dnl No need to hardcode the standard /usr/lib.
+-                 if test "X$dir" != "X/usr/$acl_libdirstem"; then
++                 if test "X$dir" != "X/usr/$acl_libdirstem" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem2" \
++                    && test "X$dir" != "X/usr/$acl_libdirstem3"; then
+                    rpathdirs="$rpathdirs $dir"
+                  fi
+                  next= ;;
+@@ -600,25 +785,25 @@ AC_DEFUN([AC_LIB_LINKFLAGS_FROM_LIBS],
+           done
+         else
+           dnl The linker is used for linking directly.
+-          if test -n "$hardcode_libdir_separator"; then
++          if test -n "$acl_hardcode_libdir_separator"; then
+             dnl Weird platform: only the last -rpath option counts, the user
+             dnl must pass all path elements in one option.
+             alldirs=
+             for dir in $rpathdirs; do
+-              alldirs="${alldirs}${alldirs:+$hardcode_libdir_separator}$dir"
++              alldirs="${alldirs}${alldirs:+$acl_hardcode_libdir_separator}$dir"
+             done
+-            acl_save_libdir="$libdir"
++            acl_saved_libdir="$libdir"
+             libdir="$alldirs"
+-            eval flag=\"$hardcode_libdir_flag_spec\"
+-            libdir="$acl_save_libdir"
++            eval flag=\"$acl_hardcode_libdir_flag_spec\"
++            libdir="$acl_saved_libdir"
+             $1="$flag"
+           else
+             dnl The -rpath options are cumulative.
+             for dir in $rpathdirs; do
+-              acl_save_libdir="$libdir"
++              acl_saved_libdir="$libdir"
+               libdir="$dir"
+-              eval flag=\"$hardcode_libdir_flag_spec\"
+-              libdir="$acl_save_libdir"
++              eval flag=\"$acl_hardcode_libdir_flag_spec\"
++              libdir="$acl_saved_libdir"
+               $1="${$1}${$1:+ }$flag"
+             done
+           fi
+diff --git a/m4/lib-prefix.m4 b/m4/lib-prefix.m4
+index a8684e1..2928353 100644
+--- a/m4/lib-prefix.m4
++++ b/m4/lib-prefix.m4
+@@ -1,18 +1,13 @@
+-# lib-prefix.m4 serial 5 (gettext-0.15)
+-dnl Copyright (C) 2001-2005 Free Software Foundation, Inc.
++# lib-prefix.m4
++# serial 23
++dnl Copyright (C) 2001-2005, 2008-2025 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
+ 
+ dnl From Bruno Haible.
+ 
+-dnl AC_LIB_ARG_WITH is synonymous to AC_ARG_WITH in autoconf-2.13, and
+-dnl similar to AC_ARG_WITH in autoconf 2.52...2.57 except that is doesn't
+-dnl require excessive bracketing.
+-ifdef([AC_HELP_STRING],
+-[AC_DEFUN([AC_LIB_ARG_WITH], [AC_ARG_WITH([$1],[[$2]],[$3],[$4])])],
+-[AC_DEFUN([AC_][LIB_ARG_WITH], [AC_ARG_WITH([$1],[$2],[$3],[$4])])])
+-
+ dnl AC_LIB_PREFIX adds to the CPPFLAGS and LDFLAGS the flags that are needed
+ dnl to access previously installed libraries. The basic assumption is that
+ dnl a user will want packages to use other packages he previously installed
+@@ -32,9 +27,9 @@ AC_DEFUN([AC_LIB_PREFIX],
+     eval additional_includedir=\"$includedir\"
+     eval additional_libdir=\"$libdir\"
+   ])
+-  AC_LIB_ARG_WITH([lib-prefix],
+-[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
+-  --without-lib-prefix    don't search for libraries in includedir and libdir],
++  AC_ARG_WITH([lib-prefix],
++[[  --with-lib-prefix[=DIR] search for libraries in DIR/include and DIR/lib
++  --without-lib-prefix    don't search for libraries in includedir and libdir]],
+ [
+     if test "X$withval" = "Xno"; then
+       use_additional=no
+@@ -133,10 +128,10 @@ AC_DEFUN([AC_LIB_PREPARE_PREFIX],
+   else
+     acl_final_exec_prefix="$exec_prefix"
+   fi
+-  acl_save_prefix="$prefix"
++  acl_saved_prefix="$prefix"
+   prefix="$acl_final_prefix"
+   eval acl_final_exec_prefix=\"$acl_final_exec_prefix\"
+-  prefix="$acl_save_prefix"
++  prefix="$acl_saved_prefix"
+ ])
+ 
+ dnl AC_LIB_WITH_FINAL_PREFIX([statement]) evaluates statement, with the
+@@ -144,42 +139,196 @@ dnl variables prefix and exec_prefix bound to the values they will have
+ dnl at the end of the configure script.
+ AC_DEFUN([AC_LIB_WITH_FINAL_PREFIX],
+ [
+-  acl_save_prefix="$prefix"
++  acl_saved_prefix="$prefix"
+   prefix="$acl_final_prefix"
+-  acl_save_exec_prefix="$exec_prefix"
++  acl_saved_exec_prefix="$exec_prefix"
+   exec_prefix="$acl_final_exec_prefix"
+   $1
+-  exec_prefix="$acl_save_exec_prefix"
+-  prefix="$acl_save_prefix"
++  exec_prefix="$acl_saved_exec_prefix"
++  prefix="$acl_saved_prefix"
+ ])
+ 
+-dnl AC_LIB_PREPARE_MULTILIB creates a variable acl_libdirstem, containing
+-dnl the basename of the libdir, either "lib" or "lib64".
++dnl AC_LIB_PREPARE_MULTILIB creates
++dnl - a function acl_is_expected_elfclass, that tests whether standard input
++dn;   has a 32-bit or 64-bit ELF header, depending on the host CPU ABI,
++dnl - 3 variables acl_libdirstem, acl_libdirstem2, acl_libdirstem3, containing
++dnl   the basename of the libdir to try in turn, either "lib" or "lib64" or
++dnl   "lib/64" or "lib32" or "lib/sparcv9" or "lib/amd64" or similar.
+ AC_DEFUN([AC_LIB_PREPARE_MULTILIB],
+ [
+-  dnl There is no formal standard regarding lib and lib64. The current
+-  dnl practice is that on a system supporting 32-bit and 64-bit instruction
+-  dnl sets or ABIs, 64-bit libraries go under $prefix/lib64 and 32-bit
+-  dnl libraries go under $prefix/lib. We determine the compiler's default
+-  dnl mode by looking at the compiler's library search path. If at least
+-  dnl of its elements ends in /lib64 or points to a directory whose absolute
+-  dnl pathname ends in /lib64, we assume a 64-bit ABI. Otherwise we use the
+-  dnl default, namely "lib".
+-  acl_libdirstem=lib
+-  searchpath=`(LC_ALL=C $CC -print-search-dirs) 2>/dev/null | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
+-  if test -n "$searchpath"; then
+-    acl_save_IFS="${IFS= 	}"; IFS=":"
+-    for searchdir in $searchpath; do
+-      if test -d "$searchdir"; then
+-        case "$searchdir" in
+-          */lib64/ | */lib64 ) acl_libdirstem=lib64 ;;
+-          *) searchdir=`cd "$searchdir" && pwd`
+-             case "$searchdir" in
+-               */lib64 ) acl_libdirstem=lib64 ;;
+-             esac ;;
+-        esac
+-      fi
+-    done
+-    IFS="$acl_save_IFS"
++  dnl There is no formal standard regarding lib, lib32, and lib64.
++  dnl On most glibc systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib64 and 32-bit libraries go under $prefix/lib. However, on
++  dnl Arch Linux based distributions, it's the opposite: 32-bit libraries go
++  dnl under $prefix/lib32 and 64-bit libraries go under $prefix/lib.
++  dnl We determine the compiler's default mode by looking at the compiler's
++  dnl library search path. If at least one of its elements ends in /lib64 or
++  dnl points to a directory whose absolute pathname ends in /lib64, we use that
++  dnl for 64-bit ABIs. Similarly for 32-bit ABIs. Otherwise we use the default,
++  dnl namely "lib".
++  dnl On Solaris systems, the current practice is that on a system supporting
++  dnl 32-bit and 64-bit instruction sets or ABIs, 64-bit libraries go under
++  dnl $prefix/lib/64 (which is a symlink to either $prefix/lib/sparcv9 or
++  dnl $prefix/lib/amd64) and 32-bit libraries go under $prefix/lib.
++  AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_REQUIRE([gl_HOST_CPU_C_ABI_32BIT])
++
++  AC_CACHE_CHECK([for ELF binary format], [gl_cv_elf],
++    [AC_EGREP_CPP([Extensible Linking Format],
++       [#if defined __ELF__ || (defined __linux__ && (defined __EDG__ || defined __SUNPRO_C))
++        Extensible Linking Format
++        #endif
++       ],
++       [gl_cv_elf=yes],
++       [gl_cv_elf=no])
++    ])
++  if test $gl_cv_elf = yes; then
++    # Extract the ELF class of a file (5th byte) in decimal.
++    # Cf. https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
++    if od -A x < /dev/null >/dev/null 2>/dev/null; then
++      # Use POSIX od.
++      func_elfclass ()
++      {
++        od -A n -t d1 -j 4 -N 1
++      }
++    else
++      # Use BSD hexdump.
++      func_elfclass ()
++      {
++        dd bs=1 count=1 skip=4 2>/dev/null | hexdump -e '1/1 "%3d "'
++        echo
++      }
++    fi
++    # Use 'expr', not 'test', to compare the values of func_elfclass, because on
++    # Solaris 11 OpenIndiana and Solaris 11 OmniOS, the result is 001 or 002,
++    # not 1 or 2.
++changequote(,)dnl
++    case $HOST_CPU_C_ABI_32BIT in
++      yes)
++        # 32-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 1 > /dev/null
++        }
++        ;;
++      no)
++        # 64-bit ABI.
++        acl_is_expected_elfclass ()
++        {
++          expr "`func_elfclass | sed -e 's/[ 	]//g'`" = 2 > /dev/null
++        }
++        ;;
++      *)
++        # Unknown.
++        acl_is_expected_elfclass ()
++        {
++          :
++        }
++        ;;
++    esac
++changequote([,])dnl
++  else
++    acl_is_expected_elfclass ()
++    {
++      :
++    }
+   fi
++
++  dnl Allow the user to override the result by setting acl_cv_libdirstems.
++  AC_CACHE_CHECK([for the common suffixes of directories in the library search path],
++    [acl_cv_libdirstems],
++    [dnl Try 'lib' first, because that's the default for libdir in GNU, see
++     dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
++     acl_libdirstem=lib
++     acl_libdirstem2=
++     acl_libdirstem3=
++     case "$host_os" in
++       solaris*)
++         dnl See Solaris 10 Software Developer Collection > Solaris 64-bit Developer's Guide > The Development Environment
++         dnl <https://docs.oracle.com/cd/E19253-01/816-5138/dev-env/index.html>.
++         dnl "Portable Makefiles should refer to any library directories using the 64 symbolic link."
++         dnl But we want to recognize the sparcv9 or amd64 subdirectory also if the
++         dnl symlink is missing, so we set acl_libdirstem2 too.
++         if test $HOST_CPU_C_ABI_32BIT = no; then
++           acl_libdirstem2=lib/64
++           case "$host_cpu" in
++             sparc*)        acl_libdirstem3=lib/sparcv9 ;;
++             i*86 | x86_64) acl_libdirstem3=lib/amd64 ;;
++           esac
++         fi
++         ;;
++       netbsd*)
++         dnl On NetBSD/sparc64, there is a 'sparc' subdirectory that contains
++         dnl 32-bit libraries.
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           case "$host_cpu" in
++             sparc*) acl_libdirstem2=lib/sparc ;;
++           esac
++         fi
++         ;;
++       *)
++         dnl If $CC generates code for a 32-bit ABI, the libraries are
++         dnl surely under $prefix/lib or $prefix/lib32, not $prefix/lib64.
++         dnl Similarly, if $CC generates code for a 64-bit ABI, the libraries
++         dnl are surely under $prefix/lib or $prefix/lib64, not $prefix/lib32.
++         dnl Find the compiler's search path. However, non-system compilers
++         dnl sometimes have odd library search paths. But we can't simply invoke
++         dnl '/usr/bin/gcc -print-search-dirs' because that would not take into
++         dnl account the -m32/-m31 or -m64 options from the $CC or $CFLAGS.
++         searchpath=`(LC_ALL=C $CC $CPPFLAGS $CFLAGS -print-search-dirs) 2>/dev/null \
++                     | sed -n -e 's,^libraries: ,,p' | sed -e 's,^=,,'`
++         if test $HOST_CPU_C_ABI_32BIT != no; then
++           # 32-bit or unknown ABI.
++           if test -d /usr/lib32; then
++             acl_libdirstem2=lib32
++           fi
++         fi
++         if test $HOST_CPU_C_ABI_32BIT != yes; then
++           # 64-bit or unknown ABI.
++           if test -d /usr/lib64; then
++             acl_libdirstem3=lib64
++           fi
++         fi
++         if test -n "$searchpath"; then
++           acl_saved_IFS="${IFS= 	}"; IFS=":"
++           for searchdir in $searchpath; do
++             if test -d "$searchdir"; then
++               case "$searchdir" in
++                 */lib32/ | */lib32 ) acl_libdirstem2=lib32 ;;
++                 */lib64/ | */lib64 ) acl_libdirstem3=lib64 ;;
++                 */../ | */.. )
++                   # Better ignore directories of this form. They are misleading.
++                   ;;
++                 *) searchdir=`cd "$searchdir" && pwd`
++                    case "$searchdir" in
++                      */lib32 ) acl_libdirstem2=lib32 ;;
++                      */lib64 ) acl_libdirstem3=lib64 ;;
++                    esac ;;
++               esac
++             fi
++           done
++           IFS="$acl_saved_IFS"
++           if test $HOST_CPU_C_ABI_32BIT = yes; then
++             # 32-bit ABI.
++             acl_libdirstem3=
++           fi
++           if test $HOST_CPU_C_ABI_32BIT = no; then
++             # 64-bit ABI.
++             acl_libdirstem2=
++           fi
++         fi
++         ;;
++     esac
++     test -n "$acl_libdirstem2" || acl_libdirstem2="$acl_libdirstem"
++     test -n "$acl_libdirstem3" || acl_libdirstem3="$acl_libdirstem"
++     acl_cv_libdirstems="$acl_libdirstem,$acl_libdirstem2,$acl_libdirstem3"
++    ])
++  dnl Decompose acl_cv_libdirstems into acl_libdirstem, acl_libdirstem2, and
++  dnl acl_libdirstem3.
++changequote(,)dnl
++  acl_libdirstem=`echo "$acl_cv_libdirstems" | sed -e 's/,.*//'`
++  acl_libdirstem2=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,//' -e 's/,.*//'`
++  acl_libdirstem3=`echo "$acl_cv_libdirstems" | sed -e 's/^[^,]*,[^,]*,//' -e 's/,.*//'`
++changequote([,])dnl
+ ])
+diff --git a/m4/nls.m4 b/m4/nls.m4
+new file mode 100644
+index 0000000..c460141
+--- /dev/null
++++ b/m4/nls.m4
+@@ -0,0 +1,33 @@
++# nls.m4
++# serial 6 (gettext-0.24)
++dnl Copyright (C) 1995-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
++
++AC_PREREQ([2.50])
++
++AC_DEFUN([AM_NLS],
++[
++  AC_MSG_CHECKING([whether NLS is requested])
++  dnl Default is enabled NLS
++  AC_ARG_ENABLE([nls],
++    [  --disable-nls           do not use Native Language Support],
++    USE_NLS=$enableval, USE_NLS=yes)
++  AC_MSG_RESULT([$USE_NLS])
++  AC_SUBST([USE_NLS])
++])
+diff --git a/m4/po.m4 b/m4/po.m4
+new file mode 100644
+index 0000000..73e0436
+--- /dev/null
++++ b/m4/po.m4
+@@ -0,0 +1,157 @@
++# po.m4
++# serial 34 (gettext-0.24)
++dnl Copyright (C) 1995-2024 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
++dnl   Bruno Haible <bruno@clisp.org>, 2000-2024.
++
++AC_PREREQ([2.60])
++
++dnl Checks for all prerequisites of the po subdirectory.
++AC_DEFUN([AM_PO_SUBDIRS],
++[
++  AC_REQUIRE([AC_PROG_MAKE_SET])dnl
++  AC_REQUIRE([AC_PROG_INSTALL])dnl
++  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
++  AC_REQUIRE([AC_PROG_SED])dnl
++  AC_REQUIRE([AM_NLS])dnl
++
++  dnl Release version of the gettext macros. This is used to ensure that
++  dnl the gettext macros and po/Makefile.in.in are in sync.
++  AC_SUBST([GETTEXT_MACRO_VERSION], [0.24])
++
++  dnl Perform the following tests also if --disable-nls has been given,
++  dnl because they are needed for "make dist" to work.
++
++  dnl Search for GNU msgfmt in the PATH.
++  dnl The first test excludes Solaris msgfmt and early GNU msgfmt versions.
++  dnl The second test excludes FreeBSD msgfmt.
++  AM_PATH_PROG_WITH_TEST(MSGFMT, msgfmt,
++    [$ac_dir/$ac_word --statistics /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --statistics /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  AC_PATH_PROG([GMSGFMT], [gmsgfmt], [$MSGFMT])
++
++  dnl Test whether it is GNU msgfmt >= 0.15.
++changequote(,)dnl
++  case `$GMSGFMT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) GMSGFMT_015=: ;;
++    *) GMSGFMT_015=$GMSGFMT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([GMSGFMT_015])
++
++  dnl Search for GNU xgettext 0.12 or newer in the PATH.
++  dnl The first test excludes Solaris xgettext and early GNU xgettext versions.
++  dnl The second test excludes FreeBSD xgettext.
++  AM_PATH_PROG_WITH_TEST(XGETTEXT, xgettext,
++    [$ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1 &&
++     (if $ac_dir/$ac_word --omit-header --copyright-holder= --msgid-bugs-address= /dev/null 2>&1 >/dev/null | grep usage >/dev/null; then exit 1; else exit 0; fi)],
++    :)
++  dnl Remove leftover from FreeBSD xgettext call.
++  rm -f messages.po
++
++  dnl Test whether it is GNU xgettext >= 0.15.
++changequote(,)dnl
++  case `$XGETTEXT --version | sed 1q | sed -e 's,^[^0-9]*,,'` in
++    '' | 0.[0-9] | 0.[0-9].* | 0.1[0-4] | 0.1[0-4].*) XGETTEXT_015=: ;;
++    *) XGETTEXT_015=$XGETTEXT ;;
++  esac
++changequote([,])dnl
++  AC_SUBST([XGETTEXT_015])
++
++  dnl Search for GNU msgmerge 0.11 or newer in the PATH.
++  AM_PATH_PROG_WITH_TEST(MSGMERGE, msgmerge,
++    [$ac_dir/$ac_word --update -q /dev/null /dev/null >&]AS_MESSAGE_LOG_FD[ 2>&1], :)
++
++  dnl Test whether it is GNU msgmerge >= 0.20.
++  if LC_ALL=C $MSGMERGE --help | grep ' --for-msgfmt ' >/dev/null; then
++    MSGMERGE_FOR_MSGFMT_OPTION='--for-msgfmt'
++  else
++    dnl Test whether it is GNU msgmerge >= 0.12.
++    if LC_ALL=C $MSGMERGE --help | grep ' --no-fuzzy-matching ' >/dev/null; then
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-fuzzy-matching --no-location --quiet'
++    else
++      dnl With these old versions, $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) is
++      dnl slow. But this is not a big problem, as such old gettext versions are
++      dnl hardly in use any more.
++      MSGMERGE_FOR_MSGFMT_OPTION='--no-location --quiet'
++    fi
++  fi
++  AC_SUBST([MSGMERGE_FOR_MSGFMT_OPTION])
++
++  dnl Support for AM_XGETTEXT_OPTION.
++  test -n "${XGETTEXT_EXTRA_OPTIONS+set}" || XGETTEXT_EXTRA_OPTIONS=
++  AC_SUBST([XGETTEXT_EXTRA_OPTIONS])
++
++  if test -n "$ALL_LINGUAS"; then
++    test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
++  fi
++
++  dnl Capture the value of LINGUAS because we need it to compute CATALOGS.
++  dnl In the Makefile, call it DESIRED_LINGUAS (because there, LINGUAS denotes
++  dnl the set of available translations, given by the developer).
++  DESIRED_LINGUAS="${LINGUAS-\$(ALL_LINGUAS)}"
++  AC_SUBST([DESIRED_LINGUAS])
++
++  AC_CONFIG_COMMANDS([po-directories], [[
++    for ac_file in $CONFIG_FILES; do
++      # Support "outfile[:infile[:infile...]]"
++      case "$ac_file" in
++        *:*) ac_file=`echo "$ac_file"|sed 's%:.*%%'` ;;
++      esac
++      # PO directories have a Makefile.in generated from Makefile.in.in.
++      case "$ac_file" in */Makefile.in)
++        # Adjust a relative srcdir.
++        ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
++        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
++        ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
++        # In autoconf-2.13 it is called $ac_given_srcdir.
++        # In autoconf-2.50 it is called $srcdir.
++        test -n "$ac_given_srcdir" || ac_given_srcdir="$srcdir"
++        # Treat a directory as a PO directory if and only if it has a
++        # POTFILES.in file. This allows packages to have multiple PO
++        # directories under different names or in different locations.
++        if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
++          test -n "$as_me" && echo "$as_me: creating $ac_dir/Makefile" || echo "creating $ac_dir/Makefile"
++          cat "$ac_dir/Makefile.in" > "$ac_dir/Makefile"
++        fi
++        ;;
++      esac
++    done]],
++   [])
++])
++
++dnl Postprocesses a Makefile in a directory containing PO files.
++AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
++[
++  sed -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
++  mv "$ac_file.tmp" "$ac_file"
++])
++
++dnl Initializes the accumulator used by AM_XGETTEXT_OPTION.
++AC_DEFUN([AM_XGETTEXT_OPTION_INIT],
++[
++  XGETTEXT_EXTRA_OPTIONS=
++])
++
++dnl Registers an option to be passed to xgettext in the po subdirectory.
++AC_DEFUN([AM_XGETTEXT_OPTION],
++[
++  AC_REQUIRE([AM_XGETTEXT_OPTION_INIT])
++  XGETTEXT_EXTRA_OPTIONS="$XGETTEXT_EXTRA_OPTIONS $1"
++])
+diff --git a/m4/progtest.m4 b/m4/progtest.m4
+new file mode 100644
+index 0000000..0ae1346
+--- /dev/null
++++ b/m4/progtest.m4
+@@ -0,0 +1,93 @@
++# progtest.m4
++# serial 11 (gettext-0.26)
++dnl Copyright (C) 1996-2025 Free Software Foundation, Inc.
++dnl This file is free software; the Free Software Foundation
++dnl gives unlimited permission to copy and/or distribute it,
++dnl with or without modifications, as long as this notice is preserved.
++dnl This file is offered as-is, without any warranty.
++dnl
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
++dnl License but which still want to provide support for the GNU gettext
++dnl functionality.
++dnl Please note that the actual code of the GNU gettext library is covered
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
++dnl They are *not* in the public domain.
++
++dnl Authors:
++dnl   Ulrich Drepper <drepper@cygnus.com>, 1996.
++
++AC_PREREQ([2.53])
++
++# Search path for a program which passes the given test.
++
++dnl AM_PATH_PROG_WITH_TEST(VARIABLE, PROG-TO-CHECK-FOR,
++dnl   TEST-PERFORMED-ON-FOUND_PROGRAM [, VALUE-IF-NOT-FOUND [, PATH]])
++AC_DEFUN([AM_PATH_PROG_WITH_TEST],
++[
++# Prepare PATH_SEPARATOR.
++# The user is always right.
++if test "${PATH_SEPARATOR+set}" != set; then
++  # Determine PATH_SEPARATOR by trying to find /bin/sh in a PATH which
++  # contains only /bin. Note that ksh looks also at the FPATH variable,
++  # so we have to set that as well for the test.
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++    && { (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 \
++           || PATH_SEPARATOR=';'
++       }
++fi
++
++# Find out how to test for executable files. Don't use a zero-byte file,
++# as systems may use methods other than mode bits to determine executability.
++cat >conf$$.file <<_ASEOF
++#! /bin/sh
++exit 0
++_ASEOF
++chmod +x conf$$.file
++if test -x conf$$.file >/dev/null 2>&1; then
++  ac_executable_p="test -x"
++else
++  ac_executable_p="test -f"
++fi
++rm -f conf$$.file
++
++# Extract the first word of "$2", so it can be a program name with args.
++set dummy $2; ac_word=[$]2
++AC_MSG_CHECKING([for $ac_word])
++AC_CACHE_VAL([ac_cv_path_$1],
++[case "[$]$1" in
++  [[\\/]]* | ?:[[\\/]]*)
++    ac_cv_path_$1="[$]$1" # Let the user override the test with a path.
++    ;;
++  *)
++    gt_saved_IFS="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in m4_if([$5], , $PATH, [$5]); do
++      IFS="$gt_saved_IFS"
++      test -z "$ac_dir" && ac_dir=.
++      for ac_exec_ext in '' $ac_executable_extensions; do
++        if $ac_executable_p "$ac_dir/$ac_word$ac_exec_ext"; then
++          echo "$as_me:${as_lineno-$LINENO}: trying $ac_dir/$ac_word..." >&AS_MESSAGE_LOG_FD
++          if [$3]; then
++            ac_cv_path_$1="$ac_dir/$ac_word$ac_exec_ext"
++            break 2
++          fi
++        fi
++      done
++    done
++    IFS="$gt_saved_IFS"
++dnl If no 4th arg is given, leave the cache variable unset,
++dnl so AC_PATH_PROGS will keep looking.
++m4_if([$4], , , [  test -z "[$]ac_cv_path_$1" && ac_cv_path_$1="$4"
++])dnl
++    ;;
++esac])dnl
++$1="$ac_cv_path_$1"
++if test m4_if([$4], , [-n "[$]$1"], ["[$]$1" != "$4"]); then
++  AC_MSG_RESULT([$][$1])
++else
++  AC_MSG_RESULT([no])
++fi
++AC_SUBST([$1])dnl
++])
+-- 
+2.51.0
+

--- a/runtime-network/gwenhywfar/spec
+++ b/runtime-network/gwenhywfar/spec
@@ -1,4 +1,6 @@
-VER=5.10.2
-SRCS="tbl::https://www.aquamaniac.de/rdm/attachments/download/501/gwenhywfar-$VER.tar.gz"   
-CHKSUMS="sha256::60A7DA03542865501208F20E18DE32B45A75E3F4AA8515CA622B391A2728A9E1"
+VER=5.12.1
+# Note: The `5xx` will change with the tarball version,
+# Please manually obtain the tarball url.
+SRCS="tbl::https://www.aquamaniac.de/rdm/attachments/download/533/gwenhywfar-$VER.tar.gz"   
+CHKSUMS="sha256::d188448b9c3a9709721422ee0134b9d0b7790ab7514058d99e04399e39465dda"
 CHKUPDATE="anitya::id=6891"


### PR DESCRIPTION
Topic Description
-----------------

- spek-x: patch to include gettext macros
- xclock: patch to include gettext macros
- fluxbox: patch to include gettext macros
- cabextract: patch to include gettext macros
- libmtp: patch to include gettext macros
- dvdauthor: patch to include gettext macros
- mate-icon-theme: patch to include gettext macros
- mate-calc: patch to include gettext macros
- mate-user-guide: patch to include gettext macros
- kakasi: patch to include gettext macros

... and 5 more commits

Package(s) Affected
-------------------

- cabextract: 1.11-1
- dvdauthor: 0.7.2-3
- fbsetbg: 1.3.7-10
- fluxbox: 1.3.7-10
- gwenhywfar: 5.12.1
- ibus-kkc: 1.5.22-5
- kakasi: 2.3.6-1
- libfm: 1.4.0
- libmtp: 1.1.22-1
- mate-calc: 1.28.0-1
- mate-icon-theme: 1.28.0-1
- mate-user-guide: 1.28.0-1
- menu-cache: 1.1.0-1
- sound-theme-freedesktop: 0.8-3
- spek-x: 0.9.4-1
- xclock: 1.1.1-1
- xdg-user-dirs: 0.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfm:+stage2 menu-cache libfm xdg-user-dirs sound-theme-freedesktop gwenhywfar ibus-kkc kakasi mate-user-guide mate-calc mate-icon-theme dvdauthor libmtp cabextract fluxbox xclock spek-x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
