### PR TITLE
gitea: update to 1.25.0

### DIFF
--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,5 +1,4 @@
-VER=1.24.5
-REL=1
-SRCS="tbl::https://github.com/go-gitea/gitea/releases/download/v1.24.5/gitea-src-1.24.5.tar.gz"
-CHKSUMS="sha256::835118a9b92ee8854a7b3113d3a09670a36ea8882bb9c779303f4812c4687aeb"
+VER=1.25.0
+SRCS="tbl::https://github.com/go-gitea/gitea/releases/download/v$VER/gitea-src-$VER.tar.gz"
+CHKSUMS="sha256::6ce85e249ed6b0915aa1c5dbeb4ffe3da60ff4f27749088145938c692debee15"
 CHKUPDATE="anitya::id=13537"


### PR DESCRIPTION
Topic Description
-----------------

- gitea: update to 1.25.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gitea: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
