### PR TITLE
png++: fix build

### DIFF
--- a/runtime-imaging/png++/autobuild/build
+++ b/runtime-imaging/png++/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building png++ ..."
+make
+
+abinfo "Installing png++ ..."
+make install \
+    PREFIX="$PKGDIR"/usr

--- a/runtime-imaging/png++/autobuild/defines
+++ b/runtime-imaging/png++/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=png++
 PKGSEC=libs
 PKGDEP="gcc-runtime libpng"
-BUILDDEP="doxygen"
-PKGDES="A C++ wrapper for libpng"
+PKGDES="C++ wrapper for libpng"
 
-ABMK="docs"
-ABTYPE=plainmake
-MAKE_AFTER="PREFIX=$PKGDIR/usr"
+ABTYPE=self
+# NOTE: Header files only.
+ABHOST=noarch

--- a/runtime-imaging/png++/spec
+++ b/runtime-imaging/png++/spec
@@ -1,4 +1,5 @@
 VER=0.2.10
+REL=1
 SRCS="tbl::https://download.savannah.gnu.org/releases/pngpp/png++-$VER.tar.gz"
 CHKSUMS="sha256::998af216ab16ebb88543fbaa2dbb9175855e944775b66f2996fc945c8444eee1"
 CHKUPDATE="anitya::id=230510"


### PR DESCRIPTION
Topic Description
-----------------

- png++: fix build

Package(s) Affected
-------------------

- png++: 0.2.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit png++
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
