### PR TITLE
psiconv: fix 'fileformat_list' multiple definition

### DIFF
--- a/app-utils/psiconv/autobuild/patches/0001-fix-fileformat_list-multiple-definition.patch
+++ b/app-utils/psiconv/autobuild/patches/0001-fix-fileformat_list-multiple-definition.patch
@@ -1,0 +1,38 @@
+From ec66834d3b1f3fd7ada822d172d5268d0c5f9274 Mon Sep 17 00:00:00 2001
+From: pch666777 <1005100717@qq.com>
+Date: Sat, 4 Oct 2025 09:28:54 +0800
+Subject: [PATCH] fix 'fileformat_list' multiple definition
+
+---
+ program/psiconv/psiconv.c | 1 +
+ program/psiconv/psiconv.h | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/program/psiconv/psiconv.c b/program/psiconv/psiconv.c
+index b73b901..aa1e9bb 100644
+--- a/program/psiconv/psiconv.c
++++ b/program/psiconv/psiconv.c
+@@ -44,6 +44,7 @@
+ #include "psiconv.h"
+ #include "gen.h"
+ 
++psiconv_list fileformat_list;
+ static void print_help(void);
+ static void print_version(void);
+ static void strtoupper(char *str);
+diff --git a/program/psiconv/psiconv.h b/program/psiconv/psiconv.h
+index 1ec0a7e..68b7dc7 100644
+--- a/program/psiconv/psiconv.h
++++ b/program/psiconv/psiconv.h
+@@ -52,7 +52,7 @@ typedef struct fileformat_s {
+   output_function *output;
+ } *fileformat;
+ 
+-psiconv_list fileformat_list; /* of struct psiconv_fileformat */
++extern psiconv_list fileformat_list; /* of struct psiconv_fileformat */
+ 
+ 
+ #endif /* PSICONV_H */
+-- 
+2.51.0
+

--- a/app-utils/psiconv/spec
+++ b/app-utils/psiconv/spec
@@ -1,5 +1,5 @@
 VER=0.9.9
-REL=5
+REL=6
 SRCS="tbl::http://www.frodo.looijaard.name/system/files/software/psiconv/psiconv-$VER.tar.gz"
 CHKSUMS="sha256::6d51fe79b502a1e277bea275a574ae2db5b1b9d7daef703a8fa3635ae02a8bb0"
 CHKUPDATE="anitya::id=231638"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- psiconv: fix 'fileformat_list' multiple definition.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- psiconv: 0.9.9-5
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit psiconv
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
