### PR TITLE
vscode: update to 1.104.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.104.1
+VER=1.104.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::b2671b1d820def4c72e791e714c4af83caee684eedb2c0ae1f0590861b0ee71a"
-CHKSUMS__ARM64="sha256::a02a303abf8560a861762c9b137d368040c8cb8539c273b501b8953f5400c4bb"
+CHKSUMS__AMD64="sha256::6bbe534d4f9b9932a858111420ff48555dcaf911d67a2b6997b2a1e240fae728"
+CHKSUMS__ARM64="sha256::f3568849a9f2b45d66a41503829cd147985eec89b562c20e2e65d09302e76a2e"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.104.2
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- vscode: 1.104.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
