### PR TITLE
mlt: update to 7.34.0

### DIFF
--- a/runtime-multimedia/mlt/autobuild/defines
+++ b/runtime-multimedia/mlt/autobuild/defines
@@ -1,60 +1,63 @@
 PKGNAME=mlt
 PKGSEC=video
 PKGDEP="ffmpeg libdv libexif libsamplerate movit opencv qt-5 rubberband \
-        sdl-image sox vid.stab qt-6"
+        sdl-image sox vid.stab qt-6 frei0r-plugins"
 BUILDDEP="doxygen graphviz jack ladspa-sdk lua openjdk perl php python-3 \
           ruby swig tcl"
 # FIXME: No JNI support?!
 BUILDDEP__LOONGSON3="${BUILDDEP/openjdk/}"
-PKGDES="An open source multimedia framework"
+PKGDES="Multimedia framework for multitrack audio/video compositions"
 
 ABTYPE="cmakeninja"
 # Note: -DMOD_NDI=OFF - we have no use for NDI SDK.
 # Note: -DSWIG_*=OFF - only enabled as needed.
-CMAKE_AFTER="-DBUILD_DOCS=ON \
-             -DBUILD_TESTING=OFF \
-             -DBUILD_TESTS_WITH_QT6=OFF \
-             -DGPL=ON \
-             -DGPL3=ON \
-             -DMOD_AVFORMAT=ON \
-             -DMOD_DECKLINK=ON \
-             -DMOD_FREI0R=ON \
-             -DMOD_GDK=ON \
-             -DMOD_GLAXNIMATE=ON \
-             -DMOD_JACKRACK=ON \
-             -DMOD_KDENLIVE=ON \
-             -DMOD_MOVIT=ON \
-             -DMOD_NDI=OFF \
-             -DMOD_NORMALIZE=ON \
-             -DMOD_OLDFILM=ON \
-             -DMOD_OPENCV=ON \
-             -DMOD_PLUS=ON \
-             -DMOD_PLUSGPL=ON \
-             -DMOD_QT=ON \
-             -DMOD_QT6=ON \
-             -DMOD_RESAMPLE=ON \
-             -DMOD_RTAUDIO=ON \
-             -DMOD_RUBBERBAND=ON \
-             -DMOD_SDL1=ON \
-             -DMOD_SDL2=ON \
-             -DMOD_SOX=ON \
-             -DMOD_VIDSTAB=ON \
-             -DMOD_VORBIS=ON \
-             -DMOD_XINE=ON \
-             -DMOD_XML=ON \
-             -DRELOCATABLE=OFF \
-             -DSWIG_CSHARP=OFF \
-             -DSWIG_JAVA=ON \
-             -DSWIG_LUA=ON \
-             -DSWIG_NODEJS=OFF \
-             -DSWIG_PERL=ON \
-             -DSWIG_PHP=ON \
-             -DSWIG_PYTHON=ON \
-             -DSWIG_RUBY=ON \
-             -DSWIG_TCL=ON"
+CMAKE_AFTER=(
+    '-DBUILD_DOCS=OFF'
+    '-DBUILD_TESTING=OFF'
+    '-DBUILD_TESTS_WITH_QT6=OFF'
+    '-DGPL=ON'
+    '-DGPL3=ON'
+    '-DMOD_AVFORMAT=ON'
+    '-DMOD_DECKLINK=ON'
+    '-DMOD_FREI0R=ON'
+    '-DMOD_GDK=ON'
+    '-DMOD_GLAXNIMATE=ON'
+    '-DMOD_JACKRACK=ON'
+    '-DMOD_KDENLIVE=ON'
+    '-DMOD_MOVIT=ON'
+    '-DMOD_NDI=OFF'
+    '-DMOD_NORMALIZE=ON'
+    '-DMOD_OLDFILM=ON'
+    '-DMOD_OPENCV=ON'
+    '-DMOD_PLUS=ON'
+    '-DMOD_PLUSGPL=ON'
+    '-DMOD_QT=ON'
+    '-DMOD_QT6=ON'
+    '-DMOD_RESAMPLE=ON'
+    '-DMOD_RTAUDIO=ON'
+    '-DMOD_RUBBERBAND=ON'
+    '-DMOD_SDL1=ON'
+    '-DMOD_SDL2=ON'
+    '-DMOD_SOX=ON'
+    '-DMOD_VIDSTAB=ON'
+    '-DMOD_VORBIS=ON'
+    '-DMOD_XINE=ON'
+    '-DMOD_XML=ON'
+    '-DRELOCATABLE=OFF'
+    '-DSWIG_CSHARP=OFF'
+    '-DSWIG_JAVA=ON'
+    '-DSWIG_LUA=ON'
+    '-DSWIG_NODEJS=OFF'
+    '-DSWIG_PERL=ON'
+    '-DSWIG_PHP=ON'
+    '-DSWIG_PYTHON=ON'
+    '-DSWIG_RUBY=ON'
+    '-DSWIG_TCL=ON'
+)
 # FIXME: No JNI support?!
-CMAKE_AFTER__LOONGSON3=" \
-             ${CMAKE_AFTER} \
-             -DSWIG_JAVA=OFF"
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER[@]}"
+    '-DSWIG_JAVA=OFF'
+)
 
 PKGBREAK="kdenlive<=17.12.3 shotcut<=17.08 synfig<=1.2.1-1"

--- a/runtime-multimedia/mlt/spec
+++ b/runtime-multimedia/mlt/spec
@@ -1,4 +1,4 @@
-VER=7.32.0
+VER=7.34.0
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/mlt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11007"


### PR DESCRIPTION
Topic Description
-----------------

- mlt: update to 7.34.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mlt: 7.34.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mlt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
