### PR TITLE
lego: update to 4.28.0

### DIFF
--- a/app-web/lego/spec
+++ b/app-web/lego/spec
@@ -1,5 +1,4 @@
-VER=4.25.1
-REL=2
+VER=4.28.0
 SRCS="git::commit=tags/v$VER::https://github.com/go-acme/lego"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20764"


### PR DESCRIPTION
Topic Description
-----------------

- lego: update to 4.28.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lego: 4.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lego
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
