### PR TITLE
postgresql-16: update to 16.10

### DIFF
--- a/app-database/postgresql-16/spec
+++ b/app-database/postgresql-16/spec
@@ -1,5 +1,4 @@
-VER=16.9
-REL=1
+VER=16.10
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::07c00fb824df0a0c295f249f44691b86e3266753b380c96f633c3311e10bd005"
+CHKSUMS="sha256::de8485f4ce9c32e3ddfeef0b7c261eed1cecb54c9bcd170e437ff454cb292b42"
 CHKUPDATE="anitya::id=375691"

--- a/topics/postgresql-16-16.10.toml
+++ b/topics/postgresql-16-16.10.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 16.10"
+
+[caution]
+default = "Fixes 3 security vulnerabilities (2 of high severity)"
+zh_CN = "修复 3 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+"postgresql-16" = "< 16.10"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-16: update to 16.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postgresql-16: 16.10
- postgresql-runtime-16: 16.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-16
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
