### PR TITLE
uboot-asahi: update to 2025.07+1

### DIFF
--- a/runtime-kernel/uboot-asahi/spec
+++ b/runtime-kernel/uboot-asahi/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=2024.10-1
+UPSTREAM_VER=2025.07-1
 VER=${UPSTREAM_VER/\-/+}
 SRCS="git::commit=tags/asahi-v${UPSTREAM_VER}::https://github.com/AsahiLinux/u-boot"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- uboot-asahi: update to 2025.07+1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- uboot-asahi: 2025.07+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit uboot-asahi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
