### PR TITLE
udiskie: update to 2.5.8

### DIFF
--- a/app-utils/udiskie/spec
+++ b/app-utils/udiskie/spec
@@ -1,4 +1,4 @@
-VER=2.5.7
+VER=2.5.8
 SRCS="git::commit=tags/v$VER::https://github.com/coldfix/udiskie"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7187"


### PR DESCRIPTION
Topic Description
-----------------

- udiskie: update to 2.5.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- udiskie: 2.5.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit udiskie
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
