### PR TITLE
acpi: update to 1.8

### DIFF
--- a/app-utils/acpi/spec
+++ b/app-utils/acpi/spec
@@ -1,6 +1,4 @@
-VER=1.7
-REL=3
-
+VER=1.8
 SRCS="tbl::http://http.debian.net/debian/pool/main/a/acpi/acpi_$VER.orig.tar.gz"
-CHKSUMS="sha256::d7a504b61c716ae5b7e81a0c67a50a51f06c7326f197b66a4b823de076a35005"
+CHKSUMS="sha256::e64c6e00b53cd797427ea32a160513425b03ed4f077733f71f1f09ff340f230b"
 CHKUPDATE="anitya::id=17"


### PR DESCRIPTION
Topic Description
-----------------

- acpi: update to 1.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- acpi: 1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit acpi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
