### PR TITLE
tuned: update to 2.26.0

### DIFF
--- a/app-admin/tuned/spec
+++ b/app-admin/tuned/spec
@@ -1,4 +1,4 @@
-VER=2.25.1
+VER=2.26.0
 SRCS="git::commit=tags/v$VER::https://github.com/redhat-performance/tuned.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11277"


### PR DESCRIPTION
Topic Description
-----------------

- tuned: update to 2.26.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tuned: 2.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tuned
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
