### PR TITLE
gmpy2: update to 2.2.1

### DIFF
--- a/lang-python/gmpy2/autobuild/defines
+++ b/lang-python/gmpy2/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=gmpy2
 PKGSEC=python
-PKGDEP="mpc python-2 python-3"
+PKGDEP="mpc python-3"
 PKGDES="Provides C-coded Python modules for fast multiple-precision arithmetic"
+
+NOPYTHON2=1

--- a/lang-python/gmpy2/spec
+++ b/lang-python/gmpy2/spec
@@ -1,4 +1,4 @@
-VER=2.1.5
-SRCS="git::commit=tags/gmpy2-$VER::https://github.com/aleaxit/gmpy"
+VER=2.2.1
+SRCS="git::commit=tags/v${VER}::https://github.com/aleaxit/gmpy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7789"


### PR DESCRIPTION
Topic Description
-----------------

- gmpy2: update to 2.2.1
- gmpy2: remove python 2

Package(s) Affected
-------------------

- gmpy2: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gmpy2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
