### PR TITLE
hysteria: update to 2.6.3

### DIFF
--- a/app-proxy/hysteria/autobuild/build
+++ b/app-proxy/hysteria/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Building Hysteria ..."
-go build -o hysteria ./app
+go build -o hysteria -ldflags "${GO_LDFLAGS[*]} -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/autobuild3/specs/hardened-ld'" ./app
 
 abinfo "Installing Hysteria ..."
 install -Dvm755 "$SRCDIR"/hysteria \

--- a/app-proxy/hysteria/autobuild/defines
+++ b/app-proxy/hysteria/autobuild/defines
@@ -4,4 +4,4 @@ PKGDES="A multi-protocol network proxy"
 PKGDEP="glibc"
 BUILDDEP="git go"
 
-ABSPLITDBG=0
+GO_LDFLAGS=("-X github.com/apernet/hysteria/app/v2/cmd.appVersion=v$PKGVER")

--- a/app-proxy/hysteria/autobuild/overrides/usr/lib/sysusers.d/hysteria.conf
+++ b/app-proxy/hysteria/autobuild/overrides/usr/lib/sysusers.d/hysteria.conf
@@ -1,0 +1,2 @@
+g hysteria -
+u! hysteria - - /var/lib/hysteria

--- a/app-proxy/hysteria/autobuild/overrides/usr/lib/tmpfiles.d/hysteria.conf
+++ b/app-proxy/hysteria/autobuild/overrides/usr/lib/tmpfiles.d/hysteria.conf
@@ -1,0 +1,1 @@
+d /var/lib/hysteria 0755 hysteria hysteria

--- a/app-proxy/hysteria/autobuild/postinst
+++ b/app-proxy/hysteria/autobuild/postinst
@@ -1,0 +1,5 @@
+echo "Setting up hysteria user and group ..."
+systemd-sysusers hysteria.conf
+
+echo "Creating temporary directory for hysteria ..."
+systemd-tmpfiles --create hysteria.conf

--- a/app-proxy/hysteria/spec
+++ b/app-proxy/hysteria/spec
@@ -1,5 +1,4 @@
-VER=2.6.1
-REL=1
+VER=2.6.3
 SRCS="git::commit=tags/app/v$VER::https://github.com/apernet/hysteria"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371975"


### PR DESCRIPTION
Topic Description
-----------------

- hysteria: update to 2.6.3
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- hysteria: 2.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit hysteria
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
