### PR TITLE
gnome-keyring: fix build for GCC>=14

### DIFF
--- a/desktop-gnome/gnome-keyring/autobuild/defines
+++ b/desktop-gnome/gnome-keyring/autobuild/defines
@@ -4,6 +4,8 @@ PKGDEP="gcr libcap-ng"
 BUILDDEP="gtk-doc intltool"
 PKGDES="GNOME password management daemon"
 
-AUTOTOOLS_AFTER="--with-pam-dir=/usr/lib/security \
-                 --disable-schemas-compile"
+AUTOTOOLS_AFTER=(
+	"--with-pam-dir=/usr/lib/security"
+	"--disable-schemas-compile"
+)
 ABSHADOW=0

--- a/desktop-gnome/gnome-keyring/autobuild/patches/0001-BACKPORT-Fix-implicit-declaration-of-utimes-and-gett.patch
+++ b/desktop-gnome/gnome-keyring/autobuild/patches/0001-BACKPORT-Fix-implicit-declaration-of-utimes-and-gett.patch
@@ -1,0 +1,43 @@
+From 31bb2f0ded06c5fba2081a6415b46644d9eeafe1 Mon Sep 17 00:00:00 2001
+From: Ryan Schmidt <gnome@ryandesign.com>
+Date: Thu, 24 Mar 2022 02:47:30 +0000
+Subject: [PATCH] BACKPORT: Fix implicit declaration of utimes and
+ gettimeofday.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Link: https://gitlab.gnome.org/GNOME/gnome-keyring/-/commit/9ffd7b88dfa880ce3e3cb0e3344adb8ee7ef1bd9
+
+pkcs11/xdg-store/mock-xdg-module.c: In function ‘mock_xdg_module_touch_file’:
+pkcs11/xdg-store/mock-xdg-module.c:91:9: error: implicit declaration of function ‘gettimeofday’ [-Wimplicit-function-declaration]
+91 | gettimeofday (tv, NULL);
+| ^~~~~~~~~~~~
+pkcs11/xdg-store/mock-xdg-module.c:91:9: warning: nested extern declaration of ‘gettimeofday’ [-Wnested-externs]
+pkcs11/xdg-store/mock-xdg-module.c:95:13: error: implicit declaration of function ‘utimes’; did you mean ‘times’? [-Wimplicit-function-declaration]
+95 | if (utimes (filename, tv) < 0)
+| ^~~~~~
+| times
+pkcs11/xdg-store/mock-xdg-module.c:95:13: warning: nested extern declaration of ‘utimes’ [-Wnested-externs]
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ pkcs11/xdg-store/mock-xdg-module.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkcs11/xdg-store/mock-xdg-module.c b/pkcs11/xdg-store/mock-xdg-module.c
+index acfc85fc..631b88f7 100644
+--- a/pkcs11/xdg-store/mock-xdg-module.c
++++ b/pkcs11/xdg-store/mock-xdg-module.c
+@@ -36,7 +36,7 @@
+ #include <glib/gstdio.h>
+ 
+ #include <errno.h>
+-#include <sys/times.h>
++#include <sys/time.h>
+ 
+ #include <string.h>
+ 
+-- 
+2.51.0
+

--- a/desktop-gnome/gnome-keyring/spec
+++ b/desktop-gnome/gnome-keyring/spec
@@ -2,4 +2,4 @@ VER=40.0
 SRCS="tbl::https://download.gnome.org/sources/gnome-keyring/${VER%.*}/gnome-keyring-$VER.tar.xz"
 CHKSUMS="sha256::a3d24db08ee2fdf240fbbf0971a98c8ee295aa0e1a774537f4ea938038a3b931"
 CHKUPDATE="anitya::id=13133"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gnome-keyring: fix build for GCC>=14
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- gnome-keyring: 40.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
