### PR TITLE
unshield: update to 1.6.2

### DIFF
--- a/app-games/openmw/spec
+++ b/app-games/openmw/spec
@@ -1,4 +1,5 @@
 VER=0.50.0
+REL=1
 SRCS="git::commit=tags/openmw-$VER::https://github.com/OpenMW/openmw"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12282"

--- a/app-utils/unshield/spec
+++ b/app-utils/unshield/spec
@@ -1,5 +1,4 @@
-VER=1.4.3
-REL=2
+VER=1.6.2
 SRCS="tbl::https://github.com/twogood/unshield/archive/$VER.tar.gz"
-CHKSUMS="sha256::aa8c978dc0eb1158d266eaddcd1852d6d71620ddfc82807fe4bf2e19022b7bab"
+CHKSUMS="sha256::a937ef596ad94d16e7ed2c8553ad7be305798dcdcfd65ae60210b1e54ab51a2f"
 CHKUPDATE="anitya::id=16008"


### PR DESCRIPTION
Topic Description
-----------------

- unshield: update to 1.6.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- unshield: 1.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit unshield openmw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
