### PR TITLE
kubo: update to 0.38.2

### DIFF
--- a/app-proxy/kubo/spec
+++ b/app-proxy/kubo/spec
@@ -1,5 +1,4 @@
-VER=0.33.2
-REL=2
+VER=0.38.2
 SRCS="git::commit=tags/v$VER::https://github.com/ipfs/kubo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328587"


### PR DESCRIPTION
Topic Description
-----------------

- kubo: update to 0.38.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kubo: 0.38.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kubo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
