### PR TITLE
nvme-cli: update to 2.15

### DIFF
--- a/app-admin/nvme-cli/spec
+++ b/app-admin/nvme-cli/spec
@@ -1,4 +1,4 @@
-VER=2.11
+VER=2.15
 SRCS="git::commit=tags/v${VER}::https://github.com/linux-nvme/nvme-cli.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9074"


### PR DESCRIPTION
Topic Description
-----------------

- nvme-cli: update to 2.15
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nvme-cli: 2.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvme-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
