### PR TITLE
postgresql-18: new, 18.0

### DIFF
--- a/app-database/postgresql-18/01-runtime/beyond
+++ b/app-database/postgresql-18/01-runtime/beyond
@@ -1,0 +1,21 @@
+abinfo "Installing contrib components ..."
+make -C "$SRCDIR"/contrib \
+	DESTDIR="$PKGDIR" \
+	install
+
+abinfo "Installing SGML documentation ..."
+make -C "$SRCDIR"/doc/src/sgml \
+	DESTDIR="$PKGDIR" \
+	install-man
+
+abinfo "Using the original PKGDIR ..."
+export TMP_PKGDIR="$PKGDIR"
+export PKGDIR="$OLD_PKGDIR"
+
+abinfo "Installing PostgreSQL shared libraries ..."
+mkdir -pv "$PKGDIR"/usr/lib/postgresql-"$MAJORVER"/lib
+for lib in \
+	$(find "$TMP_PKGDIR"/usr/lib/postgresql-"$MAJORVER"/lib \
+		-maxdepth 1 -type f,l -name 'lib*.so*'); do
+	mv -v "$lib" "$PKGDIR"/usr/lib/postgresql-"$MAJORVER"/lib/
+done

--- a/app-database/postgresql-18/01-runtime/defines
+++ b/app-database/postgresql-18/01-runtime/defines
@@ -1,0 +1,42 @@
+PKGNAME=postgresql-runtime-18
+PKGSEC=database
+# Dependencies of the runtime libraries.
+PKGDEP="krb5 openssl glibc"
+# Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
+# will be recorded at 02-server/defines.
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
+	libxslt docbook2x perl docbook-xsl"
+PKGDES="PostgreSQL runtime libraries (18.x branch)"
+
+# IMPORTANT!
+# PostgreSQL keeps data directories individually for each major version.
+# Do NOT use the same data directory across the major versions.
+# NOTE: their translation files do have versioned suffixes.
+AUTOTOOLS_AFTER=(
+	"--prefix=/usr/lib/postgresql-18"
+	"--bindir=/usr/lib/postgresql-18/bin"
+	"--libdir=/usr/lib/postgresql-18/lib"
+	"--sbindir=/usr/lib/postgresql-18/bin"
+	"--datarootdir=/usr/share/postgresql-18"
+	"--datadir=/usr/share/postgresql-18"
+	"--localedir=/usr/share/locale"
+	"--with-gssapi"
+	"--with-libxml"
+	"--with-openssl"
+	"--with-perl"
+	"--with-python"
+	"--with-tcl"
+	"--with-llvm"
+	"--with-pam"
+	"--with-libxslt"
+	"--with-icu"
+	"--with-system-tzdata=/usr/share/zoneinfo"
+	"--with-uuid=e2fs"
+	"--enable-nls"
+	"PYTHON=/usr/bin/python3"
+)
+
+ABMK="world"
+ABSHADOW=0
+RECONF=0
+NOSTATIC=0

--- a/app-database/postgresql-18/01-runtime/defines.stage2
+++ b/app-database/postgresql-18/01-runtime/defines.stage2
@@ -1,0 +1,43 @@
+PKGNAME=postgresql-runtime-18
+PKGSEC=database
+# Dependencies of the runtime libraries.
+PKGDEP="krb5 openssl glibc"
+# Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
+# will be recorded at 02-server/defines.
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux \
+	libxslt docbook2x perl tcl docbook-xsl"
+PKGDES="PostgreSQL runtime libraries (18.x branch)"
+
+# IMPORTANT!
+# PostgreSQL keeps data directories individually for each major version.
+# Do NOT use the same data directory across the major versions.
+# NOTE: their translation files do have versioned suffixes.
+# NOTE: Clang is not available in stage 2.
+AUTOTOOLS_AFTER=(
+	"--prefix=/usr/lib/postgresql-18"
+	"--bindir=/usr/lib/postgresql-18/bin"
+	"--libdir=/usr/lib/postgresql-18/lib"
+	"--sbindir=/usr/lib/postgresql-18/bin"
+	"--datarootdir=/usr/share/postgresql-18"
+	"--datadir=/usr/share/postgresql-18"
+	"--localedir=/usr/share/locale"
+	"--with-gssapi"
+	"--with-libxml"
+	"--with-openssl"
+	"--with-perl"
+	"--with-python"
+	"--with-tcl"
+	"--without-llvm"
+	"--with-pam"
+	"--with-libxslt"
+	"--with-icu"
+	"--with-system-tzdata=/usr/share/zoneinfo"
+	"--with-uuid=e2fs"
+	"--enable-nls"
+	"PYTHON=/usr/bin/python3"
+)
+
+ABMK="world"
+ABSHADOW=0
+RECONF=0
+NOSTATIC=0

