### PR TITLE
parallel: update to 20251022

### DIFF
--- a/app-utils/parallel/spec
+++ b/app-utils/parallel/spec
@@ -1,4 +1,4 @@
-VER=20250422
+VER=20251022
 SRCS="tbl::https://ftp.gnu.org/gnu/parallel/parallel-$VER.tar.bz2"
-CHKSUMS="sha256::10f0a7b7fbed87edcbd63a403fdc0ee1a1f86c241a3605f33162b4b9aff248dd"
+CHKSUMS="sha256::474326d59688d2fc078cf89a7b0b4a11cc9684229b3fa0158fe8bc03f1b69ee1"
 CHKUPDATE="anitya::id=5448"


### PR DESCRIPTION
Topic Description
-----------------

- parallel: update to 20251022
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- parallel: 20251022

Security Update?
----------------

No

Build Order
-----------

```
#buildit parallel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
