### PR TITLE
ruamel-yaml-clib: fix build update to 0.2.14

### DIFF
--- a/lang-python/ruamel-yaml-clib/autobuild/defines
+++ b/lang-python/ruamel-yaml-clib/autobuild/defines
@@ -1,9 +1,7 @@
 PKGNAME=ruamel-yaml-clib
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools"
+BUILDDEP="cython setuptools"
 PKGDES="C based reader/scanner and emitter for ruamel-yaml"
 
-ABTYPE=python
-
-NOPYTHON2=1
+ABTYPE=pep517

--- a/lang-python/ruamel-yaml-clib/spec
+++ b/lang-python/ruamel-yaml-clib/spec
@@ -1,4 +1,4 @@
-VER=0.2.6
-SRCS="https://pypi.io/packages/source/r/ruamel.yaml.clib/ruamel.yaml.clib-$VER.tar.gz"
-CHKSUMS="sha256::4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"
+VER=0.2.14
+SRCS="pypi::version=$VER::ruamel.yaml.clib"
+CHKSUMS="sha256::803f5044b13602d58ea378576dd75aa759f52116a0232608e8fdada4da33752e"
 CHKUPDATE="anitya::id=131030"

--- a/lang-python/ruamel-yaml/autobuild/defines
+++ b/lang-python/ruamel-yaml/autobuild/defines
@@ -2,8 +2,7 @@ PKGNAME=ruamel-yaml
 PKGSEC=python
 PKGDEP="python-3 ruamel-yaml-clib"
 BUILDDEP="setuptools"
-PKGDES="A YAML 1.2 loader/dumper package for Python."
+PKGDES="YAML 1.2 loader/dumper package for Python"
 
-NOPYTHON2=1
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/ruamel-yaml/spec
+++ b/lang-python/ruamel-yaml/spec
@@ -1,4 +1,4 @@
-VER=0.17.19
-SRCS="https://pypi.io/packages/source/r/ruamel.yaml/ruamel.yaml-$VER.tar.gz"
-CHKSUMS="sha256::b9ce9a925d0f0c35a1dbba56b40f253c53cd526b0fa81cf7b1d24996f28fb1d7"
+VER=0.18.15
+SRCS="pypi::version=$VER::ruamel.yaml"
+CHKSUMS="sha256::dbfca74b018c4c3fba0b9cc9ee33e53c371194a9000e694995e620490fd40700"
 CHKUPDATE="anitya::id=66067"


### PR DESCRIPTION
Topic Description
-----------------

- ruamel-yaml: update to 0.18.15
use ABTYPE pep517
- ruamel-yaml-clib: fix build
update to 0.2.14

Package(s) Affected
-------------------

- ruamel-yaml: 0.18.15
- ruamel-yaml-clib: 0.2.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit ruamel-yaml-clib ruamel-yaml
```

Test Build(s) Done
------------------

