### PR TITLE
cinnamon-control-center: fix build with GCC>=14

### DIFF
--- a/desktop-cinnamon/cinnamon-control-center/autobuild/defines
+++ b/desktop-cinnamon/cinnamon-control-center/autobuild/defines
@@ -6,8 +6,10 @@ PKGDEP="at-spi2-core cinnamon-menus cinnamon-settings-daemon colord \
 BUILDDEP="gnome-common intltool"
 PKGDES="Centralized settings manager for Cinnamon"
 
-MESON_AFTER="-Dcolor=true \
-             -Dmodemmanager=true \
-             -Dnetworkmanager=true \
-             -Donlineaccounts=true \
-             -Dwacom=true"
+MESON_AFTER=(
+	"-Dcolor=true"
+	"-Dmodemmanager=true"
+	"-Dnetworkmanager=true"
+	"-Donlineaccounts=true"
+	"-Dwacom=true"
+)

--- a/desktop-cinnamon/cinnamon-control-center/autobuild/patches/0001-BACKPORT-network-Fix-warning-about-missing-cast-to-G.patch
+++ b/desktop-cinnamon/cinnamon-control-center/autobuild/patches/0001-BACKPORT-network-Fix-warning-about-missing-cast-to-G.patch
@@ -1,0 +1,31 @@
+From f6c147c8a4aee92540938599b9afca253b11db54 Mon Sep 17 00:00:00 2001
+From: Leigh Scott <leigh123linux@gmail.com>
+Date: Thu, 18 Jan 2024 21:30:28 +0000
+Subject: [PATCH] BACKPORT: network: Fix warning about missing cast to
+ GtkWidget* (#324)
+
+Based on https://github.com/GNOME/gnome-control-center/commit/167d11e2107e46b4621cf6fc370c5b191b4b7732
+
+(cherry picked from commit 0361ff2974eb4741f3cd8b6db00dbe1ab56c8a59)
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ panels/network/connection-editor/net-connection-editor.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/panels/network/connection-editor/net-connection-editor.c b/panels/network/connection-editor/net-connection-editor.c
+index b94144a..40be068 100644
+--- a/panels/network/connection-editor/net-connection-editor.c
++++ b/panels/network/connection-editor/net-connection-editor.c
+@@ -845,7 +845,7 @@ net_connection_editor_new (GtkWindow        *parent_window,
+         editor = g_object_new (NET_TYPE_CONNECTION_EDITOR, NULL);
+ 
+         if (parent_window) {
+-                editor->parent_window = g_object_ref (parent_window);
++                editor->parent_window = GTK_WIDGET (g_object_ref (parent_window));
+                 gtk_window_set_transient_for (GTK_WINDOW (editor->window),
+                                               parent_window);
+         }
+-- 
+2.51.0
+

--- a/desktop-cinnamon/cinnamon-control-center/spec
+++ b/desktop-cinnamon/cinnamon-control-center/spec
@@ -2,4 +2,4 @@ VER=5.8.1
 SRCS="tbl::https://github.com/linuxmint/cinnamon-control-center/archive/$VER.tar.gz"
 CHKSUMS="sha256::b2d7aebe0fd5b25d7d951ef79685ac72e655d23ec54763cce4aaf625b47f9675"
 CHKUPDATE="anitya::id=15189"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- cinnamon-control-center: fix build with GCC>=14
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- cinnamon-control-center: 5.8.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinnamon-control-center
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
