### PR TITLE
asymptote: update to 3.05

### DIFF
--- a/app-doc/asymptote/autobuild/beyond
+++ b/app-doc/asymptote/autobuild/beyond
@@ -1,0 +1,12 @@
+abinfo "Installing Emacs and Vim syntax files ..."
+install -Dvm644 "$PKGDIR"/usr/share/asymptote/*.el \
+    -t "$PKGDIR"/usr/share/emacs/site-lisp/
+install -Dvm644 "$PKGDIR"/usr/share/asymptote/*.vim \
+    -t "$PKGDIR"/usr/share/vim/vimfiles/syntax/
+
+abinfo "Fixing xasy symlink ..."
+rm -v "$PKGDIR"/usr/bin/xasy
+ln -sv ../share/asymptote/GUI/xasy.py "$PKGDIR"/usr/bin/xasy
+
+abinfo "Dropping docs ..."
+rm -rv "$PKGDIR"/usr/tmp_doc

--- a/app-doc/asymptote/autobuild/defines
+++ b/app-doc/asymptote/autobuild/defines
@@ -1,12 +1,21 @@
 PKGNAME=asymptote
 PKGSEC=tex
-PKGDEP="texlive freeglut glu gsl fftw pillow tix glew ghostscript imagemagick"
-BUILDDEP="glm emacs"
-PKGDES="A vector graphics language"
+PKGDEP="boost curl fftw freeglut gcc-runtime ghostscript glibc gsl libsigsegv \
+        libtirpc ncurses pycson pyqt5 texlive readline zlib"
+BUILDDEP="eigen-3 imagemagick glm"
+PKGDES="Descriptive vector graphics language for technical drawing"
 
-AUTOTOOLS_AFTER="--enable-gc=/usr \
-                 --with-latex=/usr/share/texmf/tex/latex \
-                 --with-context=/usr/share/texmf/tex/context \
-                 --enable-offscreen"
-ABMK="all"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--enable-offscreen'
+    '--enable-gc=/usr'
+    '--with-docdir=/usr/tmp_doc' # No option to disable document generation, drop it later.
+    '--with-latex=/usr/share/texmf/tex/latex'
+    '--with-context=/usr/share/texmf/tex/context'
+)
+
+# FIXME: pdflatex fails to build documentation, likely due to race condition.
+NOPARALLEL=1
+
+# FIXME: make: *** No rule to make target 'Makefile.in', needed by 'Makefile'.  Stop.
 ABSHADOW=0

--- a/app-doc/asymptote/autobuild/prepare
+++ b/app-doc/asymptote/autobuild/prepare
@@ -1,2 +1,0 @@
-export LDFLAGS="${LDFLAGS} -lgccpp"
-autoreconf -fi

--- a/app-doc/asymptote/spec
+++ b/app-doc/asymptote/spec
@@ -1,5 +1,4 @@
-VER=2.47
-REL=1
-SRCS="tbl::https://downloads.sourceforge.net/sourceforge/asymptote/asymptote-$VER.src.tgz"
-CHKSUMS="sha256::e1a4e5a36f87f62986f86bc4cff5ae922c8aa71bd3e17b5975ad7fbe8525827d"
+VER=3.05
+SRCS="tbl::https://sourceforge.net/projects/asymptote/files/$VER/asymptote-$VER.src.tgz/download"
+CHKSUMS="sha256::35c16d0a3bdd869a56e4efff4638f81c3a88b2f6b664d196471015dbf4c69a87"
 CHKUPDATE="anitya::id=125"

--- a/lang-python/pycson/autobuild/defines
+++ b/lang-python/pycson/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pycson
+PKGSEC=python
+PKGDEP="python-3 speg"
+BUILDDEP="setuptools"
+PKGDES="Python parser for Coffeescript Object Notation"
+
+ABTYPE=python
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pycson/spec
+++ b/lang-python/pycson/spec
@@ -1,0 +1,4 @@
+VER=0.8
+SRCS="pypi::version=$VER::cson"
+CHKSUMS="sha256::ee8c0166fcd1f51789887197e3e8354ac7befa396fc29706bceb5af25edc9e01"
+CHKUPDATE="anitya::id=19808"

--- a/lang-python/speg/autobuild/defines
+++ b/lang-python/speg/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=speg
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="PEG-based parser interpreter with memoization"
+
+ABTYPE=python
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/speg/spec
+++ b/lang-python/speg/spec
@@ -1,0 +1,4 @@
+VER=0.3
+SRCS="pypi::version=$VER::speg"
+CHKSUMS="sha256::10cbef47e168dfc62f14db575cf1c428037a2b881cee6c3cfceda0439c243e71"
+CHKUPDATE="anitya::id=19634"


### PR DESCRIPTION
Topic Description
-----------------

- speg: new, 0.3
- pycson: new, 0.8
- asymptote: update to 3.05
    - Drop unused prepare script.
    - Improve defines script.
    - Adjust PKGDEP and BUILDDEP.
    - Drop docs.

Package(s) Affected
-------------------

- asymptote: 3.05
- pycson: 0.8
- speg: 0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit speg pycson asymptote
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
