### PR TITLE
graphicsmagick: update to 1.3.46

### DIFF
--- a/app-utils/graphicsmagick/autobuild/defines
+++ b/app-utils/graphicsmagick/autobuild/defines
@@ -3,8 +3,14 @@ PKGSEC=graphics
 PKGDEP="jasper libpng libwmf libxml2 libtiff ghostscript freetype x11-lib lcms2 libtool bzip2 xz zstd"
 PKGDES="Image processing system"
 
-AUTOTOOLS_AFTER="--enable-shared --with-modules --with-perl \
-                 --with-gs-font-dir=/usr/share/fonts/Type1 \
-                 --with-quantum-depth=16 --with-threads"
-RECONF=0
+AUTOTOOLS_AFTER=(
+    '--enable-shared'
+    '--with-modules'
+    '--with-perl'
+    '--with-gs-font-dir=/usr/share/fonts/Type1'
+    '--with-quantum-depth=16'
+    '--with-threads'
+)
+
+# Note: Needed for plugin discovery.
 NOLIBTOOL=0

--- a/app-utils/graphicsmagick/spec
+++ b/app-utils/graphicsmagick/spec
@@ -1,4 +1,4 @@
-VER=1.3.43
+VER=1.3.46
 SRCS="tbl::https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/$VER/GraphicsMagick-$VER.tar.xz/download"
-CHKSUMS="sha256::2b88580732cd7e409d9e22c6116238bef4ae06fcda11451bf33d259f9cbf399f"
+CHKSUMS="sha256::c7c706a505e9c6c3764156bb94a0c9644d79131785df15a89c9f8721d1abd061"
 CHKUPDATE="anitya::id=1248"


### PR DESCRIPTION
Topic Description
-----------------

- graphicsmagick: update to 1.3.46
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- graphicsmagick: 1.3.46

Security Update?
----------------

No

Build Order
-----------

```
#buildit graphicsmagick
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
