### PR TITLE
iw: update to 6.17

### DIFF
--- a/app-network/iw/spec
+++ b/app-network/iw/spec
@@ -1,5 +1,4 @@
-VER=5.19
-REL=2
+VER=6.17
 SRCS="tbl::https://www.kernel.org/pub/software/network/iw/iw-$VER.tar.xz"
-CHKSUMS="sha256::f167bbe947dd53bb9ebc0c1dcef5db6ad73ac1d6084f2c6f9376c5c360cc4d4e"
+CHKSUMS="sha256::7d182e498289ab39b257da6780d562e415377107f50358ee5b55b8cfe40b1e33"
 CHKUPDATE="anitya::id=1410"


### PR DESCRIPTION
Topic Description
-----------------

- iw: update to 6.17
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- iw: 6.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit iw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
