### PR TITLE
dascript: new, 0.5.9.1

### DIFF
--- a/lang-daslang/dascript/autobuild/build
+++ b/lang-daslang/dascript/autobuild/build
@@ -1,0 +1,45 @@
+abinfo "Patching to fix dasGlfw build ..."
+cd "$SRCDIR"/modules/dasGlfw
+for i in "$SRCDIR"/autobuild/patches/*.patch.deferred.dasglfw; do
+    if [[ -e $i ]]; then
+        abinfo "Applying patch $i ..."
+        patch -Np1 -t -i "$i"
+    fi
+done
+abinfo "Patching to fix dasLLVM build ..."
+cd "$SRCDIR"/modules/dasLLVM
+for i in "$SRCDIR"/autobuild/patches/*.patch.deferred.dasllvm; do
+    if [[ -e $i ]]; then
+        abinfo "Applying patch $i ..."
+        patch -Np1 -t -i "$i"
+    fi
+done
+
+abinfo "building daScript..."
+cd "$SRCDIR"
+CC=clang
+CXX=clang++
+cmake \
+	-B./build \
+	-DCMAKE_BUILD_TYPE:STRING=Debug \
+	-DDAS_HV_DISABLED=OFF \
+	-DDAS_LLVM_DISABLED=OFF \
+	-DDAS_IMGUI_DISABLED=OFF \
+	-DDAS_MINFFT_DISABLED=OFF \
+	-DDAS_AUDIO_DISABLED=OFF \
+	-DDAS_PUGIXML_DISABLED=OFF \
+	-DDAS_SQLITE_DISABLED=OFF \
+	-DDAS_GLFW_DISABLED=OFF \
+	-G Ninja
+cd build
+ninja daslang
+
+abinfo "installing daScript..."
+cd "$SRCDIR"
+cmake --install ./build --prefix ./daslang_bundle
+
+mkdir -p "$PKGDIR"/usr/share/dascript/
+cp -a "$SRCDIR"/daslang_bundle/* \
+	"$PKGDIR"/usr/share/dascript/
+
+ln -sv /usr/share/dascript/bin/daslang "$PKGDIR"/usr/bin/daslang

--- a/lang-daslang/dascript/autobuild/defines
+++ b/lang-daslang/dascript/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=dascript
+PKGSEC=devel
+BUILDDEP="doxygen llvm ninja"
+PKGDEP="glfw glibc"
+PKGDES="statically strong typed scripting language"
+FAIL_ARCH="!(amd64|arm64)"
+USECLANG=1

--- a/lang-daslang/dascript/autobuild/patches/0001-AOSCOS-prefer-system-shared-GLFW-over-bundled-static.patch.deferred.dasglfw
+++ b/lang-daslang/dascript/autobuild/patches/0001-AOSCOS-prefer-system-shared-GLFW-over-bundled-static.patch.deferred.dasglfw
@@ -1,0 +1,94 @@
+From eeda89ebd052cfd4b722b8a1bd1a3096988f9c01 Mon Sep 17 00:00:00 2001
+From: ilikara <3435193369@qq.com>
+Date: Wed, 15 Oct 2025 17:16:40 +0800
+Subject: [PATCH] AOSCOS: prefer system shared GLFW over bundled static build
+
+Signed-off-by: ilikara <3435193369@qq.com>
+---
+ CMakeLists.txt | 63 +++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 45 insertions(+), 18 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fcecbc4..7ece5f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,7 +16,20 @@ IF((NOT DAS_GLFW_INCLUDED) AND ((NOT ${DAS_GLFW_DISABLED}) OR (NOT DEFINED DAS_G
+ 			${QUARTZCORE_LIBRARY}
+ 		)
+ 	ELSEIF(UNIX)
+-		SET(GLFW_LIBRARIES ${DAS_GLFW_DIR}/glfw/lib/libglfw3.a)
++		find_package(PkgConfig)
++		if (PkgConfig_FOUND)
++			pkg_check_modules(GLFW3 glfw3)
++		endif()
++
++		if (GLFW3_FOUND)
++			message(STATUS "Using system GLFW3 shared library.")
++			set(GLFW_INCLUDE_DIR ${GLFW3_INCLUDE_DIRS})
++			set(GLFW_LIBRARIES ${GLFW3_LIBRARIES})
++			set(USE_SYSTEM_GLFW TRUE)
++		else()
++			message(STATUS "System GLFW not found. Will build bundled static GLFW.")
++			set(GLFW_LIBRARIES ${DAS_GLFW_DIR}/glfw/lib/libglfw3.a)
++		endif()
+ 	ELSE()
+ 		SET(GLFW_LIBRARIES ${DAS_GLFW_DIR}/glfw/lib/glfw3.lib)
+ 	ENDIF()
+@@ -25,23 +38,37 @@ IF((NOT DAS_GLFW_INCLUDED) AND ((NOT ${DAS_GLFW_DISABLED}) OR (NOT DEFINED DAS_G
+ 
+ 	include(ExternalProject)
+ 
+-	IF(APPLE)
+-		ExternalProject_Add(
+-			GLFW3
+-			SOURCE_DIR ${DAS_GLFW_DIR}/libglfw
+-			CMAKE_ARGS -DOSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES} -DCMAKE_INSTALL_PREFIX=${DAS_GLFW_DIR}/glfw -DCMAKE_BUILD_TYPE=Release -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF
+-			BINARY_DIR ${DAS_GLFW_DIR}/libglfw/build
+-			BUILD_BYPRODUCTS ${DAS_GLFW_DIR}/glfw/lib/libglfw3.a
+-		)
+-	ELSE()
+-		ExternalProject_Add(
+-			GLFW3
+-			SOURCE_DIR ${DAS_GLFW_DIR}/libglfw
+-			CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${DAS_GLFW_DIR}/glfw -DCMAKE_BUILD_TYPE=Release -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_LINKER=${CMAKE_LINKER}
+-			BINARY_DIR ${DAS_GLFW_DIR}/libglfw/build
+-			BUILD_BYPRODUCTS ${DAS_GLFW_DIR}/glfw/lib/libglfw3.a
+-		)
+-	ENDIF()
++	if (NOT USE_SYSTEM_GLFW)
++		IF(APPLE)
++			ExternalProject_Add(
++				GLFW3
++				SOURCE_DIR ${DAS_GLFW_DIR}/libglfw
++				CMAKE_ARGS -DOSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
++						   -DCMAKE_INSTALL_PREFIX=${DAS_GLFW_DIR}/glfw
++						   -DCMAKE_BUILD_TYPE=Release
++						   -DGLFW_BUILD_EXAMPLES=OFF
++						   -DGLFW_BUILD_TESTS=OFF
++				BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libglfw/build
++				BUILD_BYPRODUCTS ${DAS_GLFW_DIR}/glfw/lib/libglfw3.a
++			)
++		ELSE()
++			ExternalProject_Add(
++				GLFW3
++				SOURCE_DIR ${DAS_GLFW_DIR}/libglfw
++				CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${DAS_GLFW_DIR}/glfw
++						   -DCMAKE_BUILD_TYPE=Release
++						   -DGLFW_BUILD_EXAMPLES=OFF
++						   -DGLFW_BUILD_TESTS=OFF
++						   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
++						   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
++						   -DCMAKE_LINKER=${CMAKE_LINKER}
++				BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libglfw/build
++				BUILD_BYPRODUCTS ${DAS_GLFW_DIR}/glfw/lib/libglfw3.a
++			)
++		ENDIF()
++	else()
++		add_custom_target(GLFW3)
++	endif()
+ 
+ 	SET(DAS_GLFW_BIND_DIR ${DAS_GLFW_DIR})
+ 
+-- 
+2.51.0
+

--- a/lang-daslang/dascript/autobuild/patches/0001-AOSCOS-support-high-version-llvm.patch.deferred.dasllvm
+++ b/lang-daslang/dascript/autobuild/patches/0001-AOSCOS-support-high-version-llvm.patch.deferred.dasllvm
@@ -1,0 +1,26 @@
+From ce9ce6843e4507bdeeaa882b38c2df79e91774c9 Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Wed, 15 Oct 2025 22:41:36 +0800
+Subject: [PATCH] AOSCOS: support high version llvm
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8d33fe8..3fde9f1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ IF (NOT DEFINED PATH_TO_LIBCLANG)
+ 	SET(PATH_TO_LIBCLANG "${PROJECT_SOURCE_DIR}/../libclang")
+ ENDIF()
+-find_package(LLVM 16.0.6 PATHS "${PATH_TO_LIBCLANG}")
++find_package(LLVM REQUIRED PATHS "${PATH_TO_LIBCLANG}")
+ 
+ IF ((NOT DAS_LLVM_INCLUDED) AND ${LLVM_FOUND} AND ((NOT ${DAS_LLVM_DISABLED}) OR (NOT DEFINED DAS_LLVM_DISABLED)))
+     SET(DAS_LLVM_INCLUDED TRUE)
+-- 
+2.51.0
+

--- a/lang-daslang/dascript/autobuild/prepare
+++ b/lang-daslang/dascript/autobuild/prepare
@@ -1,0 +1,6 @@
+#FIXME: dasQuirrel has a ssh submodule url
+git submodule update --init
+abinfo "Using HTTPS for quirrel submodule URL..."
+sed -i -E 's|git@github.com:(.+)/(.+)\.git|https://github.com/\1/\2.git|g' modules/dasQuirrel/.gitmodules
+git submodule sync modules/dasQuirrel/
+git submodule update --init --recursive

--- a/lang-daslang/dascript/spec
+++ b/lang-daslang/dascript/spec
@@ -1,0 +1,5 @@
+VER=0.5.9.1
+#FIXME: dasQuirrel has a ssh submodule url
+SRCS="git::commit=tags/v$VER;submodule=false;copy-repo=true::https://github.com/GaijinEntertainment/daScript.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=GaijinEntertainment/daScript"


### PR DESCRIPTION
Topic Description
-----------------

- dascript: new, 0.5.9.1
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- dascript: 0.5.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dascript
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
