### PR TITLE
ast-grep: update to 0.39.6

### DIFF
--- a/app-devel/ast-grep/autobuild/beyond
+++ b/app-devel/ast-grep/autobuild/beyond
@@ -1,10 +1,21 @@
 abinfo "Setting asg as ast-grep symlink ..."
 ln -sv ast-grep "$PKGDIR"/usr/bin/asg
 
-abinfo "Removing xtask binary ..."
-rm -fv "$PKGDIR"/usr/bin/xtask
+abinfo "Generating shell completions ..."
+for i in bash fish zsh; do
+    "$PKGDIR"/usr/bin/ast-grep completions $i \
+        > "$SRCDIR"/ast-grep.$i
+    "$PKGDIR"/usr/bin/asg completions $i \
+        > "$SRCDIR"/asg.$i
+done
 
-abinfo "Installing completions ..."
+abinfo "Installing shell completions ..."
 mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions
-"$PKGDIR"/usr/bin/ast-grep completions > "$PKGDIR"/usr/share/bash-completion/completions/ast-grep
-"$PKGDIR"/usr/bin/asg completions > "$PKGDIR"/usr/share/bash-completion/completions/asg
+for i in ast-grep asg; do
+    install -Dvm644 "$SRCDIR"/${i}.bash \
+        "$PKGDIR"/usr/share/bash-completion/completions/${i}
+    install -Dvm644 "$SRCDIR"/${i}.fish \
+        "$PKGDIR"/usr/share/fish/vendor_completions.d/${i}.fish
+    install -Dvm644 "$SRCDIR"/${i}.zsh \
+        "$PKGDIR"/usr/share/zsh/site-functions/_${i}
+done

--- a/app-devel/ast-grep/spec
+++ b/app-devel/ast-grep/spec
@@ -1,4 +1,4 @@
-VER=0.38.2
+VER=0.39.6
 SRCS="git::commit=tags/$VER::https://github.com/ast-grep/ast-grep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=361439"


### PR DESCRIPTION
Topic Description
-----------------

- ast-grep: update to 0.39.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ast-grep: 0.39.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit ast-grep
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
