### PR TITLE
duplicity: update to 3.0.5.1

### DIFF
--- a/app-utils/duplicity/spec
+++ b/app-utils/duplicity/spec
@@ -1,4 +1,4 @@
-VER=3.0.1
+VER=3.0.5.1
 SRCS="git::commit=tags/rel.$VER::https://gitlab.com/duplicity/duplicity"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=635"


### PR DESCRIPTION
Topic Description
-----------------

- duplicity: update to 3.0.5.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- duplicity: 3.0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit duplicity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
