### PR TITLE
vscodium: update to 1.105.17075

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -63,3 +63,7 @@ ln -sfv /usr/lib/vscodium/bin/codium "${PKGDIR}"/usr/bin/codium
 ln -sfv /usr/lib/vscodium/bin/codium "${PKGDIR}"/usr/bin/vscodium
 install -Dvm644 "${SRCDIR}"/VSCode-linux-${VSCODE_ARCH}/resources/app/resources/linux/code.png \
         "${PKGDIR}"/usr/share/pixmaps/vscodium.png
+
+abinfo "Installing shell completions ..."
+install -Dvm644 "$SRCDIR/VSCode-linux-$VSCODE_ARCH/resources/completions/zsh/_codium" "$PKGDIR/usr/share/zsh/site-functions/_codium"
+install -Dvm644 "$SRCDIR/VSCode-linux-$VSCODE_ARCH/resources/completions/bash/codium" "$PKGDIR/usr/share/bash-completion/completions/codium"

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.105.16954
+VER=1.105.17075
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.105.17075
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscodium: 1.105.17075

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
