### PR TITLE
steam: add support on DynaRec emulator-supported architectures

### DIFF
--- a/app-games/steam/autobuild/defines
+++ b/app-games/steam/autobuild/defines
@@ -1,10 +1,14 @@
 PKGNAME=steam
 PKGSEC=non-free/games
 PKGDEP="curl dbus freetype gdk-pixbuf hicolor-icon-theme 32subsystem zenity liberation-fonts"
+PKGDEP__with_emulator="curl dbus freetype gdk-pixbuf hicolor-icon-theme box64 zenity liberation-fonts"
+PKGDEP__ARM64="${PKGDEP__with_emulator}"
+PKGDEP__LOONGARCH64="${PKGDEP__with_emulator}"
+PKGDEP__RISCV64="${PKGDEP__with_emulator}"
 PKGDES="Official Steam client for Linux"
 
-# Note: List only amd64 or architectures with integrated emulation support.
-FAIL_ARCH="!(amd64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
 
+ABTYPE=self
 # Note: Binary repacks should not be stripped.
 ABSTRIP=0

--- a/app-games/steam/autobuild/patches/0001-hack-fix-IME-input-text.patch
+++ b/app-games/steam/autobuild/patches/0001-hack-fix-IME-input-text.patch
@@ -1,17 +1,17 @@
-From 4a202ecebbe140985d20378d933f1eda1557845a Mon Sep 17 00:00:00 2001
+From 6c31a432119a53d6594e4fc5f6478943a5a3ca0d Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 5 Jul 2024 21:21:23 +0800
-Subject: [PATCH 2/2] hack: fix IME input text
+Subject: [PATCH 1/2] hack: fix IME input text
 
 ---
  bin_steam.sh | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/bin_steam.sh b/bin_steam.sh
-index 49f9d8a..04e6be0 100755
+index 9ef1732..29bf3e4 100755
 --- a/bin_steam.sh
 +++ b/bin_steam.sh
-@@ -303,4 +303,10 @@ fi
+@@ -310,4 +310,10 @@ fi
  # go to the install directory and run the client
  cd "$LAUNCHSTEAMDIR"
  
@@ -23,5 +23,5 @@ index 49f9d8a..04e6be0 100755
 +
  exec "$LAUNCHSTEAMDIR/$STEAMBOOTSTRAP" ${log_opened+-srt-logger-opened} "$@"
 -- 
-2.47.1
+2.51.1
 

