### PR TITLE
Guix Survey

### DIFF
--- a/app-admin/guix/autobuild/defines
+++ b/app-admin/guix/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=guix
+PKGDES="Purely functional package manager"
+PKGDEP="guile guile-gnutls guile-git guile-json guile-sqlite3 guile-lib \
+    guile-gcrypt guile-zlib guile-lzlib guile-avahi guile-semver guile-ssh \
+	slirp4netns"
+BUILDDEP="po4a help2man graphviz"
+PKGSEC=admin
+
+AUTOTOOLS_AFTER="--localstatedir=/var"
+
+# FIXME: No rule to make target 'doc/contributing.de.texi'
+ABSHADOW=0
+
+FAIL_ARCH="!(amd64|arm64|ppc64el|riscv64)"

--- a/app-admin/guix/spec
+++ b/app-admin/guix/spec
@@ -1,0 +1,4 @@
+VER=1.4.0+git20250818
+SRCS="git::commit=d671b750f147d63792fbde93c9b17138492a40f5::https://codeberg.org/guix/guix.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=358460"

--- a/app-vcs/guile-git/autobuild/defines
+++ b/app-vcs/guile-git/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-git
+PKGDES="Guile bindings for libgit2"
+PKGDEP="guile git libgit2 scheme-bytestructures"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/app-vcs/guile-git/spec
+++ b/app-vcs/guile-git/spec
@@ -1,0 +1,4 @@
+VER=0.10.0
+SRCS="git::commit=tags/v${VER}::https://gitlab.com/guile-git/guile-git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=380430"

--- a/lang-lisp/guile-avahi/autobuild/defines
+++ b/lang-lisp/guile-avahi/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=guile-avahi
+PKGDES="Guile binding for Avahi"
+PKGDEP="guile avahi"
+PKGSEC=libs

--- a/lang-lisp/guile-avahi/spec
+++ b/lang-lisp/guile-avahi/spec
@@ -1,0 +1,4 @@
+VER=0.4.1
+SRCS="git::commit=tags/v${VER}::https://git.sv.gnu.org/git/guile-avahi.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386303"

--- a/lang-lisp/guile-gcrypt/autobuild/defines
+++ b/lang-lisp/guile-gcrypt/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-gcrypt
+PKGDES="Guile binding for GCrypt"
+PKGDEP="guile libgcrypt"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/guile-gcrypt/spec
+++ b/lang-lisp/guile-gcrypt/spec
@@ -1,0 +1,4 @@
+VER=0.5.0
+SRCS="git::commit=tags/v${VER}::https://notabug.org/cwebber/guile-gcrypt.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386298"

--- a/lang-lisp/guile-json/autobuild/defines
+++ b/lang-lisp/guile-json/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-json
+PKGDES="JSON module for Guile"
+PKGDEP="guile"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/guile-json/spec
+++ b/lang-lisp/guile-json/spec
@@ -1,0 +1,4 @@
+VER=4.7.3
+SRCS="git::commit=tags/${VER}::https://github.com/aconchillo/guile-json.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386297"

--- a/lang-lisp/guile-lib/autobuild/defines
+++ b/lang-lisp/guile-lib/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=guile-lib
+PKGDES="Collection of useful Guile Scheme modules"
+PKGDEP="guile"
+PKGSEC=libs
+
+ABHOST=noarch
+
+# FIXME: configure:3504: error: possibly undefined macro: AC_LIB_LINKFLAGS_FROM_LIBS
+RECONF=0

--- a/lang-lisp/guile-lib/spec
+++ b/lang-lisp/guile-lib/spec
@@ -1,0 +1,4 @@
+VER=0.2.8.1
+SRCS="tbl::https://download.savannah.gnu.org/releases/guile-lib/guile-lib-${VER}.tar.gz"
+CHKSUMS="sha256::1374c2d839e6a33d190cd1dabd9c7f87753f8384f55b866f3e142155c22b49b1"
+CHKUPDATE="anitya::id=1278"

--- a/lang-lisp/guile-lzlib/autobuild/defines
+++ b/lang-lisp/guile-lzlib/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-lzlib
+PKGDES="Guile binding for lzlib"
+PKGDEP="guile lzlib"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/guile-lzlib/spec
+++ b/lang-lisp/guile-lzlib/spec
@@ -1,0 +1,4 @@
+VER=0.3.0
+SRCS="git::commit=tags/${VER}::https://notabug.org/guile-lzlib/guile-lzlib.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386298"

