### PR TITLE
openldap: update to 2.6.10

### DIFF
--- a/app-admin/openldap/spec
+++ b/app-admin/openldap/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=2_6_9
+UPSTREAM_VER=2.6.10
 VER=${UPSTREAM_VER//_/.}
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::2cb7dc73e9c8340dff0d99357fbaa578abf30cc6619f0521972c555681e6b2ff"
+CHKSUMS="sha256::c065f04aad42737aebd60b2fe4939704ac844266bc0aeaa1609f0cad987be516"
 CHKUPDATE="anitya::id=2551"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- openldap: update to 2.6.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openldap: 2.6.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit openldap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
