### PR TITLE
typst: update to 0.14.0

### DIFF
--- a/app-doc/typst/autobuild/build
+++ b/app-doc/typst/autobuild/build
@@ -1,0 +1,8 @@
+# NOTE: Build and install the binary manually to prevent compile-time helper
+# binaries being installed
+abinfo "Building Typst ..."
+cargo build --release --locked
+
+abinfo "Installing Typst ..."
+install -Dvm755 "$SRCDIR"/target/release/typst -t \
+    "$PKGDIR"/usr/bin/

--- a/app-doc/typst/autobuild/defines
+++ b/app-doc/typst/autobuild/defines
@@ -4,10 +4,4 @@ PKGDES="A markup-based typsetting system"
 BUILDDEP="rustc llvm"
 
 PKGEPOCH=1
-
 USECLANG=1
-ABSPLITDBG=0
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1

--- a/app-doc/typst/spec
+++ b/app-doc/typst/spec
@@ -1,4 +1,4 @@
-VER=0.13.1
+VER=0.14.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/typst/typst"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=332526"


### PR DESCRIPTION
Topic Description
-----------------

- typst: update to 0.14.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- typst: 1:0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit typst
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
