### PR TITLE
qt-6: backport additional patches to fix QtWebEngine on Nouveau + Mesa 25.2

### DIFF
--- a/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
@@ -1,7 +1,7 @@
 From 038aa7bd14f5ce8fe93515999bb330a5aaf91ffc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:21:53 +0800
-Subject: [PATCH 1/5] ARCHLINUX: qtbase: respect system compiler/linker flags
+Subject: [PATCH 01/13] ARCHLINUX: qtbase: respect system compiler/linker flags
 
 Link: https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-base/-/blob/e82d4f8ad5231cdecbb7dd75a8fcaabdc201ac35/qt6-base-cflags.patch
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
@@ -1,7 +1,7 @@
 From 7b2c4dac8ff1a3209d96980953374c0ebe188910 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Mon, 1 Jul 2024 11:22:43 +0800
-Subject: [PATCH 2/5] FEDORA: qt3d: assimp: fix build with GCC >= 13
+Subject: [PATCH 02/13] FEDORA: qt3d: assimp: fix build with GCC >= 13
 
 Link: https://src.fedoraproject.org/rpms/qt6-qt3d/blob/072094f3e7e698321b92eafcb297111ba42eed15/f/qt3d-assimp-fix-build.patch
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
@@ -1,7 +1,7 @@
 From d617be4706af2bd5d5228b39d3ee79ca2c727978 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Wed, 26 Jun 2024 22:16:10 +0800
-Subject: [PATCH 3/5] AOSCOS: qtbase: fallback to GLES if GL EGL context
+Subject: [PATCH 03/13] AOSCOS: qtbase: fallback to GLES if GL EGL context
  creation failed
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

--- a/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
+++ b/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
@@ -1,8 +1,8 @@
 From c97c65c99bbabf2d80440626959aeac769c62898 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 22 Sep 2025 13:10:18 +0800
-Subject: [PATCH 4/5] AOSCOS: LOONGARCH64: qtwebengine: chromium: add LoongArch
- support
+Subject: [PATCH 04/13] AOSCOS: LOONGARCH64: qtwebengine: chromium: add
+ LoongArch support
 
 Co-authored-by: Jiajie Chen <c@jia.je>
 

--- a/runtime-desktop/qt-6/01-runtime/patches/0005-UPSTREAM-Return-to-supporting-eglCreateImage-in-EGLH.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0005-UPSTREAM-Return-to-supporting-eglCreateImage-in-EGLH.patch
@@ -1,7 +1,7 @@
 From 3868dbdef014e76978b5c28cb0a141914a9f329b Mon Sep 17 00:00:00 2001
 From: Moss Heim <moss.heim@qt.io>
 Date: Thu, 11 Sep 2025 13:47:04 +0200
-Subject: [PATCH 5/5] UPSTREAM: Return to supporting eglCreateImage in
+Subject: [PATCH 05/13] UPSTREAM: Return to supporting eglCreateImage in
  EGLHelper::queryDmaBuf
 
 eglCreateDRMImageMESA was removed in mesa 25.2.

