### PR TITLE
slurm: update to 0.5.1

### DIFF
--- a/app-network/slurm/spec
+++ b/app-network/slurm/spec
@@ -1,5 +1,4 @@
-VER=0.4.4
-REL=1
+VER=0.5.1
 SRCS="git::commit=tags/upstream/${VER}::https://github.com/mattthias/slurm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=90583"


### PR DESCRIPTION
Topic Description
-----------------

- slurm: update to 0.5.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- slurm: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit slurm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
