### PR TITLE
postgresql-17: update to 17.6

### DIFF
--- a/app-database/postgresql-17/spec
+++ b/app-database/postgresql-17/spec
@@ -1,5 +1,4 @@
-VER=17.5
-REL=1
+VER=17.6
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::fcb7ab38e23b264d1902cb25e6adafb4525a6ebcbd015434aeef9eda80f528d8"
+CHKSUMS="sha256::e0630a3600aea27511715563259ec2111cd5f4353a4b040e0be827f94cd7a8b0"
 CHKUPDATE="anitya::id=375014"

--- a/topics/postgresql-17-17.6.toml
+++ b/topics/postgresql-17-17.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 17.6"
+
+[caution]
+default = "Fixes 3 security vulnerabilities (2 of high severity)"
+zh_CN = "修复 3 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+"postgresql-17" = "< 17.6"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-17: update to 17.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postgresql-17: 17.6
- postgresql-runtime-17: 17.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-17
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
