### PR TITLE
vscode: update to 1.104.3

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.104.2
+VER=1.104.3
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::6bbe534d4f9b9932a858111420ff48555dcaf911d67a2b6997b2a1e240fae728"
-CHKSUMS__ARM64="sha256::f3568849a9f2b45d66a41503829cd147985eec89b562c20e2e65d09302e76a2e"
+CHKSUMS__AMD64="sha256::d0b1d478e0e72c1e0040c45ce4a65814ddb3bd5ffd6b372e95f6185ee92988e5"
+CHKSUMS__ARM64="sha256::2104174eec00e7970ffa1a4eaafa672341a545cbe8b83fc7f6c857bafa01daf1"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.104.3
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.104.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
