### PR TITLE
dracut-ng: update to 109

### DIFF
--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,4 @@
-VER=108
-REL=1
+VER=109
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: update to 109
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dracut-ng: 109

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
