### PR TITLE
Certbot survey Oct'25

### DIFF
--- a/app-web/certbot-apache/spec
+++ b/app-web/certbot-apache/spec
@@ -1,5 +1,4 @@
-VER=2.10.0
-SRCS="tbl::https://pypi.io/packages/source/c/certbot-apache/certbot-apache-$VER.tar.gz"
-CHKSUMS="sha256::c7a46ff67eac2834a3e3b975e7a1d1bc7a7be889f51c2cdc87825abd5ccc825a"
+VER=5.1.0
+SRCS="tbl::https://pypi.io/packages/source/c/certbot-apache/certbot_apache-$VER.tar.gz"
+CHKSUMS="sha256::83f7e7578bb06c57b3d27f82ebd3c113e6f7fc8a41dc722cdc143ac98064b0ef"
 CHKUPDATE="anitya::id=10837"
-REL=1

--- a/app-web/certbot-dns-cloudflare/spec
+++ b/app-web/certbot-dns-cloudflare/spec
@@ -1,5 +1,4 @@
-VER=2.10.0
-SRCS="tbl::https://pypi.io/packages/source/c/certbot-dns-cloudflare/certbot-dns-cloudflare-$VER.tar.gz"
-CHKSUMS="sha256::45b058c3e515a1853b33dcc3367c12978c0930990a563d26c879d9883a639c07"
+VER=5.1.0
+SRCS="tbl::https://pypi.io/packages/source/c/certbot-dns-cloudflare/certbot_dns_cloudflare-$VER.tar.gz"
+CHKSUMS="sha256::6fea3d5e2c3db018f83bc074315a48588fb680c900f7fef3349eae6a2cfc4c6c"
 CHKUPDATE="anitya::id=17035"
-REL=1

--- a/app-web/certbot-nginx/spec
+++ b/app-web/certbot-nginx/spec
@@ -1,5 +1,4 @@
-VER=2.10.0
-SRCS="tbl::https://pypi.io/packages/source/c/certbot-nginx/certbot-nginx-$VER.tar.gz"
-CHKSUMS="sha256::9add7e8b7005fe6d8405cb74fd868d4b3689a572957a9112d654a5ac1e7f4d91"
+VER=5.1.0
+SRCS="tbl::https://pypi.io/packages/source/c/certbot-nginx/certbot_nginx-$VER.tar.gz"
+CHKSUMS="sha256::fe41cdd8f54b0587b65b686aa142191ad1bf4f7abaa708a79d5ad662757fb07a"
 CHKUPDATE="anitya::id=15248"
-REL=1

--- a/app-web/certbot/spec
+++ b/app-web/certbot/spec
@@ -1,5 +1,4 @@
-VER=2.11.0
+VER=5.1.0
 SRCS="tbl::https://pypi.io/packages/source/c/certbot/certbot-$VER.tar.gz"
-CHKSUMS="sha256::257ae1cb0a534373ca50dd807c9ae96f27660e41379c45afb9b50cab0e6a7a97"
+CHKSUMS="sha256::d652a598f67af78ecf122860e85cd2e9c19a2bbe79a71775eccf6e8d642a4fca"
 CHKUPDATE="anitya::id=10690"
-REL=1

--- a/lang-python/acme/spec
+++ b/lang-python/acme/spec
@@ -1,4 +1,4 @@
-VER=2.10.0
+VER=5.1.0
 SRCS="tbl::https://pypi.io/packages/source/a/acme/acme-$VER.tar.gz"
-CHKSUMS="sha256::de110d6550f22094c920ad6022f4b329380a6bd8f58dd671135c6226c3a470cc"
+CHKSUMS="sha256::7b97820857d9baffed98bca50ab82bb6a636e447865d7a013a7bdd7972f03cda"
 CHKUPDATE="anitya::id=8231"

--- a/lang-python/cffi/spec
+++ b/lang-python/cffi/spec
@@ -1,5 +1,4 @@
-VER=1.15.0
-REL=1
+VER=2.0.0
 SRCS="tbl::https://pypi.io/packages/source/c/cffi/cffi-$VER.tar.gz"
-CHKSUMS="sha256::920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"
+CHKSUMS="sha256::44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
 CHKUPDATE="anitya::id=5536"

--- a/lang-python/cryptography/autobuild/defines
+++ b/lang-python/cryptography/autobuild/defines
@@ -2,10 +2,10 @@ PKGNAME=cryptography
 PKGDES="Exposes cryptographic recipes and primitives to Python developers"
 PKGSEC=python
 PKGDEP="asn1crypto cffi idna ipaddress pyasn1 six openssl"
-BUILDDEP="setuptools-python3 setuptools-rust appdirs wheel rustc llvm typing-extensions"
+BUILDDEP="setuptools-python3 setuptools-rust appdirs wheel rustc llvm typing-extensions maturin"
 
 NOPYTHON2=1
-ABTYPE=python
+ABTYPE=pep517
 # Rust extension broken with LTO
 # See also: https://bugs.gentoo.org/903908 & https://github.com/pyca/cryptography/issues/9023
 NOLTO=1

