### PR TITLE
uboot-tools: update to 2025.10

### DIFF
--- a/app-utils/uboot-tools/spec
+++ b/app-utils/uboot-tools/spec
@@ -1,5 +1,4 @@
-VER=2025.04
-REL=1
+VER=2025.10
 SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
-CHKSUMS="sha256::439d3bef296effd54130be6a731c5b118be7fddd7fcc663ccbc5fb18294d8718"
+CHKSUMS="sha256::b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a"
 CHKUPDATE="anitya::id=5022"


### PR DESCRIPTION
Topic Description
-----------------

- uboot-tools: update to 2025.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- uboot-tools: 2025.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit uboot-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
