### PR TITLE
marisa: update to 0.2.7

### DIFF
--- a/runtime-common/marisa/autobuild/beyond
+++ b/runtime-common/marisa/autobuild/beyond
@@ -1,15 +1,39 @@
-pushd bindings/perl
-perl Makefile.PL \
-     INC="-I${SRCDIR}/lib" \
-     LIBS="-L${SRCDIR}/lib/.libs"
-make
-make install DESTDIR="$PKGDIR"
+abinfo "Regenerating swig-python bindings"
+make swig-python \
+    --directory="$SRCDIR"/bindings
+
+pushd "$SRCDIR"/bindings/python3
+abinfo "Building Python3 bindings ..."
+python3 setup.py build_ext \
+    --include-dirs="$SRCDIR/include" \
+    --library-dirs="$SRCDIR/lib/marisa/.libs"
+abinfo "Installing Python3 bindings ..."
+python3 setup.py install \
+    --prefix=/usr \
+    --root="$PKGDIR" \
+    --optimize=1 
 popd
 
-pushd bindings/python
-python2 setup.py build_ext \
-                 --include-dirs="$SRCDIR"/lib \
-                 --library-dirs="$SRCDIR"/lib/.libs
-CC=gcc python2 setup.py build
-python2 setup.py install -O1 --root="$PKGDIR"
+pushd "$SRCDIR"/bindings/perl
+abinfo "Building Perl bindings ..."
+perl Makefile.PL \
+    -I"$SRCDIR/bindings/perl" \
+    INSTALLDIRS=vendor \
+    INC="-I$SRCDIR/include" \
+    LIBS="-L$SRCDIR/lib/marisa/.libs"
+make
+abinfo "Installing Perl bindings ..."
+make install \
+    DESTDIR="$PKGDIR"
+popd
+
+pushd "$SRCDIR"/bindings/ruby
+abinfo "Building Ruby bindings ..."
+ruby extconf.rb \
+    --vendor \
+    --with-opt-include="$SRCDIR/include" \
+    --with-opt-lib="$SRCDIR/lib/marisa/.libs"
+abinfo "Installing Ruby bindings ..."
+make install \
+    DESTDIR="$PKGDIR"
 popd

--- a/runtime-common/marisa/autobuild/defines
+++ b/runtime-common/marisa/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=marisa
 PKGSEC=libs
 PKGDEP="gcc-runtime"
-BUILDDEP="perl python-2 gobject-introspection vala"
+BUILDDEP="perl python-3 ruby gobject-introspection swig vala"
 BUILDDEP__RETRO=""
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -11,7 +11,8 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
-PKGSUG="perl python-2"
+PKGSUG="perl python-3 ruby"
 PKGDES="Static and space-efficient trie data structure library"
 
+ABTYPE=autotools
 ABSHADOW=0

--- a/runtime-common/marisa/spec
+++ b/runtime-common/marisa/spec
@@ -1,4 +1,5 @@
-VER=0.2.4
-REL=7
-SRCS="tbl::https://src.fedoraproject.org/lookaside/pkgs/marisa/marisa-0.2.4.tar.gz/55192e66f6f9e3d04924a6ebb8eec02a/marisa-0.2.4.tar.gz"
-CHKSUMS="sha256::67a7a4f70d3cc7b0a85eb08f10bc3eaf6763419f0c031f278c1f919121729fb3"
+# FIXME: For now (0.3.2), upstream CMake support remains incomplete.
+VER=0.2.7
+SRCS="git::commit=tags/v$VER::https://github.com/s-yata/marisa-trie.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242978"


### PR DESCRIPTION
Topic Description
-----------------

- marisa: update to 0.2.7
    - Drop python2 support.
    - Build Ruby binding.

Package(s) Affected
-------------------

- marisa: 0.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit marisa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
