### PR TITLE
numix-icon-theme: update to 25.10.04.2

### DIFF
--- a/desktop-themes/numix-icon-theme/spec
+++ b/desktop-themes/numix-icon-theme/spec
@@ -1,4 +1,4 @@
-VER=24.09.18
+VER=25.10.04.2
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/numixproject/numix-icon-theme.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10909"


### PR DESCRIPTION
Topic Description
-----------------

- numix-icon-theme: update to 25.10.04.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- numix-icon-theme: 1:25.10.04.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit numix-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
