### PR TITLE
publicsuffixlist: update to 1.0.2.20251009

### DIFF
--- a/lang-python/publicsuffixlist/autobuild/beyond
+++ b/lang-python/publicsuffixlist/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Removing the unneeded publicsuffixlist-download script ..."
+rm -v "$PKGDIR"/usr/bin/publicsuffixlist-download
+rmdir "$PKGDIR"/usr/bin

--- a/lang-python/publicsuffixlist/spec
+++ b/lang-python/publicsuffixlist/spec
@@ -1,4 +1,4 @@
-VER=1.0.2.20250809
+VER=1.0.2.20251009
 SRCS="git::commit=v${VER}-gha::https://github.com/ko-zu/psl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=70367"


### PR DESCRIPTION
Topic Description
-----------------

- publicsuffixlist: update to 1.0.2.20251009
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- publicsuffixlist: 1.0.2.20251009

Security Update?
----------------

No

Build Order
-----------

```
#buildit publicsuffixlist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
