### PR TITLE
slick-greeter: rework

### DIFF
--- a/desktop-displaymanagers/slick-greeter/autobuild/defines
+++ b/desktop-displaymanagers/slick-greeter/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=slick-greeter
 PKGSEC=x11
-PKGDEP="at-spi2-core atk cairo gdk-pixbuf glib glibc gtk-3 libcanberra \
+PKGDEP="at-spi2-core cairo gdk-pixbuf glib glibc gtk-3 libcanberra \
         lightdm pango x11-lib"
 BUILDDEP="intltool gnome-common vala"
 PKGDES="A slick-looking LightDM greeter"

--- a/desktop-displaymanagers/slick-greeter/spec
+++ b/desktop-displaymanagers/slick-greeter/spec
@@ -1,4 +1,5 @@
 VER=2.2.2
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/slick-greeter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14546"

--- a/desktop-gnome/atk/autobuild/defines
+++ b/desktop-gnome/atk/autobuild/defines
@@ -6,3 +6,5 @@ PKGSEC=libs
 ABHOST=noarch
 ABTYPE=dummy
 PKGEPOCH=1
+
+PKGBREAK="slick-greeter<=2.2.2"

--- a/desktop-gnome/atk/spec
+++ b/desktop-gnome/atk/spec
@@ -1,2 +1,3 @@
 VER=0
+REL=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- atk: set PKGBREAK
- slick-greeter: remove atk dependency

Package(s) Affected
-------------------

- atk: 1:0-1
- slick-greeter: 2.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit atk:-pkgbreak slick-greeter atk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
