### PR TITLE
editorconfig-core-c: update to 0.12.10

### DIFF
--- a/runtime-editors/editorconfig-core-c/spec
+++ b/runtime-editors/editorconfig-core-c/spec
@@ -1,4 +1,4 @@
-VER=0.12.9
+VER=0.12.10
 SRCS="git::commit=tags/v$VER::https://github.com/editorconfig/editorconfig-core-c"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14833"


### PR DESCRIPTION
Topic Description
-----------------

- editorconfig-core-c: update to 0.12.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- editorconfig-core-c: 0.12.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit editorconfig-core-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
