### PR TITLE
libdrm: update to 2.4.128

### DIFF
--- a/runtime-display/libdrm/spec
+++ b/runtime-display/libdrm/spec
@@ -1,4 +1,4 @@
-VER=2.4.126
+VER=2.4.128
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::6cab16d4d259b6abc9f485233863454114a3c307eca806679aad3edbe967bf42"
+CHKSUMS="sha256::3bb35db8700c2a0b569f2c6729a53f5495786856b310854c8de57782a22bddac"
 CHKUPDATE="anitya::id=1596"

--- a/runtime-optenv32/libdrm+32/spec
+++ b/runtime-optenv32/libdrm+32/spec
@@ -1,4 +1,4 @@
-VER=2.4.126
+VER=2.4.128
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::6cab16d4d259b6abc9f485233863454114a3c307eca806679aad3edbe967bf42"
+CHKSUMS="sha256::3bb35db8700c2a0b569f2c6729a53f5495786856b310854c8de57782a22bddac"
 CHKUPDATE="anitya::id=1596"


### PR DESCRIPTION
Topic Description
-----------------

- libdrm+32: update to 2.4.128
- libdrm: update to 2.4.128

Package(s) Affected
-------------------

- libdrm: 2.4.128

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdrm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
