### PR TITLE
appres: update to 1.0.7

### DIFF
--- a/app-utils/appres/spec
+++ b/app-utils/appres/spec
@@ -1,4 +1,4 @@
-VER=1.0.6
+VER=1.0.7
 SRCS="tbl::https://ftp.x.org/pub/individual/app/appres-$VER.tar.gz"
-CHKSUMS="sha256::848f383ff429612fb9df840d79e97dc193dc72dbbf53d3217a8d1e90a5aa1e26"
+CHKSUMS="sha256::a7e01072e344ffe56caf143fdbc4ba5d6ddb10d38c2f2f65319d8d9741535418"
 CHKUPDATE="anitya::id=15053"


### PR DESCRIPTION
Topic Description
-----------------

- appres: update to 1.0.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- appres: 1.0.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit appres
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
