### PR TITLE
dart-sdk: add PKGBREAK to fix upgrade files corrupt

### DIFF
--- a/lang-dart/dart-sdk/01-main/defines
+++ b/lang-dart/dart-sdk/01-main/defines
@@ -4,6 +4,6 @@ PKGDEP="dartaotruntime curl git glibc icu llvm ninja xz zlib zstd"
 BUILDDEP="dart-sdk gcc gn jq ripgrep"
 PKGDES="The Dart programming language SDK"
 
-FAIL_ARCH="!(amd64|armv7hf|arm64|riscv64)"
-
 ABTYPE=self
+
+FAIL_ARCH="!(amd64|armv7hf|arm64|riscv64)"

--- a/lang-dart/dart-sdk/02-dartaotruntime/build.stage2
+++ b/lang-dart/dart-sdk/02-dartaotruntime/build.stage2
@@ -1,4 +1,0 @@
-abinfo "Installing dartaotruntime ..."
-mv -v "$SRCDIR"/fakeroot "$PKGDIR"
-install -dvm755 ${PKGDIR}/usr/bin
-ln -sv ../lib/dart-sdk/bin/dartaotruntime ${PKGDIR}/usr/bin

--- a/lang-dart/dart-sdk/02-dartaotruntime/defines
+++ b/lang-dart/dart-sdk/02-dartaotruntime/defines
@@ -3,6 +3,9 @@ PKGSEC=devel
 PKGDEP="glibc icu zlib"
 PKGDES="Dart runtime for AOT-compiled snapshots"
 
+ABTYPE=self
+
 FAIL_ARCH="!(amd64|armv7hf|arm64|riscv64)"
 
-ABTYPE=self
+PKGBREAK="dart-sdk<=3.8.2"
+PKGREP="dart-sdk<=3.8.2"

--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -3,3 +3,4 @@ SRCS="tbl::https://repo.aosc.io/aosc-repacks/dart-sdk-${VER}.tar.zst"
 CHKSUMS="sha256::49f8777e7ef1f28d0216b4af0c933c6357eae799a34180ef0f900b6bab8a8036"
 CHKUPDATE="anitya::id=14718"
 SUBDIR="dart-sdk-${VER}"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- dart-sdk: add PKGBREAK to fix upgrade files corrupt

Package(s) Affected
-------------------

- dart-sdk: 3.9.4
- dartaotruntime: 3.9.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
