### PR TITLE
fcitx5-pinyin-moegirl: update to 20251009

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20250909
+VER=20251009
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::c2d30b8e01dbd484647341bf4791c3945fabeffa2847d5f1805b61dcba3eef0b
-         sha256::c2cc6d8933a0f7fcb3764853b8bc1d7cb7afd0c0335d6203f7a6ead40c8937a9
+CHKSUMS="sha256::b3c8b5799aeea564929a08b9dae8472e082d9f966da0317032d25e643c3fce72
+         sha256::f1699f9e47d383ccdd30abe7dc8f808392988dd6d4a5e5a181e48411cfd652cb
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20251009

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20251009
- rime-pinyin-moegirl: 20251009

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
