### PR TITLE
xorg-server: update to 21.1.19

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,9 +1,9 @@
 UPSTREAM_VER=1.15.0
-XORG_VER=21.1.18
+XORG_VER=21.1.19
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::c878d1930d87725d4a5bf498c24f4be8130d5b2646a9fd0f2994deff90116352"
+         sha256::ca6b38181685d7d7c935d0597cfe35ee8df4d0fbf8ac63301541e037e8b08f07"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"

--- a/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
@@ -1,4 +1,4 @@
-From c77be321d01ba91443845d3f5896969e0c2be546 Mon Sep 17 00:00:00 2001
+From 3e1f0cb0072cf0cf3fdaaecdafa0fec256c8ca92 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:06:28 +0800
 Subject: [PATCH 1/7] Use intel ddx only on pre-gen4 hw, newer ones will fall
@@ -40,5 +40,5 @@ index aeeed8be6..db705bf72 100644
  			break;
          }
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
@@ -1,4 +1,4 @@
-From 4cfdf63ec7370aaf877434191035c04b7ead7c6e Mon Sep 17 00:00:00 2001
+From 365b982603f0e5aa81186880f10adac48fcab46e Mon Sep 17 00:00:00 2001
 From: Ben Skeggs <bskeggs@redhat.com>
 Date: Sat, 22 Apr 2017 02:26:28 +1000
 Subject: [PATCH 2/7] xfree86: use modesetting driver by default on GeForce 8
@@ -49,5 +49,5 @@ index db705bf72..d2e78acaa 100644
  #endif
          driverList[idx++] = "nv";
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,4 +1,4 @@
-From f918df1581bd0bc707bbfdf7be941678a7839b5d Mon Sep 17 00:00:00 2001
+From 76254188831b1074eb54805ce9f9bfe972ee87c9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:18:25 +0800
 Subject: [PATCH 3/7] hw/xfree86: re-calculate the clock and refresh rate
@@ -42,7 +42,7 @@ index ef3be84c3..b275ce9d8 100644
          return "unknown reason";
      case MODE_ERROR:
 diff --git a/hw/xfree86/drivers/modesetting/drmmode_display.c b/hw/xfree86/drivers/modesetting/drmmode_display.c
-index 48dccad73..4d046169a 100644
+index 21c9222e1..d9fdadc76 100644
 --- a/hw/xfree86/drivers/modesetting/drmmode_display.c
 +++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
 @@ -2641,7 +2641,7 @@ static DisplayModePtr
@@ -85,5 +85,5 @@ index ad01b87ec..561087717 100644
      MODE_ERROR = -1             /* error condition */
  } ModeStatus;
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,4 +1,4 @@
-From 25b4c31765c73f27fa2e8f0892dd151a1c28bd43 Mon Sep 17 00:00:00 2001
+From 51e9941fd6718419c2d30045d4b7f23545807574 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:27:59 +0800
 Subject: [PATCH 4/7] xf86: Accept devices with the 'hyperv_drm' driver
@@ -28,5 +28,5 @@ index 45028f7a6..071f44b2a 100644
                      if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
                          break;
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
@@ -1,4 +1,4 @@
-From edccf4dfc0dd8dbb2c75e2e4a6e10be10f31c39b Mon Sep 17 00:00:00 2001
+From 06559e8ebe009564c300b257abb0e1f5c9beff79 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 15 Aug 2020 01:32:42 -0600
 Subject: [PATCH 5/7] Allows X to work on the Lemote Yeeloong laptop
@@ -133,5 +133,5 @@ index fd83022f6..bacbe010b 100644
      if (ioBase == NULL) {
          ioBase = (volatile unsigned char *) mmap(0, 0x20000,
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
@@ -1,4 +1,4 @@
-From 7258ef1c6301c99ebbe9b03eede5ca982bb8ed48 Mon Sep 17 00:00:00 2001
+From a555a066b6b52b0848aabea2edb03ce9229a427e Mon Sep 17 00:00:00 2001
 From: "Liu, Chang" <cl91tp@gmail.com>
 Date: Wed, 8 Nov 2023 13:02:10 +0800
 Subject: [PATCH 6/7] modesetting: match against Multimedia Video Controllers
@@ -14,7 +14,7 @@ against these types of devices as well.
  1 file changed, 3 insertions(+)
 
 diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
-index 535f49d1d..54eb42d84 100644
+index fe3315a9c..01b3f505b 100644
 --- a/hw/xfree86/drivers/modesetting/driver.c
 +++ b/hw/xfree86/drivers/modesetting/driver.c
 @@ -96,6 +96,9 @@ static const struct pci_id_match ms_device_match[] = {
@@ -28,5 +28,5 @@ index 535f49d1d..54eb42d84 100644
      {0, 0, 0},
  };
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
@@ -1,4 +1,4 @@
-From c1229340f1380149f44cbe48854afe507971aa18 Mon Sep 17 00:00:00 2001
+From c18393b1e3e5b0f592c709737a060866fe1f3f0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 17:38:44 +0800
 Subject: [PATCH 7/7] hw/xfree86: workaround bad firmware boot VGA reporting on
@@ -74,5 +74,5 @@ index fd144dbe7..a95096736 100644
          return;
  #endif
 -- 
-2.48.1
+2.51.1
 

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.18
-SRCS="tbl::https://www.x.org/archive/individual/xserver/xorg-server-$VER.tar.xz"
-CHKSUMS="sha256::c878d1930d87725d4a5bf498c24f4be8130d5b2646a9fd0f2994deff90116352"
+VER=21.1.19
+SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"

--- a/topics/tigervnc-1.15.0-xserver21.1.19.toml
+++ b/topics/tigervnc-1.15.0-xserver21.1.19.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "TigerVNC builtin X.Org Server Update"
+zh_CN = "TigerVNC 内建 X.Org Server 更新"
+
+[caution]
+default = "Fixes 3 zero-day security vulnerabilities disclosed in X.Org's Security Advisory on October 28, 2025"
+zh_CN = "修复 X.Org 在 2025 年 10 月 28 日的安全公告中披露的 3 个零日 (0-day) 安全漏洞"
+
+[packages-v2]
+"tigervnc" = "< 1.15.0+xserver21.1.19"

--- a/topics/xorg-server-21.1.19.toml
+++ b/topics/xorg-server-21.1.19.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "X.Org Server 21.1.19"
+
+[caution]
+default = "Fixes 3 zero-day security vulnerabilities disclosed in X.Org's Security Advisory on October 28, 2025"
+zh_CN = "修复 X.Org 在 2025 年 10 月 28 日的安全公告中披露的 3 个零日 (0-day) 安全漏洞"
+
+[packages-v2]
+"xorg-server" = "< 21.1.19"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add tigervnc-1.15.0-xserver21.1.19.toml
- tigervnc: update builtin xorg-server to 21.1.19
- topics: add xorg-server-21.1.19.toml
- xorg-server: update to 21.1.19
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tigervnc: 1.15.0+xserver21.1.19
- xorg-server: 21.1.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
