### PR TITLE
ss-tproxy: revamp postinst and spec

### DIFF
--- a/app-proxy/ss-tproxy/autobuild/postinst
+++ b/app-proxy/ss-tproxy/autobuild/postinst
@@ -1,8 +1,13 @@
+echo "Refreshing systemd configurations ..."
+systemctl daemon-reload
 
-echo "Check whether ss-tproxy is exist..."
-if [ $(systemctl is-enabled ss-tproxy) == "enabled" ]; then
- echo "Starting ss-tproxy service..."
- systemctl start ss-tproxy
+echo "Checking the status of the ss-tproxy service ..."
+if systemctl is-active --quiet ss-tproxy.service; then
+ echo "Restarting ss-tproxy service ..."
+ systemctl try-restart ss-tproxy.service
+elif systemctl is-enabled --quiet ss-tproxy.service; then
+ echo "Starting ss-tproxy service ..."
+ systemctl start ss-tproxy.service || true
 else
- echo "The ss-tproxy is not exist."
+ echo "Skipping ss-tproxy service ..."
 fi

--- a/app-proxy/ss-tproxy/autobuild/prerm
+++ b/app-proxy/ss-tproxy/autobuild/prerm
@@ -1,7 +1,0 @@
-echo "Check whether ss-tproxy service is running..."
-if [ $(systemctl is-active ss-tproxy) == "active" ]; then
- echo "Stopping ss-tproxy service..."
- systemctl stop ss-tproxy
-else
- echo "The ss-tproxy service is not running."
-fi

--- a/app-proxy/ss-tproxy/spec
+++ b/app-proxy/ss-tproxy/spec
@@ -1,4 +1,5 @@
 VER=4.8.3
-SRCS="https://github.com/zfl9/ss-tproxy/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::2ff227546029f8fe06cc71b224158f029105edc4d0aa52c8236754a1b7c19bb6"
+REL=1
+SRCS="git::commit=tags/v$VER::https://github.com/zfl9/ss-tproxy.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230996"


### PR DESCRIPTION
Topic Description
-----------------

- ss-tproxy: revamp postinst and spec
    - use git-based SRCS\[^1\]
    - properly treat "exist" as a verb
    - reload the systemd configuration
    - use \`is-active\` in a more elegant manner
    - with \`--quiet\` we just need to detect if systemctl returns 0
    - use \`try-restart\` instead
    - allow restarts to fail as we should allow users to debug their
    own configurations later
    \[^1\]: https://github.blog/open-source/git/update-on-the-future-stability-of-source-code-archives-and-hashes/#future-stability-of-archives-and-hashes

Package(s) Affected
-------------------

- ss-tproxy: 4.8.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ss-tproxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
