### PR TITLE
loonggpu-kernel-dkms: update to 1.0.1~alpha~lnd25.5-10

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
@@ -1,7 +1,7 @@
 From 2e20048c55fa5ec168f5a44f4f5733c7e2703346 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:15 +0800
-Subject: [PATCH 01/51] chore: initialise a gitignore file
+Subject: [PATCH 01/52] chore: initialise a gitignore file
 
 Just to make my life easier.
 ---
@@ -24,5 +24,5 @@ index 0000000..223542a
 +*.order
 +conftest
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
@@ -1,7 +1,7 @@
 From f50458a8b381bb6b5858ad27b8ab51982d7655db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:29:59 +0800
-Subject: [PATCH 02/51] loonggpu: include: use video aperture helpers for Linux
+Subject: [PATCH 02/52] loonggpu: include: use video aperture helpers for Linux
  >= 6.13.
 
 Per commit 689274a56c0c ("drm: Remove DRM aperture helpers"), the DRM
@@ -54,5 +54,5 @@ index c4f9727..fa26309 100644
  #endif
  }
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
@@ -1,7 +1,7 @@
 From c8c543febf29491562e32a6c21805ca2af963c2f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:34:47 +0800
-Subject: [PATCH 03/51] loonggpu: pass string literal parameter to
+Subject: [PATCH 03/52] loonggpu: pass string literal parameter to
  MODULE_IMPORT_NS for Linux >= 6.13
 
 With commit cdd30ebb1b9f ("module: Convert symbol namespace to string
@@ -35,5 +35,5 @@ index 90bc2c4..8bcc5a2 100644
  static void gsgpu_display_flip_callback(struct dma_fence *f,
  					 struct dma_fence_cb *cb)
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
@@ -1,7 +1,7 @@
 From d78344d1e4534a20fbe9a9691fb20c86fa605701 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 11:51:25 +0800
-Subject: [PATCH 04/51] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
+Subject: [PATCH 04/52] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
  option
 
 This option is marked deprecated and causes a warning during DKMS builds.
@@ -24,5 +24,5 @@ index d31fb96..044472a 100644
  MAKE[0]="unset ARCH; env LG_VERBOSE=1 \
      make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
@@ -1,7 +1,7 @@
 From 37c11b5b83ccc184e10bdea24dc4c8ed02474d1d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:35 +0800
-Subject: [PATCH 05/51] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
+Subject: [PATCH 05/52] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
  unused variable i
 
 A variable `i' was defined under multiple functions, triggering
@@ -40,5 +40,5 @@ index 86daef6..b0a9185 100644
  
  	/* pick the first one */
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
@@ -1,7 +1,7 @@
 From fb033217bfa7ca1b3b900ba448bd96688910b164 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:30:31 +0800
-Subject: [PATCH 06/51] loonggpu: gsgpu_vm: move struct definition to
+Subject: [PATCH 06/52] loonggpu: gsgpu_vm: move struct definition to
  include/gsgpu_vm.h
 
 Move struct definition to header so that non-static functions may access
@@ -172,5 +172,5 @@ index 4e7da19..e71570a 100644
   * DIR0->DIR1->DIR2
   */
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
@@ -1,7 +1,7 @@
 From 960d2e37e3a0b833b7f5ce34fb4d80a22e6b0c7b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:33:02 +0800
-Subject: [PATCH 07/51] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
+Subject: [PATCH 07/52] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
 
 Lots of functions in this driver were missing prototype definitions,
 triggering a large number of `-Wmissing-prototypes' warnings.
@@ -245,5 +245,5 @@ index e71570a..36e533f 100644
  			 struct gsgpu_task_info *task_info);
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From 6a96edffd9f5bbc1b2cf3a488032623b0b2a361c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 6 Feb 2025 18:12:15 +0800
-Subject: [PATCH 08/51] AOSCOS: loonggpu: remove driver date
+Subject: [PATCH 08/52] AOSCOS: loonggpu: remove driver date
 
 Following upstream changes.
 
@@ -42,5 +42,5 @@ index 8a34e3f..891c43b 100644
  long gsgpu_drm_ioctl(struct file *filp,
  		      unsigned int cmd, unsigned long arg);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
@@ -1,7 +1,7 @@
 From 535a3a5be05a569abe24eaa21ee6236a44744f3e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:03:46 +0800
