### PR TITLE
dune: update to 3.20.2

### DIFF
--- a/lang-ocaml/dune/spec
+++ b/lang-ocaml/dune/spec
@@ -1,4 +1,4 @@
-VER=3.19.1
+VER=3.20.2
 SRCS="git::commit=tags/$VER::https://github.com/ocaml/dune.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16017"


### PR DESCRIPTION
Topic Description
-----------------

- dune: update to 3.20.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dune: 3.20.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit dune
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
