### PR TITLE
usbutils: update to 019

### DIFF
--- a/app-utils/usbutils/autobuild/defines
+++ b/app-utils/usbutils/autobuild/defines
@@ -1,16 +1,7 @@
 PKGNAME=usbutils
-PKGDES="A utility used to display information about USB buses and devices"
-PKGDEP="libusb hwdata python-3 coreutils zlib"
-PKGDEP__RETRO="libusb hwdata coreutils zlib"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGSEC=utils
+PKGDEP="libusb hwdata python-3 coreutils zlib"
+PKGDES="Utility to display information about USB buses and devices"
 
 ABTYPE=meson
 PKGPROV="lsusb"

--- a/app-utils/usbutils/spec
+++ b/app-utils/usbutils/spec
@@ -1,5 +1,4 @@
-VER=018
-REL=2
+VER=019
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/usb/usbutils/usbutils-$VER.tar.xz"
-CHKSUMS="sha256::83f68b59b58547589c00266e82671864627593ab4362d8c807f50eea923cad93"
+CHKSUMS="sha256::659f40c440e31ba865c52c818a33d3ba6a97349e3353f8b1985179cb2aa71ec5"
 CHKUPDATE="anitya::id=5061"


### PR DESCRIPTION
Topic Description
-----------------

- usbutils: update to 019
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- usbutils: 019

Security Update?
----------------

No

Build Order
-----------

```
#buildit usbutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
