### PR TITLE
unbound: update to 1.24.1+icannbundle20210902

### DIFF
--- a/app-network/unbound/spec
+++ b/app-network/unbound/spec
@@ -1,8 +1,8 @@
-UPSTREAM_VER=1.23.1
+UPSTREAM_VER=1.24.1
 ICANNBUNDLE_VER=20210902
 VER=${UPSTREAM_VER}+icannbundle${ICANNBUNDLE_VER}
 SRCS="tbl::https://unbound.net/downloads/unbound-${UPSTREAM_VER}.tar.gz \
       file::rename=icannbundle.pem::https://repo.aosc.io/aosc-repacks/icannbundle-${ICANNBUNDLE_VER}.pem"
-CHKSUMS="sha256::6a6b117c799d8de3868643397e0fd71591f6d42f4473f598bdb22609ff362590 \
+CHKSUMS="sha256::7f2b1633e239409619ae0527f67878b0f33ae0ec0ee5a3a51c042c359ba1eeab \
          sha256::d4c77eafb8a3bc1d68fb7c171afbd0d2a76870dae81ad18d0c584fa46ecd1eb1"
 CHKUPDATE="anitya::id=5042"


### PR DESCRIPTION
Topic Description
-----------------

- unbound: update to 1.24.1+icannbundle20210902
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- unbound: 1.24.1+icannbundle20210902

Security Update?
----------------

No

Build Order
-----------

```
#buildit unbound
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
