### PR TITLE
[FLIGHT] linux-kernel: revert 6.16.9 CAT changes for xe

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-dt-bindings-mmc-Add-Loongson-2K-SD-SDIO-eMM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-dt-bindings-mmc-Add-Loongson-2K-SD-SDIO-eMM.patch
@@ -1,7 +1,7 @@
 From 2f29799ea898bcac8361901227f6586f134e17d5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 24 Jun 2025 19:58:10 +0800
-Subject: [PATCH 001/371] UPSTREAM: dt-bindings: mmc: Add Loongson-2K
+Subject: [PATCH 001/373] UPSTREAM: dt-bindings: mmc: Add Loongson-2K
  SD/SDIO/eMMC controller binding
 
 Add the Loongson-2K SoC's SD/SDIO/eMMC controller binding with DT schema

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-mmc-loongson2-Add-Loongson-2K-SD-SDIO-contr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-mmc-loongson2-Add-Loongson-2K-SD-SDIO-contr.patch
@@ -1,7 +1,7 @@
 From 4526db01cd7dbe91f1ad0e1541bff02f921350e5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 24 Jun 2025 19:58:11 +0800
-Subject: [PATCH 002/371] UPSTREAM: mmc: loongson2: Add Loongson-2K SD/SDIO
+Subject: [PATCH 002/373] UPSTREAM: mmc: loongson2: Add Loongson-2K SD/SDIO
  controller driver
 
 The MMC controllers on the Loongson-2K series CPUs are similar,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-dt-bindings-mmc-loongson-ls2k0500-mmc-Add-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-dt-bindings-mmc-loongson-ls2k0500-mmc-Add-c.patch
@@ -1,7 +1,7 @@
 From fc2999d1f0fba29a7fe0aed433afe8b949512b0b Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 24 Jun 2025 19:58:12 +0800
-Subject: [PATCH 003/371] UPSTREAM: dt-bindings: mmc: loongson,ls2k0500-mmc:
+Subject: [PATCH 003/373] UPSTREAM: dt-bindings: mmc: loongson,ls2k0500-mmc:
  Add compatible for Loongson-2K2000
 
 Add the devicetree compatible for Loongson-2K2000 EMMC/SD/SDIO controller.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-mmc-loongson2-Add-Loongson-2K2000-SD-SDIO-e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-mmc-loongson2-Add-Loongson-2K2000-SD-SDIO-e.patch
@@ -1,7 +1,7 @@
 From 234cce5cf8ec9b0106b370e64c70e74dc0eeed0a Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Tue, 24 Jun 2025 19:58:40 +0800
-Subject: [PATCH 004/371] UPSTREAM: mmc: loongson2: Add Loongson-2K2000
+Subject: [PATCH 004/373] UPSTREAM: mmc: loongson2: Add Loongson-2K2000
  SD/SDIO/eMMC controller driver
 
 This patch describes the two MMC controllers of the Loongson-2K2000 SoC,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-mmc-loongson2-prevent-integer-overflow-in-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-mmc-loongson2-prevent-integer-overflow-in-r.patch
@@ -1,7 +1,7 @@
 From b4540d9113fdba446be703e7738d760d5438a106 Mon Sep 17 00:00:00 2001
 From: Sergio Perez Gonzalez <sperezglz@gmail.com>
 Date: Mon, 7 Jul 2025 12:55:41 -0600
-Subject: [PATCH 005/371] UPSTREAM: mmc: loongson2: prevent integer overflow in
+Subject: [PATCH 005/373] UPSTREAM: mmc: loongson2: prevent integer overflow in
  ret variable
 
 In loongson2_mmc_dll_mode_init(), `ret` variable is declared

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-mmc-loongson2-Fix-error-code-in-loongson2_m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-mmc-loongson2-Fix-error-code-in-loongson2_m.patch
@@ -1,7 +1,7 @@
 From cddf0911f5655e94e572dc324bc7b6118865797f Mon Sep 17 00:00:00 2001
 From: Dan Carpenter <dan.carpenter@linaro.org>
 Date: Tue, 15 Jul 2025 18:00:58 -0500
-Subject: [PATCH 006/371] UPSTREAM: mmc: loongson2: Fix error code in
+Subject: [PATCH 006/373] UPSTREAM: mmc: loongson2: Fix error code in
  loongson2_mmc_resource_request()
 
 There is a cut and paste bug so we accidentally return the wrong

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-mmc-loongson2-Unify-the-function-prefixes-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-mmc-loongson2-Unify-the-function-prefixes-f.patch
@@ -1,7 +1,7 @@
 From ebf76d005a8e4f7eb816b07e0e2977d948bcc8e3 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 16 Jul 2025 14:44:21 +0800
-Subject: [PATCH 007/371] UPSTREAM: mmc: loongson2: Unify the function prefixes
+Subject: [PATCH 007/373] UPSTREAM: mmc: loongson2: Unify the function prefixes
  for loongson2_mmc_pdata
 
 The function prefixes for loongson2_mmc_pdata follow two naming

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-LoongArch-KVM-Rework-kvm_send_pv_ipi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-LoongArch-KVM-Rework-kvm_send_pv_ipi.patch
@@ -1,7 +1,7 @@
 From e37bde8c47c8f10be5b2c7abb0fc343bef0922c4 Mon Sep 17 00:00:00 2001
 From: "Yury Norov (NVIDIA)" <yury.norov@gmail.com>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 008/371] UPSTREAM: LoongArch: KVM: Rework kvm_send_pv_ipi()
+Subject: [PATCH 008/373] UPSTREAM: LoongArch: KVM: Rework kvm_send_pv_ipi()
 
 The function in fact traverses a "bitmap" stored in GPR regs A1 and A2,
 but does it in a non-obvious way by creating a single-word bitmap twice.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-LoongArch-KVM-Simplify-kvm_deliver_intr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-LoongArch-KVM-Simplify-kvm_deliver_intr.patch
@@ -1,7 +1,7 @@
 From 111f2d102f739602193ff10e3d3934b9ef7789f0 Mon Sep 17 00:00:00 2001
 From: "Yury Norov (NVIDIA)" <yury.norov@gmail.com>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 009/371] UPSTREAM: LoongArch: KVM: Simplify kvm_deliver_intr()
+Subject: [PATCH 009/373] UPSTREAM: LoongArch: KVM: Simplify kvm_deliver_intr()
 
 The function opencodes for_each_set_bit() macro, which makes it bulky.
 Using the proper API makes all the housekeeping code going away.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-LoongArch-KVM-Remove-unnecessary-local-vari.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-LoongArch-KVM-Remove-unnecessary-local-vari.patch
@@ -1,7 +1,7 @@
 From 5724d7d61589dc41ed0788a07c59946ebf3ca058 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 010/371] UPSTREAM: LoongArch: KVM: Remove unnecessary local
+Subject: [PATCH 010/373] UPSTREAM: LoongArch: KVM: Remove unnecessary local
  variable
 
 Local variable device1 can be replaced with existing variable device,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-LoongArch-KVM-Remove-unused-parameter-len.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-LoongArch-KVM-Remove-unused-parameter-len.patch
@@ -1,7 +1,7 @@
 From 92a3557d984d018587dabc5b93f43a961d032b04 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 011/371] UPSTREAM: LoongArch: KVM: Remove unused parameter len
+Subject: [PATCH 011/373] UPSTREAM: LoongArch: KVM: Remove unused parameter len
 
 Parameter len is unused in some functions with eiointc emulation driver,
 remove it here.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-LoongArch-KVM-Remove-never-called-default-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-LoongArch-KVM-Remove-never-called-default-c.patch
@@ -1,7 +1,7 @@
 From a3c20e3e29878f745e628f73d2205dcc9be7a55a Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 012/371] UPSTREAM: LoongArch: KVM: Remove never called default
+Subject: [PATCH 012/373] UPSTREAM: LoongArch: KVM: Remove never called default
  case statement
 
 IOCSR instruction supports 1/2/4/8 bytes access, len must be 1/2/4/8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-LoongArch-KVM-Use-generic-function-loongarc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-LoongArch-KVM-Use-generic-function-loongarc.patch
@@ -1,7 +1,7 @@
 From 58012c72a153b02d9175ccf529fffec55a307a7b Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 013/371] UPSTREAM: LoongArch: KVM: Use generic function
+Subject: [PATCH 013/373] UPSTREAM: LoongArch: KVM: Use generic function
  loongarch_eiointc_read()
 
 Generic read function loongarch_eiointc_read() is used for 1/2/4/8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-LoongArch-KVM-Use-generic-function-loongarc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-LoongArch-KVM-Use-generic-function-loongarc.patch
@@ -1,7 +1,7 @@
 From 36d11d589db6c923138628bb7881aabb4b068e5c Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 014/371] UPSTREAM: LoongArch: KVM: Use generic function
+Subject: [PATCH 014/373] UPSTREAM: LoongArch: KVM: Use generic function
  loongarch_eiointc_write()
 
 With all eiointc iocsr register write operation with 1/2/4/8 bytes

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-LoongArch-KVM-Replace-eiointc_enable_irq-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-LoongArch-KVM-Replace-eiointc_enable_irq-wi.patch
@@ -1,7 +1,7 @@
 From 3e06c90a2f588aec459e0c543a2b3a35ad450a1b Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 015/371] UPSTREAM: LoongArch: KVM: Replace
+Subject: [PATCH 015/373] UPSTREAM: LoongArch: KVM: Replace
  eiointc_enable_irq() with eiointc_update_irq()
 
 Function eiointc_enable_irq() checks mask value with char type, and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-LoongArch-KVM-Add-stat-information-with-ker.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-LoongArch-KVM-Add-stat-information-with-ker.patch
@@ -1,7 +1,7 @@
 From f310a249e427d252cbf04b42416ffff5919070f6 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Mon, 21 Jul 2025 09:26:32 +0800
-Subject: [PATCH 016/371] UPSTREAM: LoongArch: KVM: Add stat information with
+Subject: [PATCH 016/373] UPSTREAM: LoongArch: KVM: Add stat information with
  kernel irqchip
 
 Move stat information about kernel irqchip from VM to vCPU, since all

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-LoongArch-KVM-Add-tracepoints-for-CPUCFG-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-LoongArch-KVM-Add-tracepoints-for-CPUCFG-an.patch
@@ -1,7 +1,7 @@
 From 7b94f07917ae831ab7f106cfe2fe9667583cb09f Mon Sep 17 00:00:00 2001
 From: Yulong Han <wheatfox17@icloud.com>
 Date: Mon, 21 Jul 2025 09:26:35 +0800
-Subject: [PATCH 017/371] UPSTREAM: LoongArch: KVM: Add tracepoints for CPUCFG
+Subject: [PATCH 017/373] UPSTREAM: LoongArch: KVM: Add tracepoints for CPUCFG
  and CSR emulation exits
 
 This patch adds tracepoints to track KVM exits caused by CPUCFG and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-drm-amdkfd-enable-kfd-on-LoongArch-systems.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-drm-amdkfd-enable-kfd-on-LoongArch-systems.patch
@@ -1,7 +1,7 @@
 From a5fef20ffd769b38ba82e55b84a35efbdcacc8e3 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 9 Jul 2025 14:51:38 +0800
-Subject: [PATCH 018/371] UPSTREAM: drm/amdkfd: enable kfd on LoongArch systems
+Subject: [PATCH 018/373] UPSTREAM: drm/amdkfd: enable kfd on LoongArch systems
 
 KFD has been confirmed that can run on LoongArch systems.
 It's necessary to support CONFIG_HSA_AMD on LoongArch.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-riscv-dts-sophgo-Add-xtheadvector-to-the-sg.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-riscv-dts-sophgo-Add-xtheadvector-to-the-sg.patch
@@ -1,7 +1,7 @@
 From 441d2a6338d71fef0a4a1337e0fe1d81eff9a716 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Sat, 5 Jul 2025 15:00:12 +0800
-Subject: [PATCH 019/371] UPSTREAM: riscv: dts: sophgo: Add xtheadvector to the
+Subject: [PATCH 019/373] UPSTREAM: riscv: dts: sophgo: Add xtheadvector to the
  sg2042 devicetree
 
 The sg2042 SoCs support xtheadvector [1] so it can be included in the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-UPSTREAM-riscv-dts-sophgo-add-ziccrse-for-sg2042.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-UPSTREAM-riscv-dts-sophgo-add-ziccrse-for-sg2042.patch
@@ -1,7 +1,7 @@
 From 6dab13868dafa6608b97067880bef25ca43d3409 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Sat, 5 Jul 2025 15:00:13 +0800
-Subject: [PATCH 020/371] UPSTREAM: riscv: dts: sophgo: add ziccrse for sg2042
+Subject: [PATCH 020/373] UPSTREAM: riscv: dts: sophgo: add ziccrse for sg2042
 
 sg2042 support Ziccrse ISA extension [1].
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-riscv-dts-sophgo-add-zfh-for-sg2042.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-riscv-dts-sophgo-add-zfh-for-sg2042.patch
@@ -1,7 +1,7 @@
 From 6cc7a3020f7ace5e94c78b74216f07eec8931d15 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Sat, 5 Jul 2025 15:00:14 +0800
-Subject: [PATCH 021/371] UPSTREAM: riscv: dts: sophgo: add zfh for sg2042
+Subject: [PATCH 021/373] UPSTREAM: riscv: dts: sophgo: add zfh for sg2042
 
 sg2042 support Zfh ISA extension [1].
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-Add-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-Add-sup.patch
@@ -1,7 +1,7 @@
 From 9811f2ea8fa25c6de13977c0c624672a63e86c44 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 8 Jul 2025 14:40:49 +0800
-Subject: [PATCH 022/371] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: Add
+Subject: [PATCH 022/373] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: Add
  support for Sophgo SG2042 dwmac
 
 The GMAC IP on SG2042 is a standard Synopsys DesignWare MAC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-dwmac-sophgo-Add-support-for-Sop.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-dwmac-sophgo-Add-support-for-Sop.patch
@@ -1,7 +1,7 @@
 From 540c191c62ddbf67844de16d5d77a9d3fff7436c Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 8 Jul 2025 14:40:50 +0800
-Subject: [PATCH 023/371] UPSTREAM: net: stmmac: dwmac-sophgo: Add support for
+Subject: [PATCH 023/373] UPSTREAM: net: stmmac: dwmac-sophgo: Add support for
  Sophgo SG2042 SoC
 
 Adds device id of the ethernet controller on the Sophgo SG2042 SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-platform-Add-snps-dwmac-5.00a-IP.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-platform-Add-snps-dwmac-5.00a-IP.patch
