### PR TITLE
kdl Survey 20251003

### DIFF
--- a/runtime-common/orocos-kdl/autobuild/defines
+++ b/runtime-common/orocos-kdl/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=orocos-kdl
+PKGSEC=libs
+PKGDEP="catkin-pkg boost"
+BUILDDEP="eigen-3 cppunit"
+PKGDES="Application-independent framework for modelling and computation of kinematic chains"
+ABTYPE=cmakeninja

--- a/runtime-common/orocos-kdl/spec
+++ b/runtime-common/orocos-kdl/spec
@@ -1,0 +1,5 @@
+VER=1.5.1
+SRCS="git::commit=tags/v$VER::https://github.com/orocos/orocos_kinematics_dynamics"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=6445"
+SUBDIR=orocos-kdl/orocos_kdl

--- a/runtime-common/pykdl/autobuild/defines
+++ b/runtime-common/pykdl/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=pykdl
+PKGSEC=libs
+PKGDEP="catkin-pkg orocos-kdl"
+BUILDDEP="eigen-3"
+PKGDES="Python bindings for Kinematics and Dynamics Library (KDL)"
+ABTYPE=cmakeninja

--- a/runtime-common/pykdl/spec
+++ b/runtime-common/pykdl/spec
@@ -1,0 +1,5 @@
+VER=1.5.1
+SRCS="git::commit=tags/v$VER::https://github.com/orocos/orocos_kinematics_dynamics"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=6445"
+SUBDIR=pykdl/python_orocos_kdl


### PR DESCRIPTION
Topic Description
-----------------

- pykdl: new, 1.5.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- orocos-kdl: new, 1.5.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit orocos-kdl pykdl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
