### PR TITLE
dnscontrol: update to 4.26.0

### DIFF
--- a/app-network/dnscontrol/autobuild/defines
+++ b/app-network/dnscontrol/autobuild/defines
@@ -7,4 +7,4 @@ BUILDDEP="go"
 # executables.
 ABSPLITDBG=0
 
-GO_LDFLAGS=("-X main.version=$PKGVER")
+GO_LDFLAGS=("-X github.com/StackExchange/dnscontrol/v4/pkg/version.version=$PKGVER")

--- a/app-network/dnscontrol/spec
+++ b/app-network/dnscontrol/spec
@@ -1,5 +1,4 @@
-VER=4.22.0
-REL=1
+VER=4.26.0
 SRCS="git::commit=tags/v$VER::https://github.com/StackExchange/dnscontrol.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375553"


### PR DESCRIPTION
Topic Description
-----------------

- dnscontrol: update to 4.26.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- dnscontrol: 4.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnscontrol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
