### PR TITLE
mypy Survey 20251003

### DIFF
--- a/lang-python/flit-core/autobuild/defines
+++ b/lang-python/flit-core/autobuild/defines
@@ -7,4 +7,4 @@ PKGDES="Distribution-building parts of Flit."
 ABTYPE=pep517
 ABHOST=noarch
 NOPYTHON2=1
-PKGREP="flit<=3.7.1-1"
+PKGREP="flit<=3.9.0"

--- a/lang-python/flit-core/spec
+++ b/lang-python/flit-core/spec
@@ -1,4 +1,4 @@
-VER=3.9.0
+VER=3.12.0
 SRCS="git::commit=$VER;rename=flit::https://github.com/pypa/flit.git"
 CHKSUMS="SKIP"
 SUBDIR="flit/flit_core"

--- a/lang-python/flit/autobuild/defines
+++ b/lang-python/flit/autobuild/defines
@@ -7,4 +7,4 @@ PKGDES="A tool for packaging Python PEP-517 modules"
 ABTYPE=pep517
 ABHOST=noarch
 NOPYTHON2=1
-PKGREP="flit<=3.7.1-1"
+PKGREP="flit<=3.9.0"

--- a/lang-python/flit/spec
+++ b/lang-python/flit/spec
@@ -1,4 +1,4 @@
-VER=3.9.0
+VER=3.12.0
 SRCS="git::commit=$VER::https://github.com/pypa/flit.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=44865"

--- a/lang-python/mypy-extensions/autobuild/defines
+++ b/lang-python/mypy-extensions/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=mypy-extensions
+PKGSEC=python
+PKGDEP="python-3 types-psutil types-setuptools flit-core"
+BUILDDEP="setuptools"
+PKGDES="Extensions for mypy"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/mypy-extensions/spec
+++ b/lang-python/mypy-extensions/spec
@@ -1,0 +1,4 @@
+VER=1.1.0
+SRCS="git::commit=tags/$VER::https://github.com/python/mypy_extensions"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=23367"

--- a/lang-python/mypy/autobuild/defines
+++ b/lang-python/mypy/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=mypy
+PKGSEC=python
+PKGDEP="python-3 pathspec types-psutil types-setuptools mypy-extensions"
+BUILDDEP="setuptools"
+PKGDES="Optional static typing for Python"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/mypy/spec
+++ b/lang-python/mypy/spec
@@ -1,0 +1,4 @@
+VER=1.18.2
+SRCS="git::commit=tags/v$VER::https://github.com/python/mypy"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=8453"

--- a/lang-python/types-psutil/autobuild/defines
+++ b/lang-python/types-psutil/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=types-psutil
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Typing stubs for psutil"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/types-psutil/spec
+++ b/lang-python/types-psutil/spec
@@ -1,0 +1,4 @@
+VER=7.0.0.20251001
+SRCS="pypi::version=$VER::types-psutil"
+CHKSUMS="sha256::60d696200ddae28677e7d88cdebd6e960294e85adefbaafe0f6e5d0e7b4c1963"
+CHKUPDATE="anitya::id=221807"

--- a/lang-python/types-setuptools/autobuild/defines
+++ b/lang-python/types-setuptools/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=types-setuptools
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Typing stubs for setuptools"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/types-setuptools/spec
+++ b/lang-python/types-setuptools/spec
@@ -1,0 +1,4 @@
+VER=80.9.0.20250822
+SRCS="pypi::version=$VER::types-setuptools"
+CHKSUMS="sha256::070ea7716968ec67a84c7f7768d9952ff24d28b65b6594797a464f1b3066f965"
+CHKUPDATE="anitya::id=214295"


### PR DESCRIPTION
Topic Description
-----------------

- mypy: new, 1.18.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- mypy-extensions: new, 1.1.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- types-setuptools: new, 80.9.0.20250822
    Signed-off-by: stydxm <stydxm@outlook.com>
- types-psutil: new, 7.0.0.20251001
    Signed-off-by: stydxm <stydxm@outlook.com>
- flit: update to 3.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- flit-core: update to 3.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit flit-core flit types-psutil types-setuptools mypy-extensions mypy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
