### PR TITLE
flatpak: update to 1.17.0

### DIFF
--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,5 +1,4 @@
-VER=1.16.1
-REL=3
+VER=1.17.0
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- flatpak: update to 1.17.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- flatpak: 1.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
