### PR TITLE
netcat: update to 1.234

### DIFF
--- a/app-network/netcat/spec
+++ b/app-network/netcat/spec
@@ -1,4 +1,4 @@
-VER=1.219
+VER=1.234
 SRCS="tbl::http://http.debian.net/debian/pool/main/n/netcat-openbsd/netcat-openbsd_$VER.orig.tar.gz"
-CHKSUMS="sha256::576487c3a4930987a5dc7b369340f07f3ef15abe7cd743d88036990bd8d89dca"
+CHKSUMS="sha256::121c18d9441ec42b92a9b566468a596bbcf673894db8b12d892947552a8e3bbe"
 CHKUPDATE="anitya::id=21534"


### PR DESCRIPTION
Topic Description
-----------------

- netcat: update to 1.234
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- netcat: 1.234

Security Update?
----------------

No

Build Order
-----------

```
#buildit netcat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
