### PR TITLE
chafa: update to 1.16.2

### DIFF
--- a/app-utils/chafa/autobuild/defines
+++ b/app-utils/chafa/autobuild/defines
@@ -1,7 +1,5 @@
 PKGNAME=chafa
-PKGDES="A image-to-text converter for terminal"
 PKGSEC=utils
-PKGDEP="bash libjpeg-turbo librsvg glib cairo libtiff libwebp libjxl freetype libavif"
-BUILDDEP="libxml2 libxslt libtool gtk-doc imagemagick"
-
-AUTOTOOLS_AFTER="--enable-gtk-doc"
+PKGDEP="bash libjpeg-turbo librsvg glib cairo libtiff libwebp libjxl \
+        freetype libavif"
+PKGDES="Image-to-text converter for terminal emulators"

--- a/app-utils/chafa/spec
+++ b/app-utils/chafa/spec
@@ -1,5 +1,4 @@
-VER=1.14.5
-REL=2
+VER=1.16.2
 SRCS="git::commit=tags/$VER::https://github.com/hpjansson/chafa"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17542"


### PR DESCRIPTION
Topic Description
-----------------

- chafa: update to 1.16.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- chafa: 1.16.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit chafa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
