### PR TITLE
lxgwcleargothic-font: update to 0.508

### DIFF
--- a/desktop-fonts/lxgwcleargothic-font/spec
+++ b/desktop-fonts/lxgwcleargothic-font/spec
@@ -1,8 +1,8 @@
-VER=0.503
+VER=0.508
 SRCS="file::rename=LXGWXiHeiCL.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiCL.ttf \
       file::rename=LXGWXiHeiMN.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiMN.ttf
       file::rename=LICENSE.md::https://raw.githubusercontent.com/lxgw/LxgwXiHei/v$VER/LICENSE.md"
-CHKSUMS="sha256::d7789de0ca4954ea900cd75b1aa1f7735b3ce20d116a1723f56b888ce8e536e6 \
-         sha256::e9408f431996b4a9c1227a0f26f2ab4001cdbfab412ece085485a4703009d745 \
+CHKSUMS="sha256::9e46fb41dad3e94a289a706d9899e6c554e822ace24aa8648f169a86d8967c16 \
+         sha256::b2ce4b7cf1f4f0121719e039abc79888ac0582ba6bbace3f7c2cb55757ab4531 \
          sha256::a186b1f3ad4b8d56a43dc96637ce55f5aa4f4446025d6247641d4ef13c4bb29b"
 CHKUPDATE="anitya::id=234782"


### PR DESCRIPTION
Topic Description
-----------------

- lxgwcleargothic-font: update to 0.508
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lxgwcleargothic-font: 0.508

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
