### PR TITLE
libkkc: update to 0.3.5+git20240902

### DIFF
--- a/runtime-i18n/libkkc-data/autobuild/defines
+++ b/runtime-i18n/libkkc-data/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=libkkc-data
 PKGSEC=libs
-PKGDEP="marisa"
+PKGDEP="gcc-runtime"
+BUILDDEP="marisa python-3"
 PKGDES="Language model data package for libkkc"
 
+ABTYPE=autotools
 ABSHADOW=no
 ABHOST=noarch

--- a/runtime-i18n/libkkc-data/autobuild/patches/0001-FEDORA-build-Enable-python3.patch
+++ b/runtime-i18n/libkkc-data/autobuild/patches/0001-FEDORA-build-Enable-python3.patch
@@ -1,0 +1,141 @@
+From b540351e6d565295ebfcdc8760975cf7f47036c5 Mon Sep 17 00:00:00 2001
+From: Takao Fujiwara <tfujiwar@redhat.com>
+Date: Mon, 30 Jul 2018 15:26:37 +0900
+Subject: [PATCH] FEDORA: build: Enable python3
+
+---
+ tools/genfilter.py | 18 +++++++++---------
+ tools/sortlm.py    | 23 ++++++++++-------------
+ 2 files changed, 19 insertions(+), 22 deletions(-)
+
+diff --git a/tools/genfilter.py b/tools/genfilter.py
+index 97645d5..6734b2b 100644
+--- a/tools/genfilter.py
++++ b/tools/genfilter.py
+@@ -84,24 +84,24 @@ class FilterGenerator(object):
+ 
+     def generate(self):
+         size = os.fstat(self.infile.fileno()).st_size
+-        n = size / self.record_size
++        n = size // self.record_size
+         m = int(math.ceil(-n*math.log10(ERROR_RATE) /
+                           math.pow(math.log10(2), 2)))
+-        m = (m/8 + 1)*8
++        m = (m//8 + 1)*8
+         inmem = mmap.mmap(self.infile.fileno(),
+                           size,
+                           access=mmap.ACCESS_READ)
+-        outmem = bytearray(m/8)
+-        for i in xrange(0, n):
++        outmem = bytearray(m//8)
++        for i in range(0, n):
+             offset = i*self.record_size
+             b0, b1 = struct.unpack("=LL", inmem[offset:offset+8])
+-            for k in xrange(0, 4):
++            for k in range(0, 4):
+                 h = murmur_hash3_32(b0, b1, k)
+                 h = int(h * (m / float(0xFFFFFFFF)))
+-                outmem[h/8] |= (1 << (h%8))
++                outmem[h//8] |= (1 << (h%8))
+         inmem.close()
+-        # Convert bytearray to str, for Python 2.6 compatibility.
+-        self.outfile.write(str(outmem))
++        # Convert bytearray to bytes, for Python 3 compatibility.
++        self.outfile.write(bytes(outmem))
+ 
+ if __name__ == '__main__':
+     import sys
+@@ -110,7 +110,7 @@ if __name__ == '__main__':
+     parser = argparse.ArgumentParser(description='filter')
+     parser.add_argument('infile', type=argparse.FileType('r'),
+                         help='input file')
+-    parser.add_argument('outfile', type=argparse.FileType('w'),
++    parser.add_argument('outfile', type=argparse.FileType('wb'),
+                         help='output file')
+     parser.add_argument('record_size', type=int,
+                         help='record size')
+diff --git a/tools/sortlm.py b/tools/sortlm.py
+index 9c76afe..6680d5c 100644
+--- a/tools/sortlm.py
++++ b/tools/sortlm.py
+@@ -40,10 +40,10 @@ class SortedGenerator(object):
+         self.__min_cost = 0.0
+ 
+     def read(self):
+-        print "reading N-grams"
++        print("reading N-grams")
+         self.__read_tries()
+         self.__read_ngrams()
+-        print "min cost = %lf" % self.__min_cost
++        print("min cost = %lf" % self.__min_cost)
+ 
+     def __read_tries(self):
+         while True:
+@@ -58,7 +58,7 @@ class SortedGenerator(object):
+             line = self.__infile.readline()
+             if line == "":
+                 break
+-            line = line.strip()
++            line = line.strip('\n')
+             if line == "":
+                 break
+             match = self.__ngram_line_regex.match(line)
+@@ -89,7 +89,7 @@ class SortedGenerator(object):
+                 line = self.__infile.readline()
+                 if line == "":
+                     break
+-                line = line.strip()
++                line = line.strip('\n')
+                 if line == "":
+                     break
+                 match = self.__ngram_line_regex.match(line)
+@@ -125,14 +125,11 @@ class SortedGenerator(object):
+         def quantize(cost, min_cost):
+             return max(0, min(65535, int(cost * 65535 / min_cost)))
+ 
+-        def cmp_header(a, b):
+-            return cmp(a[0], b[0])
+-
+-        print "writing 1-gram file"
++        print("writing 1-gram file")
+         unigram_offsets = {}
+         unigram_file = open("%s.1gram" % self.__output_prefix, "wb")
+         offset = 0
+-        for ids, value in sorted(self.__ngram_entries[0].iteritems()):
++        for ids, value in sorted(self.__ngram_entries[0].items()):
+             unigram_offsets[ids[0]] = offset
+             s = struct.pack("=HHH",
+                             quantize(value[0], self.__min_cost),
+@@ -143,13 +140,13 @@ class SortedGenerator(object):
+             offset += 1
+         unigram_file.close()
+ 
+-        print "writing 2-gram file"
++        print("writing 2-gram file")
+         bigram_offsets = {}
+         bigram_file = open("%s.2gram" % self.__output_prefix, "wb")
+         keys = self.__ngram_entries[1].keys()
+         items = [(struct.pack("=LL", ids[1], unigram_offsets[ids[0]]), ids) for ids in keys]
+         offset = 0
+-        for header, ids in sorted(items, cmp=cmp_header):
++        for header, ids in sorted(items, key=lambda x: x[0]):
+             value = self.__ngram_entries[1][ids]
+             bigram_offsets[ids] = offset
+             s = struct.pack("=HH",
+@@ -160,11 +157,11 @@ class SortedGenerator(object):
+         bigram_file.close()
+ 
+         if len(self.__ngram_entries[2]) > 0:
+-            print "writing 3-gram file"
++            print("writing 3-gram file")
+             trigram_file = open("%s.3gram" % self.__output_prefix, "wb")
+             keys = self.__ngram_entries[2].keys()
+             items = [(struct.pack("=LL", ids[2], bigram_offsets[(ids[0], ids[1])]), ids) for ids in keys]
+-            for header, ids in sorted(items, cmp=cmp_header):
++            for header, ids in sorted(items, key=lambda x: x[0]):
+                 value = self.__ngram_entries[2][ids]
+                 s = struct.pack("=H",
+                                 quantize(value[0], self.__min_cost))
+-- 
+2.51.0
+

--- a/runtime-i18n/libkkc-data/spec
+++ b/runtime-i18n/libkkc-data/spec
@@ -1,6 +1,6 @@
 VER=0.2.7
 KKCVER=0.3.5
-REL=4
+REL=5
 SRCS="tbl::https://github.com/ueno/libkkc/releases/download/v$KKCVER/libkkc-data-$VER.tar.xz"
-CHKUPDATE="anitya::id=228900"
 CHKSUMS="sha256::9e678755a030043da68e37a4049aa296c296869ff1fb9e6c70026b2541595b99"
+CHKUPDATE="anitya::id=228900"

--- a/runtime-i18n/libkkc/autobuild/defines
+++ b/runtime-i18n/libkkc/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="libgee marisa json-glib"
 BUILDDEP="vala gobject-introspection intltool"
 PKGDES="Japanese Kana Kanji conversion library"
 
-AUTOTOOLS_AFTER="--disable-silent-rules"
+ABTYPE=autotools
 ABSHADOW=0
-
-PKGEPOCH=1
+AUTOTOOLS_AFTER=(
+    '--disable-silent-rules'
+)

--- a/runtime-i18n/libkkc/autobuild/prepare
+++ b/runtime-i18n/libkkc/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Appending -lstdc++ to LDFLAGS to fix build ..."
-export LDFLAGS="${LDFLAGS} -lstdc++"

--- a/runtime-i18n/libkkc/spec
+++ b/runtime-i18n/libkkc/spec
@@ -1,4 +1,5 @@
-VER=0.3.5+git20210213
-SRCS="git::commit=4583ab1753594b72592df5857106aedad98e533d::https://github.com/ueno/libkkc"
+VER=0.3.5+git20240902
+EPOCH=1
+SRCS="git::commit=ce17a35d3dca32706ae2dd48c7859a36531a9b59::https://github.com/ueno/libkkc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=228901"


### PR DESCRIPTION
Topic Description
-----------------

- libkkc-data: fix build
    - Adjust PKGDEP and BUILDDEP.
- libkkc: update to 0.3.5+git20240902
    - Drop unused prepare script.

Package(s) Affected
-------------------

- libkkc: 0.3.5+git20240902
- libkkc-data: 0.2.7-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libkkc libkkc-data
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
