### PR TITLE
libcava: update to 0.10.6

### DIFF
--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,4 +1,5 @@
 VER=0.14.0
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/Alexays/Waybar"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21287"

--- a/runtime-multimedia/libcava/autobuild/defines
+++ b/runtime-multimedia/libcava/autobuild/defines
@@ -21,4 +21,4 @@ MESON_AFTER=(
     '-Doutput_sdl_glsl=enabled'
 )
 
-PKGBREAK="waybar<=0.12.0-1"
+PKGBREAK="waybar<=0.14.0"

--- a/runtime-multimedia/libcava/spec
+++ b/runtime-multimedia/libcava/spec
@@ -1,4 +1,4 @@
-VER=0.10.4
+VER=0.10.6
 SRCS="git::commit=tags/$VER::https://github.com/LukashonakV/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372377"


### PR DESCRIPTION
Topic Description
-----------------

- libcava: update to 0.10.6
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- libcava: 0.10.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcava:-pkgbreak waybar libcava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