--- a/runtime-desktop/qt-6/01-runtime/patches/0006-UPSTREAM-Add-GBM-information-to-context-log.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0006-UPSTREAM-Add-GBM-information-to-context-log.patch
@@ -1,0 +1,27 @@
+From 4c5b62e3994d9baa529b9f49109961b5c72de391 Mon Sep 17 00:00:00 2001
+From: Peter Varga <pvarga@inf.u-szeged.hu>
+Date: Tue, 13 May 2025 16:51:29 +0200
+Subject: [PATCH 06/13] UPSTREAM: Add GBM information to context log
+
+Pick-to: 6.10
+Change-Id: Ia2c07b887be65da0b45febc29c339e6a3b1e46bc
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+---
+ qtwebengine/src/core/web_engine_context.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index bf26e18f20..a6e050d0d7 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -446,6 +446,7 @@ static void logContext(const std::string &glType, base::CommandLine *cmd)
+ #if BUILDFLAG(IS_OZONE)
+         log += "Using GLX: "_L1 + (OzoneUtilQt::usingGLX() ? "yes"_L1 : "no"_L1) + u'\n';
+         log += "Using EGL: "_L1 + (OzoneUtilQt::usingEGL() ? "yes"_L1 : "no"_L1) + u'\n';
++        log += "Using GBM: "_L1 + (WebEngineContext::isGbmSupported() ? "yes"_L1 : "no"_L1) + u'\n';
+ #endif // BUILDFLAG(IS_OZONE)
+         log += "Using Shared GL: "_L1 + (QOpenGLContext::globalShareContext() ? "yes"_L1 : "no"_L1)
+                 + u'\n';
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0007-UPSTREAM-Remove-enable-webgl-software-rendering.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0007-UPSTREAM-Remove-enable-webgl-software-rendering.patch
@@ -1,0 +1,102 @@
+From 22f5c18762194cef83adf486705099f8a1985266 Mon Sep 17 00:00:00 2001
+From: Peter Varga <pvarga@inf.u-szeged.hu>
+Date: Wed, 14 May 2025 13:08:16 +0200
+Subject: [PATCH 07/13] UPSTREAM: Remove --enable-webgl-software-rendering
+
+Most probably it is useless with the new default ANGLE backend.
+The original code has been trimmed and now it is just equivalent with
+passing the following command line arguments:
+--webEngineArgs --disable-gpu-rasterization --ignore-gpu-blocklist
+
+As a drive-by, change WebEngineContext::initCommandLine() parameter to
+pointer instead of reference to make it clear on the caller side it will
+not use but it is expected to change the parameter's value.
+
+Pick-to: 6.10
+Change-Id: Ic118fa55071c5d8ac0730db2f640c3132375db8b
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+---
+ qtwebengine/src/core/web_engine_context.cpp | 22 +++++----------------
+ qtwebengine/src/core/web_engine_context.h   |  3 +--
+ 2 files changed, 6 insertions(+), 19 deletions(-)
+
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index a6e050d0d7..92774bde98 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -813,10 +813,8 @@ WebEngineContext::WebEngineContext()
+     // Allow us to inject javascript like any webview toolkit.
+     content::RenderFrameHost::AllowInjectingJavaScript();
+ 
+-    bool useEmbeddedSwitches = false;
+-    bool enableGLSoftwareRendering = false;
+-    base::CommandLine *parsedCommandLine =
+-            initCommandLine(useEmbeddedSwitches, enableGLSoftwareRendering);
++    bool useEmbeddedSwitches;
++    base::CommandLine *parsedCommandLine = initCommandLine(&useEmbeddedSwitches);
+ 
+     setupProxyPac(parsedCommandLine);
+     parsedCommandLine->AppendSwitchPath(switches::kBrowserSubprocessPath, WebEngineLibraryInfo::getPath(content::CHILD_PROCESS_EXE));
+@@ -946,10 +944,6 @@ WebEngineContext::WebEngineContext()
+ 
+     initializeFeatureList(parsedCommandLine, enableFeatures, disableFeatures);
+ 
+-    // If user requested GL support instead of using Skia rendering to
+-    // bitmaps, use software rendering via software OpenGL. This might be less
+-    // performant, but at least provides WebGL support.
+-    // TODO(miklocek), check if this still works with latest chromium
+     const bool disableGpu = parsedCommandLine->HasSwitch(switches::kDisableGpu);
+     std::string glType;
+     if (parsedCommandLine->HasSwitch(switches::kUseGL))
+@@ -962,10 +956,6 @@ WebEngineContext::WebEngineContext()
+     parsedCommandLine->AppendSwitch(switches::kInProcessGPU);
+ 
+     if (glType != gl::kGLImplementationDisabledName) {
+-        if (enableGLSoftwareRendering) {
+-            parsedCommandLine->AppendSwitch(switches::kDisableGpuRasterization);
+-            parsedCommandLine->AppendSwitch(switches::kIgnoreGpuBlocklist);
+-        }
+         if (glType != gl::kGLImplementationANGLEName) {
+             qWarning("Only --use-gl=angle is supported on this platform.");
+         }
+@@ -1066,8 +1056,7 @@ printing::PrintJobManager* WebEngineContext::getPrintJobManager()
+ }
+ #endif
+ 
+-base::CommandLine *WebEngineContext::initCommandLine(bool &useEmbeddedSwitches,
+-                                                     bool &enableGLSoftwareRendering)
++base::CommandLine *WebEngineContext::initCommandLine(bool *useEmbeddedSwitches)
+ {
+     if (!base::CommandLine::CreateEmpty())
+         qFatal("base::CommandLine has been initialized unexpectedly.");
+@@ -1094,11 +1083,10 @@ base::CommandLine *WebEngineContext::initCommandLine(bool &useEmbeddedSwitches,
+         }
+     }
+ #if defined(QTWEBENGINE_EMBEDDED_SWITCHES)
+-    useEmbeddedSwitches = !appArgs.contains("--disable-embedded-switches"_L1);
++    *useEmbeddedSwitches = !appArgs.contains("--disable-embedded-switches"_L1);
+ #else
+-    useEmbeddedSwitches = appArgs.contains("--enable-embedded-switches"_L1);
++    *useEmbeddedSwitches = appArgs.contains("--enable-embedded-switches"_L1);
+ #endif
+-    enableGLSoftwareRendering = appArgs.removeAll("--enable-webgl-software-rendering"_L1);
+     appArgs.removeAll("--disable-embedded-switches"_L1);
+     appArgs.removeAll("--enable-embedded-switches"_L1);
+ 
+diff --git a/qtwebengine/src/core/web_engine_context.h b/qtwebengine/src/core/web_engine_context.h
+index 6f2bf04c4b..f95f582487 100644
+--- a/qtwebengine/src/core/web_engine_context.h
++++ b/qtwebengine/src/core/web_engine_context.h
+@@ -80,8 +80,7 @@ public:
+     void removeProfileAdapter(ProfileAdapter *profileAdapter);
+     bool profileExistOnPath(const QString &dataPath);
+     void destroy();
+-    static base::CommandLine *initCommandLine(bool &useEmbeddedSwitches,
+-                                              bool &enableGLSoftwareRendering);
++    static base::CommandLine *initCommandLine(bool *useEmbeddedSwitches);
+ 
+ private:
+     friend class base::RefCounted<WebEngineContext>;
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0008-UPSTREAM-Clean-up-GL-and-Vulkan-type-detection.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0008-UPSTREAM-Clean-up-GL-and-Vulkan-type-detection.patch
@@ -1,0 +1,407 @@
+From a4feef4e4d30599738dbf806acc0f884d1505a6f Mon Sep 17 00:00:00 2001
+From: Peter Varga <pvarga@inf.u-szeged.hu>
+Date: Wed, 14 May 2025 12:53:34 +0200
+Subject: [PATCH 08/13] UPSTREAM: Clean up GL and Vulkan type detection
+
+Pick-to: 6.10
+Change-Id: I7add950538fb8782257de0eff45d8ee1b2010a9a
+Reviewed-by: Moss Heim <moss.heim@qt.io>
+---
+ qtwebengine/src/core/web_engine_context.cpp | 205 ++++++++++++--------
+ 1 file changed, 122 insertions(+), 83 deletions(-)
+
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index 92774bde98..074accb6cf 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -353,6 +353,22 @@ private:
+     QString m_adapterLuid;
+ };
+ 
++static bool isFeatureEnabled(const std::string &feature, const base::CommandLine &commandLine)
++{
++    auto isInFeatureList = [&feature, commandLine](const std::string_view featuresSwitch) -> bool {
++        if (!commandLine.HasSwitch(featuresSwitch))
++            return false;
++
++        std::string featuresString = commandLine.GetSwitchValueASCII(featuresSwitch);
++        std::vector<std::string> features = base::SplitString(
++                featuresString, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++        return std::find(features.begin(), features.end(), feature) != features.end();
++    };
++
++    return !isInFeatureList(switches::kDisableFeatures)
++            && isInFeatureList(switches::kEnableFeatures);
++}
++
+ static bool usingSupportedSGBackend()
+ {
+     if (QQuickWindow::graphicsApi() != QSGRendererInterface::OpenGL
+@@ -381,37 +397,45 @@ static bool usingSupportedSGBackend()
+     return device.isEmpty() || device == "rhi"_L1;
+ }
+ 
+-static std::string getGLType(bool disableGpu)
++static std::string getGLType(const base::CommandLine &cmd)
+ {
+-    if (disableGpu || !usingSupportedSGBackend())
++    if (cmd.HasSwitch(switches::kUseGL))
++        return cmd.GetSwitchValueASCII(switches::kUseGL);
++
++    if (!usingSupportedSGBackend() || cmd.HasSwitch(switches::kDisableGpu))
+         return gl::kGLImplementationDisabledName;
+ 
+     return gl::kGLImplementationANGLEName;
+ }
+ 
+-static std::string getVulkanType(base::CommandLine *cmd)
++static bool isGLTypeSupported(const std::string &glType)
++{
++    if (glType == gl::kGLImplementationANGLEName || glType == gl::kGLImplementationDisabledName)
++        return true;
++
++    return false;
++}
++
++static std::string getVulkanType(const base::CommandLine &cmd)
+ {
+ #if QT_CONFIG(webengine_vulkan)
+-    if (cmd->HasSwitch(switches::kUseVulkan))
+-        return cmd->GetSwitchValueASCII(switches::kUseVulkan);
++    if (isFeatureEnabled(features::kVulkan.name, cmd)) {
++        if (cmd.HasSwitch(switches::kUseVulkan))
++            return cmd.GetSwitchValueASCII(switches::kUseVulkan);
++        return switches::kVulkanImplementationNameNative;
++    }
+ #endif
+ 
+     return "disabled";
+ }
+ 
+-static std::string getAngleType(const std::string &glType, base::CommandLine *cmd)
++static std::string getANGLEType(const base::CommandLine &cmd)
+ {
+-    if (glType == gl::kGLImplementationANGLEName) {
+-        if (cmd->HasSwitch(switches::kUseANGLE))
+-            return cmd->GetSwitchValueASCII(switches::kUseANGLE);
++    if (getGLType(cmd) == gl::kGLImplementationANGLEName) {
++        if (cmd.HasSwitch(switches::kUseANGLE))
++            return cmd.GetSwitchValueASCII(switches::kUseANGLE);
+ 
+-#if defined(Q_OS_WIN)
+-        return gl::kANGLEImplementationD3D11Name;
+-#elif defined(Q_OS_MACOS)
+-        return gl::kANGLEImplementationMetalName;
+-#else
+         return gl::kANGLEImplementationDefaultName;
+-#endif
+     }
+ 
+     return "disabled";
+@@ -423,14 +447,14 @@ void dummyGetPluginCallback(const std::vector<content::WebPluginInfo>&)
+ }
+ #endif
+ 
+-static void logContext(const std::string &glType, base::CommandLine *cmd)
++static void logContext(const base::CommandLine &cmd)
+ {
+     if (Q_UNLIKELY(webEngineContextLog().isDebugEnabled())) {
+         QString log;
+         log += u'\n';
+ 
+-        log += "Chromium GL Backend: "_L1 + QLatin1StringView(glType) + "\n"_L1;
+-        log += "Chromium ANGLE Backend: "_L1 + QLatin1StringView(getAngleType(glType, cmd)) + u'\n';
++        log += "Chromium GL Backend: "_L1 + QLatin1StringView(getGLType(cmd)) + u'\n';
++        log += "Chromium ANGLE Backend: "_L1 + QLatin1StringView(getANGLEType(cmd)) + u'\n';
+         log += "Chromium Vulkan Backend: "_L1 + QLatin1StringView(getVulkanType(cmd)) + u'\n';
+         log += u'\n';
+ 
+@@ -454,7 +478,7 @@ static void logContext(const std::string &glType, base::CommandLine *cmd)
+ #endif // QT_CONFIG(opengl)
+ 
+         log += "Init Parameters:\n"_L1;
+-        const base::CommandLine::SwitchMap switchMap = cmd->GetSwitches();
++        const base::CommandLine::SwitchMap switchMap = cmd.GetSwitches();
+         for (const auto &pair : switchMap)
+             log += " *  "_L1 + toQt(pair.first) + u' ' + toQt(pair.second) + u'\n';
+ 
+@@ -464,10 +488,10 @@ static void logContext(const std::string &glType, base::CommandLine *cmd)
+ 
+ extern std::unique_ptr<base::MessagePump> messagePumpFactory();
+ 
+-static void setupProxyPac(base::CommandLine *commandLine)
++static void setupProxyPac(base::CommandLine &commandLine)
+ {
+-    if (commandLine->HasSwitch(switches::kProxyPacUrl)) {
+-        QUrl pac_url(toQt(commandLine->GetSwitchValueASCII(switches::kProxyPacUrl)));
++    if (commandLine.HasSwitch(switches::kProxyPacUrl)) {
++        QUrl pac_url(toQt(commandLine.GetSwitchValueASCII(switches::kProxyPacUrl)));
+         if (pac_url.isValid()
+             && (pac_url.isLocalFile()
+                 || !pac_url.scheme().compare("qrc"_L1, Qt::CaseInsensitive))) {
+@@ -478,9 +502,12 @@ static void setupProxyPac(base::CommandLine *commandLine)
+                 file.setFileName(pac_url.path().prepend(QLatin1Char(':')));
+             if (file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                 const QByteArray ba = file.readAll();
+-                commandLine->RemoveSwitch(switches::kProxyPacUrl);
+-                commandLine->AppendSwitchASCII(switches::kProxyPacUrl,
+-                        ba.toBase64().prepend("data:application/x-javascript-config;base64,").toStdString());
++                commandLine.RemoveSwitch(switches::kProxyPacUrl);
++                commandLine.AppendSwitchASCII(
++                        switches::kProxyPacUrl,
++                        ba.toBase64()
++                                .prepend("data:application/x-javascript-config;base64,")
++                                .toStdString());
+             }
+         }
+     }
+@@ -741,11 +768,14 @@ ProxyAuthentication WebEngineContext::qProxyNetworkAuthentication(QString host,
+ const static char kChromiumFlagsEnv[] = "QTWEBENGINE_CHROMIUM_FLAGS";
+ const static char kDisableSandboxEnv[] = "QTWEBENGINE_DISABLE_SANDBOX";
+ 
+-static void initializeFeatureList(base::CommandLine *commandLine, std::vector<std::string> enableFeatures, std::vector<std::string> disableFeatures)
++static void initializeFeatureList(base::CommandLine &commandLine,
++                                  std::vector<std::string> enableFeatures,
++                                  std::vector<std::string> disableFeatures)
+ {
+     std::string enableFeaturesString = base::JoinString(enableFeatures, ",");
+-    if (commandLine->HasSwitch(switches::kEnableFeatures)) {
+-        std::string commandLineEnableFeatures = commandLine->GetSwitchValueASCII(switches::kEnableFeatures);
++    if (commandLine.HasSwitch(switches::kEnableFeatures)) {
++        std::string commandLineEnableFeatures =
++                commandLine.GetSwitchValueASCII(switches::kEnableFeatures);
+ 
+         for (const std::string &enableFeature : base::SplitString(commandLineEnableFeatures, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+             auto it = std::find(disableFeatures.begin(), disableFeatures.end(), enableFeature);
+@@ -764,8 +794,9 @@ static void initializeFeatureList(base::CommandLine *commandLine, std::vector<st
+     }
+ 
+     std::string disableFeaturesString = base::JoinString(disableFeatures, ",");
+-    if (commandLine->HasSwitch(switches::kDisableFeatures)) {
+-        std::string commandLineDisableFeatures = commandLine->GetSwitchValueASCII(switches::kDisableFeatures);
++    if (commandLine.HasSwitch(switches::kDisableFeatures)) {
++        std::string commandLineDisableFeatures =
++                commandLine.GetSwitchValueASCII(switches::kDisableFeatures);
+ 
+         for (const std::string &disableFeature : base::SplitString(commandLineDisableFeatures, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+             auto it = std::find(enableFeatures.begin(), enableFeatures.end(), disableFeature);
+@@ -779,8 +810,8 @@ static void initializeFeatureList(base::CommandLine *commandLine, std::vector<st
+         disableFeaturesString = disableFeaturesString + "," + commandLineDisableFeatures;
+     }
+ 
+-    commandLine->AppendSwitchASCII(switches::kEnableFeatures, enableFeaturesString);
+-    commandLine->AppendSwitchASCII(switches::kDisableFeatures, disableFeaturesString);
++    commandLine.AppendSwitchASCII(switches::kEnableFeatures, enableFeaturesString);
++    commandLine.AppendSwitchASCII(switches::kDisableFeatures, disableFeaturesString);
+     base::FeatureList::InitInstance(enableFeaturesString, disableFeaturesString);
+ }
+ 
+@@ -814,26 +845,29 @@ WebEngineContext::WebEngineContext()
+     content::RenderFrameHost::AllowInjectingJavaScript();
+ 
+     bool useEmbeddedSwitches;
+-    base::CommandLine *parsedCommandLine = initCommandLine(&useEmbeddedSwitches);
++    base::CommandLine &parsedCommandLine = *initCommandLine(&useEmbeddedSwitches);
+ 
+     setupProxyPac(parsedCommandLine);
+-    parsedCommandLine->AppendSwitchPath(switches::kBrowserSubprocessPath, WebEngineLibraryInfo::getPath(content::CHILD_PROCESS_EXE));
++    parsedCommandLine.AppendSwitchPath(switches::kBrowserSubprocessPath,
++                                       WebEngineLibraryInfo::getPath(content::CHILD_PROCESS_EXE));
+ 
+-    parsedCommandLine->AppendSwitchASCII(switches::kApplicationName, QCoreApplication::applicationName().toUtf8().toPercentEncoding().toStdString());
++    parsedCommandLine.AppendSwitchASCII(
++            switches::kApplicationName,
++            QCoreApplication::applicationName().toUtf8().toPercentEncoding().toStdString());
+ 
+     // Enable sandboxing on OS X and Linux (Desktop / Embedded) by default.
+     bool disable_sandbox = qEnvironmentVariableIsSet(kDisableSandboxEnv);
+     if (!disable_sandbox) {
+ #if defined(Q_OS_LINUX)
+-        parsedCommandLine->AppendSwitch(sandbox::policy::switches::kDisableSetuidSandbox);
++        parsedCommandLine.AppendSwitch(sandbox::policy::switches::kDisableSetuidSandbox);
+ #endif
+     } else {
+-        parsedCommandLine->AppendSwitch(sandbox::policy::switches::kNoSandbox);
++        parsedCommandLine.AppendSwitch(sandbox::policy::switches::kNoSandbox);
+         qInfo("Sandboxing disabled by user.");
+     }
+ 
+     // Do not advertise a feature we have removed at compile time
+-    parsedCommandLine->AppendSwitch(switches::kDisableSpeechAPI);
++    parsedCommandLine.AppendSwitch(switches::kDisableSpeechAPI);
+ 
+     std::vector<std::string> disableFeatures;
+     std::vector<std::string> enableFeatures;
+@@ -847,19 +881,19 @@ WebEngineContext::WebEngineContext()
+ 
+     // By default the Touch Events API support (presence of 'ontouchstart' in 'window' object)
+     // will be determined based on the availability of touch screen devices.
+-    if (!parsedCommandLine->HasSwitch(switches::kTouchEventFeatureDetection))
+-        parsedCommandLine->AppendSwitchASCII(switches::kTouchEventFeatureDetection,
+-                                             switches::kTouchEventFeatureDetectionAuto);
++    if (!parsedCommandLine.HasSwitch(switches::kTouchEventFeatureDetection))
++        parsedCommandLine.AppendSwitchASCII(switches::kTouchEventFeatureDetection,
++                                            switches::kTouchEventFeatureDetectionAuto);
+ 
+     // Not implemented but it overrides the devtools eyedropper
+     // Should be sync with kEyeDropper base::Feature
+-    parsedCommandLine->AppendSwitchASCII(switches::kDisableBlinkFeatures, "EyeDropperAPI");
++    parsedCommandLine.AppendSwitchASCII(switches::kDisableBlinkFeatures, "EyeDropperAPI");
+     disableFeatures.push_back(features::kEyeDropper.name);
+ 
+     // Explicitly tell Chromium about default-on features we do not support
+     disableFeatures.push_back(features::kBackgroundFetch.name);
+     disableFeatures.push_back(features::kInstalledApp.name);
+-    parsedCommandLine->AppendSwitchASCII(switches::kDisableBlinkFeatures, "WebOTP");
++    parsedCommandLine.AppendSwitchASCII(switches::kDisableBlinkFeatures, "WebOTP");
+     disableFeatures.push_back(features::kWebOTP.name);
+     disableFeatures.push_back(features::kWebPayments.name);
+     disableFeatures.push_back(features::kWebUsb.name);
+@@ -871,38 +905,59 @@ WebEngineContext::WebEngineContext()
+     if (useEmbeddedSwitches) {
+         // embedded switches are based on the switches for Android, see content/browser/android/content_startup_flags.cc
+         enableFeatures.push_back(features::kOverlayScrollbar.name);
+-        parsedCommandLine->AppendSwitch(switches::kEnableViewport);
+-        parsedCommandLine->AppendSwitch(input::switches::kValidateInputEventStream);
+-        parsedCommandLine->AppendSwitch(cc::switches::kDisableCompositedAntialiasing);
++        parsedCommandLine.AppendSwitch(switches::kEnableViewport);
++        parsedCommandLine.AppendSwitch(input::switches::kValidateInputEventStream);
++        parsedCommandLine.AppendSwitch(cc::switches::kDisableCompositedAntialiasing);
+     }
+ 
+ #if BUILDFLAG(IS_OZONE)
+     if (!isGbmSupported()) {
+         disableFeatures.push_back(media::kVaapiVideoDecodeLinux.name);
+-        parsedCommandLine->AppendSwitch(switches::kDisableGpuMemoryBufferVideoFrames);
++        parsedCommandLine.AppendSwitch(switches::kDisableGpuMemoryBufferVideoFrames);
+     }
++#endif
++
++    // Init GPU switches.
++    parsedCommandLine.AppendSwitch(switches::kInProcessGPU);
++
++    std::string glType = getGLType(parsedCommandLine);
++    // Always set --use-gl.
++    if (!parsedCommandLine.HasSwitch(switches::kUseGL))
++        parsedCommandLine.AppendSwitchASCII(switches::kUseGL, glType);
++
++    if (glType == gl::kGLImplementationDisabledName) {
++        // Always set --disable-gpu to avoid unexpected GL contexts, see QTBUG-128784.
++        if (!parsedCommandLine.HasSwitch(switches::kDisableGpu))
++            parsedCommandLine.AppendSwitch(switches::kDisableGpu);
++    } else {
++        // Warn on custom --use-gl if hardware rendering is disabled.
++        if (!usingSupportedSGBackend())
++            qWarning("--use-gl=%s is set with unsupported SceneGraph Backend. Expect troubles!",
++                     glType.c_str());
+ 
+-    bool usingANGLE = true;
+-    // ANGLE is the default but it can be overridden from command line.
+-    if (parsedCommandLine->HasSwitch(switches::kUseGL)) {
+-        usingANGLE = (parsedCommandLine->GetSwitchValueASCII(switches::kUseGL)
+-                      == gl::kGLImplementationANGLEName);
++        if (parsedCommandLine.HasSwitch(switches::kDisableGpu))
++            qWarning("--use-gl=%s is set with --disable-gpu. Expect troubles!", glType.c_str());
+     }
+ 
+-#if QT_CONFIG(webengine_vulkan)
++#if BUILDFLAG(IS_OZONE) && QT_CONFIG(webengine_vulkan)
+     if (QQuickWindow::graphicsApi() == QSGRendererInterface::OpenGL && usingSupportedSGBackend()) {
+-        if (usingANGLE && !isGbmSupported()) {
++        const bool disableGpu = parsedCommandLine.HasSwitch(switches::kDisableGpu);
++        const bool usingVulkan = isFeatureEnabled(features::kVulkan.name, parsedCommandLine);
++        if (!disableGpu && !usingVulkan && !isGbmSupported()) {
+             qWarning("GBM is not supported with the current configuration. "
+                      "Fallback to Vulkan rendering in Chromium.");
+-            parsedCommandLine->AppendSwitchASCII(switches::kUseVulkan,
+-                                                 switches::kVulkanImplementationNameNative);
++            parsedCommandLine.AppendSwitchASCII(switches::kUseVulkan,
++                                                switches::kVulkanImplementationNameNative);
+             enableFeatures.push_back(features::kVulkan.name);
+         }
+     }
+ 
+     if (QQuickWindow::graphicsApi() == QSGRendererInterface::Vulkan && usingSupportedSGBackend()) {
+-        parsedCommandLine->AppendSwitchASCII(switches::kUseVulkan,
+-                                             switches::kVulkanImplementationNameNative);
++        // TODO: Try not to force Chromium's Vulkan backend on Linux.
++        //       Currently we force it because OzoneImageBackingFactory does not support to create
++        //       SharedImage in RGBA8888 format under GLX.
++        parsedCommandLine.AppendSwitchASCII(switches::kUseVulkan,
++                                            switches::kVulkanImplementationNameNative);
+         enableFeatures.push_back(features::kVulkan.name);
+ 
+         const char deviceExtensionsVar[] = "QT_VULKAN_DEVICE_EXTENSIONS";
+@@ -926,15 +981,14 @@ WebEngineContext::WebEngineContext()
+             qputenv(deviceExtensionsVar, requiredDeviceExtensions.join(';'));
+         }
+     }
+-#endif // QT_CONFIG(webengine_vulkan)
+-#endif // BUILDFLAG(IS_OZONE)
++#endif // BUILDFLAG(IS_OZONE) && QT_CONFIG(webengine_vulkan)
+ 
+ #if defined(Q_OS_WIN)
+     if (QQuickWindow::graphicsApi() == QSGRendererInterface::Direct3D11
+         || QQuickWindow::graphicsApi() == QSGRendererInterface::Vulkan) {
+         const QString luid = GPUInfo::instance()->getAdapterLuid();
+         if (!luid.isEmpty())
+-            parsedCommandLine->AppendSwitchASCII(switches::kUseAdapterLuid, luid.toStdString());
++            parsedCommandLine.AppendSwitchASCII(switches::kUseAdapterLuid, luid.toStdString());
+     }
+ #endif
+     // We need the FieldTrialList to make sure Chromium features are provided to child processes
+@@ -944,26 +998,11 @@ WebEngineContext::WebEngineContext()
+ 
+     initializeFeatureList(parsedCommandLine, enableFeatures, disableFeatures);
+ 
+-    const bool disableGpu = parsedCommandLine->HasSwitch(switches::kDisableGpu);
+-    std::string glType;
+-    if (parsedCommandLine->HasSwitch(switches::kUseGL))
+-        glType = parsedCommandLine->GetSwitchValueASCII(switches::kUseGL);
+-    else {
+-        glType = getGLType(disableGpu);
+-        parsedCommandLine->AppendSwitchASCII(switches::kUseGL, glType);
+-    }
+-
+-    parsedCommandLine->AppendSwitch(switches::kInProcessGPU);
+-
+-    if (glType != gl::kGLImplementationDisabledName) {
+-        if (glType != gl::kGLImplementationANGLEName) {
+-            qWarning("Only --use-gl=angle is supported on this platform.");
+-        }
+-    } else if (!disableGpu) {
+-        parsedCommandLine->AppendSwitch(switches::kDisableGpu);
+-    }
++    logContext(parsedCommandLine);
+ 
+-    logContext(glType, parsedCommandLine);
++    // Early error on unsupported --use-gl settings.
++    if (!isGLTypeSupported(glType))
++        qFatal("--use-gl=%s is not supported with the current configuration.", glType.c_str());
+ 
+     registerMainThreadFactories();
+ 
+@@ -1067,7 +1106,7 @@ base::CommandLine *WebEngineContext::initCommandLine(bool *useEmbeddedSwitches)
+                "base::CommandLine cannot be properly initialized.");
+     }
+ 
+-    base::CommandLine *parsedCommandLine = base::CommandLine::ForCurrentProcess();
++    base::CommandLine *commandLine = base::CommandLine::ForCurrentProcess();
+     int index = appArgs.indexOf(QRegularExpression(u"--webEngineArgs"_s,
+                                                    QRegularExpression::CaseInsensitiveOption));
+     if (qEnvironmentVariableIsSet(kChromiumFlagsEnv)) {
+@@ -1115,9 +1154,9 @@ base::CommandLine *WebEngineContext::initCommandLine(bool *useEmbeddedSwitches)
+     for (int i = 0; i < appArgs.size(); ++i)
+         argv[i] = appArgs[i].toStdString();
+ #endif
+-    parsedCommandLine->InitFromArgv(argv);
++    commandLine->InitFromArgv(argv);
+ 
+-    return parsedCommandLine;
++    return commandLine;
+ }
+ 
+ bool WebEngineContext::closingDown()
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0009-UPSTREAM-Make-possible-to-use-fake-GL-API-with-Vulka.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0009-UPSTREAM-Make-possible-to-use-fake-GL-API-with-Vulka.patch
@@ -1,0 +1,82 @@
+From e1e4a635f8bf7c1e2ccd0d3949b254b782cee449 Mon Sep 17 00:00:00 2001
+From: Peter Varga <pvarga@inf.u-szeged.hu>
+Date: Wed, 14 May 2025 14:02:56 +0200
+Subject: [PATCH 09/13] UPSTREAM: Make possible to use fake GL API with Vulkan
+
+This configuration disables ANGLE but it still renders with Vulkan.
+
+Enable it with:
+--webEngineArgs --enable-features=Vulkan --use-vulkan=native
+--use-gl=stub
+
+WebGL is not expected to work with this configuration since it requires
+real GL API.
+
+Pick-to: 6.10
+Change-Id: I7bc292e0c131c2cebe345f70bd3163dd3e6b2972
+Reviewed-by: Moss Heim <moss.heim@qt.io>
+---
+ qtwebengine/src/core/compositor/display_overrides.cpp |  3 ---
+ qtwebengine/src/core/ozone/surface_factory_qt.cpp     |  1 +
+ qtwebengine/src/core/web_engine_context.cpp           | 11 +++++++++--
+ 3 files changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/qtwebengine/src/core/compositor/display_overrides.cpp b/qtwebengine/src/core/compositor/display_overrides.cpp
+index 32012f7cf3..c33e79e54e 100644
+--- a/qtwebengine/src/core/compositor/display_overrides.cpp
++++ b/qtwebengine/src/core/compositor/display_overrides.cpp
+@@ -40,9 +40,6 @@ viz::SkiaOutputSurfaceImplOnGpu::CreateOutputDevice()
+ 
+ #if QT_CONFIG(opengl)
+     if (graphicsApi == QSGRendererInterface::OpenGL) {
+-        if (gl::GetGLImplementation() != gl::kGLImplementationEGLANGLE)
+-            qFatal("OpenGL is only supported over ANGLE.");
+-
+         return std::make_unique<QtWebEngineCore::NativeSkiaOutputDeviceOpenGL>(
+                 context_state_, renderer_settings_.requires_alpha_channel,
+                 shared_gpu_deps_->memory_tracker(), dependency_.get(), shared_image_factory_.get(),
+diff --git a/qtwebengine/src/core/ozone/surface_factory_qt.cpp b/qtwebengine/src/core/ozone/surface_factory_qt.cpp
+index 95af160a72..05f5b43f7e 100644
+--- a/qtwebengine/src/core/ozone/surface_factory_qt.cpp
++++ b/qtwebengine/src/core/ozone/surface_factory_qt.cpp
+@@ -39,6 +39,7 @@ SurfaceFactoryQt::SurfaceFactoryQt()
+     m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationEGLANGLE),
+                         std::make_unique<ui::GLOzoneANGLEQt>() });
+ #endif
++    m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationStubGL), nullptr });
+     m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationDisabled), nullptr });
+ }
+ 
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index 074accb6cf..9f11b39951 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -408,8 +408,15 @@ static std::string getGLType(const base::CommandLine &cmd)
+     return gl::kGLImplementationANGLEName;
+ }
+ 
+-static bool isGLTypeSupported(const std::string &glType)
++static bool isGLTypeSupported(const std::string &glType, bool usingVulkan = false)
+ {
++#if BUILDFLAG(IS_OZONE)
++    if (glType == gl::kGLImplementationStubName)
++        return usingVulkan;
++#else
++    Q_UNUSED(usingVulkan);
++#endif
++
+     if (glType == gl::kGLImplementationANGLEName || glType == gl::kGLImplementationDisabledName)
+         return true;
+ 
+@@ -1001,7 +1008,7 @@ WebEngineContext::WebEngineContext()
+     logContext(parsedCommandLine);
+ 
+     // Early error on unsupported --use-gl settings.
+-    if (!isGLTypeSupported(glType))
++    if (!isGLTypeSupported(glType, isFeatureEnabled(features::kVulkan.name, parsedCommandLine)))
+         qFatal("--use-gl=%s is not supported with the current configuration.", glType.c_str());
+ 
+     registerMainThreadFactories();
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0010-UPSTREAM-NativeSkiaOutputDevice-Set-color-type-accor.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0010-UPSTREAM-NativeSkiaOutputDevice-Set-color-type-accor.patch
@@ -1,0 +1,187 @@
+From 40e75dafb479269aeb8d426bd2db31e7522d3287 Mon Sep 17 00:00:00 2001
+From: Peter Varga <pvarga@inf.u-szeged.hu>
+Date: Fri, 30 May 2025 15:34:34 +0200
+Subject: [PATCH 10/13] UPSTREAM: NativeSkiaOutputDevice: Set color type
+ according to NativePixmap support
+
+NativePixmapEGLX11Binding requires the BGRA_8888 color type, use it for
+the check too. The GL graphics context doesn't necessarily mean that we
+need BGRA.
+
+Pick-to: 6.10
+Change-Id: I41a4f1f6da94c10f8e6843e6edfed913bb98fabd
+Reviewed-by: Moss Heim <moss.heim@qt.io>
+---
+ .../compositor/native_skia_output_device.cpp  | 15 +++++++++++
+ .../native_skia_output_device_opengl.cpp      |  5 ++--
+ .../src/core/ozone/gl_ozone_angle_qt.cpp      | 27 ++++++-------------
+ .../src/core/ozone/gl_ozone_angle_qt.h        | 20 ++++++++++++++
+ 4 files changed, 46 insertions(+), 21 deletions(-)
+
+diff --git a/qtwebengine/src/core/compositor/native_skia_output_device.cpp b/qtwebengine/src/core/compositor/native_skia_output_device.cpp
+index f42b2b9334..948686be7a 100644
+--- a/qtwebengine/src/core/compositor/native_skia_output_device.cpp
++++ b/qtwebengine/src/core/compositor/native_skia_output_device.cpp
+@@ -20,6 +20,8 @@
+ #include "ui/gl/gl_fence.h"
+ 
+ #if BUILDFLAG(IS_OZONE)
++#include "ozone/gl_ozone_angle_qt.h"
++
+ #include "ui/ozone/public/ozone_platform.h"
+ #endif
+ 
+@@ -63,6 +65,19 @@ NativeSkiaOutputDevice::NativeSkiaOutputDevice(
+                                         .supports_native_pixmaps;
+     qCDebug(lcWebEngineCompositor, "Native Buffer Supported: %s",
+             m_isNativeBufferSupported ? "yes" : "no");
++
++    auto typeToString = [](ui::NativePixmapSupportType type) -> const char * {
++        switch (type) {
++        case ui::NativePixmapSupportType::kDMABuf:
++            return "DMABuf";
++        case ui::NativePixmapSupportType::kX11Pixmap:
++            return "X11Pixmap";
++        default:
++            return "None";
++        }
++    };
++    qCDebug(lcWebEngineCompositor, "Native Pixmap Support Type: %s",
++            typeToString(ui::GLOzoneANGLEQt::getNativePixmapSupportType()));
+ #endif
+ }
+ 
+diff --git a/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp b/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp
+index 7cfc390d8a..46eb337b44 100644
+--- a/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp
++++ b/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp
+@@ -12,6 +12,7 @@
+ 
+ #if BUILDFLAG(IS_OZONE)
+ #include "ozone/gl_helper.h"
++#include "ozone/gl_ozone_angle_qt.h"
+ #include "ozone/ozone_util_qt.h"
+ 
+ #include "base/posix/eintr_wrapper.h"
+@@ -62,8 +63,8 @@ NativeSkiaOutputDeviceOpenGL::NativeSkiaOutputDeviceOpenGL(
+     qCDebug(lcWebEngineCompositor, "Native Skia Output Device: OpenGL");
+ 
+     SkColorType skColorType = kRGBA_8888_SkColorType;
+-#if BUILDFLAG(IS_OZONE_X11) && QT_CONFIG(xcb_glx_plugin)
+-    if (OzoneUtilQt::usingGLX() && m_contextState->gr_context_type() == gpu::GrContextType::kGL)
++#if BUILDFLAG(IS_OZONE)
++    if (ui::GLOzoneANGLEQt::getNativePixmapSupportType() == ui::NativePixmapSupportType::kX11Pixmap)
+         skColorType = kBGRA_8888_SkColorType;
+ #endif
+ 
+diff --git a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp b/qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp
+index 359d04a454..b5fa45cd89 100644
+--- a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp
++++ b/qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp
+@@ -6,6 +6,7 @@
+ // found in the LICENSE file.
+ 
+ #include "gl_ozone_angle_qt.h"
++#include "surface_factory_qt.h"
+ 
+ #include "ui/base/ozone_buildflags.h"
+ #include "ui/gl/gl_bindings.h"
+@@ -26,23 +27,12 @@ extern __eglMustCastToProperFunctionPointerType EGL_GetProcAddress(const char *p
+ }
+ 
+ namespace ui {
+-namespace {
+-// Based on //ui/ozone/platform/x11/x11_surface_factory.cc
+-enum class NativePixmapSupportType {
+-    // Importing native pixmaps not supported.
+-    kNone,
+-
+-    // Native pixmaps are imported directly into EGL using the
+-    // EGL_EXT_image_dma_buf_import extension.
+-    kDMABuf,
+-
+-    // Native pixmaps are first imported as X11 pixmaps using DRI3 and then into
+-    // EGL.
+-    kX11Pixmap,
+-};
+-
+-NativePixmapSupportType GetNativePixmapSupportType()
++
++NativePixmapSupportType GLOzoneANGLEQt::getNativePixmapSupportType()
+ {
++    if (!QtWebEngineCore::SurfaceFactoryQt::SupportsNativePixmaps())
++        return NativePixmapSupportType::kNone;
++
+     if (gl::GLSurfaceEGL::GetGLDisplayEGL()->ext->b_EGL_EXT_image_dma_buf_import)
+         return NativePixmapSupportType::kDMABuf;
+ 
+@@ -53,7 +43,6 @@ NativePixmapSupportType GetNativePixmapSupportType()
+ 
+     return NativePixmapSupportType::kNone;
+ }
+-} // namespace
+ 
+ bool GLOzoneANGLEQt::LoadGLES2Bindings(const gl::GLImplementationParts & /*implementation*/)
+ {
+@@ -107,7 +96,7 @@ gl::EGLDisplayPlatform GLOzoneANGLEQt::GetNativeDisplay()
+ 
+ bool GLOzoneANGLEQt::CanImportNativePixmap(gfx::BufferFormat format)
+ {
+-    switch (GetNativePixmapSupportType()) {
++    switch (getNativePixmapSupportType()) {
+     case NativePixmapSupportType::kDMABuf:
+         return NativePixmapEGLBinding::IsBufferFormatSupported(format);
+ #if BUILDFLAG(IS_OZONE_X11)
+@@ -125,7 +114,7 @@ GLOzoneANGLEQt::ImportNativePixmap(scoped_refptr<gfx::NativePixmap> pixmap,
+                                    gfx::Size plane_size, const gfx::ColorSpace &color_space,
+                                    GLenum target, GLuint texture_id)
+ {
+-    switch (GetNativePixmapSupportType()) {
++    switch (getNativePixmapSupportType()) {
+     case NativePixmapSupportType::kDMABuf:
+         return NativePixmapEGLBinding::Create(pixmap, plane_format, plane, plane_size, color_space,
+                                               target, texture_id);
+diff --git a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.h b/qtwebengine/src/core/ozone/gl_ozone_angle_qt.h
+index e8d7af6aa7..240fa98b6c 100644
+--- a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.h
++++ b/qtwebengine/src/core/ozone/gl_ozone_angle_qt.h
+@@ -1,6 +1,10 @@
+ // Copyright (C) 2024 The Qt Company Ltd.
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+ 
++// Copyright 2016 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
+ #ifndef GL_OZONE_ANGLE_QT_H
+ #define GL_OZONE_ANGLE_QT_H
+ 
+@@ -8,9 +12,25 @@
+ 
+ namespace ui {
+ 
++// Based on //ui/ozone/platform/x11/x11_surface_factory.cc
++enum class NativePixmapSupportType {
++    // Importing native pixmaps not supported.
++    kNone,
++
++    // Native pixmaps are imported directly into EGL using the
++    // EGL_EXT_image_dma_buf_import extension.
++    kDMABuf,
++
++    // Native pixmaps are first imported as X11 pixmaps using DRI3 and then into
++    // EGL.
++    kX11Pixmap,
++};
++
+ class GLOzoneANGLEQt : public GLOzoneEGL
+ {
+ public:
++    static NativePixmapSupportType getNativePixmapSupportType();
++
+     bool InitializeStaticGLBindings(const gl::GLImplementationParts &implementation) override;
+     bool InitializeExtensionSettingsOneOffPlatform(gl::GLDisplay *display) override;
+     scoped_refptr<gl::GLSurface> CreateViewGLSurface(gl::GLDisplay *display,
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0011-UPSTREAM-Make-possible-to-use-system-EGL-instead-of-.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0011-UPSTREAM-Make-possible-to-use-system-EGL-instead-of-.patch
@@ -1,0 +1,368 @@
+From 0a11d1aba85020ceaabddf1ff9a5161c2b7951a7 Mon Sep 17 00:00:00 2001
+From: Peter Varga <pvarga@inf.u-szeged.hu>
+Date: Sun, 26 Oct 2025 02:03:24 +0800
+Subject: [PATCH 11/13] UPSTREAM: Make possible to use system EGL instead of
+ ANGLE on Linux
+
+This is not the same direct EGL rendering solution what we used to have
+before QtWebEngine 6.9. With this configuration, the texture is accessed
+via NativePixmap instead of using shared GL context. Thus this
+implementation doesn't need adaptations in Chromium.
+
+This configuration is meant to be used for identifying ANGLE specific
+issues.
+
+Enable it with:
+--webEngineArgs --use-gl=egl
+
+Pick-to: 6.10
+Change-Id: Ib8db5573b2001157eaee799c6b333f722ab87604
+Reviewed-by: Moss Heim <moss.heim@qt.io>
+---
+ qtwebengine/src/core/CMakeLists.txt           |  2 +-
+ .../compositor/native_skia_output_device.cpp  |  4 +-
+ .../native_skia_output_device_opengl.cpp      | 10 +-
+ ...{gl_ozone_angle_qt.cpp => gl_ozone_qt.cpp} | 96 +++++++++++++++----
+ .../{gl_ozone_angle_qt.h => gl_ozone_qt.h}    | 29 ++++--
+ .../src/core/ozone/surface_factory_qt.cpp     |  4 +-
+ qtwebengine/src/core/web_engine_context.cpp   |  3 +
+ 7 files changed, 119 insertions(+), 29 deletions(-)
+ rename qtwebengine/src/core/ozone/{gl_ozone_angle_qt.cpp => gl_ozone_qt.cpp} (56%)
+ rename qtwebengine/src/core/ozone/{gl_ozone_angle_qt.h => gl_ozone_qt.h} (79%)
+
+diff --git a/qtwebengine/src/core/CMakeLists.txt b/qtwebengine/src/core/CMakeLists.txt
+index 9052f0f06b..7dff43b505 100644
+--- a/qtwebengine/src/core/CMakeLists.txt
++++ b/qtwebengine/src/core/CMakeLists.txt
+@@ -207,7 +207,7 @@ foreach(arch ${archs})
+ 
+         extend_gn_target(${buildGn} CONDITION LINUX
+             SOURCES
+-                ozone/gl_ozone_angle_qt.cpp ozone/gl_ozone_angle_qt.h
++                ozone/gl_ozone_qt.cpp ozone/gl_ozone_qt.h
+                 ozone/ozone_util_qt.cpp ozone/ozone_util_qt.h
+                 ozone/platform_window_qt.cpp ozone/platform_window_qt.h
+                 ozone/surface_factory_qt.cpp ozone/surface_factory_qt.h
+diff --git a/qtwebengine/src/core/compositor/native_skia_output_device.cpp b/qtwebengine/src/core/compositor/native_skia_output_device.cpp
+index 948686be7a..bf8fd575ab 100644
+--- a/qtwebengine/src/core/compositor/native_skia_output_device.cpp
++++ b/qtwebengine/src/core/compositor/native_skia_output_device.cpp
+@@ -20,7 +20,7 @@
+ #include "ui/gl/gl_fence.h"
+ 
+ #if BUILDFLAG(IS_OZONE)
+-#include "ozone/gl_ozone_angle_qt.h"
++#include "ozone/gl_ozone_qt.h"
+ 
+ #include "ui/ozone/public/ozone_platform.h"
+ #endif
+@@ -77,7 +77,7 @@ NativeSkiaOutputDevice::NativeSkiaOutputDevice(
+         }
+     };
+     qCDebug(lcWebEngineCompositor, "Native Pixmap Support Type: %s",
+-            typeToString(ui::GLOzoneANGLEQt::getNativePixmapSupportType()));
++            typeToString(ui::GLOzoneQt::getNativePixmapSupportType()));
+ #endif
+ }
+ 
+diff --git a/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp b/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp
+index 46eb337b44..fe5070c409 100644
+--- a/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp
++++ b/qtwebengine/src/core/compositor/native_skia_output_device_opengl.cpp
+@@ -12,7 +12,7 @@
+ 
+ #if BUILDFLAG(IS_OZONE)
+ #include "ozone/gl_helper.h"
+-#include "ozone/gl_ozone_angle_qt.h"
++#include "ozone/gl_ozone_qt.h"
+ #include "ozone/ozone_util_qt.h"
+ 
+ #include "base/posix/eintr_wrapper.h"
+@@ -64,8 +64,14 @@ NativeSkiaOutputDeviceOpenGL::NativeSkiaOutputDeviceOpenGL(
+ 
+     SkColorType skColorType = kRGBA_8888_SkColorType;
+ #if BUILDFLAG(IS_OZONE)
+-    if (ui::GLOzoneANGLEQt::getNativePixmapSupportType() == ui::NativePixmapSupportType::kX11Pixmap)
++    ui::NativePixmapSupportType type = ui::GLOzoneQt::getNativePixmapSupportType();
++    if (type == ui::NativePixmapSupportType::kX11Pixmap)
+         skColorType = kBGRA_8888_SkColorType;
++
++    if (type == ui::NativePixmapSupportType::kDMABuf && OzoneUtilQt::usingGLX()
++        && gl::GetGLImplementation() == gl::kGLImplementationEGLGLES2) {
++        skColorType = kBGRA_8888_SkColorType;
++    }
+ #endif
+ 
+     capabilities_.sk_color_type_map[viz::SinglePlaneFormat::kRGBA_8888] = skColorType;
+diff --git a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp b/qtwebengine/src/core/ozone/gl_ozone_qt.cpp
+similarity index 56%
+rename from qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp
+rename to qtwebengine/src/core/ozone/gl_ozone_qt.cpp
+index b5fa45cd89..2a9bd18b7d 100644
+--- a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.cpp
++++ b/qtwebengine/src/core/ozone/gl_ozone_qt.cpp
+@@ -5,8 +5,12 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "gl_ozone_angle_qt.h"
++#include "gl_ozone_qt.h"
+ #include "surface_factory_qt.h"
++#include "ozone_util_qt.h"
++
++#include <QtCore/private/qconfig_p.h>
++#include <QtGui/qopenglcontext.h>
+ 
+ #include "ui/base/ozone_buildflags.h"
+ #include "ui/gl/gl_bindings.h"
+@@ -21,6 +25,10 @@
+ #include "ui/ozone/platform/x11/native_pixmap_egl_x11_binding.h"
+ #endif
+ 
++#if QT_CONFIG(dlopen)
++#include <dlfcn.h>
++#endif
++
+ extern "C" {
+ typedef void (*__eglMustCastToProperFunctionPointerType)(void);
+ extern __eglMustCastToProperFunctionPointerType EGL_GetProcAddress(const char *procname);
+@@ -28,7 +36,7 @@ extern __eglMustCastToProperFunctionPointerType EGL_GetProcAddress(const char *p
+ 
+ namespace ui {
+ 
+-NativePixmapSupportType GLOzoneANGLEQt::getNativePixmapSupportType()
++NativePixmapSupportType GLOzoneQt::getNativePixmapSupportType()
+ {
+     if (!QtWebEngineCore::SurfaceFactoryQt::SupportsNativePixmaps())
+         return NativePixmapSupportType::kNone;
+@@ -44,32 +52,31 @@ NativePixmapSupportType GLOzoneANGLEQt::getNativePixmapSupportType()
+     return NativePixmapSupportType::kNone;
+ }
+ 
+-bool GLOzoneANGLEQt::LoadGLES2Bindings(const gl::GLImplementationParts & /*implementation*/)
++bool GLOzoneQt::LoadGLES2Bindings(const gl::GLImplementationParts & /*implementation*/)
+ {
+-    gl::SetGLGetProcAddressProc(&EGL_GetProcAddress);
+-    return true;
++    return false;
+ }
+ 
+-bool GLOzoneANGLEQt::InitializeStaticGLBindings(const gl::GLImplementationParts &implementation)
++bool GLOzoneQt::InitializeStaticGLBindings(const gl::GLImplementationParts &implementation)
+ {
+     return GLOzoneEGL::InitializeStaticGLBindings(implementation);
+ }
+ 
+-bool GLOzoneANGLEQt::InitializeExtensionSettingsOneOffPlatform(gl::GLDisplay *display)
++bool GLOzoneQt::InitializeExtensionSettingsOneOffPlatform(gl::GLDisplay *display)
+ {
+     return GLOzoneEGL::InitializeExtensionSettingsOneOffPlatform(
+             static_cast<gl::GLDisplayEGL *>(display));
+ }
+ 
+-scoped_refptr<gl::GLSurface> GLOzoneANGLEQt::CreateViewGLSurface(gl::GLDisplay * /*display*/,
+-                                                                 gfx::AcceleratedWidget /*window*/)
++scoped_refptr<gl::GLSurface> GLOzoneQt::CreateViewGLSurface(gl::GLDisplay * /*display*/,
++                                                            gfx::AcceleratedWidget /*window*/)
+ {
+     return nullptr;
+ }
+ 
+ // based on GLOzoneEGLX11::CreateOffscreenGLSurface() (x11_surface_factory.cc)
+-scoped_refptr<gl::GLSurface> GLOzoneANGLEQt::CreateOffscreenGLSurface(gl::GLDisplay *display,
+-                                                                      const gfx::Size &size)
++scoped_refptr<gl::GLSurface> GLOzoneQt::CreateOffscreenGLSurface(gl::GLDisplay *display,
++                                                                 const gfx::Size &size)
+ {
+     gl::GLDisplayEGL *eglDisplay = display->GetAs<gl::GLDisplayEGL>();
+ 
+@@ -79,7 +86,7 @@ scoped_refptr<gl::GLSurface> GLOzoneANGLEQt::CreateOffscreenGLSurface(gl::GLDisp
+     return InitializeGLSurface(new gl::PbufferGLSurfaceEGL(eglDisplay, size));
+ }
+ 
+-gl::EGLDisplayPlatform GLOzoneANGLEQt::GetNativeDisplay()
++gl::EGLDisplayPlatform GLOzoneQt::GetNativeDisplay()
+ {
+ #if BUILDFLAG(IS_OZONE_X11)
+     static EGLNativeDisplayType nativeDisplay =
+@@ -94,7 +101,7 @@ gl::EGLDisplayPlatform GLOzoneANGLEQt::GetNativeDisplay()
+     return gl::EGLDisplayPlatform(EGL_DEFAULT_DISPLAY);
+ }
+ 
+-bool GLOzoneANGLEQt::CanImportNativePixmap(gfx::BufferFormat format)
++bool GLOzoneQt::CanImportNativePixmap(gfx::BufferFormat format)
+ {
+     switch (getNativePixmapSupportType()) {
+     case NativePixmapSupportType::kDMABuf:
+@@ -109,10 +116,10 @@ bool GLOzoneANGLEQt::CanImportNativePixmap(gfx::BufferFormat format)
+ }
+ 
+ std::unique_ptr<NativePixmapGLBinding>
+-GLOzoneANGLEQt::ImportNativePixmap(scoped_refptr<gfx::NativePixmap> pixmap,
+-                                   gfx::BufferFormat plane_format, gfx::BufferPlane plane,
+-                                   gfx::Size plane_size, const gfx::ColorSpace &color_space,
+-                                   GLenum target, GLuint texture_id)
++GLOzoneQt::ImportNativePixmap(scoped_refptr<gfx::NativePixmap> pixmap,
++                              gfx::BufferFormat plane_format, gfx::BufferPlane plane,
++                              gfx::Size plane_size, const gfx::ColorSpace &color_space,
++                              GLenum target, GLuint texture_id)
+ {
+     switch (getNativePixmapSupportType()) {
+     case NativePixmapSupportType::kDMABuf:
+@@ -129,4 +136,59 @@ GLOzoneANGLEQt::ImportNativePixmap(scoped_refptr<gfx::NativePixmap> pixmap,
+     }
+ }
+ 
++bool GLOzoneANGLEQt::LoadGLES2Bindings(const gl::GLImplementationParts & /*implementation*/)
++{
++    gl::SetGLGetProcAddressProc(&EGL_GetProcAddress);
++    return true;
++}
++
++void GLOzoneEGLQt::ShutdownGL(gl::GLDisplay *display)
++{
++    GLOzoneEGL::ShutdownGL(display);
++#if QT_CONFIG(dlopen)
++    if (m_nativeEGLHandle)
++        dlclose(m_nativeEGLHandle);
++#endif
++}
++
++bool GLOzoneEGLQt::LoadGLES2Bindings(const gl::GLImplementationParts & /*implementation*/)
++{
++    gl::GLGetProcAddressProc getProcAddressPtr = nullptr;
++
++    if (OzoneUtilQt::usingEGL()) {
++        QOpenGLContext *context = OzoneUtilQt::getQOpenGLContext();
++        getProcAddressPtr = reinterpret_cast<gl::GLGetProcAddressProc>(
++                context->getProcAddress("eglGetProcAddress"));
++    }
++
++#if QT_CONFIG(dlopen)
++    if (getProcAddressPtr == nullptr) {
++        const char *eglPath = "libEGL.so.1";
++        m_nativeEGLHandle = dlopen(eglPath, RTLD_NOW);
++        if (!m_nativeEGLHandle) {
++            qWarning("Failed to load EGL library %s: %s", eglPath, dlerror());
++            return false;
++        }
++
++        getProcAddressPtr = reinterpret_cast<gl::GLGetProcAddressProc>(
++                dlsym(m_nativeEGLHandle, "eglGetProcAddress"));
++    }
++#endif // QT_CONFIG(dlopen)
++
++    if (!getProcAddressPtr) {
++        char *error = nullptr;
++#if QT_CONFIG(dlopen)
++        error = dlerror();
++#endif
++        qWarning("Failed to get address of eglGetProcAddress: %s", error ? error : "no error.");
++        return false;
++    }
++
++    gl::SetGLGetProcAddressProc(getProcAddressPtr);
++    // TODO: Log EGL driver information.
++    //       Nvidia fails to make EGL context current if libEGL.so.1 is loaded directly. This could
++    //       be because of loading the wrong driver.
++    return true;
++}
++
+ } // namespace ui
+diff --git a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.h b/qtwebengine/src/core/ozone/gl_ozone_qt.h
+similarity index 79%
+rename from qtwebengine/src/core/ozone/gl_ozone_angle_qt.h
+rename to qtwebengine/src/core/ozone/gl_ozone_qt.h
+index 240fa98b6c..aba63cbb20 100644
+--- a/qtwebengine/src/core/ozone/gl_ozone_angle_qt.h
++++ b/qtwebengine/src/core/ozone/gl_ozone_qt.h
+@@ -1,12 +1,11 @@
+-// Copyright (C) 2024 The Qt Company Ltd.
++// Copyright (C) 2025 The Qt Company Ltd.
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+ 
+ // Copyright 2016 The Chromium Authors
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+-
+-#ifndef GL_OZONE_ANGLE_QT_H
+-#define GL_OZONE_ANGLE_QT_H
++#ifndef GL_OZONE_QT_H
++#define GL_OZONE_QT_H
+ 
+ #include "ui/ozone/common/gl_ozone_egl.h"
+ 
+@@ -26,7 +25,7 @@ enum class NativePixmapSupportType {
+     kX11Pixmap,
+ };
+ 
+-class GLOzoneANGLEQt : public GLOzoneEGL
++class GLOzoneQt : public GLOzoneEGL
+ {
+ public:
+     static NativePixmapSupportType getNativePixmapSupportType();
+@@ -53,6 +52,24 @@ protected:
+     bool LoadGLES2Bindings(const gl::GLImplementationParts &implementation) override;
+ };
+ 
++class GLOzoneANGLEQt : public GLOzoneQt
++{
++protected:
++    bool LoadGLES2Bindings(const gl::GLImplementationParts &implementation) override;
++};
++
++class GLOzoneEGLQt : public GLOzoneQt
++{
++public:
++    void ShutdownGL(gl::GLDisplay *display) override;
++
++protected:
++    bool LoadGLES2Bindings(const gl::GLImplementationParts &implementation) override;
++
++private:
++    void *m_nativeEGLHandle = nullptr;
++};
++
+ } // namespace ui
+ 
+-#endif // GL_OZONE_ANGLE_QT_H
++#endif // GL_OZONE_QT_H
+diff --git a/qtwebengine/src/core/ozone/surface_factory_qt.cpp b/qtwebengine/src/core/ozone/surface_factory_qt.cpp
+index 05f5b43f7e..bda4bfb8a6 100644
+--- a/qtwebengine/src/core/ozone/surface_factory_qt.cpp
++++ b/qtwebengine/src/core/ozone/surface_factory_qt.cpp
+@@ -4,7 +4,7 @@
+ #include "surface_factory_qt.h"
+ 
+ #include "qtwebenginecoreglobal_p.h"
+-#include "ozone/gl_ozone_angle_qt.h"
++#include "ozone/gl_ozone_qt.h"
+ #include "ozone/ozone_util_qt.h"
+ #include "qtwebenginecoreglobal_p.h"
+ 
+@@ -38,6 +38,8 @@ SurfaceFactoryQt::SurfaceFactoryQt()
+ #if QT_CONFIG(opengl)
+     m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationEGLANGLE),
+                         std::make_unique<ui::GLOzoneANGLEQt>() });
++    m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationEGLGLES2),
++                        std::make_unique<ui::GLOzoneEGLQt>() });
+ #endif
+     m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationStubGL), nullptr });
+     m_impls.push_back({ gl::GLImplementationParts(gl::kGLImplementationDisabled), nullptr });
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index 9f11b39951..e5d3cd8385 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -411,6 +411,9 @@ static std::string getGLType(const base::CommandLine &cmd)
+ static bool isGLTypeSupported(const std::string &glType, bool usingVulkan = false)
+ {
+ #if BUILDFLAG(IS_OZONE)
++    if (glType == gl::kGLImplementationEGLName)
++        return true;
++
+     if (glType == gl::kGLImplementationStubName)
+         return usingVulkan;
+ #else
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0012-UPSTREAM-Disable-GBM-if-Ozone-X11-is-not-available.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0012-UPSTREAM-Disable-GBM-if-Ozone-X11-is-not-available.patch
@@ -1,0 +1,50 @@
+From c5ada331bec79142c85a5cddb49d538a2c3c8651 Mon Sep 17 00:00:00 2001
+From: Marcell Brauner <bmarcell@inf.u-szeged.hu>
+Date: Tue, 9 Sep 2025 14:15:13 +0200
+Subject: [PATCH 12/13] UPSTREAM: Disable GBM if Ozone X11 is not available
+
+If certain X11 libraries are missing then the BUILDFLAG(IS_OZONE_X11) is
+false. In this case, the GLX code path is unable to create GBM buffer
+without Ozone X11 support. This results in the web view being empty and
+the warning messages are not helpful.
+
+To circumvent this, add a more meaningful warning message and fallback
+to a different rendering path.
+
+Pick-to: 6.10 6.9 6.8
+Change-Id: Id4bc9a7e88c6f19713c764437138b92a3aee86e6
+Reviewed-by: Moss Heim <moss.heim@qt.io>
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+---
+ qtwebengine/src/core/web_engine_context.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index e5d3cd8385..5905b6c379 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -1207,12 +1207,20 @@ bool WebEngineContext::isGbmSupported()
+             return false;
+         }
+ 
++#if !BUILDFLAG(IS_OZONE_X11)
++        if (OzoneUtilQt::usingGLX()) {
++            qWarning("GLX: Disable GBM because Ozone X11 is not available. "
++                     "Possibly caused by missing libraries for qpa-xcb support.");
++            return false;
++        }
++#endif
++
+         return true;
+     }();
+ 
+     return supported;
+ }
+-#endif
++#endif // BUILDFLAG(IS_OZONE)
+ 
+ void WebEngineContext::registerMainThreadFactories()
+ {
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/01-runtime/patches/0013-UPSTREAM-Fallback-to-software-rendering-if-both-GBM-.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0013-UPSTREAM-Fallback-to-software-rendering-if-both-GBM-.patch
@@ -1,0 +1,72 @@
+From c85029c9580db89419f3fb096b17d9a09db4ffd0 Mon Sep 17 00:00:00 2001
+From: Marcell Brauner <bmarcell@inf.u-szeged.hu>
+Date: Thu, 18 Sep 2025 14:05:40 +0200
+Subject: [PATCH 13/13] UPSTREAM: Fallback to software rendering if both GBM
+ and Vulkan are unavailable
+
+Fixes: QTBUG-136160
+Pick-to: 6.10 6.9
+Change-Id: Ibc258c2c921294af5f69843022b52f2b66a0ec1b
+Reviewed-by: Peter Varga <pvarga@inf.u-szeged.hu>
+---
+ qtwebengine/src/core/web_engine_context.cpp | 31 +++++++++++++++------
+ 1 file changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/qtwebengine/src/core/web_engine_context.cpp b/qtwebengine/src/core/web_engine_context.cpp
+index 5905b6c379..4d0bb0ad7e 100644
+--- a/qtwebengine/src/core/web_engine_context.cpp
++++ b/qtwebengine/src/core/web_engine_context.cpp
+@@ -949,19 +949,33 @@ WebEngineContext::WebEngineContext()
+             qWarning("--use-gl=%s is set with --disable-gpu. Expect troubles!", glType.c_str());
+     }
+ 
+-#if BUILDFLAG(IS_OZONE) && QT_CONFIG(webengine_vulkan)
++#if BUILDFLAG(IS_OZONE)
+     if (QQuickWindow::graphicsApi() == QSGRendererInterface::OpenGL && usingSupportedSGBackend()) {
+         const bool disableGpu = parsedCommandLine.HasSwitch(switches::kDisableGpu);
+         const bool usingVulkan = isFeatureEnabled(features::kVulkan.name, parsedCommandLine);
+         if (!disableGpu && !usingVulkan && !isGbmSupported()) {
+-            qWarning("GBM is not supported with the current configuration. "
+-                     "Fallback to Vulkan rendering in Chromium.");
+-            parsedCommandLine.AppendSwitchASCII(switches::kUseVulkan,
+-                                                switches::kVulkanImplementationNameNative);
+-            enableFeatures.push_back(features::kVulkan.name);
++#if QT_CONFIG(webengine_vulkan)
++            QVulkanInstance vulkanInstance;
++            vulkanInstance.setApiVersion(QVersionNumber(1, 1));
++            QRhiVulkanInitParams params;
++            params.inst = &vulkanInstance;
++
++            if (vulkanInstance.create() && QRhi::probe(QRhi::Vulkan, &params)) {
++                qWarning("GBM is not supported with the current configuration. "
++                         "Fallback to Vulkan rendering in Chromium.");
++                parsedCommandLine.AppendSwitchASCII(switches::kUseVulkan,
++                                                    switches::kVulkanImplementationNameNative);
++                enableFeatures.push_back(features::kVulkan.name);
++            } else
++#endif
++            {
++                qWarning("GBM is not supported with the current configuration and Vulkan is not "
++                         "available. Fallback to software rendering.");
++                parsedCommandLine.AppendSwitch(switches::kDisableGpu);
++            }
+         }
+     }
+-
++#if QT_CONFIG(webengine_vulkan)
+     if (QQuickWindow::graphicsApi() == QSGRendererInterface::Vulkan && usingSupportedSGBackend()) {
+         // TODO: Try not to force Chromium's Vulkan backend on Linux.
+         //       Currently we force it because OzoneImageBackingFactory does not support to create
+@@ -991,7 +1005,8 @@ WebEngineContext::WebEngineContext()
+             qputenv(deviceExtensionsVar, requiredDeviceExtensions.join(';'));
+         }
+     }
+-#endif // BUILDFLAG(IS_OZONE) && QT_CONFIG(webengine_vulkan)
++#endif // QT_CONFIG(webengine_vulkan)
++#endif // BUILDFLAG(IS_OZONE)
+ 
+ #if defined(Q_OS_WIN)
+     if (QQuickWindow::graphicsApi() == QSGRendererInterface::Direct3D11
+-- 
+2.51.0
+

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.9.2
-REL=1
+REL=2
 SRCS="https://download.qt.io/official_releases/qt/${VER:0:3}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::643f1fe35a739e2bf5e1a092cfe83dbee61ff6683684e957351c599767ca279c"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: backport additional patches to fix QtWebEngine on Nouveau + Mesa 25.2
    Track patches at AOSC-Tracking/qt-6 @ aosc/v6.9.2
    \(HEAD: c85029c9580db89419f3fb096b17d9a09db4ffd0\).

Package(s) Affected
-------------------

- qt-6: 6.9.2-2
- qt-6-doc: 6.9.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
