### PR TITLE
ncompress: update to 5.0

### DIFF
--- a/app-utils/ncompress/autobuild/build
+++ b/app-utils/ncompress/autobuild/build
@@ -1,5 +1,8 @@
+abinfo "Building ncompress ..."
 make
-install -dm755 "$PKGDIR"/usr/bin
-install -dm755 "$PKGDIR"/usr/share/man/man1
-install -m755 compress "$PKGDIR"/usr/bin
-install -m644 compress.1 "$PKGDIR"/usr/share/man/man1
+
+abinfo "Installing ncompress ..."
+install -Dvm755 "$SRCDIR"/compress \
+    "$PKGDIR"/usr/bin/compress
+install -Dvm644 "$SRCDIR"/compress.1 \
+    "$PKGDIR"/usr/share/man/man1/compress.1

--- a/app-utils/ncompress/autobuild/defines
+++ b/app-utils/ncompress/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=ncompress
 PKGSEC=utils
 PKGDEP="glibc"
-PKGDES="The classic Unix compression utility which can handle the ancient .Z archive"
+PKGDES="Utility to handle .Z archives"
 
+ABTYPE=self
 PKGPROV="compress"

--- a/app-utils/ncompress/spec
+++ b/app-utils/ncompress/spec
@@ -1,5 +1,4 @@
-VER=4.2.4.6
-REL=1
-SRCS="tbl::https://github.com/vapier/ncompress/archive/v$VER.tar.gz"
-CHKSUMS="sha256::112acfc76382e7b631d6cfc8e6ff9c8fd5b3677e5d49d3d9f1657bc15ad13d13"
+VER=5.0
+SRCS="git::commit=tags/v$VER::https://github.com/vapier/ncompress"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2056"


### PR DESCRIPTION
Topic Description
-----------------

- ncompress: update to 5.0
  - change to git source
  Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- ncompress: 5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncompress
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
