### PR TITLE
tor: update to 0.4.8.19

### DIFF
--- a/app-proxy/tor/spec
+++ b/app-proxy/tor/spec
@@ -1,4 +1,4 @@
-VER=0.4.8.13
+VER=0.4.8.19
 SRCS="tbl::https://www.torproject.org/dist/tor-$VER.tar.gz"
-CHKSUMS="sha256::9baf26c387a2820b3942da572146e6eb77c2bc66862af6297cd02a074e6fba28"
+CHKSUMS="sha256::3cb649a1d33ba6a65f109d224534e93aaf0a6de84a5b1cb4b054bfa06bb74f5a"
 CHKUPDATE="anitya::id=4991"


### PR DESCRIPTION
Topic Description
-----------------

- tor: update to 0.4.8.19
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tor: 0.4.8.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit tor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
