### PR TITLE
gtk-4: update to 4.20.1

### DIFF
--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,4 +1,4 @@
-VER=4.18.5
+VER=4.20.1
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
-CHKSUMS="sha256::bb5267a062f5936947d34c9999390a674b0b2b0d8aa3472fe0d05e2064955abc"
+CHKSUMS="sha256::bf32fac019171c45681b2c45d05658ee8598c6341572e32a6a6bcb0b5673998d"
 CHKUPDATE="anitya::id=13942"


### PR DESCRIPTION
Topic Description
-----------------

- gtk-4: update to 4.20.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gtk-4: 1:4.20.1
- gtk-update-icon-cache: 4.20.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
