### PR TITLE
renderdoc: update to 1.41

### DIFF
--- a/app-devel/renderdoc/spec
+++ b/app-devel/renderdoc/spec
@@ -1,4 +1,4 @@
-VER=1.40
+VER=1.41
 SRCS="git::commit=tags/v$VER::https://github.com/baldurk/renderdoc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14973"


### PR DESCRIPTION
Topic Description
-----------------

- renderdoc: update to 1.41
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- renderdoc: 1.41

Security Update?
----------------

No

Build Order
-----------

```
#buildit renderdoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
