### PR TITLE
intel-media-driver: update to 25.3.4

### DIFF
--- a/runtime-devices/intel-gmmlib/autobuild/defines
+++ b/runtime-devices/intel-gmmlib/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="Intel Graphics Memory Management Library"
 
+ABTYPE=cmakeninja
 FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
@@ -1,7 +1,7 @@
-From 27ad288af3fc4219284db965e64a2fc11667fcd9 Mon Sep 17 00:00:00 2001
+From d70f467cf2140827814e7bf41222b3e5451abed5 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Thu, 24 Apr 2025 10:20:33 +0800
-Subject: [PATCH 1/3] AOSCOS: remove compiler options exceeding baseline
+Subject: [PATCH 1/4] AOSCOS: remove compiler options exceeding baseline
 
 Signed-off-by: Qing Yun <kf@aosc.io>
 ---
@@ -82,5 +82,5 @@ index e090fd6..c412853 100644
                      #define MOVNTDQA_R(Reg, Src) ((Reg) = (Reg))
                      StreamingLoadSupported = 0;
 -- 
-2.50.1
+2.51.0
 

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMEXT-Disable-AuxTable-test-on-aarch64.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMEXT-Disable-AuxTable-test-on-aarch64.am
@@ -1,7 +1,7 @@
-From dd30fd3e3d51e1cf1f39b0c6c56505b3a1cef711 Mon Sep 17 00:00:00 2001
+From a4d40b02baa46e84e89351ee33e3531d80c62c78 Mon Sep 17 00:00:00 2001
 From: Vihang Mehta <vihang@gimletlabs.ai>
 Date: Wed, 26 Feb 2025 09:59:15 -0800
-Subject: [PATCH 2/3] ARM64: FROMEXT: Disable AuxTable test on aarch64
+Subject: [PATCH 2/4] ARM64: FROMEXT: Disable AuxTable test on aarch64
 
 Link: https://github.com/intel/gmmlib/commit/5f7d53ef6c1a6c40d0ff2d717dca59533ad633d5
 Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
@@ -10,7 +10,7 @@ Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
  1 file changed, 7 insertions(+)
 
 diff --git a/Source/GmmLib/ULT/GmmAuxTableULT.cpp b/Source/GmmLib/ULT/GmmAuxTableULT.cpp
-index c6a9b53..46a66f5 100644
+index 7af6249..ceb4569 100644
 --- a/Source/GmmLib/ULT/GmmAuxTableULT.cpp
 +++ b/Source/GmmLib/ULT/GmmAuxTableULT.cpp
 @@ -213,7 +213,14 @@ TEST_F(CTestAuxTable, DISABLED_TestUpdateAuxTableStress)
@@ -29,5 +29,5 @@ index c6a9b53..46a66f5 100644
      GmmPageTableMgr *mgr = pGmmULTClientContext->CreatePageTblMgrObject(&DeviceCBInt, TT_TYPE::AUXTT);
  
 -- 
-2.50.1
+2.51.0
 

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0003-LOONGARCH64-HACK-add-experimental-support-for-LoongA.am.loongarch64
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0003-LOONGARCH64-HACK-add-experimental-support-for-LoongA.am.loongarch64
@@ -1,7 +1,7 @@
-From c7b088acbb833922211703973b24fcc18319cf45 Mon Sep 17 00:00:00 2001
+From fa8f3b9e58da69d3cea8159008e993a16576c5a1 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:03:47 +0800
-Subject: [PATCH 3/3] HACK: add experimental support for LoongArch
+Subject: [PATCH 3/4] LOONGARCH64: HACK: add experimental support for LoongArch
 
 Ref: https://github.com/FanFansfan/gmmlib/commit/5b95524c513b00f93bbcf0f23b4d7226facf773d
 ---
@@ -110,5 +110,5 @@ index 0000000..4379740
 @@ -0,0 +1 @@
 +Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 -- 
