### PR TITLE
86box: bump REL for rtmidi udpate

### DIFF
--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,4 +1,5 @@
 VER=5.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"

--- a/groups/rtmidi-rebuilds
+++ b/groups/rtmidi-rebuilds
@@ -1,2 +1,3 @@
 app-multimedia/milkytracker
 app-multimedia/polyphone
+app-emulation/86box

--- a/runtime-multimedia/rtmidi/autobuild/defines
+++ b/runtime-multimedia/rtmidi/autobuild/defines
@@ -9,4 +9,4 @@ AUTOTOOLS_AFTER=(
 )
 AB_FLAGS_SPECS=0
 
-PKGBREAK="milkytracker<=1.04.00 polyphone<=2.5.1"
+PKGBREAK="milkytracker<=1.04.00 polyphone<=2.5.1 86box<=5.1"

--- a/runtime-multimedia/rtmidi/spec
+++ b/runtime-multimedia/rtmidi/spec
@@ -1,4 +1,5 @@
 VER=6.0.0
+REL=1
 SRCS="git::commit=tags/${VER}::https://github.com/thestk/rtmidi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4220"


### PR DESCRIPTION
Topic Description
-----------------

- rtmidi: add PKGBREAK for 86box
- groups/rtmidi-rebuilds: add 86box
- 86box: bump REL for rtmidi update

Package(s) Affected
-------------------

- 86box: 5.1-1
- rtmidi: 6.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rtmidi 86box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