@@ -1,7 +1,7 @@
 From 041ef1cc48bca163c11306ea87fb09af4083992a Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 8 Jul 2025 14:40:51 +0800
-Subject: [PATCH 024/371] UPSTREAM: net: stmmac: platform: Add snps,dwmac-5.00a
+Subject: [PATCH 024/373] UPSTREAM: net: stmmac: platform: Add snps,dwmac-5.00a
  IP compatible string
 
 Add "snps,dwmac-5.30a" compatible string for 5.00a version that

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-riscv-dts-sophgo-add-ethernet-GMAC-device-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-riscv-dts-sophgo-add-ethernet-GMAC-device-f.patch
@@ -1,7 +1,7 @@
 From 5cfdba1dfdceefad413fccfcb2c3d79c33970315 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 8 Jul 2025 14:46:25 +0800
-Subject: [PATCH 025/371] UPSTREAM: riscv: dts: sophgo: add ethernet GMAC
+Subject: [PATCH 025/373] UPSTREAM: riscv: dts: sophgo: add ethernet GMAC
  device for sg2042
 
 Add ethernet GMAC device node for the sg2042.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-dt-bindings-soc-sophgo-Move-SoCs-boards-fro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-dt-bindings-soc-sophgo-Move-SoCs-boards-fro.patch
@@ -1,7 +1,7 @@
 From 3ef2fe81ae15079e09ff413b0f3df1c5956ec522 Mon Sep 17 00:00:00 2001
 From: Alexander Sverdlin <alexander.sverdlin@gmail.com>
 Date: Thu, 12 Jun 2025 15:28:09 +0200
-Subject: [PATCH 026/371] UPSTREAM: dt-bindings: soc: sophgo: Move SoCs/boards
+Subject: [PATCH 026/373] UPSTREAM: dt-bindings: soc: sophgo: Move SoCs/boards
  from riscv into soc, add SG2000
 
 Move sophgo.yaml from riscv into soc/sophgo so that it can be shared for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-dt-bindings-riscv-add-Sophgo-SG2042_EVB_V1..patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-dt-bindings-riscv-add-Sophgo-SG2042_EVB_V1..patch
@@ -1,7 +1,7 @@
 From d467163356d0b4b086ab64d1d322bdc803a0597a Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Sat, 5 Jul 2025 15:39:54 +0800
-Subject: [PATCH 027/371] UPSTREAM: dt-bindings: riscv: add Sophgo
+Subject: [PATCH 027/373] UPSTREAM: dt-bindings: riscv: add Sophgo
  SG2042_EVB_V1.X/V2.0 bindings
 
 Add DT binding documentation for the Sophgo SG2042_EVB_V1.X/V2.0 board [1].

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-riscv-dts-sophgo-add-Sophgo-SG2042_EVB_V1.X.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-riscv-dts-sophgo-add-Sophgo-SG2042_EVB_V1.X.patch
@@ -1,7 +1,7 @@
 From aa1c1e32ef8bcb18f516cc8b948fb597e665e35d Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Sat, 5 Jul 2025 15:39:55 +0800
-Subject: [PATCH 028/371] UPSTREAM: riscv: dts: sophgo: add Sophgo
+Subject: [PATCH 028/373] UPSTREAM: riscv: dts: sophgo: add Sophgo
  SG2042_EVB_V1.X board device tree
 
 Sophgo SG2042_EVB_V1.X [1] is a prototype development board based on SG2042

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-riscv-dts-sophgo-add-Sophgo-SG2042_EVB_V2.0.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-riscv-dts-sophgo-add-Sophgo-SG2042_EVB_V2.0.patch
@@ -1,7 +1,7 @@
 From 6db3877875cb30b4297652f4bf3fadc03cf2d232 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Sat, 5 Jul 2025 15:39:56 +0800
-Subject: [PATCH 029/371] UPSTREAM: riscv: dts: sophgo: add Sophgo
+Subject: [PATCH 029/373] UPSTREAM: riscv: dts: sophgo: add Sophgo
  SG2042_EVB_V2.0 board device tree
 
 Sophgo SG2042_EVB_V2.0 [1] is a prototype development board based on SG2042

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-spi-dt-bindings-spi-sg2044-nor-Change-SOPHG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-spi-dt-bindings-spi-sg2044-nor-Change-SOPHG.patch
@@ -1,7 +1,7 @@
 From 164415094a60660f1e55c73dd2541473b94f755d Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Sun, 20 Jul 2025 16:31:43 +0800
-Subject: [PATCH 030/371] UPSTREAM: spi: dt-bindings: spi-sg2044-nor: Change
+Subject: [PATCH 030/373] UPSTREAM: spi: dt-bindings: spi-sg2044-nor: Change
  SOPHGO SG2042
 
 With further testing, directly using the spi-sg2044-nor driver on SG2042

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-spi-spi-sg2044-nor-Add-configurable-chip_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-spi-spi-sg2044-nor-Add-configurable-chip_in.patch
@@ -1,7 +1,7 @@
 From 8ce687551a2aa50e51854691de43ce6c4f348149 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Sun, 20 Jul 2025 16:31:44 +0800
-Subject: [PATCH 031/371] UPSTREAM: spi: spi-sg2044-nor: Add configurable
+Subject: [PATCH 031/373] UPSTREAM: spi: spi-sg2044-nor: Add configurable
  chip_info
 
 SG2044 and SG2042 have similar SPI-NOR flash controller design,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-spi-spi-sg2044-nor-Add-SPI-NOR-controller-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-spi-spi-sg2044-nor-Add-SPI-NOR-controller-f.patch
@@ -1,7 +1,7 @@
 From b78eaec7c3806c80d534efd842f5501846638fef Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Sun, 20 Jul 2025 16:31:45 +0800
-Subject: [PATCH 032/371] UPSTREAM: spi: spi-sg2044-nor: Add SPI-NOR controller
+Subject: [PATCH 032/373] UPSTREAM: spi: spi-sg2044-nor: Add SPI-NOR controller
  for SG2042
 
 Add support for SOPHGO SG2042 SPI-NOR flash controller.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-ALSA-usb-audio-move-mixer_quirks-min_mute-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-ALSA-usb-audio-move-mixer_quirks-min_mute-i.patch
@@ -1,7 +1,7 @@
 From 427e21c773d14734fcc082da2f1222de6f7f105c Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia@uniontech.com>
 Date: Wed, 27 Aug 2025 11:29:02 +0800
-Subject: [PATCH 033/371] UPSTREAM: ALSA: usb-audio: move mixer_quirks'
+Subject: [PATCH 033/373] UPSTREAM: ALSA: usb-audio: move mixer_quirks'
  min_mute into common quirk
 
 We have found more and more devices that have the same problem, that

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-MIPS-Loongson-Fix-build-warnings-about-expor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-FROMGIT-MIPS-Loongson-Fix-build-warnings-about-expor.patch
@@ -1,7 +1,7 @@
 From 771e3aedc60391906b373960367a2d6dafec7d33 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 8 Jun 2025 22:20:10 +0800
-Subject: [PATCH 034/371] FROMGIT: MIPS/Loongson: Fix build warnings about
+Subject: [PATCH 034/373] FROMGIT: MIPS/Loongson: Fix build warnings about
  export.h
 
 After commit a934a57a42f64a4 ("scripts/misc-check: check missing #include

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 26472e9c493158b343d543a6a3af507a452d757b Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 035/371] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 035/373] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
@@ -1,7 +1,7 @@
 From 18662268ba9605321acb909b16a280e730df8795 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 036/371] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
+Subject: [PATCH 036/373] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
  before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From eba1e98ef325fc34b1986cff2856bae2dd5ad9bf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 037/371] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 037/373] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From e3b379b1a499c6bd351595f09dcdedcf97b97e40 Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 038/371] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 038/373] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMLIST-dt-bindings-serial-Add-Loongson-UART-contro.patch
@@ -1,7 +1,7 @@
 From b82594ef29fa2f73b2afef58506bb5beced339de Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:03 +0800
-Subject: [PATCH 039/371] FROMLIST: dt-bindings: serial: Add Loongson UART
+Subject: [PATCH 039/373] FROMLIST: dt-bindings: serial: Add Loongson UART
  controller
 
 Add Loongson UART controller binding with DT schema format using

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-FROMLIST-tty-serial-8250-Add-loongson-uart-driver-su.patch
@@ -1,7 +1,7 @@
 From 4a17552ec2ff63dc2d6315ab5d25e8d6bd44612c Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:04 +0800
-Subject: [PATCH 040/371] FROMLIST: tty: serial: 8250: Add loongson uart driver
+Subject: [PATCH 040/373] FROMLIST: tty: serial: 8250: Add loongson uart driver
  support
 
 Due to certain hardware design challenges, we have opted to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-FROMLIST-LoongArch-Update-dts-to-support-Loongson-UA.patch
@@ -1,7 +1,7 @@
 From d3e531e9a425db34b15d2ab2a78c69df9af2a725 Mon Sep 17 00:00:00 2001
 From: Haowei Zheng <zhenghaowei@loongson.cn>
 Date: Mon, 26 Aug 2024 10:47:05 +0800
-Subject: [PATCH 041/371] FROMLIST: LoongArch: Update dts to support Loongson
+Subject: [PATCH 041/373] FROMLIST: LoongArch: Update dts to support Loongson
  UART driver.
 
 Change to use the Loongson UART driver for Loongson-2K2000,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From 51d8da49684485a96a778a969e2206f65ea8d7e2 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 042/371] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 042/373] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From 9e1bf463055e165e6d25f3cd8981ddd86efbb433 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 043/371] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 043/373] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 6cea71e1d4f7d94875c45744c540582a101eba9b Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 044/371] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 044/373] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From 470cad80f025f0b09aaf0f77f82c7d98b2eedabf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 045/371] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 045/373] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
@@ -1,7 +1,7 @@
 From 1a9c18066fca89723d67238d9d92e8a9a7f10b50 Mon Sep 17 00:00:00 2001
 From: WangYuli <wangyuli@uniontech.com>
 Date: Tue, 18 Mar 2025 14:11:25 +0800
-Subject: [PATCH 046/371] FROMLIST: scsi: Bypass certain SCSI commands on disks
+Subject: [PATCH 046/373] FROMLIST: scsi: Bypass certain SCSI commands on disks
  with "use_192_bytes_for_3f" attribute
 
 On some external USB hard drives, mounting can fail if "lshw" is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
@@ -1,7 +1,7 @@
 From 4c8dc95fbf65ffa4d8c93409a5a371629dc357a0 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Sun, 11 May 2025 16:34:12 +0800
-Subject: [PATCH 047/371] FROMLIST: PCI: Use local_pci_probe() when best
+Subject: [PATCH 047/373] FROMLIST: PCI: Use local_pci_probe() when best
  selected cpu is offline
 
 When the best selected CPU is offline, work_on_cpu() will stuck forever.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From ada4fa318a447b0d7fab85ddaf3c980a0338e234 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 11 May 2025 16:34:13 +0800
-Subject: [PATCH 048/371] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 048/373] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
@@ -1,7 +1,7 @@
 From e36d8cdd1dde098913d21b6e7f621d5b3d7d34f5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 17 Aug 2025 22:19:09 +0800
-Subject: [PATCH 049/371] REVERT: Revert "Mark xe driver as BROKEN if kernel
+Subject: [PATCH 049/373] REVERT: Revert "Mark xe driver as BROKEN if kernel
  page size is not 4kB"
 
 This reverts commit 022906afdf90327bce33d52fb4fb41b6c7d618fb.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-drm-xe-bo-fix-alignment-with-non-4KiB-kerne.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-drm-xe-bo-fix-alignment-with-non-4KiB-kerne.patch
@@ -1,7 +1,7 @@
 From 22ae8dbab692784a6bdc769abe3816820ba08a12 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 13 Jun 2025 09:11:29 +0800
-Subject: [PATCH 050/371] FROMLIST: drm/xe/bo: fix alignment with non-4KiB
+Subject: [PATCH 050/373] FROMLIST: drm/xe/bo: fix alignment with non-4KiB
  kernel page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-drm-xe-guc-use-GUC_SIZE-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-drm-xe-guc-use-GUC_SIZE-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From ea312b530ecc409bed1b5889837a9dc293299495 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 13 Jun 2025 09:11:30 +0800
-Subject: [PATCH 051/371] FROMLIST: drm/xe/guc: use GUC_SIZE (SZ_4K) for
+Subject: [PATCH 051/373] FROMLIST: drm/xe/guc: use GUC_SIZE (SZ_4K) for
  alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size-calculat.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size-calculat.patch
@@ -1,7 +1,7 @@
 From 8f47d1bc3b892e41dc4f799cc4c1cac7fbda352f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 13 Jun 2025 09:11:31 +0800
-Subject: [PATCH 052/371] FROMLIST: drm/xe/regs: fix RING_CTL_SIZE(size)
+Subject: [PATCH 052/373] FROMLIST: drm/xe/regs: fix RING_CTL_SIZE(size)
  calculation
 
 Similar to the preceding patch for GuC (and with the same references),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-drm-xe-use-4KiB-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-drm-xe-use-4KiB-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From 2236e7208cd3ba453532d1da04bc5f16b6127950 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 13 Jun 2025 09:11:32 +0800
-Subject: [PATCH 053/371] FROMLIST: drm/xe: use 4KiB alignment for cursor jumps
+Subject: [PATCH 053/373] FROMLIST: drm/xe: use 4KiB alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4KiB alignment.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From 7d359b46fcc1fd16469901cb5444a16b2d38594b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 13 Jun 2025 09:11:33 +0800
-Subject: [PATCH 054/371] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 054/373] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-LoongArch-Support-mem-SIZE-kernel-parameter.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-LoongArch-Support-mem-SIZE-kernel-parameter.patch
@@ -1,7 +1,7 @@
 From ccf00fec43608fb6511e7ce21c8390cb0897fd45 Mon Sep 17 00:00:00 2001
 From: Ming Wang <wangming01@loongson.cn>
 Date: Tue, 1 Jul 2025 17:04:49 +0800
-Subject: [PATCH 055/371] FROMLIST: LoongArch: Support mem=SIZE kernel
+Subject: [PATCH 055/373] FROMLIST: LoongArch: Support mem=SIZE kernel
  parameter
 
 The LoongArch mem= parameter parser was previously limited to the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
