### PR TITLE
qtractor: update to 1.5.9

### DIFF
--- a/app-multimedia/aubio/autobuild/patches/0001-source_avcodec-avoid-deprecation-warning-with-latest.patch
+++ b/app-multimedia/aubio/autobuild/patches/0001-source_avcodec-avoid-deprecation-warning-with-latest.patch
@@ -1,7 +1,7 @@
 From 604d6dea23ab05e2a10f055ff9dd9ea7c05922cb Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Sun, 26 Dec 2021 01:52:16 -0500
-Subject: [PATCH 1/7] [source_avcodec] avoid deprecation warning with latest
+Subject: [PATCH 01/10] [source_avcodec] avoid deprecation warning with latest
  avcodec api (58.134.100)
 
 ---
@@ -156,5 +156,5 @@ index 5b25d85c..e0ae93b5 100644
      AUBIO_FREE(s->path);
    }
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0002-source_avcodec-define-FF_API_LAVF_AVCTX-for-libavcod.patch
+++ b/app-multimedia/aubio/autobuild/patches/0002-source_avcodec-define-FF_API_LAVF_AVCTX-for-libavcod.patch
@@ -1,8 +1,8 @@
 From 362d5409b906a9fb0a0d0b2783836721708e67d4 Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Tue, 25 Jan 2022 18:30:27 +0100
-Subject: [PATCH 2/7] [source_avcodec] define FF_API_LAVF_AVCTX for libavcodec
- > 59, thx @berolinux (closes gh-353)
+Subject: [PATCH 02/10] [source_avcodec] define FF_API_LAVF_AVCTX for
+ libavcodec > 59, thx @berolinux (closes gh-353)
 
 ---
  src/io/source_avcodec.c | 4 ++++
@@ -24,5 +24,5 @@ index e0ae93b5..1421bd9a 100644
    uint_t hop_size;
    uint_t samplerate;
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0003-source_avcodec-drop-support-for-libavresample.patch
+++ b/app-multimedia/aubio/autobuild/patches/0003-source_avcodec-drop-support-for-libavresample.patch
@@ -1,7 +1,7 @@
 From 21c912d034e46fb50500c15fa6563b6a56d2041c Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Wed, 27 Dec 2023 18:09:23 +0100
-Subject: [PATCH 3/7] [source_avcodec] drop support for libavresample
+Subject: [PATCH 03/10] [source_avcodec] drop support for libavresample
 
 ---
  src/io/source_avcodec.c | 53 +----------------------------------------
