### PR TITLE
rustc: update to 1.90.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From c62e1c6dcc6eeb8db7619b6e30e00657b98f5162 Mon Sep 17 00:00:00 2001
+From 5891d6935a66852be54a1c6d18584b12ba0cbf9b Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/4] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/4] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 7a49f00407..b675552ff6 100644
+index 033590e01a..3cf3fd4a70 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1750,6 +1750,7 @@ supported_targets! {
+@@ -1899,6 +1899,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),

--- a/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,4 +1,4 @@
-From d775cc8d435c34ad5147161c5082775bc1a0f45b Mon Sep 17 00:00:00 2001
+From 4e7d9710bdd166d0fb3e671dcafedaad5fe1eb41 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 20:12:53 +0200
 Subject: [PATCH 2/4] ARCHLINUX: compiler: Swap primary and secondary lib dirs

--- a/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,4 +1,4 @@
-From 4558c3cef1db12eb171c992e12c88a53b79101ed Mon Sep 17 00:00:00 2001
+From ff025502e771540faa8d562bfe8906377f2db1e9 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 19:01:26 +0200
 Subject: [PATCH 3/4] ARCHLINUX: bootstrap: Workaround for system stage0
@@ -9,10 +9,10 @@ See: https://github.com/rust-lang/rust/issues/143735
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
-index f6efb23e8d..1b9359f619 100644
+index 30cbcc05c4..0b5f1b55a4 100644
 --- a/src/bootstrap/src/core/build_steps/compile.rs
 +++ b/src/bootstrap/src/core/build_steps/compile.rs
-@@ -807,7 +807,10 @@ impl Step for StdLink {
+@@ -796,7 +796,10 @@ impl Step for StdLink {
                  let _ = fs::remove_dir_all(sysroot.join("lib/rustlib/src/rust"));
              }
  

--- a/lang-rust/rustc/autobuild/patches/0004-compiler-Apply-target-features-to-the-entry-function.patch
+++ b/lang-rust/rustc/autobuild/patches/0004-compiler-Apply-target-features-to-the-entry-function.patch
@@ -1,4 +1,4 @@
-From 874b53e68456b421b3a0bf7e2f48a2390758e71d Mon Sep 17 00:00:00 2001
+From dc836aaaf18805de52e7d4dae86b9c2ef0e5c78a Mon Sep 17 00:00:00 2001
 From: WANG Rui <wangrui@loongson.cn>
 Date: Wed, 3 Sep 2025 11:34:15 +0800
 Subject: [PATCH 4/4] compiler: Apply target features to the entry function
@@ -9,7 +9,7 @@ Subject: [PATCH 4/4] compiler: Apply target features to the entry function
  2 files changed, 20 insertions(+), 9 deletions(-)
 
 diff --git a/compiler/rustc_codegen_llvm/src/attributes.rs b/compiler/rustc_codegen_llvm/src/attributes.rs
-index adb53e0b66..3313b1f4c4 100644
+index c548f46758..0270298c11 100644
 --- a/compiler/rustc_codegen_llvm/src/attributes.rs
 +++ b/compiler/rustc_codegen_llvm/src/attributes.rs
 @@ -302,6 +302,19 @@ pub(crate) fn tune_cpu_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribu
@@ -32,7 +32,7 @@ index adb53e0b66..3313b1f4c4 100644
  /// Get the `NonLazyBind` LLVM attribute,
  /// if the codegen options allow skipping the PLT.
  pub(crate) fn non_lazy_bind_attr<'ll>(cx: &CodegenCx<'ll, '_>) -> Option<&'ll Attribute> {
-@@ -535,13 +548,7 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
+@@ -519,13 +532,7 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
          }
      }
  
@@ -48,10 +48,10 @@ index adb53e0b66..3313b1f4c4 100644
      attributes::apply_to_llfn(llfn, Function, &to_add);
  }
 diff --git a/compiler/rustc_codegen_llvm/src/context.rs b/compiler/rustc_codegen_llvm/src/context.rs
-index 0324dff6ff..55d335923d 100644
+index ee77774c68..765e93b04c 100644
 --- a/compiler/rustc_codegen_llvm/src/context.rs
 +++ b/compiler/rustc_codegen_llvm/src/context.rs
-@@ -822,7 +822,7 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
+@@ -840,7 +840,7 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
      fn declare_c_main(&self, fn_type: Self::Type) -> Option<Self::Function> {
          let entry_name = self.sess().target.entry_name.as_ref();
          if self.get_declared_value(entry_name).is_none() {
@@ -60,7 +60,7 @@ index 0324dff6ff..55d335923d 100644
                  entry_name,
                  llvm::CallConv::from_conv(
                      self.sess().target.entry_abi,
-@@ -830,7 +830,11 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
+@@ -848,7 +848,11 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                  ),
                  llvm::UnnamedAddr::Global,
                  fn_type,

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,8 +1,7 @@
-VER=1.89.0
-REL=2
+VER=1.90.0
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::0b9d55610d8270e06c44f459d1e2b7918a5e673809c592abed9b9c600e33d95a"
+CHKSUMS="sha256::6bfeaddd90ffda2f063492b092bfed925c4b8c701579baf4b1316e021470daac"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.90.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.90.0
    \(HEAD: dc836aaaf18805de52e7d4dae86b9c2ef0e5c78a\).

Package(s) Affected
-------------------

- rustc: 1:1.90.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
