### PR TITLE
caligula: update to 0.4.9

### DIFF
--- a/app-utils/caligula/autobuild/defines
+++ b/app-utils/caligula/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=caligula
-PKGDES="A TUI program for imaging disks"
+PKGSEC=utils
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="rustc"
-PKGSEC="utils"
+BUILDDEP="llvm rustc"
+PKGDES="Disk imaging utility"
 
-# FIXME: lzma-sys need gcc to build
-NOLTO=1
+USECLANG=1

--- a/app-utils/caligula/autobuild/prepare
+++ b/app-utils/caligula/autobuild/prepare
@@ -1,3 +1,0 @@
-abinfo "set RUSTFLAGS --cfg tracing_unstable to fix build ..."
-# https://github.com/tokio-rs/tracing/discussions/1906
-export RUSTFLAGS="${RUSTFLAGS} --cfg tracing_unstable"

--- a/app-utils/caligula/spec
+++ b/app-utils/caligula/spec
@@ -1,4 +1,4 @@
-VER=0.4.5
+VER=0.4.9
 SRCS="git::commit=tags/v$VER::https://github.com/ifd3f/caligula"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372353"


### PR DESCRIPTION
Topic Description
-----------------

- caligula: update to 0.4.9
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- caligula: 0.4.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit caligula
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
