### PR TITLE
powerpc-utils: update to 1.3.13

### DIFF
--- a/app-admin/powerpc-utils/autobuild/defines
+++ b/app-admin/powerpc-utils/autobuild/defines
@@ -6,9 +6,11 @@ PKGDES="Utilities for PowerPC/POWER-based systems"
 PKGBREAK="pmac-utils<=1.1.3"
 PKGREP="pmac-utils<=1.1.3"
 
-AUTOTOOLS_AFTER="--disable-werror \
-                 --with-librtas \
-                 --with-systemd=/usr/lib/systemd/system"
+AUTOTOOLS_AFTER=(
+    '--disable-werror'
+    '--with-librtas'
+    '--with-systemd=/usr/lib/systemd/system'
+)
 
 # FIXME: /usr/bin/install: cannot stat 'var/lib/powerpc-utils/smt.state':
 # No such file or directory

--- a/app-admin/powerpc-utils/autobuild/prepare
+++ b/app-admin/powerpc-utils/autobuild/prepare
@@ -1,2 +1,5 @@
-abinfo "Appending -Wno-error=stack-protection, -Wno-error=format= to fix build ..."
-export CFLAGS="${CFLAGS} -Wno-error=stack-protector -Wno-error=format="
+# FIXME: Fails to build with C23.
+#
+# Link: https://src.fedoraproject.org/rpms/powerpc-utils/c/d9f7ac98a959b7a95c9bd1aab23c6b2e1f6695e9
+# Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118112
+CFLAGS="$RPM_OPT_FLAGS -std=gnu17"

--- a/app-admin/powerpc-utils/spec
+++ b/app-admin/powerpc-utils/spec
@@ -1,4 +1,4 @@
-VER=1.3.12
+VER=1.3.13
 SRCS="git::commit=tags/v$VER::https://github.com/nfont/powerpc-utils"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10715"

--- a/runtime-admin/librtas/autobuild/defines
+++ b/runtime-admin/librtas/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=librtas
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="A set of libraries for user-space access to the Run-Time Abstraction Services"
+PKGDES="Libraries to provide userspace access to the Run-Time Abstraction Services"

--- a/runtime-admin/librtas/spec
+++ b/runtime-admin/librtas/spec
@@ -1,5 +1,4 @@
-VER=2.0.2
-REL=1
+VER=2.0.6
 SRCS="tbl::https://github.com/nfont/librtas/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b47b2a6f140347ac265e2c66ddf68293f6cdcc7c0c9a78c6e21ff52846465415"
+CHKSUMS="sha256::b88ca9ac5acafb924cd0aaf56c89a7f149c84ade0fc6840f3ef8356ab96a1254"
 CHKUPDATE="anitya::id=10717"


### PR DESCRIPTION
Topic Description
-----------------

- powerpc-utils: update to 1.3.13
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
- librtas: update to 2.0.6
- bottles: drop, orphaned
- patool: drop, orphaned

Package(s) Affected
-------------------

- librtas: 2.0.6
- powerpc-utils: 1.3.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit librtas powerpc-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