--- a/app-database/postgresql-18/01-runtime/patches/0001-Fedora-postgresql-var-run-socket.patch
+++ b/app-database/postgresql-18/01-runtime/patches/0001-Fedora-postgresql-var-run-socket.patch
@@ -1,0 +1,13 @@
+diff --git a/src/include/pg_config_manual.h b/src/include/pg_config_manual.h
+index e278fa0..9ee15d4 100644
+--- a/src/include/pg_config_manual.h
++++ b/src/include/pg_config_manual.h
+@@ -201,7 +201,7 @@
+  * support them yet.
+  */
+ #ifndef WIN32
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/run/postgresql"
+ #else
+ #define DEFAULT_PGSOCKET_DIR ""
+ #endif

--- a/app-database/postgresql-18/01-runtime/prepare
+++ b/app-database/postgresql-18/01-runtime/prepare
@@ -1,0 +1,13 @@
+export MAJORVER="${PKGVER%%.*}"
+abinfo "PostgreSQL major release: $MAJORVER"
+if ! [[ "$MAJORVER" =~ ^[0-9]+$ ]] ; then
+	abdie "Unexpected major version $MAJORVER."
+fi
+
+# FIXME: Do not unset or clear AUTOTOOLS_DEF! Otherwise Autobuild will
+# fail during array migration at proc/51-build-hwcaps.sh.
+export AUTOTOOLS_DEF=("--prefix=/usr/lib/postgresql-$MAJORVER")
+
+abinfo "Using a temporary installation directory ..."
+export OLD_PKGDIR="$PKGDIR"
+export PKGDIR="$SRCDIR"/abdist-tmp

--- a/app-database/postgresql-18/02-server/beyond
+++ b/app-database/postgresql-18/02-server/beyond
@@ -1,0 +1,24 @@
+abinfo "Deploying executable symlinks ..."
+mkdir -pv "$PKGDIR"/usr/bin
+for bin in \
+	$(find "$PKGDIR"/usr/lib/postgresql-${MAJORVER}/bin -type f -executable -printf '%P\n')
+	do
+	ln -sv ../lib/postgresql-"$MAJORVER"/bin/"$bin" \
+		"$PKGDIR"/usr/bin/"$bin"-"$MAJORVER"
+done
+
+abinfo "Deploying files ..."
+for f in $(find "$SRCDIR"/autobuild -maxdepth 1 -type f -name '*.in' -printf '%P\n') ; do
+	sed -e "s|@MAJORVER@|${MAJORVER}|g" \
+		-e "s|@PREVMAJORVER@|$((MAJORVER -1))|g" \
+		"$SRCDIR"/autobuild/$f \
+		> "$SRCDIR"/autobuild/${f%%.in}
+done
+install -Dvm755 "$SRCDIR"/autobuild/postgresql-check-db-dir \
+	"$PKGDIR"/usr/lib/postgresql-"$MAJORVER"/bin/postgresql-check-db-dir
+install -Dvm644 "$SRCDIR"/autobuild/postgresqld.service \
+	"$PKGDIR"/usr/lib/systemd/system/postgresqld-"$MAJORVER".service
+install -Dvm644 "$SRCDIR"/autobuild/postgresqld.tmpfiles \
+	"$PKGDIR"/usr/lib/tmpfiles.d/postgresqld-"$MAJORVER".conf
+install -Dvm644 "$SRCDIR"/autobuild/postgresql.sysusers \
+	"$PKGDIR"/usr/lib/sysusers.d/postgresql-"$MAJORVER".conf

