### PR TITLE
audacious: update to 4.5.1

### DIFF
--- a/app-multimedia/audacious/autobuild/beyond
+++ b/app-multimedia/audacious/autobuild/beyond
@@ -3,12 +3,6 @@ cd "$SRCDIR"/../audacious-plugins-$PKGVER
 abinfo "Applying patches for plugins ..."
 ab_apply_patches "$SRCDIR"/autobuild/patches/*.plugins
 
-OPTION=""
-if ab_match_arch arm64; then
-    abinfo "Disable Qt to fix arm64 build ..."
-    OPTION+=" --disable-qt"
-fi
-
 abinfo "Configuring audacious-plugins ..."
 meson setup builddir --prefix=/usr --sbindir=/usr/bin
 

--- a/app-multimedia/audacious/autobuild/defines
+++ b/app-multimedia/audacious/autobuild/defines
@@ -3,39 +3,9 @@ PKGSEC=sound
 PKGDEP="gnome-icon-theme glib libguess hicolor-icon-theme desktop-file-utils \
         unzip alsa-lib pulseaudio jack lame libvorbis flac mpg123 faad2 \
         ffmpeg libmodplug fluidsynth libcdio-paranoia wavpack dbus-glib \
-        libnotify curl libmtp neon libmms libcue libsidplayfp qt-6"
-PKGDEP__RETRO="alsa-lib curl dbus-glib desktop-file-utils faad2 ffmpeg flac \
-               gnome-icon-theme hicolor-icon-theme glib gtk-2 lame \
-               libcdio-paranoia libcue libguess libmtp libmms libnotify \
-               libsidplayfp libvorbis mpg123 neon unzip wavpack libsamplerate"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
+        libnotify curl libmtp neon libmms libcue libsidplayfp qt-6 opusfile"
 BUILDDEP="appstream-glib audacious"
-BUILDDEP__RETRO="audacious"
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
-PKGDES="A simple audio player (Qt 5)"
-PKGDES__RETRO="A simple audio player (GTK+ 2)"
-PKGDES__ARMV4="${PKGDES__RETRO}"
-PKGDES__ARMV6HF="${PKGDES__RETRO}"
-PKGDES__ARMV7HF="${PKGDES__RETRO}"
-PKGDES__I486="${PKGDES__RETRO}"
-PKGDES__LOONGSON2F="${PKGDES__RETRO}"
-PKGDES__M68K="${PKGDES__RETRO}"
-PKGDES__POWERPC="${PKGDES__RETRO}"
-PKGDES__PPC64="${PKGDES__RETRO}"
+PKGDES="Audio player with support for plugins"
 
 ABTYPE=meson
 

--- a/app-multimedia/audacious/autobuild/defines.stage2
+++ b/app-multimedia/audacious/autobuild/defines.stage2
@@ -3,39 +3,9 @@ PKGSEC=sound
 PKGDEP="gnome-icon-theme glib libguess hicolor-icon-theme desktop-file-utils \
         unzip alsa-lib pulseaudio jack lame libvorbis flac mpg123 faad2 \
         ffmpeg libmodplug fluidsynth libcdio-paranoia wavpack dbus-glib \
-        libnotify curl libmtp neon libmms libcue libsidplayfp qt-6"
-PKGDEP__RETRO="alsa-lib curl dbus-glib desktop-file-utils faad2 ffmpeg flac \
-               gnome-icon-theme hicolor-icon-theme glib gtk-2 lame \
-               libcdio-paranoia libcue libguess libmtp libmms libnotify \
-               libsidplayfp libvorbis mpg123 neon unzip wavpack libsamplerate"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
+        libnotify curl libmtp neon libmms libcue libsidplayfp qt-6 opusfile"
 BUILDDEP="appstream-glib"
-BUILDDEP__RETRO=""
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
-PKGDES="A simple audio player (Qt 5)"
-PKGDES__RETRO="A simple audio player (GTK+ 2)"
-PKGDES__ARMV4="${PKGDES__RETRO}"
-PKGDES__ARMV6HF="${PKGDES__RETRO}"
-PKGDES__ARMV7HF="${PKGDES__RETRO}"
-PKGDES__I486="${PKGDES__RETRO}"
-PKGDES__LOONGSON2F="${PKGDES__RETRO}"
-PKGDES__M68K="${PKGDES__RETRO}"
-PKGDES__POWERPC="${PKGDES__RETRO}"
-PKGDES__PPC64="${PKGDES__RETRO}"
+PKGDES="Audio player with support for plugins"
 
 ABTYPE=meson
 

--- a/app-multimedia/audacious/spec
+++ b/app-multimedia/audacious/spec
@@ -1,8 +1,7 @@
-VER=4.4.2
-REL=4
+VER=4.5.1
 SRCS="tbl::https://distfiles.audacious-media-player.org/audacious-$VER.tar.bz2 \
       git::rename=audacious-plugins-$VER;commit=tags/audacious-plugins-$VER::https://github.com/audacious-media-player/audacious-plugins"
-CHKSUMS="sha256::34509504f8c93b370420d827703519f0681136672e42d56335f26f7baec95005 \
+CHKSUMS="sha256::7194743a0a41b1d8f582c071488b77f7b917be47ca5e142dd76af5d81d36f9cd \
          SKIP"
 CHKUPDATE="anitya::id=138"
 SUBDIR="audacious-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- audacious: update to 4.5.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- audacious: 4.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit audacious:+stage2 audacious
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
