### PR TITLE
minicom: fix build

### DIFF
--- a/app-utils/minicom/autobuild/defines
+++ b/app-utils/minicom/autobuild/defines
@@ -3,7 +3,4 @@ PKGSEC=utils
 PKGDEP="glibc lrzsz ncurses"
 PKGDES="A text-based modem control and terminal emulation program"
 
-# FIXME: Broken configure script after re-generation.
-#
-# make[2]: *** No rule to make target '/config.status', needed by 'Makefile'.  Stop.
-RECONF=0
+ABTYPE=autotools

--- a/app-utils/minicom/autobuild/patches/0001-BACKPORT-autogen-Simplify.patch
+++ b/app-utils/minicom/autobuild/patches/0001-BACKPORT-autogen-Simplify.patch
@@ -1,0 +1,37 @@
+From 70f608cb579f485004122a223b3e03d62b7ab22f Mon Sep 17 00:00:00 2001
+From: Adam Lackorzynski <adam@l4re.org>
+Date: Sat, 22 Feb 2025 11:43:49 +0100
+Subject: [PATCH] BACKPORT: autogen: Simplify
+
+Just call "autoreconf -fi".
+---
+ autogen.sh | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index bde01a8..9aa99b9 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -2,15 +2,11 @@
+ #
+ # $Id: autogen.sh,v 1.16 2009-11-15 20:00:56 al-guest Exp $
+ 
+-AUTOMAKEVER=1.16
+-
+ set -x
+ 
+-aclocal-$AUTOMAKEVER
+-[ "$?" != 0 ] && echo "aclocal-$AUTOMAKEVER not available or failed!" && exit 1
+-autoheader || exit 1
+-automake-$AUTOMAKEVER -c --add-missing --force --gnu || exit 1
+-autoconf || exit 1
++autoreconf -fi
+ 
+ # remove once it comes via config.sub directly
+-perl -p -i -e 's/(\| hcos\* )/$1| l4re* /' config.sub
++if grep -qv l4re config.sub; then
++  perl -p -i -e 's/(\| hcos\* )/$1| l4re* /' config.sub
++fi
+-- 
+2.51.0
+

--- a/app-utils/minicom/spec
+++ b/app-utils/minicom/spec
@@ -1,4 +1,5 @@
 VER=2.10
+REL=1
 SRCS="git::commit=tags/${VER}::https://salsa.debian.org/minicom-team/minicom.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1983"


### PR DESCRIPTION
Topic Description
-----------------

- minicom: fix build

Package(s) Affected
-------------------

- minicom: 2.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit minicom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
