### PR TITLE
pkcs11-helper: update to 1.30.0

### DIFF
--- a/runtime-cryptography/pkcs11-helper/spec
+++ b/runtime-cryptography/pkcs11-helper/spec
@@ -1,5 +1,4 @@
-VER=1.29.0
+VER=1.30.0
 SRCS="git::commit=tags/pkcs11-helper-$VER::https://github.com/OpenSC/pkcs11-helper"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=91990"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pkcs11-helper: update to 1.30.0
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- pkcs11-helper: 1.30.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkcs11-helper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
