### PR TITLE
wireshark: update to 4.6.0

### DIFF
--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,5 +1,4 @@
-VER=4.4.9
+VER=4.6.0
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::60551dc787f41e87aeaa1e9c33304f9008037e3baf9fa11aef9c2d584cc0b54b"
+CHKSUMS="sha256::ab016463062bb635285b9678dd45ddd84c65938911fd40b3cca9a903a08ad8d9"
 CHKUPDATE="anitya::id=5137"
-REL=1

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,5 @@
 VER=10.5.0
+REL=1
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
 CHKUPDATE="anitya::id=13830"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: update to 4.6.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireshark: 4.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
