### PR TITLE
linyaps: update to 1.10.0

### DIFF
--- a/app-admin/linyaps-box/autobuild/defines
+++ b/app-admin/linyaps-box/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=linyaps-box
+PKGSEC=admin
+PKGDEP="libcap libseccomp"
+BUILDDEP="cli11 gtest nlohmann-json"
+PKGDES="Containerized application distribution and packaging toolkit"
+
+CMAKE_AFTER=(
+    '-DLINYAPS_BOX_STATIC_LINK=OFF'
+    '-DLINYAPS_BOX_ENABLE_SECCOMP=ON'
+    '-DLINYAPS_BOX_ENABLE_CAP=ON'
+)
+
+# Note: Project renamed during linglong-preview.
+# Note: linyaps-box was split >= 1.7.
+PKGBREAK="linglong<=1.5.6 linyaps<=1.6.3-1"
+PKGREP="linglong<=1.5.6 linyaps<=1.6.3-1"

--- a/app-admin/linyaps-box/spec
+++ b/app-admin/linyaps-box/spec
@@ -1,0 +1,4 @@
+VER=2.1.2
+SRCS="git::commit=tags/$VER::https://github.com/OpenAtom-Linyaps/linyaps-box"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386672"

--- a/app-admin/linyaps/autobuild/defines
+++ b/app-admin/linyaps/autobuild/defines
@@ -1,11 +1,14 @@
 PKGNAME=linyaps
 PKGSEC=admin
-PKGDEP="glib libseccomp ostree qt-5 systemd yaml-cpp"
-BUILDDEP="nlohmann-json"
+PKGDEP="glib libseccomp linyaps-box ostree qt-6 systemd yaml-cpp"
+BUILDDEP="gtest nlohmann-json"
 PKGDES="Containerized application distribution and packaging toolkit"
 
-CMAKE_AFTER="-DCPM_LOCAL_PACKAGES_ONLY=ON \
-             -DLINGLONG_DEFAULT_OCI_RUNTIME=ll-box"
+CMAKE_AFTER=(
+    '-DQT_VERSION_MAJOR=6'
+    '-DCPM_LOCAL_PACKAGES_ONLY=ON'
+    '-DLINGLONG_DEFAULT_OCI_RUNTIME=ll-box'
+)
 
 # Note: Project renamed during linglong-preview.
 PKGBREAK="linglong<=1.5.6"

--- a/app-admin/linyaps/autobuild/postinst
+++ b/app-admin/linyaps/autobuild/postinst
@@ -1,8 +1,33 @@
 echo "Creating user account for the Linglong daemon owner ..."
 systemd-sysusers linglong.conf
 
-echo "Reloading D-Bus configurations ..."
-dbus-send \
-	--system \
-	--type=method_call \
-	--dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+echo "Creating daemon directories for Linglong ..."
+systemd-tmpfiles --create linglong.conf
+
+# Borrowed from Debian.
+_systemctl() {
+	if [ -z "$DPKG_ROOT" ] && [ -d /run/systemd/system ]; then
+		systemctl "$@" 1>&2
+	else
+		return 127
+	fi
+}
+
+# Add `|| true' just to be safe, but this shouldn't be needed unless
+# the package upgrade sequence is messed up (i.e., whilst updating
+# OpenSSL, breaking systemd programs).
+_systemctl daemon-reload || true
+
+# Only preset these services for a fresh installation
+# i.e. installing for the first time or after purging
+if [ "$1" = configure ] && [ -z "$2" ]; then
+	_systemctl preset org.deepin.linglong.PackageManager.service || true
+fi
+
+if ! systemd-detect-virt --container; then
+	echo "Reloading D-Bus configurations ..."
+	dbus-send \
+		--system \
+		--type=method_call \
+		--dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+fi

--- a/app-admin/linyaps/spec
+++ b/app-admin/linyaps/spec
@@ -1,5 +1,4 @@
-VER=1.6.3
-REL=1
+VER=1.10.0
 SRCS="git::commit=tags/$VER::https://github.com/OpenAtom-Linyaps/linyaps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372461"


### PR DESCRIPTION
Topic Description
-----------------

- linyaps: add linyaps-box dep
    Also switch to Qt 6.
- linyaps-box: new, 2.1.2
    Split from linyaps \(was vendored\).
- linyaps: update to 1.10.0
    - Add gtest build dep.
    - Revise CMAKE_AFTER as an array.
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- linyaps: 1.10.0
- linyaps-box: 2.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linyaps-box linyaps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