--- a/app-games/steam/autobuild/patches/0002-fix-steam.desktop-make-sure-Steam-recognises-our-32-.patch.amd64
+++ b/app-games/steam/autobuild/patches/0002-fix-steam.desktop-make-sure-Steam-recognises-our-32-.patch.amd64
@@ -1,0 +1,26 @@
+From 1292f1ec0af07a8f49c9b49af1402f9212e59d57 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 4 Mar 2024 14:59:34 +0800
+Subject: [PATCH 2/2] fix(steam.desktop): make sure Steam recognises our 32-bit
+ x86 environment (optenv32)
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 66f2aa5..93ce5dd 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -27,7 +27,7 @@ Comment[th]=โปรแกรมสำหรับจัดการและ
+ Comment[tr]=Steam üzerinden oyun oynama ve düzenleme uygulaması
+ Comment[uk]=Програма для керування іграми та запуску ігор у Steam
+ Comment[vi]=Ứng dụng để quản lý và chơi trò chơi trên Steam
+-Exec=/usr/bin/steam %U
++Exec=env LD_LIBRARY_PATH=/opt/32/lib:/usr/lib /usr/bin/steam %U
+ Icon=steam
+ Terminal=false
+ Type=Application
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0002-fix-steam.desktop-mark-emulated-Steam-entry-with-an-.patch.arm64
+++ b/app-games/steam/autobuild/patches/0002-fix-steam.desktop-mark-emulated-Steam-entry-with-an-.patch.arm64
@@ -1,0 +1,24 @@
+From 7887479e25094371f5e0f7d5cfc2e322b9841560 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 4 Mar 2024 15:02:51 +0800
+Subject: [PATCH 2/4] fix(steam.desktop): mark emulated Steam entry with an
+ (x86) marker
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 66f2aa5..18521a2 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -1,5 +1,5 @@
+ [Desktop Entry]
+-Name=Steam
++Name=Steam (x86)
+ Comment=Application for managing and playing games on Steam
+ Comment[pt_BR]=Aplicativo para jogar e gerenciar jogos no Steam
+ Comment[bg]=Приложение за ръководене и пускане на игри в Steam
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0002-fix-steam.desktop-mark-emulated-Steam-entry-with-an-.patch.loongarch64
+++ b/app-games/steam/autobuild/patches/0002-fix-steam.desktop-mark-emulated-Steam-entry-with-an-.patch.loongarch64
@@ -1,0 +1,24 @@
+From 7887479e25094371f5e0f7d5cfc2e322b9841560 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 4 Mar 2024 15:02:51 +0800
+Subject: [PATCH 2/4] fix(steam.desktop): mark emulated Steam entry with an
+ (x86) marker
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 66f2aa5..18521a2 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -1,5 +1,5 @@
+ [Desktop Entry]
+-Name=Steam
++Name=Steam (x86)
+ Comment=Application for managing and playing games on Steam
+ Comment[pt_BR]=Aplicativo para jogar e gerenciar jogos no Steam
+ Comment[bg]=Приложение за ръководене и пускане на игри в Steam
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0002-fix-steam.desktop-mark-emulated-Steam-entry-with-an-.patch.riscv64
+++ b/app-games/steam/autobuild/patches/0002-fix-steam.desktop-mark-emulated-Steam-entry-with-an-.patch.riscv64
@@ -1,0 +1,24 @@
+From 7887479e25094371f5e0f7d5cfc2e322b9841560 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 4 Mar 2024 15:02:51 +0800
+Subject: [PATCH 2/4] fix(steam.desktop): mark emulated Steam entry with an
+ (x86) marker
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 66f2aa5..18521a2 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -1,5 +1,5 @@
+ [Desktop Entry]
+-Name=Steam
++Name=Steam (x86)
+ Comment=Application for managing and playing games on Steam
+ Comment[pt_BR]=Aplicativo para jogar e gerenciar jogos no Steam
+ Comment[bg]=Приложение за ръководене и пускане на игри в Steam
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0003-fix-steam.desktop-add-environment-for-emulation.patch.arm64
+++ b/app-games/steam/autobuild/patches/0003-fix-steam.desktop-add-environment-for-emulation.patch.arm64
@@ -1,0 +1,25 @@
+From bf928c00e07902ca10ddf3af5a59a872caefcc2e Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Sat, 1 Nov 2025 01:20:22 +0800
+Subject: [PATCH 3/4] fix(steam.desktop): add environment for emulation
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 18521a2..a937c7c 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -27,7 +27,7 @@ Comment[th]=โปรแกรมสำหรับจัดการและ
+ Comment[tr]=Steam üzerinden oyun oynama ve düzenleme uygulaması
+ Comment[uk]=Програма для керування іграми та запуску ігор у Steam
+ Comment[vi]=Ứng dụng để quản lý và chơi trò chơi trên Steam
+-Exec=/usr/bin/steam %U
++Exec=env STEAMOS=1 STEAM_RUNTIME=1 PROTON_USE_WOW64=1 DBUS_FATAL_WARNINGS=0 /usr/bin/steam %U
+ Icon=steam
+ Terminal=false
+ Type=Application
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0003-fix-steam.desktop-add-environment-for-emulation.patch.loongarch64
+++ b/app-games/steam/autobuild/patches/0003-fix-steam.desktop-add-environment-for-emulation.patch.loongarch64
@@ -1,0 +1,25 @@
+From bf928c00e07902ca10ddf3af5a59a872caefcc2e Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Sat, 1 Nov 2025 01:20:22 +0800
+Subject: [PATCH 3/4] fix(steam.desktop): add environment for emulation
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 18521a2..a937c7c 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -27,7 +27,7 @@ Comment[th]=โปรแกรมสำหรับจัดการและ
+ Comment[tr]=Steam üzerinden oyun oynama ve düzenleme uygulaması
+ Comment[uk]=Програма для керування іграми та запуску ігор у Steam
+ Comment[vi]=Ứng dụng để quản lý và chơi trò chơi trên Steam
+-Exec=/usr/bin/steam %U
++Exec=env STEAMOS=1 STEAM_RUNTIME=1 PROTON_USE_WOW64=1 DBUS_FATAL_WARNINGS=0 /usr/bin/steam %U
+ Icon=steam
+ Terminal=false
+ Type=Application
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0003-fix-steam.desktop-add-environment-for-emulation.patch.riscv64
+++ b/app-games/steam/autobuild/patches/0003-fix-steam.desktop-add-environment-for-emulation.patch.riscv64
@@ -1,0 +1,25 @@
+From bf928c00e07902ca10ddf3af5a59a872caefcc2e Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Sat, 1 Nov 2025 01:20:22 +0800
+Subject: [PATCH 3/4] fix(steam.desktop): add environment for emulation
+
+---
+ steam.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/steam.desktop b/steam.desktop
+index 18521a2..a937c7c 100644
+--- a/steam.desktop
++++ b/steam.desktop
+@@ -27,7 +27,7 @@ Comment[th]=โปรแกรมสำหรับจัดการและ
+ Comment[tr]=Steam üzerinden oyun oynama ve düzenleme uygulaması
+ Comment[uk]=Програма для керування іграми та запуску ігор у Steam
+ Comment[vi]=Ứng dụng để quản lý và chơi trò chơi trên Steam
+-Exec=/usr/bin/steam %U
++Exec=env STEAMOS=1 STEAM_RUNTIME=1 PROTON_USE_WOW64=1 DBUS_FATAL_WARNINGS=0 /usr/bin/steam %U
+ Icon=steam
+ Terminal=false
+ Type=Application
+-- 
+2.51.1
+

