### PR TITLE
pdlzip: update to 1.14

### DIFF
--- a/app-utils/pdlzip/spec
+++ b/app-utils/pdlzip/spec
@@ -1,5 +1,4 @@
-VER=1.9
-REL=1
+VER=1.14
 SRCS="tbl::https://download.savannah.gnu.org/releases/lzip/pdlzip/pdlzip-$VER.tar.lz"
-CHKSUMS="sha256::5a09982bf71b34a5c74cc3dba84a52b4149e8907d9417d04ab83dc3d4f394069"
+CHKSUMS="sha256::647c2285cbe77d8f81a36ac5eb2d0b73bf2e2929e1e4efa91361162b890d54df"
 CHKUPDATE="anitya::id=231630"


### PR DESCRIPTION
Topic Description
-----------------

- pdlzip: update to 1.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pdlzip: 1.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit pdlzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
