### PR TITLE
libx86emu: update to 3.7

### DIFF
--- a/runtime-common/libx86emu/spec
+++ b/runtime-common/libx86emu/spec
@@ -1,4 +1,4 @@
-VER=3.5
+VER=3.7
 SRCS="git::commit=tags/$VER::https://github.com/wfeldt/libx86emu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16229"


### PR DESCRIPTION
Topic Description
-----------------

- libx86emu: update to 3.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libx86emu: 3.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libx86emu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
