### PR TITLE
nokogiri: update to 1.18.10

### DIFF
--- a/lang-ruby/nokogiri/spec
+++ b/lang-ruby/nokogiri/spec
@@ -1,6 +1,5 @@
-VER=1.18.4
-REL=1
+VER=1.18.10
 SRCS="tbl::https://rubygems.org/downloads/nokogiri-$VER.gem"
-CHKSUMS="sha256::bb7820521c1bbae1d3e0092ff03b27a8e700912b37d80f962b7e4567947a64ac"
+CHKSUMS="sha256::d5cc0731008aa3b3a87b361203ea3d19b2069628cb55e46ac7d84a0445e69cc1"
 CHKUPDATE="anitya::id=4641"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- nokogiri: update to 1.18.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nokogiri: 1.18.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit nokogiri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
