### PR TITLE
shotwell: update to 0.32.13

### DIFF
--- a/desktop-gnome/shotwell/autobuild/defines
+++ b/desktop-gnome/shotwell/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=shotwell
 PKGSEC=gnome
 PKGDEP="dconf desktop-file-utils gexiv2 gst-plugins-base-1-0 \
-        hicolor-icon-theme json-glib libgee libgphoto2 libraw \
-        python-3 rest webkit2gtk gcr libgdata libchamplain libgudev"
-BUILDDEP="gtk-doc intltool vala"
+        hicolor-icon-theme json-glib libgee libgphoto2 libraw python-3 \
+        rest webkit2gtk gcr libgdata libchamplain libgudev libportal"
+BUILDDEP="intltool vala"
 PKGDES="Digital photo organizer designed for the GNOME desktop environment"
+ABTYPE=meson

--- a/desktop-gnome/shotwell/spec
+++ b/desktop-gnome/shotwell/spec
@@ -1,4 +1,4 @@
-VER=0.31.4
-SRCS="tbl::https://download.gnome.org/sources/shotwell/${VER:0:4}/shotwell-$VER.tar.xz"
-CHKSUMS="sha256::b16f4f457c5f34c6fd9509d582f94635944142040cd952671febad93174fa2ef"
+VER=0.32.13
+SRCS="git::commit=tags/shotwell-${VER}::https://gitlab.gnome.org/GNOME/shotwell"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4811"


### PR DESCRIPTION
Topic Description
-----------------

- shotwell: update to 0.32.13
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- shotwell: 0.32.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit shotwell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
