### PR TITLE
reportlab: update to 4.2.2

### DIFF
--- a/lang-python/reportlab/autobuild/defines
+++ b/lang-python/reportlab/autobuild/defines
@@ -1,7 +1,12 @@
 PKGNAME=reportlab
 PKGSEC=python
-PKGDEP="pillow"
+PKGDEP="python-3 pillow chardet"
+BUILDDEP="setuptools"
 PKGDES="A proven industry-strength PDF generating solution"
 
-PKGREP="python3-reportlab python2-reportlab"
-PKGPROV="python3-reportlab python2-reportlab"
+PKGREP="python3-reportlab"
+PKGPROV="python3-reportlab"
+
+ABTYPE=pep517
+NOPYTHON2=1
+ABSPLITDBG=0

--- a/lang-python/reportlab/spec
+++ b/lang-python/reportlab/spec
@@ -1,5 +1,4 @@
-VER=3.5.50
+VER=4.2.2
 SRCS="tbl::https://pypi.io/packages/source/r/reportlab/reportlab-$VER.tar.gz"
-CHKSUMS="sha256::876ce59164245f62bf67b8502e127b0a3ffd40f37c7177d1b4d9da24e42a77b0"
+CHKSUMS="sha256::765eecbdd68491c56947e29c38b8b69b834ee5dbbdd2fb7409f08ebdebf04428"
 CHKUPDATE="anitya::id=3994"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- reportlab: update to 4.2.2

Package(s) Affected
-------------------

- reportlab: 4.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit reportlab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
