### PR TITLE
sanlock: update to 4.1.0

### DIFF
--- a/app-admin/sanlock/spec
+++ b/app-admin/sanlock/spec
@@ -1,4 +1,4 @@
-VER=3.8.5
+VER=4.1.0
 SRCS="tbl::https://releases.pagure.org/sanlock/sanlock-$VER.tar.gz"
-CHKSUMS="sha256::453d7558a3e0d60291527e1a7d887cb4a4907d68d76b8d2876e4c663bebe45f1"
+CHKSUMS="sha256::687814794b4fa07282b7f887fd9007ca4814ab989c3f97db0b6776f3403df14e"
 CHKUPDATE="anitya::id=6860"


### PR DESCRIPTION
Topic Description
-----------------

- sanlock: update to 4.1.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sanlock: 4.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sanlock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
