### PR TITLE
x11-app: add xeyes 1.3.1

### DIFF
--- a/runtime-display/x11-app/autobuild/build-order
+++ b/runtime-display/x11-app/autobuild/build-order
@@ -36,3 +36,4 @@ xvinfo
 xwd
 xwininfo
 xwud
+xeyes

--- a/runtime-display/x11-app/spec
+++ b/runtime-display/x11-app/spec
@@ -1,4 +1,4 @@
-VER=7.7.20240830
+VER=7.7.20251029
 __BDFTOPCF_VER=1.1
 __ICEAUTH_VER=1.0.10
 __LUIT_VER=1.1.1
@@ -15,6 +15,7 @@ __XCURSORGEN_VER=1.0.8
 __XDPYINFO_VER=1.3.4
 __XDRIINFO_VER=1.0.7
 __XEV_VER=1.2.6
+__XEYES_VER=1.3.1
 __XGAMMA_VER=1.0.7
 __XHOST_VER=1.0.9
 __XINPUT_VER=1.6.4
@@ -55,6 +56,7 @@ SRCS="tbl::${__BASE_URL}/bdftopcf-${__BDFTOPCF_VER}.tar.gz \
       tbl::${__BASE_URL}/xdpyinfo-${__XDPYINFO_VER}.tar.gz \
       tbl::${__BASE_URL}/xdriinfo-${__XDRIINFO_VER}.tar.gz \
       tbl::${__BASE_URL}/xev-${__XEV_VER}.tar.gz \
+      tbl::${__BASE_URL}/xeyes-${__XEYES_VER}.tar.gz \
       tbl::${__BASE_URL}/xgamma-${__XGAMMA_VER}.tar.gz \
       tbl::${__BASE_URL}/xhost-${__XHOST_VER}.tar.gz \
       tbl::${__BASE_URL}/xinput-${__XINPUT_VER}.tar.gz \
@@ -93,6 +95,7 @@ CHKSUMS="sha256::699d1a62012035b1461c7f8e3f05a51c8bd6f28f348983249fb89bbff7309b4
          sha256::fbd1e18885f67332b330fecd83592af25ad42d21457aaabfbd31a5a97388652a \
          sha256::9fab95510b1f67409632fb8af01369b128f4d12763fe1a2662f5666976a7d30c \
          sha256::e2e3527023017af3a9bfbef0a90f8e46ac354c506b51f0ee3834b30823e43b25 \
+         sha256::d223283270488b1a6b408d0e97bd69a7704cf6a9596c0320035d807e63cdc084 \
          sha256::61f5ef02883d65ab464678ad3d8c5445a0ff727fe6255af90b1b842ddf77370d \
          sha256::ca850367593fcddc4bff16de7ea1598aa4f6817daf5a803a1258dff5e337f7c3 \
          sha256::64e25434af1309ed0abca1ebebd035f7631bb0bc1bfac5decefe9aa98ccaf611 \


### PR DESCRIPTION
Topic Description
-----------------
x11-app: add xeyes 1.3.1

Package(s) Affected
-------------------
x11-app

Security Update?
----------------
No

Build Order
-----------

```
#buildit x11-app
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

