### PR TITLE
v2ray-rules-dat: update to 202510042211

### DIFF
--- a/runtime-data/v2ray-rules-dat/spec
+++ b/runtime-data/v2ray-rules-dat/spec
@@ -1,6 +1,6 @@
-VER=202508312212
+VER=202510042211
 SRCS="file::rename=geoip.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geoip.dat \
       file::rename=geosite.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geosite.dat"
-CHKSUMS="sha256::a663a7af78e587523d257cf9d4eafa6f0cd5fb4d5fbfdb62d014ffb86f341bac \
-         sha256::276bc29ab6140f469a08e3125f9ff15e8e5242f301c2912677a49f68238bbf26"
+CHKSUMS="sha256::ac108c8f3f110df9ef67af07709f2a26599b4ce20570e6ae51cf82ccb495e0ed \
+         sha256::14b26c48c512c664171fb2e46a4b60f6c28f22afff81f4c2a655e10c5701176b"
 CHKUPDATE="anitya::id=375331"


### PR DESCRIPTION
Topic Description
-----------------

- v2ray-rules-dat: update to 202510042211
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- v2ray-rules-dat: 202510042211

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2ray-rules-dat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
