### PR TITLE
hplip: update to 3.25.6

### DIFF
--- a/app-doc/hplip/spec
+++ b/app-doc/hplip/spec
@@ -1,5 +1,4 @@
-VER=3.25.2
-REL=3
+VER=3.25.6
 SRCS="tbl::https://prdownloads.sourceforge.net/hplip/hplip-$VER.tar.gz"
-CHKSUMS="sha256::e872ff28eb2517705a95f6e1839efa1e50a77a33aae8905278df2bd820919653"
+CHKSUMS="sha256::a6af314a7af0572f2ab6967b2fe68760e64d74628ef0e6237f8504d81047edbe"
 CHKUPDATE="anitya::id=1327"


### PR DESCRIPTION
Topic Description
-----------------

- hplip: update to 3.25.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hplip: 2:3.25.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit hplip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
