### PR TITLE
cuda: update to 13.0.2+580.95.05

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=13.0.1
-MIN_DRIVER_VER=580.82.07
+UPSTREAM_VER=13.0.2
+MIN_DRIVER_VER=580.95.05
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::4c7ac59d1f41d67be27d140a4622801738ad71088570a0facfd6ec878a4c4100"
+CHKSUMS__AMD64="sha256::81a5d0d0870ba2022efb0a531dcc60adbdc2bbff7b3ef19d6fd6d8105406c775"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::927e2c2a6a3e0d12e7e93df10dad6d8f3c688b9e27e9d2034f82d437ec2d2666"
+CHKSUMS__ARM64="sha256::93ab4c77ae2bc0f1f600ef48ccd3ff25a3203a6a6161a84511a33cbf5b5621fc"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 13.0.2+580.95.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cuda: 13.0.2+580.95.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
