### PR TITLE
pulseaudio: rebuild for spiral

### DIFF
--- a/app-multimedia/pulseaudio/autobuild/defines
+++ b/app-multimedia/pulseaudio/autobuild/defines
@@ -12,4 +12,6 @@ MESON_AFTER="-D udevrulesdir=/usr/lib/udev/rules.d \
              -D tcpwrap=disabled"
 PKGREP="pulseaudio-modules-bt"
 PKGBREAK="pulseaudio-modules-bt"
+# Note: Extra Provides for Spiral (Debian compatibility).
+PKGPROV="pulseaudio-utils_spiral"
 NOLTO=1

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,7 +1,7 @@
 UPSTREAM_VER=17.0
 XRDP_VER=0.7
 VER=${UPSTREAM_VER}+xrdp${XRDP_VER}
-REL=2
+REL=3
 SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${XRDP_VER};rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
 CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5


### PR DESCRIPTION
Topic Description
-----------------

- pulseaudio: rebuild for spiral

Package(s) Affected
-------------------

- pulseaudio: 17.0+xrdp0.7-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pulseaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
