### PR TITLE
fcitx5: update to 5.1.15

### DIFF
--- a/app-i18n/fcitx5/spec
+++ b/app-i18n/fcitx5/spec
@@ -1,7 +1,7 @@
-VER=5.1.14
+VER=5.1.15
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5 \
       tbl::https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${VER}_dict.tar.zst"
 CHKSUMS="SKIP \
-         sha256::735af197545019c0a04ccd968b20bb0b67cc18bb32f04d1765dfb94c494a23a1"
+         sha256::1fe7154b24a881669f8636e482b5f41673f535e96da3976e0871aba9a3cd1877"
 CHKUPDATE="anitya::id=138232"
 SUBDIR="fcitx5-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5: update to 5.1.15
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fcitx5: 1:5.1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
