### PR TITLE
sxhkd: update to 0.6.3

### DIFF
--- a/desktop-wm/sxhkd/spec
+++ b/desktop-wm/sxhkd/spec
@@ -1,5 +1,4 @@
-VER=0.6.2
-REL=1
+VER=0.6.3
 SRCS="git::commit=tags/$VER::https://github.com/baskerville/sxhkd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13345"


### PR DESCRIPTION
Topic Description
-----------------

- sxhkd: update to 0.6.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sxhkd: 0.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit sxhkd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
