### PR TITLE
modemmanager: update to 1.24.2

### DIFF
--- a/app-network/modemmanager/spec
+++ b/app-network/modemmanager/spec
@@ -1,4 +1,4 @@
-VER=1.24.0
+VER=1.24.2
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7306"


### PR DESCRIPTION
Topic Description
-----------------

- modemmanager: update to 1.24.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- modemmanager: 1.24.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit modemmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
