### PR TITLE
xine-ui: update to 0.99.14

### DIFF
--- a/app-multimedia/xine-ui/spec
+++ b/app-multimedia/xine-ui/spec
@@ -1,5 +1,4 @@
-VER=0.99.12
-REL=3
+VER=0.99.14
 SRCS="tbl::https://downloads.sourceforge.net/xine/xine-ui-$VER.tar.xz"
-CHKSUMS="sha256::54bfc49d8e68baba84e1625951bd36352c0a5883180895bd940f5538b4aef583"
+CHKSUMS="sha256::d4d490d5cece70e2bb9849c9e482f2cf87af0302d451b614476fdcc3642cd9c3"
 CHKUPDATE="anitya::id=5561"


### PR DESCRIPTION
Topic Description
-----------------

- xine-ui: update to 0.99.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xine-ui: 0.99.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit xine-ui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
