### PR TITLE
inetutils: update to 2.6

### DIFF
--- a/app-utils/inetutils/autobuild/defines
+++ b/app-utils/inetutils/autobuild/defines
@@ -1,46 +1,53 @@
 PKGNAME=inetutils
 PKGSEC=utils
 PKGDEP="glibc iana-etc linux-pam"
-PKGDES="A collection of common networking programs"
+PKGDES="Common networking programs"
 
-AUTOTOOLS_AFTER="--libexec=/usr/bin \
-                 --enable-servers \
-                 --enable-clients \
-                 --enable-libls \
-                 --enable-encryption \
-                 --enable-authentication \
-                 --enable-ftpd \
-                 --enable-rexecd \
-                 --enable-rlogind \
-                 --enable-rshd \
-                 --disable-syslogd \
-                 --enable-talkd \
-                 --enable-telnetd \
-                 --enable-tftpd \
-                 --disable-uucpd \
-                 --enable-ftp \
-                 --enable-dnsdomainname \
-                 --enable-hostname \
-                 --enable-ping \
-                 --enable-ping6 \
-                 --enable-rcp \
-                 --enable-rexec \
-                 --enable-rlogin \
-                 --enable-rsh \
-                 --disable-logger \
-                 --enable-talk \
-                 --enable-telnet \
-                 --enable-tftp \
-                 --enable-whois \
-                 --disable-ifconfig \
-                 --enable-traceroute \
-                 --enable-largefile \
-                 --enable-year2038 \
-                 --enable-threads=posix \
-                 --disable-rpath \
-                 --enable-ncurses \
-                 --enable-ipv4 \
-                 --enable-ipv6 \
-                 --without-wrap \
-                 --with-pam \
-                 --with-krb5=/usr"
+AUTOTOOLS_AFTER=(
+    '--libexec=/usr/bin'
+    '--enable-servers'
+    '--enable-clients'
+    '--enable-libls'
+    '--enable-encryption'
+    '--enable-authentication'
+    '--enable-ftpd'
+    '--enable-rexecd'
+    '--enable-rlogind'
+    '--enable-rshd'
+    '--disable-syslogd'
+    '--enable-talkd'
+    '--enable-telnetd'
+    '--enable-tftpd'
+    '--disable-uucpd'
+    '--enable-ftp'
+    '--enable-dnsdomainname'
+    '--enable-hostname'
+    '--enable-ping'
+    '--enable-ping6'
+    '--enable-rcp'
+    '--enable-rexec'
+    '--enable-rlogin'
+    '--enable-rsh'
+    '--disable-logger'
+    '--enable-talk'
+    '--enable-telnet'
+    '--enable-tftp'
+    '--enable-whois'
+    '--disable-ifconfig'
+    '--enable-traceroute'
+    '--enable-largefile'
+    '--enable-year2038'
+    '--enable-threads=posix'
+    '--disable-rpath'
+    '--enable-ncurses'
+    '--enable-ipv4'
+    '--enable-ipv6'
+    '--without-wrap'
+    '--with-pam'
+    '--with-krb5=/usr'
+)
+
+# FIXME: [...]/inetutils-2.6/bootstrap: Bootstrapping from a non-checked-out distribution is risky.
+#
+# Using autoreconf in prepare instead.
+RECONF=0

--- a/app-utils/inetutils/autobuild/patches/0001-DEBIAN-build-Disable-GFDL-info-files-and-useless-man.patch
+++ b/app-utils/inetutils/autobuild/patches/0001-DEBIAN-build-Disable-GFDL-info-files-and-useless-man.patch
@@ -1,4 +1,4 @@
-From c425ed51b3a957b1f7746e6a2b676e951deba427 Mon Sep 17 00:00:00 2001
+From f5cf631b91b708c91151e20094eae7b1b402a786 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 9 Jun 2010 03:56:08 +0200
 Subject: [PATCH 1/5] DEBIAN: build: Disable GFDL info files and useless man
@@ -19,10 +19,10 @@ Not forwarded upstream due to GNU policies regarding man pages.
  2 files changed, 4 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index 5db056b9..a5b5d28f 100644
+index 144d9fe5..46cae1a1 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -23,7 +23,6 @@ EXTRA_DIST = paths ChangeLog.0 ChangeLog.1 summary.sh.in CHECKLIST
+@@ -24,7 +24,6 @@ EXTRA_DIST += bootstrap bootstrap.conf bootstrap-funclib.sh
  SUBDIRS = lib \
  	libinetutils libtelnet libicmp libls \
  	src telnet telnetd ftp ftpd talk talkd whois ping ifconfig \
