### PR TITLE
metasploit-framework: new, 6.4.92

### DIFF
--- a/app-penetration/metasploit-framework/autobuild/build
+++ b/app-penetration/metasploit-framework/autobuild/build
@@ -1,0 +1,45 @@
+
+abinfo "bundle install...."
+bundle config set --local deployment 'true'
+
+bundle install -j"$(nproc)" --no-cache
+
+abinfo "install to $PKGDIR"
+
+# install dir
+install -d "$PKGDIR"/opt/metasploit
+install -d "$PKGDIR"/usr/bin
+install -d "$PKGDIR"/usr/share/zsh/site-functions
+install -d "$PKGDIR"/usr/share/licenses/metasploit
+install -d "$PKGDIR"/usr/share/doc
+
+
+abinfo "copy Metasploit-framework"
+# copy del
+rsync -a --delete --exclude ".git" "$SRCDIR"/ "$PKGDIR"/opt/metasploit/
+
+# all msf* new shell
+abinfo "Create script"
+for f in "$PKGDIR"/opt/metasploit/msf*; do
+  if [ -f "$f" ] && [ -x "$f" ]; then
+    local _msffile="$PKGDIR/usr/bin/$(basename "$f")"
+    echo " - Create script: $(basename "${_msffile}")"
+    cat > "${_msffile}" << EOF
+#!/bin/sh
+# Start metasploit
+BUNDLE_GEMFILE=/opt/metasploit/Gemfile exec bundle exec ruby /opt/metasploit/$(basename "$f") "\$@"
+EOF
+    chmod 755 "${_msffile}"
+  fi
+done
+
+abinfo "Install license and documentation"
+install -Dm 644 LICENSE COPYING -t "$PKGDIR"/usr/share/licenses/metasploit
+mv "$PKGDIR"/opt/metasploit/documentation "$PKGDIR"/usr/share/doc/metasploit
+
+
+abinfo "Remove automatic updates"
+# del update
+if [ -f "$PKGDIR/usr/bin/msfupdate" ]; then
+  rm "$PKGDIR/usr/bin/msfupdate"
+fi

--- a/app-penetration/metasploit-framework/autobuild/defines
+++ b/app-penetration/metasploit-framework/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=metasploit-framework
+PKGSEC=utils
+PKGDEP="git inetutils libpcap libxml2 libxslt postgresql ruby ruby-bundler sqlite"
+PKGDES="Penetration open platform for developing, testing, and using exploit code"
+
+ABTYPE=self
+ABSPLITDBG=0

--- a/app-penetration/metasploit-framework/spec
+++ b/app-penetration/metasploit-framework/spec
@@ -1,0 +1,5 @@
+VER=6.4.92
+SRCS="git::commit=tags/$VER::https://github.com/rapid7/metasploit-framework.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=190993"
+


### PR DESCRIPTION
Topic Description
-----------------

- metasploit-framework: new,6.4.92

Package(s) Affected
-------------------

- metasploit-framework: 6.4.92

Security Update?
----------------

No

Build Order
-----------

```
#buildit metasploit-framework
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
