### PR TITLE
Python 2 Purging Survey 20250926 2

### DIFF
--- a/app-utils/dmenu/autobuild/defines
+++ b/app-utils/dmenu/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=dmenu
 PKGSEC=x11
-PKGDEP="x11-lib pyxdg docopt"
+PKGDEP="x11-lib"
 PKGDES="A generic menu for X"
 
 AB_FLAGS_SPECS=0

--- a/app-utils/dmenu/spec
+++ b/app-utils/dmenu/spec
@@ -1,4 +1,5 @@
 VER=5.4
 SRCS="tbl::https://dl.suckless.org/tools/dmenu-$VER.tar.gz"
 CHKSUMS="sha256::8fbace2a0847aa80fe861066b118252dcc7b4ca0a0a8f3a93af02da8fb6cd453"
+REL=1
 CHKUPDATE="anitya::id=442"

--- a/app-virtualization/libvirt/autobuild/defines
+++ b/app-virtualization/libvirt/autobuild/defines
@@ -9,6 +9,7 @@ PKGDEP="avahi bridge-utils curl cyrus-sasl dbus dmidecode dnsmasq \
 BUILDDEP="docutils qemu zfs rpcsvc-proto firewalld wireshark"
 # FIXME: LTS kernel not yet available for these architectures.
 BUILDDEP__LOONGARCH64="${BUILDDEP/zfs/}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP/zfs/}"
 BUILDDEP__LOONGSON3="${BUILDDEP/zfs/}"
 BUILDDEP__RISCV64="${BUILDDEP/zfs/}"
 PKGSUG="zfs"

--- a/app-virtualization/libvirt/autobuild/defines
+++ b/app-virtualization/libvirt/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP="avahi bridge-utils curl cyrus-sasl dbus dmidecode dnsmasq \
         e2fsprogs gcc-runtime gettext gnutls iproute2 iptables \
         libcap-ng libgcrypt libgpg-error libnl libpcap libssh2 libxml2 \
-        lxc netcat netcf numactl openssl parted pm-utils polkit python-2 \
+        lxc netcat netcf numactl openssl parted pm-utils polkit python-3 \
         radvd systemd yajl x11-lib libssh qemu open-iscsi perl-xml-xpath \
         libiscsi sanlock"
 BUILDDEP="docutils qemu zfs rpcsvc-proto firewalld wireshark"

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,5 @@
 VER=10.5.0
+REL=1
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
 CHKUPDATE="anitya::id=13830"

--- a/lang-js/nodejs-20/autobuild/defines
+++ b/lang-js/nodejs-20/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=nodejs-20
 PKGSEC=devel
-PKGDEP="icu openssl python-2 zlib"
+PKGDEP="python-3 icu zlib brotli libuv openssl ca-certs"
+BUILDDEP="chrpath unzip jq"
 PKGDES="A JavaScript runtime built on the V8 JavaScript engine (LTS branch 20.x)"
 
 # https://github.com/nodejs/node/issues/44195#issuecomment-1545966528

--- a/lang-js/nodejs-20/spec
+++ b/lang-js/nodejs-20/spec
@@ -1,6 +1,6 @@
-VER=20.19.2
+VER=20.19.5
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
-CHKSUMS="sha256::4A7FF611D5180F4E420204FA6F22F9F9DEB2AC5E98619DD9A4DE87EDF5B03B6E"
+CHKSUMS="sha256::230c899f4e2489c4b8d2232edd6cc02f384fb2397c2a246a22e415837ee5da51"
 CHKUPDATE="anitya::id=369796"
 # Note: Node.js currently requires large memory to build.
 #       Prefer 3C5000 (or faster) build hosts.

--- a/lang-js/nodejs-22/autobuild/defines
+++ b/lang-js/nodejs-22/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=nodejs-22
 PKGSEC=devel
-PKGDEP="icu openssl python-2 zlib"
+PKGDEP="python-3 icu zlib brotli libuv openssl ca-certs"
+BUILDDEP="chrpath unzip jq"
 BUILDDEP__LOONGSON3="${BUILDDEP} llvm"
 PKGDES="A JavaScript runtime built on the V8 JavaScript engine (LTS branch 22.x)"
 

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,4 +1,5 @@
 VER=22.21.0
+REL=1
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
 CHKSUMS="sha256::791b18e969ea22cc952108ee8eaafbb12cddfd973bbbb0b7fc116395c0d9a81c"
 CHKUPDATE="anitya::id=374342"

--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -6,6 +6,7 @@ CHKUPDATE="anitya::id=374342"
 # Note: Node.js currently requires large memory to build. 
 #       Prefer 3C5000 (or faster) build hosts.
 ENVREQ__LOONGARCH64="total_mem=30 core=16"
