### PR TITLE
socat: update to 1.8.0.3

### DIFF
--- a/app-network/socat/spec
+++ b/app-network/socat/spec
@@ -1,4 +1,4 @@
-VER=1.8.0.0
+VER=1.8.0.3
 SRCS="tbl::http://www.dest-unreach.org/socat/download/socat-${VER/b/-b}.tar.gz"
-CHKSUMS="sha256::6010f4f311e5ebe0e63c77f78613d264253680006ac8979f52b0711a9a231e82"
+CHKSUMS="sha256::a9f9eb6cfb9aa6b1b4b8fe260edbac3f2c743f294db1e362b932eb3feca37ba4"
 CHKUPDATE="anitya::id=4848"


### PR DESCRIPTION
Topic Description
-----------------

- socat: update to 1.8.0.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- socat: 1:1.8.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit socat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
