### PR TITLE
ujson: update to 5.11.0

### DIFF
--- a/lang-python/ujson/autobuild/defines
+++ b/lang-python/ujson/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=ujson
 PKGSEC=python
-PKGDEP="python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="double-conversion gcc-runtime glibc python-3"
+BUILDDEP="setuptools setuptools-scm"
 PKGDES="Ultra fast JSON encoder and decoder for Python"
+
+ABTYPE=pep517

--- a/lang-python/ujson/autobuild/prepare
+++ b/lang-python/ujson/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Using system double-conversion ..."
+rm -rv "$SRCDIR"/src/ujson/deps
+export UJSON_BUILD_NO_STRIP=1
+export UJSON_BUILD_DC_INCLUDES='/usr/include/double-conversion'
+export UJSON_BUILD_DC_LIBS='-ldouble-conversion'

--- a/lang-python/ujson/spec
+++ b/lang-python/ujson/spec
@@ -1,5 +1,4 @@
-VER=1.35
-REL=5
-SRCS="tbl::https://pypi.io/packages/source/u/ujson/ujson-$VER.tar.gz"
-CHKSUMS="sha256::f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86"
+VER=5.11.0
+SRCS="pypi::version=$VER::ujson"
+CHKSUMS="sha256::e204ae6f909f099ba6b6b942131cee359ddda2b6e4ea39c12eb8b991fe2010e0"
 CHKUPDATE="anitya::id=124429"


### PR DESCRIPTION
Topic Description
-----------------

- ujson: update to 5.11.0
use system double-conversion

Package(s) Affected
-------------------

- ujson: 5.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ujson
```

Test Build(s) Done
------------------

