### PR TITLE
pcp: update to 7.0.2

### DIFF
--- a/app-utils/pcp/spec
+++ b/app-utils/pcp/spec
@@ -1,5 +1,4 @@
-VER=6.0.1
+VER=7.0.2
 SRCS="tbl::https://github.com/performancecopilot/pcp/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::c74708cce473566f9ce8caae933f7c78c0c2f0733abb23bd2af79b0f5a7eaf82"
+CHKSUMS="sha256::385907a7c24af7933609b4eee24efbf2cde369325498e7b2c6cae0aa703a5b95"
 CHKUPDATE="anitya::id=231628"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pcp: update to 7.0.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pcp: 7.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
