### PR TITLE
oolite: add missing ABTYPE

### DIFF
--- a/app-games/oolite/autobuild/build
+++ b/app-games/oolite/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building and installing oolite..."
+make install \
+    V=1 VERBOSE=1 \
+    BUILDROOT="$PKGDIR" DESTDIR="$PKGDIR" \
+    GNUSTEP_MAKEFILES=/usr/share/GNUstep/Makefiles \
+    DEBUG_GRAPHVIZ=no \
+    OO_JAVASCRIPT_TRACE=no

--- a/app-games/oolite/autobuild/defines
+++ b/app-games/oolite/autobuild/defines
@@ -3,10 +3,8 @@ PKGSEC=games
 PKGDEP="desktop-file-utils espeak gcc-runtime gmp gnustep-base gnustep-make \
         libogg libpng libvorbis mesa nspr openal-soft portaudio sdl sdl-mixer"
 PKGDES="Space sim game, inspired by Elite"
+ABTYPE=self
 
-MAKE_AFTER="GNUSTEP_MAKEFILES=/usr/share/GNUstep/Makefiles \
-            DEBUG_GRAPHVIZ=no \
-            OO_JAVASCRIPT_TRACE=no"
 FAIL_ARCH="!(amd64)"
 
 ABSPLITDBG=0

--- a/app-games/oolite/autobuild/patches/0001-fix-GLUfuncptr-compile-error.patch
+++ b/app-games/oolite/autobuild/patches/0001-fix-GLUfuncptr-compile-error.patch
@@ -1,0 +1,48 @@
+diff --git a/src/Core/OOPolygonSprite.m b/src/Core/OOPolygonSprite.m
+index 5ada443e..216d67f1 100644
+--- a/src/Core/OOPolygonSprite.m
++++ b/src/Core/OOPolygonSprite.m
+@@ -115,6 +115,9 @@ static void APIENTRY TessEndCallback(void *polygonData);
+ 
+ static void APIENTRY ErrorCallback(GLenum error, void *polygonData);
+ 
++// this is needed to maintain compatibility with GCC 14+
++typedef GLvoid (*TessFuncPtr)();
++
+ 
+ @implementation OOPolygonSprite
+ 
+@@ -283,11 +286,11 @@ static void APIENTRY ErrorCallback(GLenum error, void *polygonData);
+ 	dataArray = DataArrayToPoints(&polygonData, dataArray);
+ 	
+ 	/*** Tesselate polygon fill ***/
+-	gluTessCallback(tesselator, GLU_TESS_BEGIN_DATA, TessBeginCallback);
+-	gluTessCallback(tesselator, GLU_TESS_VERTEX_DATA, TessVertexCallback);
+-	gluTessCallback(tesselator, GLU_TESS_END_DATA, TessEndCallback);
+-	gluTessCallback(tesselator, GLU_TESS_ERROR_DATA, ErrorCallback);
+-	gluTessCallback(tesselator, GLU_TESS_COMBINE_DATA, TessCombineCallback);
++	gluTessCallback(tesselator, GLU_TESS_BEGIN_DATA, (TessFuncPtr)TessBeginCallback);
++	gluTessCallback(tesselator, GLU_TESS_VERTEX_DATA, (TessFuncPtr)TessVertexCallback);
++	gluTessCallback(tesselator, GLU_TESS_END_DATA, (TessFuncPtr)TessEndCallback);
++	gluTessCallback(tesselator, GLU_TESS_ERROR_DATA, (TessFuncPtr)ErrorCallback);
++	gluTessCallback(tesselator, GLU_TESS_COMBINE_DATA, (TessFuncPtr)TessCombineCallback);
+ 	
+ 	gluTessBeginPolygon(tesselator, &polygonData);
+ 	SVGDumpBeginGroup(&polygonData, @"Fill");
+@@ -351,11 +354,11 @@ static void APIENTRY ErrorCallback(GLenum error, void *polygonData);
+ 	polygonData.generatingOutline = YES;
+ #endif
+ 	
+-	gluTessCallback(tesselator, GLU_TESS_BEGIN_DATA, TessBeginCallback);
+-	gluTessCallback(tesselator, GLU_TESS_VERTEX_DATA, TessVertexCallback);
+-	gluTessCallback(tesselator, GLU_TESS_END_DATA, TessEndCallback);
+-	gluTessCallback(tesselator, GLU_TESS_ERROR_DATA, ErrorCallback);
+-	gluTessCallback(tesselator, GLU_TESS_COMBINE_DATA, TessCombineCallback);
++	gluTessCallback(tesselator, GLU_TESS_BEGIN_DATA, (TessFuncPtr)TessBeginCallback);
++	gluTessCallback(tesselator, GLU_TESS_VERTEX_DATA, (TessFuncPtr)TessVertexCallback);
++	gluTessCallback(tesselator, GLU_TESS_END_DATA, (TessFuncPtr)TessEndCallback);
++	gluTessCallback(tesselator, GLU_TESS_ERROR_DATA, (TessFuncPtr)ErrorCallback);
++	gluTessCallback(tesselator, GLU_TESS_COMBINE_DATA, (TessFuncPtr)TessCombineCallback);
+ 	gluTessProperty(tesselator, GLU_TESS_WINDING_RULE, GLU_TESS_WINDING_POSITIVE);
+ 	
+ 	gluTessBeginPolygon(tesselator, &polygonData);

--- a/app-games/oolite/spec
+++ b/app-games/oolite/spec
@@ -2,4 +2,4 @@ VER=1.90
 SRCS="git::commit=0b1ff49a78653669bfe8e153ae09699ba49cc496::https://github.com/OoliteProject/oolite.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17358"
-REL=2
+REL=3


### PR DESCRIPTION
Topic Description
-----------------

- oolite: add missing ABTYPE
- fix compile error on GCC14+

Package(s) Affected
-------------------

- oolite: 1.90-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit oolite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