--- a/lang-lisp/guile-semver/autobuild/defines
+++ b/lang-lisp/guile-semver/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-semver
+PKGDES="Guile library for semantic versions"
+PKGDEP="guile"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/guile-semver/spec
+++ b/lang-lisp/guile-semver/spec
@@ -1,0 +1,4 @@
+VER=0.2.0
+SRCS="git::commit=tags/v${VER}::https://codeberg.org/daym/guile-semver.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386305"

--- a/lang-lisp/guile-sqlite3/autobuild/defines
+++ b/lang-lisp/guile-sqlite3/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-sqlite3
+PKGDES="Guile binding for SQLite3"
+PKGDEP="guile"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/guile-sqlite3/spec
+++ b/lang-lisp/guile-sqlite3/spec
@@ -1,0 +1,4 @@
+VER=0.1.3
+SRCS="git::commit=tags/v${VER}::https://notabug.org/guile-sqlite3/guile-sqlite3.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386298"

--- a/lang-lisp/guile-ssh/autobuild/defines
+++ b/lang-lisp/guile-ssh/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-ssh
+PKGDES="SSH protocol library for Guile"
+PKGDEP="guile glibc"
+PKGSEC=libs
+
+AUTOTOOLS_AFTER=("--enable-dsa")

--- a/lang-lisp/guile-ssh/spec
+++ b/lang-lisp/guile-ssh/spec
@@ -1,0 +1,4 @@
+VER=0.18.0
+SRCS="git::commit=tags/v${VER}::https://github.com/artyom-poptsov/guile-ssh"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=380433"

--- a/lang-lisp/guile-zlib/autobuild/defines
+++ b/lang-lisp/guile-zlib/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=guile-zlib
+PKGDES="Guile binding for zlib"
+PKGDEP="guile zlib"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/guile-zlib/spec
+++ b/lang-lisp/guile-zlib/spec
@@ -1,0 +1,4 @@
+VER=0.2.2
+SRCS="git::commit=tags/v${VER}::https://notabug.org/guile-zlib/guile-zlib.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386303"

--- a/lang-lisp/scheme-bytestructures/autobuild/defines
+++ b/lang-lisp/scheme-bytestructures/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=scheme-bytestructures
+PKGDES="Guile support for structured access to bytevector contents"
+PKGDEP="guile"
+PKGSEC=libs
+
+ABHOST=noarch

--- a/lang-lisp/scheme-bytestructures/spec
+++ b/lang-lisp/scheme-bytestructures/spec
@@ -1,0 +1,4 @@
+VER=2.0.2
+SRCS="git::commit=tags/v${VER}::https://github.com/TaylanUB/scheme-bytestructures"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=380427"

--- a/runtime-cryptography/guile-gnutls/autobuild/defines
+++ b/runtime-cryptography/guile-gnutls/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=guile-gnutls
+PKGDES="Guile bindings for the GnuTLS library"
+PKGDEP="gnutls guile"
+BUILDDEP="texlive"
+PKGSEC=libs
+
+AUTOTOOLS_AFTER="--enable-srp-authentication"

--- a/runtime-cryptography/guile-gnutls/spec
+++ b/runtime-cryptography/guile-gnutls/spec
@@ -1,0 +1,4 @@
+VER=5.0.1
+SRCS="git::commit=tags/v${VER}::https://codeberg.org/guile-gnutls/guile-gnutls"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386295"


### PR DESCRIPTION
Topic Description
-----------------

- guix: new, 1.4.0+git20250818
- guile-semver: new, 0.2.0
- guile-avahi: new, 0.4.1
- guile-zlib: new, 0.2.2
- guile-lzlib: new, 0.3.0
- guile-gcrypt: new, 0.5.0
- guile-lib: new, 0.2.8.1
- guile-sqlite3: new, 0.1.3
- guile-json: new, 0.1.3
- scheme-bytestructures: new, 2.0.2

... and 2 more commits

Package(s) Affected
-------------------

- guix: 1.4.0+git20250818

Security Update?
----------------

No

Build Order
-----------

```
#buildit guix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
