### PR TITLE
robin-map: update to 1.4.1

### DIFF
--- a/runtime-games/robin-map/spec
+++ b/runtime-games/robin-map/spec
@@ -1,4 +1,4 @@
-VER=1.4.0
+VER=1.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/Tessil/robin-map"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18602"


### PR DESCRIPTION
Topic Description
-----------------

- robin-map: update to 1.4.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- robin-map: 1.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit robin-map
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
