### PR TITLE
makedumpfile: new, 1.7.7

### DIFF
--- a/app-devel/makedumpfile/autobuild/build
+++ b/app-devel/makedumpfile/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Building makedumpfile ..."
+make \
+    LINKTYPE=dynamic
+
+abinfo "Installing makedumpfile ..."
+make install \
+    DESTDIR="$PKGDIR" \
+    SBINDIR=/usr/bin

--- a/app-devel/makedumpfile/autobuild/defines
+++ b/app-devel/makedumpfile/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=makedumpfile
+PKGSEC=devel
+PKGDEP="bzip2 elfutils lzo snappy zlib zstd"
+PKGDES="Make Linux crash dump small by filtering and compressing pages"
+
+ABTYPE=self

--- a/app-devel/makedumpfile/spec
+++ b/app-devel/makedumpfile/spec
@@ -1,0 +1,4 @@
+VER=1.7.7
+SRCS="git::commit=tags/$VER::https://github.com/makedumpfile/makedumpfile"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=131396"


### PR DESCRIPTION
Topic Description
-----------------

- makedumpfile: new, 1.7.7

Package(s) Affected
-------------------

- makedumpfile: 1.7.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit makedumpfile
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
