### PR TITLE
ndctl: update to 83

### DIFF
--- a/app-admin/ndctl/spec
+++ b/app-admin/ndctl/spec
@@ -1,4 +1,4 @@
-VER=80
+VER=83
 SRCS="git::commit=tags/v$VER::https://github.com/pmem/ndctl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10381"


### PR DESCRIPTION
Topic Description
-----------------

- ndctl: update to 83
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ndctl: 83

Security Update?
----------------

No

Build Order
-----------

```
#buildit ndctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