@@ -1,7 +1,7 @@
 From b453497f51c1e622f4f29958490d81e1dd63b80d Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 4 Sep 2025 20:35:05 +0800
-Subject: [PATCH 056/371] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
+Subject: [PATCH 056/373] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
  Loongson-2K BMC core driver
 
 The Loongson-2K Board Management Controller provides an PCIe interface

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-mfd-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-FROMLIST-mfd-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
@@ -1,7 +1,7 @@
 From 8e2ae55bf9fd7f4d99d082abdea815d24bb21ee5 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 4 Sep 2025 20:35:06 +0800
-Subject: [PATCH 057/371] FROMLIST: mfd: ls2kbmc: Add Loongson-2K BMC reset
+Subject: [PATCH 057/373] FROMLIST: mfd: ls2kbmc: Add Loongson-2K BMC reset
  function support
 
 Since the display is a sub-function of the Loongson-2K BMC, when the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
@@ -1,7 +1,7 @@
 From aaa5a62a88a0382209d8ff5e930ad17e6a219fee Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 4 Sep 2025 20:35:07 +0800
-Subject: [PATCH 058/371] FROMLIST: ipmi: Add Loongson-2K BMC support
+Subject: [PATCH 058/373] FROMLIST: ipmi: Add Loongson-2K BMC support
 
 This patch adds Loongson-2K BMC IPMI support.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-PCI-Override-PCIe-bridge-supported-speeds-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-PCI-Override-PCIe-bridge-supported-speeds-f.patch
@@ -1,7 +1,7 @@
 From a7e685385fa0e7a5e3d3fd5183090d49cca34551 Mon Sep 17 00:00:00 2001
 From: Ziyao <liziyao@uniontech.com>
 Date: Fri, 22 Aug 2025 17:15:58 +0800
-Subject: [PATCH 059/371] FROMLIST: PCI: Override PCIe bridge supported speeds
+Subject: [PATCH 059/373] FROMLIST: PCI: Override PCIe bridge supported speeds
  for older Loongson 3C6000 series steppings
 
 Older steppings of the Loongson 3C6000 series incorrectly report the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
@@ -1,7 +1,7 @@
 From 303e448af825a741bbad1f5013a31166382e5a87 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Aug 2025 11:21:36 +0800
-Subject: [PATCH 060/371] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
+Subject: [PATCH 060/373] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
  LoongArch and AArch64
 
 While testing my ROCm port for LoongArch and AArch64 (patches pending) on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-pwm-loongson-Fix-LOONGSON_PWM_FREQ_DEFAULT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-FROMLIST-pwm-loongson-Fix-LOONGSON_PWM_FREQ_DEFAULT.patch
@@ -1,7 +1,7 @@
 From 14ed8445031eb76e095fb2a79856147f39ee4de9 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 10:35:04 +0800
-Subject: [PATCH 061/371] FROMLIST: pwm: loongson: Fix
+Subject: [PATCH 061/373] FROMLIST: pwm: loongson: Fix
  LOONGSON_PWM_FREQ_DEFAULT
 
 Per the 7A1000 and 7A2000 user manual, the clock frequency of their

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-FROMLIST-riscv-mmap-use-unsigned-offset-type-in-risc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-FROMLIST-riscv-mmap-use-unsigned-offset-type-in-risc.patch
@@ -1,7 +1,7 @@
 From d1ed7072f7e4c30bb277e0a45342b413ed11bb90 Mon Sep 17 00:00:00 2001
 From: Jessica Liu <liu.xuemei1@zte.com.cn>
 Date: Mon, 7 Jul 2025 19:34:11 +0800
-Subject: [PATCH 062/371] FROMLIST: riscv: mmap(): use unsigned offset type in
+Subject: [PATCH 062/373] FROMLIST: riscv: mmap(): use unsigned offset type in
  riscv_sys_mmap
 
 The variable type of offset should be consistent with the relevant

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-riscv-introduce-ioremap_wc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-riscv-introduce-ioremap_wc.patch
@@ -1,7 +1,7 @@
 From 949313330708b34526a7e3b4b24f77c20a43e068 Mon Sep 17 00:00:00 2001
 From: Yunhui Cui <cuiyunhui@bytedance.com>
 Date: Tue, 22 Jul 2025 17:15:04 +0800
-Subject: [PATCH 063/371] FROMLIST: riscv: introduce ioremap_wc()
+Subject: [PATCH 063/373] FROMLIST: riscv: introduce ioremap_wc()
 
 Compared with IO attributes, NC attributes can improve performance,
 specifically in these aspects: Relaxed Order, Gathering, Supports Read

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-FROMLIST-drm-ttm-add-pgprot-handling-for-RISC-V.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-FROMLIST-drm-ttm-add-pgprot-handling-for-RISC-V.patch
@@ -1,7 +1,7 @@
 From 0995331c0c9a6d8678acb9c42a429d489385b935 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 22 Jul 2025 19:20:50 +0800
-Subject: [PATCH 064/371] FROMLIST: drm/ttm: add pgprot handling for RISC-V
+Subject: [PATCH 064/373] FROMLIST: drm/ttm: add pgprot handling for RISC-V
 
 The RISC-V Svpbmt privileged extension provides support for overriding
 page memory coherency attributes, and, along with vendor extensions like

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-irqchip-sifive-plic-Respect-mask-state-when.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-FROMLIST-irqchip-sifive-plic-Respect-mask-state-when.patch
@@ -1,7 +1,7 @@
 From 94e141667039e59c16a8380ec4889d38615cf4ef Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Mon, 11 Aug 2025 08:26:32 +0800
-Subject: [PATCH 065/371] FROMLIST: irqchip/sifive-plic: Respect mask state
+Subject: [PATCH 065/373] FROMLIST: irqchip/sifive-plic: Respect mask state
  when setting affinity
 
 The plic_set_affinity always call plic_irq_enable(), which clears up

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-genirq-Add-irq_chip_-startup-shutdown-_pare.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-genirq-Add-irq_chip_-startup-shutdown-_pare.patch
@@ -1,7 +1,7 @@
 From 93c01153cda042ad617ce6a71e3074ef51edd250 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 14 Aug 2025 07:28:31 +0800
-Subject: [PATCH 066/371] FROMLIST: genirq: Add
+Subject: [PATCH 066/373] FROMLIST: genirq: Add
  irq_chip_(startup/shutdown)_parent()
 
 As the MSI controller on SG2044 uses PLIC as the underlying interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-PCI-MSI-Add-startup-shutdown-for-per-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-FROMLIST-PCI-MSI-Add-startup-shutdown-for-per-device.patch
@@ -1,7 +1,7 @@
 From ee204df8447a7c6f29a39b16f72190f7a2c76943 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 14 Aug 2025 07:28:32 +0800
-Subject: [PATCH 067/371] FROMLIST: PCI/MSI: Add startup/shutdown for per
+Subject: [PATCH 067/373] FROMLIST: PCI/MSI: Add startup/shutdown for per
  device domains
 
 As the RISC-V PLIC can not apply affinity setting without calling

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-irqchip-sg2042-msi-Fix-broken-affinity-sett.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-FROMLIST-irqchip-sg2042-msi-Fix-broken-affinity-sett.patch
@@ -1,7 +1,7 @@
 From ed1aefb1610551be63ebc1c231cfc61ce3632f12 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 14 Aug 2025 07:28:33 +0800
-Subject: [PATCH 068/371] FROMLIST: irqchip/sg2042-msi: Fix broken affinity
+Subject: [PATCH 068/373] FROMLIST: irqchip/sg2042-msi: Fix broken affinity
  setting
 
 When using NVME on SG2044, the NVME always complains "I/O tag XXX

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-irqchip-sg2042-msi-Set-MSI_FLAG_MULTI_PCI_M.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-FROMLIST-irqchip-sg2042-msi-Set-MSI_FLAG_MULTI_PCI_M.patch
@@ -1,7 +1,7 @@
 From 94004e9e5aa7c2b32050c83829291dbc3a5e8a56 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 14 Aug 2025 07:28:34 +0800
-Subject: [PATCH 069/371] FROMLIST: irqchip/sg2042-msi: Set
+Subject: [PATCH 069/373] FROMLIST: irqchip/sg2042-msi: Set
  MSI_FLAG_MULTI_PCI_MSI flags for SG2044
 
 The MSI controller on SG2044 has the ability to allocate multiple

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-riscv-Move-vendor-errata-definitions-to-new.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-FROMLIST-riscv-Move-vendor-errata-definitions-to-new.patch
@@ -1,7 +1,7 @@
 From 6a929dd71e0e0adb1601f57138258905465f73e0 Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:20 -0400
-Subject: [PATCH 070/371] FROMLIST: riscv: Move vendor errata definitions to
+Subject: [PATCH 070/373] FROMLIST: riscv: Move vendor errata definitions to
  new header
 
 Move vendor errata definitions into errata_list_vendors.h.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
@@ -1,7 +1,7 @@
 From 649f229346b7c4dba16f5d00ab33d1cf505e64bf Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:21 -0400
-Subject: [PATCH 071/371] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
+Subject: [PATCH 071/373] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
  fixup
 
 The early version of XuanTie C910 core has a store merge buffer

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-FROMLIST-PCI-MSI-Check-MSI_FLAG_PCI_MSI_MASK_PARENT-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-FROMLIST-PCI-MSI-Check-MSI_FLAG_PCI_MSI_MASK_PARENT-.patch
@@ -1,7 +1,7 @@
 From 507a6a8f6b8d407e567bb9037ad2af873d94fbe1 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 28 Aug 2025 07:09:42 +0800
-Subject: [PATCH 072/371] FROMLIST: PCI/MSI: Check MSI_FLAG_PCI_MSI_MASK_PARENT
+Subject: [PATCH 072/373] FROMLIST: PCI/MSI: Check MSI_FLAG_PCI_MSI_MASK_PARENT
  in cond_[startup|shutdown]_parent()
 
 For msi controller that only supports MSI_FLAG_PCI_MSI_MASK_PARENT,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
@@ -1,7 +1,7 @@
 From 2e7cfd9f0fc95f003535e0de401466960832480b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:46 +0800
-Subject: [PATCH 073/371] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
+Subject: [PATCH 073/373] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
  coherency status in ttm_device
 
 Currently TTM utilizes cached memory regardless of whether the device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
@@ -1,7 +1,7 @@
 From 9cffc31444451b6aa22e19cad5aee27282670b2f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:47 +0800
-Subject: [PATCH 074/371] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
+Subject: [PATCH 074/373] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
  write_combined when snooping not available
 
 As we can now acquire the presence of the full DMA coherency (snooping

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-FROMLIST-drm-amd-display-dml2-Guard-dml21_map_dc_sta.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-FROMLIST-drm-amd-display-dml2-Guard-dml21_map_dc_sta.patch
@@ -1,7 +1,7 @@
 From 439c43ec680b4dd2629abb93931ad04f0cbede8a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 25 Aug 2025 16:52:11 +0800
-Subject: [PATCH 075/371] FROMLIST: drm/amd/display/dml2: Guard
+Subject: [PATCH 075/373] FROMLIST: drm/amd/display/dml2: Guard
  dml21_map_dc_state_into_dml_display_cfg with DC_FP_START
 
 dml21_map_dc_state_into_dml_display_cfg calls (the call is usually

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-dts-sophgo-sg2042-added-numa-id-description.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-dts-sophgo-sg2042-added-numa-id-description.patch
@@ -1,7 +1,7 @@
 From 08d058900ff0cc3f67023e9c7c74a6b6bb7a07b5 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 10 Sep 2025 18:55:31 +0800
-Subject: [PATCH 076/371] FROMLIST: dts: sophgo: sg2042: added numa id
+Subject: [PATCH 076/373] FROMLIST: dts: sophgo: sg2042: added numa id
  description
 
 According to the description of [1], sg2042 is divided into 4 numa.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-dt-bindings-pci-Add-Sophgo-SG2042-PCIe-host.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-dt-bindings-pci-Add-Sophgo-SG2042-PCIe-host.patch
@@ -1,7 +1,7 @@
 From 4e44df3a5cc165cf90d147b800701c947233b43a Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:35:32 +0800
-Subject: [PATCH 077/371] FROMLIST: dt-bindings: pci: Add Sophgo SG2042 PCIe
+Subject: [PATCH 077/373] FROMLIST: dt-bindings: pci: Add Sophgo SG2042 PCIe
  host
 
 Add binding for Sophgo SG2042 PCIe host controller.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-PCI-cadence-Check-pcie-ops-before-using-it.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-PCI-cadence-Check-pcie-ops-before-using-it.patch
@@ -1,7 +1,7 @@
 From 08eb4375e3ad84c1f14a98afebd1ea819c2a95bd Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:36:01 +0800
-Subject: [PATCH 078/371] FROMLIST: PCI: cadence: Check pcie-ops before using
+Subject: [PATCH 078/373] FROMLIST: PCI: cadence: Check pcie-ops before using
  it
 
 ops of struct cdns_pcie may be NULL, direct use

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-PCI-sg2042-Add-Sophgo-SG2042-PCIe-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-PCI-sg2042-Add-Sophgo-SG2042-PCIe-driver.patch
@@ -1,7 +1,7 @@
 From 034701916dcdef2af350e929ce8a31fca259407d Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:36:31 +0800
-Subject: [PATCH 079/371] FROMLIST: PCI: sg2042: Add Sophgo SG2042 PCIe driver
+Subject: [PATCH 079/373] FROMLIST: PCI: sg2042: Add Sophgo SG2042 PCIe driver
 
 Add support for PCIe controller in SG2042 SoC. The controller
 uses the Cadence PCIe core programmed by pcie-cadence*.c. The

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
@@ -1,7 +1,7 @@
 From 0ec8d9b0fb0b6d5651de53d33b1224fac19fa8c8 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:36:50 +0800
-Subject: [PATCH 080/371] FROMLIST: riscv: sophgo: dts: add PCIe controllers
+Subject: [PATCH 080/373] FROMLIST: riscv: sophgo: dts: add PCIe controllers
  for SG2042
 
 Add PCIe controller nodes in DTS for Sophgo SG2042.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
@@ -1,7 +1,7 @@
 From 43bf0840532954893bbdd88bfe4e854384708218 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:37:13 +0800
-Subject: [PATCH 081/371] FROMLIST: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 081/373] FROMLIST: riscv: sophgo: dts: enable PCIe for
  PioneerBox
 
 Enable PCIe controllers for PioneerBox, which uses SG2042 SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From bed8b098a4c8c959ecff3c2d10302de5a18156f2 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:37:35 +0800
-Subject: [PATCH 082/371] FROMLIST: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 082/373] FROMLIST: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V1.X
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V1.X board,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From b7578571080272a699b932ab3b09664dd458a7f1 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:37:54 +0800
-Subject: [PATCH 083/371] FROMLIST: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 083/373] FROMLIST: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V2.0
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V2.0 board,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
@@ -1,7 +1,7 @@
 From b00144b57a2442466926c42eec85e8523d2762f7 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:50 +0800
