### PR TITLE
texmaker: update to 6.0.1

### DIFF
--- a/app-doc/texmaker/autobuild/defines
+++ b/app-doc/texmaker/autobuild/defines
@@ -1,6 +1,27 @@
 PKGNAME=texmaker
 PKGSEC=tex
-PKGDEP="ghostscript hunspell poppler qt-5 qtsingleapplication zlib"
-PKGDES="Free cross-platform LaTeX editor"
+PKGDEP="ghostscript hunspell poppler qt-6 zlib"
+PKGDES="LaTeX editor with integrated PDF reader"
 
-QT_SELECT=5
+ABTYPE=cmakeninja
+
+# Note: -DCOMPILEUSB=OFF, meant for portable builds.
+CMAKE_AFTER=(
+    '-DCOMPILEUSB=OFF'
+    '-DAUTHORIZELINUXQSTYLES=ON'
+    '-DINTERNALBROWSER=ON'
+    '-DDEBIANSPELLDIR=OFF'
+)
+CMAKE_AFTER__NOWEBENGINE=(
+    "${CMAKE_AFTER[@]}"
+    '-DINTERNALBROWSER=OFF'
+)
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER__NOWEBENGINE[@]}"
+)
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER__NOWEBENGINE[@]}"
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__NOWEBENGINE[@]}"
+)

--- a/app-doc/texmaker/autobuild/patches/0001-AOSCOS-fix-build-against-Qt-6.10.patch
+++ b/app-doc/texmaker/autobuild/patches/0001-AOSCOS-fix-build-against-Qt-6.10.patch
@@ -1,0 +1,26 @@
+From fecbee8a4e2a3f5e745beab75f277d45c3e1948f Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 4 Apr 2026 02:30:11 +0800
+Subject: [PATCH 1/3] AOSCOS: fix build against Qt 6.10
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ef6a4e6..b564be8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -386,7 +386,7 @@ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_AUTORCC ON)
+ 
+-find_package(Qt6 REQUIRED COMPONENTS Gui Concurrent Core Core5Compat Network PrintSupport Qml Widgets Xml LinguistTools)
++find_package(Qt6 REQUIRED COMPONENTS Gui Concurrent Core CorePrivate Core5Compat Network PrintSupport Qml Widgets Xml LinguistTools)
+ 
+ qt_standard_project_setup()
+ 
+-- 
+2.52.0
+

