### PR TITLE
dialog: update to 1.3+20251001

### DIFF
--- a/app-utils/dialog/spec
+++ b/app-utils/dialog/spec
@@ -1,4 +1,5 @@
-VER=1.3+20240619
-SRCS="tbl::https://invisible-mirror.net/archives/dialog/dialog-${VER/+/-}.tgz"
-CHKSUMS="sha256::5d8c4318963db3fd383525340276e0e05ee3dea9a6686c20779f5433b199547d"
+UPSTREAM_VER=1.3-20251001
+VER=${UPSTREAM_VER/-/+}
+SRCS="tbl::https://invisible-mirror.net/archives/dialog/dialog-${UPSTREAM_VER}.tgz"
+CHKSUMS="sha256::bee47347a983312facc4dbcccd7fcc86608d684e1f119d9049c4692213db96c3"
 CHKUPDATE="anitya::id=431"


### PR DESCRIPTION
Topic Description
-----------------

- dialog: update to 1.3+20251001
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dialog: 1.3+20251001

Security Update?
----------------

No

Build Order
-----------

```
#buildit dialog
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
