### PR TITLE
hyfetch: new, 2.0.4

### DIFF
--- a/app-utils/hyfetch/autobuild/defines
+++ b/app-utils/hyfetch/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=hyfetch
+PKGSEC=utils
+PKGDEP="glibc"
+BUILDDEP="llvm rustc cargo"
+PKGRECOM="neofetch fastfetch"
+PKGDES="Neofetch with LGBTQ+ pride flags! "
+ABTYPE=rust

--- a/app-utils/hyfetch/spec
+++ b/app-utils/hyfetch/spec
@@ -1,0 +1,3 @@
+VER=2.0.4
+SRCS="tbl::https://github.com/hykilpikonna/hyfetch/archive/refs/tags/$VER.tar.gz"
+CHKSUMS="sha256::8de8908334470f24dfae5693bd9660360ec8c1074b270f36eac659530e0b35ba"


### PR DESCRIPTION
Topic Description
-----------------
hyfetch: new, 2.0.4

Package(s) Affected
-------------------
hyfetch

Security Update?
----------------
No

Build Order
-----------

```
#buildit hyfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
