### PR TITLE
shh: update to 2023.10.19

### DIFF
--- a/app-utils/shh/spec
+++ b/app-utils/shh/spec
@@ -1,4 +1,4 @@
-VER=2025.9.22
+VER=2023.10.19
 SRCS="git::commit=tags/v$VER::https://github.com/desbma/shh.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377910"


### PR DESCRIPTION
Topic Description
-----------------

- shh: update to 2023.10.19
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- shh: 2023.10.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit shh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
