### PR TITLE
i3lock: update to 2.16

### DIFF
--- a/desktop-wm/i3lock/spec
+++ b/desktop-wm/i3lock/spec
@@ -1,4 +1,4 @@
-VER=2.15
+VER=2.16
 SRCS="tbl::https://i3wm.org/i3lock/i3lock-$VER.tar.xz"
-CHKSUMS="sha256::5711ae5255e82b1dc8d8b4c035c520230921aba7ceee23d66f79765b21a84baa"
+CHKSUMS="sha256::a30a5ebead35cc78e5f337571df8c5de2bdd9141426034c74b17e4d3db15f024"
 CHKUPDATE="anitya::id=1349"


### PR DESCRIPTION
Topic Description
-----------------

- i3lock: update to 2.16
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- i3lock: 2.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3lock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
