### PR TITLE
luv-icon-theme: fix build

### DIFF
--- a/desktop-themes/luv-icon-theme/autobuild/build
+++ b/desktop-themes/luv-icon-theme/autobuild/build
@@ -1,2 +1,3 @@
+abinfo "Installing luv-icon-theme ..."
 mkdir -pv "$PKGDIR"/usr/share/icons/
-cp -rv "Luv" "$PKGDIR"/usr/share/icons/
+cp -rv "$SRCDIR"/Luv "$PKGDIR"/usr/share/icons/

--- a/desktop-themes/luv-icon-theme/autobuild/defines
+++ b/desktop-themes/luv-icon-theme/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=luv-icon-theme
 PKGSEC=x11
-PKGDES="A flat but complex icon theme for freedesktop environments"
+PKGDEP="gtk-update-icon-cache"
+PKGDES="Flat but complex icon theme"
 
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-themes/luv-icon-theme/spec
+++ b/desktop-themes/luv-icon-theme/spec
@@ -1,4 +1,5 @@
-VER=0.4.9.31
-SRCS="tbl::https://github.com/Nitrux/luv-icon-theme/archive/$VER.tar.gz"
-CHKSUMS="sha256::1a4ad8793d779260733b4299d6cefe7c3f52b37f1527262a4d249d84957d92c4"
+EPOCH=1
+VER=0+git20250926
+SRCS="git::commit=31b3e00558474a3ac154b21bfbf6b6540ca60821::https://github.com/Nitrux/luv-icon-theme.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231531"


### PR DESCRIPTION
Topic Description
-----------------

- luv-icon-theme: fix build

Package(s) Affected
-------------------

- luv-icon-theme: 0+git20250926

Security Update?
----------------

No

Build Order
-----------

```
#buildit luv-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
