### PR TITLE
librime: update to 1.14.0

### DIFF
--- a/runtime-i18n/librime/spec
+++ b/runtime-i18n/librime/spec
@@ -1,5 +1,4 @@
-VER=1.11.2
-REL=1
+VER=1.14.0
 # NOTE: the following subprojects need to match the commits with the main project (usually the latest commit will do)
 OCTAGRAMCOMMIT=bd12863f45fbbd5c7db06d5ec8be8987b10253bf
 LUACOMMIT=43229d766f1e0f3198f61dc9d2e38bc1f921387f
@@ -8,7 +7,7 @@ SRCS="https://github.com/rime/librime/archive/$VER.tar.gz \
       https://github.com/lotem/librime-octagram/archive/$OCTAGRAMCOMMIT/librime-octagram-$OCTAGRAMCOMMIT.tar.gz \
       https://github.com/hchunhui/librime-lua/archive/$LUACOMMIT/librime-lua-$LUACOMMIT.tar.gz \
       https://github.com/rime/librime-charcode/archive/$CHARCODECOMMIT/librime-lua-$CHARCODECOMMIT.tar.gz"
-CHKSUMS="sha256::0a3f507d11aeb137de08e90fd319714533caf210b97223d8a12994db215684b5 \
+CHKSUMS="sha256::b2b29c3551eec6b45af1ba8fd3fcffb99e2b7451aa974c1c9ce107e69ce3ea68 \
          sha256::b76d1d01375dffea9ef3052f092eaffe6c67b3e802510cf5ceb4c184b30c311d \
          sha256::68b89fc9fe73d2758019c2380667e78473ccd048361d2d479fc7685471d9d87a \
          sha256::61029bff032b1fef7036086b8b3638fb2373a9f149534ca4e85073230a27dd06"


### PR DESCRIPTION
Topic Description
-----------------

- librime: update to 1.14.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- librime: 1:1.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit librime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