--- a/lang-python/cryptography/spec
+++ b/lang-python/cryptography/spec
@@ -1,5 +1,4 @@
-VER=40.0.0
+VER=46.0.2
 SRCS="https://pypi.io/packages/source/c/cryptography/cryptography-$VER.tar.gz"
-CHKSUMS="sha256::f421f6777592eb199ca8abac7c20b9ecef27c50ad63546e6c614b29771b46d0d"
+CHKSUMS="sha256::21b6fc8c71a3f9a604f028a329e5560009cc4a3a828bfea5fcba8eb7647d88fe"
 CHKUPDATE="anitya::id=5532"
-REL=1

--- a/lang-python/josepy/autobuild/defines
+++ b/lang-python/josepy/autobuild/defines
@@ -5,5 +5,5 @@ BUILDDEP="setuptools"
 PKGDES="JOSE protocol implementation in Python using cryptography"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/josepy/spec
+++ b/lang-python/josepy/spec
@@ -1,4 +1,4 @@
-VER=1.13.0
-SRCS="tbl::https://github.com/certbot/josepy/archive/v$VER.tar.gz"
-CHKSUMS="sha256::708208a9523f1512ecc79cb7cd581a469f3142b68d88100a55fd010c82549d76"
+VER=2.1.0
+SRCS="git::commit=tags/v$VER::https://github.com/certbot/josepy.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17050"

--- a/lang-python/maturin/spec
+++ b/lang-python/maturin/spec
@@ -1,4 +1,4 @@
-VER=1.9.3
+VER=1.9.6
 SRCS="git::commit=tags/v$VER::https://github.com/PyO3/maturin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=42653"

--- a/lang-python/pyopenssl/spec
+++ b/lang-python/pyopenssl/spec
@@ -1,4 +1,4 @@
-VER=23.1.1
-SRCS="https://pypi.io/packages/source/p/pyOpenSSL/pyOpenSSL-$VER.tar.gz"
-CHKSUMS="sha256::841498b9bec61623b1b6c47ebbc02367c07d60e0e195f19790817f10cc8db0b7"
+VER=25.3.0
+SRCS="https://pypi.io/packages/source/p/pyOpenSSL/pyopenssl-$VER.tar.gz"
+CHKSUMS="sha256::c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329"
 CHKUPDATE="anitya::id=5535"

--- a/lang-python/pyrfc3339/autobuild/defines
+++ b/lang-python/pyrfc3339/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=pyrfc3339
 PKGSEC=python
-PKGDEP="pytz python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="pytz python-3"
+BUILDDEP="setuptools setuptools-scm"
 PKGDES="Parses and generates RFC 3339-compliant timestamps using Python datetime.datetime objects"
 
 ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/pyrfc3339/spec
+++ b/lang-python/pyrfc3339/spec
@@ -1,5 +1,4 @@
-VER=1.1
-REL=4
-SRCS="tbl::https://pypi.python.org/packages/source/p/pyRFC3339/pyRFC3339-$VER.tar.gz"
-CHKSUMS="sha256::81b8cbe1519cdb79bed04910dd6fa4e181faf8c88dff1e1b987b5f7ab23a5b1a"
+VER=2.1.0
+SRCS="tbl::https://pypi.python.org/packages/source/p/pyRFC3339/pyrfc3339-$VER.tar.gz"
+CHKSUMS="sha256::c569a9714faf115cdb20b51e830e798c1f4de8dabb07f6ff25d221b5d09d8d7f"
 CHKUPDATE="anitya::id=12025"

--- a/lang-python/pytz/autobuild/defines
+++ b/lang-python/pytz/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=pytz
 PKGSEC=python
-PKGDEP="python-2 python-3"
+PKGDEP="python-3"
 PKGDES="Cross-platform timezone library for Python"
 
 ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytz/spec
+++ b/lang-python/pytz/spec
@@ -1,4 +1,4 @@
-VER=2024.2
+VER=2025.2
 SRCS="tbl::https://pypi.io/packages/source/p/pytz/pytz-$VER.tar.gz"
-CHKSUMS="sha256::2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"
+CHKSUMS="sha256::360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"
 CHKUPDATE="anitya::id=6537"


### PR DESCRIPTION
Topic Description
-----------------

- certbot-nginx: update to 5.1.0
- certbot-dns-cloudflare: update to 5.1.0
- certbot-apache: update to 5.1.0
- certbot: update to 5.1.0
- acme: update to 5.1.0
- pyrfc3339: update to 2.1.0, drop python 2 support
- josepy: update to 2.1.0
- pytz: update to 2025.2, drop python 2 support
- pyopenssl: update to 25.3.0
- cryptography: 46.0.2

... and 2 more commits

Package(s) Affected
-------------------

- acme: 5.1.0
- certbot: 5.1.0
- certbot-apache: 5.1.0
- certbot-dns-cloudflare: 5.1.0
- certbot-nginx: 5.1.0
- cffi: 2.0.0
- cryptography: 46.0.2
- josepy: 2.1.0
- maturin: 1.9.6
- pyopenssl: 25.3.0
- pyrfc3339: 2.1.0
- pytz: 2025.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cffi maturin cryptography pyopenssl pytz josepy pyrfc3339 acme certbot certbot-apache certbot-dns-cloudflare certbot-nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
