### PR TITLE
libifp: fix build with GCC>=14

### DIFF
--- a/runtime-devices/libifp/autobuild/defines
+++ b/runtime-devices/libifp/autobuild/defines
@@ -3,4 +3,6 @@ PKGSEC=libs
 PKGDEP="libusb-compat"
 PKGDES="General-purpose library-driver for iRiver iFP portable audio players"
 
-AUTOTOOLS_AFTER="--with-libusb"
+AUTOTOOLS_AFTER=(
+	"--with-libusb"
+)

--- a/runtime-devices/libifp/autobuild/patches/0001-AOSCOS-fix-build-with-GCC-14.patch
+++ b/runtime-devices/libifp/autobuild/patches/0001-AOSCOS-fix-build-with-GCC-14.patch
@@ -1,0 +1,54 @@
+From 5fb67b9c14f9b778168821211a5111ad8ade3f2d Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Mon, 29 Sep 2025 15:01:57 +0800
+Subject: [PATCH] AOSCOS: fix build with GCC>=14
+
+/var/cache/acbs/build/acbs.1dd2bt5r/libifp-1.0.0.2/src/userfile.c: In function '_ifp_upload_dir':
+/var/cache/acbs/build/acbs.1dd2bt5r/libifp-1.0.0.2/src/userfile.c:977:56: error: passing argument 3 of 'fts_open' from incompatible pointer type [-Wincompatible-pointer-types]
+977 | tw = fts_open(argv, FTS_LOGICAL | FTS_NOCHDIR, file_compare_fts);
+|                                                    ^~~~~~~~~~~~~~~~
+|                                                    |
+|                                                    int (*)(const FTSENT * const*, const FTSENT * const*) {aka int (*)(const struct _ftsent * const*, const struct _ftsent * const*)}
+
+/var/cache/acbs/build/acbs.1dd2bt5r/libifp-1.0.0.2/src/ifp_os_libusb.c: In function 'local_iconv':
+/var/cache/acbs/build/acbs.1dd2bt5r/libifp-1.0.0.2/src/ifp_os_libusb.c:53:26: error: passing argument 2 of 'iconv' from incompatible pointer type [-Wincompatible-pointer-types]
+53 | r = iconv(ICONV, &ibb, &i_n, &obb, &o_n);
+|                     ^~~~
+|                     |
+|                     const char **
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ src/ifp_os_libusb.c | 2 +-
+ src/userfile.c      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ifp_os_libusb.c b/src/ifp_os_libusb.c
+index e9b2654..418b773 100644
+--- a/src/ifp_os_libusb.c
++++ b/src/ifp_os_libusb.c
+@@ -50,7 +50,7 @@ static int local_iconv(char const * i_type, char const * o_type,
+ 		goto err;
+ 	}
+ 
+-	r = iconv(ICONV, &ibb, &i_n, &obb, &o_n);
++	r = iconv(ICONV, (char **)&ibb, &i_n, &obb, &o_n);
+ 	if (r == (size_t)-1) {
+ 		i = -errno;
+ 		ifp_err_i(i, "problem converting, i_n is %d, o_n is %d, r = %d", i_n, o_n, r);
+diff --git a/src/userfile.c b/src/userfile.c
+index 0d10a45..014f176 100644
+--- a/src/userfile.c
++++ b/src/userfile.c
+@@ -974,7 +974,7 @@ static int _ifp_upload_dir(struct ifp_device * dev,
+ 	strncpy(path, remotedir, sizeof(path));
+ 	n = strlen(path);
+ 
+-	tw = fts_open(argv, FTS_LOGICAL | FTS_NOCHDIR, file_compare_fts);
++	tw = fts_open(argv, FTS_LOGICAL | FTS_NOCHDIR, (int (*)(const FTSENT **, const FTSENT **))file_compare_fts);
+ 	if (tw == NULL) {
+ 		ifp_err("couldn't open %s", localdir);
+ 		goto err_0;
+-- 
+2.51.0
+

--- a/runtime-devices/libifp/spec
+++ b/runtime-devices/libifp/spec
@@ -1,4 +1,5 @@
 VER=1.0.0.2
+REL=1
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/ifp-driver/libifp-$VER.tar.gz"
 CHKSUMS="sha256::3b8fa50b9425b660285484eb42bad3f736f0aecc6a790c5160da276558ebfcee"
 CHKUPDATE="anitya::id=229575"


### PR DESCRIPTION
Topic Description
-----------------

- libifp: fix build with GCC>=14
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libifp: 1.0.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libifp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
