### PR TITLE
cargo-release: update to 0.25.20

### DIFF
--- a/lang-rust/cargo-release/spec
+++ b/lang-rust/cargo-release/spec
@@ -1,4 +1,4 @@
-VER=0.25.10
+VER=0.25.20
 SRCS="tbl::https://github.com/sunng87/cargo-release/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::3db220c865caa9820bf2d66c0c5a5ad5a3c7be7ec91c27c623c0f62c3754ea8b"
+CHKSUMS="sha256::34edcc83ebc6839b22c9fadb0d7c8eddad6703e12f5bdd83180ecc60905af488"
 CHKUPDATE="anitya::id=231456"


### PR DESCRIPTION
Topic Description
-----------------

- cargo-release: update to 0.25.20
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cargo-release: 0.25.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit cargo-release
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
