### PR TITLE
chore(github): update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -11,20 +11,6 @@ Package(s) Affected
 
 <!-- Please list all package(s) affected by this topic here. -->
 
-Security Update?
-----------------
-
-<!-- If this topic contains security update(s), please uncomment "Yes,"
-     mark with the `security` label and make sure to mark your commits to
-     relevant issue numbers.
-
-     Please see GitHub's documentation on "Linking a pull request to an issue":
-
-     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
-
-<!-- Yes, #ISSUENUMBER -->
-<!-- No -->
-
 Build Order
 -----------
 
@@ -67,14 +53,21 @@ Test Build(s) Done
 - [ ] PowerPC 64-bit (Little Endian) `ppc64el`
 - [ ] RISC-V 64-bit `riscv64`
 
-<!-- Maintainers should review file changes and make sure that the change(s)
-     complies with our
-     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->
+Pre-Approve Checks
+------------------
 
-<!-- Maintainers and users may now test the packages in this topic and, once
-     user/maintainer feedback indicates that the update(s) work as expected and
-     find its quality satisfactory, another maintainer may now review this pull
-     request and mark it as "Approved."
+- [ ] Conflicts with other topics have been negotiated or don't exist (ask aosc.io/contact if unsure)
+- [ ] Commits abide by [the styling manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/#git-commit-messages)
+- [ ] Scripting changes abide by [the styling manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/)
+- [ ] Dickens report exists
+  - [ ] No breaking changes (e.g., sover) or has rebuilt broken reverse dependencies
+  - [ ] No unexpected file changes (e.g., permission, massive file addition or removal)
+- [ ] At least one primary architecture has been tested LGTM
 
-     After which, the maintainer will build affected package(s) and upload them
-     to the `stable` repository. -->
+<!-- If this topic contains security update(s), please mark with the `security`
+     label and make sure to link to relevant issues in the `Development` tab on
+     GitHub.
+
+     Please see GitHub's documentation on "Linking a pull request to an issue":
+
+     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


### PR DESCRIPTION
Topic Description
-----------------

- chore\(github\): update pull request template
    - replace instruction comments with a checklist
    - remove the security update section
    - keep the security comment, but update the procedure

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
