### PR TITLE
telepathy-idle: update to 0.2.2

### DIFF
--- a/runtime-web/telepathy-idle/spec
+++ b/runtime-web/telepathy-idle/spec
@@ -1,5 +1,4 @@
-VER=0.2.0
-REL=4
+VER=0.2.2
 SRCS="tbl::https://telepathy.freedesktop.org/releases/telepathy-idle/telepathy-idle-$VER.tar.gz"
-CHKSUMS="sha256::3013ad4b38d14ee630b8cc8ada5e95ccaa849b9a6fe15d2eaf6d0717d76f2fab"
+CHKSUMS="sha256::8387e25e5fb0b4cbe701e5dc092d666d6510b833fd3e7e462e9170d36ec3c15f"
 CHKUPDATE="anitya::id=6066"


### PR DESCRIPTION
Topic Description
-----------------

- telepathy-idle: update to 0.2.2
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- telepathy-idle: 0.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telepathy-idle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
