### PR TITLE
qt-6: fix GPU rendering issue with AMD graphics cards

### DIFF
--- a/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
@@ -1,7 +1,7 @@
 From 038aa7bd14f5ce8fe93515999bb330a5aaf91ffc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:21:53 +0800
-Subject: [PATCH 1/4] ARCHLINUX: qtbase: respect system compiler/linker flags
+Subject: [PATCH 1/5] ARCHLINUX: qtbase: respect system compiler/linker flags
 
 Link: https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-base/-/blob/e82d4f8ad5231cdecbb7dd75a8fcaabdc201ac35/qt6-base-cflags.patch
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
@@ -1,7 +1,7 @@
 From 7b2c4dac8ff1a3209d96980953374c0ebe188910 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:22:43 +0800
-Subject: [PATCH 2/4] FEDORA: qt3d: assimp: fix build with GCC >= 13
+Subject: [PATCH 2/5] FEDORA: qt3d: assimp: fix build with GCC >= 13
 
 Link: https://src.fedoraproject.org/rpms/qt6-qt3d/blob/072094f3e7e698321b92eafcb297111ba42eed15/f/qt3d-assimp-fix-build.patch
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
@@ -1,7 +1,7 @@
 From d617be4706af2bd5d5228b39d3ee79ca2c727978 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Wed, 26 Jun 2024 22:16:10 +0800
-Subject: [PATCH 3/4] AOSCOS: qtbase: fallback to GLES if GL EGL context
+Subject: [PATCH 3/5] AOSCOS: qtbase: fallback to GLES if GL EGL context
  creation failed
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

--- a/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
+++ b/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
@@ -1,7 +1,7 @@
 From c97c65c99bbabf2d80440626959aeac769c62898 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 22 Sep 2025 13:10:18 +0800
-Subject: [PATCH 4/4] AOSCOS: LOONGARCH64: qtwebengine: chromium: add LoongArch
+Subject: [PATCH 4/5] AOSCOS: LOONGARCH64: qtwebengine: chromium: add LoongArch
  support
 
 Co-authored-by: Jiajie Chen <c@jia.je>

