### PR TITLE
mesa: update to 25.2.6

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -20,7 +20,7 @@ BUILDDEP="x11-proto mako systemd valgrind llvm libunwind glslang \
           directx-headers"
 # FIXME: Valgrind is not yet available.
 BUILDDEP__LOONGARCH64="${BUILDDEP/valgrind/}"
-BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP_LOONGARCH64}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP__LOONGARCH64}"
 BUILDDEP__RISCV64="${BUILDDEP/valgrind/}"
 
 BUILDDEP__RETRO="x11-proto llvm mako"

--- a/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-display/mesa/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,4 +1,4 @@
-From 624a5a547bcc1c7bc10e058774191e3b154661a4 Mon Sep 17 00:00:00 2001
+From 177534b9902e6e9e0b8a7f3f6773fdbd82ec32ca Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
 Subject: [PATCH 1/4] AOSCOS: r600: disable buggy VC-1 hardware decoding
@@ -33,5 +33,5 @@ index 0502c50b48d..a3727ce2ca7 100644
  			return false;
  		case PIPE_VIDEO_FORMAT_JPEG:
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-display/mesa/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,4 +1,4 @@
-From 29096328a1bf7042291714629ed4f5270e1e9336 Mon Sep 17 00:00:00 2001
+From 7c967f335487445cc7f53cb3c2f489cbb0efcf49 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
 Subject: [PATCH 2/4] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
