### PR TITLE
cloud-init: update to 25.3

### DIFF
--- a/app-admin/cloud-init/spec
+++ b/app-admin/cloud-init/spec
@@ -1,4 +1,4 @@
-VER=24.4.1
+VER=25.3
 SRCS="git::commit=tags/$VER::https://github.com/canonical/cloud-init"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11545"


### PR DESCRIPTION
Topic Description
-----------------

- cloud-init: update to 25.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cloud-init: 25.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cloud-init
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
