### PR TITLE
gtk-update-icon Survey 20250923

### DIFF
--- a/app-creativity/gimp/autobuild/defines
+++ b/app-creativity/gimp/autobuild/defines
@@ -5,8 +5,8 @@ PKGDEP="babl dbus-glib desktop-file-utils gegl-0.4 hicolor-icon-theme \
         alsa-lib curl ghostscript gutenprint poppler libheif \
         gvfs gexiv2 libmypaint mypaint-brushes+1 libwebp aalib libgudev \
         gtk-3 json-glib libarchive libunwind xz openjpeg libjxl cfitsio \
-        appstream-glib"
-BUILDDEP="gtk-4 gtk-doc gtk-update-icon-cache intltool iso-codes gjs \
+        appstream-glib gtk-update-icon-cache"
+BUILDDEP="gtk-4 gtk-doc intltool iso-codes gjs \
           appstream xorg-server vala"
 PKGDES="GNU Image Manipulation Program"
 

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,5 +1,5 @@
 VER=3.0.4
-REL=1
+REL=2
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:3}/gimp-${VER/~rc/-RC}.tar.xz"
 CHKSUMS="sha256::8caa2ec275bf09326575654ac276afc083f8491e7cca45d19cf29e696aecab25"
 CHKUPDATE="anitya::id=1161"

--- a/app-doc/rnote/autobuild/defines
+++ b/app-doc/rnote/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=rnote
 PKGDES="Vector-based drawing app for sketching and handwritten notes"
 PKGSEC=doc
-PKGDEP="gtk-4 glib libadwaita poppler gstreamer alsa-lib"
-BUILDDEP="rustc llvm gtk-update-icon-cache appstream"
+PKGDEP="gtk-4 glib libadwaita poppler gstreamer alsa-lib gtk-update-icon-cache"
+BUILDDEP="rustc llvm appstream"
 ABTYPE=meson
 MESON_AFTER="-Dcli=true"
 

--- a/app-doc/rnote/spec
+++ b/app-doc/rnote/spec
@@ -1,4 +1,5 @@
 VER=0.13.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/flxzt/rnote.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375549"

--- a/app-imaging/curtail/autobuild/defines
+++ b/app-imaging/curtail/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=curtail
 PKGSEC=graphics
 PKGDES="Image compressor that supports PNG, JPEG, WebP and SVG file"
-PKGDEP="dconf gdk-pixbuf glib gtk-4 hicolor-icon-theme jpegoptim libadwaita libwebp pngquant python-3 pygobject-3 scour oxipng"
-BUILDDEP="appstream gtk-update-icon-cache"
+PKGDEP="dconf gdk-pixbuf glib gtk-4 hicolor-icon-theme jpegoptim libadwaita \
+        libwebp pngquant python-3 pygobject-3 scour oxipng \
+        gtk-update-icon-cache"
+BUILDDEP="appstream"
 
 ABHOST=noarch

--- a/app-imaging/curtail/spec
+++ b/app-imaging/curtail/spec
@@ -1,4 +1,5 @@
 VER=1.12.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/Huluti/Curtail.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=312431"

--- a/app-multimedia/easyeffects/autobuild/defines
+++ b/app-multimedia/easyeffects/autobuild/defines
@@ -3,8 +3,9 @@ PKGDES="Audio effects for PipeWire"
 PKGSEC=sound
 PKGDEP="pipewire zita-convolver tbb rnnoise libportal pipewire gtk-4 \
         libadwaita libsigc++-3.0 lilv lv2 libbs2b libsndfile fftw \
-        libsamplerate libebur128 soundtouch speex nlohmann-json fmt gsl"
+        libsamplerate libebur128 soundtouch speex nlohmann-json fmt gsl \
+        gtk-update-icon-cache"
 PKGRECOM="calf lsp-plugins"
-BUILDDEP="appstream-glib itstool ladspa-sdk gtk-update-icon-cache desktop-file-utils"
+BUILDDEP="appstream-glib itstool ladspa-sdk desktop-file-utils"
 
 ABTYPE=meson

