### PR TITLE
gnome-usage: update to 46.1

### DIFF
--- a/desktop-gnome/gnome-usage/autobuild/defines
+++ b/desktop-gnome/gnome-usage/autobuild/defines
@@ -1,5 +1,10 @@
 PKGNAME=gnome-usage
 PKGSEC=gnome
-PKGDEP="accountsservice gtk-3 libgtop libdazzle libhandy tracker"
+PKGDEP="accountsservice gtk-4 json-glib libadwaita libgee libgtop \
+        networkmanager tracker"
 BUILDDEP="gobject-introspection vala"
 PKGDES="View information about system resource usage"
+
+MESON_AFTER=(
+    '-Dprofile=default'
+)

--- a/desktop-gnome/gnome-usage/spec
+++ b/desktop-gnome/gnome-usage/spec
@@ -1,5 +1,4 @@
-VER=3.38.1
+VER=46.1
 SRCS="https://download.gnome.org/sources/gnome-usage/${VER%.*}/gnome-usage-$VER.tar.xz"
-CHKSUMS="sha256::98c766e17e1565711fc74b9a24fd2ed0d5fad7ccb45519612dd4e214768ed393"
+CHKSUMS="sha256::7bda088e4bf6f582bb3c0245dd4ed59cb8064ac56cf2be4682196beccad880e3"
 CHKUPDATE="anitya::id=228561"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gnome-usage: update to 46.1
    - Update dependencies.
    - Specify Meson options explicitly where applicable.

Package(s) Affected
-------------------

- gnome-usage: 46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-usage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
