### PR TITLE
iproute2: update to 6.17.0

### DIFF
--- a/app-network/iproute2/spec
+++ b/app-network/iproute2/spec
@@ -1,4 +1,4 @@
-VER=6.11.0
+VER=6.17.0
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$VER.tar.xz"
-CHKSUMS="sha256::1f795398a04aeaacd06a8f6ace2cfd913c33fa5953ca99daae83bb5c534611c3"
+CHKSUMS="sha256::9781e59410ab7dea8e9f79bb10ff1488e63d10fcbb70503b94426ba27a8e2dec"
 CHKUPDATE="anitya::id=1392"


### PR DESCRIPTION
Topic Description
-----------------

- iproute2: update to 6.17.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- iproute2: 6.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iproute2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