--- a/app-doc/texmaker/autobuild/patches/0002-AOSCOS-cmake-correctly-handle-CMake-options.patch
+++ b/app-doc/texmaker/autobuild/patches/0002-AOSCOS-cmake-correctly-handle-CMake-options.patch
@@ -1,0 +1,111 @@
+From a57f87a6b787b643d71ef43c2fbb33294c698c2c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 4 Apr 2026 16:36:38 +0800
+Subject: [PATCH 2/3] AOSCOS: cmake: correctly handle CMake options
+
+Previously, the string-based options were considered uninitialized (and
+hard-coded). Allow specifying with if clauses.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ CMakeLists.txt | 25 ++++++++++---------------
+ 1 file changed, 10 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b564be8..a0a4d3b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,20 +17,15 @@ cmake_minimum_required(VERSION 3.16)
+ project(texmaker VERSION 6.0.1 LANGUAGES CXX C)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
+ 
+-################ OPTIONS ####################
+-set(COMPILEUSB "no")
+-set(AUTHORIZELINUXQSTYLES "yes")
+-set(INTERNALBROWSER "yes")
+-set(DEBIANSPELLDIR "no")
+ ################# INSTALL_DIR #####################
+ if (UNIX AND NOT APPLE)
+-    if (${COMPILEUSB} STREQUAL "yes")
++    if (${COMPILEUSB})
+         set(INSTALL_DIR ${CMAKE_SOURCE_DIR}/deploy/linux_portable)
+     else()
+         set(INSTALL_DIR "/usr")
+     endif()
+ elseif (WIN32)
+-    if (${COMPILEUSB} STREQUAL "yes")
++    if (${COMPILEUSB})
+         set(INSTALL_DIR ${CMAKE_SOURCE_DIR}/deploy/win_portable)
+     else()
+         set(INSTALL_DIR ${CMAKE_SOURCE_DIR}/deploy/win_desktop)
+@@ -1148,7 +1143,7 @@ set_property(SOURCE 3rdparty/pdfium/third_party/bigint/BigUnsignedInABase.hh PRO
+ set_property(SOURCE 3rdparty/pdfium/third_party/bigint/NumberlikeArray.hh PROPERTY SKIP_AUTOGEN ON)
+ 
+ 
+-if (${INTERNALBROWSER} STREQUAL "yes")
++if (${INTERNALBROWSER})
+ find_package(Qt6 REQUIRED COMPONENTS WebEngineWidgets)
+ set(texmaker_SRCS
+ ${texmaker_SRCS}
+@@ -1315,7 +1310,7 @@ add_definitions(
+ )
+ endif()
+ 
+-if (${INTERNALBROWSER} STREQUAL "yes")
++if (${INTERNALBROWSER})
+ target_compile_definitions(${PROJECT_NAME} PRIVATE
+         INTERNAL_BROWSER
+     )
+@@ -1335,7 +1330,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
+         _FX_CPU_=_FX_X64_
+         HAVE_UNISTD_H
+     )
+-if (${COMPILEUSB} STREQUAL "yes")
++if (${COMPILEUSB})
+   target_compile_definitions(${PROJECT_NAME} PRIVATE
+         USB_VERSION
+     )
+@@ -1347,19 +1342,19 @@ endif()
+ target_compile_definitions(${PROJECT_NAME} PRIVATE
+     PREFIX=\"${PREFIX}\"
+     )
+-if (${AUTHORIZELINUXQSTYLES} STREQUAL "yes")
++if (${AUTHORIZELINUXQSTYLES})
+ target_compile_definitions(${PROJECT_NAME} PRIVATE
+         AUTHORIZE_LINUX_QSTYLES
+     )
+ endif()
+-if (${DEBIANSPELLDIR} STREQUAL "yes")
++if (${DEBIANSPELLDIR})
+ target_compile_definitions(${PROJECT_NAME} PRIVATE
+         DEBIAN_SPELLDIR
+     )
+ endif()
+ 
+ 
+-if (${COMPILEUSB} STREQUAL "yes")
++if (${COMPILEUSB})
+   install( TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX})
+   install( FILES ${UTILITIES_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX})
+   install( FILES ${DESKTOP_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX})
+@@ -1417,7 +1412,7 @@ if(WIN32)
+         user32
+         shlwapi
+     )
+-if (${COMPILEUSB} STREQUAL "yes")
++if (${COMPILEUSB})
+   target_compile_definitions(${PROJECT_NAME} PRIVATE
+         USB_VERSION
+     )
+@@ -1456,7 +1451,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
+         Qt6::Xml
+ )
+ 
+-if (${INTERNALBROWSER} STREQUAL "yes")
++if (${INTERNALBROWSER})
+ target_link_libraries(${PROJECT_NAME} PRIVATE
+         Qt6::WebEngineWidgets
+ )
+-- 
+2.52.0
+