-Subject: [PATCH 084/371] FROMLIST: riscv: dts: sophgo: Add SPI NOR node for
+Subject: [PATCH 084/373] FROMLIST: riscv: dts: sophgo: Add SPI NOR node for
  SG2042
 
 Add SPI NOR controller node for SG2042

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
@@ -1,7 +1,7 @@
 From 46b9c0e60721537d1ca1c4958aa996acaaa233b1 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:51 +0800
-Subject: [PATCH 085/371] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 085/373] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
  PioneerBox
 
 Enable SPI NOR node for PioneerBox device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 363a6a59c5de0b18841c08b531f716b2d72f5d5d Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:52 +0800
-Subject: [PATCH 086/371] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 086/373] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V1
 
 Enable SPI NOR node for SG2042_EVB_V1 device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 8f2e5330e532eae9ef2093ff966c61b42ac61d4f Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:53 +0800
-Subject: [PATCH 087/371] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 087/373] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V2
 
 Enable SPI NOR node for SG2042_EVB_V2 device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-scsi-dc395x-correctly-discard-the-return-va.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-scsi-dc395x-correctly-discard-the-return-va.patch
@@ -1,7 +1,7 @@
 From 40e84df7cd7bd04b535d055c39c500b9f128a490 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 24 Sep 2025 13:56:26 +0800
-Subject: [PATCH 088/371] FROMLIST: scsi: dc395x: correctly discard the return
+Subject: [PATCH 088/373] FROMLIST: scsi: dc395x: correctly discard the return
  value in certain reads
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-scsi-dc395x-improve-code-formatting-for-the.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-FROMLIST-scsi-dc395x-improve-code-formatting-for-the.patch
@@ -1,7 +1,7 @@
 From ebcc6f5e47d1c2f3efb71b804b34400f7fe630d9 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 24 Sep 2025 13:56:27 +0800
-Subject: [PATCH 089/371] FROMLIST: scsi: dc395x: improve code formatting for
+Subject: [PATCH 089/373] FROMLIST: scsi: dc395x: improve code formatting for
  the macros
 
 The DC395x_* macros does not have white spaces between their arguments,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From f829372aa48a23905918c8b144ae720713482d87 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 090/371] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 090/373] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From 7e71a8d54ed7ae325a8e2bc7182cb61935368343 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 091/371] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 091/373] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From aff49c6ccfd490825468f042fa7ef2d33271eebf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 092/371] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 092/373] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 61a1dfee090a4fd2e3b6640f1f4e82739910aa31 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 093/371] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 093/373] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From f720e92f20d6821dddba28dc1a3ec4f91f31827c Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 094/371] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 094/373] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 0b56a2811c30c134b467a6869b3dcaaa94c271f6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 095/371] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 095/373] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From d996f534c0c6fad152448ec7194eec228f433f1d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 096/371] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 096/373] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From b13ad7b75711f044bfff905e1a63512f80240c72 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 097/371] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 097/373] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From e9408afdc85e3af75a7e7a98d28fd9b29cf85ce1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 098/371] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 098/373] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From 0b35431a62f373d3473dbb796838c59069b78217 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 099/371] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 099/373] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From 6ff0056bb8a3d983070d2d98e38a40d1fd4be853 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 100/371] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 100/373] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From e2972aa5a3642a73bb94d19c6c6b80c5f40564c3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 101/371] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 101/373] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From 0e9a9630c67326a72839535944aba2beeb4c2597 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 102/371] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 102/373] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-LOONGSON-ACPICA-Allow-to-skip-Global-Lock-initializa.patch
@@ -1,7 +1,7 @@
 From 122262bef677d79f07c81e473958e9e15e0865b1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:34:55 +0800
-Subject: [PATCH 103/371] LOONGSON: ACPICA: Allow to skip Global Lock
+Subject: [PATCH 103/373] LOONGSON: ACPICA: Allow to skip Global Lock
  initialization
 
 Introduce acpi_gbl_use_global_lock, which allows to skip the Global

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-LOONGSON-LoongArch-Init-acpi_gbl_use_global_lock-to-.patch
@@ -1,7 +1,7 @@
 From 43dcf3339cd187e575541d193834b612ca648032 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 17 Apr 2025 20:38:26 +0800
-Subject: [PATCH 104/371] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
+Subject: [PATCH 104/373] LOONGSON: LoongArch: Init acpi_gbl_use_global_lock to
  false
 
 Init acpi_gbl_use_global_lock to false, in order to void error messages

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From 8763355821118c4b6baa23e61d9cefba8bf9eab7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 105/371] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 105/373] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-LOONGSON-LoongArch-BPF-Set-bpf_jit_bypass_spec_v1-v4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-LOONGSON-LoongArch-BPF-Set-bpf_jit_bypass_spec_v1-v4.patch
@@ -1,7 +1,7 @@
 From 22012744ce33c475f2f397d426e796e0faf8d76e Mon Sep 17 00:00:00 2001
 From: Tiezhu Yang <yangtiezhu@loongson.cn>
 Date: Tue, 17 Jun 2025 14:32:06 +0800
-Subject: [PATCH 106/371] LOONGSON: LoongArch: BPF: Set
+Subject: [PATCH 106/373] LOONGSON: LoongArch: BPF: Set
  bpf_jit_bypass_spec_v1/v4()
 
 JITs can set bpf_jit_bypass_spec_v1/v4() if they want the verifier to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From 86afad612ee4cb0624a2fb84ce81ca72a7ae0812 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 107/371] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 107/373] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From fe08492273f5e3a253b9622cd7f75d7862c25bd2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 108/371] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 108/373] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
@@ -1,7 +1,7 @@
 From f9a661c6076ed8cfa0f6d2c5d9b7f91dfffb841b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 May 2025 20:08:26 +0800
-Subject: [PATCH 109/371] LOONGSON: drm/ast: Restore vaddr field to struct
+Subject: [PATCH 109/373] LOONGSON: drm/ast: Restore vaddr field to struct
  ast_plane
 
 Revert "drm/ast: Remove vaddr field from struct ast_plane".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From 1483fd86dc3ad289bb0dad7ca3c33a698262a10a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 28 Feb 2025 20:28:08 +0800
-Subject: [PATCH 110/371] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 110/373] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-LOONGSON-LoongArch-Allow-specify-SIMD-width-via-kern.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-LOONGSON-LoongArch-Allow-specify-SIMD-width-via-kern.patch
@@ -1,7 +1,7 @@
 From 294ce7da55ab221da18c8f1b53b7065afb95aa79 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 4 Sep 2025 15:13:41 +0800
-Subject: [PATCH 111/371] LOONGSON: LoongArch: Allow specify SIMD width via
+Subject: [PATCH 111/373] LOONGSON: LoongArch: Allow specify SIMD width via
  kernel parameters
 
 For power saving or debugging purpose, we usually want to limit the SIMD

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From af7e59d4d4d04cda05f4ef7df0cc26b0b7d3cd9a Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 112/371] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 112/373] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From 143d519c21cac9b0dd033236984325b02532101d Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 113/371] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 113/373] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From a6f350ce98df88ad67b59f3e79453e20afac51ac Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 114/371] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 114/373] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From 75841aa37781d87bbd5ec9a232e1f906fc61f22a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 115/371] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 115/373] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From 2deb9ca6e1e81cbd5528b496a7d8c97e3ea8628d Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 116/371] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 116/373] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From 2d53384b107408d6039976c86fa4b908e7ba6676 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 117/371] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 117/373] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From a80591a88af206035d874e30f7de9f74a4967b2d Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 118/371] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 118/373] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From c02e6dbdaee945f948e8feff9dc3bc73204dfa48 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 119/371] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 119/373] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From 0a19da2443866e896b45c215de2177e5186083a1 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 120/371] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 120/373] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From 961070a7c464f3fcce29e085515509e4974e97d5 Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 121/371] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 121/373] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From 0f0fd2d130b9af885e2e8e7b5b70824c098ecc61 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 122/371] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 122/373] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From 8b3e140012ea31dd0160fe1eea8063059b231d51 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 123/371] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 123/373] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From 24f3135061e1c0f29e6eedda56ffaa32258ff6f6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 124/371] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 124/373] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From bd0d653382b0c4663667530bd6104b59fd29ee58 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 125/371] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 125/373] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From f5498afe28a52253cead7c540c74c7ed15cc376c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 126/371] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 126/373] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From c2e93d62fa8cc2738c6cd459f85d56f69afcc130 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 127/371] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 127/373] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From ca0407bf2aea19960aeabb117000f4479a63a9c3 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 128/371] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 128/373] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From 38adf2a5c8188864aa624097d0603276ecb2934f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 129/371] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 129/373] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From 3e38b1f5b04090398ed6370986fb9ae38d3b6673 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 130/371] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 130/373] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From 7015432ea2a0d75bab8f1f43445fbce0aa2b3fef Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 131/371] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 131/373] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From c321d4b7d063399c3f6324db4e7c43ff23c5b8e1 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 132/371] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 132/373] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From 2f6aaeb5577a134bb2fc547ddbf71ec4a6ff4351 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 133/371] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 133/373] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From d1aa8a70b9dc55060b20105231c610261c93f654 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 134/371] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 134/373] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From 916610f6d8efde820a3118fd8183dc91b316bfea Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 135/371] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 135/373] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 43fde21bbc259966fafd40f0a7ea4720bca6311d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 136/371] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 136/373] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From 9528f5d363f05c6a57d3a5d58685eea725112aa1 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 137/371] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 137/373] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From a18f255038617a5a7bb8b7cb86315c198e202a23 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 138/371] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 138/373] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 5bef9d68e2f83329d994e77b84717ed06466a5db Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 139/371] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 139/373] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 45b70b5138d52a41c6d9837edc098cf3564693fa Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 140/371] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 140/373] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
@@ -1,7 +1,7 @@
 From d22396f236cace40fb58c81ae7c04384b70a0e91 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 15 Aug 2024 17:06:59 +0800
-Subject: [PATCH 141/371] PHYTIUM: net/phytmac: Add support for phytmac v2.0
+Subject: [PATCH 141/373] PHYTIUM: net/phytmac: Add support for phytmac v2.0
 
 This patch Adds support for phtymac v2.0,including acpi description,
 rx tail pointer supporting, power management and other functions.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
@@ -1,7 +1,7 @@
 From 1a2dc533fce6914da7ddcb66fca541c7e171fab8 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 142/371] PHYTIUM: net/phytmac: Slove left-shift out of bound
+Subject: [PATCH 142/373] PHYTIUM: net/phytmac: Slove left-shift out of bound
  issue
 
 When the value of the bd_prefetch is equal to 0, subtracting 1 and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
@@ -1,7 +1,7 @@
 From d18cedb299bf3aaa8d4ff841a0896a0ea1d9934e Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:29:38 +0800
-Subject: [PATCH 143/371] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
+Subject: [PATCH 143/373] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
  PHY supports WOL"
 
 This reverts commit 94967211afe596a9e9c5d80ca9d54e915de3a335.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
@@ -1,7 +1,7 @@
 From 0f95dc646176a8f8155c8befc44711193f38c281 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:36:36 +0800
-Subject: [PATCH 144/371] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
+Subject: [PATCH 144/373] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
  issue"
 
 This reverts commit 3161ed880479e35c7759e127c62c37d2d722edee.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 9ff175515ed97466e411dbfda45701bd3395ccb4 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 145/371] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 145/373] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
  supports WOL feature
 
 Don't manage WoL on MAC, if PHY sets wol fails, So modify if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
@@ -1,7 +1,7 @@
 From 682e4422d7eabfd80199eaeca73354e3dc82d03c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 146/371] PHYTIUM: net/phytmac: Fixed the PTP test failure
+Subject: [PATCH 146/373] PHYTIUM: net/phytmac: Fixed the PTP test failure
  issue
 
 The bit of RX_TS_VALID should be retained in the process of zero RX

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
@@ -1,7 +1,7 @@
 From 84a5d6c93cd7306cc905ea8a7de89f9c9b31599a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 147/371] PHYTIUM: net/phytmac: Cancels the power-on/off
+Subject: [PATCH 147/373] PHYTIUM: net/phytmac: Cancels the power-on/off
  capability
 
 The MAC register is powered on by default in the firmware

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
@@ -1,7 +1,7 @@
 From bc98a8c0a0e2bdde56de34dd09873fd1c0b543ab Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 148/371] PHYTIUM: net/phytmac: Exit probe when MDIO times out
+Subject: [PATCH 148/373] PHYTIUM: net/phytmac: Exit probe when MDIO times out
 
 Exit early to avoid system stuck due to MDIO timeout.
 We have added a callback function for mdio_idle and improved

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
@@ -1,7 +1,7 @@
 From 813aee03269aa76627485790c8fbb2e380c9c9ea Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 149/371] PHYTIUM: net/phytmac: Add XDP feature support
+Subject: [PATCH 149/373] PHYTIUM: net/phytmac: Add XDP feature support
 
 Add XDP feature support to the phytmac driver.XDP by optimizing
 the data processing flow provided significant performance improvements

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
@@ -1,7 +1,7 @@
 From d89b27245854d3aeca19aaf45b2060627ff88730 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 150/371] PHYTIUM: net/phytmac: Clear RX descriptor address
+Subject: [PATCH 150/373] PHYTIUM: net/phytmac: Clear RX descriptor address
  after the skb construction
 
 If the skb build failed, the descriptor address has been cleared,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
@@ -1,7 +1,7 @@
 From 184709c5d90ff04965c62cf4b7107fd2b1eb1df2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 151/371] PHYTIUM: net/phytmac: Enable the tail pointer by the
+Subject: [PATCH 151/373] PHYTIUM: net/phytmac: Enable the tail pointer by the
  driver
 
 It is need to enable the RX/TX tail pointer to ensure the NIC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
@@ -1,7 +1,7 @@
 From d8fb4158bc982ffc1fab24ffc4ede17698e0b943 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 152/371] PHYTIUM: net/phytmac: Modify cmd processing function