--- a/app-multimedia/easyeffects/spec
+++ b/app-multimedia/easyeffects/spec
@@ -1,4 +1,5 @@
 VER=7.2.5
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/wwmm/easyeffects.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242876"

--- a/app-multimedia/netease-cloud-music-gtk/autobuild/defines
+++ b/app-multimedia/netease-cloud-music-gtk/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=netease-cloud-music-gtk
 PKGDES="An unofficial client for Netease Cloud Music"
 PKGDEP="openssl curl gstreamer at-spi2-core gdk-pixbuf osdlyrics gtk-4 \
-        libadwaita"
-BUILDDEP="cargo llvm gtk-update-icon-cache"
+        libadwaita gtk-update-icon-cache"
+BUILDDEP="cargo llvm"
 PKGSEC="sound"
 
 USECLANG=1

--- a/app-multimedia/netease-cloud-music-gtk/spec
+++ b/app-multimedia/netease-cloud-music-gtk/spec
@@ -1,4 +1,4 @@
-VER=2.5.0
+VER=2.5.2
 SRCS="git::commit=tags/$VER::https://github.com/gmg137/netease-cloud-music-gtk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230942"

--- a/app-multimedia/rhythmbox/autobuild/defines
+++ b/app-multimedia/rhythmbox/autobuild/defines
@@ -2,9 +2,10 @@ PKGNAME=rhythmbox
 PKGSEC=gnome
 PKGDEP="dconf desktop-file-utils gst-plugins-base-1-0 gst-plugins-good-1-0 \
         json-glib libnotify libpeas libsoup media-player-info pygobject-3 \
-        tdb totem-pl-parser webkit2gtk libdmapsharing libgpod check libgudev"
+        tdb totem-pl-parser webkit2gtk libdmapsharing libgpod check libgudev \
+        gtk-update-icon-cache"
 PKGSUG="brasero grilo-plugins gst-libav-1-0 gst-plugins-bad-1-0 \
-          gst-plugins-ugly-1-0 gvfs libgpod libmtp mako lirc"
+        gst-plugins-ugly-1-0 gvfs libgpod libmtp mako lirc"
 BUILDDEP="brasero gobject-introspection grilo intltool itstool \
           libgpod libmtp vala lirc yelp-tools"
 PKGDES="An iTunes-like music player and manager"

--- a/app-multimedia/rhythmbox/spec
+++ b/app-multimedia/rhythmbox/spec
@@ -1,5 +1,5 @@
 VER=3.4.7
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/rhythmbox/${VER:0:3}/rhythmbox-$VER.tar.xz"
 CHKSUMS="sha256::2f6d56c13fc1a64c534f500788fb482936ce547b343ed90c67de1f2bce0cfa7e"
 CHKUPDATE="anitya::id=9525"

--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=tsukimi
 PKGSEC=video
 PKGDES="A desktop client implementation for Emby"
-BUILDDEP="meson llvm rustc gtk-update-icon-cache"
-PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv openssl pango"
+BUILDDEP="meson llvm rustc"
+PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv \
+        openssl pango gtk-update-icon-cache"
 
 ABTYPE=meson
 

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,5 @@
 VER=0.21.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376111"

--- a/app-utils/flatseal/autobuild/defines
+++ b/app-utils/flatseal/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=flatseal
 PKGSEC=utils
-PKGDEP="appstream flatpak gjs gtk-4 libadwaita libhandy webkit2gtk"
-BUILDDEP="gtk-update-icon-cache"
+PKGDEP="appstream flatpak gjs gtk-4 libadwaita libhandy webkit2gtk gtk-update-icon-cache"
 PKGDES="Utility to review and modify permissions for Flatpak applications"
 
 ABTYPE=meson

--- a/app-utils/flatseal/spec
+++ b/app-utils/flatseal/spec
@@ -1,4 +1,5 @@
 VER=2.3.1
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/tchx84/Flatseal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=320449"

