### PR TITLE
sccache: update to 0.12.0

### DIFF
--- a/app-devel/sccache/spec
+++ b/app-devel/sccache/spec
@@ -1,4 +1,4 @@
-VER=0.11.0
+VER=0.12.0
 SRCS="tbl::https://github.com/mozilla/sccache/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::eed7ba2b55f91511481df75e238307ac95885064fe734e0aab945654244ecec8"
+CHKSUMS="sha256::309edaf43f44088e55e99ce14eb9cfdee8f85acad290171ebfd29eb9e368def3"
 CHKUPDATE="anitya::id=227267"


### PR DESCRIPTION
Topic Description
-----------------

- sccache: update to 0.12.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sccache: 0.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sccache
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
