### PR TITLE
geoclue2: update to 2.8.0

### DIFF
--- a/runtime-gis/geoclue2/autobuild/beyond
+++ b/runtime-gis/geoclue2/autobuild/beyond
@@ -1,4 +1,0 @@
-abinfo "Moving dbus system configuration to /usr"
-mkdir -vp "${PKGDIR}/usr/share/dbus-1/system.d/"
-mv -v "${PKGDIR}/etc/dbus-1/system.d/"*.conf "${PKGDIR}/usr/share/dbus-1/system.d"
-rm -rv "${PKGDIR}/etc/dbus-1"

--- a/runtime-gis/geoclue2/autobuild/defines
+++ b/runtime-gis/geoclue2/autobuild/defines
@@ -1,18 +1,20 @@
 PKGNAME=geoclue2
 PKGSEC=libs
-PKGDEP="avahi geoip-api-c json-glib libnotify libsoup modemmanager \
+PKGDEP="avahi geoip-api-c json-glib libnotify libsoup-3 modemmanager \
         networkmanager"
-BUILDDEP="gobject-introspection gtk-doc intltool systemd vala"
+BUILDDEP="gobject-introspection intltool systemd vala"
 PKGDES="Modular geoinformation service built on the D-Bus messaging system"
 
-MESON_AFTER="-Dlibgeoclue=true \
-             -Dintrospection=true \
-             -Dvapi=true \
-             -Dgtk-doc=true \
-             -D3g-source=true \
-             -Dcdma-source=true \
-             -Dmodem-gps-source=true \
-             -Dnmea-source=true \
-             -Dcompass=true \
-             -Denable-backend=true \
-             -Ddemo-agent=true"
+MESON_AFTER=(
+    '-Dlibgeoclue=true'
+    '-Dintrospection=true'
+    '-Dvapi=true'
+    '-Dgtk-doc=false'
+    '-D3g-source=true'
+    '-Dcdma-source=true'
+    '-Dmodem-gps-source=true'
+    '-Dnmea-source=true'
+    '-Dcompass=true'
+    '-Denable-backend=true'
+    '-Ddemo-agent=true'
+)

--- a/runtime-gis/geoclue2/spec
+++ b/runtime-gis/geoclue2/spec
@@ -1,5 +1,4 @@
-VER=2.6.0
-REL=1
+VER=2.8.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/geoclue/geoclue"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13108"


### PR DESCRIPTION
Topic Description
-----------------

- geoclue2: update to 2.8.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- geoclue2: 2.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit geoclue2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
