### PR TITLE
bind: update to 9.20.13

### DIFF
--- a/app-network/bind/spec
+++ b/app-network/bind/spec
@@ -1,4 +1,4 @@
-VER=9.20.4
+VER=9.20.13
 SRCS="tbl::https://downloads.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
-CHKSUMS="sha256::3a8e1a05e00e3e9bc02bdffded7862faf7726ba76ba997f42ab487777bd8210b"
+CHKSUMS="sha256::151f9376ead317e646a5d0c9f01c060386d891118d7437a7f829bb9727c7b34c"
 CHKUPDATE="anitya::id=14923"


### PR DESCRIPTION
Topic Description
-----------------

- bind: update to 9.20.13
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bind: 1:9.20.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit bind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
