### PR TITLE
rhythmbox: update to 3.4.9

### DIFF
--- a/app-multimedia/rhythmbox/autobuild/defines
+++ b/app-multimedia/rhythmbox/autobuild/defines
@@ -13,7 +13,18 @@ PKGDES="An iTunes-like music player and manager"
 ABTYPE=meson
 
 # FIXME: Enable grilo after grilo built against libsoup3 - gnome 43
-MESON_AFTER="-Dgrilo=disabled \
-             -Ddaap=enabled"
+#
+# FIXME: -Dplugins_python=disabled
+#
+#        Python support was removed from libpeas.
+#
+#        libpeas still requires girepository-1.0 but PyGObject now
+#        requires girepository-2.0. The two may not be called in the
+#        same process.
+MESON_AFTER=(
+    '-Dgrilo=disabled'
+    '-Ddaap=enabled'
+    '-Dplugins_python=disabled'
+)
 
 PKGQUIRK=gnome

--- a/app-multimedia/rhythmbox/spec
+++ b/app-multimedia/rhythmbox/spec
@@ -1,5 +1,4 @@
-VER=3.4.7
-REL=2
+VER=3.4.9
 SRCS="tbl::https://download.gnome.org/sources/rhythmbox/${VER:0:3}/rhythmbox-$VER.tar.xz"
-CHKSUMS="sha256::2f6d56c13fc1a64c534f500788fb482936ce547b343ed90c67de1f2bce0cfa7e"
+CHKSUMS="sha256::e42291a18df7a21ffe6b352bf73f05d7e298bb4e05bce5967f98ee8cee4408f1"
 CHKUPDATE="anitya::id=9525"


### PR DESCRIPTION
Topic Description
-----------------

- rhythmbox: update to 3.4.9
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rhythmbox: 3.4.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit rhythmbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
