### PR TITLE
telepathy-logger: fix build with python3 and c89

### DIFF
--- a/runtime-web/telepathy-logger/autobuild/defines
+++ b/runtime-web/telepathy-logger/autobuild/defines
@@ -4,8 +4,10 @@ PKGDEP="telepathy-glib sqlite libxml2 dconf"
 BUILDDEP="libxslt intltool gobject-introspection"
 PKGDES="Telepathy framework logging daemon"
 
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib/telepathy \
-                 --disable-static \
-                 --disable-schemas-compile"
+AUTOTOOLS_AFTER=(
+	"--libexecdir=/usr/lib/telepathy"
+	"--disable-static"
+	"--disable-schemas-compile"
+)
 RECONF=0
 ABTYPE=autotools

--- a/runtime-web/telepathy-logger/autobuild/patches/0001-BACKPORT-tools-Fix-the-build-with-Python-3.patch
+++ b/runtime-web/telepathy-logger/autobuild/patches/0001-BACKPORT-tools-Fix-the-build-with-Python-3.patch
@@ -1,0 +1,432 @@
+From ebba40ac64d2c5fcbe497f807da1419acc21d0a3 Mon Sep 17 00:00:00 2001
+From: Debarshi Ray <debarshir@freedesktop.org>
+Date: Mon, 10 Feb 2020 15:20:38 +0100
+Subject: [PATCH 1/2] BACKPORT: tools: Fix the build with Python 3
+
+This is a subset of commit 4a9fdeb64bc87f09 from master.
+
+https://gitlab.freedesktop.org/telepathy/telepathy-logger/merge_requests/1
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ tools/c-constants-gen.py            | 12 ++++++------
+ tools/glib-client-gen.py            | 18 ++++++------------
+ tools/glib-client-marshaller-gen.py | 20 ++++++++++----------
+ tools/glib-ginterface-gen.py        | 22 ++++++++--------------
+ tools/glib-gtypes-generator.py      | 14 +++++++-------
+ tools/glib-interfaces-gen.py        | 14 +++++++-------
+ tools/libglibcodegen.py             |  4 ++--
+ tools/libtpcodegen.py               | 22 +++++++++++++++++++++-
+ tools/xincludator.py                | 13 ++++++++++---
+ 9 files changed, 77 insertions(+), 62 deletions(-)
+
+diff --git a/tools/c-constants-gen.py b/tools/c-constants-gen.py
+index c7a93d3..a08afee 100644
+--- a/tools/c-constants-gen.py
++++ b/tools/c-constants-gen.py
+@@ -3,7 +3,7 @@
+ from sys import argv, stdout, stderr
+ import xml.dom.minidom
+ 
+-from libtpcodegen import file_set_contents
++from libtpcodegen import file_set_contents, u
+ from libglibcodegen import NS_TP, get_docstring, \
+         get_descendant_text, get_by_path
+ 
+@@ -12,7 +12,7 @@ class Generator(object):
+         self.prefix = prefix + '_'
+         self.spec = get_by_path(dom, "spec")[0]
+ 
+-	self.output_base = output_base
++        self.output_base = output_base
+         self.__header = []
+         self.__docs = []
+ 
+@@ -21,14 +21,14 @@ class Generator(object):
+         self.do_body()
+         self.do_footer()
+ 
+-        file_set_contents(self.output_base + '.h', ''.join(self.__header))
+-        file_set_contents(self.output_base + '-gtk-doc.h', ''.join(self.__docs))
++        file_set_contents(self.output_base + '.h', u('').join(self.__header).encode('utf-8'))
++        file_set_contents(self.output_base + '-gtk-doc.h', u('').join(self.__docs).encode('utf-8'))
+ 
+     def write(self, code):
+-        self.__header.append(code.encode('utf-8'))
++        self.__header.append(code)
+ 
+     def d(self, code):
+-        self.__docs.append(code.encode('utf-8'))
++        self.__docs.append(code)
+ 
+     # Header
+     def do_header(self):
+diff --git a/tools/glib-client-gen.py b/tools/glib-client-gen.py
+index 6b2b97f..fb083a1 100644
+--- a/tools/glib-client-gen.py
++++ b/tools/glib-client-gen.py
+@@ -27,8 +27,8 @@ import os.path
+ import xml.dom.minidom
+ from getopt import gnu_getopt
+ 
+-from libtpcodegen import file_set_contents
+-from libglibcodegen import Signature, type_to_gtype, cmp_by_name, \
++from libtpcodegen import file_set_contents, key_by_name, u
++from libglibcodegen import Signature, type_to_gtype, \
+         get_docstring, xml_escape, get_deprecated
+ 
+ 
+@@ -74,18 +74,12 @@ class Generator(object):
+         self.guard = opts.get('--guard', None)
+ 
+     def h(self, s):
+-        if isinstance(s, unicode):
+-            s = s.encode('utf-8')
+         self.__header.append(s)
+ 
+     def b(self, s):
+-        if isinstance(s, unicode):
+-            s = s.encode('utf-8')
+         self.__body.append(s)
+ 
+     def d(self, s):
+-        if isinstance(s, unicode):
+-            s = s.encode('utf-8')
+         self.__docs.append(s)
+ 
+     def get_iface_quark(self):
+@@ -1187,7 +1181,7 @@ class Generator(object):
+         self.b('')
+ 
+         nodes = self.dom.getElementsByTagName('node')
+-        nodes.sort(cmp_by_name)
++        nodes.sort(key=key_by_name)
+ 
+         for node in nodes:
+             self.do_interface(node)
+@@ -1240,9 +1234,9 @@ class Generator(object):
+             self.h('#endif /* defined (%s) */' % self.guard)
+             self.h('')
+ 
+-        file_set_contents(self.basename + '.h', '\n'.join(self.__header))
+-        file_set_contents(self.basename + '-body.h', '\n'.join(self.__body))
+-        file_set_contents(self.basename + '-gtk-doc.h', '\n'.join(self.__docs))
++        file_set_contents(self.basename + '.h', u('\n').join(self.__header).encode('utf-8'))
++        file_set_contents(self.basename + '-body.h', u('\n').join(self.__body).encode('utf-8'))
++        file_set_contents(self.basename + '-gtk-doc.h', u('\n').join(self.__docs).encode('utf-8'))
+ 
+ def types_to_gtypes(types):
+     return [type_to_gtype(t)[1] for t in types]
+diff --git a/tools/glib-client-marshaller-gen.py b/tools/glib-client-marshaller-gen.py
+index cb27d63..cd9823b 100644
+--- a/tools/glib-client-marshaller-gen.py
++++ b/tools/glib-client-marshaller-gen.py
+@@ -31,23 +31,23 @@ class Generator(object):
+         for signal in signals:
+             self.do_signal(signal)
+ 
+-        print 'void'
+-        print '%s_register_dbus_glib_marshallers (void)' % self.prefix
+-        print '{'
++        print('void')
++        print('%s_register_dbus_glib_marshallers (void)' % self.prefix)
++        print('{')
+ 
+-        all = self.marshallers.keys()
++        all = list(self.marshallers.keys())
+         all.sort()
+         for marshaller in all:
+             rhs = self.marshallers[marshaller]
+ 
+-            print '  dbus_g_object_register_marshaller ('
+-            print '      g_cclosure_marshal_generic,'
+-            print '      G_TYPE_NONE,       /* return */'
++            print('  dbus_g_object_register_marshaller (')
++            print('      g_cclosure_marshal_generic,')
++            print('      G_TYPE_NONE,       /* return */')
+             for type in rhs:
+-                print '      G_TYPE_%s,' % type.replace('VOID', 'NONE')
+-            print '      G_TYPE_INVALID);'
++                print('      G_TYPE_%s,' % type.replace('VOID', 'NONE'))
++            print('      G_TYPE_INVALID);')
+ 
+-        print '}'
++        print('}')
+ 
+ 
+ def types_to_gtypes(types):
+diff --git a/tools/glib-ginterface-gen.py b/tools/glib-ginterface-gen.py
+index 7843977..97369d3 100644
+--- a/tools/glib-ginterface-gen.py
++++ b/tools/glib-ginterface-gen.py
+@@ -26,8 +26,8 @@ import sys
+ import os.path
+ import xml.dom.minidom
+ 
+-from libtpcodegen import file_set_contents
+-from libglibcodegen import Signature, type_to_gtype, cmp_by_name, \
++from libtpcodegen import file_set_contents, key_by_name, u
++from libglibcodegen import Signature, type_to_gtype, \
+         NS_TP, dbus_gutils_wincaps_to_uscore
+ 
+ 
+@@ -85,18 +85,12 @@ class Generator(object):
+         self.allow_havoc = allow_havoc
+ 
+     def h(self, s):
+-        if isinstance(s, unicode):
+-            s = s.encode('utf-8')
+         self.__header.append(s)
+ 
+     def b(self, s):
+-        if isinstance(s, unicode):
+-            s = s.encode('utf-8')
+         self.__body.append(s)
+ 
+     def d(self, s):
+-        if isinstance(s, unicode):
+-            s = s.encode('utf-8')
+         self.__docs.append(s)
+ 
+     def do_node(self, node):
+@@ -733,7 +727,7 @@ class Generator(object):
+ 
+     def __call__(self):
+         nodes = self.dom.getElementsByTagName('node')
+-        nodes.sort(cmp_by_name)
++        nodes.sort(key=key_by_name)
+ 
+         self.h('#include <glib-object.h>')
+         self.h('#include <dbus/dbus-glib.h>')
+@@ -763,12 +757,12 @@ class Generator(object):
+ 
+         self.h('')
+         self.b('')
+-        file_set_contents(self.basename + '.h', '\n'.join(self.__header))
+-        file_set_contents(self.basename + '.c', '\n'.join(self.__body))
+-        file_set_contents(self.basename + '-gtk-doc.h', '\n'.join(self.__docs))
++        file_set_contents(self.basename + '.h', u('\n').join(self.__header).encode('utf-8'))
++        file_set_contents(self.basename + '.c', u('\n').join(self.__body).encode('utf-8'))
++        file_set_contents(self.basename + '-gtk-doc.h', u('\n').join(self.__docs).encode('utf-8'))
+ 
+ def cmdline_error():
+-    print """\
++    print("""\
+ usage:
+     gen-ginterface [OPTIONS] xmlfile Prefix_
+ options:
+@@ -788,7 +782,7 @@ options:
+             void symbol (DBusGMethodInvocation *context)
+         and return some sort of "not implemented" error via
+             dbus_g_method_return_error (context, ...)
+-"""
++""")
+     sys.exit(1)
+ 
+ 
+diff --git a/tools/glib-gtypes-generator.py b/tools/glib-gtypes-generator.py
+index 21dfc6a..1477bd3 100644
+--- a/tools/glib-gtypes-generator.py
++++ b/tools/glib-gtypes-generator.py
+@@ -23,7 +23,7 @@
+ import sys
+ import xml.dom.minidom
+ 
+-from libtpcodegen import file_set_contents
++from libtpcodegen import file_set_contents, u
+ from libglibcodegen import escape_as_identifier, \
+                            get_docstring, \
+                            NS_TP, \
+@@ -68,13 +68,13 @@ class GTypesGenerator(object):
+         self.need_other_arrays = {}
+ 
+     def h(self, code):
+-        self.header.append(code.encode("utf-8"))
++        self.header.append(code)
+ 
+     def c(self, code):
+-        self.body.append(code.encode("utf-8"))
++        self.body.append(code)
+ 
+     def d(self, code):
+-        self.docs.append(code.encode('utf-8'))
++        self.docs.append(code)
+ 
+     def do_mapping_header(self, mapping):
+         members = mapping.getElementsByTagNameNS(NS_TP, 'member')
+@@ -292,9 +292,9 @@ class GTypesGenerator(object):
+             self.c('  return t;\n')
+             self.c('}\n\n')
+ 
+-        file_set_contents(self.output + '.h', ''.join(self.header))
+-        file_set_contents(self.output + '-body.h', ''.join(self.body))
+-        file_set_contents(self.output + '-gtk-doc.h', ''.join(self.docs))
++        file_set_contents(self.output + '.h', u('').join(self.header).encode('utf-8'))
++        file_set_contents(self.output + '-body.h', u('').join(self.body).encode('utf-8'))
++        file_set_contents(self.output + '-gtk-doc.h', u('').join(self.docs).encode('utf-8'))
+ 
+ if __name__ == '__main__':
+     argv = sys.argv[1:]
+diff --git a/tools/glib-interfaces-gen.py b/tools/glib-interfaces-gen.py
+index 410762c..b67d7b4 100644
+--- a/tools/glib-interfaces-gen.py
++++ b/tools/glib-interfaces-gen.py
+@@ -3,7 +3,7 @@
+ from sys import argv, stdout, stderr
+ import xml.dom.minidom
+ 
+-from libtpcodegen import file_set_contents
++from libtpcodegen import file_set_contents, u
+ from libglibcodegen import NS_TP, get_docstring, \
+         get_descendant_text, get_by_path
+ 
+@@ -24,22 +24,22 @@ class Generator(object):
+         self.spec = get_by_path(dom, "spec")[0]
+ 
+     def h(self, code):
+-        self.decls.append(code.encode('utf-8'))
++        self.decls.append(code)
+ 
+     def c(self, code):
+-        self.impls.append(code.encode('utf-8'))
++        self.impls.append(code)
+ 
+     def d(self, code):
+-        self.docs.append(code.encode('utf-8'))
++        self.docs.append(code)
+ 
+     def __call__(self):
+         for f in self.h, self.c:
+             self.do_header(f)
+         self.do_body()
+ 
+-        file_set_contents(self.implfile, ''.join(self.impls))
+-        file_set_contents(self.declfile, ''.join(self.decls))
+-        file_set_contents(self.docfile, ''.join(self.docs))
++        file_set_contents(self.implfile, u('').join(self.impls).encode('utf-8'))
++        file_set_contents(self.declfile, u('').join(self.decls).encode('utf-8'))
++        file_set_contents(self.docfile, u('').join(self.docs).encode('utf-8'))
+ 
+     # Header
+     def do_header(self, f):
+diff --git a/tools/libglibcodegen.py b/tools/libglibcodegen.py
+index 6a9d214..6cd1a62 100644
+--- a/tools/libglibcodegen.py
++++ b/tools/libglibcodegen.py
+@@ -154,7 +154,7 @@ def type_to_gtype(s):
+         return ("GHashTable *", "DBUS_TYPE_G_STRING_STRING_HASHTABLE", "BOXED", False)
+     elif s[:2] == 'a{':  #some arbitrary hash tables
+         if s[2] not in ('y', 'b', 'n', 'q', 'i', 'u', 's', 'o', 'g'):
+-            raise Exception, "can't index a hashtable off non-basic type " + s
++            raise Exception("can't index a hashtable off non-basic type " + s)
+         first = type_to_gtype(s[2])
+         second = type_to_gtype(s[3:-1])
+         return ("GHashTable *", "(dbus_g_type_get_map (\"GHashTable\", " + first[1] + ", " + second[1] + "))", "BOXED", False)
+@@ -169,4 +169,4 @@ def type_to_gtype(s):
+         return ("GValueArray *", gtype, "BOXED", True)
+ 
+     # we just don't know ..
+-    raise Exception, "don't know the GType for " + s
++    raise Exception("don't know the GType for " + s)
+diff --git a/tools/libtpcodegen.py b/tools/libtpcodegen.py
+index 7e9eb9a..99de663 100644
+--- a/tools/libtpcodegen.py
++++ b/tools/libtpcodegen.py
+@@ -21,6 +21,7 @@ please make any changes there.
+ # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+ import os
++import sys
+ from string import ascii_letters, digits
+ 
+ 
+@@ -28,6 +29,20 @@ NS_TP = "http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0"
+ 
+ _ASCII_ALNUM = ascii_letters + digits
+ 
++if sys.version_info[0] >= 3:
++    def u(s):
++        """Return s, which must be a str literal with no non-ASCII characters.
++        This is like a more restricted form of the Python 2 u'' syntax.
++        """
++        return s.encode('ascii').decode('ascii')
++else:
++    def u(s):
++        """Return a Unicode version of s, which must be a str literal
++        (a bytestring) in which each byte is an ASCII character.
++        This is like a more restricted form of the u'' syntax.
++        """
++        return s.decode('ascii')
++
+ def file_set_contents(filename, contents):
+     try:
+         os.remove(filename)
+@@ -38,13 +53,15 @@ def file_set_contents(filename, contents):
+     except OSError:
+         pass
+ 
+-    open(filename + '.tmp', 'w').write(contents)
++    open(filename + '.tmp', 'wb').write(contents)
+     os.rename(filename + '.tmp', filename)
+ 
+ def cmp_by_name(node1, node2):
+     return cmp(node1.getAttributeNode("name").nodeValue,
+                node2.getAttributeNode("name").nodeValue)
+ 
++def key_by_name(node):
++    return node.getAttributeNode("name").nodeValue
+ 
+ def escape_as_identifier(identifier):
+     """Escape the given string to be a valid D-Bus object path or service
+@@ -168,6 +185,9 @@ class _SignatureIter:
+         self.remaining = string
+ 
+     def next(self):
++        return self.__next__()
++
++    def __next__(self):
+         if self.remaining == '':
+             raise StopIteration
+ 
+diff --git a/tools/xincludator.py b/tools/xincludator.py
+index 63e106a..f9ed49c 100644
+--- a/tools/xincludator.py
++++ b/tools/xincludator.py
+@@ -1,17 +1,19 @@
+ #!/usr/bin/python
+ 
++import sys
+ from sys import argv, stdout, stderr
+ import codecs, locale
+ import os
+ import xml.dom.minidom
+ 
+-stdout = codecs.getwriter('utf-8')(stdout)
++if sys.version_info[0] < 3:
++    stdout = codecs.getwriter('utf-8')(stdout)
+ 
+ NS_XI = 'http://www.w3.org/2001/XInclude'
+ 
+ def xincludate(dom, base, dropns = []):
+     remove_attrs = []
+-    for i in xrange(dom.documentElement.attributes.length):
++    for i in range(dom.documentElement.attributes.length):
+         attr = dom.documentElement.attributes.item(i)
+         if attr.prefix == 'xmlns':
+             if attr.localName in dropns:
+@@ -34,6 +36,11 @@ if __name__ == '__main__':
+     argv = argv[1:]
+     dom = xml.dom.minidom.parse(argv[0])
+     xincludate(dom, argv[0])
+-    xml = dom.toxml()
++
++    if sys.version_info[0] >= 3:
++        xml = dom.toxml(encoding=None)
++    else:
++        xml = dom.toxml()
++
+     stdout.write(xml)
+     stdout.write('\n')
+-- 
+2.51.0
+

--- a/runtime-web/telepathy-logger/autobuild/patches/0002-BACKPORT-Fix-incompatible-pointer-types.patch
+++ b/runtime-web/telepathy-logger/autobuild/patches/0002-BACKPORT-Fix-incompatible-pointer-types.patch
@@ -1,0 +1,57 @@
+From 0e292d9df0e861fbc54387ea3ee29a916b9cde08 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Thu, 1 Aug 2024 19:26:43 +0200
+Subject: [PATCH 2/2] BACKPORT: Fix incompatible pointer types
+
+gcc14 defaults to -Werror=incompatible-pointer-types .
+Fix build error with this option.
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ telepathy-logger/conf.c         | 2 +-
+ telepathy-logger/dbus-service.c | 2 +-
+ telepathy-logger/log-manager.c  | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/telepathy-logger/conf.c b/telepathy-logger/conf.c
+index d9e21fb..e35c759 100644
+--- a/telepathy-logger/conf.c
++++ b/telepathy-logger/conf.c
+@@ -127,7 +127,7 @@ tpl_conf_constructor (GType type,
+ 
+   if (conf_singleton != NULL)
+     {
+-      retval = g_object_ref (conf_singleton);
++      retval = g_object_ref (G_OBJECT (conf_singleton));
+     }
+   else
+     {
+diff --git a/telepathy-logger/dbus-service.c b/telepathy-logger/dbus-service.c
+index 9300c0e..1a91d03 100644
+--- a/telepathy-logger/dbus-service.c
++++ b/telepathy-logger/dbus-service.c
+@@ -96,7 +96,7 @@ favourite_contact_closure_new (TplDBusService *self,
+   FavouriteContactClosure *closure;
+ 
+   closure = g_slice_new0 (FavouriteContactClosure);
+-  closure->service = g_object_ref (G_OBJECT (self));
++  closure->service = TPL_DBUS_SERVICE (g_object_ref (G_OBJECT (self)));
+   closure->account = g_strdup (account);
+   closure->contact_id = g_strdup (contact_id);
+   /* XXX: ideally we'd up the ref count or duplicate this */
+diff --git a/telepathy-logger/log-manager.c b/telepathy-logger/log-manager.c
+index 37ff1d4..daded96 100644
+--- a/telepathy-logger/log-manager.c
++++ b/telepathy-logger/log-manager.c
+@@ -159,7 +159,7 @@ log_manager_constructor (GType type,
+   GObject *retval = NULL;
+ 
+   if (G_LIKELY (manager_singleton))
+-    retval = g_object_ref (manager_singleton);
++    retval = g_object_ref (G_OBJECT (manager_singleton));
+   else
+     {
+       retval = G_OBJECT_CLASS (tpl_log_manager_parent_class)->constructor (
+-- 
+2.51.0
+

--- a/runtime-web/telepathy-logger/spec
+++ b/runtime-web/telepathy-logger/spec
@@ -1,5 +1,5 @@
 VER=0.8.2
-REL=2
+REL=3
 SRCS="tbl::https://telepathy.freedesktop.org/releases/telepathy-logger/telepathy-logger-$VER.tar.bz2"
 CHKSUMS="sha256::8fcad534d653b1b365132c5b158adae947810ffbae9843f72dd1797966415dae"
 CHKUPDATE="anitya::id=6067"


### PR DESCRIPTION
Topic Description
-----------------

- telepathy-logger: fix build with python3 and c89
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- telepathy-logger: 0.8.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit telepathy-logger
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
