### PR TITLE
uncrustify: update to 0.81.0

### DIFF
--- a/app-devel/uncrustify/autobuild/beyond
+++ b/app-devel/uncrustify/autobuild/beyond
@@ -1,2 +1,3 @@
-install -d -m755 "$PKGDIR"/usr/share/uncrustify
-install -m644 etc/*.cfg "$PKGDIR"/usr/share/uncrustify
+abinfo "Installing configurations ..."
+install -Dvm644 "$SRCDIR"/etc/*.cfg \
+    -t "$PKGDIR"/usr/share/uncrustify/

--- a/app-devel/uncrustify/autobuild/defines
+++ b/app-devel/uncrustify/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=uncrustify
 PKGSEC=devel
 PKGDEP="gcc-runtime"
 BUILDDEP="cmake"
-PKGDES="A source code beautifier"
+PKGDES="Source code beautifier"

--- a/app-devel/uncrustify/spec
+++ b/app-devel/uncrustify/spec
@@ -1,4 +1,4 @@
-VER=0.78.1
+VER=0.81.0
 SRCS="tbl::https://downloads.sourceforge.net/uncrustify/uncrustify-$VER.tar.gz"
-CHKSUMS="sha256::5f92c90734e16b603c950ba7306bf8a2959afa41d4ecc6a52b4966183a1ea3cd"
+CHKSUMS="sha256::fa269567d1371169659112f2a13e1e8aa4c4867a0e6a79947099c5bf9cd2282c"
 CHKUPDATE="anitya::id=5043"


### PR DESCRIPTION
Topic Description
-----------------

- uncrustify: update to 0.81.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- uncrustify: 0.81.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit uncrustify
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
