### PR TITLE
gstreamer: update to 1.26.7

### DIFF
--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,4 @@
-VER=1.26.4
-REL=2
+VER=1.26.7
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: update to 1.26.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gstreamer: 1.26.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
