### PR TITLE
flent: update to 2.2.0

### DIFF
--- a/app-network/flent/spec
+++ b/app-network/flent/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
+VER=2.2.0
 SRCS="tbl::https://pypi.io/packages/source/f/flent/flent-$VER.tar.gz"
-CHKSUMS="sha256::43e04e8388242e69c1fb09ee4454ba181c09eef14fd354d1c0a651d97b2f46cc"
-REL=3
+CHKSUMS="sha256::04fc21de858863560423e79c822f405225f829afd8e5d62293099fbef341f9e8"
 CHKUPDATE="anitya::id=48812"


### PR DESCRIPTION
Topic Description
-----------------

- flent: update to 2.2.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- flent: 2.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit flent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
