### PR TITLE
coreboot-utils: update to 25.09

### DIFF
--- a/app-admin/coreboot-utils/spec
+++ b/app-admin/coreboot-utils/spec
@@ -1,4 +1,4 @@
-VER=24.08
+VER=25.09
 SRCS="https://www.coreboot.org/releases/coreboot-$VER.tar.xz"
-CHKSUMS="sha256::1fc9a997d497539f915dc6498e4aca4bf049955d4db9a17a85454ad6b342710c"
+CHKSUMS="sha256::7bdc8f177bc3705e11099fef1d0028a39fc9ae659c9b1e5055781a9a762f6da4"
 CHKUPDATE="anitya::id=10128"


### PR DESCRIPTION
Topic Description
-----------------

- coreboot-utils: update to 25.09
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreboot-utils: 25.09

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreboot-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