--- a/app-utils/font-manager/autobuild/defines
+++ b/app-utils/font-manager/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=font-manager
 PKGSEC=utils
 PKGDEP="libxml2 sqlite glib freetype fontconfig cairo gtk-4 harfbuzz json-glib \
-        cairo libsoup-3 webkit2gtk libadwaita file-roller"
-BUILDDEP="gobject-introspection gtk-update-icon-cache gettext vala yelp-tools \
-          nautilus nemo thunar gtk-doc"
+        cairo libsoup-3 webkit2gtk libadwaita file-roller gtk-update-icon-cache"
+BUILDDEP="gobject-introspection gettext vala yelp-tools nautilus nemo thunar"
 PKGDES="Simple font management for GTK+ desktop environments"
 
 ABTYPE=meson
@@ -19,7 +18,6 @@ MESON_AFTER=(
     -Dnautilus=true
     -Dnemo=true
     -Dthunar=true
-    -Dgtk-doc=true
     -Dreproducible=true
     -Dapp-armor=false
 )

--- a/app-utils/font-manager/spec
+++ b/app-utils/font-manager/spec
@@ -1,4 +1,5 @@
 VER=0.9.4
+REL=1
 SRCS="tbl::https://github.com/FontManager/font-manager/releases/download/$VER/font-manager-$VER.tar.xz"
 CHKSUMS="sha256::6a0899ac753f50d0779751828c62fa6220024213ebd2179b6f64a3a9bff51f96"
 CHKUPDATE="anitya::id=15389"

--- a/app-utils/gearlever/autobuild/defines
+++ b/app-utils/gearlever/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=gearlever
 PKGSEC=utils
 PKGDEP="7-zip coreutils dbus-python gtk-4 hicolor-icon-theme libadwaita \
-        pygobject-3 python-3 pyxdg requests squashfs-tools"
-BUILDDEP="appstream desktop-file-utils gettext gtk-update-icon-cache"
+        pygobject-3 python-3 pyxdg requests squashfs-tools gtk-update-icon-cache"
+BUILDDEP="appstream desktop-file-utils gettext"
 PKGDES="A utility to manage AppImages"
 
 ABTYPE=meson

--- a/app-utils/gearlever/spec
+++ b/app-utils/gearlever/spec
@@ -1,4 +1,5 @@
 VER=3.4.3
+REL=1
 SRCS="git::commit=tags/${VER}::https://github.com/mijorus/gearlever"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378021"

--- a/app-utils/mission-center/autobuild/defines
+++ b/app-utils/mission-center/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=mission-center
 PKGSEC=utils
 PKGDES="A GUI tool displays CPU, memory, disk, network and GPU usage"
 PKGDEP="cairo gcc-runtime gdk-pixbuf glib glibc graphene gtk-4 libadwaita \
-        pango mesa systemd nethogs polkit"
-BUILDDEP="rustc llvm gtk-update-icon-cache desktop-file-utils blueprint-compiler appdata-tools"
+        pango mesa systemd nethogs polkit gtk-update-icon-cache"
+BUILDDEP="rustc llvm desktop-file-utils blueprint-compiler appdata-tools"
 
 ABTYPE=meson
 

--- a/app-utils/mission-center/spec
+++ b/app-utils/mission-center/spec
@@ -1,4 +1,5 @@
 VER=1.0.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://gitlab.com/mission-center-devs/mission-center"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377664"

--- a/app-utils/showmethekey/autobuild/defines
+++ b/app-utils/showmethekey/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=showmethekey
 PKGSEC=utils
 PKGDES="Show keys you typed on screen"
 PKGDEP="systemd libadwaita libevdev libinput gtk-4 glib json-glib cairo pango \
-        libxkbcommon polkit"
-BUILDDEP="gtk-update-icon-cache"
+        libxkbcommon polkit gtk-update-icon-cache"
 
 ABTYPE=meson

--- a/app-utils/showmethekey/spec
+++ b/app-utils/showmethekey/spec
@@ -1,4 +1,5 @@
 VER=1.18.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AlynxZhou/showmethekey"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236314"