@@ -31,10 +31,10 @@ index 5db056b9..a5b5d28f 100644
  
  DISTCLEANFILES = pathdefs.make paths.defs
 diff --git a/configure.ac b/configure.ac
-index bbbb1986..a70d5c2f 100644
+index fe60ef35..564c3a97 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -141,7 +141,6 @@ AC_PROG_RANLIB
+@@ -142,7 +142,6 @@ AC_PROG_RANLIB
  AC_PROG_YACC
  AC_PROG_LN_S
  AC_PROG_SED
@@ -42,7 +42,7 @@ index bbbb1986..a70d5c2f 100644
  AC_ARG_VAR(GREP, [Location of preferred 'grep' utility.])
  AC_ARG_VAR(EGREP, [Location of preferred 'egrep' utility.])
  AC_ARG_VAR(FGREP, [Location of preferred 'fgrep' utility.])
-@@ -983,8 +982,6 @@ whois/Makefile
+@@ -986,8 +985,6 @@ whois/Makefile
  ping/Makefile
  ifconfig/Makefile
  ifconfig/system/Makefile
@@ -52,5 +52,5 @@ index bbbb1986..a70d5c2f 100644
  confpaths.h:confpaths.h.in
  ])
 -- 
-2.48.1
+2.51.0
 

--- a/app-utils/inetutils/autobuild/patches/0002-DEBIAN-build-Use-runstatedir-for-run-directory.patch
+++ b/app-utils/inetutils/autobuild/patches/0002-DEBIAN-build-Use-runstatedir-for-run-directory.patch
@@ -1,4 +1,4 @@
-From ed7819cc26c9bd2e77e1cde19027548051cc0254 Mon Sep 17 00:00:00 2001
+From 80eed508e62e934e9daff447b04ae9ef6d14fbb5 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Sun, 5 Sep 2021 05:00:23 +0200
 Subject: [PATCH 2/5] DEBIAN: build: Use runstatedir for /run directory
@@ -8,7 +8,7 @@ Subject: [PATCH 2/5] DEBIAN: build: Use runstatedir for /run directory
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/paths b/paths
-index 6cdd79d1..84d4c1a2 100644
+index ca363661..e56cc52b 100644
 --- a/paths
 +++ b/paths
 @@ -77,12 +77,12 @@ PATH_FTPLOGINMESG /etc/motd
@@ -38,5 +38,5 @@ index 6cdd79d1..84d4c1a2 100644
  PATH_RLOGIN	x $(bindir)/rlogin
  PATH_RSH	x $(bindir)/rsh
 -- 
-2.48.1
+2.51.0
 

--- a/app-utils/inetutils/autobuild/patches/0003-DEBIAN-inetd-Change-protocol-semantics-in-inetd.conf.patch
+++ b/app-utils/inetutils/autobuild/patches/0003-DEBIAN-inetd-Change-protocol-semantics-in-inetd.conf.patch
@@ -1,4 +1,4 @@
-From 4055c81064507d426a557fa561bee5e3519f86f2 Mon Sep 17 00:00:00 2001
+From a2a683c27fcad4cd6b65882c3a185cd4a2875835 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Mon, 6 Sep 2010 10:52:27 +0200
 Subject: [PATCH 3/5] DEBIAN: inetd: Change protocol semantics in inetd.conf
@@ -15,7 +15,7 @@ Fixes: commit a12021ee959a88b48cd16e947c671f8f59e29c9d
  1 file changed, 1 deletion(-)
 
 diff --git a/src/inetd.c b/src/inetd.c
-index eed7cc76..2c5448ae 100644
+index 52453fbd..10581a77 100644
 --- a/src/inetd.c
 +++ b/src/inetd.c
 @@ -1112,7 +1112,6 @@ getconfigent (FILE *fconfig, const char *file, size_t *line)
@@ -27,5 +27,5 @@ index eed7cc76..2c5448ae 100644
  	      if (strcmp (&sep->se_proto[3], "6only") == 0)
  		sep->se_v4mapped = 0;
 -- 
-2.48.1
+2.51.0
 

--- a/app-utils/inetutils/autobuild/patches/0004-DEBIAN-Use-krb5_auth_con_getsendsubkey-instead-of-kr.patch
+++ b/app-utils/inetutils/autobuild/patches/0004-DEBIAN-Use-krb5_auth_con_getsendsubkey-instead-of-kr.patch
@@ -1,4 +1,4 @@
-From e6ab680e7729ca595f11c6ee24685e52fa59823f Mon Sep 17 00:00:00 2001
+From b364fe3c9e97b02e8836b8f0e09e2507c8efdb6f Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 10 Aug 2022 01:57:24 +0200
 Subject: [PATCH 4/5] DEBIAN: Use krb5_auth_con_getsendsubkey() instead of
