### PR TITLE
tcpdump: update to 4.99.5

### DIFF
--- a/app-network/tcpdump/spec
+++ b/app-network/tcpdump/spec
@@ -1,4 +1,4 @@
-VER=4.99.4
+VER=4.99.5
 SRCS="tbl::https://www.tcpdump.org/release/tcpdump-$VER.tar.gz"
-CHKSUMS="sha256::0232231bb2f29d6bf2426e70a08a7e0c63a0d59a9b44863b7f5e2357a6e49fea"
+CHKSUMS="sha256::8c75856e00addeeadf70dad67c9ff3dd368536b2b8563abf6854d7c764cd3adb"
 CHKUPDATE="anitya::id=4947"


### PR DESCRIPTION
Topic Description
-----------------

- tcpdump: update to 4.99.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tcpdump: 4.99.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit tcpdump
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
