### PR TITLE
libxslt: update to 1.1.43

### DIFF
--- a/runtime-common/libxslt/spec
+++ b/runtime-common/libxslt/spec
@@ -1,4 +1,4 @@
-VER=1.1.42
+VER=1.1.43
 SRCS="git::commit=tags/v$VER::https://github.com/GNOME/libxslt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13301"

--- a/runtime-optenv32/libxslt+32/spec
+++ b/runtime-optenv32/libxslt+32/spec
@@ -1,4 +1,4 @@
-VER=1.1.42
+VER=1.1.43
 SRCS="git::commit=tags/v$VER::https://github.com/GNOME/libxslt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13301"

--- a/topics/libxslt-1.1.43.toml
+++ b/topics/libxslt-1.1.43.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libxslt 1.1.43"
+
+[caution]
+default = "Fixes 2 use-after-free vulnerabilities - CVE-2025-24855, CVE-2024-55549 (Severity: High)"
+zh_CN = "修复 2 个释放后使用 (use-after-free) 漏洞，漏洞编号 CVE-2025-24855, CVE-2024-55549（严重性：高）"
+
+[packages-v2]
+"libxslt" = "< 1.1.43"
+"libxslt+32" = "< 1.1.43"


### PR DESCRIPTION
Topic Description
-----------------

- libxslt: update to 1.1.43
    Co-authored-by: billchenchina \(@billchenchina\) <billchenchina2001@gmail.com>

Package(s) Affected
-------------------

- libxslt: 1.1.43

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxslt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
