### PR TITLE
openssh: update to 10.2p1

### DIFF
--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,4 @@
-VER=10.0p1
+VER=10.2p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
+CHKSUMS="sha256::ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2"
 CHKUPDATE="anitya::id=2565"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- openssh: update to 10.2p1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openssh: 10.2p1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
