### PR TITLE
gcc-13: fix defines

### DIFF
--- a/app-devel/gcc-13/autobuild/defines
+++ b/app-devel/gcc-13/autobuild/defines
@@ -41,29 +41,33 @@ AUTOTOOLS_AFTER=(
 	"--program-suffix=-13"
 )
 
-AUTOTOOLS_AFTER__WITHGO="--enable-languages=c,c++,fortran,lto,go,objc,obj-c++,m2,d,ada"
-AUTOTOOLS_AFTER__WITHOUTGO="--enable-languages=c,c++,fortran,lto,objc,obj-c++,m2,d,ada"
+AUTOTOOLS_AFTER__WITHGO=(
+	"--enable-languages=c,c++,fortran,lto,go,objc,obj-c++,m2,d,ada"
+)
+AUTOTOOLS_AFTER__WITHOUTGO=(
+	"--enable-languages=c,c++,fortran,lto,objc,obj-c++,m2,d,ada"
+)
 AUTOTOOLS_AFTER__AMD64=(
 	"${AUTOTOOLS_AFTER[@]}"
 	"${AUTOTOOLS_AFTER__WITHGO[@]}"
 )
 AUTOTOOLS_AFTER__ARM64=(
 	"${AUTOTOOLS_AFTER[@]}"
-	"${AUTOTOOLS_AFTER__WITHGO}"
+	"${AUTOTOOLS_AFTER__WITHGO[@]}"
 	"-with-arch=armv8-a"
 	"--enable-fix-cortex-a53-835769"
 	"--enable-fix-cortex-a53-843419"
 )
 AUTOTOOLS_AFTER__LOONGARCH64=(
 	"${AUTOTOOLS_AFTER[@]}"
-	"${AUTOTOOLS_AFTER__WITHOUTGO/,ada/}"
+	"${AUTOTOOLS_AFTER__WITHOUTGO[@]/,ada/}"
 	"--with-abi=lp64d"
 	"--with-arch=loongarch64"
 	"--with-tune=la464"
 )
 AUTOTOOLS_AFTER__LOONGSON3=(
 	"${AUTOTOOLS_AFTER[@]}"
-	"${AUTOTOOLS_AFTER__WITHOUTGO/,ada/}"
+	"${AUTOTOOLS_AFTER__WITHOUTGO[@]/,ada/}"
 	"--enable-languages=c,c++,fortran,lto,objc,obj-c++,m2,d"
 	"--with-abi=64"
 	"--with-arch=gs464"
@@ -72,7 +76,7 @@ AUTOTOOLS_AFTER__LOONGSON3=(
 )
 AUTOTOOLS_AFTER__PPC64EL=(
 	"${AUTOTOOLS_AFTER[@]}"
-	"${AUTOTOOLS_AFTER_WITHGO}"
+	"${AUTOTOOLS_AFTER_WITHGO[@]}"
 	"--with-libphobos-druntime-only=no"
 	"--with-cpu=power8"
 	"--with-tune=power9"

--- a/app-devel/gcc-13/spec
+++ b/app-devel/gcc-13/spec
@@ -1,5 +1,5 @@
 VER=13.4.0
-REL=1
+REL=2
 SRCS="https://sourceware.org/pub/gcc/releases/gcc-${VER}/gcc-${VER}.tar.xz"
 CHKSUMS="sha256::9c4ce6dbb040568fdc545588ac03c5cbc95a8dbf0c7aa490170843afb59ca8f5"
 # NOTE: Pinning the major version number to 13. The non-capturing group


### PR DESCRIPTION
Topic Description
-----------------

- gcc-13: fix defines
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- gcc-13: 13.4.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcc-13
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
