### PR TITLE
m1n1: update to 1.5.1+logo20231113.1

### DIFF
--- a/runtime-kernel/m1n1/spec
+++ b/runtime-kernel/m1n1/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.5.0
+UPSTREAM_VER=1.5.1
 LOGO_VER=20231113.1
 VER=${UPSTREAM_VER}+logo${LOGO_VER}
 SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/AsahiLinux/m1n1 \


### PR DESCRIPTION
Topic Description
-----------------

- m1n1: update to 1.5.1+logo20231113.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- m1n1: 1.5.1+logo20231113.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit m1n1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
