### PR TITLE
openmw: update to 0.50.0

### DIFF
--- a/app-games/openmw/spec
+++ b/app-games/openmw/spec
@@ -1,5 +1,4 @@
-VER=0.48.0+git20240902
-REL=3
+VER=0.50.0
 # FIXME: 0.48.0 does not come with FFmpeg >= 5.0 support and upstream patch
 # is next to impossible to backport.
 SRCS="git::commit=89976a9424d2a355433fbe753572b9cc6abf4508::https://github.com/OpenMW/openmw"


### PR DESCRIPTION
Topic Description
-----------------

- openmw: update to 0.50.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openmw: 0.50.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit openmw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
