### PR TITLE
squashfs-tools: update to 4.7.3

### DIFF
--- a/app-admin/squashfs-tools/spec
+++ b/app-admin/squashfs-tools/spec
@@ -1,4 +1,4 @@
-VER=4.7.2
+VER=4.7.3
 SRCS="git::commit=tags/$VER::https://github.com/plougher/squashfs-tools.git"
 CHKSUMS="SKIP"
 SUBDIR="squashfs-tools/squashfs-tools"


### PR DESCRIPTION
Topic Description
-----------------

- squashfs-tools: update to 4.7.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- squashfs-tools: 4.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit squashfs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
