### PR TITLE
mpfi: fix build with GCC>=14

### DIFF
--- a/runtime-scientific/mpfi/autobuild/patches/0001-FEDORA-fix-compiler-warnings-and-errors-uninit-misma.patch
+++ b/runtime-scientific/mpfi/autobuild/patches/0001-FEDORA-fix-compiler-warnings-and-errors-uninit-misma.patch
@@ -1,0 +1,64 @@
+From 897dbec2d9ab1985b436d3fb048fc1dc4d8a668b Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Fri, 24 Oct 2025 18:36:50 +0800
+Subject: [PATCH] FEDORA: fix compiler warnings and errors: -uninit,
+ -mismatched-type, -bad-ref and -test
+
+Link: https://src.fedoraproject.org/rpms/mpfi/c/7e3150846939dccd4f06c84e347b3cd581dba11e?branch=rawhide
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ src/div_ext.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/div_ext.c b/src/div_ext.c
+index 30cd3db..90402e0 100644
+--- a/src/div_ext.c
++++ b/src/div_ext.c
+@@ -59,17 +59,17 @@ mpfi_div_ext (mpfi_ptr res1, mpfi_ptr res2, mpfi_srcptr op1, mpfi_srcptr op2)
+       mpfr_init2 (tmp1, mpfi_get_prec(res1));
+       mpfr_init2 (tmp2, mpfi_get_prec(res2));
+       if ( mpfr_number_p (&(op2->left)) ) {
+-        tmp = mpfr_div (&(tmp2), &(op1->right), &(op2->left), MPFI_RNDD);
++        tmp = mpfr_div (tmp2, &(op1->right), &(op2->left), MPFI_RNDD);
+       }
+       else { /* denominator has infinite left endpoint */
+-        mpfr_set_zero (&(tmp2), 1);
++        mpfr_set_zero (tmp2, 1);
+       }
+ 
+       if ( mpfr_number_p (&(op2->right)) ) {
+-        tmp = mpfr_div ( &(tmp1), &(op1->right), &(op2->right), MPFI_RNDU);
++        tmp = mpfr_div (tmp1, &(op1->right), &(op2->right), MPFI_RNDU);
+       }
+       else { /* denominator has infinite right endpoint */
+-        mpfr_set_zero( &(tmp1), -1);
++        mpfr_set_zero(tmp1, -1);
+       }
+ 
+       mpfr_set_inf (&(res1->left), -1);
+@@ -86,17 +86,17 @@ mpfi_div_ext (mpfi_ptr res1, mpfi_ptr res2, mpfi_srcptr op1, mpfi_srcptr op2)
+       mpfr_init2 (tmp1, mpfi_get_prec(res1));
+       mpfr_init2 (tmp2, mpfi_get_prec(res2));
+       if ( mpfr_number_p (&(op2->left)) ) {
+-        tmp = mpfr_div (&(tmp1), &(op1->left), &(op2->left), MPFI_RNDU);
++        tmp = mpfr_div (tmp1, &(op1->left), &(op2->left), MPFI_RNDU);
+       }
+       else { /* denominator has infinite left endpoint */
+-        mpfr_set_zero (&(tmp1), -1);
++        mpfr_set_zero (tmp1, -1);
+       }
+ 
+       if ( mpfr_number_p (&(op2->right)) ) {
+-        tmp = mpfr_div ( &(tmp2), &(op1->left), &(op2->right), MPFI_RNDD);
++        tmp = mpfr_div (tmp2, &(op1->left), &(op2->right), MPFI_RNDD);
+       }
+       else { /* denominator has infinite right endpoint */
+-        mpfr_set_zero( &(tmp2), 1);
++        mpfr_set_zero(tmp2, 1);
+       }
+       mpfr_set_inf (&(res1->left), -1);
+       mpfr_set (&(res1->right), tmp1, MPFI_RNDU);
+-- 
+2.51.0
+

--- a/runtime-scientific/mpfi/spec
+++ b/runtime-scientific/mpfi/spec
@@ -1,4 +1,5 @@
 VER=1.5.4
-SRCS="tbl::https://github.com/arpra-project/mpfi/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::32e6ad529c97aa5ce03e28d01c921d1bce1a464fb4c57fbc248d7be21e652782"
+REL=1
+SRCS="git::commit=tags/${VER}::https://github.com/arpra-project/mpfi"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230458"


### PR DESCRIPTION
Topic Description
-----------------

- mpfi: fix build with GCC>=14
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- mpfi: 1.5.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpfi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
