### PR TITLE
loonggl: Fix prerm script

### DIFF
--- a/runtime-display/loonggl/autobuild/prerm
+++ b/runtime-display/loonggl/autobuild/prerm
@@ -1,1 +1,1 @@
-rm /usr/share/glvnd/40_loonggpu.json
+rm -f /usr/share/glvnd/egl_vendor.d/40_loonggpu.json

--- a/runtime-display/loonggl/spec
+++ b/runtime-display/loonggl/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
-REL=2
+REL=3
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggl/loonggl_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::b5815a6cc0aef84d742cfd052cb506e148da45d6046c046d4daef9aa96c6fbc9"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

We need to use "rm -f" so it won't fail when the symlink does not exist. And the path was incorrect as well :(.

Package(s) Affected
-------------------

- loonggl: `1.0.1~alpha~lnd25.5-3`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggl
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`
