### PR TITLE
element-desktop: update to 1.12.0

### DIFF
--- a/app-web/element-desktop/autobuild/patches/0001-Disable-update-check.patch.deferred
+++ b/app-web/element-desktop/autobuild/patches/0001-Disable-update-check.patch.deferred
@@ -1,4 +1,4 @@
-From 5a80fb1ed4565338edff64fe10ebca3b033ecc11 Mon Sep 17 00:00:00 2001
+From 145845939b9d27939416fe5808e732ed9f11339e Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Tue, 29 Apr 2025 00:42:26 -0700
 Subject: [PATCH 1/2] Disable update check

--- a/app-web/element-desktop/autobuild/patches/0002-Do-not-build-deb.patch.deferred
+++ b/app-web/element-desktop/autobuild/patches/0002-Do-not-build-deb.patch.deferred
@@ -1,4 +1,4 @@
-From 9eaa034aa3690510b139797ff640874854a3a917 Mon Sep 17 00:00:00 2001
+From 577b8160618e162161ab6e89ff25a2de7e4d06ac Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Tue, 29 Apr 2025 03:48:10 -0700
 Subject: [PATCH 2/2] Do not build deb
@@ -9,18 +9,18 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/electron-builder.ts b/electron-builder.ts
-index d2fd537..06a7f71 100644
+index 9ddf531..2c23c67 100644
 --- a/electron-builder.ts
 +++ b/electron-builder.ts
-@@ -91,7 +91,7 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
-         electron_protocol: DEFAULT_PROTOCOL_SCHEME,
+@@ -127,7 +127,7 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
+         electron_protocol: variant.protocols[0],
      },
      linux: {
 -        target: ["tar.gz", "deb"],
 +        target: ["tar.gz"],
          category: "Network;InstantMessaging;Chat",
          icon: "build/icon.png",
-         executableName: pkg.name, // element-desktop or element-desktop-nightly
+         executableName: variant.name, // element-desktop or element-desktop-nightly
 -- 
 2.51.0
 

--- a/app-web/element-desktop/spec
+++ b/app-web/element-desktop/spec
@@ -1,4 +1,4 @@
-VER=1.11.112
+VER=1.12.0
 SRCS="git::commit=tags/v$VER;rename=element-web::https://github.com/element-hq/element-web \
       git::commit=tags/v$VER;rename=element-desktop::https://github.com/element-hq/element-desktop"
 CHKSUMS="SKIP SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- element-desktop: update to 1.12.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- element-desktop: 1.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit element-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
