### PR TITLE
pixiewps: fix build

### DIFF
--- a/app-penetration/pixiewps/autobuild/build
+++ b/app-penetration/pixiewps/autobuild/build
@@ -1,3 +1,6 @@
-make -C src CCFLAGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -std=c99"
-mkdir -p "$PKGDIR"/usr/bin
-cp -a src/pixiewps "$PKGDIR"/usr/bin/
+abinfo "Building pixiewps ..."
+make CCFLAGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -std=c99"
+
+abinfo "Installing pixiewps ..."
+mkdir -pv "$PKGDIR"/usr/bin
+cp -av "$SRCDIR"/pixiewps "$PKGDIR"/usr/bin/

--- a/app-penetration/pixiewps/spec
+++ b/app-penetration/pixiewps/spec
@@ -1,4 +1,5 @@
 VER=1.4.2
-SRCS="tbl::https://github.com/wiire/pixiewps/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c73ffd58c461a88504cca36e5a29981dc68b78f8fdd31d7c546bc204fad7c435"
+REL=1
+SRCS="git::commit=tags/v${VER}::https://github.com/wiire/pixiewps"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21568"


### PR DESCRIPTION
Topic Description
-----------------

- pixiewps: fix build
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pixiewps: 1.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pixiewps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
