### PR TITLE
adguardhome: new, 0.107.67

### DIFF
--- a/app-web/adguardhome/autobuild/defines
+++ b/app-web/adguardhome/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=adguardhome
+PKGSEC=web
+PKGDES="Network-level advertisement and tracker blocking DNS server"
+PKGDEP="glibc"
+BUILDDEP="go nodejs"
+ABTYPE=gomod

--- a/app-web/adguardhome/autobuild/defines
+++ b/app-web/adguardhome/autobuild/defines
@@ -4,3 +4,7 @@ PKGDES="Network-level advertisement and tracker blocking DNS server"
 PKGDEP="glibc"
 BUILDDEP="go nodejs"
 ABTYPE=gomod
+# FIXME: Build fails due to SV39 limitation on SG2042 build hosts.
+#
+# RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
+FAIL_ARCH="riscv64"

--- a/app-web/adguardhome/autobuild/overrides/usr/lib/systemd/system/adguardhome.service
+++ b/app-web/adguardhome/autobuild/overrides/usr/lib/systemd/system/adguardhome.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Network-level advertisement and tracker blocking DNS server
+After=syslog.target network-online.target
+
+[Service]
+DynamicUser=true
+StateDirectory=adguardhome
+WorkingDirectory=/var/lib/adguardhome
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+ExecStart=/usr/bin/AdGuardHome -w /var/lib/adguardhome -l syslog
+
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+NoNewPrivileges=true
+MemoryDenyWriteExecute=true
+LockPersonality=true
+ProtectHostname=true
+
+[Install]
+WantedBy=multi-user.target

--- a/app-web/adguardhome/autobuild/prepare
+++ b/app-web/adguardhome/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Installing NPM dependencies ..."
+npm --prefix client ci
+abinfo "Building static assets ..."
+npm --prefix client run build-prod

--- a/app-web/adguardhome/spec
+++ b/app-web/adguardhome/spec
@@ -1,0 +1,4 @@
+VER=0.107.67
+SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=301521"


### PR DESCRIPTION
Topic Description
-----------------

- adguardhome: new

Package(s) Affected
-------------------

- adguardhome: 0.107.67

Security Update?
----------------

No

Build Order
-----------

```
#buildit adguardhome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
