### PR TITLE
makedumpfile: update to 1.7.8

### DIFF
--- a/app-devel/makedumpfile/spec
+++ b/app-devel/makedumpfile/spec
@@ -1,4 +1,4 @@
-VER=1.7.7
+VER=1.7.8
 SRCS="git::commit=tags/$VER::https://github.com/makedumpfile/makedumpfile"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=131396"


### PR DESCRIPTION
Topic Description
-----------------

- makedumpfile: update to 1.7.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- makedumpfile: 1.7.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit makedumpfile
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
