### PR TITLE
lfortran: update to 0.57.0

### DIFF
--- a/app-devel/lfortran/autobuild/defines
+++ b/app-devel/lfortran/autobuild/defines
@@ -1,13 +1,7 @@
 PKGNAME=lfortran
 PKGSEC=devel
-# Note: LLVM 20 is required since lfortran built with LLVM 18 crashes on loongarch64.
-# ...
-# >>> real :: a = 10
-# >>> a + 10
-# Program received signal SIGSEGV, Segmentation fault.
-# 0x00005555571d4ac4 in llvm::RuntimeDyldELF::computePlaceholderAddress(unsigned int, unsigned long) const ()
-PKGDEP="gcc-runtime glibc libunwind llvm-20 ncurses python-3"
-BUILDDEP="fmt libunwind llvm-20 python-3 re2c zlib-static zstd-static"
+PKGDEP="gcc-runtime glibc libunwind llvm ncurses python-3"
+BUILDDEP="fmt libunwind llvm python-3 re2c zlib-static zstd-static"
 PKGDES="Interactive LLVM-based Fortran compiler"
 
 ABTYPE=cmakeninja

--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,4 +1,4 @@
-VER=0.56.0
+VER=0.57.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::34b92d2f4e6003d06bd981a5f1f082ca16ccab9e56915b15f92a6601a00f7d52"
+CHKSUMS="sha256::187e80ff267257332a929eeabf1f7bb4cc348af2e6c54fcae63c3f49d6c392cf"
 CHKUPDATE="anitya::id=370998"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.57.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.57.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