--- a/app-web/tuba/autobuild/defines
+++ b/app-web/tuba/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=tuba
 PKGSEC=web
 PKGDEP="json-glib libgee libsoup-3 libadwaita libsecret gtksourceview-5 icu \
-        libspelling gstreamer libxml2"
-BUILDDEP="vala gtk-update-icon-cache"
+        libspelling gstreamer libxml2 gtk-update-icon-cache"
+BUILDDEP="vala"
 PKGDES="Mastodon client"
 
 ABTYPE=meson

--- a/app-web/tuba/spec
+++ b/app-web/tuba/spec
@@ -1,4 +1,5 @@
 VER=0.10.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/GeopJr/Tuba.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=359620"

--- a/app-web/wike/autobuild/defines
+++ b/app-web/wike/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=wike
 PKGSEC=web
-PKGDEP="dconf glib gtk-4 hicolor-icon-theme libadwaita libsoup-3 pango python-3 pygobject-3 webkit2gtk"
-BUILDDEP="appstream gtk-update-icon-cache"
+PKGDEP="dconf glib gtk-4 hicolor-icon-theme libadwaita libsoup-3 pango \
+        python-3 pygobject-3 webkit2gtk gtk-update-icon-cache"
+BUILDDEP="appstream"
 PKGDES="A native desktop reader for Wikipedia"
 ABHOST=noarch

--- a/app-web/wike/spec
+++ b/app-web/wike/spec
@@ -1,4 +1,5 @@
 VER=3.1.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/hugolabe/Wike.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=221463"

--- a/desktop-gnome/adwaita-icon-theme-legacy/autobuild/defines
+++ b/desktop-gnome/adwaita-icon-theme-legacy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=adwaita-icon-theme-legacy
 PKGSEC=gnome
-PKGDEP="hicolor-icon-theme"
-BUILDDEP="gtk-update-icon-cache icon-naming-utils intltool"
+PKGDEP="hicolor-icon-theme gtk-update-icon-cache"
+BUILDDEP=" icon-naming-utils intltool"
 PKGDES="Fallback icons for Adwaita icon theme"
 
 ABSHADOW=0

--- a/desktop-gnome/adwaita-icon-theme-legacy/spec
+++ b/desktop-gnome/adwaita-icon-theme-legacy/spec
@@ -1,4 +1,5 @@
 VER=46.2
+REL=1
 SRCS="git::commit=$VER::https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372552"

--- a/desktop-gnome/adwaita-icon-theme/autobuild/defines
+++ b/desktop-gnome/adwaita-icon-theme/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=adwaita-icon-theme
 PKGSEC=gnome
-PKGDEP="hicolor-icon-theme"
+PKGDEP="hicolor-icon-theme gtk-update-icon-cache"
 PKGRECOM="adwaita-icon-theme-legacy"
-BUILDDEP="gtk-update-icon-cache icon-naming-utils intltool"
+BUILDDEP=" icon-naming-utils intltool"
 PKGDES="Adwaita icon theme, the official icon theme of GNOME"
 
 ABSHADOW=0

--- a/desktop-gnome/adwaita-icon-theme/spec
+++ b/desktop-gnome/adwaita-icon-theme/spec
@@ -1,4 +1,5 @@
 VER=47.0
+REL=1
 SRCS="https://download.gnome.org/sources/adwaita-icon-theme/${VER%%.*}/adwaita-icon-theme-${VER/\~/.}.tar.xz"
 CHKSUMS="sha256::ad088a22958cb8469e41d9f1bba0efb27e586a2102213cd89cc26db2e002bdfe"
 CHKUPDATE="anitya::id=13117"

--- a/desktop-gnome/calls/autobuild/defines
+++ b/desktop-gnome/calls/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=calls
 PKGSEC=gnome
