### PR TITLE
ruby: update to 3.4.7

### DIFF
--- a/lang-ruby/ruby/spec
+++ b/lang-ruby/ruby/spec
@@ -1,4 +1,4 @@
-VER=3.4.5
+VER=3.4.7
 SRCS="tbl::https://cache.ruby-lang.org/pub/ruby/${VER:0:3}/ruby-$VER.tar.xz"
-CHKSUMS="sha256::7b3a905b84b8777aa29f557bada695c3ce108390657e614d2cc9e2fb7e459536"
+CHKSUMS="sha256::db425a86f6e07546957578f4946cc700a91e7fd51115a86c56e096f30e0530c7"
 CHKUPDATE="anitya::id=4223"


### PR DESCRIPTION
Topic Description
-----------------

- ruby: update to 3.4.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ruby: 3.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit ruby
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
