### PR TITLE
sound-juicer: update to 3.40.0

### DIFF
--- a/desktop-gnome/sound-juicer/spec
+++ b/desktop-gnome/sound-juicer/spec
@@ -1,5 +1,4 @@
-VER=3.38.0
+VER=3.40.0
 SRCS="https://download.gnome.org/sources/sound-juicer/${VER:0:4}/sound-juicer-$VER.tar.xz"
-CHKSUMS="sha256::ae375f357a1b8b81e4aff737c9d6c98bc2dadfe20e71754b1d52a79f036aa521"
+CHKSUMS="sha256::2ee882744391beb4c6d64a0f6825fb765510b706ec2b704bfb42e42afaae1de6"
 CHKUPDATE="anitya::id=4856"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- sound-juicer: update to 3.40.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sound-juicer: 3.40.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sound-juicer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
