### PR TITLE
syncthing: update to 2.0.11

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,5 +1,4 @@
-VER=2.0.10
-REL=1
+VER=2.0.11
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::c36d11060580e290dabbd01a56f38b0ae58e6873031c25712bb7b5fdaaec8942"
+CHKSUMS="sha256::a9656cded5048bac4937e7046b1b4d5fb6d78bca01df2eed495335be6d4ab643"
 CHKUPDATE="anitya::id=11814"


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 2.0.11
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- syncthing: 2.0.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