@@ -10,10 +10,10 @@ The latter is not exposed in the headers anymore.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libinetutils/kerberos5.c b/libinetutils/kerberos5.c
-index 5df12e77..f77bc412 100644
+index 217b64e0..6d993dd3 100644
 --- a/libinetutils/kerberos5.c
 +++ b/libinetutils/kerberos5.c
-@@ -154,7 +154,7 @@ kerberos_auth (krb5_context *ctx, int verbose, char **cname,
+@@ -152,7 +152,7 @@ kerberos_auth (krb5_context *ctx, int verbose, char **cname,
    krb5_data_free (&cksum_data);
  # endif
  
@@ -23,5 +23,5 @@ index 5df12e77..f77bc412 100644
    /* send size of AP-REQ to the server */
  
 -- 
-2.48.1
+2.51.0
 

--- a/app-utils/inetutils/autobuild/patches/0005-FROMLIST-telnet-telnetd-fix-build-with-GCC-14.patch
+++ b/app-utils/inetutils/autobuild/patches/0005-FROMLIST-telnet-telnetd-fix-build-with-GCC-14.patch
@@ -1,4 +1,4 @@
-From e67f01c46c07d40f40e40a42c098818594736a4a Mon Sep 17 00:00:00 2001
+From b69d494101ab5d34291b4ec0c49ebd40a01bb4d4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 10 Feb 2025 18:04:09 +0800
 Subject: [PATCH 5/5] FROMLIST: telnet: telnetd: fix build with GCC >= 14
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 12 insertions(+)
 
 diff --git a/am/libcurses.m4 b/am/libcurses.m4
-index 7c8c69a9..40c6aa31 100644
+index 15b5c5e7..276ffa37 100644
 --- a/am/libcurses.m4
 +++ b/am/libcurses.m4
 @@ -135,6 +135,10 @@ AC_DEFUN([IU_LIB_TERMCAP], [
@@ -29,7 +29,7 @@ index 7c8c69a9..40c6aa31 100644
  	&& test "$ac_cv_lib_termcap_tgetent" = no; then
        AC_CHECK_LIB(termlib, tgetent, LIBTERMCAP=-ltermlib)
 diff --git a/telnet/telnet.c b/telnet/telnet.c
-index 8884b6ec..4c340b57 100644
+index 1efa50ab..cf2c6667 100644
 --- a/telnet/telnet.c
 +++ b/telnet/telnet.c
 @@ -758,6 +758,10 @@ mklist (char *buf, char *name)
@@ -44,7 +44,7 @@ index 8884b6ec..4c340b57 100644
  init_term (char *tname, int *errp)
  {
 diff --git a/telnetd/utility.c b/telnetd/utility.c
-index 01b94297..69cc9673 100644
+index 4f82042f..7b78e3e3 100644
 --- a/telnetd/utility.c
 +++ b/telnetd/utility.c
 @@ -44,6 +44,10 @@
@@ -59,5 +59,5 @@ index 01b94297..69cc9673 100644
    && defined HAVE_STROPTS_H
  # include <stropts.h>
 -- 
-2.48.1
+2.51.0
 

--- a/app-utils/inetutils/autobuild/prepare
+++ b/app-utils/inetutils/autobuild/prepare
@@ -1,0 +1,3 @@
+# FIXME: See defines.
+abinfo "Re-generating autotools scripts ..."
+autoreconf -fvi

--- a/app-utils/inetutils/spec
+++ b/app-utils/inetutils/spec
@@ -1,5 +1,4 @@
-VER=2.5
-REL=1
+VER=2.6
 SRCS="tbl::https://ftp.gnu.org/gnu/inetutils/inetutils-$VER.tar.gz"
-CHKSUMS="sha256::fa043bbbc426eae1869070d2b6e29a98069615ac00681cdb92e20911d9292260"
+CHKSUMS="sha256::ccaa256e0d646df7f285ff158a3291f37cd1fc8382f3774d22f7254127635da7"
 CHKUPDATE="anitya::id=13805"


### PR DESCRIPTION
Topic Description
-----------------

- inetutils: update to 2.6
    Track patches at AOSC-Tracking/inetutils @ aosc/v2.6
    \(HEAD: b69d494101ab5d34291b4ec0c49ebd40a01bb4d4\).

Package(s) Affected
-------------------

- inetutils: 2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit inetutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
