### PR TITLE
redis: update to 8.2.2

### DIFF
--- a/app-database/redis/spec
+++ b/app-database/redis/spec
@@ -1,4 +1,4 @@
-VER=8.0.2
+VER=8.2.2
 SRCS="tbl::http://download.redis.io/releases/redis-$VER.tar.gz"
-CHKSUMS="sha256::e9296b67b54c91befbcca046d67071c780a1f7c9f9e1ae5ed94773c3bb9b542f"
+CHKSUMS="sha256::4e340e8e822a82114b6fb0f7ca581b749fa876e31e36e9fbcb75416bec9d0608"
 CHKUPDATE="anitya::id=4181"


### PR DESCRIPTION
Topic Description
-----------------

- redis: update to 8.2.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- redis: 8.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit redis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
