### PR TITLE
i7z: fix build errors

### DIFF
--- a/app-utils/i7z/autobuild/patches/0004-Debian-use-stdbool.patch
+++ b/app-utils/i7z/autobuild/patches/0004-Debian-use-stdbool.patch
@@ -1,0 +1,40 @@
+Author: Andreas Beckmann <anbe@debian.org>
+Description: use a consistent bool type
+Bug-Debian: #749724
+
+--- a/i7z.h
++++ b/i7z.h
+@@ -11,18 +11,13 @@
+  * ----------------------------------------------------------------------- */
+ 
+ #include <sys/time.h>
++#include <stdbool.h>
+ 
+ #define i7z_VERSION_INFO "svn-r93-(27-MAY-2013)"
+ 
+ //structure to store the information about the processor
+ #define proccpuinfo "/proc/cpuinfo"
+ 
+-#ifndef bool
+-#define bool int
+-#endif
+-#define false 0
+-#define true 1
+-
+ #define MAX_PROCESSORS  128
+ #define MAX_HI_PROCESSORS    MAX_PROCESSORS
+ #define MAX_SK_PROCESSORS    (MAX_PROCESSORS/4)
+--- a/cpuinfo.c
++++ b/cpuinfo.c
+@@ -2,10 +2,8 @@
+ #include "string.h"
+ #include "stdlib.h"
+ #include "assert.h"
++#include <stdbool.h>
+ #define MAX_PROCESSORS  32
+-#define bool int
+-#define false 0
+-#define true 1
+ 
+ #define MAX_HI_PROCESSORS    MAX_PROCESSORS
+ 

--- a/app-utils/i7z/autobuild/patches/0006-Debian-fix-cpuid-asm.patch
+++ b/app-utils/i7z/autobuild/patches/0006-Debian-fix-cpuid-asm.patch
@@ -1,0 +1,21 @@
+Author: Andreas Beckmann <anbe@debian.org>
+Description: fix cpuid inline assembly
+ the old code zeroed the upper half of %rbx
+
+--- a/helper_functions.c
++++ b/helper_functions.c
+@@ -101,13 +101,7 @@ static inline void cpuid (unsigned int i
+                           unsigned int *ecx, unsigned int *edx)
+ {
+     unsigned int _eax = info, _ebx, _ecx, _edx;
+-    asm volatile ("mov %%ebx, %%edi;" // save ebx (for PIC)
+-                  "cpuid;"
+-                  "mov %%ebx, %%esi;" // pass to caller
+-                  "mov %%edi, %%ebx;" // restore ebx
+-                  :"+a" (_eax), "=S" (_ebx), "=c" (_ecx), "=d" (_edx)
+-                  :      /* inputs: eax is handled above */
+-                  :"edi" /* clobbers: we hit edi directly */);
++    asm volatile ("cpuid\n\t" : "+a" (_eax), "=b" (_ebx), "=c" (_ecx), "=d" (_edx) : : );
+     if (eax) *eax = _eax;
+     if (ebx) *ebx = _ebx;
+     if (ecx) *ecx = _ecx;

--- a/app-utils/i7z/autobuild/patches/0007-Debian-nehalem.patch
+++ b/app-utils/i7z/autobuild/patches/0007-Debian-nehalem.patch
@@ -1,0 +1,15 @@
+Author: Andreas Beckmann <anbe@debian.org>
+Description: fix some nehalem detected as haswell, too
+Bug-Debian: https://bugs.debian.org/856806
+
+--- a/helper_functions.c
++++ b/helper_functions.c
+@@ -420,7 +420,7 @@ void Print_Information_Processor(bool* n
+    	    *nehalem = true;
+ 	    *sandy_bridge = false;
+ 	    *ivy_bridge = false;
+-	    *haswell = true;
++	    *haswell = false;
+ 
+         } else if (proc_info.extended_model == 0x2) {
+             switch (proc_info.model)

--- a/app-utils/i7z/autobuild/patches/0009-Debian-gcc-10.patch
+++ b/app-utils/i7z/autobuild/patches/0009-Debian-gcc-10.patch
@@ -1,0 +1,17 @@
+Author: Andreas Beckmann <anbe@debian.org>
+Description: fix FTBFS with gcc-10
+ gcc-10 defaults to -fno-common
+ see https://gcc.gnu.org/gcc-10/porting_to.html
+Bug-Debian: https://bugs.debian.org/957351
+
+--- a/i7z_Dual_Socket.c
++++ b/i7z_Dual_Socket.c
+@@ -37,7 +37,7 @@ float Read_Voltage_CPU(int cpu_num);
+ extern struct program_options prog_options;
+ FILE *fp_log_file;
+ 
+-struct timespec global_ts;
++extern struct timespec global_ts;
+ extern FILE *fp_log_file_freq_1, *fp_log_file_freq_2;
+ 
+ extern char* CPU_FREQUENCY_LOGGING_FILE_single;

--- a/app-utils/i7z/spec
+++ b/app-utils/i7z/spec
@@ -1,4 +1,5 @@
 VER=20131012
+REL=1
 SRCS="git::commit=5023138d7c35c4667c938b853e5ea89737334e92::https://github.com/ajaiantilal/i7z"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231592"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Fix type ‘int’ should match type ‘_Bool’.
- Fix multiple definition of `global_ts'.
- Introduce other useful Debian patches.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- i7z: 20131012
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit i7z
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