@@ -35,5 +35,5 @@ index 9afe13cf322..a733b62826f 100644
  #define WARN_ONCE(cond, fmt...) do {                            \
     if (unlikely(cond)) {                                        \
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-display/mesa/autobuild/patches/0003-BACKPORT-UPSTREAM-anv-Use-os_get_page_size-for-mmap-.patch
+++ b/runtime-display/mesa/autobuild/patches/0003-BACKPORT-UPSTREAM-anv-Use-os_get_page_size-for-mmap-.patch
@@ -1,4 +1,4 @@
-From ad461b8e7bdfffc601edc8e7240a5a9c492e9a09 Mon Sep 17 00:00:00 2001
+From 556caf6558cacbe24ab49b3e97882fb0a8a73bd0 Mon Sep 17 00:00:00 2001
 From: Zhou Qiankang <wszqkzqk@qq.com>
 Date: Tue, 16 Sep 2025 14:03:48 +0800
 Subject: [PATCH 3/4] BACKPORT: UPSTREAM: anv: Use os_get_page_size for mmap
@@ -99,5 +99,5 @@ index 29abca76f6a..dffcfb85130 100644
       *
       * When running in a virtual context, the timestamp register is unreadable
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-display/mesa/autobuild/patches/0004-FROMLIST-gallivm-orcjit-put-object-cache-under-the-p.patch
+++ b/runtime-display/mesa/autobuild/patches/0004-FROMLIST-gallivm-orcjit-put-object-cache-under-the-p.patch
@@ -1,4 +1,4 @@
-From ff4dcf999bdd04254add94999c64a0d359d45de9 Mon Sep 17 00:00:00 2001
+From e75dd672e8d59c619013c744f21fab99cab7063a Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Sep 2025 22:52:30 +0800
 Subject: [PATCH 4/4] FROMLIST: gallivm: orcjit: put object cache under the
@@ -90,5 +90,5 @@ index 3d2b8cf81bc..6651ea439da 100644
  
  void
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,4 +1,4 @@
-VER=25.2.5
+VER=25.2.6
 SRCS="tbl::https://archive.mesa3d.org/mesa-${VER}.tar.xz"
-CHKSUMS="sha256::bb6243e7a6f525febfa1e6ab50827ca4d4bfdad73812377b0ca9b6c50998b03e"
+CHKSUMS="sha256::361c97e8afa5fe20141c5362c5b489040751e12861c186a16c621a2fb182fc42"
 CHKUPDATE="anitya::id=1970"

--- a/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0001-AOSCOS-r600-disable-buggy-VC-1-hardware-decoding.patch
@@ -1,4 +1,4 @@
-From 624a5a547bcc1c7bc10e058774191e3b154661a4 Mon Sep 17 00:00:00 2001
+From 177534b9902e6e9e0b8a7f3f6773fdbd82ec32ca Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 30 Aug 2024 17:27:37 +0800
 Subject: [PATCH 1/4] AOSCOS: r600: disable buggy VC-1 hardware decoding
@@ -33,5 +33,5 @@ index 0502c50b48d..a3727ce2ca7 100644
  			return false;
  		case PIPE_VIDEO_FORMAT_JPEG:
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0002-AOSCOS-fix-iris_bufmgr.c-set-PAGE_SIZE-as-16384-on-L.patch
@@ -1,4 +1,4 @@
-From 29096328a1bf7042291714629ed4f5270e1e9336 Mon Sep 17 00:00:00 2001
+From 7c967f335487445cc7f53cb3c2f489cbb0efcf49 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 12 Mar 2024 00:17:46 +0800
 Subject: [PATCH 2/4] AOSCOS: fix(iris_bufmgr.c): set PAGE_SIZE as 16384 on
@@ -35,5 +35,5 @@ index 9afe13cf322..a733b62826f 100644
  #define WARN_ONCE(cond, fmt...) do {                            \
     if (unlikely(cond)) {                                        \
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-UPSTREAM-anv-Use-os_get_page_size-for-mmap-.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0003-BACKPORT-UPSTREAM-anv-Use-os_get_page_size-for-mmap-.patch
@@ -1,4 +1,4 @@
-From ad461b8e7bdfffc601edc8e7240a5a9c492e9a09 Mon Sep 17 00:00:00 2001
+From 556caf6558cacbe24ab49b3e97882fb0a8a73bd0 Mon Sep 17 00:00:00 2001
 From: Zhou Qiankang <wszqkzqk@qq.com>
 Date: Tue, 16 Sep 2025 14:03:48 +0800
 Subject: [PATCH 3/4] BACKPORT: UPSTREAM: anv: Use os_get_page_size for mmap
@@ -99,5 +99,5 @@ index 29abca76f6a..dffcfb85130 100644
       *
       * When running in a virtual context, the timestamp register is unreadable
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-gallivm-orcjit-put-object-cache-under-the-p.patch
+++ b/runtime-optenv32/mesa+32/autobuild/patches/0004-FROMLIST-gallivm-orcjit-put-object-cache-under-the-p.patch
@@ -1,4 +1,4 @@
-From ff4dcf999bdd04254add94999c64a0d359d45de9 Mon Sep 17 00:00:00 2001
+From e75dd672e8d59c619013c744f21fab99cab7063a Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 20 Sep 2025 22:52:30 +0800
 Subject: [PATCH 4/4] FROMLIST: gallivm: orcjit: put object cache under the
@@ -90,5 +90,5 @@ index 3d2b8cf81bc..6651ea439da 100644
  
  void
 -- 
-2.51.0
+2.51.1
 

--- a/runtime-optenv32/mesa+32/spec
+++ b/runtime-optenv32/mesa+32/spec
@@ -1,10 +1,9 @@
-UPSTREAM_VER=25.2.5
+UPSTREAM_VER=25.2.6
 DXHEADERS_VER=1.618.2
 VER=${UPSTREAM_VER/\-/\~}+dxheaders${DXHEADERS_VER}
-REL=1
 SRCS="tbl::https://archive.mesa3d.org/mesa-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${DXHEADERS_VER};rename=dxheaders::https://github.com/microsoft/DirectX-Headers.git"
-CHKSUMS="sha256::bb6243e7a6f525febfa1e6ab50827ca4d4bfdad73812377b0ca9b6c50998b03e \
+CHKSUMS="sha256::361c97e8afa5fe20141c5362c5b489040751e12861c186a16c621a2fb182fc42 \
          SKIP"
 SUBDIR="mesa-${UPSTREAM_VER}"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa+32: update to 25.2.6
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.2.6
    \(HEAD: e75dd672e8d59c619013c744f21fab99cab7063a\).
- mesa: update to 25.2.6
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.2.6
    \(HEAD: e75dd672e8d59c619013c744f21fab99cab7063a\).

Package(s) Affected
-------------------

- mesa: 1:25.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
