### PR TITLE
asymptote: update to 2.47

### DIFF
--- a/app-doc/asymptote/spec
+++ b/app-doc/asymptote/spec
@@ -1,4 +1,4 @@
-VER=3.05
+VER=2.47
 SRCS="tbl::https://sourceforge.net/projects/asymptote/files/$VER/asymptote-$VER.src.tgz/download"
-CHKSUMS="sha256::35c16d0a3bdd869a56e4efff4638f81c3a88b2f6b664d196471015dbf4c69a87"
+CHKSUMS="sha256::e1a4e5a36f87f62986f86bc4cff5ae922c8aa71bd3e17b5975ad7fbe8525827d"
 CHKUPDATE="anitya::id=125"


### PR DESCRIPTION
Topic Description
-----------------

- asymptote: update to 2.47
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- asymptote: 2.47

Security Update?
----------------

No

Build Order
-----------

```
#buildit asymptote
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
