### PR TITLE
brotli: update to 1.2.0

### DIFF
--- a/app-utils/brotli/autobuild/patches/0001-FROMLIST-disable-BROTLI_MODEL-macro-for-some-targets.patch
+++ b/app-utils/brotli/autobuild/patches/0001-FROMLIST-disable-BROTLI_MODEL-macro-for-some-targets.patch
@@ -1,0 +1,48 @@
+From 9130b9667206275a9030d64d6da2672dc2d3b089 Mon Sep 17 00:00:00 2001
+From: Evgenii Kliuchnikov <eustas@google.com>
+Date: Wed, 29 Oct 2025 02:01:53 -0700
+Subject: [PATCH] FROMLIST: disable BROTLI_MODEL macro for some targets
+
+PiperOrigin-RevId: 825438559
+
+Link: https://github.com/google/brotli/pull/1369
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ c/common/platform.h | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/c/common/platform.h b/c/common/platform.h
+index b59f9b8..e1254d5 100644
+--- a/c/common/platform.h
++++ b/c/common/platform.h
+@@ -213,6 +213,10 @@ OR:
+ #define BROTLI_TARGET_MIPS64
+ #endif
+ 
++#if defined(__ia64__) || defined(_M_IA64)
++#define BROTLI_TARGET_IA64
++#endif
++
+ #if defined(BROTLI_TARGET_X64) || defined(BROTLI_TARGET_ARMV8_64) || \
+     defined(BROTLI_TARGET_POWERPC64) || defined(BROTLI_TARGET_RISCV64) || \
+     defined(BROTLI_TARGET_LOONGARCH64) || defined(BROTLI_TARGET_MIPS64)
+@@ -665,13 +669,14 @@ BROTLI_UNUSED_FUNCTION void BrotliSuppressUnusedFunctions(void) {
+ #undef BROTLI_TEST
+ #endif
+ 
+-#if BROTLI_GNUC_HAS_ATTRIBUTE(model, 3, 0, 3)
++#if !defined(BROTLI_MODEL) && BROTLI_GNUC_HAS_ATTRIBUTE(model, 3, 0, 3) && \
++    !defined(BROTLI_TARGET_IA64) && !defined(BROTLI_TARGET_LOONGARCH64)
+ #define BROTLI_MODEL(M) __attribute__((model(M)))
+ #else
+ #define BROTLI_MODEL(M) /* M */
+ #endif
+ 
+-#if BROTLI_GNUC_HAS_ATTRIBUTE(cold, 4, 3, 0)
++#if !defined(BROTLI_COLD) && BROTLI_GNUC_HAS_ATTRIBUTE(cold, 4, 3, 0)
+ #define BROTLI_COLD __attribute__((cold))
+ #else
+ #define BROTLI_COLD /* cold */
+-- 
+2.51.1
+

--- a/app-utils/brotli/spec
+++ b/app-utils/brotli/spec
@@ -1,4 +1,4 @@
-VER=1.1.0
+VER=1.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/google/brotli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15235"


### PR DESCRIPTION
Topic Description
-----------------

- brotli: update to 1.2.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- brotli: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit brotli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
