### PR TITLE
cherry-studio: update to 1.6.6

### DIFF
--- a/app-utils/cherry-studio/spec
+++ b/app-utils/cherry-studio/spec
@@ -1,4 +1,4 @@
-VER=1.6.1
+VER=1.6.6
 SRCS="git::commit=tags/v${VER}::https://github.com/CherryHQ/cherry-studio"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379206"


### PR DESCRIPTION
Topic Description
-----------------

- cherry-studio: update to 1.6.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- cherry-studio: 1.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit cherry-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
