### PR TITLE
wlroots: update to 0.19.1

### DIFF
--- a/runtime-display/wlroots/spec
+++ b/runtime-display/wlroots/spec
@@ -1,4 +1,4 @@
-VER=0.19.0
+VER=0.19.1
 SRCS="git::commit=tags/${VER/\~/-}::https://gitlab.freedesktop.org/wlroots/wlroots"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18357"


### PR DESCRIPTION
Topic Description
-----------------

- wlroots: update to 0.19.1
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- wlroots: 0.19.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wlroots
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