-PKGDEP="wayland gtk-3 gom libpeas gsound folks evolution-data-server \
-        modemmanager libhandy callaudiod feedbackd sofia-sip"
-BUILDDEP="appstream-glib gtk-doc vala docutils"
+PKGDEP="wayland gtk-4 gom libpeas gsound folks evolution-data-server \
+        modemmanager libhandy callaudiod feedbackd sofia-sip libadwaita"
+BUILDDEP="appstream-glib vala docutils gtk-update-icon-cache"
 PKGDES="Phone dialer and call handler for GNOME/Phosh"
 
-MESON_AFTER="-Dgtk_doc=true"
+MESON_AFTER="-Dgtk_doc=false"

--- a/desktop-gnome/calls/spec
+++ b/desktop-gnome/calls/spec
@@ -1,4 +1,5 @@
 VER=46.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/GNOME/calls"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=111609"

--- a/desktop-gnome/dconf-editor/autobuild/defines
+++ b/desktop-gnome/dconf-editor/autobuild/defines
@@ -1,6 +1,5 @@
 PKGNAME=dconf-editor
 PKGSEC=gnome
-PKGDEP="dconf gtk-3 glib libhandy"
-# dconf-editor tries to run gtk4-update-icon-cache
+PKGDEP="dconf gtk-3 glib libhandy gtk-update-icon-cache"
 BUILDDEP="gtk-doc intltool vala meson ninja gtk-4"
 PKGDES="An editor for DConf settings"

--- a/desktop-gnome/dconf-editor/spec
+++ b/desktop-gnome/dconf-editor/spec
@@ -1,4 +1,5 @@
 VER=45.0.1
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/dconf-editor/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=100776"

--- a/desktop-gnome/eog/autobuild/defines
+++ b/desktop-gnome/eog/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=eog
 PKGSEC=gnome
 PKGDEP="gnome-desktop libexif lcms2 desktop-file-utils exempi \
         libpeas librsvg dconf cairo gdk-pixbuf gobject-introspection \
-        gtk-3 libjpeg-turbo x11-lib libportal libhandy"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool itstool"
+        gtk-3 libjpeg-turbo x11-lib libportal libhandy gtk-update-icon-cache"
+BUILDDEP="gobject-introspection intltool itstool"
 PKGDES="An image viewing and cataloging program for GNOME"
 
 MESON_AFTER="-Dlibexif=true \
@@ -11,7 +11,6 @@ MESON_AFTER="-Dlibexif=true \
              -Dxmp=true \
              -Dlibjpeg=true \
              -Dlibrsvg=true \
-             -Dgtk_doc=true \
              -Dintrospection=true \
              -Dinstalled_tests=false \
              -Dlibportal=true \

--- a/desktop-gnome/eog/spec
+++ b/desktop-gnome/eog/spec
@@ -1,4 +1,5 @@
 VER=42.3
+REL=1
 SRCS="https://download.gnome.org/sources/eog/${VER%.*}/eog-$VER.tar.xz"
 CHKSUMS="sha256::30c1b3c28bc6dc2854d878ebd31a22eaa15bf959c134206a2a1904193e47f43a"
 CHKUPDATE="anitya::id=5393"

--- a/desktop-gnome/fractal/autobuild/defines
+++ b/desktop-gnome/fractal/autobuild/defines
@@ -2,9 +2,8 @@ PKGNAME=fractal
 PKGSEC=gnome
 PKGDEP="glib gtk-4 libadwaita gstreamer gtksourceview-5 openssl libshumate \
         sqlite pango graphene libseccomp lcms2 libwebp glycin gstreamer \
-        gst-plugins-rs"
-BUILDDEP="meson ninja rustc llvm xdg-desktop-portal gtk-update-icon-cache \
-          desktop-file-utils grass"
+        gst-plugins-rs gtk-update-icon-cache"
+BUILDDEP="meson ninja rustc llvm xdg-desktop-portal desktop-file-utils grass"
 PKGDES="Matrix messaging client for GNOME"
 
 USECLANG=1

--- a/desktop-gnome/fractal/spec
+++ b/desktop-gnome/fractal/spec
@@ -1,4 +1,5 @@
 VER=12.1
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/World/fractal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=197366"

