### PR TITLE
editline: update to 1.17.1

### DIFF
--- a/runtime-common/editline/autobuild/defines
+++ b/runtime-common/editline/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=editline
 PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="A readline() replacement for UNIX without termcap (ncurses)"
+
+ABTYPE=autotools

--- a/runtime-common/editline/autobuild/patches/0001-BACKPORT-fix-syntax-error-in-configure.ac-file.patch
+++ b/runtime-common/editline/autobuild/patches/0001-BACKPORT-fix-syntax-error-in-configure.ac-file.patch
@@ -1,0 +1,54 @@
+From 356304ff347445bf23c31b90279bb1656573a019 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Mon, 6 Oct 2025 17:02:34 +0800
+Subject: [PATCH] BACKPORT: fix syntax error in configure.ac file
+
+https://github.com/troglobit/editline/commit/127d9958552b51c1a906b1781aa0ef2eb7bdb9b2
+---
+ configure.ac | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6f5b032..6cb7958 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -5,7 +5,7 @@ AM_SILENT_RULES([yes])
+ 
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_CONFIG_SRCDIR([src/editline.c])
+-AC_CONFIG_HEADER([config.h])
++AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_FILES([Makefile libeditline.pc src/Makefile include/Makefile man/Makefile examples/Makefile])
+ 
+ # Checks for programs.
+@@ -18,7 +18,7 @@ LT_INIT
+ # Checks for header files.
+ AC_HEADER_DIRENT
+ AC_HEADER_STAT
+-AC_HEADER_STDC
++
+ # Check for malloc.h instead of AC_FUNC_MALLOC/REALLOC AIX and others
+ # mess up the traditional malloc check.
+ AC_CHECK_HEADERS([malloc.h signal.h stdlib.h string.h termcap.h termio.h termios.h sgtty.h unistd.h])
+@@ -83,7 +83,7 @@ AS_IF([test "x$enable_terminal_bell" = "xyes"],
+    AC_DEFINE(CONFIG_TERMINAL_BELL, 1, [Define to enable terminal bell on completion.]))
+ 
+ # Check for a termcap compatible library if enabled
+-AS_IF([test "x$enable_termcap" = "xyes"],
++AS_IF([test "x$enable_termcap" = "xyes"], [
+    AC_DEFINE(CONFIG_USE_TERMCAP, 1, [Define to use the termcap library for terminal size.])
+    AC_CHECK_LIB(terminfo, tgetent, , [
+       AC_CHECK_LIB(termcap, tgetent, , [
+@@ -94,7 +94,8 @@ AS_IF([test "x$enable_termcap" = "xyes"],
+                ])
+             ])
+          ])
+-      ]))
++      ])
++    ])
+ 
+ # Generate all files
+ AC_OUTPUT
+-- 
+2.51.0
+

--- a/runtime-common/editline/spec
+++ b/runtime-common/editline/spec
@@ -1,4 +1,4 @@
-VER=1.16.1
+VER=1.17.1
 SRCS="tbl::https://github.com/troglobit/editline/releases/download/$VER/editline-$VER.tar.xz"
-CHKSUMS="sha256::6518cc0d8241bcebc860432d1babc662a9ce0f5d6035649effe38b5bc9463f8c"
+CHKSUMS="sha256::df223b3333a545fddbc67b49ded3d242c66fadf7a04beb3ada20957fcd1ffc0e"
 CHKUPDATE="anitya::id=229375"


### PR DESCRIPTION
Topic Description
-----------------

- editline: update to 1.17.1

Package(s) Affected
-------------------

- editline: 1.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit editline
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
