### PR TITLE
gitea: update to 1.25.1

### DIFF
--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,4 +1,4 @@
-VER=1.25.0
+VER=1.25.1
 SRCS="tbl::https://github.com/go-gitea/gitea/releases/download/v$VER/gitea-src-$VER.tar.gz"
-CHKSUMS="sha256::6ce85e249ed6b0915aa1c5dbeb4ffe3da60ff4f27749088145938c692debee15"
+CHKSUMS="sha256::127f9d6efce69cc9cbe92b6cf84b98709b458407f9b21c6d15b007d68b656148"
 CHKUPDATE="anitya::id=13537"


### PR DESCRIPTION
Topic Description
-----------------

- gitea: update to 1.25.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gitea: 1.25.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
