### PR TITLE
ctags: update to 6.2.20251005.0

### DIFF
--- a/app-devel/ctags/autobuild/defines
+++ b/app-devel/ctags/autobuild/defines
@@ -3,5 +3,6 @@ PKGSEC=devel
 PKGDEP="aspell jansson libseccomp libxml2 yaml"
 PKGDES="Generates an index file of language objects found in source files"
 
-AUTOTOOLS_AFTER="--disable-external-sort"
-ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--disable-external-sort'
+)

--- a/app-devel/ctags/spec
+++ b/app-devel/ctags/spec
@@ -1,5 +1,5 @@
-VER=20191203
-REL=1
-SRCS=git::commit=2ebf5b1bed1f8ce2f2cccec66e613cd33bcee571::https://github.com/universal-ctags/ctags
+VER=6.2.20251005.0
+EPOCH=1
+SRCS="git::commit=tags/p${VER}::https://github.com/universal-ctags/ctags"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=223832"


### PR DESCRIPTION
Topic Description
-----------------

- ctags: update to 6.2.20251005.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ctags: 6.2.20251005.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ctags
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
