### PR TITLE
racc: drop, orphaned

### DIFF
--- a/groups/ruby-rebuilds
+++ b/groups/ruby-rebuilds
@@ -18,7 +18,6 @@ lang-ruby/kramdown-parser-gfm
 lang-ruby/mini-portile
 lang-ruby/mustache
 lang-ruby/nokogiri
-lang-ruby/racc
 lang-ruby/rdiscount
 lang-ruby/rexml
 lang-ruby/ronn

--- a/lang-ruby/nokogiri/autobuild/defines
+++ b/lang-ruby/nokogiri/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=nokogiri
 PKGSEC=ruby
-PKGDES="An HTML, XML, SAX and Reader parser"
-PKGDEP="libxml2 libxslt mini-portile racc ruby"
+PKGDES="HTML, XML, SAX reader and parser"
+PKGDEP="libxml2 libxslt mini-portile ruby"
 
 ABTYPE=ruby
 

--- a/lang-ruby/nokogiri/spec
+++ b/lang-ruby/nokogiri/spec
@@ -1,4 +1,5 @@
 VER=1.18.4
+REL=1
 SRCS="tbl::https://rubygems.org/downloads/nokogiri-$VER.gem"
 CHKSUMS="sha256::bb7820521c1bbae1d3e0092ff03b27a8e700912b37d80f962b7e4567947a64ac"
 CHKUPDATE="anitya::id=4641"

--- a/lang-ruby/racc/autobuild/defines
+++ b/lang-ruby/racc/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=racc
-PKGSEC=ruby
-PKGDES="An LALR(1) parser generator"
-PKGDEP="ruby"
-
-ABHOST=noarch
-ABTYPE=ruby

--- a/lang-ruby/racc/spec
+++ b/lang-ruby/racc/spec
@@ -1,6 +1,0 @@
-VER=1.6.0
-SRCS="tbl::https://rubygems.org/downloads/racc-$VER.gem"
-CHKSUMS="sha256::2dede3b136eeabd0f7b8c9356b958b3d743c00158e2615acab431af141354551"
-CHKUPDATE="anitya::id=9140"
-SUBDIR="."
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- nokogiri: drop racc dep
    Also improve PKGDES.
- racc: drop, orphaned
    racc \(1.8.1\) is now part of the current Ruby distribution.

Package(s) Affected
-------------------

- nokogiri: 1.18.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nokogiri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
