### PR TITLE
nodejs-22: update to 22.21.0

### DIFF
--- a/lang-js/nodejs-22/spec
+++ b/lang-js/nodejs-22/spec
@@ -1,9 +1,11 @@
-VER=22.17.1
+VER=22.21.0
 SRCS="tbl::https://nodejs.org/dist/v$VER/node-v$VER.tar.xz"
-CHKSUMS="sha256::327415FD76FCEBB98133BF56E2D90E3AC048B038FAC2676F03B6DB91074575B9"
+CHKSUMS="sha256::791b18e969ea22cc952108ee8eaafbb12cddfd973bbbb0b7fc116395c0d9a81c"
 CHKUPDATE="anitya::id=374342"
 # Note: Node.js currently requires large memory to build. 
 #       Prefer 3C5000 (or faster) build hosts.
 ENVREQ__LOONGARCH64="total_mem=30 core=16"
-# Note: Prefer larger RAM.  
+# Note: Prefer larger RAM.
 ENVREQ__ARM64="total_mem=60"
+# Note: Larger RAM per core needed.
+ENVREQ__PPC64EL="total_mem_per_core=2"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-22: update to 22.21.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nodejs-22: 22.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
