### PR TITLE
libplist: update to 2.7.0

### DIFF
--- a/runtime-common/libplist/spec
+++ b/runtime-common/libplist/spec
@@ -1,5 +1,4 @@
-VER=2.6.0
-REL=1
+VER=2.7.0
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/libimobiledevice/libplist.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11675"


### PR DESCRIPTION
Topic Description
-----------------

- libplist: update to 2.7.0

Package(s) Affected
-------------------

- libplist: 2.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libplist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
