### PR TITLE
php: update to 8.4.14

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,5 +1,4 @@
-VER=8.4.7
-REL=4
+VER=8.4.14
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::e29f4c23be2816ed005aa3f06bbb8eae0f22cc133863862e893515fc841e65e3"
+CHKSUMS="sha256::bac90ee7cf738e814c89b6b27d4d2c4b70e50942a420837e1a22f5fd5f9867a3"
 CHKUPDATE="anitya::id=3627"


### PR DESCRIPTION
Topic Description
-----------------

- php: update to 8.4.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- php: 1:8.4.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
