### PR TITLE
podman: update to 5.6.2+vsock0.8.4

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,5 +1,4 @@
-UPSTREAM_VER=5.5.2
-REL=3
+UPSTREAM_VER=5.6.2
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile


### PR DESCRIPTION
Topic Description
-----------------

- podman: update to 5.6.2+vsock0.8.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- podman: 5.6.2+vsock0.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
