### PR TITLE
docutils: update to 0.22.2

### DIFF
--- a/app-doc/sphinx/autobuild/defines
+++ b/app-doc/sphinx/autobuild/defines
@@ -4,7 +4,8 @@ PKGDEP="alabaster babel docutils jinja2 pygments six snowballstemmer \
         sphinx-rtd-theme imagesize requests packaging \
         sphinxcontrib-applehelp sphinxcontrib-devhelp \
         sphinxcontrib-htmlhelp sphinxcontrib-jsmath sphinxcontrib-qthelp \
-        sphinxcontrib-serializinghtml sphinxcontrib-websupport"
+        sphinxcontrib-serializinghtml sphinxcontrib-websupport \
+        roman-numerals-py"
 PKGSUG="texlive"
 BUILDDEP="python-build python-installer wheel"
 PKGDES="Python documentation generator"

--- a/app-doc/sphinx/autobuild/patches/0001-Support-Docutils-0.22.patch
+++ b/app-doc/sphinx/autobuild/patches/0001-Support-Docutils-0.22.patch
@@ -1,0 +1,55 @@
+From 6e54cffe66fabd07f9cf626b9b78736731a37354 Mon Sep 17 00:00:00 2001
+From: Adam Turner <9087854+aa-turner@users.noreply.github.com>
+Date: Tue, 29 Jul 2025 18:30:54 +0100
+Subject: [PATCH 1/2] Support Docutils 0.22
+
+---
+ CHANGES.rst         | 4 ++++
+ doc/changes/7.3.rst | 2 +-
+ pyproject.toml      | 2 +-
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/CHANGES.rst b/CHANGES.rst
+index c257b3b11..914abc771 100644
+--- a/CHANGES.rst
++++ b/CHANGES.rst
+@@ -4,6 +4,10 @@ Release 8.3.0 (in development)
+ Dependencies
+ ------------
+ 
++* #13786: Support `Docutils 0.22`_. Patch by Adam Turner.
++
++  .. _Docutils 0.22: https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-22-2026-07-29
++
+ Incompatible changes
+ --------------------
+ 
+diff --git a/doc/changes/7.3.rst b/doc/changes/7.3.rst
+index b544a7220..c9395c18c 100644
+--- a/doc/changes/7.3.rst
++++ b/doc/changes/7.3.rst
+@@ -86,7 +86,7 @@ Dependencies
+ 
+ * #11858: Increase the minimum supported version of Alabaster to 0.7.14.
+   Patch by Adam Turner.
+-* #11411: Support `Docutils 0.21`_. Patch by Adam Turner.
++* #12267: Support `Docutils 0.21`_. Patch by Adam Turner.
+ 
+   .. _Docutils 0.21: https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09
+ * #12012: Use ``types-docutils`` instead of ``docutils-stubs``.
+diff --git a/pyproject.toml b/pyproject.toml
+index c4b1b6d73..e566ce93f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -75,7 +75,7 @@ dependencies = [
+     "sphinxcontrib-serializinghtml>=1.1.9",
+     "Jinja2>=3.1",
+     "Pygments>=2.17",
+-    "docutils>=0.20,<0.22",
++    "docutils>=0.20,<0.23",
+     "snowballstemmer>=2.2",
+     "babel>=2.13",
+     "alabaster>=0.7.14",
+-- 
+2.51.0
+

--- a/app-doc/sphinx/autobuild/patches/0002-Satisfy-mypy.patch
+++ b/app-doc/sphinx/autobuild/patches/0002-Satisfy-mypy.patch
@@ -1,0 +1,53 @@
+From 37fa7ed12ae71bfa6b5c97915981a75e35b22515 Mon Sep 17 00:00:00 2001
+From: Adam Turner <9087854+aa-turner@users.noreply.github.com>
+Date: Tue, 29 Jul 2025 18:35:37 +0100
+Subject: [PATCH 2/2] Satisfy mypy
+
+---
+ sphinx/transforms/__init__.py    | 2 +-
+ sphinx/transforms/references.py  | 2 +-
+ tests/test_markup/test_markup.py | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/sphinx/transforms/__init__.py b/sphinx/transforms/__init__.py
+index e1f905d2d..1bb08af9e 100644
+--- a/sphinx/transforms/__init__.py
++++ b/sphinx/transforms/__init__.py
+@@ -367,7 +367,7 @@ def apply(self, **kwargs: Any) -> None:
+         # override default settings with :confval:`smartquotes_action`
+         self.smartquotes_action = self.config.smartquotes_action
+ 
+-        super().apply()  # type: ignore[no-untyped-call]
++        super().apply()
+ 
+     def is_available(self) -> bool:
+         builders = self.config.smartquotes_excludes.get('builders', [])
+diff --git a/sphinx/transforms/references.py b/sphinx/transforms/references.py
+index 447e9ded5..d9bb28c25 100644
+--- a/sphinx/transforms/references.py
++++ b/sphinx/transforms/references.py
+@@ -25,7 +25,7 @@ def apply(self, **kwargs: Any) -> None:
+ 
+             # suppress INFO level messages for a while
+             reporter.report_level = max(reporter.WARNING_LEVEL, reporter.report_level)
+-            super().apply()  # type: ignore[no-untyped-call]
++            super().apply()
+         finally:
+             reporter.report_level = report_level
+ 
+diff --git a/tests/test_markup/test_markup.py b/tests/test_markup/test_markup.py
+index 3a370ee46..05c591cb0 100644
+--- a/tests/test_markup/test_markup.py
++++ b/tests/test_markup/test_markup.py
+@@ -69,7 +69,7 @@ def parse_(rst):
+         document = new_document()
+         parser = RstParser()
+         parser.parse(rst, document)
+-        SphinxSmartQuotes(document, startnode=None).apply()  # type: ignore[no-untyped-call]
++        SphinxSmartQuotes(document, startnode=None).apply()
+         for msg in list(document.findall(nodes.system_message)):
+             if msg['level'] == 1:
+                 msg.replace_self([])
+-- 
+2.51.0
+

--- a/app-doc/sphinx/spec
+++ b/app-doc/sphinx/spec
@@ -1,4 +1,4 @@
-VER=7.0.1
-SRCS="tbl::https://pypi.io/packages/source/S/Sphinx/Sphinx-$VER.tar.gz"
-CHKSUMS="sha256::61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d"
+VER=8.2.3
+SRCS="pypi::version=$VER::sphinx"
+CHKSUMS="sha256::398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348"
 CHKUPDATE="anitya::id=4031"

--- a/lang-python/docutils/spec
+++ b/lang-python/docutils/spec
@@ -1,4 +1,4 @@
-VER=0.21.2
+VER=0.22.2
 SRCS="tbl::https://pypi.io/packages/source/d/docutils/docutils-$VER.tar.gz"
-CHKSUMS="sha256::3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"
+CHKSUMS="sha256::9fdb771707c8784c8f2728b67cb2c691305933d68137ef95a75db5f4dfbc213d"
 CHKUPDATE="anitya::id=3849"

--- a/lang-python/roman-numerals-py/autobuild/defines
+++ b/lang-python/roman-numerals-py/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=roman-numerals-py
+PKGSEC=python
+PKGDEP="python-3"
+PKGDES="Python module to manipulate formed Roman numerals"
+
+ABTYPE=pep517
+NOPYTHON2=1
+
+ABHOST=noarch

--- a/lang-python/roman-numerals-py/spec
+++ b/lang-python/roman-numerals-py/spec
@@ -1,0 +1,4 @@
+VER=3.1.0
+SRCS="pypi::version=3.1.0::roman-numerals-py"
+CHKSUMS="sha256::be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d"
+CHKUPDATE="anitya::id=377048"


### PR DESCRIPTION
Topic Description
-----------------

- sphinx: add roman-numerals-py dep
- roman-numerals-py: new, 3.1.0
- sphinx: update to 8.2.3
    - Backport a patch series to fix compatibility with docutils >= 0.22.
    - Track patches at AOSC-Tracking/sphinx @ aosc/v8.2.3
    \(HEAD: 37fa7ed12ae71bfa6b5c97915981a75e35b22515\).
- docutils: update to 0.22.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- docutils: 2:0.22.2
- roman-numerals-py: 3.1.0
- sphinx: 8.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit docutils roman-numerals-py sphinx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