--- a/desktop-gnome/ghex/autobuild/defines
+++ b/desktop-gnome/ghex/autobuild/defines
@@ -1,11 +1,10 @@
 PKGNAME=ghex
 PKGSEC=gnome
-PKGDEP="gtk-4 hicolor-icon-theme libadwaita"
-BUILDDEP="docbook-xsl gi-docgen gobject-introspection gtk-doc intltool itstool gtk-update-icon-cache"
+PKGDEP="gtk-4 hicolor-icon-theme libadwaita gtk-update-icon-cache"
+BUILDDEP="docbook-xsl gobject-introspection intltool itstool"
 PKGDES="A simple Bin/Hex editor for GNOME"
 
 MESON_AFTER="-Ddevelopment=false \
              -Dmmap-buffer-backend=true \
              -Dintrospection=enabled \
-             -Dgtk_doc=true \
              -Dstatic-html-help=true"

--- a/desktop-gnome/ghex/spec
+++ b/desktop-gnome/ghex/spec
@@ -1,4 +1,5 @@
 VER=46.0
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/ghex/${VER%%.*}/ghex-$VER.tar.xz"
 CHKSUMS="sha256::a1c46f3020cb358b8323025db3a539c97d994a4c46f701f48edc6357f7fbcbd1"
 CHKUPDATE="anitya::id=10936"

--- a/desktop-gnome/gnome-clocks/autobuild/defines
+++ b/desktop-gnome/gnome-clocks/autobuild/defines
@@ -1,10 +1,7 @@
 PKGNAME=gnome-clocks
 PKGSEC=gnome
 PKGDEP="gtk-4 libcanberra libgweather gnome-desktop hicolor-icon-theme \
-        geoclue2 geocode-glib gsound libhandy desktop-file-utils libadwaita"
-BUILDDEP="appstream-glib gobject-introspection gtk-doc intltool itstool vala"
+        geoclue2 geocode-glib gsound libhandy desktop-file-utils libadwaita \
+        gtk-update-icon-cache"
+BUILDDEP="appstream-glib gobject-introspection intltool itstool vala"
 PKGDES="Clocks application for GNOME"
-
-# FIXME: Vala documentation generation broken, as it still attempts to link
-# the now unavailable libgweather-3.0 Gir library.
-MESON_AFTER="-Ddocs=false"

--- a/desktop-gnome/gnome-clocks/spec
+++ b/desktop-gnome/gnome-clocks/spec
@@ -1,4 +1,5 @@
 VER=42.0
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-clocks/${VER%.*}/gnome-clocks-$VER.tar.xz"
 CHKSUMS="sha256::0e7118db4a032e3cea3212d98cbb828d6b7cf22fe05e0c5fc8b391c6a3dd6fe0"
 CHKUPDATE="anitya::id=10905"

--- a/desktop-gnome/gnome-contacts/autobuild/defines
+++ b/desktop-gnome/gnome-contacts/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=gnome-contacts
 PKGSEC=gnome
 PKGDEP="gtk-4 folks libnotify gnome-desktop gnome-online-accounts dconf \
         libgee telepathy-glib cheese evolution-data-server protobuf \
-        libchamplain clutter-gtk libportal libadwaita"
+        libchamplain clutter-gtk libportal libadwaita gtk-update-icon-cache"
 BUILDDEP="appstream-glib gobject-introspection intltool vala \
           docbook-xml docbook-xsl"
 PKGDES="Contacts manager for GNOME"

--- a/desktop-gnome/gnome-contacts/spec
+++ b/desktop-gnome/gnome-contacts/spec
@@ -1,4 +1,5 @@
 VER=42.0
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-contacts/${VER%.*}/gnome-contacts-$VER.tar.xz"
 CHKSUMS="sha256::8802c38fdc23f528dac128f53bdcf1f6ca30e0e1c6848c42cd6c84a5e22c5216"
 CHKUPDATE="anitya::id=204994"

