### PR TITLE
polymake: update to 4.15

### DIFF
--- a/app-scientific/gf2x/autobuild/defines
+++ b/app-scientific/gf2x/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=gf2x
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="Routines for fast arithmetic in GF(2)[x]"
-PKGEPOCH=1
+PKGDES="Routines for arithmetic in GF(2)[x]"
 
-AUTOTOOLS_AFTER__AMD64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-sse2 \
-                 --disable-pclmul"
+AUTOTOOLS_AFTER__AMD64=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--enable-sse2'
+    '--disable-pclmul'
+)

--- a/app-scientific/gf2x/autobuild/patches/0002-UPSTREAM-this-unconditional-x86_sse2-is-most-probabl.patch
+++ b/app-scientific/gf2x/autobuild/patches/0002-UPSTREAM-this-unconditional-x86_sse2-is-most-probabl.patch
@@ -1,0 +1,32 @@
+From 68738619afaae60a048b12c680db5abb2e17a234 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Emmanuel=20Thom=C3=A9?= <Emmanuel.Thome@inria.fr>
+Date: Wed, 17 Nov 2021 23:47:59 -0800
+Subject: [PATCH 2/2] UPSTREAM: this unconditional x86_sse2 is most probably
+ incorrect
+
+Link: https://gitlab.inria.fr/gf2x/gf2x/-/commit/d1b391dfe88e98451c8bffb346129b993cb6e2de
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ configure.ac | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5316218..dc623f4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -200,7 +200,11 @@ if test x$hwdir = x ; then
+         if test "$gf2x_cv_cc_supports_sse2" = "no" ; then
+          hwdir=generic$gf2x_wordsize
+         else
+-         hwdir=x86_sse2
++         if test "$gf2x_cv_cc_supports_sse2" = "no" ; then
++          hwdir=generic32
++         else
++          hwdir=x86_sse2
++         fi
+         fi;;
+       *)
+        AC_MSG_ERROR([The default ABI for this compiler has $gf2x_wordsize-bit unsigned longs, this is not supported])
+-- 
+2.51.0
+

--- a/app-scientific/gf2x/spec
+++ b/app-scientific/gf2x/spec
@@ -1,5 +1,6 @@
 VER=1.3.0
-REL=1
+REL=2
+EPOCH=1
 SRCS="git::commit=tags/gf2x-$VER::https://gitlab.inria.fr/gf2x/gf2x"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6340"

--- a/app-scientific/normaliz/autobuild/defines
+++ b/app-scientific/normaliz/autobuild/defines
@@ -2,6 +2,10 @@ PKGNAME=normaliz
 PKGSEC=math
 PKGDEP="gmp"
 BUILDDEP="boost"
-PKGDES="A tool for computations in affine monoids, vector configurations, lattice polytopes, and rational cones"
+PKGDES="Tool to compute affine monoids, vector configurations, lattice polytopes, and rational cones"
 
 AB_FLAGS_O3=1
+
+AUTOTOOLS_AFTER=(
+    '--enable-openmp'
+)

--- a/app-scientific/normaliz/spec
+++ b/app-scientific/normaliz/spec
@@ -1,5 +1,4 @@
-VER=3.6.3
-REL=2
+VER=3.10.5
 SRCS="tbl::https://github.com/Normaliz/Normaliz/releases/download/v$VER/normaliz-$VER.tar.gz"
-CHKSUMS="sha256::701b39189758eb9a13e189ea1a43218e1c001f19c228e761a80949d610fe3900"
+CHKSUMS="sha256::58492cfbfebb2ee5702969a03c3c73a2cebcbca2262823416ca36e7b77356a44"
 CHKUPDATE="anitya::id=7722"

--- a/app-scientific/polymake/autobuild/build
+++ b/app-scientific/polymake/autobuild/build
@@ -1,3 +1,11 @@
-./configure --prefix=/usr
+abinfo "Configuring polymake ..."
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    "${AUTOTOOLS_AFTER[@]}"
+
+abinfo "Building polymake ..."
 make
-make install DESTDIR="$PKGDIR"
+
+abinfo "Installing polymake ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/app-scientific/polymake/autobuild/defines
+++ b/app-scientific/polymake/autobuild/defines
@@ -1,13 +1,34 @@
 PKGNAME=polymake
 PKGSEC=math
