### PR TITLE
libutf8proc: update to 2.11.0

### DIFF
--- a/runtime-i18n/libutf8proc/spec
+++ b/runtime-i18n/libutf8proc/spec
@@ -1,4 +1,4 @@
-VER=2.10.0
+VER=2.11.0
 SRCS="git::commit=tags/v$VER::https://github.com/JuliaStrings/utf8proc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7455"


### PR DESCRIPTION
Topic Description
-----------------

- libutf8proc: update to 2.11.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libutf8proc: 2.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libutf8proc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
