### PR TITLE
obs-studio: update to 32.0.1

### DIFF
--- a/app-multimedia/obs-studio/autobuild/defines
+++ b/app-multimedia/obs-studio/autobuild/defines
@@ -9,7 +9,7 @@ PKGDEP__AMD64="${PKGDEP} ${PKGDEP__INTEL_QSV}"
 PKGRECOM="v4l2loopback"
 
 BUILDDEP="cmake x264 swig vlc pipewire jack patchelf python-3 nlohmann-json \
-          ffnvcodec extra-cmake-modules"
+          ffnvcodec extra-cmake-modules simde"
 BUILDDEP__AMD64="${BUILDDEP} luajit"
 BUILDDEP__ARM64="${BUILDDEP__AMD64}"
 BUILDDEP__LOONGSON3="${BUILDDEP__AMD64}"

--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,4 @@
-VER=31.1.2
+VER=32.0.1
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # Check https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux#obs-browser
 # for upstream required CEF version for reference.
@@ -15,4 +15,3 @@ CHKSUMS__ARM64="SKIP \
          sha256::b3c751f7bac03b49825306e96273d6c98dedf26a2fab4e4785964a965859741b"
 SUBDIR="obs-studio"
 CHKUPDATE="anitya::id=7239"
-REL=1

--- a/runtime-common/simde/spec
+++ b/runtime-common/simde/spec
@@ -1,4 +1,4 @@
-VER=0.8.2
-SRCS="git::commit=tags/v$VER::https://github.com/simd-everywhere/simde"
+VER=0.8.4~rc1
+SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/simd-everywhere/simde"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180908"


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: update to 32.0.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- simde: backport lsx implementation
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- obs-studio: 32.0.1-1
- simde: 0.8.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit simde obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
