### PR TITLE
pipewire: Replace PulseAudio as the default audio server

### DIFF
--- a/app-multimedia/pipewire/autobuild/beyond
+++ b/app-multimedia/pipewire/autobuild/beyond
@@ -1,0 +1,14 @@
+abinfo "Adding symlinks to start PipeWire on login by default ..."
+abinfo "Creating symlink to the generic name for wireplumber ..."
+ln -svf wireplumber.service \
+	"$PKGDIR"/usr/lib/systemd/user/pipewire-session-manager.service
+
+abinfo "Enabling PipeWire and its related services by default ..."
+mkdir -pv "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
+mkdir -pv "$PKGDIR"/usr/lib/systemd/user/pipewire.service.wants
+ln -svf ../pipewire.socket \
+	"$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pipewire.socket
+ln -svf ../pipewire-pulse.socket \
+	"$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pipewire-pulse.socket
+ln -svf ../wireplumber.service \
+	"$PKGDIR"/usr/lib/systemd/user/pipewire.service.wants/wireplumber.service

--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -16,7 +16,7 @@ PKGPROV="gstreamer1.0-pipewire_spiral"
 # to make building fairly straightforward as they say
 ABTYPE=meson
 MESON_AFTER=(
-    -Ddocs=enabled
+    -Ddocs=disabled
     -Dman=enabled
     -Dgstreamer=enabled
     -Dsystemd=enabled

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,5 @@
 VER=1.4.9
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/app-multimedia/pulseaudio/autobuild/beyond
+++ b/app-multimedia/pulseaudio/autobuild/beyond
@@ -1,15 +1,17 @@
+abinfo "Disbaling flat volume model ..."
 sed -e '/flat-volumes/iflat-volumes=no' \
     -i "$PKGDIR"/etc/pulse/daemon.conf
 
+abinfo "Disabling auto spawning of the server ..."
 sed -e '/autospawn/iautospawn=no' \
     -i "$PKGDIR"/etc/pulse/client.conf
 
+abinfo "Disabling problematic modules ..."
 sed -e 's|/usr/bin/pactl load-module module-x11-cork-request|#&|' \
     -i "$PKGDIR"/usr/bin/start-pulseaudio-x11
 
-mkdir -v "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
-ln -vs ../pulseaudio.socket \
-    "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
+abinfo "Removing XDG Autostart configurations and XWayland session file ..."
+rm -r "$PKGDIR"/etc/xdg
 
 # FIXME: GDM does not release A2DP socket.
 # Note: gdm daemon owner GID/UID are both 771.

--- a/app-multimedia/pulseaudio/autobuild/beyond.stage2
+++ b/app-multimedia/pulseaudio/autobuild/beyond.stage2
@@ -7,10 +7,6 @@ sed -e '/autospawn/iautospawn=no' \
 sed -e 's|/usr/bin/pactl load-module module-x11-cork-request|#&|' \
     -i "$PKGDIR"/usr/bin/start-pulseaudio-x11
 
-mkdir -v "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants
-ln -vs ../pulseaudio.socket \
-    "$PKGDIR"/usr/lib/systemd/user/sockets.target.wants/pulseaudio.socket
-
 # FIXME: GDM does not release A2DP socket.
 # Note: gdm daemon owner GID/UID are both 771.
 setfacl -m u:771:r "$PKGDIR"/usr/bin/pulseaudio

--- a/app-multimedia/pulseaudio/autobuild/defines
+++ b/app-multimedia/pulseaudio/autobuild/defines
@@ -8,8 +8,12 @@ PKGSUG="alsa-plugins"
 BUILDDEP="check intltool doxygen pulseaudio"
 PKGDES="A full featured, general-purpose sound server"
 
-MESON_AFTER="-D udevrulesdir=/usr/lib/udev/rules.d \
-             -D tcpwrap=disabled"
+MESON_AFTER=(
+	"-Ddoxygen=false"
+	"-Dudevrulesdir=/usr/lib/udev/rules.d"
+        "-Dtcpwrap=disabled"
+)
+
 PKGREP="pulseaudio-modules-bt"
 PKGBREAK="pulseaudio-modules-bt"
 # Note: Extra Provides for Spiral (Debian compatibility).

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,7 +1,7 @@
 UPSTREAM_VER=17.0
 XRDP_VER=0.7
 VER=${UPSTREAM_VER}+xrdp${XRDP_VER}
-REL=3
+REL=4
 SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${XRDP_VER};rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
 CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: use as the default audio server; replace PulseAudio
    It's the time for us to migrate to PipeWire:
    - Asahi Linux, the effort to bring Linux to Apple Silicon devices, uses
    PipeWire for their sound server, PulseAudio simply won't work.
    - PipeWire is more flexible, brings tons of features to the user, such
    as rounting the audio on the fly - see qpwgraph\(1\).
    - PipeWire has less delay than PulseAudio, thus has some advantages on
    certain usages, such as audio production, and rhythm gaming.
    \* Disbale documentations. No one reads them, and they are available
    online.
- pulseaudio: disable auto start for PipeWire migration
    It's the time for us to migrate to PipeWire:
    - Asahi Linux, the effort to bring Linux to Apple Silicon devices, uses
    PipeWire for their sound server, PulseAudio simply won't work.
    - PipeWire is more flexible, brings tons of features to the user, such
    as rounting the audio on the fly - see qpwgraph\(1\).
    - PipeWire has less delay than PulseAudio, thus has some advantages on
    certain usages, such as audio production, and rhythm gaming.
    \* Add informative output in beyond script.
    \* Disbale documentations.
    \* Convert MESON_AFTER to array.

Package(s) Affected
-------------------

- pipewire: 1.4.9-1
- pulseaudio: 17.0+xrdp0.7-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit pulseaudio pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
