### PR TITLE
mtr: update to 0.96

### DIFF
--- a/app-network/mtr/spec
+++ b/app-network/mtr/spec
@@ -1,4 +1,4 @@
-VER=0.95
+VER=0.96
 SRCS="git::commit=tags/v$VER::https://github.com/traviscross/mtr"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2029"


### PR DESCRIPTION
Topic Description
-----------------

- mtr: update to 0.96
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mtr: 0.96

Security Update?
----------------

No

Build Order
-----------

```
#buildit mtr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
