### PR TITLE
nuget: update to 6.14.0

### DIFF
--- a/lang-dotnet/nuget/autobuild/build
+++ b/lang-dotnet/nuget/autobuild/build
@@ -1,1 +1,3 @@
-install -Dm 0644 ${SRCDIR}/nuget.exe ${PKGDIR}/usr/lib/nuget/nuget.exe
+abinfo "Installing NuGet ..."
+install -Dvm0644 "$SRCDIR"/nuget.exe \
+    "$PKGDIR"/usr/lib/nuget/nuget.exe

--- a/lang-dotnet/nuget/autobuild/defines
+++ b/lang-dotnet/nuget/autobuild/defines
@@ -3,4 +3,10 @@ PKGSEC=cli-mono
 PKGDEP="mono"
 PKGDES="Package manager for NuGet repos"
 
-PKGEPOCH=1
+ABTYPE=self
+
+# NOTE: Only one pre-built binary.
+ABSPLITDBG=0
+
+# FIXME: Missing Mono support.
+FAIL_ARCH="!(amd64|arm64|ppc64el)"

--- a/lang-dotnet/nuget/autobuild/overrides/usr/bin/nuget
+++ b/lang-dotnet/nuget/autobuild/overrides/usr/bin/nuget
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/bin/mono --runtime=v4.0 /usr/lib/nuget/nuget.exe $*
+exec /usr/bin/mono /usr/lib/nuget/nuget.exe "$@"

--- a/lang-dotnet/nuget/autobuild/postinst
+++ b/lang-dotnet/nuget/autobuild/postinst
@@ -1,4 +1,1 @@
-mozroots --import --machine --sync
-yes | certmgr -ssl -m https://go.microsoft.com
-yes | certmgr -ssl -m https://nugetgallery.blob.core.windows.net
-yes | certmgr -ssl -m https://nuget.org
+cert-sync /etc/ssl/certs/ca-certificates.crt

--- a/lang-dotnet/nuget/autobuild/prepare
+++ b/lang-dotnet/nuget/autobuild/prepare
@@ -1,1 +1,0 @@
-wget https://dist.nuget.org/win-x86-commandline/v${PKGVER}/nuget.exe -O ${SRCDIR}/nuget.exe

--- a/lang-dotnet/nuget/spec
+++ b/lang-dotnet/nuget/spec
@@ -1,4 +1,5 @@
-VER=4.9.4
-REL=1
-DUMMYSRC=1
+EPOCH=1
+VER=6.14.0
+SRCS="file::rename=nuget.exe::https://dist.nuget.org/win-x86-commandline/v$VER/nuget.exe"
+CHKSUMS="SHA256::92dbed160ddee0f64b901e907439e021211b428e57c089ecc12fc38dcc4bd9a5"
 CHKUPDATE="anitya::id=6997"


### PR DESCRIPTION
Topic Description
-----------------

- nuget: update to 6.14.0

Package(s) Affected
-------------------

- nuget: 6.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nuget
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
