### PR TITLE
godot: update to 4.5.1

### DIFF
--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -1,4 +1,4 @@
-VER=4.5
+VER=4.5.1
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373975"


### PR DESCRIPTION
Topic Description
-----------------

- godot: update to 4.5.1
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- godot: 4.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit godot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
