### PR TITLE
dos2unix: update to 7.5.3

### DIFF
--- a/app-utils/dos2unix/spec
+++ b/app-utils/dos2unix/spec
@@ -1,4 +1,4 @@
-VER=7.5.2
+VER=7.5.3
 SRCS="tbl::https://sourceforge.net/projects/dos2unix/files/dos2unix/$VER/dos2unix-$VER.tar.gz"
-CHKSUMS="sha256::264742446608442eb48f96c20af6da303cb3a92b364e72cb7e24f88239c4bf3a"
+CHKSUMS="sha256::28a4b0d9f9179da4e44c567b9c01f818b070a20827115fffd96f760dcfa0f3b2"
 CHKUPDATE="anitya::id=453"


### PR DESCRIPTION
Topic Description
-----------------

- dos2unix: update to 7.5.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dos2unix: 7.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit dos2unix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