+Subject: [PATCH 152/373] PHYTIUM: net/phytmac: Modify cmd processing function
 
 Change the para size in the msg struct from 64 to 56
 and add mutux to avoid race.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 02ffbbb528f5f9a13d3370b8ee3ca1f3086affb8 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 153/371] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 153/373] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
@@ -1,7 +1,7 @@
 From 7e2d5d6251982bdbfe8ae659d15b2ac61cf3b9c5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 154/371] PHYTIUM: net/phytmac: Bugfix invalid wait context
+Subject: [PATCH 154/373] PHYTIUM: net/phytmac: Bugfix invalid wait context
 
 After the spinlock is called, the mutex should no longer to be
 invoked, which will lead to unnecessary sleep.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
@@ -1,7 +1,7 @@
 From 67b2fbc09879993b6b89986fe085e3d42758c2b5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 155/371] PHYTIUM: net/phytmac: Change the requested resource
+Subject: [PATCH 155/373] PHYTIUM: net/phytmac: Change the requested resource
  type from nRE to nRnE
 
 The resource type is changed from nRE to nRnE to avoid interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
@@ -1,7 +1,7 @@
 From 7a606f6bd547f2991539cbd91eb3ac9bfd40299b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 156/371] PHYTIUM: net/phytmac: BugFix Memory leak when
+Subject: [PATCH 156/373] PHYTIUM: net/phytmac: BugFix Memory leak when
  releasing resource
 
 The size of the memory released in the dma_free_coherent is smaller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
@@ -1,7 +1,7 @@
 From b484c3a2c0be0c698e1c704db7c7ec8bdd685ad7 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 157/371] PHYTIUM: net/phytmac: Limit the number of retries to
+Subject: [PATCH 157/373] PHYTIUM: net/phytmac: Limit the number of retries to
  avoid deadlock
 
 It is need to limit retries that messages are processed

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-PHYTIUM-net-phytmac-update-to-1.0.47.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-PHYTIUM-net-phytmac-update-to-1.0.47.patch
@@ -1,7 +1,7 @@
 From c8527a0fb132beaef45b165ffa7bee5cdb151526 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 11:41:46 +0800
-Subject: [PATCH 158/371] PHYTIUM: net: phytmac: update to 1.0.47
+Subject: [PATCH 158/373] PHYTIUM: net: phytmac: update to 1.0.47
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From 4a5e19ed7320d836233f274b7c8d80271bb0c18b Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 159/371] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 159/373] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From e93e174bd4fefaf62c563a247f3938c4f1692ca8 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 160/371] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 160/373] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From fb910fe987c70c73e16beee1f575cb519e8c9e3f Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 161/371] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 161/373] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 4fbb39b8c31cbed4f0dc20fc8c7712baa15d3c3e Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 162/371] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 162/373] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From 2f32f9f21670d13a258ded155b8317d8c546849e Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 163/371] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 163/373] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From dcf220c630b4dbd9e0c81fab1b171aae51b6f4d4 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 164/371] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 164/373] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From 595ad692e119fd60043002e8dead6def4ffb191c Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 165/371] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 165/373] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
@@ -1,7 +1,7 @@
 From 8f60e7f31124ce4fd80d4057eaf58dc207747ad8 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 12 Aug 2024 14:28:31 +0800
-Subject: [PATCH 166/371] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 166/373] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for SKL integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2062951

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
@@ -1,7 +1,7 @@
 From 010ace55d1ce4745d3cdec71a09c15d3516bd9e1 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 18 Nov 2024 09:28:40 +0800
-Subject: [PATCH 167/371] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 167/373] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for KBL and CML integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2086587

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From 5f6c08ab1d9c26a8ce381a3642098e84da4fb135 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 168/371] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 168/373] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From 2c2f942ed2ece1b68f56b1b112d29aeebe1a94f5 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 169/371] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 169/373] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From 0596fa469c9efa380a268273757eb5aae758bafd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 170/371] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 170/373] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
 From b07be1986df0877aed82c7bc2115be79929e8e98 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 171/371] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 171/373] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
@@ -1,7 +1,7 @@
 From 8141e2cdaafd5abd2c187d7bd308d15f5751b0b2 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 172/371] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
+Subject: [PATCH 172/373] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
  transition of devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
 From 27c1d6d199b487316c09e1714db7e9ba41160df0 Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 173/371] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 173/373] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From 757d256c95df952375ae39c9624766bfb2798373 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 174/371] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 174/373] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 95185f6f2082a91f0261c3378ee906e14f8de09a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 175/371] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 175/373] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From 5a42029c59a21734146795b1c6375c666241f235 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 176/371] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 176/373] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From dccee6945d7e3255a1327f4f1d6492b47aa52bcf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 177/371] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 177/373] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From 3b54ca99582f79242ccf2c2aa3975349be8a8640 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 178/371] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 178/373] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From 9ab647c16097cd766e5eb57451aa5f0872e646e8 Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 179/371] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 179/373] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
@@ -1,7 +1,7 @@
 From 8030faa876660ab26872f7e312c1816baa16bba4 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
-Subject: [PATCH 180/371] SURFACE: (surface3-oemb) add DMI matches for Surface
+Subject: [PATCH 180/373] SURFACE: (surface3-oemb) add DMI matches for Surface
  3 with broken DMI table
 
 On some Surface 3, the DMI table gets corrupted for unknown reasons

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
@@ -1,7 +1,7 @@
 From 1b6bf58c25bcc91f82bd5fb51f3f4bf6812570f1 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
-Subject: [PATCH 181/371] SURFACE: surface3-spi: workaround: disable DMA mode
+Subject: [PATCH 181/373] SURFACE: surface3-spi: workaround: disable DMA mode
  to avoid crash by default
 
 On Arch Linux kernel at least after 4.19, touch input is broken after suspend

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From c7c21e22de1e7829a1044579b0f3babb58c8b193 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 182/371] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 182/373] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From 6afe89a827e5a3b093c5f032ec438577d897789c Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 183/371] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 183/373] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
 From 3ed51dda81065110b476457cfdb75980ce472b76 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 184/371] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 184/373] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
@@ -1,7 +1,7 @@
 From 4b3889ac911963bd93675aa4e372320e466c6bdf Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
-Subject: [PATCH 185/371] SURFACE: ath10k: Add module parameters to override
+Subject: [PATCH 185/373] SURFACE: ath10k: Add module parameters to override
  board files
 
 Some Surface devices, specifically the Surface Go and AMD version of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From 25e58ae451fdfdfdbfd4fb7af27efc2eedffe507 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 186/371] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 186/373] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
@@ -1,7 +1,7 @@
 From 88ea0f61328befcc39edc6d6df970dce038569b5 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 187/371] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
+Subject: [PATCH 187/373] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
  for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
@@ -1,7 +1,7 @@
 From 766561144bf885fa0f2654d094f09389b4d188ba Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 188/371] SURFACE: hid: Add support for Intel Precise Touch and
+Subject: [PATCH 188/373] SURFACE: hid: Add support for Intel Precise Touch and
  Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
@@ -1,7 +1,7 @@
 From cbdaab65028ce3cb83f4cddc9b52128eead6ae60 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
-Subject: [PATCH 189/371] SURFACE: iommu: intel: Disable source id verification
+Subject: [PATCH 189/373] SURFACE: iommu: intel: Disable source id verification
  for ITHC
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
@@ -1,7 +1,7 @@
 From 749c9411f005a8374ed6e44e68405e007128d22c Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
-Subject: [PATCH 190/371] SURFACE: hid: Add support for Intel Touch Host
+Subject: [PATCH 190/373] SURFACE: hid: Add support for Intel Touch Host
  Controller
 
 Based on quo/ithc-linux@34539af4726d.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
@@ -1,7 +1,7 @@
 From 7010cf8a2dfe45a0d0dfdb70a4401d537b5f1027 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
-Subject: [PATCH 191/371] SURFACE: rtc: Add basic support for RTC via Surface
+Subject: [PATCH 191/373] SURFACE: rtc: Add basic support for RTC via Surface
  System Aggregator Module
 
 Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
@@ -1,7 +1,7 @@
 From eaee470a5f6e1c2b519c02e7bd3afaf39c725422 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
-Subject: [PATCH 192/371] SURFACE: platform/surface: aggregator_registry: Add
+Subject: [PATCH 192/373] SURFACE: platform/surface: aggregator_registry: Add
  Surface Laptop 7 (ACPI)
 
 Patchset: surface-sam

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
@@ -1,7 +1,7 @@
 From f881be1856b593d8badcec9686fa8f3f2e1da1b1 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
-Subject: [PATCH 193/371] SURFACE: i2c: acpi: Implement RawBytes read access
+Subject: [PATCH 193/373] SURFACE: i2c: acpi: Implement RawBytes read access
 
 Microsoft Surface Pro 4 and Book 1 devices access the MSHW0030 I2C
 device via a generic serial bus operation region and RawBytes read

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
@@ -1,7 +1,7 @@
 From 8a04bd497e3166b44855aaf7988d43e2357e43ca Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
-Subject: [PATCH 194/371] SURFACE: platform/surface: Add driver for Surface
+Subject: [PATCH 194/373] SURFACE: platform/surface: Add driver for Surface
  Book 1 dGPU switch
 
 Add driver exposing the discrete GPU power-switch of the  Microsoft

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
@@ -1,7 +1,7 @@
 From 03d7e0c9d4ed4c0de75a0925ccc637c5c8d4c376 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
-Subject: [PATCH 195/371] SURFACE: Input: soc_button_array - support AMD
+Subject: [PATCH 195/373] SURFACE: Input: soc_button_array - support AMD
  variant Surface devices
 
 The power button on the AMD variant of the Surface Laptop uses the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
@@ -1,7 +1,7 @@
 From 0f1aa48427cce86b137cc0f75ad8f7aad7517b0d Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
-Subject: [PATCH 196/371] SURFACE: platform/surface: surfacepro3_button: don't
+Subject: [PATCH 196/373] SURFACE: platform/surface: surfacepro3_button: don't
  load on amd variant
 
 The AMD variant of the Surface Laptop report 0 for their OEM platform

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
@@ -1,7 +1,7 @@
 From 29284bf7e1c7e79b7a46c5acf960d03b4dfa7afe Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
-Subject: [PATCH 197/371] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
+Subject: [PATCH 197/373] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
  Surface Go 3 Type-Cover
 
 The touchpad on the Type-Cover of the Surface Go 3 is sometimes not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From 5f941cf70d910cd817ac9c2b9b441dccda57dabf Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 198/371] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 198/373] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
 From 6cc04d3aeb03c36ea074fa33475b190bc01c1ae3 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 199/371] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 199/373] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-SURFACE-PCI-Add-quirk-to-prevent-calling-shutdown-me.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-SURFACE-PCI-Add-quirk-to-prevent-calling-shutdown-me.patch
@@ -1,7 +1,7 @@
 From f75e39e62169a337b7d3090799bd3ec13759e114 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH 200/371] SURFACE: PCI: Add quirk to prevent calling shutdown
+Subject: [PATCH 200/373] SURFACE: PCI: Add quirk to prevent calling shutdown
  mehtod
 
 Work around buggy EFI firmware: On some Microsoft Surface devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
@@ -1,7 +1,7 @@
 From a5405dd29d99af517aa60c7e6dccbc63c344db0d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
-Subject: [PATCH 201/371] SURFACE: platform/surface: gpe: Add support for
+Subject: [PATCH 201/373] SURFACE: platform/surface: gpe: Add support for
  Surface Pro 9
 
 Add the lid GPE used by the Surface Pro 9.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 483251671cb81c5220aac0ae71eaedee4a4e3332 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 202/371] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 202/373] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
@@ -1,7 +1,7 @@
 From a5edbe493e835a4bd511282c5232f7f08dc0570d Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 203/371] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
+Subject: [PATCH 203/373] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
  passthrough mode for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From 0d67661772f322cb653160c78e3fb6f8cf3d1101 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 204/371] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 204/373] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From 9818562d21b2d7a742edceca0226b621412428fb Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 205/371] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 205/373] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From ce7267ab83150583711ddf79cc1bbda6f85a1bf5 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 206/371] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 206/373] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From 1d5e2c3a5702c7d04c497dd84fd66151deb48c88 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 207/371] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 207/373] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From ef06e0d1dfb4f1c66290439bbf2a770141da67ea Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 208/371] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 208/373] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From b344a2b12045a104ade4cf389770a5841609b033 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 209/371] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 209/373] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From a751b00c2f58e8b8163b8b9c4a1577abfdd1ba90 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 210/371] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 210/373] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
@@ -1,7 +1,7 @@
 From a7b7fac9bb872e06b67cc1ceb033fdc9869a0e5c Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
-Subject: [PATCH 211/371] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
+Subject: [PATCH 211/373] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
  missing irq 7 override
 
 This patch is the work of Thomas Gleixner <tglx@linutronix.de> and is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
@@ -1,7 +1,7 @@
 From 96c40ba4ecb262e06379b0213b4e4baf94b011aa Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
-Subject: [PATCH 212/371] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
+Subject: [PATCH 212/373] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
  irq 7 override quirk
 
 The 13" version of the Surface Laptop 4 has the same problem as the 15"

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-reduced-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-reduced-p.patch
@@ -1,7 +1,7 @@
 From e2f0805b36374dd7180b7dbe5bb682d84a8ca7da Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
-Subject: [PATCH 213/371] SURFACE: acpi: allow usage of acpi_tad on HW-reduced
+Subject: [PATCH 213/373] SURFACE: acpi: allow usage of acpi_tad on HW-reduced
  platforms
 
 The specification [1] allows so-called HW-reduced platforms,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-SURFACE-hid-ithc-Update-ITHC-driver-core.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-SURFACE-hid-ithc-Update-ITHC-driver-core.patch
@@ -1,7 +1,7 @@
 From c8b19c4b49dda8ee1cbca5143299b0ecb79a20e6 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 22 Jun 2025 02:35:06 +0200
-Subject: [PATCH 214/371] SURFACE: hid/ithc: Update ITHC driver core
+Subject: [PATCH 214/373] SURFACE: hid/ithc: Update ITHC driver core
 
 Update to latest https://github.com/quo/ithc-linux.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-FROMEXT-cjktty-6.16.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-FROMEXT-cjktty-6.16.patch.patch
@@ -1,7 +1,7 @@
 From 337288408a32b0c78a8973831594d4604d3a95b7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 7 Aug 2025 17:45:03 +0800
