### PR TITLE
dnsdiag: update to 2.9.1

### DIFF
--- a/app-network/dnsdiag/spec
+++ b/app-network/dnsdiag/spec
@@ -1,4 +1,4 @@
-VER=2.6.0
+VER=2.9.1
 SRCS="git::commit=tags/v$VER::https://github.com/farrokhi/dnsdiag"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16297"


### PR DESCRIPTION
Topic Description
-----------------

- dnsdiag: update to 2.9.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dnsdiag: 2.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnsdiag
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
