### PR TITLE
breezy: update to 3.3.15

### DIFF
--- a/app-vcs/breezy/spec
+++ b/app-vcs/breezy/spec
@@ -1,5 +1,4 @@
-VER=3.3.12
-REL=1
+VER=3.3.15
 SRCS="tbl::https://github.com/breezy-team/breezy/archive/refs/tags/brz-$VER.tar.gz"
-CHKSUMS="sha256::9ce8a3af9f45ea85761bf8a924e719cb5b20dff3e3edb1220b5c99bb37a3e46f"
+CHKSUMS="sha256::0a6353b9e42eace08abb59c2cd29e5f705d24e417abe8e2b8fc984623595b5b4"
 CHKUPDATE="anitya::id=235155"


### PR DESCRIPTION
Topic Description
-----------------

- breezy: update to 3.3.15
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- breezy: 3.3.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit breezy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
