### PR TITLE
libcdr: update to 0.1.8

### DIFF
--- a/runtime-imaging/libcdr/autobuild/defines
+++ b/runtime-imaging/libcdr/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=libs
 PKGDEP="libwpd lcms2 icu librevenge"
 BUILDDEP="boost cppunit doxygen libwpg"
 PKGDES="CorelDraw file format importer library for LibreOffice"
-PKGBREAK="inkscape<=1.3.2 libreoffice<=7.5.4.2-4"
 
-ABSHADOW=no
+AUTOTOOLS_AFTER=(
+    '--without-docs'
+)
+
+PKGBREAK="inkscape<=1.3.2 libreoffice<=7.5.4.2-4"

--- a/runtime-imaging/libcdr/spec
+++ b/runtime-imaging/libcdr/spec
@@ -1,4 +1,4 @@
-VER=0.1.7
+VER=0.1.8
 SRCS="tbl::https://dev-www.libreoffice.org/src/libcdr/libcdr-$VER.tar.xz"
-CHKSUMS="sha256::5666249d613466b9aa1e987ea4109c04365866e9277d80f6cd9663e86b8ecdd4"
+CHKSUMS="sha256::ced677c8300b29c91d3004bb1dddf0b99761bf5544991c26c2ee8f427e87193c"
 CHKUPDATE="anitya::id=1574"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- libcdr: update to 0.1.8
- fix inkscape: 1.4.2 unable to open CDR files
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- libcdr: 0.1.8
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit libcdr
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