-Subject: [PATCH 215/371] FROMEXT: cjktty-6.16.patch
+Subject: [PATCH 215/373] FROMEXT: cjktty-6.16.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-FROMEXT-WIP-drm-bridge-Add-detect_ctx-hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-FROMEXT-WIP-drm-bridge-Add-detect_ctx-hook.patch
@@ -1,7 +1,7 @@
 From f8dc985ec51c86c28654fbc71d74bc0b4da18829 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 10 Jan 2025 22:48:01 +0200
-Subject: [PATCH 217/371] FROMEXT: [WIP] drm/bridge: Add ->detect_ctx() hook
+Subject: [PATCH 217/373] FROMEXT: [WIP] drm/bridge: Add ->detect_ctx() hook
 
 Add a ->detect() variant that also provides a drm_modeset_acquire_ctx
 reference for greater flexibility in operation, e.g. to support adding

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-FROMEXT-WIP-drm-bridge-connector-Switch-from-detect-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-FROMEXT-WIP-drm-bridge-connector-Switch-from-detect-.patch
@@ -1,7 +1,7 @@
 From b04225c3be724b7b67820e3852b3d2052063f33c Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 10 Jan 2025 23:04:23 +0200
-Subject: [PATCH 218/371] FROMEXT: [WIP] drm/bridge-connector: Switch from
+Subject: [PATCH 218/373] FROMEXT: [WIP] drm/bridge-connector: Switch from
  ->detect() to ->detect_ctx()
 
 In preparation to provide scrambling support to the HDMI Connector

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-BACKPORT-FROMEXT-WIP-drm-bridge-dw-hdmi-qp-Add-high-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-BACKPORT-FROMEXT-WIP-drm-bridge-dw-hdmi-qp-Add-high-.patch
@@ -1,7 +1,7 @@
 From c36aadb41c641386758686a15d394173fa388ca5 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Fri, 13 Sep 2024 17:30:35 +0300
-Subject: [PATCH 219/371] BACKPORT: FROMEXT: [WIP] drm/bridge: dw-hdmi-qp: Add
+Subject: [PATCH 219/373] BACKPORT: FROMEXT: [WIP] drm/bridge: dw-hdmi-qp: Add
  high TMDS clock ratio and scrambling support
 
 Enable use of HDMI 2.0 display modes, e.g. 4K@60Hz, by permitting TMDS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From 85a58500c1d618888c8360226562252c879b02bd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 220/371] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 220/373] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 3726dc6440b8fcc6af19025492412994bea4a1bf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 221/371] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 221/373] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From b9ac640810527259a51c9c0f62d9474028e43b60 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 222/371] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 222/373] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From 179682149a8528522a5082d4b36f4f932eaf1cce Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 223/371] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 223/373] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From a97ff34b33b9a605d8aad2e85243724ca7621430 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 224/371] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 224/373] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From c842a24f55bf6b1c1632ab7f4623516a64381e51 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 225/371] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 225/373] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 497e50b17c6c7ea31f259aadfec00cd5ebef94a3 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 226/371] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 226/373] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From 579ca07517af8d87bdf5c71025a29fc9b07c03f0 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 227/371] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 227/373] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From 3fd41e9d728e85acbb1bf13715ea324e96c76637 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 228/371] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 228/373] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From 166ad736fba6443e4d6aba711d4486b91945e34b Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 229/371] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 229/373] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From 8f60410a30c8fccb7e45e2be8ea0437278c01f51 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 230/371] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 230/373] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From d90e30e4daa5b3ee2aaded396145260f860fc8bc Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 231/371] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 231/373] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From bb2b8e97e8415fa8579be2e4517ecaebcd90b20d Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 232/371] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 232/373] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From df9b94f1c0ced436933b72372655dc48f5dbec0b Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 233/371] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 233/373] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From a4375dbd99c499c7f703ab02ba4176c6057161c1 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 234/371] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 234/373] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 2a40ab8e9117edbad2b818d73a6d44a023691890 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 235/371] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 235/373] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 [Xi Ruoyao: Select KALLSYMS and KPROBE]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From f1d5286e7d159c78d6086c6779c4f99fa945ac17 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 236/371] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 236/373] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From a385a3201dd20abcf52a7e4cc23e2895a8c7f797 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 237/371] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 237/373] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 13197b59acb61be187383bc75979cc12b42c35e0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 238/371] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 238/373] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From 5272b738f0c0783d74f5c54051f6f09f9369ca56 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 239/371] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 239/373] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From b974806f529fddb8944cd72344cfe7f30bdc5510 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 240/371] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 240/373] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From 56fa23ab8886046f9060989a1e6c689ad826c32f Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 241/371] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 241/373] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From d4a47dc682187abab7a2457fee50591c8a4fefa4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 242/371] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 242/373] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From bc6da7785e3daa2c2582a123a253c327dffc54a4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 243/371] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 243/373] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 0509c00f6c4584b89596b2fabb996b0d5bedc482 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 244/371] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 244/373] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From af6673d690ad236f09b768e9c22622fc9c1f2165 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 245/371] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 245/373] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From c2664cab380f1e09a900b4405227d5284d77d1c0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 246/371] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 246/373] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From 39d9ea3439247bd0f0d10155af3918b435921f67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 247/371] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 247/373] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 2ea6708f28d6934ad66947831ec10eff4e63b7c8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 248/371] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 248/373] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From c89547718e15e68f7714cd6386f61326ea794b33 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 249/371] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 249/373] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From 52a50f84946c1b3743071b373d79159a3919c7da Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 250/371] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 250/373] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
@@ -1,7 +1,7 @@
 From de9ca58019919caf2c0e29b5331e781b7823d2ef Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 16:01:27 +0800
-Subject: [PATCH 251/371] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
+Subject: [PATCH 251/373] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
  support
 
 On IPASON NL38-N11 laptops, the touchpad device (a HID multitouch device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
@@ -1,7 +1,7 @@
 From dc9ba036fd2ff8b1dcc8a047d8c04a292f28ca37 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:36:15 +0800
-Subject: [PATCH 252/371] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
+Subject: [PATCH 252/373] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
  xdp_do_flush()
 
 Per 7f04bd109d4c ("net: Tree wide: Replace xdp_do_flush_map() with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
@@ -1,7 +1,7 @@
 From d1403e63f92697f3bb306548b102b4f41845b127 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:38:09 +0800
-Subject: [PATCH 253/371] AOSCOS: net/phytmac: Remove unnecessary
+Subject: [PATCH 253/373] AOSCOS: net/phytmac: Remove unnecessary
  pcim_iounmap_regions() call
 
 pcim_iounmap_regions() is removed in commit 855c634930f0 ("PCI: Remove

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
@@ -1,7 +1,7 @@
 From 3ef47c755eb67f63983cc5245a265089b257d3bf Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 21:59:21 +0800
-Subject: [PATCH 254/371] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
+Subject: [PATCH 254/373] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
 
 The driver seems relying on ACPI to power up the device.  And the device
 is only available as a part of Phytium SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-arm64-Disable-MPAM-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-arm64-Disable-MPAM-by-default.patch
@@ -1,7 +1,7 @@
 From fb0b03962c184dd76e4a122432dc69d63b71755c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 14 Jul 2025 18:06:42 +0800
-Subject: [PATCH 255/371] AOSCOS: arm64: Disable MPAM by default
+Subject: [PATCH 255/373] AOSCOS: arm64: Disable MPAM by default
 
 We have to work OotB on W510, and ARM64 does not support extending the
 built-in command line with the one from the bootloader.  So only try

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 34e42d796e7554f837cc1740bb85073accf391b6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 256/371] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 256/373] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From 1f3425e4670ac6f680c875fa38bd1cdd1742a3b5 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 257/371] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 257/373] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From 36a51c570d0c0fb4f4dcd8e7c4d61bd8713a41f4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 258/371] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 258/373] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From e8353b4873f2d17de5c2f892ea3597670d3271c0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 259/371] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 259/373] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 37d03d9740d0dfbffa260ad1709fda406c5e3dd9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 260/371] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 260/373] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From bc8c8af630c0fff7cfe90b30797d3e33e3d585a0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 261/371] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 261/373] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 85f78badb8317c7d4433b9d7329d45635eddf6bb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 262/371] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 262/373] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From 6b81c11929637fe439f247464d72deff4410e4b2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 263/371] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 263/373] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From f87a983ea2cc190ac3f5fb6065bda109cf453818 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 264/371] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 264/373] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 80f0407808107ced31d565d3ca2c0381dfd6de44 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 265/371] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 265/373] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 7a992e1a79665a3f5af5b106f360bd779cd78fd4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 266/371] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 266/373] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From 6cfec86051f82d45c7eb288619383ea3e7553af3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 267/371] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 267/373] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From 4decbe771cd5ea8c05d65b1269c96f5fe7a6f7c1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 268/371] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 268/373] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From e455461ca87efd731c081168338795b248232b9a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 269/371] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 269/373] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From 2692cde342361f182cf785397bc215124ccb21d6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 270/371] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 270/373] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From 645a7d9ae1006d7a469794f2ba20979a12910abb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 271/371] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 271/373] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From df11dcdd6efe127c359e7cd534a2867d9f21c1f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 272/371] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 272/373] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From 13f2b1a09ad12d11c1b87ed39c4829fca10bb591 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 273/371] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 273/373] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 6bb8f8525902983fc97eab6e40f4e9fdd264e1b1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 274/371] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 274/373] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From 3390f4ccd66ade83babd85b6af680aa4baef1c44 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 275/371] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 275/373] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From ad5b39f09aa782f5edea963d91f08277f348a099 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 276/371] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 276/373] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From c2e5bae494d00e5fb329476070a6da99c10aebcf Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 277/371] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 277/373] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From 91b360f5f5cb4b7458c281f8d15c6d7aa5fb42b6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 278/371] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 278/373] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From d092ea36e8868c30aec532115b7b223bd1b87a95 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 279/371] AOSCOS: input: atkbd: disable
+Subject: [PATCH 279/373] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 78dbc93fe7ad596ac8b1eee8c6f5c9a6f0b36755 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 280/371] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 280/373] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From f7f9b45a9de3f1c6367539d53c40cff0c6e8f317 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 281/371] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 281/373] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 12ee06126f97b62700f5bb7228c8e25846e9549c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 282/371] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 282/373] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 65e566998f1bb1916097959e17951cb0d0e3244b Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 283/371] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 283/373] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From e8cde7a7ff80daf3a84f31f4683c63957d773216 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 284/371] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 284/373] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 1e8578dbf1f0052a35221390de7046fd5845a834 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 285/371] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 285/373] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 179abc4f0ce33da6696b00126ca920bd6c92ec69 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 286/371] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 286/373] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From 82775ecd44cbe39c4320d2aa44b3ed6c2710a68c Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 287/371] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 287/373] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From f6881f3a34a0304532fba3184997451f6d563ab8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 288/371] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 288/373] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From da8b0b39782a060cf2651d803c2caa3e232fdcc2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 289/371] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 289/373] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference

--- a/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From a9da08de9d2cedc987a36bbfcc734e4b81473bd5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 290/371] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 290/373] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From 7563530a050665b6ae88ee8cfe39fdff40400ad8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 291/371] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 291/373] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 3a6c5e5f1715eaf57a694c9f56bb4e551cf03868 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 292/371] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 292/373] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From bb70fb10267ba6129abe6ddfe3376a8571cd9ed8 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 293/371] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 293/373] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From 824edf2a551cb1cef4cf1ea2ebb4ceda943e7d34 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 294/371] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 294/373] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From 7d135bc2c9080b519fec2b49bd1531fd0ba343c6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 295/371] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 295/373] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From 1c0d2bcf4cf0618136b9beab4253a29354e95b57 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 296/371] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 296/373] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 8603308d3c363560d2a17d76510bab62981e9a27 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 297/371] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 297/373] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From ea89f082d7634af5936d2e92ef5b4faee7b6f732 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 298/371] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 298/373] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From 47f011ed3d8fabe4a428b42a907ac8e1e6f33b58 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 299/371] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 299/373] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From aee48d898228703977c1e4bcfed7aba6e3309bad Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 300/371] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 300/373] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From 7342e2fd308dc0aa8f6e3b414457aeabf8be62a8 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 301/371] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 301/373] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From 1ba2c0b9cb3136f91accf0e4eae850e9cc1b84d3 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 302/371] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 302/373] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 2c720fce0ec263dd832e31e8946a2b1a0231f0e8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 303/371] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 303/373] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From c74de50dc4adbb5532ca950b3cda2c46e1ecb903 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 304/371] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 304/373] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From c8a3bda7480b144ae68f08ef139063eab3df8161 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 305/371] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 305/373] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From 42e1a6415dbd47033056c83204dd3a8ffcc2f074 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 306/371] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 306/373] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 9ead1785b1a7f7a3d9e336be7e7541212425fbbb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 307/371] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 307/373] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From af30864f770ce17db5c164f979f74c09f518ed95 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 308/371] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 308/373] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From cc3e2dec292cf4e1689661c66c8b500d4a51ea3e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 309/371] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 309/373] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From f5fa94ef09d06d5e34afe984d21817e6df21521a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 310/371] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 310/373] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 86bd699702b176e72a7c7578c8a3d80e911b0d6e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 311/371] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 311/373] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From 1c42108a33fc71aefa8a780faea2e99ebea4fd86 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 312/371] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 312/373] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 435a6b177efb135d0ffb846488337454e5d2d161 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 313/371] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 313/373] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From 66fbbb9ea28f3ba93798a9d01252ed8c8f554651 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 314/371] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 314/373] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 2f4caf751fb4260f74e41e8e8c9040369f52b75e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 315/371] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 315/373] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From 00937d70611efaae14aa2278c9b1158de8f91caf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 316/371] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 316/373] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From 8aef89dbea91535c94aa6e1adedaa85474a4297c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 317/371] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 317/373] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From 3d6b4fffd3263baa0d37e2912d62abd3e9f1b945 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 318/371] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 318/373] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From 561784405602dcac8f1b0f668687c59621a8172f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 319/371] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 319/373] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From 6dd76b5be86d0c12f71b2c9200c0661dee0f5cc1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 320/371] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 320/373] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From 9830495e850592cc59d44cc32b2c48322f4a653b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 321/371] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 321/373] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From adaae6fe1317d5a64bc113bac588d888ae6ea8ec Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 322/371] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 322/373] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 181c1a1d305eccae5b98038fd720112a9a1276a5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 323/371] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 323/373] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From e995fdfbe8085adefd589037588ede894c7a64ae Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 324/371] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 324/373] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From bced932107ddad7b726176d65ac5fced91a2c066 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 325/371] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 325/373] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From 3c313d94324bc99b6de971473ed23ffa65b7539f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 326/371] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 326/373] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing

