### PR TITLE
ocaml-num: update to 1.6

### DIFF
--- a/lang-ocaml/ocaml-num/spec
+++ b/lang-ocaml/ocaml-num/spec
@@ -1,5 +1,4 @@
-VER=1.3
-REL=5
+VER=1.6
 SRCS="tbl::https://github.com/ocaml/num/archive/v$VER.tar.gz"
-CHKSUMS="sha256::4f79c30e81ea9553c5b2c5b5b57bb19968ccad1e85256b3c446b5df58f33e94d"
+CHKSUMS="sha256::b5cce325449aac746d5ca963d84688a627cca5b38d41e636cf71c68b60495b3e"
 CHKUPDATE="anitya::id=17853"


### PR DESCRIPTION
Topic Description
-----------------

- ocaml-num: update to 1.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ocaml-num: 1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit ocaml-num
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