-2.50.1
+2.51.0
 

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0004-LOONGARCH64-AOSCOS-gmmlib-support-loongarch64.am.loongarch64
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0004-LOONGARCH64-AOSCOS-gmmlib-support-loongarch64.am.loongarch64
@@ -1,3 +1,13 @@
+From 2ecc0395a7a2c76e170ea83ea1d9d3db67100cfb Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Fri, 26 Sep 2025 11:47:23 +0800
+Subject: [PATCH 4/4] LOONGARCH64: AOSCOS: gmmlib support loongarch64
+
+---
+ Source/GmmLib/inc/External/Common/GmmCommonExt.h | 2 +-
+ Source/inc/portable_compiler.h                   | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
 diff --git a/Source/GmmLib/inc/External/Common/GmmCommonExt.h b/Source/GmmLib/inc/External/Common/GmmCommonExt.h
 index 1a8d7ad..20f4443 100644
 --- a/Source/GmmLib/inc/External/Common/GmmCommonExt.h
@@ -23,3 +33,6 @@ index db68312..a2c5423 100644
      #else
          #define __cdecl         __attribute__((__cdecl__))
          #define __stdcall       __attribute__((__stdcall__))
+-- 
+2.51.0
+

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,5 +1,4 @@
-VER=22.8.1
+VER=22.8.2
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"
-REL="1"

--- a/runtime-multimedia/intel-media-driver/autobuild/defines
+++ b/runtime-multimedia/intel-media-driver/autobuild/defines
@@ -4,5 +4,6 @@ PKGDEP="libva intel-gmmlib"
 BUILDDEP="cmake"
 PKGDES="Intel Media Driver for VAAPI (for Broadwell+ Intel GPUs)"
 
+ABTYPE=cmakeninja
 # FIXME: Limited by intel-gmmlib.
 FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-FROMEXT-loongarch.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-FROMEXT-loongarch.am.loongarch64
@@ -1,4 +1,4 @@
-From d015dd28276a8dd60e86489b688ed49d72bc7893 Mon Sep 17 00:00:00 2001
+From b94c6705a76c488024a0bb16f5084476532a69c9 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:23:27 +0800
 Subject: [PATCH 1/3] LOONGARCH64: FROMEXT: loongarch
@@ -303,5 +303,5 @@ index 000000000..4379740aa
 @@ -0,0 +1 @@
 +Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 -- 
-2.50.1
+2.51.0
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-FROMEXT-fix-lsx.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-FROMEXT-fix-lsx.am.loongarch64
@@ -1,4 +1,4 @@
-From ca77a3f397f62e1172f604c633e151438b13c8ae Mon Sep 17 00:00:00 2001
+From 173dbab672c3f84f78a5ca91118ac7e5ab155bb2 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 31 Mar 2024 16:00:55 +0800
 Subject: [PATCH 2/3] LOONGARCH64: FROMEXT: fix lsx
@@ -17,5 +17,5 @@ index 4379740aa..87cd663a9 160000
 -Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
 +Subproject commit 87cd663a92e78a38b203a9aaa082c8fbd67781d8
 -- 
-2.50.1
+2.51.0
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
@@ -1,4 +1,4 @@
-From 14ed056b7d5df12712c950e1e5403e86d7337715 Mon Sep 17 00:00:00 2001
+From 3a98e85e232f44eb00ac45669dfc6ca6a965e63f Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Fri, 18 Apr 2025 09:21:59 +0800
 Subject: [PATCH 3/3] ARM64: AOSCOS: fix __stdcall and __cdecl redefined on
@@ -24,5 +24,5 @@ index d5f04d1f8..396ec89b1 100644
      #define __cdecl         __attribute__((__cdecl__))
      #define __stdcall       __attribute__((__stdcall__))
 -- 
-2.50.1
+2.51.0
 

--- a/runtime-multimedia/intel-media-driver/spec
+++ b/runtime-multimedia/intel-media-driver/spec
@@ -1,4 +1,4 @@
-VER=25.2.6
+VER=25.3.4
 SRCS="git::commit=tags/intel-media-$VER;copy-repo=true::https://github.com/intel/media-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

- intel-media-driver: update to 25.3.4
    - Add missing ABTYPE
    - Track patches at AOSC-Tracking/media-driver @ aosc/intel-media-25.3.4
    \(HEAD: 3a98e85e232f44eb00ac45669dfc6ca6a965e63f\).
- intel-gmmlib: update to 22.8.2
    - Add missing ABTYPE
    - Track patches at AOSC-Tracking/gmmlib @ aosc/intel-gmmlib-22.8.2
    \(HEAD: 2ecc0395a7a2c76e170ea83ea1d9d3db67100cfb\).

Package(s) Affected
-------------------

- intel-gmmlib: 22.8.2
- intel-media-driver: 25.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib intel-media-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
