### PR TITLE
shadowsocks-rust: add network capabilities for binaries

### DIFF
--- a/app-proxy/shadowsocks-rust/autobuild/postinst
+++ b/app-proxy/shadowsocks-rust/autobuild/postinst
@@ -1,0 +1,2 @@
+setcap cap_net_bind_service,cap_net_admin+ep usr/bin/sslocal  2>/dev/null
+setcap cap_net_bind_service+ep usr/bin/ssserver 2>/dev/null

--- a/app-proxy/shadowsocks-rust/spec
+++ b/app-proxy/shadowsocks-rust/spec
@@ -1,4 +1,5 @@
 VER=1.23.5
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/shadowsocks/shadowsocks-rust.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230992"


### PR DESCRIPTION
Topic Description
-----------------

- shadowsocks-rust: add network capabilities for binaries

Package(s) Affected
-------------------

- shadowsocks-rust: 1.23.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadowsocks-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