--- a/app-doc/texmaker/autobuild/patches/0003-AOSCOS-neuter-version-check.patch
+++ b/app-doc/texmaker/autobuild/patches/0003-AOSCOS-neuter-version-check.patch
@@ -1,0 +1,365 @@
+From 5e6e23a36b6164c5a607464a1a1dd62b1140e159 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 4 Apr 2026 17:32:55 +0800
+Subject: [PATCH 3/3] AOSCOS: neuter version check
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ CMakeLists.txt                      |   1 -
+ datas/qmake_deprecated/texmaker.pro |   3 -
+ src/texmaker.cpp                    |  14 ---
+ src/texmaker.h                      |   1 -
+ src/versiondialog.cpp               |  64 --------------
+ src/versiondialog.h                 |  41 ---------
+ src/versiondialog.ui                | 129 ----------------------------
+ 7 files changed, 253 deletions(-)
+ delete mode 100644 src/versiondialog.cpp
+ delete mode 100644 src/versiondialog.h
+ delete mode 100644 src/versiondialog.ui
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a0a4d3b..8e3efdf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1130,7 +1130,6 @@ src/usermenudialog.cpp src/usermenudialog.h src/usermenudialog.ui
+ src/userquickdialog.cpp src/userquickdialog.h src/userquickdialog.ui
+ src/usertagslistwidget.cpp src/usertagslistwidget.h
+ src/usertooldialog.cpp src/usertooldialog.h src/usertooldialog.ui
+-src/versiondialog.cpp src/versiondialog.h src/versiondialog.ui
+ src/x11fontdialog.cpp src/x11fontdialog.h src/x11fontdialog.ui
+ src/xmltagslistwidget.cpp src/xmltagslistwidget.h
+ )
+diff --git a/datas/qmake_deprecated/texmaker.pro b/datas/qmake_deprecated/texmaker.pro
+index c303ca3..b5809aa 100644
+--- a/datas/qmake_deprecated/texmaker.pro
++++ b/datas/qmake_deprecated/texmaker.pro
+@@ -117,7 +117,6 @@ HEADERS	+= src/texmaker.h \
+ 	src/exportdialog.h \
+ 	src/usertagslistwidget.h \
+ 	src/addtagdialog.h \
+-	src/versiondialog.h \
+ 	src/unicodedialog.h \
+ 	src/unicodeview.h \
+ 	src/githelper.h \
+@@ -559,7 +558,6 @@ SOURCES	+= src/main.cpp \
+ 	src/exportdialog.cpp \
+ 	src/usertagslistwidget.cpp \
+ 	src/addtagdialog.cpp \
+-	src/versiondialog.cpp \
+ 	src/unicodedialog.cpp \
+ 	src/unicodeview.cpp \
+ 	src/quickbeamerdialog.cpp \
+@@ -1101,7 +1099,6 @@ FORMS   += src/findwidget.ui\
+ 	src/scandialog.ui \
+ 	src/exportdialog.ui \
+ 	src/addtagdialog.ui \
+-	src/versiondialog.ui \
+ 	src/unicodedialog.ui \
+ 	src/quickbeamerdialog.ui \
+ 	src/x11fontdialog.ui
+diff --git a/src/texmaker.cpp b/src/texmaker.cpp
+index 627aecc..be23fc9 100644
+--- a/src/texmaker.cpp
++++ b/src/texmaker.cpp
+@@ -98,7 +98,6 @@
+ #include "texdocdialog.h"
+ #include "addtagdialog.h"
+ #include "exportdialog.h"
+-#include "versiondialog.h"
+ #include "unicodedialog.h"
+ #include "githelper.h"
+ #include "theme.h"
+@@ -2815,11 +2814,6 @@ connect(Act, SIGNAL(triggered()), this, SLOT(Doculatex()));
+ helpMenu->addAction(Act);  
+ //}  
+ 
+-helpMenu->addSeparator();
+-Act = new QAction( tr("Check for Update"), this);
+-connect(Act, SIGNAL(triggered()), this, SLOT(CheckVersion()));
+-helpMenu->addAction(Act);
+-
+ helpMenu->addSeparator();
+ Act = new QAction(getIcon(":/datas/images/appicon.png"), tr("About Texmaker"), this);
+ connect(Act, SIGNAL(triggered()), this, SLOT(HelpAbout()));
+@@ -10665,14 +10659,6 @@ void Texmaker::HelpAbout()
+  abDlg->exec();
+ }
+ 
+-void Texmaker::CheckVersion()
+-{
+- VersionDialog *verDlg = new VersionDialog(this);
+- verDlg->exec();
+-}
+-
+-
+-
+ // void Texmaker::Docufrlatex()
+ // {
+ // QDesktopServices::openUrl(QUrl("http://www.xm1math.net/doculatex/index.html"));
+diff --git a/src/texmaker.h b/src/texmaker.h
+index 43190ae..ac17781 100644
+--- a/src/texmaker.h
++++ b/src/texmaker.h
+@@ -475,7 +475,6 @@ void LatexHelp();
+ void UserManualHelp();
+ void TexDocHelp();
+ void HelpAbout();
+-void CheckVersion();
+ void Doculatex();
+ //void Docufrlatex();
+ 
+diff --git a/src/versiondialog.cpp b/src/versiondialog.cpp
+deleted file mode 100644
+index a2c82f9..0000000
+--- a/src/versiondialog.cpp
++++ /dev/null
+@@ -1,64 +0,0 @@
+-/***************************************************************************
+- *   copyright       : (C) 2003-2025 by Pascal Brachet                     *
+- *   https://www.xm1math.net/texmaker/                                     *
+- *                                                                         *
+- *   This program is free software; you can redistribute it and/or modify  *
+- *   it under the terms of the GNU General Public License as published by  *
+- *   the Free Software Foundation; either version 2 of the License, or     *
+- *   (at your option) any later version.                                   *
+- *                                                                         *
+- *   @license GPL-2.0+ <https://spdx.org/licenses/GPL-2.0+.html>           *
+- ***************************************************************************/
+-
+-#include "versiondialog.h"
+-
+-#include <QtCore/QUrl>
+-#include <QDesktopServices>
+-#define STRINGIFY_INTERNAL(x) #x
+-#define STRINGIFY(x) STRINGIFY_INTERNAL(x)
+-
+-#define VERSION_STR STRINGIFY(TEXMAKERVERSION)
+-
+-VersionDialog::VersionDialog(QWidget *parent)
+-    :QDialog( parent)
+-{
+-ui.setupUi(this);
+-timer.setSingleShot(true);
+-connect(&timer, SIGNAL(timeout()), this, SLOT(stopChecker()));
+-ui.lineEditCurrent->setText(QLatin1String(VERSION_STR));
+-ui.lineEditAvailable->setText(QString::fromUtf8("?.?.?"));
+-connect(ui.pushButtonDownload, SIGNAL( clicked() ), this, SLOT( gotoDownloadPage() ) );
+-connect(ui.pushButtonCheck, SIGNAL( clicked() ), this, SLOT( launchChecker() ) );
+-}
+-
+-VersionDialog::~VersionDialog(){
+-}
+-
+-void VersionDialog::gotoDownloadPage()
+-{
+-QDesktopServices::openUrl(QUrl("https://www.xm1math.net/texmaker/download.html"));
+-}
+-
+-void VersionDialog::launchChecker()
+-{
+-ui.pushButtonCheck->setEnabled(false);
+-timer.start(10000);
+-reply = manager.get (  QNetworkRequest(QUrl("https://www.xm1math.net/texmaker/version.txt"))  );
+-QObject::connect (reply, SIGNAL (finished()),this, SLOT(showResultChecker()));
+-}
+-
+-void VersionDialog::showResultChecker()
+-{
+-timer.stop();
+-if (reply->error()) ui.lineEditAvailable->setText(tr("Error"));
+-else ui.lineEditAvailable->setText(QString(reply->readAll()));
+-ui.pushButtonCheck->setEnabled(true);
+-}
+-
+-void VersionDialog::stopChecker()
+-{
+-ui.lineEditAvailable->setText(tr("Error"));
+-QObject::disconnect (reply, SIGNAL (finished()),this, SLOT(showResultChecker()));
+-reply->abort();
+-ui.pushButtonCheck->setEnabled(true);
+-}
+diff --git a/src/versiondialog.h b/src/versiondialog.h
+deleted file mode 100644
+index 6a6017a..0000000
+--- a/src/versiondialog.h
++++ /dev/null
+@@ -1,41 +0,0 @@
+-/***************************************************************************
+- *   copyright       : (C) 2003-2025 by Pascal Brachet                     *
+- *   https://www.xm1math.net/texmaker/                                     *
+- *                                                                         *
+- *   This program is free software; you can redistribute it and/or modify  *
+- *   it under the terms of the GNU General Public License as published by  *
+- *   the Free Software Foundation; either version 2 of the License, or     *
+- *   (at your option) any later version.                                   *
+- *                                                                         *
+- *   @license GPL-2.0+ <https://spdx.org/licenses/GPL-2.0+.html>           *
+- ***************************************************************************/
+-
+-#ifndef VERSIONDIALOG_H
+-#define VERSIONDIALOG_H
+-
+-#include <QtNetwork/QNetworkAccessManager>
+-#include <QtNetwork/QNetworkRequest>
+-#include <QtNetwork/QNetworkReply>
+-#include <QTimer>
+-
+-#include "ui_versiondialog.h"
+-
+-class VersionDialog : public QDialog  {
+-   Q_OBJECT
+-public:
+-	VersionDialog(QWidget *parent=0);
+-	~VersionDialog();
+-	Ui::VersionDialog ui;
+-private:
+-    QNetworkAccessManager manager;
+-    QNetworkReply       * reply;
+-    QTimer timer;
+-private slots:
+-  void gotoDownloadPage();
+-  void launchChecker();
+-  void showResultChecker();
+-  void stopChecker();
+-};
+-
+-
+-#endif
+diff --git a/src/versiondialog.ui b/src/versiondialog.ui
+deleted file mode 100644
+index ed9d9cc..0000000
+--- a/src/versiondialog.ui
++++ /dev/null
+@@ -1,129 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<ui version="4.0">
+- <class>VersionDialog</class>
+- <widget class="QDialog" name="VersionDialog">
+-  <property name="geometry">
+-   <rect>
+-    <x>0</x>
+-    <y>0</y>
+-    <width>400</width>
+-    <height>193</height>
+-   </rect>
+-  </property>
+-  <property name="windowTitle">
+-   <string>Texmaker</string>
+-  </property>
+-  <layout class="QGridLayout" name="gridLayout">
+-   <item row="1" column="0" colspan="2">
+-    <widget class="QPushButton" name="pushButtonCheck">
+-     <property name="text">
+-      <string>Check for available version</string>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="0" column="1">
+-    <widget class="QLineEdit" name="lineEditCurrent">
+-     <property name="readOnly">
+-      <bool>true</bool>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="2" column="0">
+-    <widget class="QLabel" name="labelAvailable">
+-     <property name="text">
+-      <string>Available version</string>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="2" column="1">
+-    <widget class="QLineEdit" name="lineEditAvailable">
+-     <property name="readOnly">
+-      <bool>true</bool>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="3" column="0" colspan="2">
+-    <widget class="QPushButton" name="pushButtonDownload">
+-     <property name="text">
+-      <string>Go to the download page</string>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="5" column="0" colspan="2">
+-    <widget class="QDialogButtonBox" name="buttonBox">
+-     <property name="orientation">
+-      <enum>Qt::Horizontal</enum>
+-     </property>
+-     <property name="standardButtons">
+-      <set>QDialogButtonBox::Ok</set>
+-     </property>
+-     <property name="centerButtons">
+-      <bool>true</bool>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="0" column="0">
+-    <widget class="QLabel" name="label">
+-     <property name="text">
+-      <string>You're using the version</string>
+-     </property>
+-    </widget>
+-   </item>
+-   <item row="4" column="0" colspan="2">
+-    <spacer name="verticalSpacer">
+-     <property name="orientation">
+-      <enum>Qt::Vertical</enum>
+-     </property>
+-     <property name="sizeHint" stdset="0">
+-      <size>
+-       <width>20</width>
+-       <height>40</height>
+-      </size>
+-     </property>
+-    </spacer>
+-   </item>
+-  </layout>
+- </widget>
+- <tabstops>
+-  <tabstop>pushButtonCheck</tabstop>
+-  <tabstop>pushButtonDownload</tabstop>
+-  <tabstop>buttonBox</tabstop>
+-  <tabstop>lineEditCurrent</tabstop>
+-  <tabstop>lineEditAvailable</tabstop>
+- </tabstops>
+- <resources/>
+- <connections>
+-  <connection>
+-   <sender>buttonBox</sender>
+-   <signal>accepted()</signal>
+-   <receiver>VersionDialog</receiver>
+-   <slot>accept()</slot>
+-   <hints>
+-    <hint type="sourcelabel">
+-     <x>248</x>
+-     <y>254</y>
+-    </hint>
+-    <hint type="destinationlabel">
+-     <x>157</x>
+-     <y>274</y>
+-    </hint>
+-   </hints>
+-  </connection>
+-  <connection>
+-   <sender>buttonBox</sender>
+-   <signal>rejected()</signal>
+-   <receiver>VersionDialog</receiver>
+-   <slot>reject()</slot>
+-   <hints>
+-    <hint type="sourcelabel">
+-     <x>316</x>
+-     <y>260</y>
+-    </hint>
+-    <hint type="destinationlabel">
+-     <x>286</x>
+-     <y>274</y>
+-    </hint>
+-   </hints>
+-  </connection>
+- </connections>
+-</ui>
+-- 
+2.52.0
+

--- a/app-doc/texmaker/spec
+++ b/app-doc/texmaker/spec
@@ -1,5 +1,4 @@
-VER=5.1.2
-REL=2
+VER=6.0.1
 SRCS="tbl::https://www.xm1math.net/texmaker/texmaker-$VER.tar.bz2"
-CHKSUMS="sha256::526896f2c1ae561130eec7aae815b9dcda9e8eeb772b6541d0dc94ce91a71044"
+CHKSUMS="sha256::b8c235df0cd8fd7714cd70d3b5ee363163b0254a9dea9180781b8f0e2e46caf6"
 CHKUPDATE="anitya::id=4960"


### PR DESCRIPTION
Topic Description
-----------------

- texmaker: update to 6.0.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- texmaker: 6.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit texmaker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
