### PR TITLE
bitwarden:update to 2025.10.0

### DIFF
--- a/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
@@ -1,4 +1,4 @@
-From 9c1afb7e95706e7edcaba550c4b3a05b940e1e17 Mon Sep 17 00:00:00 2001
+From 0264dde6456f8b1f28dbe6adbef1a2932013e3d1 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:16 -0700
 Subject: [PATCH 1/4] napi: prefer glibc instead of musl libc

--- a/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
+++ b/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
@@ -1,4 +1,4 @@
-From a890235282ba1d7e78c2d3285f3857a4e38e16cf Mon Sep 17 00:00:00 2001
+From 175d1a5871a9ae28e22b43dc024b9f6c02b069ab Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
 Subject: [PATCH 2/4] napi: enable lto
@@ -9,10 +9,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index 9e8404ea8d..7e64c336f6 100644
+index 5e2e42b463..7b9528229c 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
-@@ -38,3 +38,9 @@ napi-build = { workspace = true }
+@@ -39,3 +39,9 @@ napi-build = { workspace = true }
  
  [lints]
  workspace = true

--- a/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
+++ b/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
@@ -1,4 +1,4 @@
-From 8a811de64f3b1fa2b4cfe53e1ccf2bdb5e426d3a Mon Sep 17 00:00:00 2001
+From 58418833b01b4fea6ffa169153a116e5e0022175 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Sat, 20 Sep 2025 14:59:50 +0800
 Subject: [PATCH 3/4] napi: add loongarch64 support
@@ -27,14 +27,14 @@ index bfb0e4aa69..03d8a4ffc5 100644
          nativeBinding = loadFirstAvailable(
            ["desktop_napi.linux-arm-gnu.node", "desktop_napi.linux-arm-musl.node"],
 diff --git a/apps/desktop/electron-builder.json b/apps/desktop/electron-builder.json
-index 4d0dac1242..ba9cc55f58 100644
+index 2e780bf6b1..ba9cc55f58 100644
 --- a/apps/desktop/electron-builder.json
 +++ b/apps/desktop/electron-builder.json
 @@ -20,7 +20,7 @@
      "**/node_modules/@bitwarden/desktop-napi/index.js",
      "**/node_modules/@bitwarden/desktop-napi/desktop_napi.${platform}-${arch}*.node"
    ],
--  "electronVersion": "36.8.1",
+-  "electronVersion": "36.9.3",
 +  "electronVersion": "37.2.5",
    "generateUpdatesFilesForAllChannels": true,
    "publish": {

--- a/app-utils/bitwarden/autobuild/patches/0004-fix-use-system-libsqlite3.so.patch
+++ b/app-utils/bitwarden/autobuild/patches/0004-fix-use-system-libsqlite3.so.patch
@@ -1,4 +1,4 @@
-From 27212cd7d4b3fdd0384eb593991dbecc85e3b49c Mon Sep 17 00:00:00 2001
+From 558b527369c1c9028cb8764f2a6f0d10019e77bd Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Mon, 22 Sep 2025 16:09:53 +0800
 Subject: [PATCH 4/4] fix: use  system libsqlite3.so
@@ -8,15 +8,15 @@ Subject: [PATCH 4/4] fix: use  system libsqlite3.so
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml b/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
-index 8512ed1b31..7c9e96cab6 100644
+index d1efbd006f..779b55fee5 100644
 --- a/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
 +++ b/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
-@@ -17,7 +17,7 @@ homedir = { workspace = true }
- log = { workspace = true }
+@@ -16,7 +16,7 @@ hex = { workspace = true }
+ homedir = { workspace = true }
  pbkdf2 = "=0.12.2"
  rand = { workspace = true }
--rusqlite = { version = "=0.35.0", features = ["bundled"] }
-+rusqlite = { version = "=0.35.0" }
+-rusqlite = { version = "=0.37.0", features = ["bundled"] }
++rusqlite = { version = "=0.37.0" }
  serde = { workspace = true, features = ["derive"] }
  serde_json = { workspace = true }
  sha1 = "=0.10.6"

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,5 +1,4 @@
-VER=2025.9.0
-REL=1
+VER=2025.10.0
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden:update to 2025.10.0

Package(s) Affected
-------------------

- bitwarden: 2025.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
