### PR TITLE
[FLIGHT] xorg-server: downgrade to 21.1.18 with FlipPixels

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
@@ -1,7 +1,7 @@
 From 3e1f0cb0072cf0cf3fdaaecdafa0fec256c8ca92 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:06:28 +0800
-Subject: [PATCH 1/7] Use intel ddx only on pre-gen4 hw, newer ones will fall
+Subject: [PATCH 1/8] Use intel ddx only on pre-gen4 hw, newer ones will fall
  back to modesetting
 
 Co-authored-by: Timo Aaltonen <tjaalton@debian.org>

--- a/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
@@ -1,7 +1,7 @@
 From 365b982603f0e5aa81186880f10adac48fcab46e Mon Sep 17 00:00:00 2001
 From: Ben Skeggs <bskeggs@redhat.com>
 Date: Sat, 22 Apr 2017 02:26:28 +1000
-Subject: [PATCH 2/7] xfree86: use modesetting driver by default on GeForce 8
+Subject: [PATCH 2/8] xfree86: use modesetting driver by default on GeForce 8
  and newer
 
 Signed-off-by: Ben Skeggs <bskeggs@redhat.com>

--- a/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,7 +1,7 @@
 From 76254188831b1074eb54805ce9f9bfe972ee87c9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:18:25 +0800
-Subject: [PATCH 3/7] hw/xfree86: re-calculate the clock and refresh rate
+Subject: [PATCH 3/8] hw/xfree86: re-calculate the clock and refresh rate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,7 +1,7 @@
 From 51e9941fd6718419c2d30045d4b7f23545807574 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:27:59 +0800
-Subject: [PATCH 4/7] xf86: Accept devices with the 'hyperv_drm' driver
+Subject: [PATCH 4/8] xf86: Accept devices with the 'hyperv_drm' driver
 
 Put in a workaround to accept devices of the kernel's hyperv_drm
 driver. Makes Xorg work on HyperV Gen 1/2 with the DRM graphics

--- a/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
@@ -1,7 +1,7 @@
 From 06559e8ebe009564c300b257abb0e1f5c9beff79 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 15 Aug 2020 01:32:42 -0600
-Subject: [PATCH 5/7] Allows X to work on the Lemote Yeeloong laptop
+Subject: [PATCH 5/8] Allows X to work on the Lemote Yeeloong laptop
 
 ---
  hw/xfree86/common/compiler.h            | 64 ++++++++++++++++++++++++-

--- a/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
@@ -1,7 +1,7 @@
 From a555a066b6b52b0848aabea2edb03ce9229a427e Mon Sep 17 00:00:00 2001
 From: "Liu, Chang" <cl91tp@gmail.com>
 Date: Wed, 8 Nov 2023 13:02:10 +0800
-Subject: [PATCH 6/7] modesetting: match against Multimedia Video Controllers
+Subject: [PATCH 6/8] modesetting: match against Multimedia Video Controllers
  as well
 
 Some GPU devices such as those found in the Loongson 7A2000 bridge

--- a/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
@@ -1,7 +1,7 @@
 From c18393b1e3e5b0f592c709737a060866fe1f3f0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 17:38:44 +0800
-Subject: [PATCH 7/7] hw/xfree86: workaround bad firmware boot VGA reporting on
+Subject: [PATCH 7/8] hw/xfree86: workaround bad firmware boot VGA reporting on
  MIPS Loongson devices
 
 Loongson (MIPS) platforms based on (at least) the 7A bridge chip has

