### PR TITLE
ffmpeg: use dav1d for AV1 decoding

### DIFF
--- a/app-multimedia/ffmpeg/01-ffmpeg/build
+++ b/app-multimedia/ffmpeg/01-ffmpeg/build
@@ -72,7 +72,8 @@ CONFIGURE_OPTIONS=" \
     --enable-vdpau \
     --enable-version3 \
     --enable-vaapi \
-    --enable-libaom \
+    --disable-libaom \
+    --enable-libdav1d \
     --enable-libsmbclient \
     --enable-libsvtav1 \
     --enable-libwebp \

--- a/app-multimedia/ffmpeg/01-ffmpeg/defines
+++ b/app-multimedia/ffmpeg/01-ffmpeg/defines
@@ -1,9 +1,9 @@
 PKGNAME=ffmpeg
 PKGSEC=sound
-PKGDEP="alsa-lib aom bzip2 fontconfig freetype glibc gnutls gsm lame libass \
+PKGDEP="alsa-lib bzip2 fontconfig freetype glibc gnutls gsm lame libass \
         libbluray libdrm libmodplug libssh libtheora libva libvdpau libvorbis \
         libvpx libwebp libxcb opencore-amr opus pulseaudio samba sdl2 soxr \
-        speex svt-av1 v4l-utils x11-lib x264 x265 xvidcore xz zlib harfbuzz"
+        speex dav1d svt-av1 v4l-utils x11-lib x264 x265 xvidcore xz zlib harfbuzz"
 PKGDEP__AMD64="${PKGDEP} libvpl"
 PKGRECOM="avisynthplus"
 BUILDDEP="avisynthplus nasm"

--- a/app-multimedia/ffmpeg/02-static-libs-sunshine/defines
+++ b/app-multimedia/ffmpeg/02-static-libs-sunshine/defines
@@ -1,6 +1,6 @@
 PKGNAME=ffmpeg-static-libs-for-sunshine
 PKGSEC=dev
-PKGDES="A FFmpeg development package for Sunshine"
+PKGDES="FFmpeg development package for Sunshine"
 PKGDEP="glibc ffmpeg"
 
 NOSTATIC=0

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1.1
-REL=2
+REL=3
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: use dav1d for AV1 decoding
    - dav1d is known to be \(much\) more performant when compared to AOM's
    implementation.
    - Improve PKGDES for sunshine subpackage.

Package(s) Affected
-------------------

- ffmpeg: 7.1.1-3
- ffmpeg-static-libs-for-sunshine: 7.1.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
