### PR TITLE
incus: update to 6.17.0

### DIFF
--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,5 +1,4 @@
-VER=6.15.0
-REL=1
+VER=6.17.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"


### PR DESCRIPTION
Topic Description
-----------------

- incus: update to 6.17.0
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- incus: 6.17.0
- incus-agent: 6.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
