### PR TITLE
libscfg: update to 0.2.0

### DIFF
--- a/runtime-common/libscfg/spec
+++ b/runtime-common/libscfg/spec
@@ -1,4 +1,4 @@
-VER=0.1.1
-SRCS="git::commit=tags/v$VER::https://git.sr.ht/~emersion/libscfg"
+VER=0.2.0
+SRCS="git::commit=tags/v$VER::https://codeberg.org/emersion/libscfg.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371762"


### PR DESCRIPTION
Topic Description
-----------------

- libscfg: update to 0.2.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libscfg: 0.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libscfg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
