### PR TITLE
lsp-plugins: update to 1.2.25

### DIFF
--- a/app-multimedia/lsp-plugins/spec
+++ b/app-multimedia/lsp-plugins/spec
@@ -1,5 +1,4 @@
-VER=1.2.24
-REL=1
+VER=1.2.25
 SRCS="tbl::https://github.com/lsp-plugins/lsp-plugins/releases/download/${VER}/lsp-plugins-src-${VER}.tar.gz"
-CHKSUMS="sha256::ac329fdcfa916be94b65c1c640d45704691c9e190c35d13d2689389f7fdbb463"
+CHKSUMS="sha256::a829b70df445ecb47ac24e53b42febd46200d9923b62bad94ca3478cb0e32673"
 CHKUPDATE="anitya::id=242897"


### PR DESCRIPTION
Topic Description
-----------------

- lsp-plugins: update to 1.2.25
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lsp-plugins: 1.2.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit lsp-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
