### PR TITLE
doxygen: update to 1.15.0

### DIFF
--- a/app-doc/doxygen/spec
+++ b/app-doc/doxygen/spec
@@ -1,4 +1,4 @@
-VER=1.14.0
+VER=1.15.0
 SRCS="git::commit=tags/Release_${VER//./_}::https://github.com/doxygen/doxygen.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=457"


### PR DESCRIPTION
Topic Description
-----------------

- doxygen: update to 1.15.0
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- doxygen: 1.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit doxygen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
