### PR TITLE
tree-sitter: update to 0.26.0, 0.26.0

### DIFF
--- a/app-devel/tree-sitter/spec
+++ b/app-devel/tree-sitter/spec
@@ -1,4 +1,4 @@
-VER=0.25.3
+VER=0.26.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=142464"


### PR DESCRIPTION
Topic Description
-----------------

- tree-sitter: update to 0.26.0

Package(s) Affected
-------------------

- tree-sitter: 0.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree-sitter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
