### PR TITLE
usage: update to 2.6.0

### DIFF
--- a/app-utils/usage/spec
+++ b/app-utils/usage/spec
@@ -1,4 +1,4 @@
-VER=2.2.2
+VER=2.6.0
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/usage.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376568"


### PR DESCRIPTION
Topic Description
-----------------

- usage: update to 2.6.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- usage: 2.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit usage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
