### PR TITLE
f3: update to 9.0

### DIFF
--- a/app-utils/f3/spec
+++ b/app-utils/f3/spec
@@ -1,4 +1,4 @@
-VER=8.0
+VER=9.0
 SRCS="tbl::https://github.com/AltraMayor/f3/archive/v$VER.tar.gz"
-CHKSUMS="sha256::fb5e0f3b0e0b0bff2089a4ea6af53278804dfe0b87992499131445732e311ab4"
+CHKSUMS="sha256::569ec069dc3ec1c74d90d6704aa8b7f45240f5998a9dc6f14f1736c917506ecb"
 CHKUPDATE="anitya::id=141665"


### PR DESCRIPTION
Topic Description
-----------------

- f3: update to 9.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- f3: 9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit f3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
