### PR TITLE
cryptsetup: update to 2.8.1

### DIFF
--- a/app-admin/cryptsetup/autobuild/defines
+++ b/app-admin/cryptsetup/autobuild/defines
@@ -2,72 +2,71 @@ PKGNAME=cryptsetup
 PKGSEC=utils
 PKGDEP="argon2 json-c libpwquality libssh lvm2 openssl popt util-linux"
 BUILDDEP="asciidoctor"
-PKGDES="A utility for setting up encrypted disks"
-BUILDDEP="asciidoctor"
+PKGDES="Utilities and libraries for handling encrypted disks"
 
 # Note: For all cipher related options, refer to configure --help for defaults.
 # FIXME: FIPS is incompatible with static builds.
-AUTOTOOLS_AFTER="--disable-static \
-                 --enable-shared \
-                 --enable-fast-install \
-                 --enable-libtool-lock \
-                 --enable-asciidoc \
-                 --enable-keyring \
-                 --enable-largefile \
-                 --enable-external-tokens \
-                 --enable-ssh-token \
-                 --enable-luks2-reencryption \
-                 --enable-nls \
-                 --enable-rpath \
-                 --enable-fips \
-                 --enable-pwquality \
-                 --disable-fuzz-targets \
-                 --disable-passwdqc \
-                 --disable-static-cryptsetup \
-                 --enable-cryptsetup \
-                 --enable-veritysetup \
-                 --enable-integritysetup \
-                 --disable-selinux \
-                 --enable-udev \
-                 --enable-kernel_crypto \
-                 --enable-gcrypt-pbkdf2 \
-                 --disable-internal-argon2 \
-                 --enable-libargon2 \
-                 --disable-internal-sse-argon2 \
-                 --enable-blkid \
-                 --disable-dev-random \
-                 --enable-luks-adjust-xts-keysize \
-                 --with-crypto_backend=openssl \
-                 --with-plain-hash=ripemd160 \
-                 --with-plain-cipher=aes \
-                 --with-plain-mode=cbc-essiv:sha256 \
-                 --with-plain-keybits=256 \
-                 --with-luks1-hash=sha256 \
-                 --with-luks1-cipher=aes \
-                 --with-luks1-mode=xts-plain64 \
-                 --with-luks1-keybits=256 \
-                 --with-luks2-pbkdf=argon2id \
-                 --with-luks1-iter-time=2000 \
-                 --with-luks2-iter-time=2000 \
-                 --with-luks2-memory-kb=1048576 \
-                 --with-luks2-parallel-threads=4 \
-                 --with-luks2-keyslot-cipher=aes-xts-plain64 \
-                 --with-luks2-keyslot-keybits=512 \
-                 --with-loopaes-cipher=aes \
-                 --with-loopaes-keybits=256 \
-                 --with-keyfile-size-maxkb=8192 \
-                 --with-integrity-keyfile-size-maxkb=4 \
-                 --with-passphrase-size-max=512 \
-                 --with-verity-hash=sha256 \
-                 --with-verity-data-block=4096 \
-                 --with-verity-hash-block=4096 \
-                 --with-verity-salt-size=32 \
-                 --with-verity-fec-roots=2 \
-                 --with-tmpfilesdir= \
-                 --with-luks2-lock-path=/run/cryptsetup \
-                 --with-luks2-lock-dir-perms=0700 \
-                 --with-luks2-external-tokens-path=/usr/lib/cryptsetup \
-                 --with-default-luks-format=LUKS2"
-ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--disable-static'
+    '--enable-shared'
+    '--enable-fast-install'
+    '--enable-libtool-lock'
+    '--enable-asciidoc'
+    '--enable-keyring'
+    '--enable-largefile'
+    '--enable-external-tokens'
+    '--enable-ssh-token'
+    '--enable-luks2-reencryption'
+    '--enable-nls'
+    '--enable-rpath'
+    '--enable-fips'
+    '--enable-pwquality'
+    '--disable-fuzz-targets'
+    '--disable-passwdqc'
+    '--disable-static-cryptsetup'
+    '--enable-cryptsetup'
+    '--enable-veritysetup'
+    '--enable-integritysetup'
+    '--disable-selinux'
+    '--enable-udev'
+    '--enable-kernel_crypto'
+    '--enable-gcrypt-pbkdf2'
+    '--disable-internal-argon2'
+    '--enable-libargon2'
+    '--disable-internal-sse-argon2'
+    '--enable-blkid'
+    '--disable-dev-random'
+    '--enable-luks-adjust-xts-keysize'
+    '--with-crypto_backend=openssl'
+    '--with-plain-hash=ripemd160'
+    '--with-plain-cipher=aes'
+    '--with-plain-mode=cbc-essiv:sha256'
+    '--with-plain-keybits=256'
+    '--with-luks1-hash=sha256'
+    '--with-luks1-cipher=aes'
+    '--with-luks1-mode=xts-plain64'
+    '--with-luks1-keybits=256'
+    '--with-luks2-pbkdf=argon2id'
+    '--with-luks1-iter-time=2000'
+    '--with-luks2-iter-time=2000'
+    '--with-luks2-memory-kb=1048576'
+    '--with-luks2-parallel-threads=4'
+    '--with-luks2-keyslot-cipher=aes-xts-plain64'
+    '--with-luks2-keyslot-keybits=512'
+    '--with-loopaes-cipher=aes'
+    '--with-loopaes-keybits=256'
+    '--with-keyfile-size-maxkb=8192'
+    '--with-integrity-keyfile-size-maxkb=4'
+    '--with-passphrase-size-max=512'
+    '--with-verity-hash=sha256'
+    '--with-verity-data-block=4096'
+    '--with-verity-hash-block=4096'
+    '--with-verity-salt-size=32'
+    '--with-verity-fec-roots=2'
+    '--with-luks2-lock-path=/run/cryptsetup'
+    '--with-luks2-lock-dir-perms=0700'
+    '--with-luks2-external-tokens-path=/usr/lib/cryptsetup'
+    '--with-default-luks-format=LUKS2'
+)
 
 PKGBREAK="systemd<=1:238 volume-key<=0.3.9"

--- a/app-admin/cryptsetup/autobuild/defines.stage2
+++ b/app-admin/cryptsetup/autobuild/defines.stage2
@@ -1,9 +1,11 @@
 PKGNAME=cryptsetup
 PKGSEC=utils
 PKGDEP="json-c libgcrypt util-linux popt libpwquality libssh lvm2"
-PKGDES="A utility for setting up encrypted disks"
+PKGDES="Utilities and libraries to handle encrypted disks"
 
-AUTOTOOLS_AFTER="--enable-fips \
-                 --enable-pwquality"
-ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--enable-fips'
+    '--enable-pwquality'
+)
+
 PKGBREAK="systemd<=1:238 volume-key<=0.3.9"

--- a/app-admin/cryptsetup/spec
+++ b/app-admin/cryptsetup/spec
@@ -1,4 +1,4 @@
-VER=2.7.5
+VER=2.8.1
 SRCS="https://www.kernel.org/pub/linux/utils/cryptsetup/v${VER:0:3}/cryptsetup-$VER.tar.xz"
-CHKSUMS="sha256::d2be4395b8f503b0ebf4b2d81db90c35a97050a358ee21fe62a0dfb66e5d5522"
+CHKSUMS="sha256::2c3379eb76597dcab50911449b013e2697c4bffcc716dbbf0d9b0e8fbbb46fb4"
 CHKUPDATE="anitya::id=13709"


### PR DESCRIPTION
Topic Description
-----------------

- cryptsetup: update to 2.8.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cryptsetup: 2.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cryptsetup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
