### PR TITLE
libtheora: downgrade to 1.1.1

### DIFF
--- a/runtime-multimedia/libtheora/autobuild/defines
+++ b/runtime-multimedia/libtheora/autobuild/defines
@@ -14,8 +14,11 @@ BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGSEC=libs
 
 ABTYPE=autotools
+
+# FIXME: configure: error: source directory already configured; run "make distclean" there first
+ABSHADOW=0
+
 AUTOTOOLS_AFTER=(
-    '--disable-doc'
     '--disable-spec'
     '--disable-examples'
 )

--- a/runtime-multimedia/libtheora/spec
+++ b/runtime-multimedia/libtheora/spec
@@ -1,4 +1,5 @@
-VER=1.2.0
+VER=1.1.1
+EPOCH=1
 SRCS="tbl::https://downloads.xiph.org/releases/theora/libtheora-$VER.tar.xz"
-CHKSUMS="sha256::ebdf77a8f5c0a8f7a9e42323844fa09502b34eb1d1fece7b5f54da41fe2122ec"
+CHKSUMS="sha256::f36da409947aa2b3dcc6af0a8c2e3144bc19db2ed547d64e9171c59c66561c61"
 CHKUPDATE="anitya::id=11793"

--- a/runtime-optenv32/libtheora+32/autobuild/defines
+++ b/runtime-optenv32/libtheora+32/autobuild/defines
@@ -7,8 +7,11 @@ PKGDES="An open video codec developed by the Xiph.org (32-bit x86 runtime)"
 ABHOST=optenv32
 
 ABTYPE=autotools
+
+# FIXME: configure: error: source directory already configured; run "make distclean" there first
+ABSHADOW=0
+
 AUTOTOOLS_AFTER=(
-    '--disable-doc'
     '--disable-spec'
     '--disable-examples'
 )

--- a/runtime-optenv32/libtheora+32/spec
+++ b/runtime-optenv32/libtheora+32/spec
@@ -1,4 +1,5 @@
-VER=1.2.0
+VER=1.1.1
+EPOCH=1
 SRCS="tbl::https://downloads.xiph.org/releases/theora/libtheora-$VER.tar.xz"
-CHKSUMS="sha256::ebdf77a8f5c0a8f7a9e42323844fa09502b34eb1d1fece7b5f54da41fe2122ec"
+CHKSUMS="sha256::f36da409947aa2b3dcc6af0a8c2e3144bc19db2ed547d64e9171c59c66561c61"
 CHKUPDATE="anitya::id=11793"


### PR DESCRIPTION
Topic Description
-----------------

- libtheora+32: downgrade to 1.1.1
    1.2.0 introduced a soname change, which we are not yet ready to tackle.
- libtheora: downgrade to 1.1.1
    1.2.0 introduced a soname change, which we are not yet ready to tackle.
- tailscale: update to 1.90.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libtheora: 1.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtheora
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