-Subject: [PATCH 09/51] loonggpu: Remove unused fbdev_list field in
+Subject: [PATCH 09/52] loonggpu: Remove unused fbdev_list field in
  gsgpu_framebuffer
 
 This field is referred nowhere.
@@ -24,5 +24,5 @@ index e5d2cfd..4e21dbc 100644
  };
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
@@ -1,7 +1,7 @@
 From 67052920d0d65c559f3d91cc1087dd7794eb9018 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:21:48 +0800
-Subject: [PATCH 10/51] loonggpu: Remove the unused gsgpu_fbdev_total_size
+Subject: [PATCH 10/52] loonggpu: Remove the unused gsgpu_fbdev_total_size
  function
 
 It's referred nowhere.
@@ -49,5 +49,5 @@ index 4e21dbc..0845aa2 100644
  int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
  int gsgpu_display_modeset_create_props(struct gsgpu_device *adev);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
@@ -1,7 +1,7 @@
 From 6505d6bb76b24f59444420c3105d20052cf02c23 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:27:04 +0800
-Subject: [PATCH 11/51] loonggpu: Improve fbdev object-test helper
+Subject: [PATCH 11/52] loonggpu: Improve fbdev object-test helper
 
 Follow the change of our reference implementation, allowing us to
 remove struct gsgpu_fbdev later.
@@ -48,5 +48,5 @@ index a1447af..81294a9 100644
 +	return true;
  }
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
@@ -1,7 +1,7 @@
 From 84c8becebd2d7d1429b514a9b887b785fc98dcaf Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:34:42 +0800
-Subject: [PATCH 12/51] loonggpu: Remove struct gsgpu_fbdev and add some clean
+Subject: [PATCH 12/52] loonggpu: Remove struct gsgpu_fbdev and add some clean
  up code
 
 Both data fields in struct gsgpu_fbdev, the framebuffer and the
@@ -237,5 +237,5 @@ index 0845aa2..860a68d 100644
  	int			num_hpd; /* number of hpd pins */
  	int			num_i2c;
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
@@ -1,7 +1,7 @@
 From a169f227222a60a30f99c4640de9823f6dbacfff Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:50:01 +0800
-Subject: [PATCH 13/51] loonggpu: Move fbdev cleanup code into fb_destroy
+Subject: [PATCH 13/52] loonggpu: Move fbdev cleanup code into fb_destroy
  callback
 
 Fbdev calls struct fb_ops.fb_destroy after cleaning up the final
@@ -124,5 +124,5 @@ index aa213b4..5bee711 100644
  	kfree(adev->ddev->fb_helper);
  	adev->ddev->fb_helper = NULL;
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
@@ -1,7 +1,7 @@
 From 9b5968d63571d2beff31fe0fbadd6b98540c7473 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:59:39 +0800
-Subject: [PATCH 14/51] loonggpu: Remove redundant info->par assignment
+Subject: [PATCH 14/52] loonggpu: Remove redundant info->par assignment
 
 It's already assigned by lg_drm_fb_helper_fill_info (no matter what the
 kernel version is).
@@ -24,5 +24,5 @@ index 5bee711..7b3f38b 100644
  
  	fb = kzalloc(sizeof(struct gsgpu_framebuffer), GFP_KERNEL);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
@@ -1,7 +1,7 @@
 From 3d6e1f3088cddf98c0bc419812908fdc14534ee1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:19:37 +0800
-Subject: [PATCH 15/51] loonggpu: Remove test for !screen_base in fbdev probing
+Subject: [PATCH 15/52] loonggpu: Remove test for !screen_base in fbdev probing
 
 The screen_base field comes from the fbdev BO and contains the fbdev
 framebuffer base address. We get the BO memory via gsgpu_bo_kmap(),
@@ -34,5 +34,5 @@ index 7b3f38b..fb0253c 100644
  	DRM_INFO("vram apper at 0x%lX\n",  (unsigned long)adev->gmc.aper_base);
  	DRM_INFO("size %lu\n", (unsigned long)gsgpu_bo_size(abo));
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
@@ -1,7 +1,7 @@
 From fd00f34c73088c7a838276c85a188a441549bbb1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:21:28 +0800
