### PR TITLE
lact: update to 0.8.2

### DIFF
--- a/app-admin/lact/autobuild/defines
+++ b/app-admin/lact/autobuild/defines
@@ -7,11 +7,7 @@ BUILDDEP="rustc gtk-4 llvm blueprint-compiler"
 # FIXME: no nvidia support yet
 CARGO_AFTER__LOONGSON3="--no-default-features --features lact-gui"
 CARGO_AFTER__LOONGARCH64="--no-default-features --features lact-gui"
+CARGO_AFTER__LOONGARCH64_NOSIMD="${CARGO_AFTER__LOONGARCH64}"
 
 USECLANG=1
-
-# FIXME: ld.lld is not yet available for these architectures.
-NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1
-
 ABTYPE=rust

--- a/app-admin/lact/spec
+++ b/app-admin/lact/spec
@@ -1,5 +1,4 @@
-VER=0.8.1
-REL=1
+VER=0.8.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ilya-zlobintsev/LACT"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372202"


### PR DESCRIPTION
Topic Description
-----------------

- lact: update to 0.8.2
    - Enable LTO on loongarch64 and loongson3
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- lact: 0.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lact
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
