### PR TITLE
fuse-overlayfs: update to 1.16

### DIFF
--- a/app-admin/fuse-overlayfs/spec
+++ b/app-admin/fuse-overlayfs/spec
@@ -1,4 +1,4 @@
-VER=1.13
+VER=1.16
 SRCS="https://github.com/containers/fuse-overlayfs/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::96d10344921d5796bcba7a38580ae14a53c4e60399bb90b238ac5a10b3bb65b2"
+CHKSUMS="sha256::45968517603389ead067222d234bc8d8ed33e4b4f8ba16216bdd3e6aedcccea9"
 CHKUPDATE="anitya::id=101220"


### PR DESCRIPTION
Topic Description
-----------------

- fuse-overlayfs: update to 1.16
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- fuse-overlayfs: 1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuse-overlayfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
