### PR TITLE
alsa-utils: add alsa-plugins to PKGDEP

### DIFF
--- a/app-multimedia/alsa-utils/autobuild/defines
+++ b/app-multimedia/alsa-utils/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=alsa-utils
 PKGDES="ALSA utilities"
 PKGSEC=utils
-PKGDEP="alsa-lib pciutils ncurses psmisc libsamplerate systemd"
-PKGDEP__RETRO="alsa-lib pciutils ncurses psmisc"
+PKGDEP="alsa-lib alsa-plugins pciutils ncurses psmisc libsamplerate systemd"
+PKGDEP__RETRO="alsa-lib alsa-plugins pciutils ncurses psmisc"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
@@ -22,16 +22,18 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--enable-nls \
-                 --disable-rpath
-                 --enable-alsatopology \
-                 --disable-alsatest \
-                 --disable-alsabat-backend-tiny \
-                 --enable-bat \
-                 --enable-alsamixer \
-                 --enable-alsaconf \
-                 --enable-alsa-loop \
-                 --enable-xmlto \
-                 --disable-rst2man \
-                 --enable-largefile \
-                 --with-librt"
+AUTOTOOLS_AFTER=(
+	"--enable-nls"
+	"--disable-rpath"
+	"--enable-alsatopology"
+	"--disable-alsatest"
+	"--disable-alsabat-backend-tiny"
+	"--enable-bat"
+	"--enable-alsamixer"
+	"--enable-alsaconf"
+	"--enable-alsa-loop"
+	"--enable-xmlto"
+	"--disable-rst2man"
+	"--enable-largefile"
+	"--with-librt"
+)

--- a/app-multimedia/alsa-utils/spec
+++ b/app-multimedia/alsa-utils/spec
@@ -1,4 +1,5 @@
 VER=1.2.13
+REL=1
 SRCS="tbl::https://www.alsa-project.org/files/pub/utils/alsa-utils-${VER}.tar.bz2"
 CHKSUMS="sha256::1702a6b1cdf9ba3e996ecbc1ddcf9171e6808f5961d503d0f27e80ee162f1daa"
 CHKUPDATE="anitya::id=37"


### PR DESCRIPTION
Topic Description
-----------------

- alsa-utils: add alsa-plugins to PKGDEP
    - Aplay depends /usr/lib/alsa-lib/libasound_module_pcm_pulse.so provided by
    alsa-plugins
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- alsa-utils: 1.2.13-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit alsa-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
