### PR TITLE
lsp-plugins: Move desktop entries to top-level menu

### DIFF
--- a/app-multimedia/lsp-plugins/autobuild/patches/0001-shared-move-desktop-entries-to-toplevel-category.patch
+++ b/app-multimedia/lsp-plugins/autobuild/patches/0001-shared-move-desktop-entries-to-toplevel-category.patch
@@ -1,0 +1,51 @@
+From e77006b1d06d7866f1401dc8722da19ec6fdd543 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Mon, 3 Nov 2025 13:55:38 +0800
+Subject: [PATCH] shared: move desktop entries to toplevel category
+
+* Change category name to "LSP SFX Plugins".
+* Add translations to the category.
+---
+ .../res/xdg/dirs/lsp-plugins.directory              |  4 +++-
+ .../res/xdg/menus/lsp-plugins.menu                  | 13 +++++--------
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/modules/lsp-plugins-shared/res/xdg/dirs/lsp-plugins.directory b/modules/lsp-plugins-shared/res/xdg/dirs/lsp-plugins.directory
+index 6bcc23d..cf6bfe6 100644
+--- a/modules/lsp-plugins-shared/res/xdg/dirs/lsp-plugins.directory
++++ b/modules/lsp-plugins-shared/res/xdg/dirs/lsp-plugins.directory
+@@ -1,5 +1,7 @@
+ [Desktop Entry]
+-Name=LSP Plugins
++Name=LSP SFX Plugins
++Name[zh_CN]=LSP 音效插件
++Name[zh_TW]=LSP 音效插件
+ Icon=lsp-plugins
+ Type=Directory
+ Keywords=audio;sound;jackd;lsp-plugins;
+diff --git a/modules/lsp-plugins-shared/res/xdg/menus/lsp-plugins.menu b/modules/lsp-plugins-shared/res/xdg/menus/lsp-plugins.menu
+index a2beb97..c64d754 100644
+--- a/modules/lsp-plugins-shared/res/xdg/menus/lsp-plugins.menu
++++ b/modules/lsp-plugins-shared/res/xdg/menus/lsp-plugins.menu
+@@ -2,13 +2,10 @@
+ <Menu>
+   <Name>Applications</Name>
+   <Menu>
+-    <Name>Multimedia</Name>
+-    <Menu>
+-      <Name>lsp-plugins</Name>
+-      <Directory>lsp-plugins.directory</Directory>
+-      <Include>
+-        <Category>X-LSP-Plugins</Category>
+-      </Include>
+-    </Menu>
++    <Name>lsp-plugins</Name>
++    <Directory>lsp-plugins.directory</Directory>
++    <Include>
++      <Category>X-LSP-Plugins</Category>
++    </Include>
+   </Menu>
+ </Menu>
+-- 
+2.51.0
+

--- a/app-multimedia/lsp-plugins/spec
+++ b/app-multimedia/lsp-plugins/spec
@@ -1,4 +1,5 @@
 VER=1.2.24
+REL=1
 SRCS="tbl::https://github.com/lsp-plugins/lsp-plugins/releases/download/${VER}/lsp-plugins-src-${VER}.tar.gz"
 CHKSUMS="sha256::ac329fdcfa916be94b65c1c640d45704691c9e190c35d13d2689389f7fdbb463"
 CHKUPDATE="anitya::id=242897"


### PR DESCRIPTION
Topic Description
-----------------

- lsp-plugins: move desktop entries to toplevel category
    \* Change category name to "LSP SFX Plugins".
    \* Add translations to the category.

Package(s) Affected
-------------------

- lsp-plugins: 1.2.24-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lsp-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
