### PR TITLE
atuin: update to 18.10.0

### DIFF
--- a/app-utils/atuin/spec
+++ b/app-utils/atuin/spec
@@ -1,4 +1,4 @@
-VER=18.5.0
+VER=18.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/atuinsh/atuin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243615"


### PR DESCRIPTION
Topic Description
-----------------

- atuin: update to 18.10.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- atuin: 18.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit atuin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