--- a/app-games/steam/autobuild/patches/0004-fix-steam.desktop-add-workaround-parameter-to-disbal.patch.loongarch64
+++ b/app-games/steam/autobuild/patches/0004-fix-steam.desktop-add-workaround-parameter-to-disbal.patch.loongarch64
@@ -1,26 +1,26 @@
-From 90ccc0b2d57b004f032dbeb7e1162f4a3792a22f Mon Sep 17 00:00:00 2001
-From: Mingcong Bai <jeffbai@aosc.io>
-Date: Mon, 4 Mar 2024 14:59:34 +0800
-Subject: [PATCH 1/2] fix(steam.desktop): make sure Steam recognises our 32-bit
- x86 environment (optenv32)
+From 8c384d45c0bfb11e77648f54488dceea790bbaed Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Sat, 1 Nov 2025 01:20:50 +0800
+Subject: [PATCH 4/4] fix(steam.desktop): add workaround parameter to disbale
+ GPU for LoongArch
 
 ---
  steam.desktop | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/steam.desktop b/steam.desktop
-index 77314e0..bdaea30 100644
+index a937c7c..87ee4c2 100644
 --- a/steam.desktop
 +++ b/steam.desktop
 @@ -27,7 +27,7 @@ Comment[th]=โปรแกรมสำหรับจัดการและ
  Comment[tr]=Steam üzerinden oyun oynama ve düzenleme uygulaması
  Comment[uk]=Програма для керування іграми та запуску ігор у Steam
  Comment[vi]=Ứng dụng để quản lý và chơi trò chơi trên Steam
--Exec=/usr/bin/steam %U
-+Exec=env LD_LIBRARY_PATH=/opt/32/lib:/usr/lib /usr/bin/steam %U
+-Exec=env STEAMOS=1 STEAM_RUNTIME=1 PROTON_USE_WOW64=1 DBUS_FATAL_WARNINGS=0 /usr/bin/steam %U
++Exec=env STEAMOS=1 STEAM_RUNTIME=1 PROTON_USE_WOW64=1 DBUS_FATAL_WARNINGS=0 /usr/bin/steam -cef-disable-gpu -cef-disable-gpu-compositing %U
  Icon=steam
  Terminal=false
  Type=Application
 -- 
-2.47.1
+2.51.1
 

--- a/app-games/steam/autobuild/prepare
+++ b/app-games/steam/autobuild/prepare
@@ -1,7 +1,0 @@
-abinfo "Arch Linux: Tweaking UDev rules ..."
-sed -r 's|("0666")|"0660", TAG+="uaccess"|g' \
-    -i "$SRCDIR"/subprojects/steam-devices/60-steam-input.rules
-sed -r 's|("misc")|\1, OPTIONS+="static_node=uinput"|g' \
-    -i "$SRCDIR"/subprojects/steam-devices/60-steam-input.rules
-sed -r 's|(, TAG\+="uaccess")|, MODE="0660"\1|g' \
-    -i "$SRCDIR"/subprojects/steam-devices/60-steam-vr.rules

--- a/app-games/steam/spec
+++ b/app-games/steam/spec
@@ -1,4 +1,5 @@
 VER=1.0.0.85
+REL=1
 SRCS="tbl::https://repo.steampowered.com/steam/pool/steam/s/steam/steam_$VER.tar.gz"
 CHKSUMS="sha256::7f2d374a2fb413ced5b8125151456219d918a255872b4bb77016cbccf38bb7f1"
 CHKUPDATE="anitya::id=12318"


### PR DESCRIPTION
Topic Description
-----------------

- steam: add support on DynaRec emulator-supported architectures
    - remove unnecessary prepare.
    - add missing ABTYPE.
    - Track amd64 patches at AOSC-Tracking/steam @ aosc/v1.0.0.85
    \(HEAD: 1292f1ec0af07a8f49c9b49af1402f9212e59d57\).
    - Track arm64 loongarch64 riscv64 patches at AOSC-Tracking/steam @ aosc/v1.0.0.85-emu
    \(HEAD: 8c384d45c0bfb11e77648f54488dceea790bbaed\).

Package(s) Affected
-------------------

- steam: 1.0.0.85-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit steam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
