### PR TITLE
kitty: update to 0.43.1

### DIFF
--- a/app-utils/kitty/autobuild/build
+++ b/app-utils/kitty/autobuild/build
@@ -1,7 +1,9 @@
-abinfo "Building & installing binaries"
-python3 setup.py linux-package
+abinfo "Building kitty ..."
+python3 "$SRCDIR"/setup.py linux-package
 
-mkdir -vp "$PKGDIR"/usr/
+abinfo "Installing kitty ..."
+mkdir -pv "$PKGDIR"/usr/
 for i in bin share lib; do
-    cp -arv linux-package/$i "$PKGDIR"/usr/
+    cp -av "$SRCDIR"/linux-package/$i \
+        "$PKGDIR"/usr/
 done

--- a/app-utils/kitty/autobuild/defines
+++ b/app-utils/kitty/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=kitty
 PKGSEC=utils
-PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync simde"
-BUILDDEP="go symbols-nerd-font"
+PKGDEP="fontconfig glew glfw python-3 x11-app lcms2 librsync"
+BUILDDEP="go simde symbols-nerd-font"
 PKGDES="Terminal emulator featuring OpenGL acceleration"

--- a/app-utils/kitty/autobuild/prepare
+++ b/app-utils/kitty/autobuild/prepare
@@ -1,2 +1,3 @@
 # FIXME: build system of this package doesn't use CPPFLAGS, instead merge it with CFLAGS
+abinfo "Appending CPPFLAGS to CFLAGS ..."
 export CFLAGS="${CFLAGS} ${CPPFLAGS}"

--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,4 @@
-VER=0.42.2
-REL=1
+VER=0.43.1
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::719796b6f67f81d212e80a5dcd51ba84cff54e009f32a728108f6854f00306a1"
+CHKSUMS="sha256::44a875e34e6a5f9b8f599b25b0796c07a1506fec2b2310573e03077ef1ae159f"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.43.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kitty: 0.43.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
