### PR TITLE
squid: update to 7.3

### DIFF
--- a/app-web/squid/autobuild/conffiles
+++ b/app-web/squid/autobuild/conffiles
@@ -1,4 +1,0 @@
-/etc/squid/squid.conf
-/etc/squid/cachemgr.conf
-/etc/squid/errorpage.css
-/etc/squid/mime.conf

--- a/app-web/squid/autobuild/defines
+++ b/app-web/squid/autobuild/defines
@@ -1,49 +1,49 @@
 PKGNAME=squid
 PKGSEC=web
 PKGDEP="gnutls krb5 libcap libtool linux-pam nettle openssl perl libnsl2"
-PKGDES="Full-featured Web proxy cache server"
+PKGDES="Web proxy cache server"
 
-ABSHADOW=0
+# FIXME: [...]/squid-7.3/cfgaux/missing: line 85: aclocal-1.17: command not found
+RECONF=0
+
 # FIXME: Option checking disabled, as this is a multi-level source with
 #        each of their set of autotools parameters.
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--datadir=/usr/share/squid \
-                 --sysconfdir=/etc/squid \
-                 --libexecdir=/usr/lib/squid \
-                 --localstatedir=/var \
-                 --with-logdir=/var/log/squid \
-                 --with-pidfile=/run/squid.pid \
-                 --enable-auth \
-                 --enable-auth-basic \
-                 --enable-auth-ntlm \
-                 --enable-auth-digest \
-                 --enable-auth-negotiate \
-                 --enable-removal-policies=lru,heap \
-                 --enable-storeio=aufs,ufs,diskd,rock \
-                 --enable-delay-pools \
-                 --enable-arp-acl \
-                 --with-openssl \
-                 --enable-snmp \
-                 --enable-linux-netfilter \
-                 --enable-ident-lookups \
-                 --enable-useragent-log \
-                 --enable-cache-digests \
-                 --enable-referer-log \
-                 --enable-arp-acl \
-                 --enable-htcp \
-                 --enable-carp \
-                 --enable-epoll \
-                 --with-large-files \
-                 --enable-arp-acl \
-                 --with-default-user=proxy \
-                 --enable-async-io \
-                 --enable-truncate \
-                 --enable-icap-client \
-                 --enable-ssl-crtd \
-                 --disable-arch-native \
-                 --disable-strict-error-checking \
-                 --enable-wccpv2"
-
-RECONF=0
-
-NOLTO__LOONGSON3=1
+AUTOTOOLS_AFTER=(
+    '--datadir=/usr/share/squid'
+    '--sysconfdir=/etc/squid'
+    '--libexecdir=/usr/lib/squid'
+    '--localstatedir=/var'
+    '--with-logdir=/var/log/squid'
+    '--with-pidfile=/run/squid.pid'
+    '--enable-auth'
+    '--enable-auth-basic'
+    '--enable-auth-ntlm'
+    '--enable-auth-digest'
+    '--enable-auth-negotiate'
+    '--enable-removal-policies=lru,heap'
+    '--enable-storeio=aufs,ufs,diskd,rock'
+    '--enable-delay-pools'
+    '--enable-arp-acl'
+    '--with-openssl'
+    '--enable-snmp'
+    '--enable-linux-netfilter'
+    '--enable-ident-lookups'
+    '--enable-useragent-log'
+    '--enable-cache-digests'
+    '--enable-referer-log'
+    '--enable-arp-acl'
+    '--enable-htcp'
+    '--enable-carp'
+    '--enable-epoll'
+    '--with-large-files'
+    '--enable-arp-acl'
+    '--with-default-user=proxy'
+    '--enable-async-io'
+    '--enable-truncate'
+    '--enable-icap-client'
+    '--enable-ssl-crtd'
+    '--disable-arch-native'
+    '--disable-strict-error-checking'
+    '--enable-wccpv2'
+)

--- a/app-web/squid/spec
+++ b/app-web/squid/spec
@@ -1,5 +1,4 @@
-VER=5.7
-REL=3
-SRCS="tbl::http://www.squid-cache.org/Versions/v5/squid-${VER}.tar.xz"
-CHKSUMS="sha256::6b0753aaba4c9c4efd333e67124caecf7ad6cc2d38581f19d2f0321f5b7ecd81"
+VER=7.3
+SRCS="tbl::https://github.com/squid-cache/squid/releases/download/SQUID_${VER//./_}/squid-$VER.tar.xz"
+CHKSUMS="sha256::dadc2a9a3926ce1b3babeaa7a7d7b21cbb089025876daa3f5c19e7eb6391ddcd"
 CHKUPDATE="anitya::id=4880"


### PR DESCRIPTION
Topic Description
-----------------

- squid: update to 7.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- squid: 7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit squid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
