### PR TITLE
flatpak-builder: update to 1.4.7

### DIFF
--- a/app-devel/flatpak-builder/spec
+++ b/app-devel/flatpak-builder/spec
@@ -1,4 +1,4 @@
-VER=1.4.4
+VER=1.4.7
 SRCS="tbl::https://github.com/flatpak/flatpak-builder/releases/download/$VER/flatpak-builder-$VER.tar.xz"
-CHKSUMS="sha256::dc27159394baaa2cb523f52f874472ff50d161983233264ca2a22e850741ec7a"
+CHKSUMS="sha256::fd5bc36fe3b974395f782e6c920d8955cee168f513370c32cc800b69acd980d0"
 CHKUPDATE="anitya::id=16046"


### PR DESCRIPTION
Topic Description
-----------------

- flatpak-builder: update to 1.4.7
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- flatpak-builder: 1.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak-builder
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
