### PR TITLE
goreleaser: update to 2.12.6

### DIFF
--- a/lang-golang/goreleaser/spec
+++ b/lang-golang/goreleaser/spec
@@ -1,5 +1,4 @@
-VER=2.8.2
-REL=1
+VER=2.12.6
 SRCS="git::commit=tags/v$VER::https://github.com/goreleaser/goreleaser.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374129"


### PR DESCRIPTION
Topic Description
-----------------

- goreleaser: update to 2.12.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- goreleaser: 2.12.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit goreleaser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
