### PR TITLE
libevdev: update to 1.13.5

### DIFF
--- a/runtime-devices/libevdev/spec
+++ b/runtime-devices/libevdev/spec
@@ -1,4 +1,4 @@
-VER=1.13.4
+VER=1.13.5
 SRCS="tbl::https://www.freedesktop.org/software/libevdev/libevdev-$VER.tar.xz"
-CHKSUMS="sha256::f00ab8d42ad8b905296fab67e13b871f1a424839331516642100f82ad88127cd"
+CHKSUMS="sha256::89918ae7b7c13936e6482604a77a2bfbbb74544c5d039fde01c3fa1bdf639987"
 CHKUPDATE="anitya::id=20540"


### PR DESCRIPTION
Topic Description
-----------------

- libevdev: update to 1.13.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libevdev: 1.13.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libevdev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
