### PR TITLE
maple-font: update to 7.8

### DIFF
--- a/desktop-fonts/maple-font/spec
+++ b/desktop-fonts/maple-font/spec
@@ -1,12 +1,12 @@
-VER=7.7
+VER=7.8
 SRCS="tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-Variable.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-TTF.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-NF-unhinted.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-CN-unhinted.zip \
       tbl::https://github.com/subframe7536/maple-font/releases/download/v${VER}/MapleMono-NF-CN-unhinted.zip"
-CHKSUMS="sha256::5a8736d2eca43d0aece94aca28aa0540d644c2d416582ba8e433b6f991cce4a4 \
-         sha256::60793a95a5032b40d5fd734fdbc06a7aba1e9f80a328a1ed8a8fb2f0372650e4 \
-         sha256::6e237b3c671d9dce2f6e32c027c80ff7e8e6b94f19989010190f653e2d3bbe8b \
-         sha256::b39143c70724a1b7c8deb67b64c12464f86de23770cdd9c87811fd1b9383d6ee \
-         sha256::b8cb09527237cf1cfff6db395d8dee861e522b50932bb31f6559c54b78619202"
+CHKSUMS="sha256::1589bc7175ebdb5a9f0d1207423164a1f9bac58f09ffc9939376394f3f0e78a1 \
+         sha256::03269d6a873181ecf7be521010c232dc0883e3239ddd894786b6d671851b1f5f \
+         sha256::dc0cafb055f4f1030439d2de0cce1f527730648df3c9de451e24399b34c33165 \
+         sha256::781f936bd2b183e6bdf969808c805439abd0bdb7d6aac1fc8a9b38d50a5c2ffa \
+         sha256::c531c2f499480c42c6c085acabff19554c332a3c03d9af8471e32c422f23f23a"
 CHKUPDATE="anitya::id=375863"


### PR DESCRIPTION
Topic Description
-----------------

- maple-font: update to 7.8
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- maple-font: 7.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit maple-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