-Subject: [PATCH 16/51] loonggpu: Correctly clean up failed display probing
+Subject: [PATCH 16/52] loonggpu: Correctly clean up failed display probing
 
 Improve the fbdev probing function to fully clean up if it failed.
 Allows to remove special cases from fb_destroy as well.
@@ -147,5 +147,5 @@ index fb0253c..ad1990e 100644
  }
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
@@ -1,7 +1,7 @@
 From 83ef7728a8f023468e5c0aa4ec907b442ddd7d54 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:10:14 +0800
-Subject: [PATCH 17/51] loonggpu: Remove load callback from kms_driver
+Subject: [PATCH 17/52] loonggpu: Remove load callback from kms_driver
 
 The ".load" callback in "struct drm_driver" is deprecated. In order to
 remove the callback, we have to manually call "gsgpu_driver_load_kms"
@@ -37,5 +37,5 @@ index 94d9f88..d0d51cf 100644
  	.postclose = gsgpu_driver_postclose_kms,
  	lg_drm_driver_set_lastclose
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,7 +1,7 @@
 From 6a2e84785264b6dfc36a910b86fa7acd1b54d114 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:21:11 +0800
-Subject: [PATCH 18/51] loonggpu: Implement client-based fbdev emulation
+Subject: [PATCH 18/52] loonggpu: Implement client-based fbdev emulation
 
 Implement fbdev emulation on top of struct drm_client and its helpers.
 Replaces ad-hoc interfaces for restoring and closing fbdev emulation with
@@ -267,5 +267,5 @@ index 860a68d..a66bfaf 100644
  bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
  int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,7 +1,7 @@
 From 09c4bae40f4d1191a3d8a8caab81a70f8c5d35c3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:31:20 +0800
-Subject: [PATCH 19/51] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
+Subject: [PATCH 19/52] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
  call
 
 It's not needed anymore as now the generic drm_client_register() calls
@@ -29,5 +29,5 @@ index 5057665..f1d9546 100644
  
  	return;
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,7 +1,7 @@
 From 443a5275c42e8833079eb621775b7faf144e7b7c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:35:32 +0800
-Subject: [PATCH 20/51] loonggpu: Disable outputs when releasing fbdev client
+Subject: [PATCH 20/52] loonggpu: Disable outputs when releasing fbdev client
 
 Following up the reference implementation change to avoid potential
 errors.
