### PR TITLE
cargo-c: fix dependencies and drop old hacks

### DIFF
--- a/lang-rust/cargo-c/autobuild/defines
+++ b/lang-rust/cargo-c/autobuild/defines
@@ -1,17 +1,7 @@
 PKGNAME=cargo-c
 PKGSEC="utils"
+PKGDEP="curl gcc-runtime glibc libgit2 openssl"
 BUILDDEP="rustc llvm"
-PKGDES="cargo applet to build and install C-ABI compatible dynamic and static libraries"
+PKGDES="Cargo applet to build and install C-ABI compatible libraries"
 
 USECLANG=1
-ABSPLITDBG=0
-NOLTO__RISCV64=1
-
-# FIXME: ld.lld is not available on loongarch64.
-NOLTO__LOONGARCH64=1
-
-# FIXME: Signal 11 on linkage.
-USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1
-
-ABSPLITDBG__LOONGSON3=0

--- a/lang-rust/cargo-c/spec
+++ b/lang-rust/cargo-c/spec
@@ -1,6 +1,7 @@
 VER=0.10.15
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/lu-zero/cargo-c"
 CHKUPDATE="anitya::id=58394"
 CHKSUMS="SKIP"
 
-ENVREQ="total_mem=20"
+ENVREQ="total_mem=30"


### PR DESCRIPTION
Topic Description
-----------------

- cargo-c: fix dependencies and drop old hacks

Package(s) Affected
-------------------

- cargo-c: 0.10.15-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cargo-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
