### PR TITLE
qutebrowser: update to 3.6.1+pdfjs5.4.296

### DIFF
--- a/app-web/qutebrowser/spec
+++ b/app-web/qutebrowser/spec
@@ -1,11 +1,11 @@
-UPSTREAM_VER=3.6.0
+UPSTREAM_VER=3.6.1
 # NOTE: Find the latest pdf.js version in
 # https://github.com/mozilla/pdf.js/releases
 PDFJS_VER=5.4.296
 VER=${UPSTREAM_VER}+pdfjs${PDFJS_VER}
 SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$UPSTREAM_VER/qutebrowser-$UPSTREAM_VER.tar.gz \
       file::rename=pdfjs.zip::https://github.com/mozilla/pdf.js/releases/download/v$PDFJS_VER/pdfjs-$PDFJS_VER-dist.zip"
-CHKSUMS="sha256::5c1b518c0881bd2311170756d5164ad99427c708737637cae4ee9266b1d467bc \
+CHKSUMS="sha256::f5bdf550f2739ac1825e608021bfbc5cc1232a7bc52043b4328cd696e1d86d90 \
          sha256::c00128ab92dfc73249cdf276ef7b34a0d8403e40ecbfcc7b9344411e33dd43e4"
 SUBDIR="qutebrowser-$UPSTREAM_VER"
 CHKUPDATE="anitya::id=9759"


### PR DESCRIPTION
Topic Description
-----------------

- qutebrowser: update to 3.6.1+pdfjs5.4.296
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- qutebrowser: 3.6.1+pdfjs5.4.296

Security Update?
----------------

No

Build Order
-----------

```
#buildit qutebrowser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
