### PR TITLE
ansible: update to 2.20.0

### DIFF
--- a/app-admin/ansible/spec
+++ b/app-admin/ansible/spec
@@ -1,4 +1,4 @@
-VER=2.12.1
+VER=2.20.0
 SRCS="tbl::https://github.com/ansible/ansible/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::69b3cdeb56513fffad95bee5323f4f96a04d5bcc9236d9897cf603eb2a50959c"
+CHKSUMS="sha256::e44e032baddbbeeab5541bb0a6eba6fb9237e69cb55d95f5523a106036bb9242"
 CHKUPDATE="anitya::id=6097"


### PR DESCRIPTION
Topic Description
-----------------

- ansible: update to 2.20.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ansible: 2.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ansible
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
