### PR TITLE
cpufetch: update to 1.07

### DIFF
--- a/app-utils/cpufetch/autobuild/patches/0001-v1.07-PPC-Fix-build-since-40374121b8b1.patch
+++ b/app-utils/cpufetch/autobuild/patches/0001-v1.07-PPC-Fix-build-since-40374121b8b1.patch
@@ -1,0 +1,34 @@
+From e347b9c3c7715ffbd550bc595c62d8659ce4aac9 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 2 Nov 2025 18:11:47 +0800
+Subject: [PATCH] [v1.07][PPC] Fix build since 40374121b8b1
+
+Since commit 40374121b8b1 ("[v1.06] Replace emalloc+memset with ecalloc
+when possible. Refactor some memory allocation code"), variable `path' was
+erroneously renamed as `name' in the call to `memset()'.
+
+Rename it back to `path' to fix build.
+
+Fixes #350, #360.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/ppc/udev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ppc/udev.c b/src/ppc/udev.c
+index ffa26d2..254f286 100644
+--- a/src/ppc/udev.c
++++ b/src/ppc/udev.c
+@@ -13,7 +13,7 @@ bool fill_array_from_sys(int *core_ids, int total_cores, char* SYS_PATH) {
+   char* buf;
+   char* end;
+   char path[128];
+-  memset(name, 0, sizeof(char) * 128);
++  memset(path, 0, sizeof(char) * 128);
+ 
+   for(int i=0; i < total_cores; i++) {
+     sprintf(path, "%s%s/cpu%d/%s", _PATH_SYS_SYSTEM, _PATH_SYS_CPU, i, SYS_PATH);
+-- 
+2.51.1
+

--- a/app-utils/cpufetch/spec
+++ b/app-utils/cpufetch/spec
@@ -1,4 +1,4 @@
-VER=1.06
+VER=1.07
 SRCS="git::commit=tags/v$VER::https://github.com/Dr-Noob/cpufetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=187771"


### PR DESCRIPTION
Topic Description
-----------------

- cpufetch: update to 1.07
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cpufetch: 1.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit cpufetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
