### PR TITLE
aosc-media-writer: update to 0.4.0

### DIFF
--- a/app-utils/aosc-media-writer/autobuild/defines
+++ b/app-utils/aosc-media-writer/autobuild/defines
@@ -1,4 +1,4 @@
-PKGNAME="aosc-media-writer"
-PKGDES="Write .iso/raw images to portable boot media"
+PKGNAME=aosc-media-writer
+PKGSEC=utils
 PKGDEP="qt-6 adwaita-qt udisks-2 xz"
-PKGSEC="utils"
+PKGDES="Utility to write .iso/raw images to portable boot media"

--- a/app-utils/aosc-media-writer/spec
+++ b/app-utils/aosc-media-writer/spec
@@ -1,5 +1,4 @@
-VER="0.3.4"
-SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/MediaWriter"
+VER=0.4.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/MediaWriter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371926"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- aosc-media-writer: update to 0.4.0

Package(s) Affected
-------------------

- aosc-media-writer: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-media-writer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
