### PR TITLE
postgresql-13: update to 13.22

### DIFF
--- a/app-database/postgresql-13/spec
+++ b/app-database/postgresql-13/spec
@@ -1,5 +1,4 @@
-VER=13.21
-REL=1
+VER=13.22
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::dcda1294df45f033b0656cf7a8e4afbbc624c25e1b144aec79530f74d7ef4ab4"
+CHKSUMS="sha256::d36d83dc89e625502cf6fb1d0529642ba1266bd614b4e4a41cefd1dddcf09080"
 CHKUPDATE="anitya::id=210464"

--- a/topics/postgresql-13-13.22.toml
+++ b/topics/postgresql-13-13.22.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 13.22"
+
+[caution]
+default = "Fixes 3 security vulnerabilities (2 of high severity)"
+zh_CN = "修复 3 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+"postgresql-13" = "< 13.22"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-13: update to 13.22
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postgresql-13: 13.22
- postgresql-runtime-13: 13.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-13
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