+ENVREQ__LOONGARCH64_NOSIMD="total_mem=30 core=16"
 # Note: Prefer larger RAM.
 ENVREQ__ARM64="total_mem=60"
 # Note: Larger RAM per core needed.

--- a/lang-python/docopt/spec
+++ b/lang-python/docopt/spec
@@ -1,5 +1,5 @@
 VER=0.6.2
 REL=5
-SRCS="tbl::https://github.com/docopt/docopt/archive/$VER.tar.gz"
-CHKSUMS="sha256::2113eed1e7fbbcd43fb7ee6a977fb02d0b482753586c9dc1a8e3b7d541426e99"
+SRCS="pypi::version=$VER::docopt"
+CHKSUMS="sha256::49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
 CHKUPDATE="anitya::id=19769"

--- a/lang-python/ipy/autobuild/defines
+++ b/lang-python/ipy/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=ipy
 PKGSEC=python
-PKGDEP="python-2"
+PKGDEP="python-3"
 PKGDES="Python class and tools for handling of IPv4 and IPv6 addresses and networks"
 
-NOPYTHON3=1
 ABTYPE=python
 ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/ipy/spec
+++ b/lang-python/ipy/spec
@@ -1,6 +1,5 @@
-VER=0.83
-REL=2
-SRCS="tbl::https://pypi.io/packages/source/I/IPy/IPy-$VER.tar.gz"
-CHKSUMS="sha256::61da5a532b159b387176f6eabf11946e7458b6df8fb8b91ff1d345ca7a6edab8"
+VER=1.01
+SRCS="pypi::version=$VER::IPy"
+CHKSUMS="sha256::edeca741dea2d54aca568fa23740288c3fe86c0f3ea700344571e9ef14a7cc1a"
 SUBDIR="IPy-$VER"
 CHKUPDATE="anitya::id=19783"

--- a/lang-python/pyinotify/autobuild/build
+++ b/lang-python/pyinotify/autobuild/build
@@ -1,9 +1,0 @@
-cd pyinotify-$PKGVER
-python2 setup.py build
-python2 setup.py install --root="$PKGDIR" -O1
-
-cd ../pyinotify3-$PKGVER
-python3 setup.py build
-python3 setup.py install --root="$PKGDIR" -O1
-
-cd "$SRCDIR"

--- a/lang-python/pyinotify/autobuild/defines
+++ b/lang-python/pyinotify/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=pyinotify
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 PKGDES="Python module used for monitoring filesystems events on Linux platforms with inotify"
 
 ABHOST=noarch
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/pyinotify/autobuild/patches/0001-modify-shebang-to-python3.patch
+++ b/lang-python/pyinotify/autobuild/patches/0001-modify-shebang-to-python3.patch
@@ -1,0 +1,22 @@
+From 0d831d1b9cba828a0c19516ed99896da9f863a49 Mon Sep 17 00:00:00 2001
+From: ShellWen <me@shellwen.com>
+Date: Sat, 27 Sep 2025 00:06:43 +0800
+Subject: [PATCH 1/1] modify shebang to python3
+
+---
+ python3/pyinotify.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python3/pyinotify.py b/python3/pyinotify.py
+index bc24313..6940697 100755
+--- a/python3/pyinotify.py
++++ b/python3/pyinotify.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # pyinotify.py - python interface to inotify
+ # Copyright (c) 2005-2015 Sebastien Martini <seb@dbzteam.org>
+-- 
+2.51.0
+

--- a/lang-python/pyinotify/autobuild/prepare
+++ b/lang-python/pyinotify/autobuild/prepare
@@ -1,1 +1,0 @@
-cp -r pyinotify-$PKGVER pyinotify3-$PKGVER

--- a/lang-python/pyinotify/spec
+++ b/lang-python/pyinotify/spec
@@ -1,6 +1,5 @@
 VER=0.9.6
-REL=7
-SRCS="tbl::https://seb.dbzteam.org/pub/pyinotify/releases/pyinotify-$VER.tar.gz"
+REL=8
+SRCS="pypi::version=$VER::pyinotify"
 CHKSUMS="sha256::9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4"
-SUBDIR=.
 CHKUPDATE="anitya::id=6291"

--- a/lang-python/pyperf/autobuild/defines
+++ b/lang-python/pyperf/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=pyperf
 PKGSEC=python
-PKGDEP="six python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="pypsutil python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="A Python toolkit to write, run and analyze benchmarks"
 
 ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/pyperf/spec
+++ b/lang-python/pyperf/spec
@@ -1,5 +1,4 @@
-VER=2.5.0
-SRCS="tbl::https://pypi.io/packages/source/p/pyperf/pyperf-$VER.tar.gz"
-CHKSUMS="sha256::9fd9be5b57224e68b5a5b88f7126f15b6c8667573f62a0a39faf14d6fdd13909"
+VER=2.9.0
+SRCS="pypi::version=$VER::pyperf"
+CHKSUMS="sha256::dbe0feef8ec1a465df191bba2576149762d15a8c9985c9fea93ab625d875c362"
 CHKUPDATE="anitya::id=83843"
