### PR TITLE
xiccd: update to 0.4.1

### DIFF
--- a/app-utils/xiccd/autobuild/defines
+++ b/app-utils/xiccd/autobuild/defines
@@ -1,6 +1,16 @@
 PKGNAME=xiccd
 PKGSEC=utils
 PKGDEP="x11-lib glib colord"
-PKGDES="A color management daemon for displays, printers, etc."
+PKGDES="Color management daemon for displays, printers, etc."
+
+# FIXME:
+#
+# Makefile.am: error: required file './AUTHORS' not found
+# Makefile.am: installing './INSTALL'
+# Makefile.am: error: required file './NEWS' not found
+# Makefile.am: installing './depcomp'
+#
+# Re-configuration needs to be handled manually (see prepare).
+RECONF=0
 
 ABTYPE=autotools

--- a/app-utils/xiccd/autobuild/prepare
+++ b/app-utils/xiccd/autobuild/prepare
@@ -1,0 +1,15 @@
+abinfo "Regenerating Autotools scripts (aclocal) ..."
+aclocal \
+    --verbose
+
+abinfo "Regenerating Autotools scripts (autoconf) ..."
+autoconf \
+    --verbose
+
+abinfo "Regenerating Autotools scripts (automake) ..."
+automake \
+    --add-missing \
+    --foreign \
+    --force \
+    --copy \
+    --verbose

--- a/app-utils/xiccd/spec
+++ b/app-utils/xiccd/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
-SRCS="tbl::https://github.com/agalakhov/xiccd/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::94dbe352ad3043079fa5edd8150318ec88f1dc87b75f69b1fced8ce2981c36a9"
+VER=0.4.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/agalakhov/xiccd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16659"


### PR DESCRIPTION
Topic Description
-----------------

- xiccd: update to 0.4.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xiccd: 0.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xiccd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
