### PR TITLE
mvfst: update to 2025.10.27.00

### DIFF
--- a/runtime-network/mvfst/spec
+++ b/runtime-network/mvfst/spec
@@ -1,4 +1,4 @@
-VER=2025.09.01.00
+VER=2025.10.27.00
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/mvfst.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373578"


### PR DESCRIPTION
Topic Description
-----------------

- mvfst: update to 2025.10.27.00
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mvfst: 2025.10.27.00

Security Update?
----------------

No

Build Order
-----------

```
#buildit mvfst
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
