### PR TITLE
iosevka-fonts: update to 33.3.2

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.3.1
+VER=33.3.2
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::ec5c5c29b7cbd8ca87942d541396d89e665850bef3e355799901390f1be8a495 \
-         sha256::79af9b2918646fa3c954a7be92b664a0adfca1cb0d10936f999285124e1c5821 \
-         sha256::54de30f36b4d00982e78f965076be6d4dc902e66212a63ec818b6ebf6b10ee27 \
-         sha256::95e280cc6fc17242c15008a79bcb5785b6f85ae19cca5ddd4f7257bbff4ea066 \
-         sha256::ec5f0e3a55e03e01d07aa3d31f1488e480e8e14b09a8770146f1849780c21ffe \
-         sha256::dbd1232824f4c28e48d09094c1c6ed93519dfc498ac23f145615d7132dbaff1a \
-         sha256::ee6c1e84044d5bffd5e32f662cc357e629143d1437aafe9f1a3e9adacb0ddd1f \
-         sha256::4b84032bc4bb898ae3265fd148798ce95883df2536457d04677cd379bb85acdd \
-         sha256::c40e92e7ad92b57245960bf111be6362666a48bdeea83ac45caefdb42922b6da \
-         sha256::91dad61fa3583ad5350a7a4368b1b0956eaa08c017aa5974273f8770fd67fc63 \
-         sha256::e0988b2266c3eccd1794ab07ba5739fa6ccb2f096b1a584caaaaff2103e7096f \
-         sha256::f0722c9f0914887453e5974b7977ec89013a6e812f4b68c96a8b0c9028da07a5 \
-         sha256::0f7887f59ae5cd7e9afed243e8e727b56c8286b0a32a014664d82a4f7bb752ce \
-         sha256::51b1797e6aa3566ee9198a53228160e07f4f5981ce727b845813bbcd6f883893 \
-         sha256::1be74d3d08d848be38d8c09bd336f9674545e4cb7ba8b8030d951697522604fa \
-         sha256::8c9592ce7847d34719f27b011457b7bc31598bde9c430a030a5d03f31cd3edc9 \
-         sha256::44773ac50757409d366439cf4242a46397ec7f513a2227c51e77aa8b753c30a0 \
-         sha256::f1022c65488ab764befc231ef581432c6243d3bd873591903c75e12c913fe57b \
-         sha256::4f57324266741101e060a62033cba6578d089d0ab87e16bf31c53a53f84c712b \
-         sha256::c1efff70fe36103580ca16f8a93afc943fd6d4a82507c46a5edf183165125c0c \
-         sha256::22c221fffe9d6b3cda4bb50f0381fcdb0b646d78ce32e31f00e4b105f7792d2a \
-         sha256::cee72196c93aa3e7c549e0d2eb1cbc7b0109218a355044ba194c93ea4cf9d2e4 \
-         sha256::50bed9424552dc34238995405c8340af63b3912d781ac4f292a6f031b4e1f941 \
-         sha256::c63bd55968111fb32b20e752504c50fc3ce9e234b7b65db10a8d4e3295b21125 \
+CHKSUMS="sha256::7ff718e992537334db8fcffdbe602913f484315ce82148d2fc7f7d7118f175eb \
+         sha256::bb09add8fbeeb2a5f09f95b1da79c01628bc4f710d13c1487e73b6917fc87cb0 \
+         sha256::f2f60b16901a6348997b36dcc1a1d79543a3fe6c539f2c34207ca2d34f08b82f \
+         sha256::773ffe9540f6f1369e42eff7f3ca04ca8fc4b0baf21a0e996b692246d80990a5 \
+         sha256::6a54bbcf8d51d9ae3d0650fd22b89cca0f59604320064eb418bd929d7ee3acce \
+         sha256::39e366f5d8146220d33c01f97d46d22f5259ea4f67f433535d53f2254a39fcfb \
+         sha256::6eae0323e224ee211068972138ebc7160e5d4642e060691d9300657002aa86f4 \
+         sha256::d30a9fc24bb3aa3652ce48d6bf160a4a0ad39a8c3cdb32ad9f21da88671d348f \
+         sha256::dba0cb8fa387924adc77e44e27017977dda4a99868b95e0d70e027f913b88beb \
+         sha256::bf7b4c08321f7ae371aa32748c544435b16ecc4f63c854a42b1597779a747736 \
+         sha256::b08c0fdb4efe2c10787aa61001f063fa9a204bf29b057e449b31c98c95ae2e5c \
+         sha256::e2300879412415f4493c1148616af221ae5b34caf1a480492daebce0e511fcb8 \
+         sha256::2915de2f30ce009775ccf3d2f943ff43ebd40c84a77ad01cc4615cec38a06227 \
+         sha256::b611e4542a64b41269c29565aa4d8106a4267de1f6452842fd180466407292b6 \
+         sha256::4fbedbb3073120d9fd8ff7aa81f13b9955d7090cd8d2891df27f6a41e1d936fa \
+         sha256::897d8b849d4a9316148d669e5c722992a7035c31dedce507dce9956bc998d0bc \
+         sha256::5b5110eb4341b2cff7802aad3cdca2c77765b8bb5c19ad72dc0f74a2c44557cf \
+         sha256::11d9550cf644e1f29d50f784e58157b13f301eb87f5c2e0c303253a0dbf2cab2 \
+         sha256::f84c7203577b3bc43cc77622afd6dd2b46f2d1d499242f9fd050072ffd0170f2 \
+         sha256::c0926a0a3fbbcfc021b42d67b4e1a31bcf285c8de780fe3c09dd766d5b4e2a52 \
+         sha256::5b7ee80c0d56f28e3b757819598516e7ea79f993bda01b39434cbfc73ce9e9a4 \
+         sha256::92e65def26646fb080d40aa1f803f5c3d7ed673da30de7de245c5c0af9f6eed9 \
+         sha256::ae8d7aa1d55c3c6b07306571e235a28ec640c6231a10bc0d72526f654c430555 \
+         sha256::c0e5ebf34c9add42584db8c3bee23b4ab580743957928e8f2734931cfc4dda84 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.3.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- iosevka-fonts: 33.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
