### PR TITLE
fractal: update to 13

### DIFF
--- a/desktop-gnome/fractal/autobuild/defines
+++ b/desktop-gnome/fractal/autobuild/defines
@@ -3,7 +3,8 @@ PKGSEC=gnome
 PKGDEP="glib gtk-4 libadwaita gstreamer gtksourceview-5 openssl libshumate \
         sqlite pango graphene libseccomp lcms2 libwebp glycin gstreamer \
         gst-plugins-rs gtk-update-icon-cache"
-BUILDDEP="meson ninja rustc llvm xdg-desktop-portal desktop-file-utils grass"
+BUILDDEP="meson ninja rustc llvm xdg-desktop-portal desktop-file-utils grass \
+          blueprint-compiler"
 PKGDES="Matrix messaging client for GNOME"
 
 USECLANG=1

--- a/desktop-gnome/fractal/spec
+++ b/desktop-gnome/fractal/spec
@@ -1,5 +1,4 @@
-VER=12.1
-REL=1
+VER=13
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/World/fractal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=197366"

--- a/desktop-gnome/glycin/autobuild/defines
+++ b/desktop-gnome/glycin/autobuild/defines
@@ -1,24 +1,26 @@
 PKGNAME=glycin
 PKGSEC=gnome
 PKGDEP="lcms2 glib gtk-4 libseccomp fontconfig libjxl librsvg libheif cairo \
-        gdk-pixbuf pango"
-BUILDDEP="rustc llvm gobject-introspection vala gettext gi-docgen"
-PKGDES="A Sass compiler written in Rust"
+        gdk-pixbuf pango libopenraw"
+BUILDDEP="rustc llvm gobject-introspection vala gettext python-3 tomli"
+PKGDES="Sass compiler written in Rust"
 
 ABTYPE=meson
 USECLANG=1
 
 MESON_AFTER=(
-    -Dprofile=release
-    -Dglycin-loaders=true
-    -Dloaders=glycin-heif,glycin-image-rs,glycin-jxl,glycin-svg
-    -Dtests=false
-    -Dlibglycin=true
-    -Dintrospection=true
-    -Dvapi=true
-    -Dcapi_docs=true
-    -Dpython_tests=false
+    '-Dlto=true'
+    '-Dprofile=release'
+    '-Dglycin-loaders=true'
+    '-Dloaders=glycin-heif,glycin-image-rs,glycin-jxl,glycin-svg,glycin-raw'
+    '-Dtests=false'
+    '-Dlibglycin=true'
+    '-Dlibglycin-gtk4=true'
+    '-Dintrospection=true'
+    '-Dvapi=true'
+    '-Dcapi_docs=false'
+    '-Dpython_tests=false'
+    '-Dglycin-thumbnailer=true'
 )
 
-# FIXME: ld.lld is not yet available on loongson3
-NOLTO__LOONGSON3=1
+PKGBREAK="fractal<=12.1-1 loupe<=47.4-1"

--- a/desktop-gnome/glycin/autobuild/patches/0001-Use-tomli-instead-of-tomllib-for-Python-3.11.patch
+++ b/desktop-gnome/glycin/autobuild/patches/0001-Use-tomli-instead-of-tomllib-for-Python-3.11.patch
@@ -1,0 +1,34 @@
+From b0b9a86bce605ba402476ac9408c725eea4f0aff Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Fri, 7 Nov 2025 09:32:27 -0800
+Subject: [PATCH] Use tomli instead of tomllib for Python<3.11
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ build-aux/crates-version.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build-aux/crates-version.py b/build-aux/crates-version.py
+index 80a7321..3f4df9d 100755
+--- a/build-aux/crates-version.py
++++ b/build-aux/crates-version.py
+@@ -1,6 +1,6 @@
+ #!/usr/bin/python3
+ 
+-import tomllib
++import tomli
+ import sys
+ import os.path
+ 
+@@ -8,7 +8,7 @@ crate = sys.argv[1]
+ gnome_version = False if len(sys.argv) < 3 else sys.argv[2] == 'gnome'
+ 
+ path = os.path.dirname(__file__)
+-data = tomllib.load(open(f'{path}/../{crate}/Cargo.toml', 'rb'))
++data = tomli.load(open(f'{path}/../{crate}/Cargo.toml', 'rb'))
+ version = data['package']['version']
+ 
+ if gnome_version:
+-- 
+2.51.1
+

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,5 +1,4 @@
-VER=1.1.4
-REL=2
+VER=2.0.5
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369437"

--- a/desktop-gnome/gtk-4/spec
+++ b/desktop-gnome/gtk-4/spec
@@ -1,4 +1,4 @@
-VER=4.20.1
+VER=4.20.2
 SRCS="https://download.gnome.org/sources/gtk/${VER%.*}/gtk-$VER.tar.xz"
-CHKSUMS="sha256::bf32fac019171c45681b2c45d05658ee8598c6341572e32a6a6bcb0b5673998d"
+CHKSUMS="sha256::5e8240edecafaff2b8baf4663bdceaa668ef10a207bee4d7f90e010e10bddc5c"
 CHKUPDATE="anitya::id=13942"

--- a/desktop-gnome/loupe/autobuild/defines
+++ b/desktop-gnome/loupe/autobuild/defines
@@ -6,5 +6,3 @@ BUILDDEP="itstool rustc llvm inkscape"
 PKGDES="Image Viewer for GNOME"
 
 USECLANG=1
-# FIXME: ld.lld: relocation R_MIPS_64 cannot be used against local symbol
-NOLTO__LOONGSON3=1

--- a/desktop-gnome/loupe/spec
+++ b/desktop-gnome/loupe/spec
@@ -1,5 +1,4 @@
-VER=47.4
-REL=1
+VER=49.1
 SRCS="https://download.gnome.org/sources/loupe/${VER%.*}/loupe-$VER.tar.xz"
-CHKSUMS="sha256::8dc926829a9c338800c8f432b5a347246e6dcbd9ad2dd1a24c498eafdd3e89ab"
+CHKSUMS="sha256::30098bc979a1c87a2ecb27b4a5ab725abf900bd710bb9c2bcc0c942d515c51c5"
 CHKUPDATE="antiya::id=368849"


### PR DESCRIPTION
Topic Description
-----------------

- fractal: update to 13
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- fractal: 13

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtk-4 glycin:-pkgbreak fractal loupe glycin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
