### PR TITLE
starship: update to 1.24.0

### DIFF
--- a/app-utils/starship/autobuild/patches/0001-feat-status-add-success_symbol_rootuser-option.patch
+++ b/app-utils/starship/autobuild/patches/0001-feat-status-add-success_symbol_rootuser-option.patch
@@ -1,4 +1,4 @@
-From 0afe2aaad6c8424738fc1a9e4a11223642ab52e7 Mon Sep 17 00:00:00 2001
+From eef2620b28a1f782920b50a688b1533198390bc1 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 17 Sep 2023 18:30:43 +0800
 Subject: [PATCH 1/2] feat(status): add `success_symbol_rootuser` option
@@ -12,33 +12,33 @@ This commit will allow user to set a different success symbol for root users tha
  4 files changed, 43 insertions(+)
 
 diff --git a/.github/config-schema.json b/.github/config-schema.json
-index b5dcb83d..cac5d9b8 100644
+index 04f293d5..4d5f5c23 100644
 --- a/.github/config-schema.json
 +++ b/.github/config-schema.json
-@@ -1606,6 +1606,7 @@
-         "signal_symbol": "⚡",
-         "style": "bold red",
+@@ -1619,6 +1619,7 @@
+         "format": "[$symbol$status]($style) ",
+         "symbol": "❌",
          "success_symbol": "",
 +        "success_symbol_rootuser": "",
