### PR TITLE
imhex: fix packaging

### DIFF
--- a/app-editors/imhex/autobuild/beyond
+++ b/app-editors/imhex/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing imhex-updater ..."
+rm -v "$PKGDIR"/usr/bin/imhex-updater

--- a/app-editors/imhex/autobuild/defines
+++ b/app-editors/imhex/autobuild/defines
@@ -1,23 +1,44 @@
 PKGNAME=imhex
 PKGSEC=devel
-PKGDEP__with_dotnet="dotnet-runtime-8.0"
-PKGDES="A hex editor with Pattern and YARA Rule support"
-PKGDEP="glfw"
-BUILDDEP="yara fmt nlohmann-json capstone llvm boost"
+PKGDEP="capstone curl fmt glfw file fmt fontconfig mbedtls yara"
+PKGDEP__DOTNET="${PKGDEP} dotnet-runtime-8.0"
+BUILDDEP="nlohmann-json llvm boost"
+PKGDES="Hex editor with Pattern and YARA Rule support"
 
-CMAKE_AFTER="-DUSE_SYSTEM_FMT=ON \
-        -DUSE_SYSTEM_YARA=ON \
-        -DUSE_SYSTEM_NLOHMANN_JSON=ON \
-        -DUSE_SYSTEM_CAPSTONE=ON \
-        -DUSE_SYSTEM_LLVM=ON \
-        -DUSE_SYSTEM_BOOST=ON \
-        -DIMHEX_ENABLE_LTO=ON \
-        -DIMHEX_STRIP_RELEASE=OFF \
-        -DIMHEX_ENABLE_UNIT_TESTS=OFF \
-        -DIMHEX_PATTERNS_PULL_MASTER=ON \
-        -DIMHEX_USE_GTK_FILE_PICKER=OFF \
-        -DLLVM_DIR=/usr/lib/cmake/llvm \
-        -DCMAKE_PREFIX_PATH=/usr"
+PKGDEP__AMD64="${PKGDEP__DOTNET}"
+PKGDEP__ARM64="${PKGDEP__DOTNET}"
 
-CMAKE_AFTER__without_dotnet="$CMAKE_AFTER \
-        -DIMHEX_EXCLUDE_PLUGINS=script_loader"
+CMAKE_AFTER=(
+    '-DUSE_SYSTEM_FMT=ON'
+    '-DUSE_SYSTEM_YARA=ON'
+    '-DUSE_SYSTEM_NLOHMANN_JSON=ON'
+    '-DUSE_SYSTEM_CAPSTONE=ON'
+    '-DUSE_SYSTEM_LLVM=ON'
+    '-DUSE_SYSTEM_BOOST=ON'
+    '-DIMHEX_ENABLE_LTO=ON'
+    '-DIMHEX_STRIP_RELEASE=OFF'
+    '-DIMHEX_ENABLE_UNIT_TESTS=OFF'
+    '-DIMHEX_PATTERNS_PULL_MASTER=ON'
+    '-DIMHEX_USE_GTK_FILE_PICKER=OFF'
+    '-DLLVM_DIR=/usr/lib/cmake/llvm'
+    '-DCMAKE_PREFIX_PATH=/usr'
+)
+CMAKE_AFTER__NODOTNET=(
+    "${CMAKE_AFTER[@]}"
+    '-DIMHEX_EXCLUDE_PLUGINS=script_loader'
+)
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER__NODOTNET[@]}"
+)
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER__NODOTNET[@]}" 
+)
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER__NODOTNET[@]}" 
+)
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER__NODOTNET[@]}" 
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__NODOTNET[@]}" 
+)

--- a/app-editors/imhex/spec
+++ b/app-editors/imhex/spec
@@ -1,4 +1,5 @@
 VER=1.37.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/WerWolv/ImHex.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141621"


### PR DESCRIPTION
Topic Description
-----------------

- imhex: fix packaging
    - Add missing dependency in defines.
    - Revise CMAKE_AFTER\* as arrays.
    - Make .NET/no-.NET logic work.
    - Drop imhex-updater.

Package(s) Affected
-------------------

- imhex: 1.37.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit imhex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
