### PR TITLE
OOBE and Pre-Built Image Survey 20251010

### DIFF
--- a/app-admin/aosc-os-oobe-cli/autobuild/build
+++ b/app-admin/aosc-os-oobe-cli/autobuild/build
@@ -1,0 +1,30 @@
+abinfo "Building oobe-cli ..."
+cargo build --release --package oobe-cli
+
+abinfo "Installing oobe-cli ..."
+install -Dvm755 "$SRCDIR"/target/release/oobe-cli \
+	"$PKGDIR"/usr/libexec/aosc-os-oobe/aosc-os-oobe-cli
+
+abinfo "Installing script ..."
+install -Dvm755 "$SRCDIR"/contrib/aosc-os-oobe-cli-launcher \
+	"$PKGDIR"/usr/bin/aosc-os-oobe-cli-launcher
+
+abinfo "Installing systemd service ..."
+install -Dvm644 "$SRCDIR"/contrib/aosc-os-oobe-cli.service \
+	"$PKGDIR"/usr/lib/systemd/system/aosc-os-oobe-cli.service
+
+abinfo "Enabling the service ..."
+for tgt in first-boot-complete.target multi-user.target ; do
+	mkdir -p "$PKGDIR"/usr/lib/systemd/system/"$tgt".wants
+	ln -sv ../aosc-os-oobe-cli.service \
+		"$PKGDIR"/usr/lib/systemd/system/"$tgt".wants/aosc-os-oobe-cli.service
+done
+
+abinfo "Installing translations ..."
+for file in $(find "$SRCDIR"/contrib/po -type f -name '*.po' -printf "%P\n") ; do
+	lang="${file%%.po}"
+	abinfo "Installing $lang ..."
+	mkdir -pv "$PKGDIR"/usr/share/locale/"$lang"/LC_MESSAGES
+	msgfmt -o "$PKGDIR"/usr/share/locale/"$lang"/LC_MESSAGES/aosc-os-oobe-launcher.mo \
+		"$SRCDIR"/contrib/po/"$file"
+done

--- a/app-admin/aosc-os-oobe-cli/autobuild/defines
+++ b/app-admin/aosc-os-oobe-cli/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=aosc-os-oobe-cli
+PKGDES="AOSC OS out-of-the-box setup wizard (command-line interface)"
+PKGSEC=admin
+
+PKGDEP="glibc"
+BUILDDEP="rustc llvm"

--- a/app-admin/aosc-os-oobe-cli/spec
+++ b/app-admin/aosc-os-oobe-cli/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/oobe.git"
+CHKSUMS="SKIP"

--- a/app-admin/aosc-os-oobe-gui/autobuild/build
+++ b/app-admin/aosc-os-oobe-gui/autobuild/build
@@ -1,0 +1,24 @@
+# NOTE: This is a shared Cargo workspace. The output will be placed in
+# the workspace, not the source directory. Rust template does not work.
+abinfo "Building the OOBE program ..."
+pushd "$SRCDIR"/oobe-gui/src-tauri
+cargo build --release --features custom-protocol
+
+abinfo "Installing the OOBE program ..."
+install -Dvm755 "$SRCDIR"/target/release/oobe-gui \
+	"$PKGDIR"/usr/libexec/aosc-os-oobe/aosc-os-oobe-gui
+
+abinfo "Installing script ..."
+install -Dvm755 "$SRCDIR"/contrib/aosc-os-oobe-gui-launcher \
+	"$PKGDIR"/usr/bin/aosc-os-oobe-gui-launcher
+
+abinfo "Installing systemd unit file ..."
+install -Dvm644 "$SRCDIR"/contrib/aosc-os-oobe-gui.service \
+	"$PKGDIR"/usr/lib/systemd/system/aosc-os-oobe-gui.service
+
+abinfo "Enabling the service ..."
+for tgt in first-boot-complete.target multi-user.target ; do
+	mkdir -p "$PKGDIR"/usr/lib/systemd/system/"$tgt".wants
+	ln -sv ../aosc-os-oobe-gui.service \
+		"$PKGDIR"/usr/lib/systemd/system/"$tgt".wants/aosc-os-oobe-gui.service
+done

--- a/app-admin/aosc-os-oobe-gui/autobuild/defines
+++ b/app-admin/aosc-os-oobe-gui/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=aosc-os-oobe-gui
+PKGSEC=admin
+PKGDES="AOSC OS out-of-the-box setup wizard (graphical interface)"
+PKGDEP="gcc-runtime webkit2gtk adobe-source-sans wmctrl xinit"
+BUILDDEP="rustc llvm yarn"
+
+NONPMAUDIT=1

--- a/app-admin/aosc-os-oobe-gui/autobuild/prepare
+++ b/app-admin/aosc-os-oobe-gui/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Installing pre-built Web assets ..."
+cp -rv "$SRCDIR"/../dist \
+    "$SRCDIR"/oobe-gui/dist

--- a/app-admin/aosc-os-oobe-gui/spec
+++ b/app-admin/aosc-os-oobe-gui/spec
@@ -1,0 +1,6 @@
+VER=0.1.2
+SRCS="git::rename=oobe;commit=tags/v${VER}::https://github.com/AOSC-Dev/oobe.git \
+      tbl::rename=dist.tar.xz::https://github.com/AOSC-Dev/oobe/releases/download/v${VER}/dist.tar.xz"
+CHKSUMS="SKIP \
+         sha256::2cc869aed027a269f444da2f061c771eeb619585dfb1973a53a067c729d160c4"
+SUBDIR="oobe"

--- a/app-admin/devena-firstboot-asahi/autobuild/build
+++ b/app-admin/devena-firstboot-asahi/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing devena-firstboot files ..."
+make DEVICE=asahi DESTDIR="$PKGDIR"

--- a/app-admin/devena-firstboot-asahi/autobuild/defines
+++ b/app-admin/devena-firstboot-asahi/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=devena-firstboot-asahi
+PKGSEC=admin
+PKGDES="Devena first-boot setup suite (Apple Silicon devices)"
+PKGDEP="bash parted util-linux xfsprogs e2fsprogs btrfs-progs bc dracut"
+BUILDDEP="make"
+
+ABHOST=noarch

--- a/app-admin/devena-firstboot-asahi/spec
+++ b/app-admin/devena-firstboot-asahi/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/devena-firstboot"
+CHKSUMS="SKIP"

--- a/app-admin/devena-firstboot-generic/autobuild/build
+++ b/app-admin/devena-firstboot-generic/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing devena-firstboot files ..."
+make DEVICE=generic DESTDIR="$PKGDIR"

--- a/app-admin/devena-firstboot-generic/autobuild/defines
+++ b/app-admin/devena-firstboot-generic/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=devena-firstboot-generic
+PKGSEC=admin
+PKGDES="Devena first-boot setup suite (generic devices with EFI support)"
+PKGDEP="bash parted util-linux xfsprogs e2fsprogs btrfs-progs bc dracut"
+BUILDDEP="make"
+
+ABHOST=noarch

--- a/app-admin/devena-firstboot-generic/spec
+++ b/app-admin/devena-firstboot-generic/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/devena-firstboot"
+CHKSUMS="SKIP"

--- a/app-admin/devena-firstboot-rpi/autobuild/build
+++ b/app-admin/devena-firstboot-rpi/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Installing devena-firstboot files ..."
+make DEVICE=rpi DESTDIR="$PKGDIR"

--- a/app-admin/devena-firstboot-rpi/autobuild/defines
+++ b/app-admin/devena-firstboot-rpi/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=devena-firstboot-rpi
+PKGSEC=admin
+PKGDES="Devena first-boot setup suite (Raspberry Pi devices)"
+PKGDEP="bash parted util-linux xfsprogs e2fsprogs btrfs-progs bc dracut"
+BUILDDEP="make"
+
+ABHOST=noarch

--- a/app-admin/devena-firstboot-rpi/spec
+++ b/app-admin/devena-firstboot-rpi/spec
@@ -1,0 +1,3 @@
+VER=0.1.2
+SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/devena-firstboot"
+CHKSUMS="SKIP"

--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From 2ec97c359ea87a2152e4076770c9ec8f7cbd225d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/65] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/70] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From a3daa95d2769516586f7c38af93029663c9133a4 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/65] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/70] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 6bd3d7c7b9e643f6452e8dff6fcebc60d2c4d512 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/65] Don't add '*' to highlighted row
+Subject: [PATCH 03/70] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From e5c241ea0ea922abbb2ecb8b3140518a6e2a03cd Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/65] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/70] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 2b35e4db8d9f1f9cab8004e0761a28be960fbf7f Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/65] Indent menu entries
+Subject: [PATCH 05/70] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From d21e8096b9cc9eecfe6da4bb101c6d5d43cec3c5 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/65] Fix margins
+Subject: [PATCH 06/70] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 8ea6cc861054a03a1b437356a0b9b114a0d21adf Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/65] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/70] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From 59c31c490870dd98bc6ca72862a97862bcef0c1b Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/65] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/70] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 12e6fa95ada35a999b46adcbc35a34a73d178ebf Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/65] Don't draw a border around the menu
+Subject: [PATCH 09/70] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 8a14427edcdf93bc2c38822465d1082672bb9263 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/65] Use the standard margin for the timeout string
+Subject: [PATCH 10/70] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 5ff724e6a6e01cb6f03f5ce09d6cb01a44ad3d67 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/65] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/70] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From b127120988f3d85ebc75c493eba08fc54c8b99dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/65] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/70] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From 42a8d6a924f700586328325eb3abe28c4055cc5e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/65] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/70] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 59e7ba1bf0d63ddcd8e3d40888bcac0b7223e70e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/65] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/70] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From c23c121bde5381debb61889fb3cc94a6061628ab Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/65] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/70] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From 71cb4fcc6a76c5cdc3a629351097a73c664fb6f5 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/65] commands: add new command memsize
+Subject: [PATCH 16/70] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From b98c6eb9ba1e8f88e7d2df1c6700fef74a9b4fe2 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/65] commands: add new command 'pause'
+Subject: [PATCH 17/70] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From 5855f82d979f2db3e185e75c356686f5b23943ae Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/65] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/70] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From 0ec6cd51f5f49d1c2b82737279589431427f3838 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/65] po: add patch to disable parallel execution
+Subject: [PATCH 19/70] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.

