### PR TITLE
zathura-ps: update to 0.2.9

### DIFF
--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,4 +1,4 @@
-VER=0.2.8
+VER=0.2.9
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-ps: update to 0.2.9
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- zathura-ps: 0.2.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura-ps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
