### PR TITLE
spacebar: rebuild for libphonenumber

### DIFF
--- a/desktop-kde/spacebar/spec
+++ b/desktop-kde/spacebar/spec
@@ -1,4 +1,5 @@
 VER=23.01.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma-mobile/${VER}/spacebar-${VER}.tar.xz"
 CHKSUMS="sha256::545b596dca1c99010379111a149309f5c4b9320d90092ce5ec8f01b4ecda3c6b"
 CHKUPDATE="anitya::id=229048"


### PR DESCRIPTION
Topic Description
-----------------

- spacebar: rebuild for libphonenumber
    I don't know why the ABI of libphonenumber changed, but it happens and
    the _ZNK4i18n12phonenumbers11PhoneNumber13IsInitializedEv symbol that
    spacebar referenced is now missing.
    Rebuild spacebar.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- spacebar: 23.01.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit spacebar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
