### PR TITLE
libinput: update to 1.29.2

### DIFF
--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,4 +1,4 @@
-VER=1.29.0
+VER=1.29.2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- libinput: update to 1.29.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libinput: 1.29.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
