### PR TITLE
cinnamon-settings-daemon: fix build with GCC>=14

### DIFF
--- a/desktop-cinnamon/cinnamon-settings-daemon/autobuild/patches/0001-BAKCPORT-Fix-compile-issue-386.patch
+++ b/desktop-cinnamon/cinnamon-settings-daemon/autobuild/patches/0001-BAKCPORT-Fix-compile-issue-386.patch
@@ -1,0 +1,43 @@
+From cc989ff0cbf2b4f63e87a0bb08de09564990aef1 Mon Sep 17 00:00:00 2001
+From: Leigh Scott <leigh123linux@gmail.com>
+Date: Mon, 5 Feb 2024 16:07:03 +0000
+Subject: [PATCH] BAKCPORT: Fix compile issue (#386)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+(Warning becomes an error due to gcc 14 changes)
+
+Link: https://github.com/linuxmint/cinnamon-settings-daemon/commit/48da3c4763bea93ea3e1d2ba2e2dfdb7f41d8afc
+
+../plugins/keyboard/gkbd-configuration.c: In function ‘gkbd_configuration_get_group_names’:
+../plugins/keyboard/gkbd-configuration.c:343:35: error: returning ‘gchar **’ {aka ‘char **’} from a function with incompatible return type ‘const char * const*’ [-Wincompatible-pointer-types]
+343 | return configuration->priv->full_group_names;
+| ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ plugins/keyboard/gkbd-configuration.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/plugins/keyboard/gkbd-configuration.c b/plugins/keyboard/gkbd-configuration.c
+index ca39492..6d8e682 100644
+--- a/plugins/keyboard/gkbd-configuration.c
++++ b/plugins/keyboard/gkbd-configuration.c
+@@ -340,11 +340,11 @@ gkbd_configuration_get_xkl_engine (GkbdConfiguration *configuration)
+ const char * const *
+ gkbd_configuration_get_group_names (GkbdConfiguration *configuration)
+ {
+-	return configuration->priv->full_group_names;
++	return (const char * const *)configuration->priv->full_group_names;
+ }
+ 
+ const char * const *
+ gkbd_configuration_get_short_group_names (GkbdConfiguration *configuration)
+ {
+-	return configuration->priv->short_group_names;
++	return (const char * const *)configuration->priv->short_group_names;
+ }
+-- 
+2.51.0
+

--- a/desktop-cinnamon/cinnamon-settings-daemon/spec
+++ b/desktop-cinnamon/cinnamon-settings-daemon/spec
@@ -1,4 +1,5 @@
 VER=5.8.1
+REL=1
 SRCS="tbl::https://github.com/linuxmint/cinnamon-settings-daemon/archive/$VER.tar.gz"
 CHKSUMS="sha256::8b8a80b24755061128e45a064dc8320ce94b7f9bc9e13fd66fc5fae07e9de3a4"
 CHKUPDATE="anitya::id=6389"


### PR DESCRIPTION
Topic Description
-----------------

- cinnamon-settings-daemon: fix build with GCC>=14
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- cinnamon-settings-daemon: 5.8.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinnamon-settings-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
