### PR TITLE
run-scaled: transitionalise => xpra

### DIFF
--- a/app-network/xpra/autobuild/defines
+++ b/app-network/xpra/autobuild/defines
@@ -5,4 +5,8 @@ PKGDEP="cryptography dbus-python ffmpeg libvpx netifaces numpy pillow gtk-3 \
 BUILDDEP="cython setuptools"
 PKGDES="An open-source multi-platform persistent remote display server and client"
 
+ABTYPE=pep517
 NOPYTHON2=1
+
+PKGBREAK="run-scaled<=20180603"
+PKGREP="run-scaled<=20180603"

--- a/app-network/xpra/autobuild/prepare
+++ b/app-network/xpra/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CFLAGS} -fno-strict-aliasing -Wno-error=strict-prototypes -Wno-error=deprecated-declarations"

--- a/app-network/xpra/spec
+++ b/app-network/xpra/spec
@@ -1,4 +1,4 @@
-VER=6.3
+VER=6.3.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/Xpra-org/xpra"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5445"

--- a/runtime-display/run-scaled/autobuild/build
+++ b/runtime-display/run-scaled/autobuild/build
@@ -1,2 +1,0 @@
-mkdir -p "$PKGDIR"/usr/bin
-cp -v run_scaled "$PKGDIR"/usr/bin/

--- a/runtime-display/run-scaled/autobuild/defines
+++ b/runtime-display/run-scaled/autobuild/defines
@@ -1,4 +1,7 @@
 PKGNAME=run-scaled
 PKGSEC=x11
-PKGDEP="xpra xorg-server bc"
-PKGDES="A script that uses xpra to scale X11 applications for HIDPI display"
+PKGDEP="xpra"
+PKGDES="Scaling for X11 applications on HiDPI display (transitional package for xpra)"
+
+ABTYPE=dummy
+ABHOST=noarch

--- a/runtime-display/run-scaled/spec
+++ b/runtime-display/run-scaled/spec
@@ -1,4 +1,3 @@
-VER=20180603
-SRCS="git::commit=fa71b3c17e627a96ff707ad69f1def5361f2245c::https://github.com/kaueraal/run_scaled"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=231986"
+EPOCH=1
+VER=0
+DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- xpra: update to 6.3.3
    - Drop unused prepare script.
- run-scaled: transitionalise => xpra

Package(s) Affected
-------------------

- run-scaled: 0
- xpra: 6.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit run-scaled:-pkgbreak xpra run-scaled
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