--- a/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-bash-completion-Load-scripts-on-demand.patch
@@ -1,7 +1,7 @@
 From b69e36efa6f9745e73e9312d2db26875ce83a8fc Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Tue, 30 Jan 2024 14:41:10 +0800
-Subject: [PATCH 20/65] util/bash-completion: Load scripts on demand
+Subject: [PATCH 20/70] util/bash-completion: Load scripts on demand
 
 There are two system directories for bash-completion scripts. One is
 /usr/share/bash-completion/completions/ and the other is

--- a/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
+++ b/app-admin/grub/autobuild/patches/0021-util-bash-completion-Fix-for-bash-completion-2.12.patch
@@ -1,7 +1,7 @@
 From 1632a45c5d4d78dea18e449b3592120cc8517bff Mon Sep 17 00:00:00 2001
 From: Gary Lin <glin@suse.com>
 Date: Mon, 25 Mar 2024 10:11:34 +0800
-Subject: [PATCH 21/65] util/bash-completion: Fix for bash-completion 2.12
+Subject: [PATCH 21/70] util/bash-completion: Fix for bash-completion 2.12
 
 _split_longopt() was the bash-completion private API and removed since
 bash-completion 2.12. This commit initializes the bash-completion

--- a/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0022-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From 2f40e35813a4677b7409d6d6b9459c0ed3e98bca Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 22/65] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 22/70] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:

--- a/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0023-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 624eb1c0887dba508ef03385e7f49f7d951b3ac4 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 23/65] loongarch64: able to start on legacy firmware
+Subject: [PATCH 23/70] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.

--- a/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0024-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,7 +1,7 @@
 From 977635494cb3f3418924842943088801ee241ee5 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 19:29:21 +0800
-Subject: [PATCH 24/65] Add support for forcing EFI installation to the
+Subject: [PATCH 24/70] Add support for forcing EFI installation to the
  removable media path
 
 Add an extra option to grub-install "--force-extra-removable". On EFI

--- a/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0025-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,7 +1,7 @@
 From 6015952363f071aacf6f5d2de607fc168daa1746 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 14 Aug 2024 19:34:26 +0800
-Subject: [PATCH 25/65] grub-install: (loongarch64-efi) also install
+Subject: [PATCH 25/70] grub-install: (loongarch64-efi) also install
  BOOTLOONGARCH.EFI
 
 Some old-world firmware (especially that of the BPI01000 revision) does not

--- a/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
+++ b/app-admin/grub/autobuild/patches/0026-mips64-Add-support-for-64-bit-MIPS.patch
@@ -1,7 +1,7 @@
 From 61a3db3ad1e300a531aaa7dcdd4bf496f1b5be65 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Mon, 9 Jan 2017 14:42:41 +0800
-Subject: [PATCH 26/65] mips64: Add support for 64-bit MIPS.
+Subject: [PATCH 26/70] mips64: Add support for 64-bit MIPS.
 
 ---
  configure.ac                         |  21 +-

--- a/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
+++ b/app-admin/grub/autobuild/patches/0027-mips64-Add-support-for-Loongson.patch
@@ -1,7 +1,7 @@
 From e4e7a42521c5b178a86caf1ac950dfc1f79e0a30 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Fri, 13 Jan 2017 16:02:41 +0800
-Subject: [PATCH 27/65] mips64: Add support for Loongson.
+Subject: [PATCH 27/70] mips64: Add support for Loongson.
 
 ---
  configure.ac                            |   6 +-

--- a/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
+++ b/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-fix-missing-type-args-while-load.patch
@@ -1,7 +1,7 @@
 From e5d36fc00b3467b49851f20effb4e9c3400e73ce Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:59:42 +0800
-Subject: [PATCH 28/65] loader/mips64/linux: fix missing type args while
+Subject: [PATCH 28/70] loader/mips64/linux: fix missing type args while
  loading kernel
 
 ---

--- a/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
+++ b/app-admin/grub/autobuild/patches/0029-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
@@ -1,7 +1,7 @@
 From fb3c7be5f6bd065554321f75d65132dfd53bb2d4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:33:13 +0800
-Subject: [PATCH 29/65] util/grub-mkimagexx: fix uncorrect section var in
+Subject: [PATCH 29/70] util/grub-mkimagexx: fix uncorrect section var in
  `make_reloc_section`
 
 ---

--- a/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
+++ b/app-admin/grub/autobuild/patches/0030-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
@@ -1,7 +1,7 @@
 From 828d7983742c9336e8a512b1bd4ec74cb3e4ec33 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:03:46 +0800
-Subject: [PATCH 30/65] loader/mips64/linux: drop argv[] args when calling
+Subject: [PATCH 30/70] loader/mips64/linux: drop argv[] args when calling
  grub_initrd_load()
 
 ---

--- a/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
+++ b/app-admin/grub/autobuild/patches/0031-lib-mips64-drop-all-efi_call-wrappers.patch
@@ -1,7 +1,7 @@
 From d4942f62fdf97f922516b3e7ea3d72e7c8dcf772 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:20:57 +0800
-Subject: [PATCH 31/65] lib/mips64: drop all efi_call wrappers
+Subject: [PATCH 31/70] lib/mips64: drop all efi_call wrappers
 
 ---
  grub-core/kern/mips64/efi/init.c    | 8 ++++----

--- a/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
+++ b/app-admin/grub/autobuild/patches/0032-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
@@ -1,7 +1,7 @@
 From 402da3bece331169230d07b83496885cd305529a Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:27:17 +0800
-Subject: [PATCH 32/65] lib/mips64: use a common GUID impl in GRUB
+Subject: [PATCH 32/70] lib/mips64: use a common GUID impl in GRUB
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 2 +-

--- a/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
+++ b/app-admin/grub/autobuild/patches/0033-kern-mips64-fix-error-catch-output-type-mismatch.patch
@@ -1,7 +1,7 @@
 From 8ca095a942e8e19033c3e0dde9da7412c62f8698 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:46:18 +0800
-Subject: [PATCH 33/65] kern/mips64: fix error catch output type mismatch
+Subject: [PATCH 33/70] kern/mips64: fix error catch output type mismatch
 
 ---
  grub-core/kern/mips64/dl.c | 2 +-

--- a/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
+++ b/app-admin/grub/autobuild/patches/0034-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
@@ -1,7 +1,7 @@
 From 8d9bff60ccfd4e9d67e83479df15b5c072fd7b14 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:01 +0800
-Subject: [PATCH 34/65] kern/mips64: fix missing grub_install_get_time_ms
+Subject: [PATCH 34/70] kern/mips64: fix missing grub_install_get_time_ms
  prototype
 
 ---

--- a/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
+++ b/app-admin/grub/autobuild/patches/0035-lib-mips64-silence-werror.patch
@@ -1,7 +1,7 @@
 From 1c99dd698362042f2da9e9ac7283061984405c8c Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:28 +0800
-Subject: [PATCH 35/65] lib/mips64: silence werror
+Subject: [PATCH 35/70] lib/mips64: silence werror
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 5 ++++-

--- a/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
+++ b/app-admin/grub/autobuild/patches/0036-loader-mips64-fix-warnings-and-style.patch
@@ -1,7 +1,7 @@
 From cb1215b5499cb16020d9cca639d95ca0ba31b642 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:32:14 +0800
-Subject: [PATCH 36/65] loader/mips64: fix warnings and style
+Subject: [PATCH 36/70] loader/mips64: fix warnings and style
 
 ---
  grub-core/loader/mips64/linux.c | 82 ++++++++++++++++++---------------

--- a/app-admin/grub/autobuild/patches/0037-util-grub-install-mips64el-efi-rename-removable-exec.patch
+++ b/app-admin/grub/autobuild/patches/0037-util-grub-install-mips64el-efi-rename-removable-exec.patch
@@ -1,7 +1,7 @@
 From c85d646b63131e14167b622b81ed5366a5b62257 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 9 Oct 2024 15:26:25 +0800
-Subject: [PATCH 37/65] util/grub-install: mips64el-efi: rename removable
+Subject: [PATCH 37/70] util/grub-install: mips64el-efi: rename removable
  executable
 
 as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI

--- a/app-admin/grub/autobuild/patches/0038-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
+++ b/app-admin/grub/autobuild/patches/0038-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
@@ -1,7 +1,7 @@
 From 136f9eb1e60e7a6dbfdb3d0223ddcaccde4bf312 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 10 Oct 2024 14:40:32 +0800
