### PR TITLE
exfatprogs: update to 1.3.0

### DIFF
--- a/app-admin/exfatprogs/spec
+++ b/app-admin/exfatprogs/spec
@@ -1,4 +1,4 @@
-VER=1.2.5
+VER=1.3.0
 SRCS="tbl::https://github.com/exfatprogs/exfatprogs/releases/download/$VER/exfatprogs-$VER.tar.xz"
-CHKSUMS="sha256::f27160dcc1ddd17c96cd41a6ceef7037adc2796ab5c5633d3d85cf532c3ee2f0"
+CHKSUMS="sha256::11135e5f5320935cc0623b0d394417e667edb827d04b953680f1bbffc575045f"
 CHKUPDATE="anitya::id=94441"


### PR DESCRIPTION
Topic Description
-----------------

- exfatprogs: update to 1.3.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- exfatprogs: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit exfatprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
