### PR TITLE
hysteria: update to 2.6.5

### DIFF
--- a/app-proxy/hysteria/spec
+++ b/app-proxy/hysteria/spec
@@ -1,4 +1,4 @@
-VER=2.6.3
+VER=2.6.5
 SRCS="git::commit=tags/app/v$VER::https://github.com/apernet/hysteria"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371975"


### PR DESCRIPTION
Topic Description
-----------------

- hysteria: update to 2.6.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- hysteria: 2.6.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit hysteria
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
