### PR TITLE
djvulibre: update to 3.5.29

### DIFF
--- a/app-doc/djvulibre/spec
+++ b/app-doc/djvulibre/spec
@@ -1,5 +1,4 @@
-VER=3.5.28
-CHKSUMS="SKIP"
+VER=3.5.29
 SRCS=git::commit=7e5a7cb60731cfc7328468cb7136a4e8b52f12cb::https://git.code.sf.net/p/djvu/djvulibre-git
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10159"


### PR DESCRIPTION
Topic Description
-----------------

- djvulibre: update to 3.5.29
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- djvulibre: 3.5.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit djvulibre
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