--- a/app-database/postgresql-18/02-server/build
+++ b/app-database/postgresql-18/02-server/build
@@ -1,0 +1,9 @@
+export MAJORVER="${PKGVER%%.*}"
+abinfo "PostgreSQL major release: $MAJORVER"
+if ! [[ "$MAJORVER" =~ ^[0-9]+$ ]] ; then
+	abdie "Unexpected major version $MAJORVER."
+fi
+
+abinfo "Installing files ..."
+rm -rf "$PKGDIR"
+mv "$SRCDIR"/abdist-tmp "$PKGDIR"

--- a/app-database/postgresql-18/02-server/defines
+++ b/app-database/postgresql-18/02-server/defines
@@ -1,0 +1,7 @@
+PKGNAME=postgresql-18
+PKGSEC=database
+PKGDEP="postgresql-runtime-18 krb5 libxml2 linux-pam openssl python-3
+        readline tcl util-linux llvm-runtime-20 libxslt"
+PKGDES="A sophisticated object-relational DBMS (18.x branch)"
+
+ABTYPE=self

--- a/app-database/postgresql-18/02-server/defines.stage2
+++ b/app-database/postgresql-18/02-server/defines.stage2
@@ -1,0 +1,7 @@
+PKGNAME=postgresql-18
+PKGSEC=database
+PKGDEP="postgresql-runtime-18 krb5 libxml2 linux-pam openssl python-3
+        readline tcl util-linux libxslt"
+PKGDES="A sophisticated object-relational DBMS (18.x branch)"
+
+ABTYPE=self

--- a/app-database/postgresql-18/02-server/postgresql-check-db-dir.in
+++ b/app-database/postgresql-18/02-server/postgresql-check-db-dir.in
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This script verifies that the postgresql data directory has been correctly
+# initialized.  We do not want to automatically initdb it, because that has
+# a risk of catastrophic failure (ie, overwriting a valuable database) in
+# corner cases, such as a remotely mounted database on a volume that's a
+# bit slow to mount.  But we can at least emit a message advising newbies
+# what to do.
+
+PGDATA="$1"
+
+if [ -z "$PGDATA" ]
+then
+    echo "Usage: $0 database-path"
+    exit 1
+fi
+
+# PGMAJORVERSION is major version
+PGMAJORVERSION=@MAJORVER@
+# PREVMAJORVERSION is the previous major version, e.g., 8.4, for upgrades
+PREVMAJORVERSION=@PREVMAJORVER@
+
+# Check for the PGDATA structure
+if [ -f "$PGDATA/PG_VERSION" ] && [ -d "$PGDATA/base" ]
+then
+    # Check version of existing PGDATA
+    if [ x`cat "$PGDATA/PG_VERSION"` = x"$PGMAJORVERSION" ]
+    then
+        : A-OK
+    elif [ x`cat "$PGDATA/PG_VERSION"` = x"$PREVMAJORVERSION" ]
+    then
+        echo $"An old version of the database format was found."
+        exit 1
+    else
+        echo $"An old version of the database format was found."
+        echo $"You need to dump and reload before using PostgreSQL $PGMAJORVERSION."
+        echo $"See http://www.postgresql.org/docs/$PGMAJORVERSION/static/upgrading.html"
+        exit 1
+    fi
+else
+    # No existing PGDATA! Warn the user to initdb it.
+    echo $"\"$PGDATA\" is missing or empty. Use a command like"
+    echo $"  su - postgres -c \"initdb --locale en_US.UTF-8 -D '$PGDATA'\""
+    echo $"with relevant options, to initialize the database cluster."
+    exit 1
+fi
+
+exit 0
+

