### PR TITLE
aosc-media-writer: update to 0.3.5

### DIFF
--- a/app-utils/aosc-media-writer/spec
+++ b/app-utils/aosc-media-writer/spec
@@ -1,5 +1,4 @@
-VER="0.3.4"
-SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/MediaWriter"
+VER=0.3.5
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/MediaWriter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371926"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-media-writer: update to 0.3.5
    Co-authored-by: Gray David \(@grayawa\)

Package(s) Affected
-------------------

- aosc-media-writer: 0.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-media-writer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
