### PR TITLE
podman: fix template, 5.5.2

### DIFF
--- a/app-containers/podman/autobuild/templates
+++ b/app-containers/podman/autobuild/templates
@@ -15,6 +15,7 @@ Description: Notes for Podman Rootless Container Users
  Alternatively, you can use the following commands:
  .
  $ sudo usermod --add-subuids 100000-165535 $(whoami)
+ .
  $ sudo usermod --add-subgids 100000-165535 $(groups | cut -d' ' -f1)
  .
  For more infomation, please refer to Podman documentation:
@@ -33,6 +34,7 @@ Description-zh_CN.UTF-8: 关于 Podman 非特权容器的提示
  您也可以使用以下命令：
  .
  $ sudo usermod --add-subuids 100000-165535 $(whoami)
+ .
  $ sudo usermod --add-subgids 100000-165535 $(groups | cut -d' ' -f1)
  .
  有关更多信息，请参阅 Podman 文档：

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,5 +1,5 @@
 UPSTREAM_VER=5.5.2
-REL=2
+REL=3
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile


### PR DESCRIPTION
Topic Description
-----------------

- podman: update templates
    Add missing newline

Package(s) Affected
-------------------

- podman: 5.5.2+vsock0.8.4-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
