### PR TITLE
maxima: update to 5.48.1

### DIFF
--- a/app-scientific/maxima/spec
+++ b/app-scientific/maxima/spec
@@ -1,5 +1,4 @@
-VER=5.48.0
-REL=1
+VER=5.48.1
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/maxima/maxima-$VER.tar.gz"
-CHKSUMS="sha256::75af2bf1894df2a17aef8a5c378d72d4d53c669b9f47d60ec5ba8c8676c4aaab"
+CHKSUMS="sha256::b0916b5fb37b6eeaae400083175e68e28f80b9a1ab580c106a05448cf1c496b2"
 CHKUPDATE="anitya::id=6365"


### PR DESCRIPTION
Topic Description
-----------------

- maxima: update to 5.48.1
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- maxima: 5.48.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit maxima
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
