### PR TITLE
cbindgen: update to 0.29.2

### DIFF
--- a/lang-rust/cbindgen/spec
+++ b/lang-rust/cbindgen/spec
@@ -1,4 +1,4 @@
-VER=0.29.0
+VER=0.29.2
 SRCS="git::commit=tags/v$VER::https://github.com/mozilla/cbindgen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16690"


### PR DESCRIPTION
Topic Description
-----------------

- cbindgen: update to 0.29.2
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- cbindgen: 0.29.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cbindgen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
