### PR TITLE
fluidsynth: update to 2.5.1

### DIFF
--- a/app-multimedia/fluidsynth/spec
+++ b/app-multimedia/fluidsynth/spec
@@ -1,4 +1,4 @@
-VER=2.3.6
+VER=2.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/FluidSynth/fluidsynth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10437"


### PR DESCRIPTION
Topic Description
-----------------

- fluidsynth: update to 2.5.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fluidsynth: 2.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fluidsynth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
