### PR TITLE
rtmidi: update to 6.0.0

### DIFF
--- a/app-multimedia/milkytracker/spec
+++ b/app-multimedia/milkytracker/spec
@@ -1,4 +1,4 @@
-VER=1.04.00
-SRCS="tbl::https://github.com/milkytracker/MilkyTracker/archive/v$VER.tar.gz"
-CHKSUMS="sha256::29b9c9572ad8bf8f4add2de19c3f8fb0382738763a92e76f3d01dea82c40ff72"
+VER=1.06
+SRCS="git::commit=tags/v${VER}::https://github.com/milkytracker/MilkyTracker"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9135"

--- a/app-multimedia/polyphone/spec
+++ b/app-multimedia/polyphone/spec
@@ -1,4 +1,5 @@
 VER=2.5.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/davy7125/polyphone.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372486"

--- a/groups/rtmidi-rebuilds
+++ b/groups/rtmidi-rebuilds
@@ -1,0 +1,2 @@
+app-multimedia/milkytracker
+app-multimedia/polyphone

--- a/runtime-multimedia/rtmidi/autobuild/defines
+++ b/runtime-multimedia/rtmidi/autobuild/defines
@@ -3,7 +3,10 @@ PKGSEC=sound
 PKGDEP="jack"
 PKGDES="A set of C++ classes that provides a common API for realtime MIDI input/output"
 
-AUTOTOOLS_AFTER="--with-alsa --with-jack"
+AUTOTOOLS_AFTER=(
+	"--with-alsa"
+	"--with-jack"
+)
 AB_FLAGS_SPECS=0
 
-PKGBREAK="milkytracker<=1.02.00-1"
+PKGBREAK="milkytracker<=1.04.00 polyphone<=2.5.1"

--- a/runtime-multimedia/rtmidi/spec
+++ b/runtime-multimedia/rtmidi/spec
@@ -1,4 +1,4 @@
-VER=4.0.0
-SRCS="tbl::https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-$VER.tar.gz"
-CHKSUMS="sha256::370cfe710f43fbeba8d2b8c8bc310f314338c519c2cf2865e2d2737b251526cd"
+VER=6.0.0
+SRCS="git::commit=tags/${VER}::https://github.com/thestk/rtmidi"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4220"


### PR DESCRIPTION
Topic Description
-----------------

- polyphone: rebuild for rtmidi 6.0.0
    Signed-off-by: Ilikara <3435193369@qq.com>
- milkytracker: update to 1.06
    - rebuild for rtmidi 6.0.0
    Signed-off-by: Ilikara <3435193369@qq.com>
- rtmidi: update to 6.0.0
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- milkytracker: 1.06
- polyphone: 2.5.1-1
- rtmidi: 6.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rtmidi groups/rtmidi-rebuilds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
