### PR TITLE
pycryptodomex: update to 3.23.0

### DIFF
--- a/lang-python/pycryptodomex/spec
+++ b/lang-python/pycryptodomex/spec
@@ -1,4 +1,4 @@
-VER=3.22.0x
+VER=3.23.0
 SRCS="git::commit=tags/v${VER}::https://github.com/Legrandin/pycryptodome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=36851"


### PR DESCRIPTION
Topic Description
-----------------

- pycryptodomex: update to 3.23.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pycryptodomex: 3.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycryptodomex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
