### PR TITLE
openvswitch: update to 3.6.0

### DIFF
--- a/app-network/openvswitch/spec
+++ b/app-network/openvswitch/spec
@@ -1,4 +1,4 @@
-VER=3.5.2
+VER=3.6.0
 SRCS="tbl::http://openvswitch.org/releases/openvswitch-$VER.tar.gz"
-CHKSUMS="sha256::6737afe67101fb9d1451f598efe8afdbceddf661f5d54cd691790ed61d6aaca9"
+CHKSUMS="sha256::379b609c69d3b7198924f39e2565fadacb06ec9e322e961ec6e2cd9835743981"
 CHKUPDATE="anitya::id=2568"


### PR DESCRIPTION
Topic Description
-----------------

- openvswitch: update to 3.6.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openvswitch: 3.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit openvswitch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