-PKGDEP="gmp openjdk perl-term-readline-gnu perl-xml-libxml \
-        perl-xml-libxslt perl-xml-writer ppl singular perl-json"
-BUILDDEP="apache-ant bliss-graphs boost cddlib lrs normaliz"
-PKGDES="Open source software for research in polyhedral geometry"
+PKGDEP="cddlib flint gmp lrs normaliz openjdk perl-json \
+        perl-term-readline-gnu perl-xml-libxml perl-xml-libxslt \
+        perl-xml-writer ppl singular"
+BUILDDEP="apache-ant bliss-graphs boost"
+PKGDES="Tool to aid research on polyhedral geometry"
 
 AB_FLAGS_O3=1
-AB_FLAGS_SPECS=0
-NOLTO=1
-ABSHADOW=no
 
-AUTOTOOLS_AFTER="--with-singular=/usr"
+# Note:
+#
+#    --with-libcxx	build against the libc++ library instead of the GNU libstdc++, useful when
+#			building with LLVM/Clang. (sets -stdlib=libc++, -lc++ and -lc++abi)
+#			see also --with-toolchain when using a custom LLVM installation
+#
+#  --without-native	build without "-march=native" flag to allow execution on different CPU types
+#			(passing one of -m{cpu,arch,tune} via CFLAGS or CXXFLAGS also disables "-march=native")
+AUTOTOOLS_AFTER=(
+    '--with-bliss=/usr'
+    '--with-cdd=/usr'
+    '--with-flint=/usr'
+    '--with-lrs=/usr'
+    '--with-libnormaliz=/usr'
+    '--with-singular=/usr'
+    '--without-libcxx'
+    '--with-callable'
+    '--with-prereq'
+    '--with-openmp'
+    '--without-native'
+)
+
+# Note: Not a genuine GNU Autotools source.
+ABTYPE=self

--- a/app-scientific/polymake/autobuild/prepare
+++ b/app-scientific/polymake/autobuild/prepare
@@ -1,1 +1,0 @@
-rm -rf bundled/singular/

--- a/app-scientific/polymake/spec
+++ b/app-scientific/polymake/spec
@@ -1,5 +1,4 @@
-VER=3.3
+VER=4.15
 SRCS="tbl::https://polymake.org/lib/exe/fetch.php/download/polymake-$VER-minimal.tar.bz2"
-CHKSUMS="sha256::f7867137f99d5e8b86035ba05b59a63c5b73a95b21b88059fd2439216c128792"
-REL=3
+CHKSUMS="sha256::30e0a8f89013cf7a9a44ed90db2f69c49bf181050664c7e6bdb861c610b1bdb9"
 CHKUPDATE="anitya::id=7783"

--- a/app-scientific/singular/autobuild/defines
+++ b/app-scientific/singular/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=singular
 PKGSEC=math
-PKGDEP="cddlib flint python-2"
-BUILDDEP="doxygen"
+PKGDEP="cddlib flint"
 PKGDES="Computer Algebra System for polynomial computations"
 
 AB_FLAGS_O3=1
+
+# Note: Multi-level Autotools source with pre-determined options.
 AUTOTOOLS_STRICT=0

