### PR TITLE
shotcut: update to 25.10.30

### DIFF
--- a/app-creativity/shotcut/spec
+++ b/app-creativity/shotcut/spec
@@ -1,4 +1,4 @@
-VER=25.10.9
+VER=25.10.30
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/shotcut"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20347"


### PR DESCRIPTION
Topic Description
-----------------

- shotcut: update to 25.10.30
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- shotcut: 25.10.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit shotcut
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
