### PR TITLE
xwayland: update to 24.1.9

### DIFF
--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=24.1.8
+VER=24.1.9
 SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::c8908d57c8ed9ceb8293c16ba7ad5af522efaf1ba7e51f9e4cf3c0774d199907"
+CHKSUMS="sha256::f297af27a84508db9b80d1cbbcc69c3801da38eb64c72f3b5b50f582459afdd0"
 CHKUPDATE="anitya::id=180949"

--- a/topics/xwayland-24.1.9.toml
+++ b/topics/xwayland-24.1.9.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Xwayland 24.1.9"
+
+[caution]
+default = "Fixes 3 zero-day security vulnerabilities disclosed in X.Org's Security Advisory on October 28, 2025"
+zh_CN = "修复 X.Org 在 2025 年 10 月 28 日的安全公告中披露的 3 个零日 (0-day) 安全漏洞"
+
+[packages-v2]
+"xwayland" = "< 24.1.9"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland: update to 24.1.9
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xwayland: 24.1.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
