### PR TITLE
evtest: update to 1.36

### DIFF
--- a/app-utils/evtest/spec
+++ b/app-utils/evtest/spec
@@ -1,4 +1,4 @@
-VER=1.35
+VER=1.36
 SRCS="git::commit=tags/evtest-$VER::https://gitlab.freedesktop.org/libevdev/evtest"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21347"


### PR DESCRIPTION
Topic Description
-----------------

- evtest: update to 1.36
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- evtest: 1.36

Security Update?
----------------

No

Build Order
-----------

```
#buildit evtest
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
