### PR TITLE
importlib-resources: update to 6.5.2

### DIFF
--- a/lang-python/importlib-resources/autobuild/defines
+++ b/lang-python/importlib-resources/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=importlib-resources
+PKGSEC=python
+PKGDEP="python-3 setuptools-scm"
+BUILDDEP="setuptools"
+PKGDES="Backport of the importlib.resources module"
+
+ABTYPE=pep517
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/importlib-resources/spec
+++ b/lang-python/importlib-resources/spec
@@ -1,0 +1,4 @@
+VER=6.5.2
+SRCS="pypi::version=$VER::importlib-resources"
+CHKSUMS="sha256::185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"
+CHKUPDATE="anitya::id=80906"


### PR DESCRIPTION
Topic Description
-----------------

- importlib-resources: update to 6.5.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- importlib-resources: 6.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit importlib-resources
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
