### PR TITLE
stress-ng: update to 0.19.05

### DIFF
--- a/app-benchmarks/stress-ng/autobuild/defines
+++ b/app-benchmarks/stress-ng/autobuild/defines
@@ -11,3 +11,7 @@ ABTYPE=self
 # {standard input}: Assembler messages:
 # {standard input}:48268: Error: unrecognized opcode: `darn'
 NOLTO__PPC64EL=1
+
+# FXIME: Official temporary solution for known test failures, which will be fixed in next release.
+# https://github.com/ColinIanKing/stress-ng/issues/568
+NOLTO=1

--- a/app-benchmarks/stress-ng/spec
+++ b/app-benchmarks/stress-ng/spec
@@ -1,4 +1,4 @@
-VER=0.19.04
+VER=0.19.05
 SRCS="git::commit=tags/V${VER}::https://github.com/ColinIanKing/stress-ng.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12538"


### PR DESCRIPTION
Topic Description
-----------------

- stress-ng: update to 0.19.05
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- stress-ng: 0.19.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit stress-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
