### PR TITLE
onedrive: update to 2.5.8

### DIFF
--- a/app-web/onedrive/spec
+++ b/app-web/onedrive/spec
@@ -1,4 +1,4 @@
-VER=2.5.5
+VER=2.5.8
 SRCS="git::commit=tags/v$VER::https://github.com/abraunegg/onedrive"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16974"


### PR DESCRIPTION
Topic Description
-----------------

- onedrive: update to 2.5.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- onedrive: 2.5.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit onedrive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
