### PR TITLE
git-credential-oauth:
 new, 
0.16.0

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.12.11
+VER=4.12.12
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-vcs/git-credential-oauth/autobuild/build
+++ b/app-vcs/git-credential-oauth/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building git-credential-oauth ..."
+go build -ldflags "-X main.version=$PKGVER" -o $PKGNAME .
+
+abinfo "Installing git-credential-oauth ..."
+install -Dvm755 "$SRCDIR"/$PKGNAME "$PKGDIR"/usr/bin/$PKGNAME
+install -Dvm644 "$SRCDIR"/git-credential-oauth.1 -t "$PKGDIR"/usr/share/man/man1/

--- a/app-vcs/git-credential-oauth/autobuild/defines
+++ b/app-vcs/git-credential-oauth/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=git-credential-oauth
+PKGSEC=vcs
+PKGDEP="glibc git"
+BUILDDEP="go"
+PKGDES="Authentication helper for various hosted Git platforms"

--- a/app-vcs/git-credential-oauth/spec
+++ b/app-vcs/git-credential-oauth/spec
@@ -1,0 +1,4 @@
+VER=0.16.0
+SRCS="git::commit=tags/v$VER::https://github.com/hickford/git-credential-oauth"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=301894"


### PR DESCRIPTION
Topic Description
-----------------

- git-credential-oauth: new, 0.16.0
- autobuild4: update to 4.12.12

Package(s) Affected
-------------------

- autobuild4: 4.12.12
- git-credential-oauth: 0.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 git-credential-oauth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
