### PR TITLE
wangle: update to 2025.10.27.00

### DIFF
--- a/runtime-network/wangle/spec
+++ b/runtime-network/wangle/spec
@@ -1,4 +1,4 @@
-VER=2025.09.01.00
+VER=2025.10.27.00
 SRCS="git::commit=tags/v$VER::https://github.com/facebook/wangle.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138224"


### PR DESCRIPTION
Topic Description
-----------------

- wangle: update to 2025.10.27.00
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wangle: 2025.10.27.00

Security Update?
----------------

No

Build Order
-----------

```
#buildit wangle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
