### PR TITLE
gtk4-layer-shell: update to 1.3.0

### DIFF
--- a/desktop-gnome/gtk4-layer-shell/spec
+++ b/desktop-gnome/gtk4-layer-shell/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/wmww/gtk4-layer-shell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=359774"


### PR DESCRIPTION
Topic Description
-----------------

- gtk4-layer-shell: update to 1.3.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gtk4-layer-shell: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk4-layer-shell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
