### PR TITLE
devscripts: update to 2.25.24

### DIFF
--- a/app-devel/devscripts/spec
+++ b/app-devel/devscripts/spec
@@ -1,4 +1,4 @@
-VER=2.25.22
+VER=2.25.24
 SRCS="git::commit=tags/v$VER::https://salsa.debian.org/debian/devscripts.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5419"


### PR DESCRIPTION
Topic Description
-----------------

- devscripts: update to 2.25.24
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- devscripts: 2.25.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit devscripts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
