### PR TITLE
86box: new, 5.1

### DIFF
--- a/app-emulation/86box-roms/autobuild/build
+++ b/app-emulation/86box-roms/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Installing ROMs ..."
+mkdir -pv "$PKGDIR"/usr/share/86Box/roms
+cp -rv "$SRCDIR"/!(LICENSE|README.md|$(basename "$PKGDIR")) \
+    "$PKGDIR"/usr/share/86Box/roms/

--- a/app-emulation/86box-roms/autobuild/defines
+++ b/app-emulation/86box-roms/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=86box-roms
+PKGSEC=non-free/misc
+PKGDES="ROMs for use with 86Box"
+
+ABHOST=noarch
+ABTYPE=self

--- a/app-emulation/86box-roms/spec
+++ b/app-emulation/86box-roms/spec
@@ -1,0 +1,5 @@
+VER=5.1+git20250926
+SRCS="git::commit=983cd7fcd7216d217828e6ee7ac9d525caf6f190::https://github.com/86Box/roms"
+CHKSUMS="SKIP"
+# Note: We will just follow master, there is no point in following tags.
+#CHKUPDATE="anitya::id=268433"

--- a/app-emulation/86box/autobuild/beyond
+++ b/app-emulation/86box/autobuild/beyond
@@ -1,0 +1,10 @@
+abinfo "Installing .desktop entry ..."
+install -Dvm644 "$SRCDIR"/src/unix/assets/net.86box.86Box.desktop \
+    "$PKGDIR"/usr/share/applications/net.86box.86Box.desktop
+
+abinfo "Installing icons ..."
+mkdir -pv "$PKGDIR"/usr/share/icons/hicolor
+for i in 48 64 72 96 128 192 256 512; do
+    install -Dvm644 "$SRCDIR"/src/unix/assets/${i}x${i}/net.86box.86Box.png \
+        "$PKGDIR"/usr/share/icons/hicolor/${i}x${i}/apps/net.86box.86Box.png
+done

--- a/app-emulation/86box/autobuild/defines
+++ b/app-emulation/86box/autobuild/defines
@@ -1,0 +1,35 @@
+PKGNAME=86box
+PKGSEC=utils
+PKGDEP="gcc-runtime fluidsynth glib jack libevdev libpng libserialport \
+        libslirp libsndfile libxcb openal-soft qt-5 rtmidi sdl2 wayland \
+        x11-lib zlib"
+PKGRECOM="86box-roms"
+PKGDES="Emulator for x86-based machines"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DUSE_QT6=OFF'
+    '-DSTATIC_BUILD=OFF'
+    '-DRELEASE=ON'
+    '-DDYNAREC=OFF'
+    '-DOPENAL=ON'
+    '-DRTMIDI=ON'
+    '-DFLUIDSYNTH=ON'
+    '-DMUNT=OFF'
+    '-DVNC=OFF'
+    '-DMINITRACE=OFF'
+    '-DGDBSTUB=OFF'
+    '-DDEV_BRANCH=OFF'
+    '-DDISCORD=ON'
+    '-DDEBUGREGS486=OFF'
+    '-DLIBASAN=OFF'
+)
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER[@]}"
+    '-DDYNAREC=ON'
+)
+# Upstream advised to use "new" dynamic recompiler for arm64.
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    '-DNEW_DYNAREC=ON'
+)

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,0 +1,4 @@
+VER=5.1
+SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
Topic Description
-----------------

- 86box: new, 5.1
- 86box-roms: new, 5.1+git20250926

Package(s) Affected
-------------------

- 86box: 5.1
- 86box-roms: 5.1+git20250926

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box-roms 86box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
