### PR TITLE
deskflow: update to 1.24.0

### DIFF
--- a/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
+++ b/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
@@ -1,11 +1,8 @@
-From 000aa13d78fb5881d5f7ff1ce7a1efb555e49a09 Mon Sep 17 00:00:00 2001
-From: Mingcong Bai <jeffbai@aosc.io>
-Date: Fri, 9 May 2025 00:22:30 +0800
+From 6940f1b9b93e530f53729e0227b3038d8bc0dbe8 Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Fri, 24 Oct 2025 09:49:02 +0800
 Subject: [PATCH] AOSCOS: fix: neuter version checking functionalities
 
-As required by the Styling Manual.
-
-Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  src/lib/common/Settings.cpp            |  3 ---
  src/lib/common/Settings.h              |  4 ----
@@ -15,11 +12,11 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  src/lib/gui/Messages.cpp               | 18 ------------------
  src/lib/gui/Messages.h                 |  2 --
  src/lib/gui/dialogs/SettingsDialog.cpp |  3 ---
- src/lib/gui/dialogs/SettingsDialog.ui  |  8 --------
- 9 files changed, 61 deletions(-)
+ src/lib/gui/dialogs/SettingsDialog.ui  | 10 +---------
+ 9 files changed, 1 insertion(+), 62 deletions(-)
 
 diff --git a/src/lib/common/Settings.cpp b/src/lib/common/Settings.cpp
-index ee9ffc94e..64b837444 100644
+index e36809ce7..4475e0303 100644
 --- a/src/lib/common/Settings.cpp
 +++ b/src/lib/common/Settings.cpp
 @@ -112,9 +112,6 @@ QVariant Settings::defaultValue(const QString &key)
@@ -33,10 +30,10 @@ index ee9ffc94e..64b837444 100644
      return QStringLiteral("%1/%2-server.conf").arg(Settings::settingsPath(), kAppId);
  
 diff --git a/src/lib/common/Settings.h b/src/lib/common/Settings.h
-index c3bc87a48..2f55d1f99 100644
+index 339779d73..6a475e498 100644
 --- a/src/lib/common/Settings.h
 +++ b/src/lib/common/Settings.h
-@@ -48,7 +48,6 @@ public:
+@@ -49,7 +49,6 @@ public:
      inline static const auto ProcessMode = QStringLiteral("core/processMode");
      inline static const auto ScreenName = QStringLiteral("core/screenName");
      inline static const auto StartedBefore = QStringLiteral("core/startedBefore");
