### PR TITLE
bolt: update to 0.9.10

### DIFF
--- a/app-admin/bolt/spec
+++ b/app-admin/bolt/spec
@@ -1,4 +1,4 @@
-VER=0.9.8
+VER=0.9.10
 SRCS="tbl::https://gitlab.freedesktop.org/bolt/bolt/-/archive/${VER}/bolt-${VER}.tar.gz"
-CHKSUMS="sha256::5a4306aa21ee398e1e9f2a5072748c9469c9360bf5edc7dcec2f12fc17be122e"
+CHKSUMS="sha256::0e9646ff153f4445d85bfaac1b0d77d86df9c639f84888f15ee7b0f1fa892b58"
 CHKUPDATE="anitya::id=17645"


### PR DESCRIPTION
Topic Description
-----------------

- bolt: update to 0.9.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- bolt: 0.9.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit bolt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
