### PR TITLE
strace: update to 6.17

### DIFF
--- a/app-devel/strace/spec
+++ b/app-devel/strace/spec
@@ -1,4 +1,4 @@
-VER=6.14
+VER=6.17
 SRCS="tbl::https://github.com/strace/strace/releases/download/v$VER/strace-$VER.tar.xz"
-CHKSUMS="sha256::244f3b5c20a32854ca9b7ca7a3ee091dd3d4bd20933a171ecee8db486c77d3c9"
+CHKSUMS="sha256::0a7c7bedc7efc076f3242a0310af2ae63c292a36dd4236f079e88a93e98cb9c0"
 CHKUPDATE="anitya::id=4897"


### PR DESCRIPTION
Topic Description
-----------------

- strace: update to 6.17
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- strace: 6.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit strace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
