### PR TITLE
minizip: replace incorrect PKGEPOCH with EPOCH

### DIFF
--- a/runtime-common/minizip/spec
+++ b/runtime-common/minizip/spec
@@ -1,5 +1,5 @@
 VER=4.0.10
-PKGEPOCH=1
+EPOCH=1
 SRCS="git::commit=tags/$VER::https://github.com/zlib-ng/minizip-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301509"


### PR DESCRIPTION
Topic Description
-----------------

- minizip: replace incorrect PKGEPOCH with EPOCH

Package(s) Affected
-------------------

- minizip: 4.0.10
- minizip-static: 4.0.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit minizip
```

Test Build(s) Done
------------------