--- a/desktop-gnome/gnome-icon-theme-symbolic/autobuild/defines
+++ b/desktop-gnome/gnome-icon-theme-symbolic/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-icon-theme-symbolic
 PKGSEC=gnome
-PKGDEP="gnome-icon-theme"
+PKGDEP="gnome-icon-theme gtk-update-icon-cache"
 BUILDDEP="gtk-4 icon-naming-utils"
 PKGDES="GNOME icon theme (symbolic icons)"
 

--- a/desktop-gnome/gnome-icon-theme-symbolic/spec
+++ b/desktop-gnome/gnome-icon-theme-symbolic/spec
@@ -1,5 +1,5 @@
 VER=3.12.0
-REL=4
+REL=5
 SRCS="tbl::https://download.gnome.org/sources/gnome-icon-theme-symbolic/3.12/gnome-icon-theme-symbolic-$VER.tar.xz"
 CHKSUMS="sha256::851a4c9d8e8cb0000c9e5e78259ab8b8e67c5334e4250ebcc8dfdaa33520068b"
 CHKUPDATE="anitya::id=227751"

--- a/desktop-gnome/gnome-system-monitor/autobuild/defines
+++ b/desktop-gnome/gnome-system-monitor/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-system-monitor
 PKGSEC=gnome
-PKGDEP="desktop-file-utils gtkmm-3 libgtop libhandy librsvg systemd"
+PKGDEP="desktop-file-utils gtkmm-3 libgtop libhandy librsvg systemd gtk-update-icon-cache"
 BUILDDEP="appstream-glib docbook-xsl intltool itstool"
 PKGDES="A system monitor for GNOME"
 

--- a/desktop-gnome/gnome-system-monitor/spec
+++ b/desktop-gnome/gnome-system-monitor/spec
@@ -1,4 +1,5 @@
 VER=42.0
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-system-monitor/${VER%.*}/gnome-system-monitor-$VER.tar.xz"
 CHKSUMS="sha256::13239d22032201a22bd29833c575b684816700d2de168a1530223577c5c075dc"
 CHKUPDATE="anitya::id=13137"

--- a/desktop-gnome/gtranslator/autobuild/defines
+++ b/desktop-gnome/gtranslator/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=gtranslator
 PKGSEC=gnome
-PKGDEP="gspell gtk-4 gtksourceview-5 libadwaita libdazzle libgda libhandy libsoup-3"
-BUILDDEP="gtk-update-icon-cache itstool"
+PKGDEP="gspell gtk-4 gtksourceview-5 libadwaita libdazzle libgda libhandy \
+        libsoup-3 gtk-update-icon-cache"
+BUILDDEP="itstool"
 PKGDES="A Gettext catalog editor for GNOME"

--- a/desktop-gnome/gtranslator/spec
+++ b/desktop-gnome/gtranslator/spec
@@ -1,4 +1,5 @@
 VER=46.1
+REL=1
 SRCS="https://download.gnome.org/sources/gtranslator/${VER%.*}/gtranslator-$VER.tar.xz"
 CHKSUMS="sha256::b4af3184891491fd89c1a0465652310156c07d156b6a24e1c07f3a4cf7579568"
 CHKUPDATE="anitya::id=1274"

--- a/desktop-gnome/loupe/autobuild/defines
+++ b/desktop-gnome/loupe/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=loupe
 PKGSEC=gnome
 PKGDEP="cairo dconf fontconfig gcc-runtime glib glibc glycin graphene gtk-4 hicolor-icon-theme \
-        lcms2 libadwaita libgweather libseccomp pango gdk-pixbuf"
-BUILDDEP="itstool rustc gtk-update-icon-cache llvm inkscape"
+        lcms2 libadwaita libgweather libseccomp pango gdk-pixbuf gtk-update-icon-cache"
+BUILDDEP="itstool rustc llvm inkscape"
 PKGDES="Image Viewer for GNOME"
 
 USECLANG=1

--- a/desktop-gnome/loupe/spec
+++ b/desktop-gnome/loupe/spec
@@ -1,4 +1,5 @@
 VER=47.4
