### PR TITLE
pyx: update to 0.16

### DIFF
--- a/lang-python/pyx/autobuild/defines
+++ b/lang-python/pyx/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pyx
 PKGSEC=python
 PKGDEP="python-3"
-PKGSUG="texlive"
+PKGRECOM="texlive"
 PKGDES="Python library for the creation of PostScript and PDF files"
 
 NOPYTHON2=1

--- a/lang-python/pyx/spec
+++ b/lang-python/pyx/spec
@@ -1,5 +1,4 @@
-VER=0.14.1
-REL=7
+VER=0.16
 SRCS="tbl::https://pypi.python.org/packages/source/P/PyX/PyX-$VER.tar.gz"
-CHKSUMS="sha256::05d1b7fc813379d2c12fcb5bd0195cab522b5aabafac88f72913f1d47becd912"
+CHKSUMS="sha256::4d8e3e471cd3e9a9bd13d5086cdf7c0af1b0c3f3e195e74f5f63318dc40a66d8"
 CHKUPDATE="anitya::id=7028"


### PR DESCRIPTION
Topic Description
-----------------

- pyx: update to 0.16

Package(s) Affected
-------------------

- pyx: 0.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
