### PR TITLE
zathura-pdf-poppler: update to 0.3.4

### DIFF
--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,5 +1,4 @@
-VER=0.3.3
-REL=1
+VER=0.3.4
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-pdf-poppler: update to 0.3.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zathura-pdf-poppler: 0.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura-pdf-poppler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