@@ -140,5 +140,5 @@ index 1421bd9a..011c3d78 100644
    s->avr = NULL;
    if (s->avCodecCtx != NULL) {
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0004-source_avcodec-use-a-const-pointer-for-AVCodec.patch
+++ b/app-multimedia/aubio/autobuild/patches/0004-source_avcodec-use-a-const-pointer-for-AVCodec.patch
@@ -1,7 +1,7 @@
 From c3b874712301a84e49f1db18dc8c13d3bea7c8ad Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Wed, 27 Dec 2023 18:18:00 +0100
-Subject: [PATCH 4/7] [source_avcodec] use a const pointer for AVCodec
+Subject: [PATCH 04/10] [source_avcodec] use a const pointer for AVCodec
 
 ---
  src/io/source_avcodec.c | 2 +-
@@ -21,5 +21,5 @@ index 011c3d78..bac74a5b 100644
    int err;
    if (path == NULL) {
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0005-source_avcodec-add-support-for-AVChannelLayout-ffmpe.patch
+++ b/app-multimedia/aubio/autobuild/patches/0005-source_avcodec-add-support-for-AVChannelLayout-ffmpe.patch
@@ -1,8 +1,8 @@
 From 6fdc2f5becca178f008bba2632b8712addc5d366 Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Wed, 27 Dec 2023 18:39:35 +0100
-Subject: [PATCH 5/7] [source_avcodec] add support for AVChannelLayout (ffmpeg
- 5.1)
+Subject: [PATCH 05/10] [source_avcodec] add support for AVChannelLayout
+ (ffmpeg 5.1)
 
 ---
  src/io/source_avcodec.c | 30 +++++++++++++++++++++++++++---
@@ -87,5 +87,5 @@ index bac74a5b..713ad040 100644
        (uint8_t **)&output, max_out_samples,
        (const uint8_t **)avFrame->data, in_samples);
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0006-source_avcodec-adjust-detection-of-AVChannelLayout-f.patch
+++ b/app-multimedia/aubio/autobuild/patches/0006-source_avcodec-adjust-detection-of-AVChannelLayout-f.patch
@@ -1,7 +1,7 @@
 From 50574b6e669589994b74c064cb905339a337ddc9 Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Wed, 27 Dec 2023 18:58:55 +0100
-Subject: [PATCH 6/7] [source_avcodec] adjust detection of AVChannelLayout (>
+Subject: [PATCH 06/10] [source_avcodec] adjust detection of AVChannelLayout (>
  ffmpeg 5.0)
 
 ---
@@ -62,5 +62,5 @@ index 713ad040..7b4dd857 100644
  #else
    int frame_channels = avFrame->channels;
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0007-source_avcodec-remove-deprecation-warning-ffmpeg-5.1.patch
+++ b/app-multimedia/aubio/autobuild/patches/0007-source_avcodec-remove-deprecation-warning-ffmpeg-5.1.patch
@@ -1,7 +1,7 @@
 From 8bc186c475df139c71244995606df098c171f988 Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Wed, 27 Dec 2023 19:23:13 +0100
-Subject: [PATCH 7/7] [source_avcodec] remove deprecation warning (< ffmpeg
+Subject: [PATCH 07/10] [source_avcodec] remove deprecation warning (< ffmpeg
  5.1)
 
 ---
@@ -22,5 +22,5 @@ index 7b4dd857..71ea8b5f 100644
  #define LIBAVUTIL_HAS_CH_LAYOUT
  #endif
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0008-add-const-qualifiers-to-ufuncs-prototypes-for-latest.patch
+++ b/app-multimedia/aubio/autobuild/patches/0008-add-const-qualifiers-to-ufuncs-prototypes-for-latest.patch
@@ -1,7 +1,7 @@
-From 95ff046c698156f21e2ca0d1d8a02c23ab76969f Mon Sep 17 00:00:00 2001
+From 39bb7e922d04c4c4a5f6a076ff39a8d4e12db221 Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Thu, 2 Jul 2020 11:16:13 +0200
-Subject: [PATCH] [py] add const qualifiers to ufuncs prototypes for latest
+Subject: [PATCH 08/10] add const qualifiers to ufuncs prototypes for latest
  numpy
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH] [py] add const qualifiers to ufuncs prototypes for latest
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/python/ext/ufuncs.c b/python/ext/ufuncs.c
-index d373d7258..e5641342e 100644
+index d373d725..e5641342 100644
 --- a/python/ext/ufuncs.c
 +++ b/python/ext/ufuncs.c
 @@ -3,8 +3,8 @@
@@ -34,4 +34,6 @@ index d373d7258..e5641342e 100644
  {
      npy_intp i;
      npy_intp n = dimensions[0];
+-- 
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0009-bump-to-2.0.26.patch
+++ b/app-multimedia/aubio/autobuild/patches/0009-bump-to-2.0.26.patch
@@ -1,14 +1,14 @@
-From 665561fbd1230093cddc56b2b07a3073a71b5256 Mon Sep 17 00:00:00 2001
+From 119a6f23eaa607e8ae0cb4655e526a497fec0fe6 Mon Sep 17 00:00:00 2001
 From: Paul Brossier <piem@piem.org>
 Date: Wed, 27 Dec 2023 18:12:54 +0100
-Subject: [PATCH] [waf] bump to 2.0.26
+Subject: [PATCH 09/10] bump to 2.0.26
 
 ---
  scripts/get_waf.sh | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/get_waf.sh b/scripts/get_waf.sh
-index c7d921710514..0a40e09aa127 100755
+index c7d92171..0a40e09a 100755
 --- a/scripts/get_waf.sh
 +++ b/scripts/get_waf.sh
 @@ -3,7 +3,7 @@
@@ -20,8 +20,6 @@ index c7d921710514..0a40e09aa127 100755
  WAFTARBALL=waf-$WAFVERSION.tar.bz2
  WAFURL=https://waf.io/$WAFTARBALL
  WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/raw/master/utils/pubkey.asc
-
-base-commit: 90bd27a23123fcc524c31787c9c8fc0ae4c79378
 -- 
-2.46.0
+2.51.1
 

--- a/app-multimedia/aubio/autobuild/patches/0010-AOSCOS-fix-use-python3.patch
+++ b/app-multimedia/aubio/autobuild/patches/0010-AOSCOS-fix-use-python3.patch
@@ -1,0 +1,58 @@
+From 0b4102a643817d4cde795192919f39af94354602 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 2 Nov 2025 17:50:14 +0800
+Subject: [PATCH 10/10] AOSCOS: fix: use python3
+
+As of the end of October, 2025, AOSC OS no longer ships the python
+(python2) command. The relevant scripts have been tested to work with
+Python 3 (python3).
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ Makefile            | 2 +-
+ scripts/get_waf.sh  | 2 +-
+ tests/wscript_build | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index a21c0d63..acd4aeb4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -9,7 +9,7 @@
+ # $ make install
+ # $ make test_python
+ 
+-WAFCMD=python waf
++WAFCMD=python3 waf
+ 
+ #WAFOPTS:=
+ # turn on verbose mode
+diff --git a/scripts/get_waf.sh b/scripts/get_waf.sh
+index 0a40e09a..f7cd12b0 100755
+--- a/scripts/get_waf.sh
++++ b/scripts/get_waf.sh
+@@ -39,7 +39,7 @@ function fetchwaf () {
+ function buildwaf () {
+   tar xf $WAFTARBALL
+   pushd waf-$WAFVERSION
+-  NOCLIMB=1 python waf-light --tools=c_emscripten $*
++  NOCLIMB=1 python3 waf-light --tools=c_emscripten $*
+   popd
+ }
+ 
+diff --git a/tests/wscript_build b/tests/wscript_build
+index c99a051e..f0e1385c 100644
+--- a/tests/wscript_build
++++ b/tests/wscript_build
+@@ -13,7 +13,7 @@ test_sound_abspath = bld.path.get_bld().make_node(test_sound_target)
+ test_sound_abspath = str(test_sound_abspath).replace('\\', '\\\\')
+ 
+ b = bld(name='create_tests_source',
+-    rule='python ${SRC} ${TGT}',
++    rule='python3 ${SRC} ${TGT}',
+     source='create_tests_source.py',
+     target=test_sound_target)
+ # use post() to create the task, keep a reference to it
+-- 
+2.51.1
+

--- a/app-multimedia/aubio/spec
+++ b/app-multimedia/aubio/spec
@@ -1,5 +1,5 @@
 VER=0.4.9
-REL=5
+REL=6
 SRCS="tbl::https://aubio.org/pub/aubio-$VER.tar.bz2"
 CHKSUMS="sha256::d48282ae4dab83b3dc94c16cf011bcb63835c1c02b515490e1883049c3d1f3da"
 CHKUPDATE="anitya::id=10301"

--- a/app-multimedia/qtractor/autobuild/defines
+++ b/app-multimedia/qtractor/autobuild/defines
@@ -1,10 +1,12 @@
 PKGNAME=qtractor
 PKGSEC=sound
-PKGDEP="jack qt-5 alsa-lib libsndfile ladspa-sdk libsamplerate libmad libvorbis rubberband \
-        dssi liblo lv2 lilv suil aubio"
-PKGDES="Audio/MIDI multi-track sequencer application written in C++ with the Qt framework"
-
-CMAKE_AFTER="-DCONFIG_VST3SDK=$SRCDIR/../VST_SDK/VST3_SDK/"
+PKGDEP="alsa-lib aubio gcc-runtime gtk-2 jack liblo libmad libogg \
+        libsamplerate libsndfile libvorbis lilv qt-6 rubberband zlib"
+PKGDES="Audio/MIDI multi-track sequencer application"
 
 ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DCONFIG_VST3SDK=$SRCDIR/../vst3sdk/"
+)
+
 AB_FLAGS_O3=1

--- a/app-multimedia/qtractor/spec
+++ b/app-multimedia/qtractor/spec
@@ -1,8 +1,10 @@
-VER=0.9.23
-REL=2
+VER=1.5.9
+# Note: Only used for its headers, not reflecting this version component
+# in the main package version.
+VST3SDK_VER=3.8.0_build_66
 SRCS="tbl::https://downloads.sourceforge.net/qtractor/qtractor-${VER}.tar.gz \
-      tbl::https://download.steinberg.net/sdk_downloads/vst-sdk_3.7.2_build-28_2021-03-30.zip"
-CHKSUMS="sha256::1a00dced63389d51a5abef04730c49ecc9d23d8c007a3e7520cacdd209424db4 \
-         sha256::1557710b8d3acfb7f787c6945306c202afe61cb23473a626e30625362ff296a4"
+      git::commit=tags/v${VST3SDK_VER};rename=vst3sdk::https://github.com/steinbergmedia/vst3sdk"
+CHKSUMS="sha256::774bbf2e5372afb6521b64243f70f7856d121c2618f4dc44beae77c7bfaca90f \
+         SKIP"
 CHKUPDATE="anitya::id=8938"
-SUBDIR="qtractor-$VER"
+SUBDIR="qtractor-${VER}"


### PR DESCRIPTION
Topic Description
-----------------

- aubio: fix build post-python2 removal
- qtractor: update to 1.5.9
    - Update vst3sdk source.
    - Update package dependencies.
    - Improve PKGDES.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aubio: 0.4.9-6
- qtractor: 1.5.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit aubio qtractor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
