### PR TITLE
docker: update to 28.5.2+tini0.19.0

### DIFF
--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,5 +1,4 @@
-UPSTREAM_VER=28.5.1
-REL=1
+UPSTREAM_VER=28.5.2
 # Find tini version at:
 #
 # https://github.com/moby/moby/blob/v$UPSTREAM_VER/hack/dockerfile/install/tini.installer


### PR DESCRIPTION
Topic Description
-----------------

- docker: update to 28.5.2+tini0.19.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- docker: 28.5.2+tini0.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