+REL=1
 SRCS="https://download.gnome.org/sources/loupe/${VER%.*}/loupe-$VER.tar.xz"
 CHKSUMS="sha256::8dc926829a9c338800c8f432b5a347246e6dcbd9ad2dd1a24c498eafdd3e89ab"
 CHKUPDATE="antiya::id=368849"

--- a/desktop-gnome/polari/autobuild/defines
+++ b/desktop-gnome/polari/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=polari
 PKGSEC=gnome
 PKGDEP="desktop-file-utils gjs gspell gtk-4 libsecret libsoup-3 \
         telepathy-glib telepathy-idle telepathy-mission-control \
-        telepathy-logger desktop-file-utils"
+        telepathy-logger desktop-file-utils gtk-update-icon-cache"
 BUILDDEP="appstream-glib gobject-introspection intltool itstool"
 PKGDES="An IRC client for GNOME"
 

--- a/desktop-gnome/polari/spec
+++ b/desktop-gnome/polari/spec
@@ -1,4 +1,5 @@
 VER=42.1
+REL=1
 SRCS="https://download.gnome.org/sources/polari/${VER%%.*}/polari-$VER.tar.xz"
 CHKSUMS="sha256::af90cf0848ecbe407eb2306404836974fd38f31c30d474f46d1b29218a966b3d"
 CHKUPDATE="anitya::id=90897"

--- a/desktop-gnome/zenity/autobuild/defines
+++ b/desktop-gnome/zenity/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=zenity
 PKGSEC=gnome
-PKGDEP="libadwaita webkit2gtk"
-BUILDDEP="help2man itstool yelp-tools gtk-update-icon-cache"
+PKGDEP="libadwaita webkit2gtk gtk-update-icon-cache"
+BUILDDEP="help2man itstool yelp-tools"
 PKGDES="Display graphical dialog boxes from shell scripts"
 
 MESON_AFTER=(

--- a/desktop-gnome/zenity/spec
+++ b/desktop-gnome/zenity/spec
@@ -1,4 +1,5 @@
 VER=4.2.0
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/zenity/${VER:0:3}/zenity-$VER.tar.xz"
 CHKSUMS="sha256::5f983340c6fa55f4fab5a9769d0771b2cdf1365e2c158ac11cc16ffd892f6bcd"
 CHKUPDATE="anitya::id=13165"

--- a/runtime-editors/gtksourceview-5/autobuild/defines
+++ b/runtime-editors/gtksourceview-5/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=gtksourceview-5
 PKGSEC=gnome
-PKGDEP="gtk-4 libxml2"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool vala gtk-update-icon-cache"
+PKGDEP="gtk-4 libxml2 gtk-update-icon-cache"
+BUILDDEP="gobject-introspection intltool vala"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 5)"
 
 MESON_AFTER="-Dinstall-tests=false \
              -Dvapi=true \
-             -Ddocumentation=true \
              -Dsysprof=false"

--- a/runtime-editors/gtksourceview-5/spec
+++ b/runtime-editors/gtksourceview-5/spec
@@ -1,4 +1,5 @@
 VER=5.14.2
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
 CHKSUMS="sha256::1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtksourceview/${VER%.*}/;pattern=gtksourceview-(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- rhythmbox: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- polari: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- gnome-icon-theme-symbolic: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- eog: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- gnome-contacts: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- dconf-editor: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- gnome-system-monitor: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- gnome-clocks: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- calls: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>
- gtksourceview-5: make gtk-update-icon-cache a PKGDEP
    Signed-off-by: stydxm <stydxm@outlook.com>

... and 20 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit telepathy-idle gimp rnote curtail easyeffects netease-cloud-music-gtk tsukimi flatseal font-manager gearlever mission-center showmethekey tuba wike adwaita-icon-theme adwaita-icon-theme-legacy fractal ghex gtranslator loupe zenity gtksourceview-5 calls gnome-clocks gnome-system-monitor dconf-editor gnome-contacts eog gnome-icon-theme-symbolic polari rhythmbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
