### PR TITLE
smartmontools: fix autogen.sh with automake >= 1.18

### DIFF
--- a/app-admin/smartmontools/autobuild/defines
+++ b/app-admin/smartmontools/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=smartmontools
 PKGSEC=utils
 PKGDEP="gcc-runtime bash libcap-ng"
-PKGDES="Control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives"
+PKGDES="Utility to control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives"
 
 # --enable-sample         Enables appending .sample to the installed smartd rc
 #                         script and configuration file

--- a/app-admin/smartmontools/autobuild/defines.stage2
+++ b/app-admin/smartmontools/autobuild/defines.stage2
@@ -1,7 +1,9 @@
 PKGNAME=smartmontools
 PKGSEC=utils
-PKGDES="Control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives"
 PKGDEP="gcc-runtime bash libcap-ng"
+PKGDES="Utility to control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives"
 
-AUTOTOOLS_AFTER="--sysconfdir=/etc \
-                 --with-libcap-ng=yes"
+AUTOTOOLS_AFTER=(
+    '--sysconfdir=/etc'
+    '--with-libcap-ng=yes'
+)

--- a/app-admin/smartmontools/autobuild/patches/0001-UPSTREAM-Add-automake-1.18-to-the-list-of-tested-ver.patch
+++ b/app-admin/smartmontools/autobuild/patches/0001-UPSTREAM-Add-automake-1.18-to-the-list-of-tested-ver.patch
@@ -1,0 +1,37 @@
+From 4857db542e91cdc8c5d8c8a39aae43db4f97fdff Mon Sep 17 00:00:00 2001
+From: Christian Franke <christian.franke@t-online.de>
+Date: Fri, 6 Jun 2025 15:23:13 +0200
+Subject: [PATCH 1/2] UPSTREAM: Add automake 1.18 to the list of tested
+ versions
+
+Signed-off-by: Christian Franke <christian.franke@t-online.de>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ smartmontools/autogen.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index ad80e708..405276e9 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -23,7 +23,7 @@ if [ -n "$AUTOMAKE" ]; then
+   ver=$("$AUTOMAKE" --version) || exit 1
+ else
+   maxver=
+-  for v in 1.17 1.16 1.15 1.14 1.13; do
++  for v in 1.18 1.17 1.16 1.15 1.14 1.13; do
+     minver=$v; test -n "$maxver" || maxver=$v
+     ver=$(automake-$v --version 2>/dev/null) || continue
+     AUTOMAKE="automake-$v"
+@@ -59,7 +59,7 @@ case "$ver" in
+     # OK
+     ;;
+ 
+-  1.14|1.14.1|1.15|1.15.1|1.16|1.16.[1-5]|1.17)
++  1.14|1.14.1|1.15|1.15.1|1.16|1.16.[1-5]|1.17|1.18)
+     # TODO: Enable 'subdir-objects' in configure.ac
+     # For now, suppress 'subdir-objects' forward-incompatibility warning
+     test -n "$warnings" || amwarnings="--warnings=no-unsupported"
+-- 
+2.51.0
+

--- a/app-admin/smartmontools/autobuild/patches/0002-BACKPORT-UPSTREAM-Add-automake-1.18.1-to-the-list-of.patch
+++ b/app-admin/smartmontools/autobuild/patches/0002-BACKPORT-UPSTREAM-Add-automake-1.18.1-to-the-list-of.patch
@@ -1,0 +1,28 @@
+From 08b44eb291a93fe3f734c25be83b2062324180b0 Mon Sep 17 00:00:00 2001
+From: Christian Franke <christian.franke@t-online.de>
+Date: Sat, 12 Jul 2025 11:57:10 +0200
+Subject: [PATCH 2/2] BACKPORT: UPSTREAM: Add automake 1.18.1 to the list of
+ tested versions
+
+Signed-off-by: Christian Franke <christian.franke@t-online.de>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ smartmontools/autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 405276e9..761b1a2a 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -55,7 +55,7 @@ case "$ver" in
+     echo "GNU Automake $ver is not supported."; exit 1
+     ;;
+ 
+-  1.13.[34])
++  1.13.[34]|1.14|1.14.1|1.15|1.15.1|1.16|1.16.[1-5]|1.17|1.18|1.18.1)
+     # OK
+     ;;
+ 
+-- 
+2.51.0
+

--- a/app-admin/smartmontools/spec
+++ b/app-admin/smartmontools/spec
@@ -1,4 +1,5 @@
 VER=7.5
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/smartmontools/files/smartmontools/$VER/smartmontools-$VER.tar.gz"
 CHKSUMS="sha256::690b83ca331378da9ea0d9d61008c4b22dde391387b9bbad7f29387f2595f76e"
 CHKUPDATE="anitya::id=4835"


### PR DESCRIPTION
Topic Description
-----------------

- smartmontools: fix autogen.sh with automake >= 1.18
    - Improve PKGDES.
    - Track patches at AOSC-Tracking/smartmontools @ aosc/RELEASE_7_5
    \(HEAD: 08b44eb291a93fe3f734c25be83b2062324180b0\) - note that the
    \`/smartmontools' prefix must be removed as the Git tree at that
    point put the source code in an extra level.

Package(s) Affected
-------------------

- smartmontools: 7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit smartmontools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
