### PR TITLE
spdlog: update to 1.16.0

### DIFF
--- a/runtime-common/spdlog/spec
+++ b/runtime-common/spdlog/spec
@@ -1,4 +1,4 @@
-VER=1.14.1
+VER=1.16.0
 SRCS="tbl::https://github.com/gabime/spdlog/archive/v$VER.tar.gz"
-CHKSUMS="sha256::1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b"
+CHKSUMS="sha256::8741753e488a78dd0d0024c980e1fb5b5c85888447e309d9cb9d949bdb52aa3e"
 CHKUPDATE="anitya::id=15599"


### PR DESCRIPTION
Topic Description
-----------------

- spdlog: update to 1.16.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- spdlog: 1.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit spdlog
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