@@ -44,7 +41,7 @@ index c3bc87a48..2f55d1f99 100644
    };
    struct Daemon
    {
-@@ -60,7 +59,6 @@ public:
+@@ -61,7 +60,6 @@ public:
    struct Gui
    {
      inline static const auto Autohide = QStringLiteral("gui/autoHide");
@@ -52,7 +49,7 @@ index c3bc87a48..2f55d1f99 100644
      inline static const auto CloseReminder = QStringLiteral("gui/closeReminder");
      inline static const auto CloseToTray = QStringLiteral("gui/closeToTray");
      inline static const auto LogExpanded = QStringLiteral("gui/logExpanded");
-@@ -165,7 +163,6 @@ private:
+@@ -172,7 +170,6 @@ private:
      , Settings::Core::ProcessMode
      , Settings::Core::ScreenName
      , Settings::Core::StartedBefore
@@ -60,7 +57,7 @@ index c3bc87a48..2f55d1f99 100644
      , Settings::Daemon::Command
      , Settings::Daemon::Elevate
      , Settings::Daemon::LogFile
-@@ -173,7 +170,6 @@ private:
+@@ -180,7 +177,6 @@ private:
      , Settings::Log::Level
      , Settings::Log::ToFile
      , Settings::Gui::Autohide
@@ -69,11 +66,11 @@ index c3bc87a48..2f55d1f99 100644
      , Settings::Gui::CloseToTray
      , Settings::Gui::LogExpanded
 diff --git a/src/lib/gui/CMakeLists.txt b/src/lib/gui/CMakeLists.txt
-index 01bf8cfb7..fcfba4fe9 100644
+index 1aabcda25..432704ef6 100644
 --- a/src/lib/gui/CMakeLists.txt
 +++ b/src/lib/gui/CMakeLists.txt
-@@ -42,8 +42,6 @@ add_library(${target} STATIC
-   ServerConfig.h
+@@ -40,8 +40,6 @@ add_library(${target} STATIC
+   ScreenSetupModel.h
    Styles.h
    StyleUtils.h
 -  VersionChecker.cpp
@@ -82,10 +79,10 @@ index 01bf8cfb7..fcfba4fe9 100644
    config/Screen.cpp
    config/Screen.h
 diff --git a/src/lib/gui/MainWindow.cpp b/src/lib/gui/MainWindow.cpp
-index 71b987008..a98de39eb 100644
+index ba1c82191..b664e5dd7 100644
 --- a/src/lib/gui/MainWindow.cpp
 +++ b/src/lib/gui/MainWindow.cpp
-@@ -324,8 +324,6 @@ void MainWindow::connectSlots()
+@@ -301,8 +301,6 @@ void MainWindow::connectSlots()
    connect(m_actionRestartCore, &QAction::triggered, this, &MainWindow::resetCore);
    connect(m_actionStopCore, &QAction::triggered, this, &MainWindow::stopCore);
  
@@ -94,7 +91,7 @@ index 71b987008..a98de39eb 100644
  // Mac os tray will only show a menu
  #ifndef Q_OS_MAC
    connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
-@@ -409,12 +407,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
+@@ -402,12 +400,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
    isVisible() ? hide() : showAndActivate();
  }
  
@@ -107,7 +104,7 @@ index 71b987008..a98de39eb 100644
  void MainWindow::coreProcessError(CoreProcess::Error error)
  {
    if (error == CoreProcess::Error::AddressMissing) {
-@@ -634,16 +626,6 @@ void MainWindow::open()
+@@ -672,16 +664,6 @@ void MainWindow::open()
    const auto kCriticalDialogDelay = 100;
    QTimer::singleShot(kCriticalDialogDelay, this, &messages::raiseCriticalDialog);
  
@@ -125,18 +122,18 @@ index 71b987008..a98de39eb 100644
      if (ui->rbModeClient->isChecked() && ui->lineHostname->text().isEmpty())
        return;
 diff --git a/src/lib/gui/MainWindow.h b/src/lib/gui/MainWindow.h
-index 0e1705a01..8c305587f 100644
+index 79fbcf2d4..9d0844b27 100644
 --- a/src/lib/gui/MainWindow.h
 +++ b/src/lib/gui/MainWindow.h
-@@ -17,7 +17,6 @@
+@@ -16,7 +16,6 @@
+ #include <QSystemTrayIcon>
  #include <QThread>
  
- #include "ServerConfig.h"
 -#include "VersionChecker.h"
+ #include "config/ServerConfig.h"
  #include "gui/core/ClientConnection.h"
  #include "gui/core/CoreProcess.h"
- #include "gui/core/ServerConnection.h"
-@@ -97,7 +96,6 @@ private:
+@@ -99,7 +98,6 @@ private:
    void coreProcessError(CoreProcess::Error error);
    void coreConnectionStateChanged(CoreProcess::ConnectionState state);
    void coreProcessStateChanged(CoreProcess::ProcessState state);
@@ -144,7 +141,7 @@ index 0e1705a01..8c305587f 100644
    void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
    void serverConnectionConfigureClient(const QString &clientName);
  
-@@ -164,7 +162,6 @@ private:
+@@ -169,7 +167,6 @@ private:
    inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
    inline static const auto m_nameRegEx = QRegularExpression(QStringLiteral("^[\\w\\-_\\.]{0,255}$"));
  
@@ -153,10 +150,10 @@ index 0e1705a01..8c305587f 100644
    bool m_saveOnExit = true;
    deskflow::gui::core::WaylandWarnings m_waylandWarnings;
 diff --git a/src/lib/gui/Messages.cpp b/src/lib/gui/Messages.cpp
-index a8a285f3d..b5523a65e 100644
+index f6dc0865f..de061b3fd 100644
 --- a/src/lib/gui/Messages.cpp
 +++ b/src/lib/gui/Messages.cpp
-@@ -286,24 +286,6 @@ void showWaylandLibraryError(QWidget *parent)
+@@ -309,24 +309,6 @@ void showWaylandLibraryError(QWidget *parent)
    );
  }
  
@@ -195,10 +192,10 @@ index f035e2092..339eb8dfb 100644
  
  } // namespace deskflow::gui::messages
 diff --git a/src/lib/gui/dialogs/SettingsDialog.cpp b/src/lib/gui/dialogs/SettingsDialog.cpp
-index 2dd47cbf0..2fa2d1a52 100644
+index 75e13371f..59caeb58c 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.cpp
 +++ b/src/lib/gui/dialogs/SettingsDialog.cpp
-@@ -133,7 +133,6 @@ void SettingsDialog::accept()
+@@ -144,7 +144,6 @@ void SettingsDialog::accept()
    Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
    Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
    Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
@@ -206,7 +203,7 @@ index 2dd47cbf0..2fa2d1a52 100644
    Settings::setValue(Settings::Core::PreventSleep, ui->cbPreventSleep->isChecked());
    Settings::setValue(Settings::Security::Certificate, ui->lineTlsCertPath->text());
    Settings::setValue(Settings::Security::KeySize, ui->comboTlsKeyLength->currentText().toInt());
-@@ -167,7 +166,6 @@ void SettingsDialog::loadFromConfig()
+@@ -178,7 +177,6 @@ void SettingsDialog::loadFromConfig()
    ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
    ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
    ui->cbElevateDaemon->setChecked(Settings::value(Settings::Daemon::Elevate).toBool());
@@ -214,7 +211,7 @@ index 2dd47cbf0..2fa2d1a52 100644
  
    const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
    ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);
-@@ -258,7 +256,6 @@ void SettingsDialog::updateControls()
+@@ -262,7 +260,6 @@ void SettingsDialog::updateControls()
    ui->comboLogLevel->setEnabled(writable);
    ui->cbLogToFile->setEnabled(writable);
    ui->cbAutoHide->setEnabled(writable);
@@ -223,10 +220,10 @@ index 2dd47cbf0..2fa2d1a52 100644
    ui->lineTlsCertPath->setEnabled(writable);
    ui->comboTlsKeyLength->setEnabled(writable);
 diff --git a/src/lib/gui/dialogs/SettingsDialog.ui b/src/lib/gui/dialogs/SettingsDialog.ui
-index 1ff603b05..55a7d1721 100644
+index ca4742a02..848764b45 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.ui
 +++ b/src/lib/gui/dialogs/SettingsDialog.ui
-@@ -84,13 +84,6 @@
+@@ -77,14 +77,7 @@
            <string>App</string>
           </property>
           <layout class="QVBoxLayout" name="_9">
@@ -237,17 +234,19 @@ index 1ff603b05..55a7d1721 100644
 -            </property>
 -           </widget>
 -          </item>
-           <item>
-            <widget class="QCheckBox" name="cbCloseToTray">
+-          <item>
++         <item>
+            <widget class="QCheckBox" name="cbAutoHide">
              <property name="text">
-@@ -612,7 +605,6 @@
-   <tabstop>cbPreventSleep</tabstop>
+              <string>Hide the window when the app starts</string>
+@@ -641,7 +634,6 @@
+   <tabstop>tabWidget</tabstop>
    <tabstop>cbLanguageSync</tabstop>
    <tabstop>cbScrollDirection</tabstop>
 -  <tabstop>cbAutoUpdate</tabstop>
    <tabstop>cbCloseToTray</tabstop>
-   <tabstop>cbAutoHide</tabstop>
    <tabstop>rbIconColorful</tabstop>
+   <tabstop>rbIconMono</tabstop>
 -- 
-2.50.1
+2.51.0
 

--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -1,5 +1,4 @@
-VER=1.23.0
+VER=1.24.0
 SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375452"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- deskflow: update to 1.24.0
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- deskflow: 1.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deskflow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
