### PR TITLE
msmtp: update to 1.8.32

### DIFF
--- a/app-web/msmtp/spec
+++ b/app-web/msmtp/spec
@@ -1,4 +1,4 @@
-VER=1.8.30
+VER=1.8.32
 SRCS="tbl::https://marlam.de/msmtp/releases/msmtp-${VER}.tar.xz"
-CHKSUMS="sha256::f826a3c500c4dfeed814685097cead9b2b3dca5a2ec3897967cb9032570fa9ab"
+CHKSUMS="sha256::20cd58b58dd007acf7b937fa1a1e21f3afb3e9ef5bbcfb8b4f5650deadc64db4"
 CHKUPDATE="anitya::id=2024"


### PR DESCRIPTION
Topic Description
-----------------

- msmtp: update to 1.8.32
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- msmtp: 1.8.32

Security Update?
----------------

No

Build Order
-----------

```
#buildit msmtp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
