### PR TITLE
clash-verge-rev: add missing appindicator dependency

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=clash-verge-rev
 PKGSEC=net
 PKGDEP="bzip2 cairo gcc-runtime gdk-pixbuf glib \
         glibc gtk-3 libsoup-3 openssl pango webkit2gtk \
+        libayatana-appindicator libappindicator \
         xz mihomo clash-verge-service mihomo-rules-dat"
 BUILDDEP="nodejs rustc llvm-20 tauri-cli"
 PKGDES="A GUI configuration manager for the Clash rule-based proxy"

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,5 +1,5 @@
 VER=2.3.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: add missing appindicator dependency

Package(s) Affected
-------------------

- clash-verge-rev: 1:2.3.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