@@ -25,5 +25,5 @@ index f1d9546..4c16273 100644
  	} else {
  		drm_client_release(&fb_helper->client);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,7 +1,7 @@
 From 5d470d0074d8db599d7aaf3334b56c9a51d266f6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:58:47 +0800
-Subject: [PATCH 21/51] loonggpu: Run DRM default client setup
+Subject: [PATCH 21/52] loonggpu: Run DRM default client setup
 
 Rework fbdev probing to support fbdev_probe in struct drm_driver
 and remove the old fb_probe callback. Provide an initializer macro
@@ -218,5 +218,5 @@ index a66bfaf..be2e123 100644
  bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
  int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
@@ -1,7 +1,7 @@
 From 0871ad4bb96b29174dd0cb86b4758bd77592b376 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:36:09 +0800
-Subject: [PATCH 22/51] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
+Subject: [PATCH 22/52] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
 
 A comment in Kbuild says "using EXTRA_CFLAGS for compatibility with
 kernel older than 2.6.24" which does not make any sense for loonggpu: we
@@ -127,5 +127,5 @@ index 9a5a508..84e0566 100644
  LG_CONFTEST_COMPILE_TEST_HEADERS := $(obj)/conftest/macros.h
  LG_CONFTEST_COMPILE_TEST_HEADERS += $(obj)/conftest/functions.h
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
@@ -1,7 +1,7 @@
 From 8a7019df11c908bddbcc0ded58a6a38ce557318d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:59:23 +0800
-Subject: [PATCH 23/51] AOSCOS: loonggpu: Adapt for drm_sched_init struct
+Subject: [PATCH 23/52] AOSCOS: loonggpu: Adapt for drm_sched_init struct
  params
 
 Since kernel commit 796a9f55a8d1 ("drm/sched: Use struct for
@@ -115,5 +115,5 @@ index fa26309..ebe56f0 100644
  #else
  	kthread_unpark(ring->sched.thread);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
@@ -1,7 +1,7 @@
 From 7b7a3db4e073f207cff231791a11d6a11a80c2cb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:07:26 +0800
-Subject: [PATCH 24/51] AOSCOS: loonggpu: Adapt for renaming of from_timer to
+Subject: [PATCH 24/52] AOSCOS: loonggpu: Adapt for renaming of from_timer to
  timer_container_of
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -79,5 +79,5 @@ index ebe56f0..4d56c91 100644
 +
  #endif /* __GSGPU_HELPER_H__ */
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
@@ -1,7 +1,7 @@
 From 51778b8977329840486c9c0c3d7b65a9917461dd Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:15:51 +0800
-Subject: [PATCH 25/51] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
+Subject: [PATCH 25/52] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
  to timer_delete_sync
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -76,5 +76,5 @@ index 4d56c91..8cb4fa3 100644
 +
  #endif /* __GSGPU_HELPER_H__ */
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
@@ -1,7 +1,7 @@
 From 5a01159f90249c17dd9acafe01b42ddd27f06e15 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 22 Jun 2025 16:05:51 +0800
-Subject: [PATCH 26/51] loonggpu: bridge: Adapt for recent kernel API changes
+Subject: [PATCH 26/52] loonggpu: bridge: Adapt for recent kernel API changes
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
@@ -48,5 +48,5 @@ index 921583e..353a481 100644
  	struct gsgpu_bridge_phy *phy = to_bridge_phy(bridge);
  	struct gsgpu_connector *lconnector;
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,7 +1,7 @@
 From cbfbdeabb1ae75c3979ddb0f8c35d1d7c01685f2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 10:49:40 +0800
-Subject: [PATCH 27/51] loonggpu: Remove the check against moving pinned BOs
+Subject: [PATCH 27/52] loonggpu: Remove the check against moving pinned BOs
 
 The check is already in the generic code.
 
@@ -29,5 +29,5 @@ index 6d06d42..e048982 100644
  
  	if (!old_mem || (old_mem->mem_type == TTM_PL_SYSTEM && bo->ttm == NULL)) {
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
@@ -1,7 +1,7 @@
 From f24dbfb4d81ab70a5919f9281d349accdebcf2e2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 11:18:49 +0800
-Subject: [PATCH 28/51] loonggpu: Remove dead code
+Subject: [PATCH 28/52] loonggpu: Remove dead code
 
 The body of this if statement is obviously unreachable.
 
@@ -27,5 +27,5 @@ index e048982..4c85ac3 100644
  	     new_mem->mem_type == TTM_PL_SYSTEM) ||
  	    (old_mem->mem_type == TTM_PL_SYSTEM &&
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,7 +1,7 @@
 From 3f819995623623251838683cd761144fcd961d0d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 12:11:28 +0800
-Subject: [PATCH 29/51] loonggpu: NFC: Clean up gsgpu_bo_move
+Subject: [PATCH 29/52] loonggpu: NFC: Clean up gsgpu_bo_move
 
 Just use goto to deduplicate some identical code, and wrap a long line
 to make the flow more similar to the reference implementation.
@@ -50,5 +50,5 @@ index 4c85ac3..8f4d6a3 100644
  	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
  	gsgpu_bo_move_notify(bo, evict, new_mem);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
@@ -1,7 +1,7 @@
 From c9a04e21d03f0385b57a074d8018e4011e3ec9df Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:08:07 +0800
-Subject: [PATCH 30/51] loonggpu: Handle tt moves properly
+Subject: [PATCH 30/52] loonggpu: Handle tt moves properly
 
 It seems required since a TTM move refactoring in 2020.  Following up the
 reference implementation change (and several changes after that).
@@ -58,5 +58,5 @@ index 8f4d6a3..a12f0c0 100644
  		goto memcpy;
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
@@ -1,7 +1,7 @@
 From 95174f237cc75370e7c99a69ab8779e2b263324a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:35:15 +0800
-Subject: [PATCH 31/51] loonggpu: Use multihop
+Subject: [PATCH 31/52] loonggpu: Use multihop
 
 Remove the code to move resources directly between
 SYSTEM and VRAM in favour of using the core ttm mulithop code.
@@ -231,5 +231,5 @@ index a12f0c0..dd76658 100644
  	/* update statistics */
  	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,7 +1,7 @@
 From 859801da3ffd26fdc27a5a6f77484c9137a100f5 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:42:37 +0800
-Subject: [PATCH 32/51] loonggpu: Drop the unused no_wait_gpu parameter of
+Subject: [PATCH 32/52] loonggpu: Drop the unused no_wait_gpu parameter of
  gsgpu_move_blit
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -33,5 +33,5 @@ index dd76658..95ccd5e 100644
  		r = -ENODEV;
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,7 +1,7 @@
 From fef5eeb09edd5421ab852efc8e1bff0db0030e80 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:49:20 +0800
-Subject: [PATCH 33/51] loonggpu: Drop lg_ttm_tt_bind
+Subject: [PATCH 33/52] loonggpu: Drop lg_ttm_tt_bind
 
 Get rid of the ttm_tt_populate usage: this symbol is only exported if
 DRM_TTM_KUNIT_TEST which requires COMPILE_TEST on LoongArch.
@@ -83,5 +83,5 @@ index 5eeebf3..f352344 100644
  {
  #if defined(LG_TTM_BO_MEM_PUT) && defined(LG_DRM_TTM_TTM_BO_DRIVER_H_PRESENT)
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
@@ -1,7 +1,7 @@
 From 17d2c2dec632865fbb4bde88ac66e838153ace10 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:09:20 +0800
-Subject: [PATCH 34/51] loonggpu: Make the mode parameter of the mode_valid
+Subject: [PATCH 34/52] loonggpu: Make the mode parameter of the mode_valid
  callback of bridge_phy_cfg_funcs a pointer to const
 
 Fix a -Wdiscarded-qualifiers warning.
@@ -53,5 +53,5 @@ index 1e494ec..7abb77c 100644
          if (mode->hdisplay == 1680 && mode->vdisplay == 1050)
              return MODE_BAD;
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,7 +1,7 @@
 From f2f40bb47d116791d979df9fd1e6f09b5210bc0f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:24:23 +0800
-Subject: [PATCH 35/51] loonggpu: Remove an invalid "const" qualifier
+Subject: [PATCH 35/52] loonggpu: Remove an invalid "const" qualifier
 
 You obviously cannot sprintf things into a const char array!
 
@@ -24,5 +24,5 @@ index 8a2fa3b..8b97512 100644
  	sprintf(pwm_name, "pwm%d", ls_bl->pwm_id);
  	ls_bl->pwm = lg_pwm_request(adev->ddev->dev, pwm_name, ls_bl->pwm_id, "Loongson_bl");
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,7 +1,7 @@
 From 45ca1bad62a6824155b08fdbe627bb0a74d49763 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:26:21 +0800
-Subject: [PATCH 36/51] loonggpu: Fix the parameter order of a kmalloc_array
+Subject: [PATCH 36/52] loonggpu: Fix the parameter order of a kmalloc_array
  call
 
 The element size should be the second parameter.
@@ -25,5 +25,5 @@ index ed06003..cc3d157 100644
  		return -ENOMEM;
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,7 +1,7 @@
 From 5d88458aaf0edfb43d7674b8afa674e80406ea8e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 16:10:04 +0800
-Subject: [PATCH 37/51] loonggpu: Handle the different drm_client_setup.h
+Subject: [PATCH 37/52] loonggpu: Handle the different drm_client_setup.h
  location in 6.12
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -28,5 +28,5 @@ index 4e31e33..924d3bb 100644
  #include <drm/drm_drv.h>
  #include <drm/drm_device.h>
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
@@ -1,7 +1,7 @@
 From aedb6d4c922ba8a8d3019cbf29bc5b9a79b76022 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 13 Aug 2025 12:38:30 +0800
-Subject: [PATCH 38/51] loonggpu: Handle the error from gsgpu_driver_load_kms
+Subject: [PATCH 38/52] loonggpu: Handle the error from gsgpu_driver_load_kms
  correctly
 
 With a 4KiB-page kernel, gsgpu_gart_init will fail because it requires
@@ -34,5 +34,5 @@ index 924d3bb..ede1066 100644
  retry_init:
  	ret = drm_dev_register(dev, pci_gpu_flags);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
@@ -1,7 +1,7 @@
 From b5446a8767e99c4d35fb5e9057a8eda188d791c2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:06:53 +0800
-Subject: [PATCH 39/51] loonggpu: Adapt for drm_get_format_info() API change
+Subject: [PATCH 39/52] loonggpu: Adapt for drm_get_format_info() API change
 
 Link: https://git.kernel.org/torvalds/c/0e7d5874fb6b
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -27,5 +27,5 @@ index 936c36b..eedbe38 100644
  
  	/* need to align pitch with crtc limits */
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-Adapt-for-.fb_create-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-Adapt-for-.fb_create-API-change.patch
@@ -1,7 +1,7 @@
 From 2d8b77ff31988dec54db98bff35d6315b9815b57 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:12:24 +0800
-Subject: [PATCH 40/51] loonggpu: Adapt for .fb_create API change
+Subject: [PATCH 40/52] loonggpu: Adapt for .fb_create API change
 
 Link: https://git.kernel.org/torvalds/c/81112eaac559
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -47,5 +47,5 @@ index 46523aa..eb3f0ca 100644
  int gsgpu_display_crtc_page_flip_target(struct drm_crtc *crtc,
                                  struct drm_framebuffer *fb,
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
@@ -1,7 +1,7 @@
 From 0a1e7a25605f1df7048e5f4dd105a9e38fd201f8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:15:46 +0800
-Subject: [PATCH 41/51] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
+Subject: [PATCH 41/52] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
  change
 
 Link: https://git.kernel.org/torvalds/c/a34cc7bf1034
@@ -29,5 +29,5 @@ index 69980f5..05e760f 100644
  	if (ret) {
  		rfb->base.obj[0] = NULL;
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
@@ -1,7 +1,7 @@
 From 1b821f27321c039151ff82fe9f8bd0e06210c9b8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:24:55 +0800
-Subject: [PATCH 42/51] loonggpu: Pass along the format info from .fb_create()
+Subject: [PATCH 42/52] loonggpu: Pass along the format info from .fb_create()
  to drm_helper_mode_fill_fb_struct()
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -128,5 +128,5 @@ index be2e123..b08b967 100644
  				   struct drm_gem_object *obj);
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
@@ -1,7 +1,7 @@
 From 97ce999696fd7372e983b480a333666f23633723 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:18:18 +0800
-Subject: [PATCH 43/51] loonggpu: Pass DRM client ID to drm_sched_job_init
+Subject: [PATCH 43/52] loonggpu: Pass DRM client ID to drm_sched_job_init
 
 Adapt for upstream API change.
 
@@ -172,5 +172,5 @@ index eed859c..5b4d3ab 100644
  			     struct dma_fence **fence);
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
@@ -1,7 +1,7 @@
 From eaf52006639d5e39fa24879d86f00629b3db0f0f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:20:01 +0800
-Subject: [PATCH 44/51] loonggpu: Adapt for the rename of
+Subject: [PATCH 44/52] loonggpu: Adapt for the rename of
  DRM_GPU_SCHED_STAT_NOMINAL to DRM_GPU_SCHED_STAT_RESET
 
 Link: https://git.kernel.org/torvalds/c/0a5dc1b67ef5
@@ -27,5 +27,5 @@ index 8fa0bf7..e21d402 100644
  #define lg_gsgpu_job_timedout_ret void
  #define LG_DRM_GPU_SCHED_STAT_NOMINAL
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Don-t-directly-use-ttm_bo_get.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Don-t-directly-use-ttm_bo_get.patch
@@ -1,7 +1,7 @@
 From dfba9f4e909cf8d30265a3aa38850eea4d98cd74 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:23:20 +0800
-Subject: [PATCH 45/51] loonggpu: Don't directly use ttm_bo_get
+Subject: [PATCH 45/52] loonggpu: Don't directly use ttm_bo_get
 
 Adapt for upstream API change which made this function internal.
 
@@ -100,5 +100,5 @@ index 06b8ef9..20e6760 100644
  int gsgpu_gem_object_open(struct drm_gem_object *obj,
  				struct drm_file *file_priv);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-backlight-Get-PWM-correctly-and-skip-GPIO-f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-backlight-Get-PWM-correctly-and-skip-GPIO-f.patch
@@ -1,7 +1,7 @@
 From aaee8cb5d7f879ba4cd2cb268a8591f99735b729 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 19:15:10 +0800
-Subject: [PATCH 46/51] loonggpu: backlight: Get PWM correctly and skip GPIO
+Subject: [PATCH 46/52] loonggpu: backlight: Get PWM correctly and skip GPIO
  for now
 
 This should make backlight control at least usable with AOSC 6.16.1-rc1
@@ -115,5 +115,5 @@ index 8ecc610..178c225 100644
  int gsgpu_backlight_register(struct drm_connector *connector);
  int gsgpu_late_register(struct drm_connector *connector);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-Get-rid-of-drm_sched_job.id.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-Get-rid-of-drm_sched_job.id.patch
@@ -1,7 +1,7 @@
 From e1f22e5a2793ff149cf71b7d5cff8aaefbe9e45c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 27 Aug 2025 10:31:29 +0800
-Subject: [PATCH 47/51] loonggpu: Get rid of drm_sched_job.id
+Subject: [PATCH 47/52] loonggpu: Get rid of drm_sched_job.id
 
 It's removed in the upstream kernel.  I don't bother to add a #ifdef for
 kernel version check here because our users don't care about tracing
@@ -70,5 +70,5 @@ index 2b43c9e..42ca767 100644
  );
  
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
@@ -1,7 +1,7 @@
 From 781daf42e56e1907fff7a6bf33c1ee0a0598e64c Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:28:47 +0800
-Subject: [PATCH 48/51] loonggpu: fix typo mistake in
+Subject: [PATCH 48/52] loonggpu: fix typo mistake in
  include/gsgpu_ttm_resource_helper.h
 
 ---
@@ -19,5 +19,5 @@ index 361517c..c12b3f5 100644
  
  #if !defined (LG_DRM_TTM_TTM_BO_H_PRESENT)
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,7 +1,7 @@
 From 743e20b11c639d09b66fac43704238f5265e0b07 Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:33:29 +0800
-Subject: [PATCH 49/51] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
+Subject: [PATCH 49/52] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
  switched to c23
 
 ---
@@ -25,5 +25,5 @@ index 497c1f4..e7df1a1
      if [ "$OUTPUT" != "$SOURCES" ]; then
          OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
@@ -1,7 +1,7 @@
 From e3b7e8daaf2462138213cd845bddb862f1d41349 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 13 Oct 2025 11:37:06 +0800
-Subject: [PATCH 50/51] loonggpu: Get rid of ida_simple_get and
+Subject: [PATCH 50/52] loonggpu: Get rid of ida_simple_get and
  ida_simple_remove
 
 They'd been a deprecated wrapper of ida_alloc_range and ida_free since
@@ -43,5 +43,5 @@ index cc3d157..edf4678 100644
  
  static void gsgpu_pasid_free_cb(struct dma_fence *fence,
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
@@ -1,7 +1,7 @@
 From d6aab208624b345e19debc1424910c1984cd3d19 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 30 Oct 2025 10:12:33 +0800
-Subject: [PATCH 51/51] loonggpu: Only build a dummy if page size is 4 KiB
+Subject: [PATCH 51/52] loonggpu: Only build a dummy if page size is 4 KiB
 
 The hack [1] is not enough as when we install a kernel package (like
 linux-kernel-6.17.1), the postinstall script of the kernel package still
@@ -63,5 +63,5 @@ index 0000000..4c38f23
 +MODULE_LICENSE("GPL");
 +#endif
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Drop-CLEAN-from-dkms.conf.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Drop-CLEAN-from-dkms.conf.patch
@@ -1,0 +1,24 @@
+From 8673745cf5ef57269f03496c00b98e196a66c82b Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 4 Nov 2025 11:26:37 +0800
+Subject: [PATCH 52/52] loonggpu: Drop CLEAN= from dkms.conf
+
+It's unneeded and deprecated in the recent dkms release.
+
+Link: https://github.com/dkms-project/dkms/issues/502
+---
+ dkms.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 044472a..ee69c4e 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -11,4 +11,3 @@ AUTOINSTALL=yes
+ 
+ MAKE[0]="unset ARCH; env LG_VERBOSE=1 \
+     make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
+-CLEAN="make KERNEL_UNAME=${kernelver} clean"
+-- 
+2.51.1
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
-REL=9
+REL=10
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- Add a patch to remove useless and deprecated CLEAN= setting in dkms.conf.
- Tracking AOSC patches at https://github.com/AOSC-Tracking/loonggpu-kernel-dkms (HEAD: 8673745cf5ef57269f03496c00b98e196a66c82b).

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: `1.0.1~alpha~lnd25.5~10`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`
