### PR TITLE
postgresql-15: update to 15.14

### DIFF
--- a/app-database/postgresql-15/spec
+++ b/app-database/postgresql-15/spec
@@ -1,5 +1,4 @@
-VER=15.13
-REL=1
+VER=15.14
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::4f62e133d22ea08a0401b0840920e26698644d01a80c34341fb732dd0a90ca5d"
+CHKSUMS="sha256::06dd75d305cd3870ee62b3932e661c624543eaf9ae2ba37cdec0a4f8edd051d2"
 CHKUPDATE="anitya::id=301832"

--- a/topics/postgresql-15-15.14.toml
+++ b/topics/postgresql-15-15.14.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 15.14"
+
+[caution]
+default = "Fixes 3 security vulnerabilities (2 of high severity)"
+zh_CN = "修复 3 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+"postgresql-15" = "< 15.14"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-15: update to 15.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postgresql-15: 15.14
- postgresql-runtime-15: 15.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-15
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
