### PR TITLE
telegram-desktop: update to 6.1.4

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -12,25 +12,32 @@ PKGDES="The official Telegram desktop application"
 
 PKGPROV="telegram tdesktop"
 
-CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX='/usr' \
-             -DCMAKE_BUILD_TYPE=Release \
-             -DDESKTOP_APP_SPECIAL_TARGET= \
-             -DTDESKTOP_LAUNCHER_BASENAME=telegramdesktop \
-             -DDESKTOP_APP_DISABLE_WEBRTC_INTEGRATION=OFF \
-             -DDESKTOP_APP_DISABLE_WAYLAND_INTEGRATION=OFF \
-             -DDESKTOP_APP_DISABLE_X11_INTEGRATION=OFF \
-             -DDESKTOP_APP_USE_PACKAGED=OFF \
-             -DDESKTOP_APP_USE_PACKAGED_FONTS=OFF \
-             -DQT_VERSION_MAJOR=5"
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+    '-DCMAKE_BUILD_TYPE=Release'
+    '-DDESKTOP_APP_SPECIAL_TARGET='
+    '-DTDESKTOP_LAUNCHER_BASENAME=telegramdesktop'
+    '-DDESKTOP_APP_DISABLE_WEBRTC_INTEGRATION=OFF'
+    '-DDESKTOP_APP_DISABLE_WAYLAND_INTEGRATION=OFF'
+    '-DDESKTOP_APP_DISABLE_X11_INTEGRATION=OFF'
+    '-DDESKTOP_APP_USE_PACKAGED=OFF'
+    '-DDESKTOP_APP_USE_PACKAGED_FONTS=OFF'
+    '-DQT_VERSION_MAJOR=5'
+)
+# FIXME:
+#
+# Telegram/CMakeFiles/td_scheme.dir/gen/scheme.cpp.o: in function `MTPDupdateBotInlineSend::read(int const*&, int const*)':
+# [...]/Telegram/gen/scheme.cpp:30938:(.text+0xb4630): relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
+# Telegram/CMakeFiles/td_scheme.dir/gen/scheme.cpp.o: in function `MTPDupdateBotInlineQuery::read(int const*&, int const*)':
+# [...]/Telegram/gen/scheme.cpp:30899:(.text+0x126860): relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
+# collect2: error: ld returned 1 exit status
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER[@]}"
+    "-DCMAKE_CXX_FLAGS_RELEASE=${CXXFLAGS} -fno-lto -Os"
+)
 
 ABTYPE=cmakeninja
 
 # FIXME: LTO fails on riscv64
 # lto1: fatal error: LTO_symtab_tags out of range: Range is 0 to 5, value is 237
 NOLTO__RISCV64=1
-
-# FIXME: LTO requires enormous amount of RAM
-NOLTO__LOONGSON3=1
-
-# FIXME: relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
-AB_FLAGS_OS__LOONGSON3=1

--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,4 +1,4 @@
-From 0c8413f88e9ad2ab06c1a7a3d2158c7fb5a57223 Mon Sep 17 00:00:00 2001
+From c0f98fa4a6371f340a6e8abd237d898542a91189 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
 Subject: [PATCH 01/13] fix(window.style): set default window width to 360px

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,4 +1,4 @@
-From 62d7478f1e15632e023474e7fec5a10420596fba Mon Sep 17 00:00:00 2001
+From b5101994109e22fc4a5311378394386f089252c4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
 Subject: [PATCH 02/13] fix(core_settings.h): use system window decoration by

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From 57ecfccb077557aa8c2dfad908453a243b547336 Mon Sep 17 00:00:00 2001
+From 98f68e59b3845f5ea0d067d14e46bc66ec8b6dc4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
 Subject: [PATCH 03/13] fix(ui): fix build with Qt 5

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,4 +1,4 @@
-From a949da6a9ad00303fa2b04b038e50b911e49d094 Mon Sep 17 00:00:00 2001
+From 0cf06b7095fbf0ca1a46f9dc0f4bcd469057ac22 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
 Subject: [PATCH 04/13] fix(core/launcher.cpp): revert to old HiDPI handling

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From 4793226eb8cfe9710e8fd027d48b2a69ed35a869 Mon Sep 17 00:00:00 2001
+From 7d5d2cb40cf4fca316f809a80c319c1a3114be37 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 05/13] fix(settings): use system fonts by default

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From 7ee0e218255643e6ab4fdde85c98f5fad67dbff5 Mon Sep 17 00:00:00 2001
+From 19810af8b08b9c54354a181f56cb750f662047dc Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 06/13] Remove the confusing "Default" option from selectable

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,4 +1,4 @@
-From b880e72810976d4b494996690339d0f231d36de5 Mon Sep 17 00:00:00 2001
+From 1e1fcafcecbf62c2b32a4abe486091563299c2b3 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
 Subject: [PATCH 07/13] fix(lib_tl): add missing cstring include

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,4 +1,4 @@
-From a7185b55867aecd93643594c19ca5435b9ebee0a Mon Sep 17 00:00:00 2001
+From 47a0308a35614c3d5f9234d1569229b4913278b4 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
 Subject: [PATCH 08/13] fix(lib_webview): add missing cstdint include
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/lib_webview/webview/webview_interface.h b/Telegram/lib_webview/webview/webview_interface.h
-index 4a92fe3020..3cf6125358 100644
+index 75214a2993..c95a2e238a 100644
 --- a/Telegram/lib_webview/webview/webview_interface.h
 +++ b/Telegram/lib_webview/webview/webview_interface.h
 @@ -12,6 +12,7 @@

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,4 +1,4 @@
-From 1efab5d4513d335888a930ca31820c90d0cf87cf Mon Sep 17 00:00:00 2001
+From ae6f7f9d43774e660775afe7f16f17305b6efe88 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
 Subject: [PATCH 09/13] fix(current_geo_location_linux): add missing

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,4 +1,4 @@
-From aecdd037f9241d98475c3492f50bb5e9e60313a9 Mon Sep 17 00:00:00 2001
+From a45919366b48238c19c339f14a7a15dcc5129d23 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
 Subject: [PATCH 10/13] fix(core_settings.h): enable video hardware

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,4 +1,4 @@
-From 7c96df63ffd37d362e6c28cb8959b37f9125924d Mon Sep 17 00:00:00 2001
+From 6e0afc481870635c4194d3e99248529c54900cfc Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
 Subject: [PATCH 11/13] fix(cmake): disable CMP0160 to workaround KF5 cmake

