### PR TITLE
docker-compose: update to 2.40.2

### DIFF
--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,5 +1,4 @@
-VER=2.35.0
-REL=2
+VER=2.40.2
 SRCS="git::commit=tags/v$VER::https://github.com/docker/compose"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6185"


### PR DESCRIPTION
Topic Description
-----------------

- docker-compose: update to 2.40.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- docker-compose: 2.40.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker-compose
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
