### PR TITLE
quickshell: update to 0.2.1

### DIFF
--- a/runtime-desktop/quickshell/spec
+++ b/runtime-desktop/quickshell/spec
@@ -1,5 +1,4 @@
-VER=0.2.0
+VER=0.2.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/quickshell-mirror/quickshell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378649"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- quickshell: update to 0.2.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- quickshell: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit quickshell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
