### PR TITLE
patool: update to 4.0.2

### DIFF
--- a/app-utils/patool/spec
+++ b/app-utils/patool/spec
@@ -1,5 +1,4 @@
-VER=1.12
-REL=1
+VER=4.0.2
 SRCS="tbl::https://pypi.python.org/packages/source/p/patool/patool-$VER.tar.gz"
-CHKSUMS="sha256::e3180cf8bfe13bedbcf6f5628452fca0c2c84a3b5ae8c2d3f55720ea04cb1097"
+CHKSUMS="sha256::e7f62d222f4a8a6c48dbfb38056dc7f9e5778ccc07c1f16d9653a316812f83ba"
 CHKUPDATE="anitya::id=19018"


### PR DESCRIPTION
Topic Description
-----------------

- patool: update to 4.0.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- patool: 4.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit patool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
