### PR TITLE
astyle: update to 3.6.13

### DIFF
--- a/app-devel/astyle/spec
+++ b/app-devel/astyle/spec
@@ -1,4 +1,4 @@
-VER=3.6.6
+VER=3.6.13
 SRCS="git::commit=tags/$VER::https://gitlab.com/saalen/astyle"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=123"


### PR DESCRIPTION
Topic Description
-----------------

- astyle: update to 3.6.13
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- astyle: 3.6.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit astyle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
