### PR TITLE
vscodium: update to 1.104.16282

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -23,10 +23,13 @@ elif [[ "${CROSS:-$ARCH}" = "arm64" ]]; then
   export VSCODE_ARCH="arm64"
 elif [[ "${CROSS:-$ARCH}" = "loongarch64" ]]; then
   export VSCODE_ARCH="loong64"
+  export SHOULD_REPLACE_TSGO="true"
 elif [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
   export VSCODE_ARCH="ppc64le"
+  export SHOULD_REPLACE_TSGO="true"
 elif [[ "${CROSS:-$ARCH}" = "riscv64" ]]; then
   export VSCODE_ARCH="riscv64"
+  export SHOULD_REPLACE_TSGO="true"
 else
   aberr "Platform not supported" && exit 1
 fi

--- a/app-editors/vscodium/autobuild/patches/0001-fix-cli-add-an-option-to-use-system-Cargo-rustc.patch
+++ b/app-editors/vscodium/autobuild/patches/0001-fix-cli-add-an-option-to-use-system-Cargo-rustc.patch
@@ -1,7 +1,7 @@
-From 5c02340d56bcfac2f58b258b6685764d1f41edde Mon Sep 17 00:00:00 2001
+From 8e9718411284b364c8493def9417937cc6562c66 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 11:23:43 +0800
-Subject: [PATCH 1/3] fix(cli): add an option to use system Cargo/rustc
+Subject: [PATCH 1/4] fix(cli): add an option to use system Cargo/rustc
 
 Allow using the `cargo' and `rustc' executables installed in the system so
 that distribution packagers won't have to install rustup as part of their
@@ -39,5 +39,5 @@ index 6998735..ded94cf 100755
      cargo build --release --target "${VSCODE_CLI_TARGET}" --bin=code
  
 -- 
-2.49.0
+2.50.1
 

--- a/app-editors/vscodium/autobuild/patches/0002-fix-build_cli.sh-drop-hard-coded-cross-compiler-sett.patch
+++ b/app-editors/vscodium/autobuild/patches/0002-fix-build_cli.sh-drop-hard-coded-cross-compiler-sett.patch
@@ -1,7 +1,7 @@
-From f4049cee11acd8facf8bcf81b081afc574548ae3 Mon Sep 17 00:00:00 2001
+From aac4e0aec1b03ac76b18495ec5b216360f442011 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 12:49:44 +0800
-Subject: [PATCH 2/3] fix(build_cli.sh): drop hard-coded cross compiler setting
+Subject: [PATCH 2/4] fix(build_cli.sh): drop hard-coded cross compiler setting
 
 ARM != cross compile.
 ---
@@ -26,5 +26,5 @@ index ded94cf..9c2ae97 100755
      VSCODE_CLI_TARGET="armv7-unknown-linux-gnueabihf"
  
 -- 
-2.49.0
+2.50.1
 

--- a/app-editors/vscodium/autobuild/patches/0003-fix-use-disable-wasm-trap-handler-as-node-flag-to-av.patch.riscv64
+++ b/app-editors/vscodium/autobuild/patches/0003-fix-use-disable-wasm-trap-handler-as-node-flag-to-av.patch.riscv64
@@ -1,7 +1,7 @@
-From c613e6d80653d3f223c9e1dd504a2e1622cdb5b1 Mon Sep 17 00:00:00 2001
+From daeab94e5d93f62d0f9ff7e9dc45cc969a4b6127 Mon Sep 17 00:00:00 2001
 From: darkyzhou <me@zqy.io>
 Date: Sat, 26 Apr 2025 20:35:59 +0800
-Subject: [PATCH 3/3] fix: use --disable-wasm-trap-handler as node flag to
+Subject: [PATCH 3/4] fix: use --disable-wasm-trap-handler as node flag to
  avoid a compilation error on riscv
 
 Compilation error: RangeError: WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance
@@ -31,5 +31,5 @@ index 0000000..a6477e9
 +     "7z": "7z",
 +     "update-grammars": "node build/npm/update-all-grammars.mjs",
 -- 
-2.49.0
+2.50.1
 

--- a/app-editors/vscodium/autobuild/patches/0004-fix-replace-tsgo-package-when-SHOULD_REPLACE_TSGO-is.patch
+++ b/app-editors/vscodium/autobuild/patches/0004-fix-replace-tsgo-package-when-SHOULD_REPLACE_TSGO-is.patch
@@ -1,0 +1,32 @@
+From dc9e1b01edb196d6e48bc363b4d14b336a176b19 Mon Sep 17 00:00:00 2001
+From: darkyzhou <me@zqy.io>
+Date: Fri, 26 Sep 2025 00:24:11 +0800
+Subject: [PATCH 4/4] fix: replace tsgo package when SHOULD_REPLACE_TSGO is set
+
+---
+ build.sh | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/build.sh b/build.sh
+index bebcbba..49def40 100755
+--- a/build.sh
++++ b/build.sh
+@@ -12,6 +12,15 @@ if [[ "${SHOULD_BUILD}" == "yes" ]]; then
+ 
+   cd vscode || { echo "'vscode' dir not found"; exit 1; }
+ 
++  if [[ "${SHOULD_REPLACE_TSGO,,}" == "true" ]]; then
++    jq '
++      del(.devDependencies."@typescript/native-preview")
++      | .devDependencies."@loongdotjs/typescript-native-preview" = "7.0.0-dev.20250926.1"
++    ' package.json > package.json.tmp
++    mv package.json.tmp package.json
++    npm i
++  fi
++
+   export NODE_OPTIONS="--max-old-space-size=8192"
+ 
+   npm run monaco-compile-check
+-- 
+2.50.1
+

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.103.25610
+VER=1.104.16282
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.104.16282

Package(s) Affected
-------------------

- vscodium: 1.104.16282

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
