### PR TITLE
libunistring: update to 1.4

### DIFF
--- a/runtime-common/libunistring/spec
+++ b/runtime-common/libunistring/spec
@@ -1,4 +1,4 @@
-VER=1.3
+VER=1.4
 SRCS="tbl::https://ftp.gnu.org/gnu/libunistring/libunistring-$VER.tar.xz"
-CHKSUMS="sha256::f245786c831d25150f3dfb4317cda1acc5e3f79a5da4ad073ddca58886569527"
+CHKSUMS="sha256::708571fce9965e805fee08b410aa8e886d391a492c387f75abb7be0e195337f5"
 CHKUPDATE="anitya::id=1747"


### PR DESCRIPTION
Topic Description
-----------------

- libunistring: update to 1.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libunistring: 1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libunistring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
