### PR TITLE
openbabel: fix build

### DIFF
--- a/runtime-scientific/openbabel/autobuild/defines
+++ b/runtime-scientific/openbabel/autobuild/defines
@@ -1,12 +1,15 @@
 PKGNAME=openbabel
 PKGSEC=libs
-PKGDEP="libxml2 x11-lib eigen-3 wxgtk3"
-PKGDES="A library to convert between file formats used in molecular modeling and computational chemistry"
+PKGDEP="libxml2 wxgtk3 x11-lib"
+BUILDDEP="eigen-3 rapidjson"
+PKGDES="Library to convert between file formats used in molecular modeling and computational chemistry"
 
 PKGBREAK="kalzium<=22.08.3"
-CMAKE_AFTER="-DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-2.8 \
-             -DLIB_INSTALL_DIR=/lib"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-gtk3'
+    '-DLIB_INSTALL_DIR=/lib'
+)
+
 NOSTATIC=0
-# FIXME: bad configuration in /usr/bin/wx-config-2.8 forces disable LTO
-# any app that depends on wxwidgets
-NOLTO=1

--- a/runtime-scientific/openbabel/spec
+++ b/runtime-scientific/openbabel/spec
@@ -1,5 +1,5 @@
 VER=3.1.1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/openbabel/openbabel/releases/download/openbabel-${VER//\./-}/openbabel-$VER-source.tar.bz2"
 CHKSUMS="sha256::a6ec8381d59ea32a4b241c8b1fbd799acb52be94ab64cdbd72506fb4e2270e68"
 CHKUPDATE="anitya::id=2539"


### PR DESCRIPTION
Topic Description
-----------------

- openbabel: fix build
    - Add rapidjson to build dependency.
    - Move eigen-3 to build dependency.
    - Improve PKGDES.
    - Use wxgtk3.

Package(s) Affected
-------------------

- openbabel: 3.1.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openbabel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