-Subject: [PATCH 38/65] fix(util/grub-mkrescue): fix EFI executable name for
+Subject: [PATCH 38/70] fix(util/grub-mkrescue): fix EFI executable name for
  mips64el-efi
 
 Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.

--- a/app-admin/grub/autobuild/patches/0039-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
+++ b/app-admin/grub/autobuild/patches/0039-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
@@ -1,7 +1,7 @@
 From 2dd46c9cc02ab810716a583838ad3d82ca0154b4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:53:43 +0800
-Subject: [PATCH 39/65] grub.d: 00-header: disable graphical output for
+Subject: [PATCH 39/70] grub.d: 00-header: disable graphical output for
  MacBook6,2
 
 MacBook Pro 15'' (Mid-2010, MacBookPro6,2) are known to have broken

--- a/app-admin/grub/autobuild/patches/0040-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
+++ b/app-admin/grub/autobuild/patches/0040-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
@@ -1,7 +1,7 @@
 From f64be25b3cd8255dcfaa2449fc550c62f445111e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:33:38 +0800
-Subject: [PATCH 40/65] menu: add GRUB_RIGHT_TO_SELECT to toggle
+Subject: [PATCH 40/70] menu: add GRUB_RIGHT_TO_SELECT to toggle
  select-by-right-arrow-key
 
 Normally, GRUB allows using a combination of the Return/Enter (`\n' and

--- a/app-admin/grub/autobuild/patches/0041-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
+++ b/app-admin/grub/autobuild/patches/0041-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
@@ -1,7 +1,7 @@
 From 7a26ce92adcdcbd8eca96b8d51c7cf91db01d614 Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Fri, 15 Nov 2024 16:49:55 +0800
-Subject: [PATCH 41/65] templates: make UEFI fwsetup menu entry label
+Subject: [PATCH 41/70] templates: make UEFI fwsetup menu entry label
  translatable
 
 When the "UEFI Firmware Settings" entries was added in commit 46d76f8fe

--- a/app-admin/grub/autobuild/patches/0042-gitignore-reconsider-PO-files-and-grub.pot-template.patch
+++ b/app-admin/grub/autobuild/patches/0042-gitignore-reconsider-PO-files-and-grub.pot-template.patch
@@ -1,7 +1,7 @@
 From 8f6d580d52d02b1187a98dab69b2635a5d6df187 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:12 +0800
-Subject: [PATCH 42/65] gitignore: reconsider PO files and grub.pot template
+Subject: [PATCH 42/70] gitignore: reconsider PO files and grub.pot template
 
 ---
  .gitignore | 3 ---

--- a/app-admin/grub/autobuild/patches/0043-po-add-PO-files-from-translationproject.org.patch
+++ b/app-admin/grub/autobuild/patches/0043-po-add-PO-files-from-translationproject.org.patch
@@ -1,7 +1,7 @@
 From 8556c3e1a5603b41c633cecf3be86527d776c3d5 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:48 +0800
-Subject: [PATCH 43/65] po: add PO files from translationproject.org
+Subject: [PATCH 43/70] po: add PO files from translationproject.org
 
 To generate grub.pot, you can run the following command:
 

--- a/app-admin/grub/autobuild/patches/0044-po-update-zh_CN-translation.patch
+++ b/app-admin/grub/autobuild/patches/0044-po-update-zh_CN-translation.patch
@@ -1,7 +1,7 @@
 From bb33cdb51dc7882993ed51b0e2d36ed8fa41edb9 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 22:38:48 +0800
-Subject: [PATCH 44/65] po: update zh_CN translation
+Subject: [PATCH 44/70] po: update zh_CN translation
 
 ---
  po/zh_CN.po | 1314 +++++++++++++++++++++++++++++++++------------------

--- a/app-admin/grub/autobuild/patches/0045-po-update-zh_TW-translations.patch
+++ b/app-admin/grub/autobuild/patches/0045-po-update-zh_TW-translations.patch
@@ -1,7 +1,7 @@
 From ac6126aec4f0231046d1e6df52ba4ee7edc2c000 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 16 Nov 2024 22:46:05 +0800
-Subject: [PATCH 45/65] po: update zh_TW translations
+Subject: [PATCH 45/70] po: update zh_TW translations
 
 Add translation for UEFI Settings.
 ---

--- a/app-admin/grub/autobuild/patches/0046-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
+++ b/app-admin/grub/autobuild/patches/0046-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
@@ -1,7 +1,7 @@
 From 280ea0f713643a5a91cdcfbaf6e4a1be78c6cec3 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sun, 19 Jan 2025 23:18:56 +0800
-Subject: [PATCH 46/65] grub.d/30_uefi-firmware: disable fwsetup menu for
+Subject: [PATCH 46/70] grub.d/30_uefi-firmware: disable fwsetup menu for
  mips64el-efi
 
 ---

--- a/app-admin/grub/autobuild/patches/0047-loader-mips64-linux-properly-prepare-memory-for-init.patch
+++ b/app-admin/grub/autobuild/patches/0047-loader-mips64-linux-properly-prepare-memory-for-init.patch
@@ -1,7 +1,7 @@
 From 739cf9f59dfb41a68956baf8ff09c389ad66a3af Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Wed, 22 Jan 2025 21:13:13 +0800
-Subject: [PATCH 47/65] loader/mips64/linux: properly prepare memory for initrd
+Subject: [PATCH 47/70] loader/mips64/linux: properly prepare memory for initrd
 
 ... instead of allocating a fixed amount at initialization
 ---

--- a/app-admin/grub/autobuild/patches/0048-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
+++ b/app-admin/grub/autobuild/patches/0048-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
@@ -1,7 +1,7 @@
 From fc693b36ff2cda955729a00bcd34494d36c7ea01 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Fri, 14 Feb 2025 15:23:20 +0800
-Subject: [PATCH 48/65] fix(util/grub-mkimagexx): unconditionaly use 64-bit
+Subject: [PATCH 48/70] fix(util/grub-mkimagexx): unconditionaly use 64-bit
  addresses for mips64el-efi
 
 grub_addr_t uses host pointer size, which becomes undesirable if the host

--- a/app-admin/grub/autobuild/patches/0049-grub.d-10_linux-Use-an-in-house-script-to-generate-l.patch
+++ b/app-admin/grub/autobuild/patches/0049-grub.d-10_linux-Use-an-in-house-script-to-generate-l.patch
@@ -1,7 +1,7 @@
 From 14a9e3ee650dce9b6a90daa0a91c2d65f72d095f Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 11 Aug 2025 10:42:41 +0800
-Subject: [PATCH 49/65] grub.d/10_linux: Use an in-house script to generate
+Subject: [PATCH 49/70] grub.d/10_linux: Use an in-house script to generate
  linux menu entries
 
 Now we have to deal with different kernel configurations for each kernel

--- a/app-admin/grub/autobuild/patches/0050-po-update-PO-files.patch
+++ b/app-admin/grub/autobuild/patches/0050-po-update-PO-files.patch
@@ -1,7 +1,7 @@
 From 1d59105a9fc2cdcf078f0ac4232229804f981fdd Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 3 Sep 2025 12:17:03 +0800
-Subject: [PATCH 50/65] po: update PO files
+Subject: [PATCH 50/70] po: update PO files
 
 ---
  po/ast.po   | 4785 ++++++++++++++++++++++-----------

--- a/app-admin/grub/autobuild/patches/0051-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0051-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From d70138ba6ec8a3bcf2a993e86465adda1ce40419 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2?= <jeffbai@aosc.io>
 Date: Thu, 4 Sep 2025 01:36:34 +0000
-Subject: [PATCH 51/65] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 51/70] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1558 of 1558 strings)

--- a/app-admin/grub/autobuild/patches/0052-10_linux-show-the-latest-kernel-for-each-variant-on-.patch
+++ b/app-admin/grub/autobuild/patches/0052-10_linux-show-the-latest-kernel-for-each-variant-on-.patch
@@ -1,7 +1,7 @@
 From 0cd3dd62fbfb408041ecf45d5185a617d6a448ee Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 5 Sep 2025 14:55:45 +0800
-Subject: [PATCH 52/65] 10_linux: show the latest kernel for each variant on
+Subject: [PATCH 52/70] 10_linux: show the latest kernel for each variant on
  toplevel menu
 
 Previously, this script just place the latest kernel in the top level

--- a/app-admin/grub/autobuild/patches/0053-po-process-transliterated-line-breaks-n.patch
+++ b/app-admin/grub/autobuild/patches/0053-po-process-transliterated-line-breaks-n.patch
@@ -1,7 +1,7 @@
 From 5e868d12e996828fa3104852e2beed29c912db7f Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 5 Sep 2025 18:03:12 +0800
-Subject: [PATCH 53/65] =?UTF-8?q?po:=20process=20transliterated=20line=20b?=
+Subject: [PATCH 53/70] =?UTF-8?q?po:=20process=20transliterated=20line=20b?=
  =?UTF-8?q?reaks:=20\=D0=BD=20->=20\n?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/grub/autobuild/patches/0054-10_linux-show-all-kernels-in-the-submenu.patch
+++ b/app-admin/grub/autobuild/patches/0054-10_linux-show-all-kernels-in-the-submenu.patch
@@ -1,7 +1,7 @@
 From a2e96565a6828f39569279a1509e43d019d0bb67 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 6 Sep 2025 00:17:44 +0800
-Subject: [PATCH 54/65] 10_linux: show all kernels in the submenu
+Subject: [PATCH 54/70] 10_linux: show all kernels in the submenu
 
 ---
  util/grub.d/10_linux.in | 3 +--

--- a/app-admin/grub/autobuild/patches/0055-10_linux-skip-showing-Processing-for-kernels-in-the-.patch
+++ b/app-admin/grub/autobuild/patches/0055-10_linux-skip-showing-Processing-for-kernels-in-the-.patch
@@ -1,7 +1,7 @@
 From 60865a5cd686d3d1d3c3bfd464215430fe3ae980 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 6 Sep 2025 00:17:44 +0800
-Subject: [PATCH 55/65] 10_linux: skip showing 'Processing' for kernels in the
+Subject: [PATCH 55/70] 10_linux: skip showing 'Processing' for kernels in the
  toplevel menu
 
 ---

--- a/app-admin/grub/autobuild/patches/0056-po-update-PO-template-and-translation-files.patch
+++ b/app-admin/grub/autobuild/patches/0056-po-update-PO-template-and-translation-files.patch
@@ -1,7 +1,7 @@
 From 866b569463d93c296460d448ab89c1d61892905a Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 15:45:24 +0800
-Subject: [PATCH 56/65] po: update PO template and translation files
+Subject: [PATCH 56/70] po: update PO template and translation files
 
 ---
  po/ast.po   | 36 ++++++++++++++++++------------------

--- a/app-admin/grub/autobuild/patches/0057-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0057-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From 26734680f772434784277b2b476d4f51be4b6ba0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2?= <jeffbai@aosc.io>
 Date: Mon, 8 Sep 2025 07:57:32 +0000
-Subject: [PATCH 57/65] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 57/70] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1558 of 1558 strings)

--- a/app-admin/grub/autobuild/patches/0058-10_linux-fix-the-formatting-of-Booting-and-Loading-K.patch
+++ b/app-admin/grub/autobuild/patches/0058-10_linux-fix-the-formatting-of-Booting-and-Loading-K.patch
@@ -1,7 +1,7 @@
 From 7b879b1cf6c19ca06b305ce464f223605d61daee Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 16:44:12 +0800
-Subject: [PATCH 58/65] 10_linux: fix the formatting of "Booting" and "Loading
+Subject: [PATCH 58/70] 10_linux: fix the formatting of "Booting" and "Loading
  Kernel" prompt
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/grub/autobuild/patches/0059-10_linux-add-an-arrow-to-the-submenu-entry.patch
+++ b/app-admin/grub/autobuild/patches/0059-10_linux-add-an-arrow-to-the-submenu-entry.patch
@@ -1,7 +1,7 @@
 From f80c4fcab96c1b9f5331c1fef4884702593bc8eb Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 16:53:09 +0800
-Subject: [PATCH 59/65] 10_linux: add an arrow to the submenu entry
+Subject: [PATCH 59/70] 10_linux: add an arrow to the submenu entry
 
 ---
  util/grub.d/10_linux.in | 2 +-

--- a/app-admin/grub/autobuild/patches/0060-10_linux-fix-initrd-detection-when-generating-submen.patch
+++ b/app-admin/grub/autobuild/patches/0060-10_linux-fix-initrd-detection-when-generating-submen.patch
@@ -1,7 +1,7 @@
 From 57294694fe51591e692344595aa0d3e14cb3fe8f Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 12:06:33 +0800
-Subject: [PATCH 60/65] 10_linux: fix initrd detection when generating submenu
+Subject: [PATCH 60/70] 10_linux: fix initrd detection when generating submenu
  entries
 
 The condition that controls the initrd message is awfully wrong. It

--- a/app-admin/grub/autobuild/patches/0061-10_linux-support-btrfs-subvolumes-for-kernel-initrd-.patch
+++ b/app-admin/grub/autobuild/patches/0061-10_linux-support-btrfs-subvolumes-for-kernel-initrd-.patch
@@ -1,7 +1,7 @@
 From 2a24c5f6728ff4f0613a4f32c92dc4900155559e Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 15:35:46 +0800
-Subject: [PATCH 61/65] 10_linux: support btrfs subvolumes for kernel/initrd
+Subject: [PATCH 61/70] 10_linux: support btrfs subvolumes for kernel/initrd
  paths
 
 ---

--- a/app-admin/grub/autobuild/patches/0062-10_linux-sort-submenu-entries-by-versions.patch
+++ b/app-admin/grub/autobuild/patches/0062-10_linux-sort-submenu-entries-by-versions.patch
@@ -1,7 +1,7 @@
 From d13db8b746659d457b39abb4b6c54723029f45d4 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 17:15:15 +0800
-Subject: [PATCH 62/65] 10_linux: sort submenu entries by versions
+Subject: [PATCH 62/70] 10_linux: sort submenu entries by versions
 
 ---
  util/grub.d/10_linux.in | 38 ++++++++++++++++++++++----------------

--- a/app-admin/grub/autobuild/patches/0063-10_linux-strip-leading-whitespaces-when-printing-ker.patch
+++ b/app-admin/grub/autobuild/patches/0063-10_linux-strip-leading-whitespaces-when-printing-ker.patch
@@ -1,7 +1,7 @@
 From 7f40da99b2bd1ea3e35d5b001f8b845011da8c68 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Sep 2025 00:04:34 +0800
-Subject: [PATCH 63/65] 10_linux: strip leading whitespaces when printing
+Subject: [PATCH 63/70] 10_linux: strip leading whitespaces when printing
  kernel and initrd path
 
 ---

--- a/app-admin/grub/autobuild/patches/0064-10_linux-rework-prioritization-logic.patch
+++ b/app-admin/grub/autobuild/patches/0064-10_linux-rework-prioritization-logic.patch
@@ -1,7 +1,7 @@
 From dd955eccc37ed33405b87884f525ac060fe22956 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 2 Oct 2025 23:56:42 +0800
-Subject: [PATCH 64/65] 10_linux: rework prioritization logic
+Subject: [PATCH 64/70] 10_linux: rework prioritization logic
 
 Previously the kernel with default configuration (e.g. -16k for
 LoongArch) will always be on top regardless of its variant, i.e. a 16k

--- a/app-admin/grub/autobuild/patches/0065-10_linux.in-read-etc-os-release-to-specify-OS-class.patch
+++ b/app-admin/grub/autobuild/patches/0065-10_linux.in-read-etc-os-release-to-specify-OS-class.patch
@@ -1,7 +1,7 @@
 From 7785a7eefdf91da83630c18478a6ed1b3ae5f52d Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 3 Oct 2025 00:07:52 +0800
-Subject: [PATCH 65/65] 10_linux.in: read /etc/os-release to specify OS class
+Subject: [PATCH 65/70] 10_linux.in: read /etc/os-release to specify OS class
 
 Some theme uses OS classes to determine OS type. We missed that in the
 initial rewrite.

--- a/app-admin/grub/autobuild/patches/0066-10_linux-fix-GRUB_KERNEL_DIR-when-using-separate-boo.patch
+++ b/app-admin/grub/autobuild/patches/0066-10_linux-fix-GRUB_KERNEL_DIR-when-using-separate-boo.patch
@@ -1,0 +1,38 @@
+From b400e1504c6223a0389f8017a3734fa85df43f90 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Sat, 11 Oct 2025 17:21:59 +0800
+Subject: [PATCH 66/70] 10_linux: fix GRUB_KERNEL_DIR when using separate /boot
+ w/ btrfs
+
+If /boot is on a separate partition, we should use / for
+GRUB_KERNEL_DIR, and there is no need to process the subvolume even if
+/boot is a btrfs filesystem.
+---
+ util/grub.d/10_linux.in | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index 560098f2a..78e38d01a 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -66,12 +66,14 @@ fi
+ # kernel changes.
+ if [ "$GRUB_DEVICE" == "$GRUB_DEVICE_BOOT" ] ; then
+ 	GRUB_KERNEL_DIR="${KERNEL_DIR%%/}/"
++	# Convert them into paths relative to the "actual" root, say, namespaces like
++	# BtrFS subvolumes.
++	GRUB_KERNEL_DIR="$(make_system_path_relative_to_its_root $GRUB_KERNEL_DIR)/"
+ else
++	# If /boot is a separate partition, the path GRUB loads the kernel should
++	# be /KERNEL_FILE instead of /boot/KERNEL_FILE.
+ 	GRUB_KERNEL_DIR="/"
+ fi
+-# Convert them into paths relative to the "actual" root, say, namespaces like
+-# BtrFS subvolumes.
+-GRUB_KERNEL_DIR="$(make_system_path_relative_to_its_root $GRUB_KERNEL_DIR)/"
+ 
+ # search --fs-uuid commands.
+ MENUENTRY_PREP="$(prepare_grub_to_access_device "$GRUB_DEVICE_BOOT")"
+-- 
+2.51.0
+

--- a/app-admin/grub/autobuild/patches/0067-Translated-using-Weblate-Esperanto.patch
+++ b/app-admin/grub/autobuild/patches/0067-Translated-using-Weblate-Esperanto.patch
@@ -1,0 +1,55 @@
+From 3fd65bc3ba4775075938f010bbb0f6495e60ea08 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Mon, 27 Oct 2025 17:42:49 +0800
+Subject: [PATCH 67/70] Translated using Weblate (Esperanto)
+
+Currently translated at 97.6% (1522 of 1559 strings)
+
+Translation: GNU GRUB/2.12-aosc
+Translate-URL: https://weblate.aosc.io/projects/grub-aosc/2-12-aosc/eo/
+---
+ po/eo.po | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/po/eo.po b/po/eo.po
+index 1d7b014ca..1e274185d 100644
+--- a/po/eo.po
++++ b/po/eo.po
+@@ -8,16 +8,18 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
+-"PO-Revision-Date: 2024-02-23 22:08-0500\n"
+-"Last-Translator: Keith Bowes <zooplah@gmail.com>\n"
+-"Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
++"POT-Creation-Date: 2025-09-08 16:44+0800\n"
++"PO-Revision-Date: 2025-10-21 19:23+0000\n"
++"Last-Translator: LiliaCyk871e <ACLZCyk871e@outlook.com>\n"
++"Language-Team: Esperanto <https://weblate.aosc.io/projects/grub-aosc/"
++"2-12-aosc/eo/>\n"
+ "Language: eo\n"
+ "MIME-Version: 1.0\n"
+ "Content-Type: text/plain; charset=UTF-8\n"
+ "Content-Transfer-Encoding: 8bit\n"
++"Plural-Forms: nplurals=2; plural=n != 1;\n"
++"X-Generator: Weblate 5.10.3\n"
+ "X-Bugs: Report translation errors to the Language-Team address.\n"
+-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+ 
+ #: grub-core/bus/usb/serial/ftdi.c:145 grub-core/bus/usb/serial/pl2303.c:158
+ #: grub-core/term/ieee1275/escc.c:169 grub-core/term/ns8250.c:262
+@@ -1559,8 +1561,9 @@ msgid "Write 32-bit VALUE to ADDR."
+ msgstr "Skribi 32-bitan valoron al ADDR."
+ 
+ #: grub-core/commands/memsize.c:44
++#, fuzzy
+ msgid "Print and export the vaule as number of bytes."
+-msgstr ""
++msgstr "Presi kaj eksporti la valoron kiel bajtokvanton."
+ 
+ #: grub-core/commands/memsize.c:46
+ msgid "Print and export the value as kibibytes."
+-- 
+2.51.0
+

--- a/app-admin/grub/autobuild/patches/0068-10_linux-add-comment-string-for-Asahi-kernel.patch
+++ b/app-admin/grub/autobuild/patches/0068-10_linux-add-comment-string-for-Asahi-kernel.patch
@@ -1,0 +1,4326 @@
+From 21cf3d60e5731fce4f9568c526f991c1325d5453 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Mon, 27 Oct 2025 18:21:07 +0800
+Subject: [PATCH 68/70] 10_linux: add comment string for Asahi kernel
+
+* Update PO Template.
+* Merge translations with the PO Template.
+---
+ po/ast.po               | 39 +++++++++++++++++++++----------------
+ po/ca.po                | 39 +++++++++++++++++++++----------------
+ po/da.po                | 39 +++++++++++++++++++++----------------
+ po/de.po                | 39 +++++++++++++++++++++----------------
+ po/eo.po                | 43 +++++++++++++++++++++++------------------
+ po/es.po                | 39 +++++++++++++++++++++----------------
+ po/fi.po                | 39 +++++++++++++++++++++----------------
+ po/fr.po                | 39 +++++++++++++++++++++----------------
+ po/gl.po                | 39 +++++++++++++++++++++----------------
+ po/grub.pot             | 39 +++++++++++++++++++++----------------
+ po/he.po                | 39 +++++++++++++++++++++----------------
+ po/hr.po                | 39 +++++++++++++++++++++----------------
+ po/hu.po                | 39 +++++++++++++++++++++----------------
+ po/id.po                | 39 +++++++++++++++++++++----------------
+ po/it.po                | 39 +++++++++++++++++++++----------------
+ po/ja.po                | 39 +++++++++++++++++++++----------------
+ po/ka.po                | 39 +++++++++++++++++++++----------------
+ po/ko.po                | 39 +++++++++++++++++++++----------------
+ po/lg.po                | 39 +++++++++++++++++++++----------------
+ po/lt.po                | 39 +++++++++++++++++++++----------------
+ po/nb.po                | 39 +++++++++++++++++++++----------------
+ po/nl.po                | 39 +++++++++++++++++++++----------------
+ po/pa.po                | 39 +++++++++++++++++++++----------------
+ po/pl.po                | 39 +++++++++++++++++++++----------------
+ po/pt.po                | 39 +++++++++++++++++++++----------------
+ po/pt_BR.po             | 39 +++++++++++++++++++++----------------
+ po/ro.po                | 39 +++++++++++++++++++++----------------
+ po/ru.po                | 39 +++++++++++++++++++++----------------
+ po/sl.po                | 39 +++++++++++++++++++++----------------
+ po/sr.po                | 39 +++++++++++++++++++++----------------
+ po/sv.po                | 39 +++++++++++++++++++++----------------
+ po/tr.po                | 39 +++++++++++++++++++++----------------
+ po/uk.po                | 39 +++++++++++++++++++++----------------
+ po/vi.po                | 39 +++++++++++++++++++++----------------
+ po/zh_CN.po             | 39 +++++++++++++++++++++----------------
+ po/zh_TW.po             | 39 +++++++++++++++++++++----------------
+ util/grub.d/10_linux.in |  3 +++
+ 37 files changed, 797 insertions(+), 614 deletions(-)
+
+diff --git a/po/ast.po b/po/ast.po
+index 844b1bc36..376768f16 100644
+--- a/po/ast.po
++++ b/po/ast.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.04-pre1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2019-04-09 21:19+0200\n"
+ "Last-Translator: enolp <enolp@softastur.org>\n"
+ "Language-Team: Asturian <alministradores@softastur.org>\n"
+@@ -7748,83 +7748,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Cargando Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Cargando'l discu de ram inicial..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Arrancando «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opciones avanzaes de %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, col kernel %s (per %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/ca.po b/po/ca.po
+index d9d335d07..0866a2fef 100644
+--- a/po/ca.po
++++ b/po/ca.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.02-pre3\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2017-02-04 15:26+0100\n"
+ "Last-Translator: Angel Mompo <mecatxis@mecatxis.cat>\n"
+ "Language-Team: Catalan <ca@dodds.net>\n"
+@@ -7792,83 +7792,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "S'està carregant el Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "S'està carregant la ramdisk inicial ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "S'arrenca «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opcions avançades de %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, amb nucli %s (a través de %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/da.po b/po/da.po
+index 4fc73306a..2b679c109 100644
+--- a/po/da.po
++++ b/po/da.po
+@@ -17,7 +17,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.02-pre3\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2017-02-16 21:11+0100\n"
+ "Last-Translator: Ask Hjorth Larsen <asklarsen@gmail.com>\n"
+ "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
+@@ -7751,83 +7751,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Indlæser Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Indlæser start-ramdisk ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Booter \"%s\""
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Avancerede indstillinger for %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, med kerne %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/de.po b/po/de.po
+index 4a5ce26ae..559fb5e31 100644
+--- a/po/de.po
++++ b/po/de.po
+@@ -9,7 +9,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-11 16:16+0200\n"
+ "Last-Translator: Roland Illig <roland.illig@gmx.de>\n"
+ "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
+@@ -7752,83 +7752,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s wird geladen …"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Initiale Ramdisk wird geladen …"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "»%s« wird gebootet"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "Bootgerät kann nicht gefunden werden"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Erweiterte Optionen für %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, mit Kernel %s (über %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/eo.po b/po/eo.po
+index 1e274185d..367ac0b94 100644
+--- a/po/eo.po
++++ b/po/eo.po
+@@ -8,11 +8,11 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 16:44+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2025-10-21 19:23+0000\n"
+ "Last-Translator: LiliaCyk871e <ACLZCyk871e@outlook.com>\n"
+-"Language-Team: Esperanto <https://weblate.aosc.io/projects/grub-aosc/"
+-"2-12-aosc/eo/>\n"
++"Language-Team: Esperanto <https://weblate.aosc.io/projects/grub-aosc/2-12-"
++"aosc/eo/>\n"
+ "Language: eo\n"
+ "MIME-Version: 1.0\n"
+ "Content-Type: text/plain; charset=UTF-8\n"
+@@ -7704,83 +7704,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Ŝargas per Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Ŝargas komencan ĉefmemoran diskon ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Ŝargas na ‘%s’"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "ne eblas trovi praŝargan aparaton"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Altnivelaj opcioj por %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, kun kerno %s (per %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/es.po b/po/es.po
+index 71e15c9d4..c895a4ca5 100644
+--- a/po/es.po
++++ b/po/es.po
+@@ -11,7 +11,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.04-pre1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2019-04-18 20:32+0200\n"
+ "Last-Translator: Miguel Ángel Arruga Vivas <rosen644835@gmail.com>\n"
+ "Language-Team: Spanish <es@tp.org.es>\n"
+@@ -7881,83 +7881,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Cargando Xen %s..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Cargando imagen de memoria inicial..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Arrancando «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opciones avanzadas para %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, con núcleo %s (vía %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/fi.po b/po/fi.po
+index 6ff18fbab..de5b96303 100644
+--- a/po/fi.po
++++ b/po/fi.po
+@@ -9,7 +9,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2021-05-10 20:56+0300\n"
+ "Last-Translator: Lauri Nurmi <lanurmi@iki.fi>\n"
+ "Language-Team: Finnish <translation-team-fi@lists.sourceforge.net>\n"
+@@ -7741,83 +7741,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Ladataan Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Ladataan alustavaa ramlevyä ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Käynnistetään ”%s”"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Käyttöjärjestelmän ”%s” lisävalitsimet"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, ytimellä %s (%s-kautta)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/fr.po b/po/fr.po
+index fcd810aa1..2c202d00d 100644
+--- a/po/fr.po
++++ b/po/fr.po
+@@ -13,7 +13,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-11 21:18+0200\n"
+ "Last-Translator: Frédéric Marchal <fmarchal@perso.be>\n"
+ "Language-Team: French <traduc@traduc.org>\n"
+@@ -7843,83 +7843,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Chargement de Xen %s…"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Chargement du disque mémoire initial…"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Démarrage de « %s »"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "impossible de trouver le périphérique d'amorçage"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Options avancées pour %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, avec le noyau %s (à l'aide de %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/gl.po b/po/gl.po
+index 5d1032bdd..1b38768d8 100644
+--- a/po/gl.po
++++ b/po/gl.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.00+20130519\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2013-09-26 11:40+0200\n"
+ "Last-Translator: Anton Meixome <meixome@certima.net>\n"
+ "Language-Team: Galician <proxecto@trasno.net>\n"
+@@ -7797,83 +7797,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Cargando Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Cargando o ramdisk inicial ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Arranque de «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opcións avanzadas para %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, con núcleo %s (vía %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/grub.pot b/po/grub.pot
+index 41afaecf7..518ec26a6 100644
+--- a/po/grub.pot
++++ b/po/grub.pot
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+ "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+ "Language-Team: LANGUAGE <LL@li.org>\n"
+@@ -7457,91 +7457,96 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format
+ #, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, c-format
+ #, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr ""
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, c-format
+ #, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format
+ #, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format
+ #, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format
+ #, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, c-format
+ #, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, c-format
+ #, sh-printf-format
+ msgid "With kernel %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format
+ #, sh-printf-format
+ msgid "Done generating entries for %s."
+diff --git a/po/he.po b/po/he.po
+index 9156d8dd0..53ab1763f 100644
+--- a/po/he.po
++++ b/po/he.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2024-07-14 12:35+0300\n"
+ "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
+ "Language-Team: Hebrew <heb-bugzap@hamakor.org.il>\n"
+@@ -7516,83 +7516,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s נטען…"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "כונן הזיכרון (ramdisk) הראשוני נטען…"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "‚%s’ נטען"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "לא ניתן למצוא התקני טעינה"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "אפשרויות מתקדמות עבור %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, עם ליבה %s (דרך %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/hr.po b/po/hr.po
+index 6ba7b2aae..09ee62dd5 100644
+--- a/po/hr.po
++++ b/po/hr.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2021-05-27 11:11+0200\n"
+ "Last-Translator: gogo <trebelnik2@gmail.com>\n"
+ "Language-Team: Croatian <lokalizacija@linux.hr>\n"
+@@ -7713,83 +7713,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Učitavanje Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Učitavanje početnog ramdiska ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Pokretanje `%s'"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Napredne mogućnosti za %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, s kernelom %s (pomoću %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/hu.po b/po/hu.po
+index ab56ae6fa..b9a7300c3 100644
+--- a/po/hu.po
++++ b/po/hu.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2022-10-21 21:35+0200\n"
+ "Last-Translator: Balázs Úr <ur.balazs@fsf.hu>\n"
+ "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
+@@ -7751,83 +7751,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s betöltése…"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Kiinduló ramdisk betöltése…"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "„%s” indítása"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Speciális beállítások ehhez: %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, %s kernellel (%s közvetítésével)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/id.po b/po/id.po
+index 75c157c16..300a910df 100644
+--- a/po/id.po
++++ b/po/id.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.02-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2014-08-04 16:30+0700\n"
+ "Last-Translator: Arif E. Nugroho <arif_endro@yahoo.com>\n"
+ "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
+@@ -7759,83 +7759,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Memuat Linux %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Memuat inisial ramdisk ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Mem-boot '%s'"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, dengan kFreeBSD %s"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/it.po b/po/it.po
+index 05e372fa5..8c71bcf01 100644
+--- a/po/it.po
++++ b/po/it.po
+@@ -21,7 +21,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.04-pre1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2019-04-09 14:02+0200\n"
+ "Last-Translator: Milo Casagrande <milo@milo.name>\n"
+ "Language-Team: Italian <tp@lists.linux.it>\n"
+@@ -7774,83 +7774,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Carica il kernel NetBSD"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, fuzzy, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Carica initrd"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Avvio di \"%s\" in corso"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "manca l'opzione obbligatoria per \"%s\""
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/ja.po b/po/ja.po
+index 0422d77cc..fecc74df8 100644
+--- a/po/ja.po
++++ b/po/ja.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2021-05-16 23:17+0900\n"
+ "Last-Translator: Hiroshi Takekawa <sian@big.or.jp>\n"
+ "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
+@@ -7603,83 +7603,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s をロード中..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "初期 RAM ディスクをロード中..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Xen %s をロード中..."
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "-- カーネルのバイナリパッケージ:"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "-- カーネルのバイナリパッケージ:"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/ka.po b/po/ka.po
+index 553be9a3d..b7098e001 100644
+--- a/po/ka.po
++++ b/po/ka.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-08-10 18:21+0200\n"
+ "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
+ "Language-Team: Georgian <(nothing)>\n"
+@@ -7505,83 +7505,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s-ის ჩატვირთვა ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "საწყისი დროებითი დისკის წაკითხვა ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "'%s'-ის ჩატვირთვა"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "ჩატვირთვადი მოწყობილობის პოვნა შეუძლებელია"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "%s-ის დამატებითი პარამეტრები"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, ბირთვით %s (%s-ის გავლით)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/ko.po b/po/ko.po
+index 103ce13f8..635412a78 100644
+--- a/po/ko.po
++++ b/po/ko.po
+@@ -18,7 +18,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-12 00:40+0900\n"
+ "Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
+ "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
+@@ -7651,83 +7651,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "젠 %s 불러오는 중 ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "초기 램디스크 불러오는 중 ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "`%s' 부팅"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "부팅 장치를 찾을 수 없습니다"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "%s 고급 옵션"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, 커널 %s (%s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/lg.po b/po/lg.po
+index db59e7b26..62f3c00dc 100644
+--- a/po/lg.po
++++ b/po/lg.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.04-pre1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2020-06-11 22:41+0100\n"
+ "Last-Translator: Kizito Birabwa <kbirabwa@yahoo.co.uk>\n"
+ "Language-Team: Luganda <kbirabwa@yahoo.co.uk>\n"
+@@ -7472,83 +7472,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Nkoleeza '%s'"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Nkoleeza '%s'"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/lt.po b/po/lt.po
+index c200cef63..047828b85 100644
+--- a/po/lt.po
++++ b/po/lt.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.02-pre3\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2017-04-26 07:26+0200\n"
+ "Last-Translator: Mindaugas Baranauskas <opensuse.lietuviu.kalba@gmail.com>\n"
+ "Language-Team: Lithuanian <komp_lt@konferencijos.lt>\n"
+@@ -7663,83 +7663,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Įkeliamas Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Įkeliamas paruošiamasis ram diskas ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Įkeliamas „%s“"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Sudėtingesnės %s parinktys"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, su %s branduoliu (per %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/nb.po b/po/nb.po
+index 335fd92a7..1ac76218b 100644
+--- a/po/nb.po
++++ b/po/nb.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2022-11-10 12:13+0100\n"
+ "Last-Translator: Johnny A. Solbu <johnny@solbu.net>\n"
+ "Language-Team: Norwegian Bokmaal <l10n-no@lister.huftis.org>\n"
+@@ -7718,83 +7718,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Laster inn Xen %s …"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Laster inn minnedisk for oppstart …"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Starter opp «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Avanserte valg for %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, med kjerne %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/nl.po b/po/nl.po
+index 7042e7f1e..3b2a76bc8 100644
+--- a/po/nl.po
++++ b/po/nl.po
+@@ -10,7 +10,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2021-05-16 11:25+0200\n"
+ "Last-Translator: Benno Schulenberg <vertaling@coevern.nl>\n"
+ "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
+@@ -7774,83 +7774,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Laden van Xen %s..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Laden van initiële RAM-schijf..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Opstarten van '%s'"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Geavanceerde opties voor %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, met kernel %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/pa.po b/po/pa.po
+index 42b56807f..b7e2870ed 100644
+--- a/po/pa.po
++++ b/po/pa.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.0.0-pre6\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2012-05-19 19:45+0530\n"
+ "Last-Translator: A S Alam <aalam@users.sf.net>\n"
+ "Language-Team: Punjabi <punjabi-l10n@lists.sourceforge.net>\n"
+@@ -7540,83 +7540,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "initial ramdisk ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "`%s' ਬੂਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "% ਲਈ ਤਕਨੀਕੀ ਚੋਣਾਂ"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/pl.po b/po/pl.po
+index fb38cd7e5..29a57cf48 100644
+--- a/po/pl.po
++++ b/po/pl.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-18 22:45+0200\n"
+ "Last-Translator: Jakub Bogusz <qboosh@pld-linux.org>\n"
+ "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
+@@ -7730,83 +7730,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Ładowanie hipernadzorcy Xen %s..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Ładowanie początkowego ramdysku..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Uruchamianie \"%s\""
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "nie można odnaleźć urządzenia rozruchowego"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opcje zaawansowane dla systemu %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, z jądrem %s (poprzez %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/pt.po b/po/pt.po
+index d9c5bb348..39bf53077 100644
+--- a/po/pt.po
++++ b/po/pt.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2021-05-11 07:53+0100\n"
+ "Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
+ "Language-Team: Portuguese <translation-team-pt@lists.sourceforge.net>\n"
+@@ -7732,83 +7732,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "A carregar Xen %s..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "A carregar ramdisk inicial..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "A iniciar \"%s\""
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opções avançadas para %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, com kernel %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/pt_BR.po b/po/pt_BR.po
+index b2289c6c8..1a30e587b 100644
+--- a/po/pt_BR.po
++++ b/po/pt_BR.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-05-17 09:58-0300\n"
+ "Last-Translator: Luiz Fernando Ranghetti <elchevive@opensuse.org>\n"
+ "Language-Team: Brazilian Portuguese <ldpbr-"
+@@ -7735,83 +7735,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Carregando o XEN %s..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Carregando o ramdisk inicial..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Iniciando '%s'"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opções avançadas para %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, com o kernel %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/ro.po b/po/ro.po
+index 3ad389d48..b3d60ebb4 100644
+--- a/po/ro.po
++++ b/po/ro.po
+@@ -17,7 +17,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-11 17:22+0200\n"
+ "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
+ "Language-Team: Romanian <translation-team-ro@lists.sourceforge.net>\n"
+@@ -7940,83 +7940,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Se încarcă Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Se încarcă imaginea de memorie inițială ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Se inițializează „%s”"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "nu se poate găsi dispozitivul de pornire"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Opțiuni avansate pentru %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, cu nucleul %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/ru.po b/po/ru.po
+index f597f84a3..2b74a093a 100644
+--- a/po/ru.po
++++ b/po/ru.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2024-06-07 17:58+0300\n"
+ "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
+ "Language-Team: Russian <gnu@d07.ru>\n"
+@@ -7732,83 +7732,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Загружается Xen %s …"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Загружается начальный виртуальный диск …"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Загружается «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "не удалось найти загрузочное устройство"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Дополнительные параметры для %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, с ядром %s (с использованием %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/sl.po b/po/sl.po
+index a9c51f093..8f40c4f32 100644
+--- a/po/sl.po
++++ b/po/sl.po
+@@ -8,7 +8,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub-2.0.0-pre6\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2012-12-11 21:02+0100\n"
+ "Last-Translator: Andrej Žnidaršič <andrej.znidarsic@gmail.com>\n"
+ "Language-Team: Slovenian <translation-team-sl@lists.sourceforge.net>\n"
+@@ -7750,83 +7750,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Nalaganje Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Nalaganje začetnega ramdiska ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Zaganjanje ` %s'"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Napredne možnosti za %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, z jedrom %s (preko %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/sr.po b/po/sr.po
+index 1a77f2294..b94c8f7ec 100644
+--- a/po/sr.po
++++ b/po/sr.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-30 07:26+0200\n"
+ "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
+ "Language-Team: Serbian <(nothing)>\n"
+@@ -7706,83 +7706,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Учитавам Иксен %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Учитавам почетни рамдиск ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Подижем „%s“"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "не могу да нађем подизни уређај"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Напредне опције за „%s“"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, са језгром %s (путем %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/sv.po b/po/sv.po
+index 2d5f1dc39..c8d638d8d 100644
+--- a/po/sv.po
++++ b/po/sv.po
+@@ -9,7 +9,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.06-pre2\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2021-06-21 04:51+0200\n"
+ "Last-Translator: Josef Andersson <l10nl18nsweja@gmail.com>\n"
+ "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+@@ -7708,83 +7708,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Läser in Xen %s …"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Läser in initial ramdisk …"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Startar upp ”%s”"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Avancerade flaggor för %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, med kärnan %s (via %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/tr.po b/po/tr.po
+index e4cd360ed..faa84d9f2 100644
+--- a/po/tr.po
++++ b/po/tr.po
+@@ -11,7 +11,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2024-05-16 13:05+0300\n"
+ "Last-Translator: Mehmet Akif Dokuzoğlu <madanadam@gmail.com>\n"
+ "Language-Team: Turkish <gnome-turk@gnome.org>\n"
+@@ -7568,83 +7568,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Xen %s yükleniyor ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Başlangıç ramdiski yükleniyor ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "`%s' açılıyor"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "açılış aygıtı bulunamadı"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "%s için gelişmiş seçenekler"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, %s çekirdeğiyle (%s aracılığıyla)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/uk.po b/po/uk.po
+index 30aee00bb..45142fe05 100644
+--- a/po/uk.po
++++ b/po/uk.po
+@@ -10,7 +10,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-11 18:53+0300\n"
+ "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+ "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
+@@ -7790,83 +7790,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Завантаження Xen %s…"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Завантаження початкового диска у оперативній пам’яті…"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Завантаження «%s»"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "не вдалося знайти пристрій завантаження"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Додаткові параметри для %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, з ядром %s (за допомогою %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/vi.po b/po/vi.po
+index f6ea90764..1e97c8f68 100644
+--- a/po/vi.po
++++ b/po/vi.po
+@@ -9,7 +9,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2023-07-18 09:34+0700\n"
+ "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
+ "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
+@@ -7718,83 +7718,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "Đang tải Xen %s …"
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "Đang tải đĩa RAM khởi tạo …"
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "Đang khởi động “%s”"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "không thể tìm thiết bị khởi động"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, fuzzy, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "Tùy chọn nâng cao cho %s"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s, với kernel %s (thông qua %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/po/zh_CN.po b/po/zh_CN.po
+index c473bab60..d9b2f9851 100644
+--- a/po/zh_CN.po
++++ b/po/zh_CN.po
+@@ -12,7 +12,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2025-09-08 08:10+0000\n"
+ "Last-Translator: 白铭骢 <jeffbai@aosc.io>\n"
+ "Language-Team: Chinese (Simplified Han script) <https://weblate.aosc.io/"
+@@ -7583,83 +7583,88 @@ msgstr "AOSC OS"
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr "内部错误：无法收集根分区信息\\n"
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr "4KiB 内核分页"
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr "16KiB 内核分页"
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr "64KiB 内核分页"
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr "预发布内核"
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr "长期支持内核"
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr "“%s”变种内核"
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "正在加载内核 %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "正在加载初始化内存盘..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "正在启动 %s ..."
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr "找到内核“%s”的初始内存盘：“%s”"
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr "未找到内核“%s”的初始内存盘"
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "内部错误：找不到根分区\\n"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr "正在处理内核“%s”\\n"
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr "%s 的所有内核选项"
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "使用 %s 内核"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr "已成功生成 %s 的启动项。"
+diff --git a/po/zh_TW.po b/po/zh_TW.po
+index 117bb7f22..20cf4bf05 100644
+--- a/po/zh_TW.po
++++ b/po/zh_TW.po
+@@ -7,7 +7,7 @@ msgid ""
+ msgstr ""
+ "Project-Id-Version: grub 1.97+20110101\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+-"POT-Creation-Date: 2025-09-08 21:37+0800\n"
++"POT-Creation-Date: 2025-10-27 18:19+0800\n"
+ "PO-Revision-Date: 2024-11-16 22:45+0800\n"
+ "Last-Translator: Mingcong Bai <jeffbai@aosc.io>\n"
+ "Language-Team: Chinese (traditional) <zh-l10n@linux.org.tw>\n"
+@@ -7674,83 +7674,88 @@ msgstr ""
+ msgid "Internal error - Failed to gather information on the root partition\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:118
++#: util/grub.d/10_linux.in:123
+ #, c-format
+ msgid "4KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:125
++#: util/grub.d/10_linux.in:130
+ #, c-format
+ msgid "16KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:132
++#: util/grub.d/10_linux.in:137
+ #, c-format
+ msgid "64KiB Kernel Page Size"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:146
++#: util/grub.d/10_linux.in:151
+ #, c-format
+ msgid "RC Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:149
++#: util/grub.d/10_linux.in:154
+ #, c-format
+ msgid "LTS Kernel"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:155
++#: util/grub.d/10_linux.in:160
++#, c-format
++msgid "Apple Silicon"
++msgstr ""
++
++#: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+ msgid "Kernel variant '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:209
++#: util/grub.d/10_linux.in:221
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Loading kernel %s ..."
+ msgstr "正在載入 Xen %s ..."
+ 
+ #. TRANSLATORS: ramdisk isn't identifier. Should be translated.
+-#: util/grub.d/10_linux.in:212 util/grub.d/20_linux_xen.in:161
++#: util/grub.d/10_linux.in:224 util/grub.d/20_linux_xen.in:161
+ #, c-format
+ msgid "Loading initial ramdisk ..."
+ msgstr "正在載入初始 ramdisk ..."
+ 
+-#: util/grub.d/10_linux.in:215
++#: util/grub.d/10_linux.in:227
+ #, fuzzy, c-format, sh-printf-format
+ msgid "Starting %s ..."
+ msgstr "正在啟動「%s」"
+ 
+-#: util/grub.d/10_linux.in:323
++#: util/grub.d/10_linux.in:357
+ #, c-format, sh-printf-format
+ msgid "Initial ramdisk image for kernel '%s': '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:333
++#: util/grub.d/10_linux.in:370
+ #, c-format, sh-printf-format
+ msgid "No initial ramdisk image found for kernel '%s'"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:396
++#: util/grub.d/10_linux.in:434
+ #, fuzzy, c-format
+ msgid "Internal error - Failed to find the root device\\n"
+ msgstr "無效的根裝置「%s」"
+ 
+-#: util/grub.d/10_linux.in:402 util/grub.d/10_linux.in:428
++#: util/grub.d/10_linux.in:440 util/grub.d/10_linux.in:471
+ #, c-format, sh-printf-format
+ msgid "Processing kernel '%s'\\n"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:420
++#: util/grub.d/10_linux.in:458
+ #, c-format, sh-printf-format
+ msgid "All kernel options for %s"
+ msgstr ""
+ 
+-#: util/grub.d/10_linux.in:431
++#: util/grub.d/10_linux.in:474
+ #, fuzzy, c-format, sh-printf-format
+ msgid "With kernel %s"
+ msgstr "%s，採用內核 %s (透過 %s)"
+ 
+-#: util/grub.d/10_linux.in:447
++#: util/grub.d/10_linux.in:491
+ #, c-format, sh-printf-format
+ msgid "Done generating entries for %s."
+ msgstr ""
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index 78e38d01a..f27a09b1b 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -156,6 +156,9 @@ variant_str() {
+ 		main)
+ 			: noop
+ 			;;
++		asahi)
++			gettext_printf "Apple Silicon"
++			;;
+ 		*)
+ 			gettext_printf "Kernel variant '%s'" "$1"
+ 			;;
+-- 
+2.51.0
+

--- a/app-admin/grub/autobuild/patches/0069-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0069-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,0 +1,41 @@
+From f8abf5b44a59abb78a2f93f919f3d10e9d3f8389 Mon Sep 17 00:00:00 2001
+From: Old Dodo <cyan@cyano.uk>
+Date: Mon, 27 Oct 2025 10:30:39 +0000
+Subject: [PATCH 69/70] Translated using Weblate (Chinese (Simplified Han
+ script))
+
+Currently translated at 100.0% (1561 of 1561 strings)
+
+Translation: GNU GRUB/2.12-aosc
+Translate-URL: https://weblate.aosc.io/projects/grub-aosc/2-12-aosc/zh_Hans/
+---
+ po/zh_CN.po | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/po/zh_CN.po b/po/zh_CN.po
+index d9b2f9851..4fbbf377b 100644
+--- a/po/zh_CN.po
++++ b/po/zh_CN.po
+@@ -13,8 +13,8 @@ msgstr ""
+ "Project-Id-Version: grub 2.12-rc1\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+ "POT-Creation-Date: 2025-10-27 18:19+0800\n"
+-"PO-Revision-Date: 2025-09-08 08:10+0000\n"
+-"Last-Translator: 白铭骢 <jeffbai@aosc.io>\n"
++"PO-Revision-Date: 2025-10-27 10:32+0000\n"
++"Last-Translator: Old Dodo <cyan@cyano.uk>\n"
+ "Language-Team: Chinese (Simplified Han script) <https://weblate.aosc.io/"
+ "projects/grub-aosc/2-12-aosc/zh_Hans/>\n"
+ "Language: zh_CN\n"
+@@ -7611,7 +7611,7 @@ msgstr "长期支持内核"
+ #: util/grub.d/10_linux.in:160
+ #, c-format
+ msgid "Apple Silicon"
+-msgstr ""
++msgstr "Apple 芯片"
+ 
+ #: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+-- 
+2.51.0
+

--- a/app-admin/grub/autobuild/patches/0070-Translated-using-Weblate-Chinese-Traditional-Han-scr.patch
+++ b/app-admin/grub/autobuild/patches/0070-Translated-using-Weblate-Chinese-Traditional-Han-scr.patch
@@ -1,0 +1,52 @@
+From 9ecdc40ac714c3fa0ee6da063809a768e1f135d5 Mon Sep 17 00:00:00 2001
+From: Old Dodo <cyan@cyano.uk>
+Date: Mon, 27 Oct 2025 10:31:57 +0000
+Subject: [PATCH 70/70] Translated using Weblate (Chinese (Traditional Han
+ script))
+
+Currently translated at 22.2% (347 of 1561 strings)
+
+Translation: GNU GRUB/2.12-aosc
+Translate-URL: https://weblate.aosc.io/projects/grub-aosc/2-12-aosc/zh_Hant/
+---
+ po/zh_TW.po | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/po/zh_TW.po b/po/zh_TW.po
+index 20cf4bf05..d87db7054 100644
+--- a/po/zh_TW.po
++++ b/po/zh_TW.po
+@@ -8,15 +8,17 @@ msgstr ""
+ "Project-Id-Version: grub 1.97+20110101\n"
+ "Report-Msgid-Bugs-To: bug-grub@gnu.org\n"
+ "POT-Creation-Date: 2025-10-27 18:19+0800\n"
+-"PO-Revision-Date: 2024-11-16 22:45+0800\n"
+-"Last-Translator: Mingcong Bai <jeffbai@aosc.io>\n"
+-"Language-Team: Chinese (traditional) <zh-l10n@linux.org.tw>\n"
++"PO-Revision-Date: 2025-10-27 10:32+0000\n"
++"Last-Translator: Old Dodo <cyan@cyano.uk>\n"
++"Language-Team: Chinese (Traditional Han script) <https://weblate.aosc.io/"
++"projects/grub-aosc/2-12-aosc/zh_Hant/>\n"
+ "Language: zh_TW\n"
+ "MIME-Version: 1.0\n"
+ "Content-Type: text/plain; charset=UTF-8\n"
+ "Content-Transfer-Encoding: 8bit\n"
++"Plural-Forms: nplurals=1; plural=0;\n"
++"X-Generator: Weblate 5.10.3\n"
+ "X-Bugs: Report translation errors to the Language-Team address.\n"
+-"X-Generator: Poedit 3.4.1\n"
+ 
+ #: grub-core/bus/usb/serial/ftdi.c:145 grub-core/bus/usb/serial/pl2303.c:158
+ #: grub-core/term/ieee1275/escc.c:169 grub-core/term/ns8250.c:262
+@@ -7702,7 +7704,7 @@ msgstr ""
+ #: util/grub.d/10_linux.in:160
+ #, c-format
+ msgid "Apple Silicon"
+-msgstr ""
++msgstr "Apple 晶片"
+ 
+ #: util/grub.d/10_linux.in:163
+ #, c-format, sh-printf-format
+-- 
+2.51.0
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -8,6 +8,7 @@ RETROFONTVER=20200402
 GNULIB_REV=9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
+REL=1
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       git::commit=${GNULIB_REV};rename=gnulib::https://https.git.savannah.gnu.org/git/gnulib.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \

--- a/app-utils/kmscon/autobuild/beyond
+++ b/app-utils/kmscon/autobuild/beyond
@@ -1,3 +1,22 @@
+abinfo "Saving BLDDIR and PKGDIR ..."
+export OLD_PKGDIR="$PKGDIR"
+export PKGDIR="$SRCDIR"/abdist-nosd
+export OLD_BLDDIR="$BLDDIR"
+export BLDDIR="$SRCDIR"/abbuild-nosd
+
+abinfo "Building kmscon without multiseat support ..."
+MESON_AFTER=("-Dmulti_seat=disabled" "${MESON_AFTER[@]}")
+build_meson_configure
+build_meson_build
+build_meson_install
+
+abinfo "Installing multiseat-less kmscon ..."
+install -Dvm755 "$PKGDIR"/usr/libexec/kmscon/kmscon \
+	"$OLD_PKGDIR"/usr/libexec/kmscon/kmscon-no-multiseat
+
+abinfo "Restoring PKGDIR ..."
+export PKGDIR="$OLD_PKGDIR"
+
 abinfo "Installing kmsconvt@.service as system-alternatives ..."
 install -Dvm644 "$PKGDIR"/usr/lib/systemd/system/kmsconvt@.service \
     "$PKGDIR"/usr/lib/systemd/system-alternatives/autovt-kmscon.service

--- a/app-utils/kmscon/spec
+++ b/app-utils/kmscon/spec
@@ -1,5 +1,5 @@
 VER=9.0.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/Aetf/kmscon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231600"


### PR DESCRIPTION
Topic Description
-----------------

- grub: fix KERNEL_DIR for separate /bnot; add string for Asahi kernel
- kmscon: also build without multi-seat support
- aosc-os-oobe: new, 0.1.2
    \* aosc-os-oobe-cli: OOBE Wizard on CLI, runs on top of kmscon.
    \* aosc-os-oobe-gui: OOBE Wizard on GUI, runs with xinit.
- devena-firstboot: new, 0.1.1
    \* devena-firstboot-generic: First setup routine for generic devices that
    uses EFI firmware.
    \* devena-firstboot-rpi: Same as above, for Raspberry Pi devices.
    \* devena-firstboot-asahi: Same as above, for Apple Silicon devices.

Package(s) Affected
-------------------

- aosc-os-oobe-cli: 0.1.2
- aosc-os-oobe-gui: 0.1.2
- devena-firstboot-asahi: 0.1.1
- devena-firstboot-generic: 0.1.1
- devena-firstboot-rpi: 0.1.1
- grub: 2:2.12+unifont17.0.02-1
- kmscon: 9.0.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit devena-firstboot-generic devena-firstboot-rpi devena-firstboot-asahi aosc-os-oobe-gui aosc-os-oobe-cli kmscon grub
```

Test Build(s) Done
------------------