--- a/runtime-display/xorg-server/autobuild/patches/0008-Revert-xfree86-Remove-flippixels.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0008-Revert-xfree86-Remove-flippixels.patch
@@ -1,0 +1,222 @@
+From c0d090d3b89fde9fb2d20a869a4ebe2a1c1319e2 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 30 Oct 2025 20:34:38 +0800
+Subject: [PATCH 8/8] Revert "xfree86: Remove -flippixels"
+
+This reverts commit d1c00c859c6676fbb540420c9055788bc19cb18f.
+---
+ hw/xfree86/common/xf86.h        | 10 ++++++++++
+ hw/xfree86/common/xf86Globals.c |  1 +
+ hw/xfree86/common/xf86Helper.c  | 16 ++++++++++++++--
+ hw/xfree86/common/xf86Init.c    |  5 +++++
+ hw/xfree86/common/xf86Priv.h    |  1 +
+ hw/xfree86/common/xf86str.h     |  1 +
+ hw/xfree86/doc/ddxDesign.xml    | 25 +++++++++++++++++++++++++
+ hw/xfree86/man/Xorg.man         |  3 +++
+ hw/xfree86/vgahw/vgaHW.c        |  4 +++-
+ 9 files changed, 63 insertions(+), 3 deletions(-)
+
+diff --git a/hw/xfree86/common/xf86.h b/hw/xfree86/common/xf86.h
+index 927a7a7f1..8d0cb0532 100644
+--- a/hw/xfree86/common/xf86.h
++++ b/hw/xfree86/common/xf86.h
+@@ -79,6 +79,14 @@ extern _X_EXPORT Bool xf86DRI2Enabled(void);
+ 
+ #define XF86SCRNINFO(p) xf86ScreenToScrn(p)
+ 
++#define XF86FLIP_PIXELS() \
++	do { \
++	    if (xf86GetFlipPixels()) { \
++		pScreen->whitePixel = (pScreen->whitePixel) ? 0 : 1; \
++		pScreen->blackPixel = (pScreen->blackPixel) ? 0 : 1; \
++	   } \
++	while (0)
++
+ #define BOOLTOSTRING(b) ((b) ? "TRUE" : "FALSE")
+ 
+ /* Compatibility functions for pre-input-thread drivers */
+@@ -278,6 +286,8 @@ xf86GetWeight(void);
+ extern _X_EXPORT Gamma
+ xf86GetGamma(void);
+ extern _X_EXPORT Bool
++xf86GetFlipPixels(void);
++extern _X_EXPORT Bool
+ xf86ServerIsExiting(void);
+ extern _X_EXPORT Bool
+ xf86ServerIsResetting(void);
+diff --git a/hw/xfree86/common/xf86Globals.c b/hw/xfree86/common/xf86Globals.c
+index 65a3192df..b48b7aada 100644
+--- a/hw/xfree86/common/xf86Globals.c
++++ b/hw/xfree86/common/xf86Globals.c
+@@ -188,6 +188,7 @@ int xf86FbBpp = -1;
+ int xf86Depth = -1;
+ rgb xf86Weight = { 0, 0, 0 };
+ 
++Bool xf86FlipPixels = FALSE;
+ Gamma xf86Gamma = { 0.0, 0.0, 0.0 };
+ 
+ Bool xf86AllowMouseOpenFail = FALSE;
+diff --git a/hw/xfree86/common/xf86Helper.c b/hw/xfree86/common/xf86Helper.c
+index 98dc3722a..404fa36fe 100644
+--- a/hw/xfree86/common/xf86Helper.c
++++ b/hw/xfree86/common/xf86Helper.c
+@@ -952,8 +952,14 @@ xf86SetDpi(ScrnInfoPtr pScrn, int x, int y)
+ void
+ xf86SetBlackWhitePixels(ScreenPtr pScreen)
+ {
+-    pScreen->whitePixel = 1;
+-    pScreen->blackPixel = 0;
++    if (xf86FlipPixels) {
++        pScreen->whitePixel = 0;
++        pScreen->blackPixel = 1;
++    }
++    else {
++        pScreen->whitePixel = 1;
++        pScreen->blackPixel = 0;
++    }
+ }
+ 
+ /*
+@@ -1395,6 +1401,12 @@ xf86GetGamma(void)
+     return xf86Gamma;
+ }
+ 
++Bool
++xf86GetFlipPixels(void)
++{
++    return xf86FlipPixels;
++}
++
+ Bool
+ xf86ServerIsExiting(void)
+ {
+diff --git a/hw/xfree86/common/xf86Init.c b/hw/xfree86/common/xf86Init.c
+index 5695e71ac..07284f49e 100644
+--- a/hw/xfree86/common/xf86Init.c
++++ b/hw/xfree86/common/xf86Init.c
+@@ -954,6 +954,10 @@ ddxProcessArgument(int argc, char **argv, int i)
+         xf86ConfigDir = argv[i + 1];
+         return 2;
+     }
++    if (!strcmp(argv[i], "-flipPixels")) {
++        xf86FlipPixels = TRUE;
++        return 1;
++    }
+ #ifdef XF86VIDMODE
+     if (!strcmp(argv[i], "-disableVidMode")) {
+         xf86VidModeDisabled = TRUE;
+@@ -1233,6 +1237,7 @@ ddxUseMsg(void)
+     ErrorF
+         ("-pointer name          specify the core pointer InputDevice name\n");
+     ErrorF("-nosilk                disable Silken Mouse\n");
++    ErrorF("-flipPixels            swap default black/white Pixel values\n");
+ #ifdef XF86VIDMODE
+     ErrorF("-disableVidMode        disable mode adjustments with xvidtune\n");
+     ErrorF
+diff --git a/hw/xfree86/common/xf86Priv.h b/hw/xfree86/common/xf86Priv.h
+index d5185d8df..662db054c 100644
+--- a/hw/xfree86/common/xf86Priv.h
++++ b/hw/xfree86/common/xf86Priv.h
+@@ -69,6 +69,7 @@ extern _X_EXPORT char *xf86KeyboardName;
+ extern _X_EXPORT int xf86FbBpp;
+ extern _X_EXPORT int xf86Depth;
+ extern _X_EXPORT rgb xf86Weight;
++extern _X_EXPORT Bool xf86FlipPixels;
+ extern _X_EXPORT Gamma xf86Gamma;
+ 
+ /* Other parameters */
+diff --git a/hw/xfree86/common/xf86str.h b/hw/xfree86/common/xf86str.h
+index 9072932cb..823ba33f4 100644
+--- a/hw/xfree86/common/xf86str.h
++++ b/hw/xfree86/common/xf86str.h
+@@ -642,6 +642,7 @@ typedef struct _ScrnInfoRec {
+     int videoRam;               /* amount of video ram (kb) */
+     unsigned long memPhysBase;  /* Physical address of FB */
+     unsigned long fbOffset;     /* Offset of FB in the above */
++    Bool flipPixels;            /* swap default black/white */
+     void *options;
+ 
+     /* Allow screens to be enabled/disabled individually */
+diff --git a/hw/xfree86/doc/ddxDesign.xml b/hw/xfree86/doc/ddxDesign.xml
+index 1eed293fe..b7da50de3 100644
+--- a/hw/xfree86/doc/ddxDesign.xml
++++ b/hw/xfree86/doc/ddxDesign.xml
+@@ -1833,6 +1833,7 @@ Some of them are:
+     xf86Depth                 -depth from the command line
+     xf86Weight                -weight from the command line
+     xf86Gamma                 -{r,g,b,}gamma from the command line
++    xf86FlipPixels            -flippixels from the command line
+     xf86ProbeOnly             -probeonly from the command line
+     defaultColorVisualClass   -cc from the command line
+ 	</literallayout>
+@@ -1893,6 +1894,17 @@ functions:
+ 
+ 	</para></blockquote>
+ 
++      <blockquote><para>
++	  <programlisting>
++    Bool xf86GetFlipPixels();
++	  </programlisting>
++	  <blockquote><para>
++      Returns <constant>TRUE</constant> if <option>-flippixels</option> is
++      present on the command line, and <constant>FALSE</constant> otherwise.
++	    </para></blockquote>
++
++	</para></blockquote>
++
+     </sect2>
+ 
+     <sect2>
+@@ -6002,6 +6014,19 @@ strongly encouraged to improve the consistency of driver behaviour.
+ 
+ 	  </blockquote></para></blockquote>
+ 
++      <blockquote><para>
++	  <programlisting>
++    void xf86SetBlackWhitePixels(ScrnInfoPtr pScrn);
++	  </programlisting>
++	  <blockquote><para>
++      This functions sets the <structfield>blackPixel</structfield> and
++      <structfield>whitePixel</structfield> fields of the <structname>ScrnInfoRec</structname>
++      according to whether or not the <option>-flipPixels</option> command
++      line options is present.
++	    </para>
++
++	  </blockquote></para></blockquote>
++
+       <blockquote><para>
+ 	  <programlisting>
+     const char *xf86GetVisualName(int visual);
+diff --git a/hw/xfree86/man/Xorg.man b/hw/xfree86/man/Xorg.man
+index 3ec6e2c25..2084653f8 100644
+--- a/hw/xfree86/man/Xorg.man
++++ b/hw/xfree86/man/Xorg.man
+@@ -171,6 +171,9 @@ bpp framebuffer rather than the (possibly default) 32 bpp framebuffer
+ (or vice versa).  Legal values are 1, 8, 16, 24, 32.  Not all drivers
+ support all values.
+ .TP 8
++.B \-flipPixels
++Swap the default values for the black and white pixels.
++.TP 8
+ .BI \-gamma " value"
+ Set the gamma correction.
+ .I value
+diff --git a/hw/xfree86/vgahw/vgaHW.c b/hw/xfree86/vgahw/vgaHW.c
+index f6888009c..902b54070 100644
+--- a/hw/xfree86/vgahw/vgaHW.c
++++ b/hw/xfree86/vgahw/vgaHW.c
+@@ -1314,8 +1314,10 @@ vgaHWInit(ScrnInfoPtr scrninfp, DisplayModePtr mode)
+     if (depth == 1) {
+         /* Initialise the Mono map according to which bit-plane gets used */
+ 
++        Bool flipPixels = xf86GetFlipPixels();
++
+         for (i = 0; i < 16; i++)
+-            if ((i & (1 << BIT_PLANE)) != 0)
++            if (((i & (1 << BIT_PLANE)) != 0) != flipPixels)
+                 regp->Attribute[i] = WHITE_VALUE;
+             else
+                 regp->Attribute[i] = BLACK_VALUE;
+-- 
+2.51.1
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,5 @@
-VER=21.1.19
+VER=21.1.18
+EPOCH=1
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.18
+VER=21.1.19
 EPOCH=1
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] xorg-server: downgrade to 21.1.18 with FlipPixels

Package(s) Affected
-------------------

- xorg-server: 21.1.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
