### PR TITLE
wireguard-tools: update to 1.0.20250521

### DIFF
--- a/app-network/wireguard-tools/spec
+++ b/app-network/wireguard-tools/spec
@@ -1,4 +1,4 @@
-VER=1.0.20210914
+VER=1.0.20250521
 SRCS="tbl::https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${VER}.tar.xz"
-CHKSUMS="sha256::97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac"
+CHKSUMS="sha256::b6f2628b85b1b23cc06517ec9c74f82d52c4cdbd020f3dd2f00c972a1782950e"
 CHKUPDATE="anitya::id=62381"


### PR DESCRIPTION
Topic Description
-----------------

- wireguard-tools: update to 1.0.20250521
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- wireguard-tools: 1.0.20250521

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireguard-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
