### PR TITLE
Prometheus node-exporter 1.9.1

### DIFF
--- a/app-admin/prometheus-node-exporter/autobuild/beyond
+++ b/app-admin/prometheus-node-exporter/autobuild/beyond
@@ -1,0 +1,8 @@
+_UPSTREAM_NAME="node_exporter"
+_PROPER_NAME="prometheus-node-exporter"
+
+abinfo "Renaming main executable"
+mv -v "$PKGDIR/usr/bin/${_UPSTREAM_NAME}" "$PKGDIR/usr/bin/${_PROPER_NAME}"
+
+abinfo "Create prometheus-node home directory"
+mkdir -pv "$PKGDIR/var/lib/prometheus/node-exporter"

--- a/app-admin/prometheus-node-exporter/autobuild/defines
+++ b/app-admin/prometheus-node-exporter/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=prometheus-node-exporter
+PKGSEC=admin
+BUILDDEP="go"
+PKGDES="Prometheus exporter for machine metrics"
+
+ABTYPE=gomod
+GO_LDFLAGS="
+	-X github.com/prometheus/common/version.Version=$PKGVER
+	-X github.com/prometheus/common/version.Revision=$PKGREL
+	-X github.com/prometheus/common/version.Branch=tarball
+	-X github.com/prometheus/common/version.BuildUser=maintainer@aosc.io
+"

--- a/app-admin/prometheus-node-exporter/autobuild/overrides/etc/default/prometheus-node-exporter
+++ b/app-admin/prometheus-node-exporter/autobuild/overrides/etc/default/prometheus-node-exporter
@@ -1,0 +1,5 @@
+# Set the command-line arguments to pass to the server.
+# Due to shell escaping, to pass backslashes for regexes, you need to double
+# them (\\d for \d). If running under systemd, you need to double them again
+# (\\\\d to mean \d), and escape newlines too.
+ARGS=""

--- a/app-admin/prometheus-node-exporter/autobuild/overrides/usr/lib/systemd/system/prometheus-node-exporter.service
+++ b/app-admin/prometheus-node-exporter/autobuild/overrides/usr/lib/systemd/system/prometheus-node-exporter.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prometheus exporter for machine metrics
+Documentation=https://github.com/prometheus/node_exporter
+
+[Service]
+Restart=on-failure
+User=prometheus-node-exporter
+Group=prometheus-node-exporter
+EnvironmentFile=/etc/default/prometheus-node-exporter
+ExecStart=/usr/bin/prometheus-node-exporter $ARGS
+ExecReload=/bin/kill -HUP $MAINPID
+TimeoutStopSec=20s
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target

--- a/app-admin/prometheus-node-exporter/autobuild/overrides/usr/lib/sysusers.d/prometheus-node-exporter.conf
+++ b/app-admin/prometheus-node-exporter/autobuild/overrides/usr/lib/sysusers.d/prometheus-node-exporter.conf
@@ -1,0 +1,1 @@
+u! prometheus-node-exporter - "Prometheus node-exporter user" /var/lib/prometheus/node-exporter

--- a/app-admin/prometheus-node-exporter/autobuild/overrides/usr/lib/tmpfiles.d/prometheus-node-exporter.conf
+++ b/app-admin/prometheus-node-exporter/autobuild/overrides/usr/lib/tmpfiles.d/prometheus-node-exporter.conf
@@ -1,0 +1,1 @@
+d /var/lib/prometheus/node-exporter 0755 prometheus-node-exporter prometheus-node-exporter -

--- a/app-admin/prometheus-node-exporter/autobuild/postinst
+++ b/app-admin/prometheus-node-exporter/autobuild/postinst
@@ -1,0 +1,4 @@
+systemctl daemon-reload || true
+
+systemd-sysusers prometheus-node-exporter.conf || true
+systemd-tmpfiles --create prometheus-node-exporter.conf || true

--- a/app-admin/prometheus-node-exporter/spec
+++ b/app-admin/prometheus-node-exporter/spec
@@ -1,0 +1,4 @@
+VER=1.9.1
+SRCS="git::commit=tags/v${VER}::https://github.com/prometheus/node_exporter.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=98081"


### PR DESCRIPTION
Topic Description
-----------------

- prometheus-node-exporter: new, 1.9.1

Package(s) Affected
-------------------

- prometheus-node-exporter: 1.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit prometheus-node-exporter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
