### PR TITLE
octave: update to 10.3.0

### DIFF
--- a/app-scientific/octave/autobuild/defines
+++ b/app-scientific/octave/autobuild/defines
@@ -8,7 +8,6 @@ PKGDES="A high-level language intended for numerical computations"
 ABTYPE=autotools
 AUTOTOOLS_AFTER=(
 	--libexecdir=/usr/lib
-	--enable-float-truncate
 	--with-qrupdate
 	--with-cxsparse
 	--with-amd

--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -1,5 +1,4 @@
-VER=9.2.0
-REL=3
+VER=10.3.0
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
-CHKSUMS="sha256::dcb2c098701cfcbc083f07e90e146261d15cdbf5e89c031032422112c89b47da"
+CHKSUMS="sha256::68bc82885a3ae67a806debb14eb229506d2fe398c969dd42e2e38cc1c35f2aff"
 CHKUPDATE="anitya::id=2528"


### PR DESCRIPTION
Topic Description
-----------------

- octave: update to 10.3.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- octave: 10.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit octave
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
