### PR TITLE
multipath-tools: update to 0.13.0

### DIFF
--- a/app-admin/multipath-tools/spec
+++ b/app-admin/multipath-tools/spec
@@ -1,5 +1,4 @@
-VER=0.9.3
-REL=1
+VER=0.13.0
 SRCS="https://github.com/opensvc/multipath-tools/archive/$VER.tar.gz"
-CHKSUMS="sha256::7d5af5d86e43b757e253d1ba244aa8a9c09bfbb1677a72accb799b1bfcc0a9ac"
+CHKSUMS="sha256::ed0bf455d5886d642875c302f7cf0362ca29cd2ab8dbc42e50cca9bd5855640b"
 CHKUPDATE="anitya::id=424"


### PR DESCRIPTION
Topic Description
-----------------

- multipath-tools: update to 0.13.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- multipath-tools: 0.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit multipath-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
