### PR TITLE
libdeflate: update to 1.25

### DIFF
--- a/runtime-common/libdeflate/spec
+++ b/runtime-common/libdeflate/spec
@@ -1,4 +1,4 @@
-VER=1.19
+VER=1.25
 SRCS="tbl::https://github.com/ebiggers/libdeflate/releases/download/v$VER/libdeflate-$VER.tar.gz"
-CHKSUMS="sha256::d9bb9bdd8cc5a8c1f7f6226fa0053dd72861e15f366e7ff7d0d191eac16d66f3"
+CHKSUMS="sha256::fed5cd22f00f30cc4c2e5329f94e2b8a901df9fa45ee255cb70e2b0b42344477"
 CHKUPDATE="anitya::id=242778"


### PR DESCRIPTION
Topic Description
-----------------

- libdeflate: update to 1.25
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libdeflate: 1.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdeflate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
