### PR TITLE
pytest-mock: new, 3.15.1

### DIFF
--- a/lang-python/pytest-mock/autobuild/defines
+++ b/lang-python/pytest-mock/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pytest-mock
+PKGSEC=python
+PKGDEP="setuptools pytest"
+BUILDDEP="setuptools-scm"
+PKGDES="Thin-wrapper around the mock package for easier use with pytest"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytest-mock/spec
+++ b/lang-python/pytest-mock/spec
@@ -1,0 +1,4 @@
+VER=3.15.1
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/pytest-dev/pytest-mock"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=11587"


### PR DESCRIPTION
Topic Description
-----------------

- pytest-mock: new, 3.15.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pytest-mock: 3.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pytest-mock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
