### PR TITLE
man-db: update to 2.13.1

### DIFF
--- a/app-utils/man-db/spec
+++ b/app-utils/man-db/spec
@@ -1,5 +1,4 @@
-VER=2.13.0
-REL=2
+VER=2.13.1
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/man-db/man-db-$VER.tar.xz"
-CHKSUMS="sha256::82f0739f4f61aab5eb937d234de3b014e777b5538a28cbd31433c45ae09aefb9"
+CHKSUMS="sha256::8afebb6f7eb6bb8542929458841f5c7e6f240e30c86358c1fbcefbea076c87d9"
 CHKUPDATE="anitya::id=1882"


### PR DESCRIPTION
Topic Description
-----------------

- man-db: update to 2.13.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- man-db: 2.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit man-db
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
