### PR TITLE
postgresql-14: update to 14.19

### DIFF
--- a/app-database/postgresql-14/spec
+++ b/app-database/postgresql-14/spec
@@ -1,5 +1,4 @@
-VER=14.18
-REL=1
+VER=14.19
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::83ab29d6bfc3dc58b2ed3c664114fdfbeb6a0450c4b8d7fa69aee91e3ca14f8e"
+CHKSUMS="sha256::727e9e334bc1a31940df808259f69fe47a59f6d42174b22ae62d67fe7a01ad80"
 CHKUPDATE="anitya::id=236443"

--- a/topics/postgresql-14-14.19.toml
+++ b/topics/postgresql-14-14.19.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 14.19"
+
+[caution]
+default = "Fixes 3 security vulnerabilities (2 of high severity)"
+zh_CN = "修复 3 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+"postgresql-14" = "< 14.19"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-14: update to 14.19
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postgresql-14: 14.19
- postgresql-runtime-14: 14.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-14
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
