### PR TITLE
oxygen-fonts: fix build

### DIFF
--- a/desktop-kde/oxygen-fonts/autobuild/defines
+++ b/desktop-kde/oxygen-fonts/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=oxygen-fonts
 PKGSEC=kde
 PKGDEP="fontconfig"
-BUILDDEP="extra-cmake-modules qt-5 fontforge"
+BUILDDEP="extra-cmake-modules fontforge"
 PKGDES="The Oxygen font family designed for the Plasma Workspace"
 
-CMAKE_AFTER="-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+ABTYPE=cmakeninja
+ABHOST=noarch

--- a/desktop-kde/oxygen-fonts/spec
+++ b/desktop-kde/oxygen-fonts/spec
@@ -1,5 +1,5 @@
 VER=5.4.3
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/Attic/plasma/$VER/oxygen-fonts-$VER.tar.xz"
 CHKSUMS="sha256::a02f6580e9a53cb16694a99adbb6dbf76f17584f3e97f469a22286299507838c"
-CHKUPDATE="html::url=https://download.kde.org/Attic/plasma/$VER/;pattern=oxygen-fonts-(.+?).tar.xz"
+CHKUPDATE="anitya::id=384128"


### PR DESCRIPTION
Topic Description
-----------------

- oxygen-fonts: fix build
    - Adjust CHKUPDATE and BUILDDEP.
    - Improve defines scripts.

Package(s) Affected
-------------------

- oxygen-fonts: 5.4.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit oxygen-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
