### PR TITLE
[FLIGHT] xorg-server: disable libunwind for something somehing

### DIFF
--- a/runtime-display/xorg-server/autobuild/defines
+++ b/runtime-display/xorg-server/autobuild/defines
@@ -20,7 +20,7 @@ MESON_AFTER="-Dipv6=true \
              -Dglamor=true \
              -Dudev=true \
              -Dsystemd_logind=true \
-             -Dlibunwind=true \
+             -Dlibunwind=false \
              -Dsuid_wrapper=true \
              -Dsha1=libgcrypt \
              -Dxkb_dir=/usr/share/X11/xkb \

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,5 @@
 VER=21.1.19
+REL=1
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] xorg-server: disable libunwind for something something

Package(s) Affected
-------------------

- xorg-server: 21.1.19-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
