### PR TITLE
niri: adjust pkgdep and pkgrecom

### DIFF
--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=niri
 PKGSEC=x11
 PKGDEP="bash cairo gcc-runtime glib glibc gnome-keyring libdisplay-info \
         libinput libxkbcommon mesa pango pipewire pixman seatd systemd \
-        wayland xdg-desktop-portal-gtk xdg-desktop-portal-gnome"
-PKGRECOM="alacritty fuzzel swaylock waybar xwayland-satellite"
+        wayland xdg-desktop-portal-gtk xdg-desktop-portal-gnome xwayland-satellite orca"
+PKGRECOM="alacritty fuzzel swaylock waybar brightnessctl"
 PKGSUG="mako-notification-daemon swaybg swayidle"
 BUILDDEP="rustc llvm"
 PKGDES="Scrollable-tiling Wayland compositor"

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,4 +1,5 @@
 VER=25.08
+REL=1
 # Note: copy-repo is required for the build system to detect commit hash
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/YaLTeR/niri"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- niri: adjust pkgdep and pkgrecom

Package(s) Affected
-------------------

- niri: 25.08-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
