### PR TITLE
libao: fix build with GCC>=14

### DIFF
--- a/runtime-multimedia/libao/autobuild/defines
+++ b/runtime-multimedia/libao/autobuild/defines
@@ -12,4 +12,6 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="Cross Platform Audio Output Library"
 
-AUTOTOOLS_AFTER="--disable-arts"
+AUTOTOOLS_AFTER=(
+	"--disable-arts"
+)

--- a/runtime-multimedia/libao/autobuild/patches/0001-BACKPORT-pulse-fix-missing-include-warning-for-nanos.patch
+++ b/runtime-multimedia/libao/autobuild/patches/0001-BACKPORT-pulse-fix-missing-include-warning-for-nanos.patch
@@ -1,0 +1,25 @@
+From 243cced48ea0723c1d2044da6d3bdbf0d2d2140e Mon Sep 17 00:00:00 2001
+From: Tristan Matthews <tmatth@videolan.org>
+Date: Sun, 15 Jan 2017 12:15:07 -0500
+Subject: [PATCH] BACKPORT: pulse: fix missing include warning for nanosleep
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ src/plugins/pulse/ao_pulse.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/pulse/ao_pulse.c b/src/plugins/pulse/ao_pulse.c
+index 9835273..2d10d57 100644
+--- a/src/plugins/pulse/ao_pulse.c
++++ b/src/plugins/pulse/ao_pulse.c
+@@ -30,6 +30,7 @@
+ #include <assert.h>
+ #include <string.h>
+ #include <signal.h>
++#include <time.h>
+ #include <limits.h>
+ 
+ #include <pulse/pulseaudio.h>
+-- 
+2.51.0
+

--- a/runtime-multimedia/libao/spec
+++ b/runtime-multimedia/libao/spec
@@ -1,5 +1,5 @@
 VER=1.2.2
-REL=2
-SRCS="tbl::https://github.com/xiph/libao/archive/$VER.tar.gz"
-CHKSUMS="sha256::df8a6d0e238feeccb26a783e778716fb41a801536fe7b6fce068e313c0e2bf4d"
+REL=3
+SRCS="git::commit=tags/${VER}::https://github.com/xiph/libao"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7629"


### PR DESCRIPTION
Topic Description
-----------------

- libao: fix build with GCC>=14
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libao: 1.2.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libao
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
