### PR TITLE
alacritty: update to 0.16.0

### DIFF
--- a/app-utils/alacritty/spec
+++ b/app-utils/alacritty/spec
@@ -1,5 +1,4 @@
-VER=0.15.1
+VER=0.16.0
 SRCS="git::commit=tags/v$VER::https://github.com/alacritty/alacritty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141678"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- alacritty: update to 0.16.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- alacritty: 0.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit alacritty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
