### PR TITLE
catatonit: update to 0.2.1

### DIFF
--- a/app-admin/catatonit/spec
+++ b/app-admin/catatonit/spec
@@ -1,4 +1,4 @@
-VER=0.2.0
+VER=0.2.1
 SRCS="https://github.com/openSUSE/catatonit/releases/download/v${VER}/catatonit.tar.xz"
-CHKSUMS="sha256::9843c2b47421f0f1959b18b786f736cde1fbf124b1d1fa0d292be2773d2d2b90"
+CHKSUMS="sha256::9950425501af862e12f618bdc930ea755c46db6a16072a1462b4fc93b2bd59bc"
 CHKUPDATE="anitya::id=301804"


### PR DESCRIPTION
Topic Description
-----------------

- catatonit: update to 0.2.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- catatonit: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit catatonit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
