### PR TITLE
libvips: update to 8.17.3

### DIFF
--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,5 +1,4 @@
-VER=8.17.1
-REL=1
+VER=8.17.3
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: update to 8.17.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libvips: 8.17.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
