### PR TITLE
mise: update to 2025.10.15

### DIFF
--- a/app-devel/mise/spec
+++ b/app-devel/mise/spec
@@ -1,4 +1,4 @@
-VER=2025.8.9
+VER=2025.10.15
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/mise.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376460"


### PR DESCRIPTION
Topic Description
-----------------

- mise: update to 2025.10.15
    Co-authored-by: \(@ZeroAurora\)

Package(s) Affected
-------------------

- mise: 2025.10.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit mise
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
