### PR TITLE
vscode: update to 1.105.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.104.3
+VER=1.105.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::d0b1d478e0e72c1e0040c45ce4a65814ddb3bd5ffd6b372e95f6185ee92988e5"
-CHKSUMS__ARM64="sha256::2104174eec00e7970ffa1a4eaafa672341a545cbe8b83fc7f6c857bafa01daf1"
+CHKSUMS__AMD64="sha256::da3676be6826dcbaab1d054b546311971e121ed6645ffd054409eeaf42675d7e"
+CHKSUMS__ARM64="sha256::4fdbbe128ed43a7e0feef4310ec133ae3fab50e6bdd52f402b2ada29e3a863bb"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.105.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.105.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
