### PR TITLE
fontconfig: remove unconditional call to systemctl enable

### DIFF
--- a/runtime-data/aosc-os-presets-desktop/autobuild/build
+++ b/runtime-data/aosc-os-presets-desktop/autobuild/build
@@ -25,6 +25,9 @@ if ab_match_arch loongarch64; then
 
 # LoongGPU OpenGL runtime switching service
 enable loonggl-sw.service
+
+# Fontconfig cache generation
+enable fc-cache.service
 EOF
 fi
 

--- a/runtime-data/aosc-os-presets-desktop/spec
+++ b/runtime-data/aosc-os-presets-desktop/spec
@@ -1,2 +1,2 @@
-VER=7
+VER=8
 DUMMYSRC=1

--- a/runtime-desktop/fontconfig/autobuild/beyond
+++ b/runtime-desktop/fontconfig/autobuild/beyond
@@ -1,5 +1,7 @@
+abinfo "Enabling 25-unhint-nonlatin ..."
 cd "$PKGDIR"/etc/fonts/conf.d
 ln -sv ../conf.avail/25-unhint-nonlatin.conf .
 cd "$SRCDIR"
 
-rm "$PKGDIR"/etc/fonts/conf.d/45-latin.conf
+abinfo "Dropping unused 45-latin ..."
+rm -v "$PKGDIR"/etc/fonts/conf.d/45-latin.conf

--- a/runtime-desktop/fontconfig/autobuild/defines
+++ b/runtime-desktop/fontconfig/autobuild/defines
@@ -11,33 +11,28 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
-PKGDES="A library for configuring and customizing font access"
+PKGDES="Library for configuring and customizing font access"
 
 AB_FLAGS_O3=1
 
 ABTYPE=meson
-MESON_AFTER="-Ddoc=enabled \
-             -Ddoc-txt=disabled \
-             -Ddoc-man=enabled \
-             -Ddoc-pdf=disabled \
-             -Ddoc-html=disabled \
-             -Dnls=enabled \
-             -Dtools=enabled \
-             -Dcache-build=disabled"
-MESON_AFTER__RETRO=" \
-             ${MESON_AFTER} \
-             -Ddoc=disabled \
-             -Ddoc-txt=disabled \
-             -Ddoc-man=disabled \
-             -Ddoc-pdf=disabled \
-             -Ddoc-html=disabled"
-MESON_AFTER__ARMV4="${MESON_AFTER__RETRO}"
-MESON_AFTER__ARMV6HF="${MESON_AFTER__RETRO}"
-MESON_AFTER__ARMV7HF="${MESON_AFTER__RETRO}"
-MESON_AFTER__I486="${MESON_AFTER__RETRO}"
-MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO}"
-MESON_AFTER__M68K="${MESON_AFTER__RETRO}"
-MESON_AFTER__POWERPC="${MESON_AFTER__RETRO}"
-MESON_AFTER__PPC64="${MESON_AFTER__RETRO}"
+MESON_AFTER=(
+    '-Ddoc=enabled'
+    '-Ddoc-txt=disabled'
+    '-Ddoc-man=enabled'
+    '-Ddoc-pdf=disabled'
+    '-Ddoc-html=disabled'
+    '-Dnls=enabled'
+    '-Dtools=enabled'
+    '-Dcache-build=disabled'
+)
+MESON_AFTER__RETRO=(
+    "${MESON_AFTER[@]}"
+    '-Ddoc=disabled'
+    '-Ddoc-txt=disabled'
+    '-Ddoc-man=disabled'
+    '-Ddoc-pdf=disabled'
+    '-Ddoc-html=disabled'
+)
 
 PKGEPOCH=1

--- a/runtime-desktop/fontconfig/autobuild/defines.stage2
+++ b/runtime-desktop/fontconfig/autobuild/defines.stage2
@@ -2,18 +2,20 @@ PKGNAME=fontconfig
 PKGSEC=x11
 PKGDEP="freetype expat"
 BUILDDEP="gperf"
-PKGDES="A library for configuring and customizing font access"
+PKGDES="Library for configuring and customizing font access"
 
 AB_FLAGS_O3=1
 
 ABTYPE=meson
-MESON_AFTER="-Ddoc=disabled \
-             -Ddoc-txt=disabled \
-             -Ddoc-man=disabled \
-             -Ddoc-pdf=disabled \
-             -Ddoc-html=disabled \
-             -Dnls=enabled \
-             -Dtools=enabled \
-             -Dcache-build=disabled"
+MESON_AFTER=(
+    '-Ddoc=disabled'
+    '-Ddoc-txt=disabled'
+    '-Ddoc-man=disabled'
+    '-Ddoc-pdf=disabled'
+    '-Ddoc-html=disabled'
+    '-Dnls=enabled'
+    '-Dtools=enabled'
+    '-Dcache-build=disabled'
+)
 
 PKGEPOCH=1

--- a/runtime-desktop/fontconfig/autobuild/postinst
+++ b/runtime-desktop/fontconfig/autobuild/postinst
@@ -1,6 +1,2 @@
 echo "Generating fontconfig cache, may take a while..."
 fc-cache -s
-
-if [[ -x /usr/bin/systemctl ]]; then
-	systemctl enable fc-cache
-fi

--- a/runtime-desktop/fontconfig/spec
+++ b/runtime-desktop/fontconfig/spec
@@ -1,5 +1,5 @@
 VER=2.15.0
-REL=1
+REL=2
 SRCS="tbl::https://www.freedesktop.org/software/fontconfig/release/fontconfig-$VER.tar.xz"
 CHKSUMS="sha256::63a0658d0e06e0fa886106452b58ef04f21f58202ea02a94c39de0d3335d7c0e"
 CHKUPDATE="anitya::id=827"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-presets-desktop: enable fc-cache.service
- fontconfig: remove unconditional call to systemctl enable
    This should be handled in preset \(and will be with
    aosc-os-presets-desktop\). If a service were to be enabled in postinst and
    such an \`systemctl enable' call were to be made via a dpkg trigger during
    OOBE/firstboot, it causes a call to \`systemctl daemon-reload', which would
    terminate oneshot services such as our OOBE service as it times out after
    the reload.
    Remove this call from postinst to prevent this issue \(and that it would be
    more appropriate\).

Package(s) Affected
-------------------

- aosc-os-presets-desktop: 8
- fontconfig: 1:2.15.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fontconfig aosc-os-presets-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
