### PR TITLE
shh: update to 2025.10.22

### DIFF
--- a/app-utils/shh/spec
+++ b/app-utils/shh/spec
@@ -1,4 +1,4 @@
-VER=2025.9.22
+VER=2025.10.22
 SRCS="git::commit=tags/v$VER::https://github.com/desbma/shh.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377910"


### PR DESCRIPTION
Topic Description
-----------------

- shh: update to 2025.10.22
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- shh: 2025.10.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit shh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
