### PR TITLE
postfix: update to 3.10.4

### DIFF
--- a/app-web/postfix/spec
+++ b/app-web/postfix/spec
@@ -1,5 +1,4 @@
-VER=3.7.3
-REL=7
+VER=3.10.4
 SRCS="tbl::https://de.postfix.org/ftpmirror/official/postfix-$VER.tar.gz"
-CHKSUMS="sha256::d22f3d37ef75613d5d573b56fc51ef097f2c0d0b0e407923711f71c1fb72911b"
+CHKSUMS="sha256::cfb66861fe8f964787ddaeab15f3ca3e7ef3de730f97171afc4a5eca338ca444"
 CHKUPDATE="anitya::id=3693"


### PR DESCRIPTION
Topic Description
-----------------

- postfix: update to 3.10.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postfix: 3.10.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit postfix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
