### PR TITLE
btrfs-progs: update to 6.17

### DIFF
--- a/app-admin/btrfs-progs/spec
+++ b/app-admin/btrfs-progs/spec
@@ -1,4 +1,4 @@
-VER=6.16.1
+VER=6.17
 SRCS="https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v$VER.tar.xz"
-CHKSUMS="sha256::70aa3f954017ca743529828deb2a10dceab2d41321583ad157e967847ddb24fc"
+CHKSUMS="sha256::277d696c9d79713ff5afb53c7efebdcead2e6a6007789b1742ec411f4e4ca229"
 CHKUPDATE="anitya::id=227"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-progs: update to 6.17
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- btrfs-progs: 6.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-progs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
