### PR TITLE
netbird: update to 0.59.8

### DIFF
--- a/app-network/netbird/spec
+++ b/app-network/netbird/spec
@@ -1,4 +1,4 @@
-VER=0.59.7
+VER=0.59.8
 SRCS="git::commit=tags/v$VER::https://github.com/netbirdio/netbird.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383363"


### PR DESCRIPTION
Topic Description
-----------------

- netbird: update to 0.59.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- netbird: 0.59.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit netbird
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
