### PR TITLE
yaru: update to 25.10.3+0ubuntu1

### DIFF
--- a/desktop-themes/yaru/spec
+++ b/desktop-themes/yaru/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=25.10.2-0ubuntu1
+UPSTREAM_VER=25.10.3-0ubuntu1
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/ubuntu/yaru"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- yaru: update to 25.10.3+0ubuntu1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- yaru: 25.10.3+0ubuntu1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yaru
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
