### PR TITLE
lxgwneoxihei-font: update to 1.226

### DIFF
--- a/desktop-fonts/lxgwneoxihei-font/spec
+++ b/desktop-fonts/lxgwneoxihei-font/spec
@@ -1,7 +1,7 @@
-VER=1.224
+VER=1.226
 SRCS="file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
       git::commit=v$VER::https://github.com/lxgw/LxgwNeoXiHei.git"
-CHKSUMS="sha256::5a26fccd9b1dc3d2b97665583f29b3bf8864021ace5b21237e5cc45fcb6fd337 \
+CHKSUMS="sha256::aca8449cd6ea4119537a96533ccf4d69abbbe185915382b6da3ac761339728e1 \
          SKIP"
 CHKUPDATE="anitya::id=234778"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- lxgwneoxihei-font: update to 1.226
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lxgwneoxihei-font: 1.226

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwneoxihei-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
