### PR TITLE
dart-sdk: update to 3.9.4

### DIFF
--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -1,5 +1,5 @@
-VER="3.8.2"
+VER=3.9.4
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/dart-sdk-${VER}.tar.zst"
-CHKSUMS="sha256::59a47166b8d9ba6c3bd459b337c5908242769e9e92aaac428b2e5838c8aa0584"
+CHKSUMS="sha256::49f8777e7ef1f28d0216b4af0c933c6357eae799a34180ef0f900b6bab8a8036"
 CHKUPDATE="anitya::id=14718"
 SUBDIR="dart-sdk-${VER}"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sdk: update to 3.9.4
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- dart-sdk: 3.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