-         "symbol": "❌"
-       },
-       "allOf": [
-@@ -5815,6 +5816,10 @@
-           "default": "",
-           "type": "string"
+         "not_executable_symbol": "🚫",
+         "not_found_symbol": "🔍",
+         "sigint_symbol": "🧱",
+@@ -6116,6 +6117,10 @@
+           "type": "string",
+           "default": ""
          },
 +        "success_symbol_rootuser": {
 +          "default": "",
 +          "type": "string"
 +        },
          "not_executable_symbol": {
-           "default": "🚫",
-           "type": "string"
+           "type": "string",
+           "default": "🚫"
 diff --git a/docs/config/README.md b/docs/config/README.md
-index 4ac9b238..d7e197ea 100644
+index 173d239a..9b756587 100644
 --- a/docs/config/README.md
 +++ b/docs/config/README.md
-@@ -4437,6 +4437,7 @@ To enable it, set `disabled` to `false` in your configuration file.
+@@ -4501,6 +4501,7 @@ The status code will cast to a signed 32-bit integer.
  | `format`                    | `'[$symbol$status]($style) '`                                                  | The format of the module                                              |
  | `symbol`                    | `'❌'`                                                                         | The symbol displayed on program error                                 |
  | `success_symbol`            | `''`                                                                           | The symbol displayed on program success                               |
@@ -46,7 +46,7 @@ index 4ac9b238..d7e197ea 100644
  | `not_executable_symbol`     | `'🚫'`                                                                         | The symbol displayed when file isn't executable                       |
  | `not_found_symbol`          | `'🔍'`                                                                         | The symbol displayed when the command can't be found                  |
  | `sigint_symbol`             | `'🧱'`                                                                         | The symbol displayed on SIGINT (Ctrl + c)                             |
-@@ -4478,6 +4479,7 @@ To enable it, set `disabled` to `false` in your configuration file.
+@@ -4542,6 +4543,7 @@ The status code will cast to a signed 32-bit integer.
  style = 'bg:blue'
  symbol = '🔴 '
  success_symbol = '🟢 SUCCESS'
@@ -55,7 +55,7 @@ index 4ac9b238..d7e197ea 100644
  map_symbol = true
  disabled = false
 diff --git a/src/configs/status.rs b/src/configs/status.rs
-index adc42e48..b7c3c522 100644
+index 489597ce..344069ca 100644
 --- a/src/configs/status.rs
 +++ b/src/configs/status.rs
 @@ -11,6 +11,7 @@ pub struct StatusConfig<'a> {
@@ -75,10 +75,10 @@ index adc42e48..b7c3c522 100644
              not_found_symbol: "🔍",
              sigint_symbol: "🧱",
 diff --git a/src/modules/status.rs b/src/modules/status.rs
-index acc11a53..d73b8371 100644
+index ae7960c2..c67c7553 100644
 --- a/src/modules/status.rs
 +++ b/src/modules/status.rs
-@@ -46,6 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+@@ -50,6 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
      // Exit code is zero while success_symbol and pipestatus are all zero or disabled/missing
      if exit_code == "0"
          && config.success_symbol.is_empty()
@@ -86,7 +86,7 @@ index acc11a53..d73b8371 100644
          && (match pipestatus_status {
              PipeStatusStatus::Pipe(ps) => ps.iter().all(|s| s == "0"),
              _ => true,
-@@ -141,6 +142,7 @@ fn format_exit_code<'a>(
+@@ -146,6 +147,7 @@ fn format_exit_code<'a>(
          formatter
              .map_meta(|var, _| match var {
                  "symbol" => match exit_code_int {
@@ -94,7 +94,7 @@ index acc11a53..d73b8371 100644
                      0 => Some(config.success_symbol),
                      126 if config.map_symbol => Some(config.not_executable_symbol),
                      127 if config.map_symbol => Some(config.not_found_symbol),
-@@ -260,6 +262,38 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
+@@ -265,6 +267,38 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
      }
  }
  
@@ -134,5 +134,5 @@ index acc11a53..d73b8371 100644
  mod tests {
      use nu_ansi_term::{Color, Style};
 -- 
-2.49.0
+2.51.1
 

--- a/app-utils/starship/autobuild/patches/0002-refactor-utils-move-is_root_user-function-to-utils-m.patch
+++ b/app-utils/starship/autobuild/patches/0002-refactor-utils-move-is_root_user-function-to-utils-m.patch
@@ -1,4 +1,4 @@
-From 61a0255e1ba2b75d319fb29408372864bc88964d Mon Sep 17 00:00:00 2001
+From eaf36c36e7d721079821190ca845bff164643832 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Thu, 21 Sep 2023 18:11:16 +0800
 Subject: [PATCH 2/2] refactor(utils): move `is_root_user` function to `utils`
@@ -13,7 +13,7 @@ Subject: [PATCH 2/2] refactor(utils): move `is_root_user` function to `utils`
  create mode 100644 src/modules/utils/is_root_user.rs
 
 diff --git a/src/modules/status.rs b/src/modules/status.rs
-index d73b8371..26dd24d3 100644
+index c67c7553..90ab33a5 100644
 --- a/src/modules/status.rs
 +++ b/src/modules/status.rs
 @@ -1,5 +1,6 @@
@@ -23,7 +23,7 @@ index d73b8371..26dd24d3 100644
  use super::{Context, Module, ModuleConfig};
  
  use crate::configs::status::StatusConfig;
-@@ -262,38 +263,6 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
+@@ -267,38 +268,6 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
      }
  }
  
@@ -63,12 +63,12 @@ index d73b8371..26dd24d3 100644
  mod tests {
      use nu_ansi_term::{Color, Style};
 diff --git a/src/modules/username.rs b/src/modules/username.rs
-index 9ce73ac0..0ab45d8d 100644
+index 165fea18..cd725c02 100644
 --- a/src/modules/username.rs
 +++ b/src/modules/username.rs
 @@ -1,3 +1,4 @@
 +use super::utils::is_root_user::is_root_user;
- use super::{Context, Module, ModuleConfig};
+ use super::{Context, Detected, Module, ModuleConfig};
  
  use crate::configs::username::UsernameConfig;
 @@ -87,38 +88,6 @@ fn is_login_user(context: &Context, username: &str) -> bool {
@@ -158,5 +158,5 @@ index 209da8ed..445898b0 100644
 +
 +pub mod is_root_user;
 -- 
-2.49.0
+2.51.1
 

--- a/app-utils/starship/spec
+++ b/app-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.23.0
+VER=1.24.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/starship/starship"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

- starship: update to 1.24.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- starship: 1.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit starship
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
