### PR TITLE
adguardhome: update to 0.107.69

### DIFF
--- a/app-web/adguardhome/autobuild/defines
+++ b/app-web/adguardhome/autobuild/defines
@@ -4,6 +4,8 @@ PKGDES="Network-level advertisement and tracker blocking DNS server"
 PKGDEP="glibc"
 BUILDDEP="go nodejs"
 ABTYPE=gomod
+GO_LDFLAGS=("-X github.com/AdguardTeam/AdGuardHome/internal/version.version=${PKGVER}"
+            "-X github.com/AdguardTeam/AdGuardHome/internal/version.channel=release")
 # FIXME: Build fails due to SV39 limitation on SG2042 build hosts.
 #
 # RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance

--- a/app-web/adguardhome/spec
+++ b/app-web/adguardhome/spec
@@ -1,5 +1,4 @@
-VER=0.107.67
-REL=1
+VER=0.107.69
 SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301521"


### PR DESCRIPTION
Topic Description
-----------------

- adguardhome: update to 0.107.69
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- adguardhome: 0.107.69

Security Update?
----------------

No

Build Order
-----------

```
#buildit adguardhome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