--- a/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From bc143716af68d7864f8ea61943c9e68cdf5db283 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 327/371] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 327/373] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From 7e3286718e09d9af50a1517ab13773b1734b165b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 328/371] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 328/373] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 89e3b1f1564cec3dc8147dfb0eb1627e74978a5b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 329/371] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 329/373] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From c0a6eaa11c0438e9ffcfc0e1cf21596d280b5a7b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 330/371] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 330/373] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From 8d4f6eff2183cf9e9add5299f64a33a0f6fefa21 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 331/371] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 331/373] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From 7f6552b3fc6580a952ab58904a229cc32593a168 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 332/371] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 332/373] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From ced2c402764d3fe674bac73de6dabe92ff801a05 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 333/371] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 333/373] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 2df16a9b579875e3d3c50734cf4e47fa27bf4b5a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 334/371] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 334/373] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number

--- a/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From 32ea34d387fd51cf35a19b1555962cc2162e7a10 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 335/371] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 335/373] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From 39917a32d6cad9242e67253b3a7f8acec008f1c8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 336/371] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 336/373] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count

--- a/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From 0f8bb6b0df7c565fcf8f32ca9478512786090b45 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 337/371] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 337/373] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From a2a8d31594fc0c477da3fe0f06e02a446eab439e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 338/371] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 338/373] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 58ee06d9a9e716191f1f9b7bc48ce832d5549e74 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 339/371] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 339/373] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From d23ac061276d37a84f65e58caf3cd6b2ddc1ef42 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 340/371] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 340/373] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as

--- a/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From f8a521ad058cb458657f22de85a409eb4dffde6c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 341/371] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 341/373] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From d128e5144b1091bf072a056f52dae3b7970f1738 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 342/371] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 342/373] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From 870943b0b6043e03df0f9c20e0bd7ebb2eb589de Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 343/371] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 343/373] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From a2426e92811bef5328bbaa92c8dd289df090ce0f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 344/371] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 344/373] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From 46619f1505bd85e78d97157fce0b22d53852ac76 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 345/371] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 345/373] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where

--- a/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From caf0a062946a1abf782a832f1d373d3461ab16f2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 346/371] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 346/373] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From 41d8653726b8544ca773eb559472cf118cfac065 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 347/371] AOSCOS: Optimize clear_page
+Subject: [PATCH 347/373] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 195ddb1519e4892f5e1b6fa7940fa0d1d3586fab Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 348/371] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 348/373] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 65c06724f01b736a2ded3001f886d843c02c1798 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 349/371] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 349/373] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 9bb16581aa7c66a670e7beea49542475b9552836 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 350/371] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 350/373] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From 29cd84243c44d75147bc631ffbb4003d4759d506 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 351/371] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 351/373] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific

--- a/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 857190311a69f0e104eaa433fd26e51285c49d41 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 352/371] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 352/373] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From ecc9aeac25b4071d3e8c1819e2f0cb9602ca3ebf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 353/371] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 353/373] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 4fd6c96eebc71482e030ff7a30825acaffd387f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 354/371] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 354/373] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From 2bb2f125a50234d25103f33b90b1e18b71119a40 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 355/371] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 355/373] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 7cab4ce0da355726e47c359de3fcd6dfec24988b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 356/371] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 356/373] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From ab8a0be607e2fa0d34e506827dbde696970eb492 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 357/371] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 357/373] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 0d03e87a69a1699972da4caf8cf380f41e806e68 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 358/371] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 358/373] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From 977046ae91c9235a7e377cd607a10c6f0ec82574 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 359/371] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 359/373] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From 7681192edb5b780239c237996b55c8f3ab78242c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 360/371] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 360/373] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From 38bc7fc458d99ca6855403dbe15ceba08a9f632d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 361/371] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 361/373] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From 9b8408336cf154637f2c5d9defb4538047ccc0bd Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 362/371] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 362/373] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper

--- a/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From 67c4a411cc50037cf41d65e451f419911fc50df6 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 363/371] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 363/373] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In

--- a/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From d6caa330d23ed7623c1c0df63b71440af640b5d8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 364/371] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 364/373] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From 2fb68bb7da95c0255443d1aecd18fb18c1b32b9d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 365/371] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 365/373] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes; Also move the struct domain_device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From 35f248391d6c0db2da20babf99f5dfe96006126f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 366/371] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 366/373] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
@@ -1,7 +1,7 @@
 From 39026f27a1d1ec40a37b1f1f8e37f0626f62dbdd Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 22:05:56 +0800
-Subject: [PATCH 367/371] AOSCOS: sb105x: Adapt for timer related function
+Subject: [PATCH 367/373] AOSCOS: sb105x: Adapt for timer related function
  renames
 
 The upstream has renamed the timer related functions to have a strict

--- a/runtime-kernel/linux-kernel/autobuild/patches/0368-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0368-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From f77555ac2e3f6bc2b94732520ee59e8b32894c82 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 368/371] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 368/373] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---

--- a/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
@@ -1,7 +1,7 @@
 From 0a5e4d91992fae91f1c2f2010d136bccdddebfe7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 09:50:44 +0800
-Subject: [PATCH 369/371] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
+Subject: [PATCH 369/373] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
  LS7A
 
 On LoongArch laptops using LG110 GPU for display, LS7A PWM3 is used for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-PCI-fix-name-for-3C6000-PCIe-bridge-speeds-qu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-PCI-fix-name-for-3C6000-PCIe-bridge-speeds-qu.patch
@@ -1,7 +1,7 @@
 From 406007011067595934e756f5370e1f46745ba460 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:54:33 +0800
-Subject: [PATCH 370/371] AOSCOS: PCI: fix name for 3C6000 PCIe bridge speeds
+Subject: [PATCH 370/373] AOSCOS: PCI: fix name for 3C6000 PCIe bridge speeds
  quirk
 
 The original patch declares the quirk under an incorrect name.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-PCI-add-break-to-cases-for-3C6000-PCIe-bridge.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-PCI-add-break-to-cases-for-3C6000-PCIe-bridge.patch
@@ -1,7 +1,7 @@
 From 5007ca53f56f6c131b627379f783364ee47132a4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 4 Sep 2025 16:25:58 +0800
