### PR TITLE
nerdctl: new, 2.1.6

### DIFF
--- a/app-containers/nerdctl/autobuild/beyond
+++ b/app-containers/nerdctl/autobuild/beyond
@@ -1,0 +1,10 @@
+abinfo "Installing kind shell completions..."
+"$PKGDIR"/usr/bin/nerdctl completion bash | \
+        install -Dvm644 /dev/stdin \
+        "$PKGDIR"/usr/share/bash-completion/completions/nerdctl
+"$PKGDIR"/usr/bin/nerdctl completion zsh | \
+        install -Dvm644 /dev/stdin \
+        "$PKGDIR"/usr/share/zsh/site-functions/_nerdctl
+"$PKGDIR"/usr/bin/nerdctl completion fish | \
+        install -Dvm644 /dev/stdin \
+        "$PKGDIR"/usr/share/fish/vendor_completions.d/nerdctl.fish

--- a/app-containers/nerdctl/autobuild/defines
+++ b/app-containers/nerdctl/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=nerdctl
+PKGDES="Docker-compatible CLI for containerd"
+BUILDDEP="go"
+PKGDEP="glibc containerd cni-plugins"
+PKGSEC="admin"
+
+ABTYPE=gomod
+GO_PACKAGES=(
+	"cmd/nerdctl"
+)

--- a/app-containers/nerdctl/autobuild/prepare
+++ b/app-containers/nerdctl/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Getting build infomation..."
+REVISION=$(git rev-parse HEAD)
+
+abinfo "Setting GO_LDFLAGS..."
+GO_LDFLAGS=(
+	"-X github.com/containerd/nerdctl/v2/pkg/version.Version=$PKGVER"
+	"-X github.com/containerd/nerdctl/v2/pkg/version.Revision=$REVISION"
+)

--- a/app-containers/nerdctl/spec
+++ b/app-containers/nerdctl/spec
@@ -1,0 +1,4 @@
+VER=2.1.6
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/nerdctl.git"
+CHKSUMS="SKIP"
+CHKUPDATE="aniya::id=242901"


### PR DESCRIPTION
Topic Description
-----------------

- nerdctl: new, 2.1.6

Package(s) Affected
-------------------

- nerdctl: 2.1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit nerdctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