--- a/app-database/postgresql-18/02-server/postgresql.sysusers.in
+++ b/app-database/postgresql-18/02-server/postgresql.sysusers.in
@@ -1,0 +1,2 @@
+g    postgres  90
+u    postgres  90:90 "Postgres Daemon Owner" /var/lib/postgres  /bin/bash

--- a/app-database/postgresql-18/02-server/postgresqld.service.in
+++ b/app-database/postgresql-18/02-server/postgresqld.service.in
@@ -1,0 +1,35 @@
+[Unit]
+Description=PostgreSQL database server Version @MAJORVER@
+After=network.target
+
+[Service]
+Type=forking
+TimeoutSec=120
+User=postgres
+Group=postgres
+
+Environment=PGROOT=/var/lib/postgres
+
+SyslogIdentifier=postgres
+PIDFile=/var/lib/postgres/data-@MAJORVER@/postmaster.pid
+RuntimeDirectory=postgresql
+RuntimeDirectoryMode=755
+
+ExecStartPre=/usr/lib/postgresql-@MAJORVER@/bin/postgresql-check-db-dir ${PGROOT}/data-@MAJORVER@
+ExecStart= /usr/lib/postgresql-@MAJORVER@/bin/pg_ctl -s -D ${PGROOT}/data-@MAJORVER@ start -w -t 120
+ExecReload=/usr/lib/postgresql-@MAJORVER@/bin/pg_ctl -s -D ${PGROOT}/data-@MAJORVER@ reload
+ExecStop=  /usr/lib/postgresql-@MAJORVER@/bin/pg_ctl -s -D ${PGROOT}/data-@MAJORVER@ stop -m fast
+
+# Due to PostgreSQL's use of shared memory, OOM killer is often overzealous in
+# killing Postgres, so adjust it downward
+OOMScoreAdjust=-200
+
+# Additional security-related features
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+

--- a/app-database/postgresql-18/02-server/postgresqld.tmpfiles.in
+++ b/app-database/postgresql-18/02-server/postgresqld.tmpfiles.in
@@ -1,0 +1,1 @@
+d /var/lib/postgres 0775 postgres postgres -

--- a/app-database/postgresql-18/02-server/postinst.in
+++ b/app-database/postgresql-18/02-server/postinst.in
@@ -1,0 +1,18 @@
+set -e
+
+echo "Setting up postgres user and group ..."
+systemd-sysusers postgresql-@MAJORVER@.conf
+
+echo "Migrating postgres home directory ..."
+usermod -d /var/lib/postgres postgres
+
+echo "Creating temporary directory for postgresql ..."
+systemd-tmpfiles --create postgresqld-@MAJORVER@.conf
+
+if [ ! -d /var/lib/postgres/data-@MAJORVER@ ]; then
+	echo "Creating initial postgresql database ..."
+	mkdir -p /var/lib/postgres/data-@MAJORVER@
+	chown 90:90 /var/lib/postgres/data-@MAJORVER@
+	su - postgres -c \
+		"/usr/lib/postgresql-@MAJORVER@/bin/initdb --locale en_US.UTF-8 -D '/var/lib/postgres/data-@MAJORVER@/'"
+fi

--- a/app-database/postgresql-18/spec
+++ b/app-database/postgresql-18/spec
@@ -1,0 +1,4 @@
+VER=18.0
+SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
+CHKSUMS="sha256::0d5b903b1e5fe361bca7aa9507519933773eb34266b1357c4e7780fdee6d6078"
+CHKUPDATE="anitya::id=383697"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-18: new, 18.0

Package(s) Affected
-------------------

- postgresql-18: 18.0
- postgresql-runtime-18: 18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-18
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
