### PR TITLE
fizz: update to 2025.10.27.00

### DIFF
--- a/app-network/fizz/spec
+++ b/app-network/fizz/spec
@@ -1,4 +1,4 @@
-VER=2025.09.01.00
+VER=2025.10.27.00
 SRCS="git::commit=tags/v$VER::https://github.com/facebookincubator/fizz.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138222"


### PR DESCRIPTION
Topic Description
-----------------

- fizz: update to 2025.10.27.00
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fizz: 2025.10.27.00

Security Update?
----------------

No

Build Order
-----------

```
#buildit fizz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
