### PR TITLE
linyaps-web-store-installer: update to 1.6.8

### DIFF
--- a/app-admin/linyaps-web-store-installer/spec
+++ b/app-admin/linyaps-web-store-installer/spec
@@ -1,4 +1,4 @@
-VER=1.6.3
+VER=1.6.8
 # FIXME: A new tag needs to be made to reflect ll-installer sync.
 SRCS="git::commit=tags/v$VER::https://github.com/OpenAtom-Linyaps/linyaps-web-store-installer"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- linyaps-web-store-installer: update to 1.6.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- linyaps-web-store-installer: 1.6.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit linyaps-web-store-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
