### PR TITLE
flat-remix-icon-theme: update to 20250709

### DIFF
--- a/desktop-themes/flat-remix-icon-theme/spec
+++ b/desktop-themes/flat-remix-icon-theme/spec
@@ -1,6 +1,5 @@
-VER=20240201
+VER=20250709
 # FIXME: Upstream uses a submodule from AUR pulled via SSH (inaccessible).
 SRCS="git::submodule=false;commit=tags/$VER::https://github.com/daniruiz/flat-remix"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231526"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- flat-remix-icon-theme: update to 20250709
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- flat-remix-icon-theme: 20250709

Security Update?
----------------

No

Build Order
-----------

```
#buildit flat-remix-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
