### PR TITLE
ogre-next: new, 3.0.0

### DIFF
--- a/runtime-imaging/ogre-next/autobuild/defines
+++ b/runtime-imaging/ogre-next/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=ogre-next
+PKGSEC=libs
+PKGDEP="freetype x11-lib sdl2 glu pugixml zlib bullet"
+BUILDDEP="graphviz mesa cppunit rapidjson vulkan-headers shaderc"
+PKGDES="3D Object-Oriented Graphics Rendering Engine"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DOGRE_INSTALL_DOCS=oFF"
+    "-DOGRE_INSTALL_SAMPLES=OFF"
+    "-DOGRE_BUILD_TESTS=OFF"
+)

--- a/runtime-imaging/ogre-next/autobuild/patches/0001-fix-rendersystem-gles2-big-endian.patch
+++ b/runtime-imaging/ogre-next/autobuild/patches/0001-fix-rendersystem-gles2-big-endian.patch
@@ -1,0 +1,14 @@
+diff --git a/RenderSystems/GLES2/src/OgreGLES2PixelFormat.cpp b/RenderSystems/GLES2/src/OgreGLES2PixelFormat.cpp
+index 0e3f88e785..d43c47a2fa 100644
+--- a/RenderSystems/GLES2/src/OgreGLES2PixelFormat.cpp
++++ b/RenderSystems/GLES2/src/OgreGLES2PixelFormat.cpp
+@@ -276,6 +276,9 @@ namespace Ogre {
+                 return GL_UNSIGNED_SHORT_5_5_5_1;
+ 
+ #if OGRE_ENDIAN == OGRE_ENDIAN_BIG
++#ifndef GL_UNSIGNED_INT_8_8_8_8_REV
++#define GL_UNSIGNED_INT_8_8_8_8_REV	0x8367
++#endif
+             case PF_X8B8G8R8:
+             case PF_X8R8G8B8:
+             case PF_A8B8G8R8:

--- a/runtime-imaging/ogre-next/autobuild/patches/0002-fix-sbuild-installation-paths.patch
+++ b/runtime-imaging/ogre-next/autobuild/patches/0002-fix-sbuild-installation-paths.patch
@@ -1,0 +1,18 @@
+diff --git a/OgreMain/CMakeLists.txt b/OgreMain/CMakeLists.txt
+index d4ad520ddd..df959a96ae 100644
+--- a/OgreMain/CMakeLists.txt
++++ b/OgreMain/CMakeLists.txt
+@@ -481,7 +481,12 @@ use_precompiled_header(${OGRE_NEXT}Main
+ # install ${OGRE_NEXT}Main
+ ogre_config_lib(${OGRE_NEXT}Main TRUE)
+ foreach(HEADER_FILE ${HEADER_FILES})
+-	string(REGEX REPLACE "((${CMAKE_CURRENT_SOURCE_DIR}|${OGRE_BINARY_DIR})/)?(include|src)/" "" RELATIVE_HEADER_FILE ${HEADER_FILE})
++  string(REGEX REPLACE "((${CMAKE_CURRENT_SOURCE_DIR}|${OGRE_BINARY_DIR})/)?(include|src)/" "" RELATIVE_HEADER_FILE ${HEADER_FILE})
++  cmake_path(GET HEADER_FILE PARENT_PATH FILE_DIR)
++  cmake_path(COMPARE ${OGRE_BINARY_DIR}/include EQUAL ${FILE_DIR} IN_OGRE_BINARY_DIR)
++  if (IS_ABSOLUTE ${HEADER_FILE} AND NOT IN_OGRE_BINARY_DIR)
++    file(RELATIVE_PATH RELATIVE_HEADER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/include ${HEADER_FILE})
++  endif()
+ 	string(REGEX MATCH "((.*)/)+" HEADER_SUBDIRECTORY ${RELATIVE_HEADER_FILE})
+ 	install(FILES ${HEADER_FILE} DESTINATION include/${OGRE_NEXT_PREFIX}/${HEADER_SUBDIRECTORY})
+ endforeach()

--- a/runtime-imaging/ogre-next/autobuild/patches/0003-hlms-missing-includes.patch
+++ b/runtime-imaging/ogre-next/autobuild/patches/0003-hlms-missing-includes.patch
@@ -1,0 +1,10 @@
+diff --git a/CMake/Templates/OGRE-Hlms.pc.in b/CMake/Templates/OGRE-Hlms.pc.in
+index 6c55a1ad66..a17ea61150 100644
+--- a/CMake/Templates/OGRE-Hlms.pc.in
++++ b/CMake/Templates/OGRE-Hlms.pc.in
+@@ -8,4 +8,4 @@ Description: HLMS component for @OGRE_NEXT_PREFIX@
+ Version: @OGRE_VERSION@
+ Requires: @OGRE_NEXT_PREFIX@ = @OGRE_VERSION@
+ Libs: -L${libdir} -l@OGRE_NEXT@HlmsPbs@OGRE_LIB_SUFFIX@ -l@OGRE_NEXT@HlmsUnlit@OGRE_LIB_SUFFIX@
+-Cflags: -I${includedir}/@OGRE_NEXT_PREFIX@/Hlms @OGRE_CFLAGS@
++Cflags: -I${includedir}/@OGRE_NEXT_PREFIX@/Hlms @OGRE_CFLAGS@ -I${includedir}/@OGRE_NEXT_PREFIX@/Hlms/Common -I${includedir}/@OGRE_NEXT_PREFIX@/Hlms/Pbs -I${includedir}/@OGRE_NEXT_PREFIX@/Hlms/Unlit @OGRE_CFLAGS@

--- a/runtime-imaging/ogre-next/autobuild/patches/0004-riscv64-loongarch64-64bits-support.patch
+++ b/runtime-imaging/ogre-next/autobuild/patches/0004-riscv64-loongarch64-64bits-support.patch
@@ -1,0 +1,14 @@
+diff --git a/OgreMain/include/OgrePlatform.h b/OgreMain/include/OgrePlatform.h
+index b5445ef31b..0739aacaaa 100644
+--- a/OgreMain/include/OgrePlatform.h
++++ b/OgreMain/include/OgrePlatform.h
+@@ -81,7 +81,8 @@ THE SOFTWARE.
+ #if defined( __x86_64__ ) || defined( _M_X64 ) || defined( _M_X64 ) || defined( _M_AMD64 ) || \
+     defined( __ppc64__ ) || defined( __PPC64__ ) || defined( __arm64__ ) || defined( __aarch64__ ) || \
+     defined( _M_ARM64 ) || defined( __mips64 ) || defined( __mips64_ ) || defined( __alpha__ ) || \
+-    defined( __ia64__ ) || defined( __e2k__ ) || defined( __s390__ ) || defined( __s390x__ )
++    defined( __ia64__ ) || defined( __e2k__ ) || defined( __s390__ ) || defined( __s390x__ ) || \
++    (defined(__riscv) && (__riscv_xlen == 64)) || defined (__loongarch64)
+ #    define OGRE_ARCH_TYPE OGRE_ARCHITECTURE_64
+ #else
+ #    define OGRE_ARCH_TYPE OGRE_ARCHITECTURE_32

--- a/runtime-imaging/ogre-next/spec
+++ b/runtime-imaging/ogre-next/spec
@@ -1,0 +1,4 @@
+VER=3.0.0
+SRCS="git::commit=tags/v$VER::https://github.com/OGRECave/ogre-next"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=241789"


### PR DESCRIPTION
Topic Description
-----------------

- ogre-next: new, 3.0.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- ogre-next: 3.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ogre-next
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