--- a/runtime-desktop/qt-6/01-runtime/patches/0005-UPSTREAM-Return-to-supporting-eglCreateImage-in-EGLH.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0005-UPSTREAM-Return-to-supporting-eglCreateImage-in-EGLH.patch
@@ -1,0 +1,217 @@
+From 3868dbdef014e76978b5c28cb0a141914a9f329b Mon Sep 17 00:00:00 2001
+From: Moss Heim <moss.heim@qt.io>
+Date: Thu, 11 Sep 2025 13:47:04 +0200
+Subject: [PATCH 5/5] UPSTREAM: Return to supporting eglCreateImage in
+ EGLHelper::queryDmaBuf
+
+eglCreateDRMImageMESA was removed in mesa 25.2.
+Keep using it where we can since this fixes support for
+panthor/panfrost, otherwise fall back to the old use of EGL API.
+
+Includes a revert of the following commits:
+Revert "Create EGLImage with eglCreateDRMImageMESA() for exporting dma_buf"
+This reverts commit 2ed5f9632292c6e531f353dae800cb12274af91a.
+Revert "Remove leftover QOffscreenSurface from EGLHelper"
+This reverts commit bcee2dbf412cc655c1b467091b581c696d234e3f.
+
+Pick-to: 6.9 6.10 6.10.0
+Task-number: QTBUG-136257
+Task-number: QTBUG-139424
+Change-Id: Ie115bd6373ce0a80651781aa568405477010ee25
+Reviewed-by: Peter Varga <pvarga@inf.u-szeged.hu>
+
+Link: https://codereview.qt-project.org/c/qt/qtwebengine/+/675112
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ qtwebengine/src/core/ozone/egl_helper.cpp | 140 ++++++++++++++++++++--
+ qtwebengine/src/core/ozone/egl_helper.h   |   1 +
+ 2 files changed, 129 insertions(+), 12 deletions(-)
+
+diff --git a/qtwebengine/src/core/ozone/egl_helper.cpp b/qtwebengine/src/core/ozone/egl_helper.cpp
+index 1ed679d239..f5c12b1ca7 100644
+--- a/qtwebengine/src/core/ozone/egl_helper.cpp
++++ b/qtwebengine/src/core/ozone/egl_helper.cpp
+@@ -2,6 +2,8 @@
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+ 
+ #include "egl_helper.h"
++
++#include "compositor/compositor.h"
+ #include "ozone_util_qt.h"
+ #include "web_engine_context.h"
+ 
+@@ -58,6 +60,84 @@ static const char *getEGLErrorString(uint32_t error)
+ 
+ QT_BEGIN_NAMESPACE
+ 
++class ScopedGLContext
++{
++public:
++    ScopedGLContext(QOffscreenSurface *surface, EGLHelper::EGLFunctions *eglFun)
++        : m_context(new QOpenGLContext()), m_eglFun(eglFun)
++    {
++        if ((m_previousEGLContext = m_eglFun->eglGetCurrentContext())) {
++            m_previousEGLDrawSurface = m_eglFun->eglGetCurrentSurface(EGL_DRAW);
++            m_previousEGLReadSurface = m_eglFun->eglGetCurrentSurface(EGL_READ);
++            m_previousEGLDisplay = m_eglFun->eglGetCurrentDisplay();
++        }
++
++        if (!m_context->create()) {
++            qWarning("Failed to create OpenGL context.");
++            return;
++        }
++
++        Q_ASSERT(surface->isValid());
++        if (!m_context->makeCurrent(surface)) {
++            qWarning("Failed to make OpenGL context current.");
++            return;
++        }
++    }
++
++    ~ScopedGLContext()
++    {
++        if (!m_textures.empty()) {
++            auto *glFun = m_context->functions();
++            glFun->glDeleteTextures(m_textures.size(), m_textures.data());
++        }
++
++        if (m_previousEGLContext) {
++            // Make sure the scoped context is not current when restoring the previous
++            // EGL context otherwise the QOpenGLContext destructor resets the restored
++            // current context.
++            m_context->doneCurrent();
++
++            m_eglFun->eglMakeCurrent(m_previousEGLDisplay, m_previousEGLDrawSurface,
++                                     m_previousEGLReadSurface, m_previousEGLContext);
++            if (m_eglFun->eglGetError() != EGL_SUCCESS)
++                qWarning("Failed to restore EGL context.");
++        }
++    }
++
++    bool isValid() const { return m_context->isValid() && (m_context->surface() != nullptr); }
++
++    EGLContext eglContext() const
++    {
++        QNativeInterface::QEGLContext *nativeInterface =
++                m_context->nativeInterface<QNativeInterface::QEGLContext>();
++        return nativeInterface->nativeContext();
++    }
++
++    uint createTexture(int width, int height)
++    {
++        auto *glFun = m_context->functions();
++
++        uint glTexture;
++        glFun->glGenTextures(1, &glTexture);
++        glFun->glBindTexture(GL_TEXTURE_2D, glTexture);
++        glFun->glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++                            NULL);
++        glFun->glBindTexture(GL_TEXTURE_2D, 0);
++
++        m_textures.push_back(glTexture);
++        return glTexture;
++    }
++
++private:
++    QScopedPointer<QOpenGLContext> m_context;
++    EGLHelper::EGLFunctions *m_eglFun;
++    EGLContext m_previousEGLContext = nullptr;
++    EGLSurface m_previousEGLDrawSurface = nullptr;
++    EGLSurface m_previousEGLReadSurface = nullptr;
++    EGLDisplay m_previousEGLDisplay = nullptr;
++    std::vector<uint> m_textures;
++};
++
+ EGLHelper::EGLFunctions::EGLFunctions()
+ {
+     QOpenGLContext *context = OzoneUtilQt::getQOpenGLContext();
+@@ -122,8 +202,23 @@ EGLHelper::EGLHelper()
+         const char *displayExtensions = m_functions->eglQueryString(m_eglDisplay, EGL_EXTENSIONS);
+         m_isDmaBufSupported = strstr(displayExtensions, "EGL_EXT_image_dma_buf_import")
+                 && strstr(displayExtensions, "EGL_EXT_image_dma_buf_import_modifiers")
+-                && strstr(displayExtensions, "EGL_MESA_drm_image")
+                 && strstr(displayExtensions, "EGL_MESA_image_dma_buf_export");
++        m_isCreateDRMImageMesaSupported = strstr(displayExtensions, "EGL_MESA_drm_image");
++        if (!m_isDmaBufSupported) {
++            qCDebug(QtWebEngineCore::lcWebEngineCompositor,
++                    "EGL: MESA extensions not found, will not use dma-buf");
++        } else if (!m_isCreateDRMImageMesaSupported) {
++            qCDebug(QtWebEngineCore::lcWebEngineCompositor,
++                    "EGL: MESA extensions found but missing EGL_MESA_drm_image, will use dma-buf, "
++                    "some older graphics cards may not be supported");
++            m_offscreenSurface.reset(new QOffscreenSurface());
++            Q_ASSERT(QThread::currentThread() == qApp->thread());
++            m_offscreenSurface->create();
++        } else {
++            qCDebug(QtWebEngineCore::lcWebEngineCompositor,
++                    "EGL: MESA extensions and EGL_MESA_drm_image found, will use dma-buf with GEM "
++                    "buffer allocation");
++        }
+     }
+ 
+     // Try to create dma-buf.
+@@ -143,17 +238,38 @@ void EGLHelper::queryDmaBuf(const int width, const int height, int *fd, int *str
+     if (!m_isDmaBufSupported)
+         return;
+ 
+-    // clang-format off
+-    EGLint attribs[] = {
+-        EGL_WIDTH, width,
+-        EGL_HEIGHT, height,
+-        EGL_DRM_BUFFER_FORMAT_MESA, EGL_DRM_BUFFER_FORMAT_ARGB32_MESA,
+-        EGL_DRM_BUFFER_USE_MESA, EGL_DRM_BUFFER_USE_SHARE_MESA,
+-        EGL_NONE
+-    };
+-    // clang-format on
+-
+-    EGLImage eglImage = m_functions->eglCreateDRMImageMESA(m_eglDisplay, attribs);
++    EGLImage eglImage = EGL_NO_IMAGE;
++    // Probably doesn't need to live to the end of the function, but just in case.
++    std::unique_ptr<ScopedGLContext> glContext;
++    if (m_isCreateDRMImageMesaSupported) {
++        // This approach is slightly worse for security and no longer supported in mesa 25.2,
++        // but it allows us to keep support for the Panthor driver prior to that mesa version.
++        // clang-format off
++        EGLint attribs[] = {
++            EGL_WIDTH, width,
++            EGL_HEIGHT, height,
++            EGL_DRM_BUFFER_FORMAT_MESA, EGL_DRM_BUFFER_FORMAT_ARGB32_MESA,
++            EGL_DRM_BUFFER_USE_MESA, EGL_DRM_BUFFER_USE_SHARE_MESA,
++            EGL_NONE
++        };
++        // clang-format on
++        eglImage = m_functions->eglCreateDRMImageMESA(m_eglDisplay, attribs);
++    } else {
++        glContext = std::make_unique<ScopedGLContext>(m_offscreenSurface.get(), m_functions.get());
++        if (!glContext->isValid())
++            return;
++
++        EGLContext eglContext = glContext->eglContext();
++        if (!eglContext) {
++            qWarning("EGL: No EGLContext.");
++            return;
++        }
++
++        uint64_t textureId = glContext->createTexture(width, height);
++        eglImage = m_functions->eglCreateImage(m_eglDisplay, eglContext, EGL_GL_TEXTURE_2D,
++                                                    (EGLClientBuffer)textureId, NULL);
++    }
++
+     if (eglImage == EGL_NO_IMAGE) {
+         qWarning("EGL: Failed to create EGLImage: %s", getLastEGLErrorString());
+         return;
+diff --git a/qtwebengine/src/core/ozone/egl_helper.h b/qtwebengine/src/core/ozone/egl_helper.h
+index 7594e1f846..12fff3510c 100644
+--- a/qtwebengine/src/core/ozone/egl_helper.h
++++ b/qtwebengine/src/core/ozone/egl_helper.h
+@@ -62,6 +62,7 @@ private:
+     QScopedPointer<EGLFunctions> m_functions;
+     QScopedPointer<QOffscreenSurface> m_offscreenSurface;
+     bool m_isDmaBufSupported = false;
++    bool m_isCreateDRMImageMesaSupported = false;
+ };
+ 
+ QT_END_NAMESPACE
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,4 +1,5 @@
 VER=6.9.2
+REL=1
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::643f1fe35a739e2bf5e1a092cfe83dbee61ff6683684e957351c599767ca279c"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: fix GPU rendering issue with AMD graphics cards
    When attempting to start Falkon or Qutebrowser with AMD graphics cards,
    the applications would throw the following errors:
    Backend texture is not a Vulkan texture.
    Compositor returned null texture
    The error message is misleading. This was actually due to a failure in
    OpenGL/EGL detection \(Vulkan is a fallback here\).
    Backport a patch to address this issue and additionally another to fix
    software rendering when neither GBM nor Vulkan works.
    Link: https://bugreports.qt.io/browse/QTBUG-139424
    Link: https://bugreports.qt.io/browse/QTBUG-136160
    Track patches at AOSC-Tracking/qt-6 @ aosc/v6.9.2
    \(HEAD: 3868dbdef014e76978b5c28cb0a141914a9f329b\).

Package(s) Affected
-------------------

- qt-6: 6.9.2-1
- qt-6-doc: 6.9.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
