### PR TITLE
dulwich: update to 0.24.4

### DIFF
--- a/runtime-vcs/dulwich/spec
+++ b/runtime-vcs/dulwich/spec
@@ -1,4 +1,4 @@
-VER=0.21.6
+VER=0.24.4
 SRCS="tbl::https://github.com/jelmer/dulwich/archive/refs/tags/dulwich-${VER}.tar.gz"
-CHKSUMS="sha256::ec05c3723bac25e0851f47d8b14c24cb418ba3e3a7686cf67f7f83923d2fb0bd"
+CHKSUMS="sha256::723ab8d5bed0396bf746a6fe0d7cef356f9321db7e2031063b563f245b241375"
 CHKUPDATE="anitya::id=6077"


### PR DESCRIPTION
Topic Description
-----------------

- dulwich: update to 0.24.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dulwich: 0.24.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dulwich
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