-Subject: [PATCH 371/371] AOSCOS: PCI: add break to cases for 3C6000 PCIe
+Subject: [PATCH 371/373] AOSCOS: PCI: add break to cases for 3C6000 PCIe
  bridge speeds quirk
 
 The original patch did not write `break;' for each case, triggering

--- a/runtime-kernel/linux-kernel/autobuild/patches/0372-Revert-drm-xe-guc-Set-RCS-CCS-yield-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0372-Revert-drm-xe-guc-Set-RCS-CCS-yield-policy.patch
@@ -1,0 +1,215 @@
+From b76d94e6bef53147f6afdef427082bcc7f79e42b Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 28 Sep 2025 10:12:41 +0800
+Subject: [PATCH 372/373] Revert "drm/xe/guc: Set RCS/CCS yield policy"
+
+This reverts commit dd1a415dcfd5984bf83abd804c3cd9e0ff9dde30.
+---
+ drivers/gpu/drm/xe/abi/guc_actions_abi.h |  1 -
+ drivers/gpu/drm/xe/abi/guc_klvs_abi.h    | 25 ---------
+ drivers/gpu/drm/xe/xe_gt.c               |  3 +-
+ drivers/gpu/drm/xe/xe_guc.c              |  6 ++-
+ drivers/gpu/drm/xe/xe_guc_submit.c       | 66 ------------------------
+ drivers/gpu/drm/xe/xe_guc_submit.h       |  2 -
+ 6 files changed, 5 insertions(+), 98 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/abi/guc_actions_abi.h b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+index 4d9896e14649c..b55d4cfb483a1 100644
+--- a/drivers/gpu/drm/xe/abi/guc_actions_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+@@ -117,7 +117,6 @@ enum xe_guc_action {
+ 	XE_GUC_ACTION_ENTER_S_STATE = 0x501,
+ 	XE_GUC_ACTION_EXIT_S_STATE = 0x502,
+ 	XE_GUC_ACTION_GLOBAL_SCHED_POLICY_CHANGE = 0x506,
+-	XE_GUC_ACTION_UPDATE_SCHEDULING_POLICIES_KLV = 0x509,
+ 	XE_GUC_ACTION_SCHED_CONTEXT = 0x1000,
+ 	XE_GUC_ACTION_SCHED_CONTEXT_MODE_SET = 0x1001,
+ 	XE_GUC_ACTION_SCHED_CONTEXT_MODE_DONE = 0x1002,
+diff --git a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+index 89034bc97ec5a..5b2502bec2dcc 100644
+--- a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+@@ -17,7 +17,6 @@
+  *  | 0 | 31:16 | **KEY** - KLV key identifier                                 |
+  *  |   |       |   - `GuC Self Config KLVs`_                                  |
+  *  |   |       |   - `GuC Opt In Feature KLVs`_                               |
+- *  |   |       |   - `GuC Scheduling Policies KLVs`_                          |
+  *  |   |       |   - `GuC VGT Policy KLVs`_                                   |
+  *  |   |       |   - `GuC VF Configuration KLVs`_                             |
+  *  |   |       |                                                              |
+@@ -140,30 +139,6 @@ enum  {
+ #define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_KEY 0x4001
+ #define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_LEN 0u
+ 
+-/**
+- * DOC: GuC Scheduling Policies KLVs
+- *
+- * `GuC KLV`_ keys available for use with UPDATE_SCHEDULING_POLICIES_KLV.
+- *
+- * _`GUC_KLV_SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD` : 0x1001
+- *      Some platforms do not allow concurrent execution of RCS and CCS
+- *      workloads from different address spaces. By default, the GuC prioritizes
+- *      RCS submissions over CCS ones, which can lead to CCS workloads being
+- *      significantly (or completely) starved of execution time. This KLV allows
+- *      the driver to specify a quantum (in ms) and a ratio (percentage value
+- *      between 0 and 100), and the GuC will prioritize the CCS for that
+- *      percentage of each quantum. For example, specifying 100ms and 30% will
+- *      make the GuC prioritize the CCS for 30ms of every 100ms.
+- *      Note that this does not necessarly mean that RCS and CCS engines will
+- *      only be active for their percentage of the quantum, as the restriction
+- *      only kicks in if both classes are fully busy with non-compatible address
+- *      spaces; i.e., if one engine is idle or running the same address space,
+- *      a pending job on the other engine will still be submitted to the HW no
+- *      matter what the ratio is
+- */
+-#define GUC_KLV_SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD_KEY	0x1001
+-#define GUC_KLV_SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD_LEN	2u
+-
+ /**
+  * DOC: GuC VGT Policy KLVs
+  *
+diff --git a/drivers/gpu/drm/xe/xe_gt.c b/drivers/gpu/drm/xe/xe_gt.c
+index eaf7569a7c1d1..e3517ce2e18c1 100644
+--- a/drivers/gpu/drm/xe/xe_gt.c
++++ b/drivers/gpu/drm/xe/xe_gt.c
+@@ -41,7 +41,6 @@
+ #include "xe_gt_topology.h"
+ #include "xe_guc_exec_queue_types.h"
+ #include "xe_guc_pc.h"
+-#include "xe_guc_submit.h"
+ #include "xe_hw_fence.h"
+ #include "xe_hw_engine_class_sysfs.h"
+ #include "xe_irq.h"
+@@ -98,7 +97,7 @@ void xe_gt_sanitize(struct xe_gt *gt)
+ 	 * FIXME: if xe_uc_sanitize is called here, on TGL driver will not
+ 	 * reload
+ 	 */
+-	xe_guc_submit_disable(&gt->uc.guc);
++	gt->uc.guc.submission_state.enabled = false;
+ }
+ 
+ static void xe_gt_enable_host_l2_vram(struct xe_gt *gt)
+diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
+index d00c87c580a53..7b1ad159b15f0 100644
+--- a/drivers/gpu/drm/xe/xe_guc.c
++++ b/drivers/gpu/drm/xe/xe_guc.c
+@@ -825,7 +825,9 @@ int xe_guc_post_load_init(struct xe_guc *guc)
+ 			return ret;
+ 	}
+ 
+-	return xe_guc_submit_enable(guc);
++	guc->submission_state.enabled = true;
++
++	return 0;
+ }
+ 
+ int xe_guc_reset(struct xe_guc *guc)
+@@ -1519,7 +1521,7 @@ void xe_guc_sanitize(struct xe_guc *guc)
+ {
+ 	xe_uc_fw_sanitize(&guc->fw);
+ 	xe_guc_ct_disable(&guc->ct);
+-	xe_guc_submit_disable(guc);
++	guc->submission_state.enabled = false;
+ }
+ 
+ int xe_guc_reset_prepare(struct xe_guc *guc)
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index 18ddbb7b98a15..e670dcb0f0932 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -32,7 +32,6 @@
+ #include "xe_guc_ct.h"
+ #include "xe_guc_exec_queue_types.h"
+ #include "xe_guc_id_mgr.h"
+-#include "xe_guc_klv_helpers.h"
+ #include "xe_guc_submit_types.h"
+ #include "xe_hw_engine.h"
+ #include "xe_hw_fence.h"
+@@ -317,71 +316,6 @@ int xe_guc_submit_init(struct xe_guc *guc, unsigned int num_ids)
+ 	return drmm_add_action_or_reset(&xe->drm, guc_submit_fini, guc);
+ }
+ 
+-/*
+- * Given that we want to guarantee enough RCS throughput to avoid missing
+- * frames, we set the yield policy to 20% of each 80ms interval.
+- */
+-#define RC_YIELD_DURATION	80	/* in ms */
+-#define RC_YIELD_RATIO		20	/* in percent */
+-static u32 *emit_render_compute_yield_klv(u32 *emit)
+-{
+-	*emit++ = PREP_GUC_KLV_TAG(SCHEDULING_POLICIES_RENDER_COMPUTE_YIELD);
+-	*emit++ = RC_YIELD_DURATION;
+-	*emit++ = RC_YIELD_RATIO;
+-
+-	return emit;
+-}
+-
+-#define SCHEDULING_POLICY_MAX_DWORDS 16
+-static int guc_init_global_schedule_policy(struct xe_guc *guc)
+-{
+-	u32 data[SCHEDULING_POLICY_MAX_DWORDS];
+-	u32 *emit = data;
+-	u32 count = 0;
+-	int ret;
+-
+-	if (GUC_SUBMIT_VER(guc) < MAKE_GUC_VER(1, 1, 0))
+-		return 0;
+-
+-	*emit++ = XE_GUC_ACTION_UPDATE_SCHEDULING_POLICIES_KLV;
+-
+-	if (CCS_MASK(guc_to_gt(guc)))
+-		emit = emit_render_compute_yield_klv(emit);
+-
+-	count = emit - data;
+-	if (count > 1) {
+-		xe_assert(guc_to_xe(guc), count <= SCHEDULING_POLICY_MAX_DWORDS);
+-
+-		ret = xe_guc_ct_send_block(&guc->ct, data, count);
+-		if (ret < 0) {
+-			xe_gt_err(guc_to_gt(guc),
+-				  "failed to enable GuC sheduling policies: %pe\n",
+-				  ERR_PTR(ret));
+-			return ret;
+-		}
+-	}
+-
+-	return 0;
+-}
+-
+-int xe_guc_submit_enable(struct xe_guc *guc)
+-{
+-	int ret;
+-
+-	ret = guc_init_global_schedule_policy(guc);
+-	if (ret)
+-		return ret;
+-
+-	guc->submission_state.enabled = true;
+-
+-	return 0;
+-}
+-
+-void xe_guc_submit_disable(struct xe_guc *guc)
+-{
+-	guc->submission_state.enabled = false;
+-}
+-
+ static void __release_guc_id(struct xe_guc *guc, struct xe_exec_queue *q, u32 xa_count)
+ {
+ 	int i;
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.h b/drivers/gpu/drm/xe/xe_guc_submit.h
+index 0d126b807c104..9b71a986c6ca6 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.h
++++ b/drivers/gpu/drm/xe/xe_guc_submit.h
+@@ -13,8 +13,6 @@ struct xe_exec_queue;
+ struct xe_guc;
+ 
+ int xe_guc_submit_init(struct xe_guc *guc, unsigned int num_ids);
+-int xe_guc_submit_enable(struct xe_guc *guc);
+-void xe_guc_submit_disable(struct xe_guc *guc);
+ 
+ int xe_guc_submit_reset_prepare(struct xe_guc *guc);
+ void xe_guc_submit_reset_wait(struct xe_guc *guc);
+-- 
+2.51.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0373-Revert-drm-xe-guc-Enable-extended-CAT-error-reportin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0373-Revert-drm-xe-guc-Enable-extended-CAT-error-reportin.patch
@@ -1,0 +1,224 @@
+From 06c4ea4d54b518eb567a9efb7c2e888553cf3160 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 28 Sep 2025 10:12:42 +0800
+Subject: [PATCH 373/373] Revert "drm/xe/guc: Enable extended CAT error
+ reporting"
+
+This reverts commit 97207a4fed5348ff5c5e71a7300db9b638640879.
+---
+ drivers/gpu/drm/xe/abi/guc_actions_abi.h |  4 --
+ drivers/gpu/drm/xe/abi/guc_klvs_abi.h    | 15 -------
+ drivers/gpu/drm/xe/xe_guc.c              | 56 ------------------------
+ drivers/gpu/drm/xe/xe_guc.h              |  1 -
+ drivers/gpu/drm/xe/xe_guc_submit.c       | 21 ++-------
+ drivers/gpu/drm/xe/xe_uc.c               |  4 --
+ 6 files changed, 3 insertions(+), 98 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/abi/guc_actions_abi.h b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+index b55d4cfb483a1..448afb86e05c7 100644
+--- a/drivers/gpu/drm/xe/abi/guc_actions_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_actions_abi.h
+@@ -142,7 +142,6 @@ enum xe_guc_action {
+ 	XE_GUC_ACTION_SET_ENG_UTIL_BUFF = 0x550A,
+ 	XE_GUC_ACTION_SET_DEVICE_ENGINE_ACTIVITY_BUFFER = 0x550C,
+ 	XE_GUC_ACTION_SET_FUNCTION_ENGINE_ACTIVITY_BUFFER = 0x550D,
+-	XE_GUC_ACTION_OPT_IN_FEATURE_KLV = 0x550E,
+ 	XE_GUC_ACTION_NOTIFY_MEMORY_CAT_ERROR = 0x6000,
+ 	XE_GUC_ACTION_REPORT_PAGE_FAULT_REQ_DESC = 0x6002,
+ 	XE_GUC_ACTION_PAGE_FAULT_RES_DESC = 0x6003,
+@@ -241,7 +240,4 @@ enum xe_guc_g2g_type {
+ #define XE_G2G_DEREGISTER_TILE	REG_GENMASK(15, 12)
+ #define XE_G2G_DEREGISTER_TYPE	REG_GENMASK(11, 8)
+ 
+-/* invalid type for XE_GUC_ACTION_NOTIFY_MEMORY_CAT_ERROR */
+-#define XE_GUC_CAT_ERR_TYPE_INVALID 0xdeadbeef
+-
+ #endif
+diff --git a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+index 5b2502bec2dcc..7de8f827281fc 100644
+--- a/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
++++ b/drivers/gpu/drm/xe/abi/guc_klvs_abi.h
+@@ -16,7 +16,6 @@
+  *  +===+=======+==============================================================+
+  *  | 0 | 31:16 | **KEY** - KLV key identifier                                 |
+  *  |   |       |   - `GuC Self Config KLVs`_                                  |
+- *  |   |       |   - `GuC Opt In Feature KLVs`_                               |
+  *  |   |       |   - `GuC VGT Policy KLVs`_                                   |
+  *  |   |       |   - `GuC VF Configuration KLVs`_                             |
+  *  |   |       |                                                              |
+@@ -125,20 +124,6 @@ enum  {
+ 	GUC_CONTEXT_POLICIES_KLV_NUM_IDS = 5,
+ };
+ 
+-/**
+- * DOC: GuC Opt In Feature KLVs
+- *
+- * `GuC KLV`_ keys available for use with OPT_IN_FEATURE_KLV
+- *
+- *  _`GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE` : 0x4001
+- *      Adds an extra dword to the XE_GUC_ACTION_NOTIFY_MEMORY_CAT_ERROR G2H
+- *      containing the type of the CAT error. On HW that does not support
+- *      reporting the CAT error type, the extra dword is set to 0xdeadbeef.
+- */
+-
+-#define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_KEY 0x4001
+-#define GUC_KLV_OPT_IN_FEATURE_EXT_CAT_ERR_TYPE_LEN 0u
+-
+ /**
+  * DOC: GuC VGT Policy KLVs
+  *
+diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
+index 7b1ad159b15f0..95aedf9449c8c 100644
+--- a/drivers/gpu/drm/xe/xe_guc.c
++++ b/drivers/gpu/drm/xe/xe_guc.c
+@@ -29,7 +29,6 @@
+ #include "xe_guc_db_mgr.h"
+ #include "xe_guc_engine_activity.h"
+ #include "xe_guc_hwconfig.h"
+-#include "xe_guc_klv_helpers.h"
+ #include "xe_guc_log.h"
+ #include "xe_guc_pc.h"
+ #include "xe_guc_relay.h"
+@@ -571,57 +570,6 @@ static int guc_g2g_start(struct xe_guc *guc)
+ 	return err;
+ }
+ 
+-static int __guc_opt_in_features_enable(struct xe_guc *guc, u64 addr, u32 num_dwords)
+-{
+-	u32 action[] = {
+-		XE_GUC_ACTION_OPT_IN_FEATURE_KLV,
+-		lower_32_bits(addr),
+-		upper_32_bits(addr),
+-		num_dwords
+-	};
+-
+-	return xe_guc_ct_send_block(&guc->ct, action, ARRAY_SIZE(action));
+-}
+-
+-#define OPT_IN_MAX_DWORDS 16
+-int xe_guc_opt_in_features_enable(struct xe_guc *guc)
+-{
+-	struct xe_device *xe = guc_to_xe(guc);
+-	CLASS(xe_guc_buf, buf)(&guc->buf, OPT_IN_MAX_DWORDS);
+-	u32 count = 0;
+-	u32 *klvs;
+-	int ret;
+-
+-	if (!xe_guc_buf_is_valid(buf))
+-		return -ENOBUFS;
+-
+-	klvs = xe_guc_buf_cpu_ptr(buf);
+-
+-	/*
+-	 * The extra CAT error type opt-in was added in GuC v70.17.0, which maps
+-	 * to compatibility version v1.7.0.
+-	 * Note that the GuC allows enabling this KLV even on platforms that do
+-	 * not support the extra type; in such case the returned type variable
+-	 * will be set to a known invalid value which we can check against.
+-	 */
+-	if (GUC_SUBMIT_VER(guc) >= MAKE_GUC_VER(1, 7, 0))
+-		klvs[count++] = PREP_GUC_KLV_TAG(OPT_IN_FEATURE_EXT_CAT_ERR_TYPE);
+-
+-	if (count) {
+-		xe_assert(xe, count <= OPT_IN_MAX_DWORDS);
+-
+-		ret = __guc_opt_in_features_enable(guc, xe_guc_buf_flush(buf), count);
+-		if (ret < 0) {
+-			xe_gt_err(guc_to_gt(guc),
+-				  "failed to enable GuC opt-in features: %pe\n",
+-				  ERR_PTR(ret));
+-			return ret;
+-		}
+-	}
+-
+-	return 0;
+-}
+-
+ static void guc_fini_hw(void *arg)
+ {
+ 	struct xe_guc *guc = arg;
+@@ -815,10 +763,6 @@ int xe_guc_post_load_init(struct xe_guc *guc)
+ 
+ 	xe_guc_ads_populate_post_load(&guc->ads);
+ 
+-	ret = xe_guc_opt_in_features_enable(guc);
+-	if (ret)
+-		return ret;
+-
+ 	if (xe_guc_g2g_wanted(guc_to_xe(guc))) {
+ 		ret = guc_g2g_start(guc);
+ 		if (ret)
+diff --git a/drivers/gpu/drm/xe/xe_guc.h b/drivers/gpu/drm/xe/xe_guc.h
+index 0d34433fd2537..5b30215ac5616 100644
+--- a/drivers/gpu/drm/xe/xe_guc.h
++++ b/drivers/gpu/drm/xe/xe_guc.h
+@@ -36,7 +36,6 @@ int xe_guc_reset(struct xe_guc *guc);
+ int xe_guc_upload(struct xe_guc *guc);
+ int xe_guc_min_load_for_hwconfig(struct xe_guc *guc);
+ int xe_guc_enable_communication(struct xe_guc *guc);
+-int xe_guc_opt_in_features_enable(struct xe_guc *guc);
+ int xe_guc_suspend(struct xe_guc *guc);
+ void xe_guc_notify(struct xe_guc *guc);
+ int xe_guc_auth_huc(struct xe_guc *guc, u32 rsa_addr);
+diff --git a/drivers/gpu/drm/xe/xe_guc_submit.c b/drivers/gpu/drm/xe/xe_guc_submit.c
+index e670dcb0f0932..45a21af126927 100644
+--- a/drivers/gpu/drm/xe/xe_guc_submit.c
++++ b/drivers/gpu/drm/xe/xe_guc_submit.c
+@@ -2088,16 +2088,12 @@ int xe_guc_exec_queue_memory_cat_error_handler(struct xe_guc *guc, u32 *msg,
+ 	struct xe_gt *gt = guc_to_gt(guc);
+ 	struct xe_exec_queue *q;
+ 	u32 guc_id;
+-	u32 type = XE_GUC_CAT_ERR_TYPE_INVALID;
+ 
+-	if (unlikely(!len || len > 2))
++	if (unlikely(len < 1))
+ 		return -EPROTO;
+ 
+ 	guc_id = msg[0];
+ 
+-	if (len == 2)
+-		type = msg[1];
+-
+ 	if (guc_id == GUC_ID_UNKNOWN) {
+ 		/*
+ 		 * GuC uses GUC_ID_UNKNOWN if it can not map the CAT fault to any PF/VF
+@@ -2111,19 +2107,8 @@ int xe_guc_exec_queue_memory_cat_error_handler(struct xe_guc *guc, u32 *msg,
+ 	if (unlikely(!q))
+ 		return -EPROTO;
+ 
+-	/*
+-	 * The type is HW-defined and changes based on platform, so we don't
+-	 * decode it in the kernel and only check if it is valid.
+-	 * See bspec 54047 and 72187 for details.
+-	 */
+-	if (type != XE_GUC_CAT_ERR_TYPE_INVALID)
+-		xe_gt_dbg(gt,
+-			  "Engine memory CAT error [%u]: class=%s, logical_mask: 0x%x, guc_id=%d",
+-			  type, xe_hw_engine_class_to_str(q->class), q->logical_mask, guc_id);
+-	else
+-		xe_gt_dbg(gt,
+-			  "Engine memory CAT error: class=%s, logical_mask: 0x%x, guc_id=%d",
+-			  xe_hw_engine_class_to_str(q->class), q->logical_mask, guc_id);
++	xe_gt_dbg(gt, "Engine memory cat error: engine_class=%s, logical_mask: 0x%x, guc_id=%d",
++		  xe_hw_engine_class_to_str(q->class), q->logical_mask, guc_id);
+ 
+ 	trace_xe_exec_queue_memory_cat_error(q);
+ 
+diff --git a/drivers/gpu/drm/xe/xe_uc.c b/drivers/gpu/drm/xe/xe_uc.c
+index 5c45b0f072a4c..3a8751a8b92dd 100644
+--- a/drivers/gpu/drm/xe/xe_uc.c
++++ b/drivers/gpu/drm/xe/xe_uc.c
+@@ -165,10 +165,6 @@ static int vf_uc_init_hw(struct xe_uc *uc)
+ 
+ 	uc->guc.submission_state.enabled = true;
+ 
+-	err = xe_guc_opt_in_features_enable(&uc->guc);
+-	if (err)
+-		return err;
+-
+ 	err = xe_gt_record_default_lrcs(uc_to_gt(uc));
+ 	if (err)
+ 		return err;
+-- 
+2.51.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.16.9
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=1.1
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] linux-kernel: revert 6.16.9 CAT changes for xe
    To fix Intel xe initialisation issues since this version:
    \[    8.005363\] xe 0000:09:00.0: probe with driver xe failed with error -105
    Link: https://lore.kernel.org/stable/616f634e-63d2-45cb-a4f9-b34973cc5dfd@iyanmv.com/
    Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/6239
    Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/6243

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.16.9-1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
