### PR TITLE
deno: update to 2.5.2

### DIFF
--- a/lang-js/deno/autobuild/defines
+++ b/lang-js/deno/autobuild/defines
@@ -17,3 +17,9 @@ USECLANG=1
 # riscv64: fails to build ring crate
 # * https://github.com/denoland/deno/issues/18702
 FAIL_ARCH="!(amd64|arm64)"
+
+# FIXME:
+# ld.lld: error: undefined symbol: aws_lc_0_26_0_EVP_parse_private_key
+# >>> referenced by evp_pkey.rs:171 (/root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-lc-rs-1.12.4/src/evp_pkey.rs:171)
+# >>> /var/cache/acbs/build/acbs.hoqni7cd/deno/target/release/deps/test_server-63bd788806c63baf.lto.o:(_$LT$rustls..crypto..aws_lc_rs..AwsLcRs$u20$as$u20$rustls..crypto..KeyProvider$GT$::load_private_key::h8359cdda80ece7cf)
+NOLTO=1

--- a/lang-js/deno/autobuild/patches/0001-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-use-local-patched-rusty_v8.patch
@@ -1,6 +1,6 @@
-From 480c8829c22a49b14f7bc001b32ed588b843ace3 Mon Sep 17 00:00:00 2001
+From 1d23cbadeb8460f7472665753d18e3724a07b346 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Thu, 11 Sep 2025 22:58:17 +0800
+Date: Thu, 25 Sep 2025 12:59:38 +0800
 Subject: [PATCH] use local patched rusty_v8
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH] use local patched rusty_v8
  2 files changed, 9 insertions(+), 8 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 49016997f..be156df68 100644
+index 34a484dc0..701e2354e 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -561,7 +561,7 @@ dependencies = [
@@ -39,7 +39,7 @@ index 49016997f..be156df68 100644
   "log",
   "prettyplease",
   "proc-macro2",
-@@ -5790,7 +5790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -5794,7 +5794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
  dependencies = [
   "cfg-if",
@@ -48,7 +48,7 @@ index 49016997f..be156df68 100644
  ]
  
  [[package]]
-@@ -7226,7 +7226,7 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+@@ -7230,7 +7230,7 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
  dependencies = [
   "bytes",
   "heck 0.5.0",
@@ -57,7 +57,7 @@ index 49016997f..be156df68 100644
   "log",
   "multimap",
   "once_cell",
-@@ -7246,7 +7246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
  dependencies = [
   "anyhow",
@@ -66,17 +66,17 @@ index 49016997f..be156df68 100644
   "proc-macro2",
   "quote",
   "syn 2.0.87",
-@@ -10077,8 +10077,6 @@ dependencies = [
+@@ -10091,8 +10091,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "140.0.0"
+ version = "140.2.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4e0ad6613428e148bb814ee8890a23bb250547a8f837922ca1ea6eba90670514"
+-checksum = "8827809a2884fb68530d678a8ef15b1ed1344bbf844879194d68c140c6f844f9"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index f753c51e1..857d0b9ff 100644
+index aafbc9757..cfad7908f 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -537,3 +537,6 @@ opt-level = 3

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.5.1
+VER=2.5.2
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=140.0.0
+RUSTY_V8_VER=140.2.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::d039d79548930742dcd770ceaf7a5aca26c571902dd9629d91ed049865bf9ccb \
+CHKSUMS="sha256::44e9db8c52da72fed0ef8f990ab7ba3435562942752b5eafe845ff31bb643438 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.5.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
