### PR TITLE
strawberry: backport loading language from system ui language patch

### DIFF
--- a/app-multimedia/strawberry/autobuild/patches/0001-fix-loading-language-from-system-ui-language.patch
+++ b/app-multimedia/strawberry/autobuild/patches/0001-fix-loading-language-from-system-ui-language.patch
@@ -1,0 +1,159 @@
+From a4de7559ac9e831f643361d689036649ced003a4 Mon Sep 17 00:00:00 2001
+From: Jonas Kvinge <jonas@jkvinge.net>
+Date: Thu, 30 Oct 2025 23:54:42 +0100
+Subject: [PATCH] Fix loading language from system UI languages
+
+Fixes #1847
+---
+ src/core/translations.cpp | 16 +++++----
+ src/core/translations.h   |  2 +-
+ src/main.cpp              | 74 +++++++++++++++++++++++++++------------
+ 3 files changed, 62 insertions(+), 30 deletions(-)
+
+diff --git a/src/core/translations.cpp b/src/core/translations.cpp
+index b7f2a3179c..0a17696153 100644
+--- a/src/core/translations.cpp
++++ b/src/core/translations.cpp
+@@ -41,17 +41,19 @@ Translations::~Translations() {
+ 
+ }
+ 
+-void Translations::LoadTranslation(const QString &prefix, const QString &path, const QString &language) {
++bool Translations::LoadTranslation(const QString &prefix, const QString &path, const QString &language) {
+ 
+   const QString basefilename = prefix + u'_' + language;
+   QTranslator *t = new QTranslator;
+-  if (t->load(basefilename, path)) {
+-    qLog(Debug) << "Tranlations loaded from" << basefilename;
+-    QCoreApplication::installTranslator(t);
+-    translations_ << t;
+-  }
+-  else {
++  if (!t->load(basefilename, path)) {
+     delete t;
++    return false;
+   }
+ 
++  qLog(Debug) << "Tranlations loaded from" << basefilename;
++  QCoreApplication::installTranslator(t);
++  translations_ << t;
++
++  return true;
++
+ }
+diff --git a/src/core/translations.h b/src/core/translations.h
+index 2285921718..703e3e1186 100644
+--- a/src/core/translations.h
++++ b/src/core/translations.h
+@@ -31,7 +31,7 @@ class Translations {
+  public:
+   explicit Translations();
+   ~Translations();
+-  void LoadTranslation(const QString &prefix, const QString &path, const QString &language);
++  bool LoadTranslation(const QString &prefix, const QString &path, const QString &language);
+ 
+  private:
+   QList<QTranslator*> translations_;
+diff --git a/src/main.cpp b/src/main.cpp
+index 9ccf2d6eb2..35fc0c05c2 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -260,46 +260,76 @@ int main(int argc, char *argv[]) {
+   IconLoader::Init();
+ 
+ #ifdef HAVE_TRANSLATIONS
+-  QString language = options.language();
+-  if (language.isEmpty()) {
++
++  QStringList languages;
++
++  // Load language from command line options
++  if (!options.language().isEmpty()) {
++    languages << options.language();
++  }
++
++  // Load language from settings
++  if (languages.isEmpty()) {
+     Settings s;
+     s.beginGroup(BehaviourSettings::kSettingsGroup);
+-    language = s.value(BehaviourSettings::kLanguage).toString();
++    const QString language = s.value(BehaviourSettings::kLanguage).toString();
+     s.endGroup();
++    if (!language.isEmpty()) {
++      languages << language;
++    }
+   }
+ 
+-  if (language.isEmpty()) {
++  // Use system UI languages
++  if (languages.isEmpty()) {
+ #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+-    const QStringList system_languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
++     languages = QLocale::system().uiLanguages(QLocale::TagSeparator::Underscore);
+ #else
+     const QStringList system_languages = QLocale::system().uiLanguages();
+-#endif
+-    if (system_languages.isEmpty()) {
+-      language = QLocale::system().name();
++    for (const QString &language : system_languages) {
++      QString language_underscore = language;
++      language_underscore = language_underscore.replace(u'-', u'_');
++      languages << language_underscore;
+     }
+-    else {
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+-      language = system_languages.first();
+-#else
+-      language = system_languages.first();
+-      language = language.replace(u'-', u'_');
+ #endif
+-    }
++  }
++
++  if (languages.isEmpty()) {
++    languages << QLocale::system().name();
+   }
+ 
+   ScopedPtr<Translations> translations(new Translations);
+ 
+-  translations->LoadTranslation(u"qt"_s, QLibraryInfo::path(QLibraryInfo::TranslationsPath), language);
+-  translations->LoadTranslation(u"strawberry"_s, u":/i18n"_s, language);
+-  translations->LoadTranslation(u"strawberry"_s, QStringLiteral(TRANSLATIONS_DIR), language);
+-  translations->LoadTranslation(u"strawberry"_s, QCoreApplication::applicationDirPath(), language);
+-  translations->LoadTranslation(u"strawberry"_s, QDir::currentPath(), language);
++  for (const QString &language : std::as_const(languages)) {
++    if (translations->LoadTranslation(u"qt"_s, QLibraryInfo::path(QLibraryInfo::TranslationsPath), language)) {
++      break;
++    }
++  }
++
++  static const QStringList language_paths = QStringList() << u":/i18n"_s
++                                                          << QStringLiteral(TRANSLATIONS_DIR)
++                                                          << QCoreApplication::applicationDirPath()
++                                                          << QDir::currentPath();
++
++  for (const QString &language : std::as_const(languages)) {
++    bool language_loaded = false;
++    for (const QString &language_path : language_paths) {
++      if (translations->LoadTranslation(u"strawberry"_s, language_path, language)) {
++        language_loaded = true;
++        break;
++      }
++    }
++    if (language_loaded) {
++      break;
++    }
++  }
+ 
+ #  ifdef HAVE_QTSPARKLE
+-  qtsparkle::LoadTranslations(language);
++  if (!languages.isEmpty()) {
++    qtsparkle::LoadTranslations(languages.first());
++  }
+ #  endif
+ 
+-#endif
++#endif  // HAVE_TRANSLATIONS
+ 
+   Application app;
+ 

--- a/app-multimedia/strawberry/spec
+++ b/app-multimedia/strawberry/spec
@@ -1,4 +1,5 @@
 VER=1.2.14
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/strawberrymusicplayer/strawberry"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19048"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Backport https://github.com/strawberrymusicplayer/strawberry/commit/a4de7559ac9e831f643361d689036649ced003a4

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

strawberry
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit strawberry
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