--- a/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
@@ -1,4 +1,4 @@
-From 0daca95d120c41ed75950d9398c8b2bc5289ae5b Mon Sep 17 00:00:00 2001
+From 1ed32ea5e44db7cf7119a269f488aa52e65bf5a3 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 3 Jul 2025 19:04:36 -0700
 Subject: [PATCH 12/13] fix(credits_amount.h): include cmath for std::floor

--- a/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
@@ -1,32 +1,32 @@
-From c1271847216ea61e19b5794601629e7f8d1acb63 Mon Sep 17 00:00:00 2001
+From ee38f939c055d287a4630dea44106092e0af2a62 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 28 Aug 2025 02:08:09 -0700
 Subject: [PATCH 13/13] fix(lib_webview): fix build with Qt 5
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
- .../linux/webview_linux_http_server.cpp       | 20 +++++++++++++++++++
- .../linux/webview_linux_webkitgtk.cpp         | 16 +++++++++++++++
- 2 files changed, 36 insertions(+)
+ .../linux/webview_linux_http_server.cpp       | 22 ++++++++++++++++++-
+ .../linux/webview_linux_webkitgtk.cpp         | 16 ++++++++++++++
+ 2 files changed, 37 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
-index 77fd81908a..072c98ab8d 100644
+index 5439d2bb42..2be7eb3ad7 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
-@@ -126,7 +126,12 @@ bool HttpServer::Private::processRedirect(
- 	request.setRawHeader("Referer", "http://desktop-app-resource/page.html");
+@@ -129,7 +129,12 @@ bool HttpServer::Private::processRedirect(
  
  	const auto reply = manager.get(request);
+ 	connect(socket, &QObject::destroyed, reply, &QObject::deleteLater);
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
- 	QObject::connect(reply, &QNetworkReply::finished, socket, [
+ 	connect(reply, &QNetworkReply::finished, socket, [=] {
 +#else
 +	QMetaObject::Connection * const connection = new QMetaObject::Connection;
-+	*connection = QObject::connect(reply, &QNetworkReply::finished, socket, [
++	*connection = connect(reply, &QNetworkReply::finished, socket, [=] {
 +#endif
- 		=, 
- 		replyGuard = std::make_unique<Guard>(crl::guard(reply, [=] {
- 			reply->deleteLater();
-@@ -155,7 +160,13 @@ bool HttpServer::Private::processRedirect(
+ 		(void) guard;
+ 		const auto input = reply->readAll();
+ 		socket->write("HTTP/1.1 200 OK\r\n");
+@@ -153,7 +158,13 @@ bool HttpServer::Private::processRedirect(
  		socket->write("Cache-Control: no-store\r\n");
  		socket->write("\r\n");
  		socket->write(input);
@@ -40,12 +40,13 @@ index 77fd81908a..072c98ab8d 100644
  
  	return true;
  }
-@@ -179,9 +190,18 @@ HttpServer::HttpServer(
+@@ -177,9 +188,18 @@ HttpServer::HttpServer(
  				socket,
  				&QObject::deleteLater);
  
+-			connect(socket, &QIODevice::readyRead, this, [=] {
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
- 			QObject::connect(socket, &QIODevice::readyRead, socket, [=] {
++			connect(socket, &QIODevice::readyRead, socket, [=] {
  				_private->handleRequest(socket);
  			}, Qt::SingleShotConnection);
 +#else
@@ -60,10 +61,10 @@ index 77fd81908a..072c98ab8d 100644
  	});
  }
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
-index 5027a4c0db..44ab526918 100644
+index 7f88a2a21d..776eefce6b 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
-@@ -716,21 +716,37 @@ void Instance::dataRequest(
+@@ -751,21 +751,37 @@ void Instance::dataRequest(
  		socket->write("HTTP/1.1 ");
  		socket->write(partial ? "206 Partial Content\r\n" : "200 OK\r\n");
  

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=6.1.3
+VER=6.1.4
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=5c5c71258777d0196dbb3a09cc37d2f56ead28ab
-TDLIBVER=6dca40bdaac8b5e66c7a793727bf3f81e9711f70
+TDLIBVER=369ee922b45bfa7e8da357e4d62e93925862d86d
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::1c6a531abf106d5f4b6d9179fc802f93cb8ab62630cc07e73d64688780125869 \
+CHKSUMS="sha256::0dc2a36eea9e5f71892530b5c8218274b16999ba6050a396a9dc4dc052033f83 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.1.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- telegram-desktop: 6.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
