### PR TITLE
dotnet-host: place documents in its own directory

### DIFF
--- a/lang-dotnet/dotnet-host/autobuild/build
+++ b/lang-dotnet/dotnet-host/autobuild/build
@@ -1,12 +1,11 @@
 abinfo "Deploying files ..."
 install -dv "$PKGDIR"/usr/bin
 install -dv "$PKGDIR"/usr/lib/dotnet
-install -dv "$PKGDIR"/usr/share/doc/dotnet
+install -dv "$PKGDIR"/usr/share/doc/dotnet-host
 # install -dv "$PKGDIR"/usr/share/man/man1
 install -dv "$PKGDIR"/usr/bin
 install -Dv "$SRCDIR"/dotnet "$PKGDIR"/usr/lib/dotnet
-install -Dv "$SRCDIR"/LICENSE.txt "$PKGDIR"/usr/share/doc/dotnet
-install -Dv "$SRCDIR"/ThirdPartyNotices.txt "$PKGDIR"/usr/share/doc/dotnet
+install -Dv "$SRCDIR"/ThirdPartyNotices.txt "$PKGDIR"/usr/share/doc/dotnet-host
 # FIXME: Missing in official distribution https://github.com/dotnet/sdk/pull/21557#issuecomment-974846918
 # install -Dv "$SRCDIR"/dotnet.1.gz "$PKGDIR"/usr/share/man/man1
 ln -sv /usr/lib/dotnet/dotnet "$PKGDIR"/usr/bin/dotnet

--- a/lang-dotnet/dotnet-host/spec
+++ b/lang-dotnet/dotnet-host/spec
@@ -1,4 +1,5 @@
 VER=8.0.10
+REL=1
 
 # Note: For use inside autobuild/.
 __VER="${VER}"


### PR DESCRIPTION
Topic Description
-----------------

- dotnet-host: place documents in its own directory

Package(s) Affected
-------------------

- dotnet-host: 8.0.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-host
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
