### PR TITLE
rootlesskit: new, 2.3.5

### DIFF
--- a/app-admin/rootlesskit/autobuild/config
+++ b/app-admin/rootlesskit/autobuild/config
@@ -1,0 +1,4 @@
+. /usr/share/debconf/confmodule
+
+db_input high rootlesskit/subordinate_ids || true
+db_go

--- a/app-admin/rootlesskit/autobuild/defines
+++ b/app-admin/rootlesskit/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=rootlesskit
+PKGDES="Linux-native 'fake root' for implementing rootless containers"
+PKGSEC=admin
+BUILDDEP="go"
+PKGDEP="glibc"
+
+ABTYPE=gomod
+GO_PACKAGES=(
+	"cmd/rootlessctl"
+	"cmd/rootlesskit"
+	"cmd/rootlesskit-docker-proxy"
+)

--- a/app-admin/rootlesskit/autobuild/postinst
+++ b/app-admin/rootlesskit/autobuild/postinst
@@ -1,0 +1,1 @@
+. /usr/share/debconf/confmodule

--- a/app-admin/rootlesskit/autobuild/postrm
+++ b/app-admin/rootlesskit/autobuild/postrm
@@ -1,0 +1,4 @@
+if [ "$1" = "purge" -a -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/app-admin/rootlesskit/autobuild/templates
+++ b/app-admin/rootlesskit/autobuild/templates
@@ -1,0 +1,29 @@
+Template: rootlesskit/subordinate_ids
+Type: note
+Description: Note for rootlesskit Users
+ rootlesskit require subordinate uid and gids be configured for 
+ an unprivileged user. To configure subordinate ids, append the following
+ content to /etc/subuid, replacing YOUR_USERNAME with your actual username:
+ .
+ YOUR_USERNAME:100000:65536
+ .
+ And the following line to /etc/subgid, replacing YOUR_PRIMARY_GROUP with your
+ actual group name:
+ .
+ YOUR_PRIMARY_GROUP:100000:65536
+ .
+ For more infomation, please refer to rootlesskit documentation:
+ https://rootlesscontaine.rs/getting-started/common/subuid
+Description-zh_CN.UTF-8: 关于 rootlesskit 相关设置的提示
+ rootlesskit 需要为非特权用户配置从属 uid 和 gid。
+ 要完成配置，您可以将如下内容填写到 /etc/subuid，并将 YOUR_USERNAME 替换为您的实际用户名：
+ .
+ YOUR_USERNAME:100000:65536
+ .
+ 以及将以下内容填写到 /etc/subgid 中，将 YOUR_PRIMARY_GROUP 替换为您的实际 unix 用户组名：
+ .
+ YOUR_PRIMARY_GROUP:100000:65536
+ .
+ 有关更多信息，参阅 rootlesskit 官方文档：
+ https://rootlesscontaine.rs/getting-started/common/subuid
+

--- a/app-admin/rootlesskit/spec
+++ b/app-admin/rootlesskit/spec
@@ -1,0 +1,4 @@
+VER=2.3.5
+SRCS="git::commit=tags/v$VER::https://github.com/rootless-containers/rootlesskit"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=369032"


### PR DESCRIPTION
Topic Description
-----------------

- rootlesskit: new, 2.3.5

Package(s) Affected
-------------------

- rootlesskit: 2.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit rootlesskit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
