### PR TITLE
NVIDIA Drivers + CUDA Toolkit 580.95.05

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=13.0.0
-MIN_DRIVER_VER=580.65.06
+UPSTREAM_VER=13.0.1
+MIN_DRIVER_VER=580.82.07
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::c64969f35ad99bf3f9e8acb8e3d22355150c6ca07acc16a853778600a9b65ba6"
+CHKSUMS__AMD64="sha256::4c7ac59d1f41d67be27d140a4622801738ad71088570a0facfd6ec878a4c4100"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::d956c956d0aef7270f26e6d8a9dbb2aeb3bd0d2214195c0e0e230a4cd37ff3d2"
+CHKSUMS__ARM64="sha256::927e2c2a6a3e0d12e7e93df10dad6d8f3c688b9e27e9d2034f82d437ec2d2666"

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,4 +1,4 @@
-VER=580.82.07
+VER=580.95.05
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=580.82.07
+VER=580.95.05
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::061e48e11fe552232095811d0b1cea9b718ba2540d605074ff227fce0628798c"
+CHKSUMS__AMD64="sha256::849ef0ef8e842b9806b2cde9f11c1303d54f1a9a769467e4e5d961b2fe1182a7"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::a2bdfffda5784d070f0e070bc4507be47fe407c9fedd1cf04ced42d996c90092"
+CHKSUMS__ARM64="sha256::ccb4426e98a29367c60daf9df34c2a577655d54d5be25463ccd409b0b2e52029"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 13.0.1+580.82.07
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-open: update to 580.95.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: update to 580.95.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cuda: 13.0.1+580.82.07
- nvidia: 580.95.05
- nvidia-firmware: 580.95.05
- nvidia-open: 580.95.05
- nvidia-utils: 580.95.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
