### PR TITLE
sqlmap: update to 1.9.10

### DIFF
--- a/app-penetration/sqlmap/spec
+++ b/app-penetration/sqlmap/spec
@@ -1,4 +1,4 @@
-VER=1.9.5
+VER=1.9.10
 SRCS="git::commit=tags/$VER::https://github.com/sqlmapproject/sqlmap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14901"


### PR DESCRIPTION
Topic Description
-----------------

- sqlmap:update to 1.9.10

Package(s) Affected
-------------------

- sqlmap: 1.9.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit sqlmap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