-REL=1

--- a/lang-python/python-linux-procfs/autobuild/defines
+++ b/lang-python/python-linux-procfs/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=python-linux-procfs
 PKGSEC=python
-PKGDEP="six python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="six python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Python classes to extract information from the Linux kernel /proc files"
 
 ABHOST=noarch
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/python-linux-procfs/spec
+++ b/lang-python/python-linux-procfs/spec
@@ -2,4 +2,4 @@ VER=0.7.3
 SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/libs/python/python-linux-procfs/python-linux-procfs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20133"
-REL=1
+REL=2

--- a/lang-python/python-schedutils/autobuild/defines
+++ b/lang-python/python-schedutils/autobuild/defines
@@ -1,5 +1,9 @@
 PKGNAME=python-schedutils
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
 PKGDES="Python interface for kernel scheduler functions"
+
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/python-schedutils/spec
+++ b/lang-python/python-schedutils/spec
@@ -2,4 +2,4 @@ VER=0.6
 SRCS="tbl::https://cdn.kernel.org/pub/software/libs/python/python-schedutils/python-schedutils-$VER.tar.xz"
 CHKSUMS="sha256::90a24f8d46574513b3d334b473e128c456e7eddaec6e3dd198d7e5ad69ddc12f"
 CHKUPDATE="anitya::id=20122"
-REL=1
+REL=2

--- a/lang-python/pyxdg/autobuild/defines
+++ b/lang-python/pyxdg/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=pyxdg
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 PKGDES="Python library to access freedesktop.org standards"
 
 ABHOST=noarch
+ABTYPE=python
+
+NOPYTHON2=1

--- a/lang-python/pyxdg/spec
+++ b/lang-python/pyxdg/spec
@@ -1,5 +1,4 @@
-VER=0.25
-REL=7
-SRCS="tbl::https://people.freedesktop.org/~takluyver/pyxdg-$VER.tar.gz"
-CHKSUMS="sha256::81e883e0b9517d624e8b0499eb267b82a815c0b7146d5269f364988ae031279d"
+VER=0.28
+SRCS="pypi::version=$VER::pyxdg"
+CHKSUMS="sha256::3267bb3074e934df202af2ee0868575484108581e6f3cb006af1da35395e88b4"
 CHKUPDATE="anitya::id=4121"

--- a/lang-python/urwid/autobuild/defines
+++ b/lang-python/urwid/autobuild/defines
@@ -1,5 +1,10 @@
 PKGNAME=urwid
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="python-3 wcwidth typing-extensions"
+BUILDDEP="setuptools-python3 setuptools-scm wheel"
 PKGDES="Curses-based user interface library for Python"
+
+ABTYPE=pep517
+ABHOST=noarch
+
+NOPYTHON2=1

--- a/lang-python/urwid/spec
+++ b/lang-python/urwid/spec
@@ -1,5 +1,4 @@
-VER=2.1.2
-SRCS="https://pypi.io/packages/source/u/urwid/urwid-$VER.tar.gz"
-CHKSUMS="sha256::588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae"
+VER=2.6.12
+SRCS="pypi::version=$VER::urwid"
+CHKSUMS="sha256::1c9f5a5b47ec3fcc88032e0e224a00d7bf21704fa0060f498db395235f1731f1"
 CHKUPDATE="anitya::id=4079"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: update deps
- nodejs-20: update to 20.19.5; update deps
- nodejs-22: update to 22.20.0; update deps
- python-schedutils: purge python 2 support
- urwid: update to 2.6.12; update deps
- docopt: update to 0.6.2; switch SRCS to pypi; purge python 2 support
- udiskie: update to 2.5.8
- dmenu: update deps
- ipy: update to 1.01; correct dep to python 3
- pyinotify: purge python 2 support; change SRCS to pypi

... and 3 more commits

Package(s) Affected
-------------------

- dmenu: 5.4-1
- docopt: 0.6.2-5
- ipy: 1.01
- libvirt: 10.5.0-1
- nodejs-20: 20.19.5
- nodejs-22: 22.20.0
- pyinotify: 0.9.6-8
- pyperf: 2.9.0
- python-linux-procfs: 0.7.3-2
- python-schedutils: 0.6-2
- pyxdg: 0.28
- udiskie: 2.5.8
- urwid: 2.6.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyxdg python-linux-procfs pyperf pyinotify ipy dmenu udiskie docopt urwid python-schedutils nodejs-22 nodejs-20 libvirt
```

Test Build(s) Done
------------------

