### PR TITLE
unifont: update to 17.0.02

### DIFF
--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -2,9 +2,8 @@ UPSTREAM_VER=2.12
 # Note: For use inside autobuild/.
 # Note: 2.12-rc1+unifont15.1.04 => 2.12~rc1+unifont15.1.04
 __GRUBVER=${UPSTREAM_VER/\-/~}
-__UNIFONTVER=17.0.01
+__UNIFONTVER=17.0.02
 RETROFONTVER=20200402
-REL=2
 # Taken from bootstrap.conf.
 GNULIB_REV=9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
@@ -15,7 +14,7 @@ SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https:/
       tbl::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"
 CHKSUMS="SKIP \
          SKIP \
-         sha256::df6bd412669f8a4b56d3f43b0f1e026155eecd74b073473061f0633ad11b037e \
+         sha256::b1a2fdadfa8c98cc9ee61fa807310a9d61a37e21b14770bbe9ace39c414ef04b \
          sha256::1609e64c2672c1895808852a272a41a1d0a02084b86ad82a22edc9207a4f63fa"
 CHKUPDATE="anitya::id=1258"
 SUBDIR=.

--- a/desktop-fonts/unifont/spec
+++ b/desktop-fonts/unifont/spec
@@ -1,4 +1,4 @@
-VER=17.0.01
+VER=17.0.02
 SRCS="tbl::https://ftp.gnu.org/gnu/unifont/unifont-$VER/unifont-$VER.tar.gz"
-CHKSUMS="sha256::234af86e7a0e851f020900db5ad0afc32691c248db362df9b2914cf50c42d940"
+CHKSUMS="sha256::0c19e2611f0fd836966080b31b0d45921998debacd5745e2506ee0bbcbc6e528"
 CHKUPDATE="anitya::id=14916"


### PR DESCRIPTION
Topic Description
-----------------

- grub: update to 2.12+unifont17.0.02
- unifont: update to 17.0.02
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- grub: 2:2.12+unifont17.0.02
- unifont: 17.0.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit unifont grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
