### PR TITLE
par2cmdline: update to 1.0.0

### DIFF
--- a/app-utils/par2cmdline/spec
+++ b/app-utils/par2cmdline/spec
@@ -1,4 +1,4 @@
-VER=0.8.1
+VER=1.0.0
 SRCS="tbl::https://github.com/Parchive/par2cmdline/archive/v$VER.tar.gz"
-CHKSUMS="sha256::529f85857ec44e501cd8d95b0c8caf47477d7daa5bfb989e422c800bb71b689a"
+CHKSUMS="sha256::9f17b4fd6812852d86b500823bd8d430d754e9189f3f4213b898a3652866116f"
 CHKUPDATE="anitya::id=12843"


### PR DESCRIPTION
Topic Description
-----------------

- par2cmdline: update to 1.0.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- par2cmdline: 1.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit par2cmdline
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
