### PR TITLE
KDL Survey 20251031

### DIFF
--- a/runtime-common/orocos-kdl/spec
+++ b/runtime-common/orocos-kdl/spec
@@ -1,5 +1,5 @@
-VER=1.5.1
-SRCS="git::commit=tags/v$VER::https://github.com/orocos/orocos_kinematics_dynamics"
+VER=1.5.3
+SRCS="git::commit=tags/$VER::https://github.com/orocos/orocos_kinematics_dynamics"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6445"
 SUBDIR=orocos-kdl/orocos_kdl

--- a/runtime-common/pykdl/spec
+++ b/runtime-common/pykdl/spec
@@ -1,5 +1,5 @@
-VER=1.5.1
-SRCS="git::commit=tags/v$VER::https://github.com/orocos/orocos_kinematics_dynamics"
+VER=1.5.3
+SRCS="git::commit=tags/$VER::https://github.com/orocos/orocos_kinematics_dynamics"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6445"
 SUBDIR=pykdl/python_orocos_kdl


### PR DESCRIPTION
Topic Description
-----------------

- pykdl: update to 1.5.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- orocos-kdl: update to 1.5.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit orocos-kdl pykdl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
