### PR TITLE
libei: update to 1.5.0

### DIFF
--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -2,4 +2,4 @@ VER=1.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375452"
-REL=1
+REL=2

--- a/runtime-desktop/libei/autobuild/defines
+++ b/runtime-desktop/libei/autobuild/defines
@@ -1,7 +1,15 @@
 PKGNAME=libei
 PKGDES="Library for handling Emulated Input (EI)"
 PKGSEC=libs
-PKGDEP="glibc libxkbcommon libevdev systemd"
-BUILDDEP="attrs jinja2"
+PKGDEP="gcc-runtime glibc libxkbcommon libevdev systemd"
+BUILDDEP="attrs jinja2 meson ninja"
 
-MESON_AFTER="-Dsd-bus-provider=libsystemd -Dliboeffis=enabled"
+ABTYPE=meson
+MESON_AFTER=(
+    '-Ddocumentation=[]'
+    '-Dsd-bus-provider=libsystemd'
+    '-Dtests=disabled'
+    '-Dliboeffis=enabled'
+    '-Dlibeis=enabled'
+    '-Dlibei=enabled'
+)

--- a/runtime-desktop/libei/spec
+++ b/runtime-desktop/libei/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.5.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libei.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=350087"


### PR DESCRIPTION
Topic Description
-----------------

- libei: update to 1.5.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>
- deskflow: rebuild for libei-1.5.0

Package(s) Affected
-------------------

- libei: 1.5.0
- deskflow: 1.23.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libei deskflow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
