### PR TITLE
freeciv: update to 3.2.1

### DIFF
--- a/app-games/freeciv/spec
+++ b/app-games/freeciv/spec
@@ -1,4 +1,4 @@
-VER=3.1.4
+VER=3.2.1
 SRCS="tbl::https://files.freeciv.org/stable/freeciv-$VER.tar.xz"
-CHKSUMS="sha256::14999bb903c4507cc287d5a8dd1b89eee623bb41b4e01e0836567fb5f13296e4"
+CHKSUMS="sha256::3fc01ef55bfc9b9c2d71432d22a9fc5ab5892285d15d3dc888ec4bb288d21caa"
 CHKUPDATE="anitya::id=8561"


### PR DESCRIPTION
Topic Description
-----------------

- freeciv: update to 3.2.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- freeciv: 3.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit freeciv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
