### PR TITLE
pyscss: drop, orphaned

### DIFF
--- a/lang-python/pyscss/autobuild/defines
+++ b/lang-python/pyscss/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME=pyscss
-PKGDES="a Scss compiler for Python"
-PKGDEP="python-3 six"
-BUILDDEP="setuptools-python3"
-PKGSEC=python
-
-ABTYPE=python
-
-NOPYTHON2=1

--- a/lang-python/pyscss/spec
+++ b/lang-python/pyscss/spec
@@ -1,5 +1,0 @@
-VER=1.4.0
-SRCS="git::commit=tags/v$VER::https://github.com/Kronuz/pyScss/"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=87682"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pyscss: drop, orphaned
    Its acceleration extension fails to build with Python 3.14.

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
