### PR TITLE
libvips: rebuild for recent libvips update

### DIFF
--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,4 +1,5 @@
 VER=8.17.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: rebuild for recent cfitsio update

Package(s) Affected
-------------------

- libvips: 8.17.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
