### PR TITLE
wireless-regdb: update to 2025.10.07

### DIFF
--- a/app-network/wireless-regdb/spec
+++ b/app-network/wireless-regdb/spec
@@ -1,4 +1,4 @@
-VER=2025.07.10
+VER=2025.10.07
 SRCS="tbl::https://www.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-$VER.tar.xz"
-CHKSUMS="sha256::a8340bcdcd1b5db6c79149879d122b170f3bb075381718d4f429ad831a6fa28d"
+CHKSUMS="sha256::d4c872a44154604c869f5851f7d21d818d492835d370af7f58de8847973801c3"
 CHKUPDATE="anitya::id=15257"


### PR DESCRIPTION
Topic Description
-----------------

- wireless-regdb: update to 2025.10.07
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireless-regdb: 2025.10.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireless-regdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
