### PR TITLE
libexttextcat: fix 'lto-type-mismatch' error during build

### DIFF
--- a/runtime-i18n/libexttextcat/autobuild/patches/0001-Fix-type-mismatch-between-declaration-and-definition.patch
+++ b/runtime-i18n/libexttextcat/autobuild/patches/0001-Fix-type-mismatch-between-declaration-and-definition.patch
@@ -1,0 +1,27 @@
+From 2fbb3244b1e265e2b18679161271dcc85cfa3142 Mon Sep 17 00:00:00 2001
+From: pch666777 <1005100717@qq.com>
+Date: Sat, 27 Sep 2025 22:15:20 +0800
+Subject: [PATCH] Fix type mismatch between declaration and definition
+
+- wg_mempool.h: extern void *wgmempool_Init(uint4 blocksize, size_t maxstrsize)
+- wg_mempool.c: extern void *wgmempool_Init(size_t blocksize, size_t maxstrsize)
+---
+ src/wg_mempool.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/wg_mempool.c b/src/wg_mempool.c
+index 89d35a1..51ca894 100644
+--- a/src/wg_mempool.c
++++ b/src/wg_mempool.c
+@@ -83,7 +83,7 @@ static void addblock(mempool_t * h)
+ }
+ 
+ 
+-extern void *wgmempool_Init(size_t blocksize, size_t maxstrsize)
++extern void *wgmempool_Init(uint4 blocksize, size_t maxstrsize)
+ {
+     mempool_t *result = (mempool_t *) malloc(sizeof(mempool_t));
+ 
+-- 
+2.51.0
+

--- a/runtime-i18n/libexttextcat/spec
+++ b/runtime-i18n/libexttextcat/spec
@@ -1,4 +1,5 @@
 VER=3.4.6
+REL=1
 SRCS="tbl::https://dev-www.libreoffice.org/src/libexttextcat/libexttextcat-$VER.tar.xz"
 CHKSUMS="sha256::6d77eace20e9ea106c1330e268ede70c9a4a89744ddc25715682754eca3368df"
 CHKUPDATE="anitya::id=1609"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Fix type mismatch between declaration and definition.
- Refer to [debian patch](https://git.launchpad.net/ubuntu/+source/libexttextcat/commit/?id=f8d4acf813b58cc6af5a6d653449f914a579fe35)
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- libexttextcat: 3.4.6
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit libexttextcat
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
