### PR TITLE
liferea: update to 1.16.6

### DIFF
--- a/app-web/liferea/spec
+++ b/app-web/liferea/spec
@@ -1,4 +1,4 @@
-VER=1.14.6
+VER=1.16.6
 SRCS="tbl::https://github.com/lwindolf/liferea/releases/download/v$VER/liferea-$VER.tar.bz2"
-CHKSUMS="sha256::36f28e51d26eebcbd3460c53eb5cb012855a5fc6cce6bca58103dfc06353cc72"
+CHKSUMS="sha256::6e5b9b1c3f55b3dda795c32c019afb6aa9e1124272020973b8e23ffba8c014cc"
 CHKUPDATE="anitya::id=6357"


### PR DESCRIPTION
Topic Description
-----------------

- liferea: update to 1.16.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- liferea: 1.16.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit liferea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
