### PR TITLE
vscode: update to 1.105.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.105.0
+VER=1.105.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::da3676be6826dcbaab1d054b546311971e121ed6645ffd054409eeaf42675d7e"
-CHKSUMS__ARM64="sha256::4fdbbe128ed43a7e0feef4310ec133ae3fab50e6bdd52f402b2ada29e3a863bb"
+CHKSUMS__AMD64="sha256::456acb8c6f2b146098e486ae4b4e9e50a4f344dbd168da60c10d6ac12bcab29b"
+CHKSUMS__ARM64="sha256::0e0f7b5d8340abc0ffaa2a15a44461d59d0eef36d95825e18e07868b804453e8"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.105.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.105.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
