### PR TITLE
libheif: update to 1.20.2

### DIFF
--- a/runtime-imaging/libheif/spec
+++ b/runtime-imaging/libheif/spec
@@ -1,4 +1,4 @@
-VER=1.19.5
+VER=1.20.2
 SRCS="tbl::https://github.com/strukturag/libheif/releases/download/v${VER}/libheif-${VER}.tar.gz"
-CHKSUMS="sha256::d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf"
+CHKSUMS="sha256::68ac9084243004e0ef3633f184eeae85d615fe7e4444373a0a21cebccae9d12a"
 CHKUPDATE="anitya::id=64439"


### PR DESCRIPTION
Topic Description
-----------------

- libheif: update to 1.20.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libheif: 1.20.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libheif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