--- a/app-scientific/singular/autobuild/patches/0001-UPSTREAM-Use-fq_nmod_mat_entry-instead-of-row-pointe.patch
+++ b/app-scientific/singular/autobuild/patches/0001-UPSTREAM-Use-fq_nmod_mat_entry-instead-of-row-pointe.patch
@@ -1,0 +1,30 @@
+From 2c48cfc4c398569b4873a7efa68f2aafd9af97d1 Mon Sep 17 00:00:00 2001
+From: Doug Torrance <dtorrance@piedmont.edu>
+Date: Sat, 14 Jun 2025 10:45:30 -0400
+Subject: [PATCH 1/2] UPSTREAM: Use fq_nmod_mat_entry instead of row pointer
+ (removed in flint 3.3.0) (#1278)
+
+fixes #1279
+
+Signed-off-by: Doug Torrance <dtorrance@piedmont.edu>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ factory/FLINTconvert.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/factory/FLINTconvert.cc b/factory/FLINTconvert.cc
+index c36f6022d..a4d86fd17 100644
+--- a/factory/FLINTconvert.cc
++++ b/factory/FLINTconvert.cc
+@@ -652,7 +652,7 @@ convertFacCFMatrix2Fq_nmod_mat_t (fq_nmod_mat_t M,
+   {
+     for(j=m.columns();j>0;j--)
+     {
+-      convertFacCF2nmod_poly_t (M->rows[i-1]+j-1, m (i,j));
++      convertFacCF2nmod_poly_t (fq_nmod_mat_entry(M, i-1, j-1), m (i,j));
+     }
+   }
+ }
+-- 
+2.51.0
+

--- a/app-scientific/singular/autobuild/patches/0002-UPSTREAM-Use-fq_nmod_mat_entry-instead-of-row-pointe.patch
+++ b/app-scientific/singular/autobuild/patches/0002-UPSTREAM-Use-fq_nmod_mat_entry-instead-of-row-pointe.patch
@@ -1,0 +1,28 @@
+From cc4a9399837cf387f2aae28ae8737b0b0947c13b Mon Sep 17 00:00:00 2001
+From: Weijia Wang <9713184+wegank@users.noreply.github.com>
+Date: Sun, 15 Jun 2025 16:14:09 +0200
+Subject: [PATCH 2/2] UPSTREAM: Use fq_nmod_mat_entry instead of row pointer
+ (take 2) (#1280)
+
+Signed-off-by: Weijia Wang <9713184+wegank@users.noreply.github.com>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libpolys/polys/flintconv.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libpolys/polys/flintconv.cc b/libpolys/polys/flintconv.cc
+index 89152f5e4..277a62bf1 100644
+--- a/libpolys/polys/flintconv.cc
++++ b/libpolys/polys/flintconv.cc
+@@ -331,7 +331,7 @@ void convSingMFlintFq_nmod_mat(matrix m, fq_nmod_mat_t M, const fq_nmod_ctx_t fq
+   {
+     for(j=MATCOLS(m);j>0;j--)
+     {
+-      convSingPFlintnmod_poly_t (M->rows[i-1]+j-1, MATELEM(m,i,j),r);
++      convSingPFlintnmod_poly_t (fq_nmod_mat_entry(M, i-1, j-1), MATELEM(m,i,j),r);
+     }
+   }
+ }
+-- 
+2.51.0
+

--- a/app-scientific/singular/spec
+++ b/app-scientific/singular/spec
@@ -1,6 +1,5 @@
-VER=4.1.1
-REL=4
-MAJOR=${VER%%p*}
-SRCS="https://repo.aosc.io/aosc-repacks/singular-$VER.tar.gz"
-CHKSUMS="sha256::3792c5707b60c1748298bf47e2277de20303d60563b797372cc0e1eff4bbc583"
+UPSTREAM_VER=4-4-1
+VER=${UPSTREAM_VER//-/.}
+SRCS="git::commit=tags/Release-${UPSTREAM_VER}::https://github.com/Singular/Singular"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20569"

--- a/runtime-scientific/ppl/autobuild/defines
+++ b/runtime-scientific/ppl/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=ppl
 PKGSEC=libs
 PKGDEP="gmp"
-PKGDES="A modern library for convex polyhedra and other numerical abstractions"
+PKGDES="Library for convex polyhedra and other numerical abstractions"
 
-AUTOTOOLS_AFTER="--enable-interfaces=c,cxx"
+AUTOTOOLS_AFTER=(
+    '--enable-interfaces=c,cxx'
+)
+
 AB_FLAGS_O3=1

--- a/runtime-scientific/ppl/spec
+++ b/runtime-scientific/ppl/spec
@@ -1,5 +1,4 @@
 VER=1.2
-SRCS="tbl::https://bugseng.com/products/ppl/download/ftp/releases/$VER/ppl-$VER.tar.gz"
+SRCS="tbl::https://repo.aosc.io/aosc-repacks/ppl-$VER.tar.gz"
 CHKSUMS="sha256::6bc36dd4a87abc429d8f9c00c53e334e5041a9b0857cfc00dbad6ef14294aac8"
-REL=1
 CHKUPDATE="anitya::id=17287"


### PR DESCRIPTION
Topic Description
-----------------

- gf2x: fix build with GCC >= 14
    - Backport upstream patches to fix GCC >= 14 and 32-bit non-x86 targets.
    - Improve PKGDES.
    - Revise AUTOTOOLS_AFTER\* as arrays.
    - Track patches at AOSC-Tracking/gf2x @ aosc/gf2x-1.3.0
    \(HEAD: 68738619afaae60a048b12c680db5abb2e17a234\).
- ppl: switch to aosc-repacks
    Improve PKGDES and revise AUTOTOOLS_AFTER as an array.
- polymake: update to 4.15
    - Improve dependency and PKGDES.
    - Improve commenting.
    - Drop unused prepare script.
    - Drop unused flag hacks.
- singular: update to 4.4.1
    - Improve commenting.
    - Drop unused python-2 dependency.
    - Track patches at AOSC-Tracking/singular @ aosc/Release-4-4-1
    \(HEAD: cc4a9399837cf387f2aae28ae8737b0b0947c13b\).
- normaliz: update to 3.10.5

Package(s) Affected
-------------------

- gf2x: 1.3.0
- normaliz: 3.10.5
- polymake: 4.15
- ppl: 1.2
- singular: 4.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppl gf2x normaliz singular polymake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
