### PR TITLE
vkpeak: update to 20251010

### DIFF
--- a/app-utils/vkpeak/autobuild/defines
+++ b/app-utils/vkpeak/autobuild/defines
@@ -1,3 +1,6 @@
 PKGNAME=vkpeak
 PKGSEC=utils
 PKGDES="Measure peak performance using Vulkan"
+
+# FIXME: lto1: fatal error: target specific builtin not available
+NOLTO__RISCV64=1

--- a/app-utils/vkpeak/spec
+++ b/app-utils/vkpeak/spec
@@ -1,4 +1,4 @@
-VER=20250531
+VER=20251010
 SRCS="git::commit=tags/$VER::https://github.com/nihui/vkpeak"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375832"


### PR DESCRIPTION
Topic Description
-----------------

- vkpeak: update to 20251010
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vkpeak: 20251010

Security Update?
----------------

No

Build Order
-----------

```
#buildit vkpeak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
