### PR TITLE
cri-o: new, 1.34.1

### DIFF
--- a/app-containers/cri-o/autobuild/beyond
+++ b/app-containers/cri-o/autobuild/beyond
@@ -1,0 +1,24 @@
+abinfo "Generate cri-o configuration..."
+"$PKGDIR"/usr/bin/crio \
+     --cni-plugin-dir /opt/cni/bin \
+     config > "$SRCDIR"/crio.conf
+
+abinfo "Installing cri-o configuration..."
+make PREFIX="$PKGDIR"/usr \
+     DESTDIR="$PKGDIR" \
+     install.config
+install -dv "$PKGDIR"/usr/share/cni/net.d
+install -Dvm644 "$SRCDIR"/contrib/cni/10-crio-bridge.conflist \
+     "$PKGDIR"/usr/share/cni/net.d/10-crio-bridge.conflist
+install -Dvm644 "$SRCDIR"/contrib/cni/99-loopback.conflist \
+     "$PKGDIR"/usr/share/cni/net.d/99-loopback.conflist
+install -Dvm644 "$SRCDIR"/contrib/sysconfig/crio \
+     "$PKGDIR"/etc/sysconfig/crio
+
+abinfo "Installing cri-o manpage..."
+make PREFIX="$PKGDIR"/usr \
+     install.man
+
+abinfo "Installing cri-o shell completions..."
+make PREFIX="$PKGDIR"/usr \
+     install.completions

--- a/app-containers/cri-o/autobuild/build
+++ b/app-containers/cri-o/autobuild/build
@@ -1,0 +1,6 @@
+abinfo "Building cri-o..."
+make
+
+abinfo "Installing cri-o..."
+make PREFIX="$PKGDIR"/usr \
+     install.bin

--- a/app-containers/cri-o/autobuild/defines
+++ b/app-containers/cri-o/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=cri-o
+PKGDES="Implementation of the Kubernetes CRI for use with OCI-compatible runtimes"
+
+BUILDDEP="go gpgme go-md2man btrfs-progs apparmor libseccomp"
+PKGDEP="gcc-runtime glibc cni-plugins containers-common conmon crun nftables iproute2"
+PKGSEC="admin"
+PKGPROV="crio"

--- a/app-containers/cri-o/autobuild/overrides/usr/lib/systemd/system/crio-wipe.service
+++ b/app-containers/cri-o/autobuild/overrides/usr/lib/systemd/system/crio-wipe.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=CRI-O Auto Update Script
+Before=crio.service
+RequiresMountsFor=/var/lib/containers
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/crio
+ExecStart=/usr/bin/crio \
+          $CRIO_CONFIG_OPTIONS \
+          $CRIO_RUNTIME_OPTIONS \
+          $CRIO_STORAGE_OPTIONS \
+          $CRIO_NETWORK_OPTIONS \
+          $CRIO_METRICS_OPTIONS \
+          wipe
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target

--- a/app-containers/cri-o/autobuild/overrides/usr/lib/systemd/system/crio.service
+++ b/app-containers/cri-o/autobuild/overrides/usr/lib/systemd/system/crio.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Container Runtime Interface for OCI (CRI-O)
+Documentation=https://github.com/cri-o/cri-o
+Wants=network-online.target
+Before=kubelet.service
+After=network-online.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/sysconfig/crio
+Environment=GOTRACEBACK=crash
+ExecStart=/usr/bin/crio \
+          $CRIO_CONFIG_OPTIONS \
+          $CRIO_RUNTIME_OPTIONS \
+          $CRIO_STORAGE_OPTIONS \
+          $CRIO_NETWORK_OPTIONS \
+          $CRIO_METRICS_OPTIONS
+ExecReload=/bin/kill -s HUP $MAINPID
+TasksMax=infinity
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+OOMScoreAdjust=-999
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+Alias=cri-o.service

--- a/app-containers/cri-o/spec
+++ b/app-containers/cri-o/spec
@@ -1,0 +1,4 @@
+VER=1.34.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/cri-o/cri-o.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=12687"


### PR DESCRIPTION
Topic Description
-----------------

- crio: new, 1.34.1

Package(s) Affected
-------------------

- crio: 1.34.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cri-o
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
