### PR TITLE
dive: rework for PKGDES

### DIFF
--- a/app-utils/dive/autobuild/defines
+++ b/app-utils/dive/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=dive
 PKGSEC=utils
 BUILDDEP="go"
 PKGDEP="glibc"
-PKGDES="Tool for exploring each layer in a docker image"
+PKGDES="Tool for exploring layers in a Docker image"
 
 ABTYPE=gomod
 GO_LDFLAGS=("-X" "main.version=$PKGVER")

--- a/app-utils/dive/spec
+++ b/app-utils/dive/spec
@@ -2,3 +2,4 @@ VER=0.13.1
 SRCS="git::commit=tags/v$VER::https://github.com/wagoodman/dive"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=385450"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- dive: rework for PKGDES

Package(s) Affected
-------------------

- dive: 0.13.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
