### PR TITLE
deno: update to 2.5.5

### DIFF
--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.5.4
+VER=2.5.5
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=140.2.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::d92d0c2b85f016769dcc2f0b86ae03861d2303bb165aac4c7911559c052301ca \
+CHKSUMS="sha256::900be91d2a925a293915b454ec24e94188ce14c68fb04916d9a00e2e2f6d5a89 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.5.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- deno: 2.5.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
