### PR TITLE
osu-lazer: update to 2025.1022.0-tachyon

### DIFF
--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=2025.816.0-lazer
+UPSTREAM_VER=2025.1022.0-tachyon
 VER=${UPSTREAM_VER/-lazer/}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/ppy/osu"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2025.1022.0-tachyon
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- osu-lazer: 2025.1022.0-tachyon

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
