### PR TITLE
speex: update to 1.2.1

### DIFF
--- a/runtime-multimedia/speex/spec
+++ b/runtime-multimedia/speex/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-REL=2
+VER=1.2.1
 SRCS="tbl::https://downloads.us.xiph.org/releases/speex/speex-$VER.tar.gz"
-CHKSUMS="sha256::eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
+CHKSUMS="sha256::4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea"
 CHKUPDATE="anitya::id=14498"

--- a/runtime-optenv32/speex+32/spec
+++ b/runtime-optenv32/speex+32/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-REL=3
+VER=1.2.1
 SRCS="tbl::https://downloads.us.xiph.org/releases/speex/speex-$VER.tar.gz"
-CHKSUMS="sha256::eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
+CHKSUMS="sha256::4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea"
 CHKUPDATE="anitya::id=14498"


### PR DESCRIPTION
Topic Description
-----------------

- speex+32: update to 1.2.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- speex: update to 1.2.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit speex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
