### PR TITLE
gnome-color-manager: update to 3.36.2

### DIFF
--- a/desktop-gnome/gnome-color-manager/spec
+++ b/desktop-gnome/gnome-color-manager/spec
@@ -1,5 +1,4 @@
-VER=3.36.0
-REL=2
+VER=3.36.2
 SRCS="https://download.gnome.org/sources/gnome-color-manager/${VER:0:4}/gnome-color-manager-$VER.tar.xz"
-CHKSUMS="sha256::9ddb9e6b6472e119801381f90905332ec1d4258981721bba831ca246ceb3ad3b"
+CHKSUMS="sha256::3904d42abb4ea566df0b880e82bf0b9f86386c692f15b318469a4c7be33a887f"
 CHKUPDATE="anitya::id=204991"


### PR DESCRIPTION
Topic Description
-----------------

- gnome-color-manager: update to 3.36.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gnome-color-manager: 3.36.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-color-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
