### PR TITLE
open-rs: update to 5.3.2

### DIFF
--- a/app-utils/open-rs/spec
+++ b/app-utils/open-rs/spec
@@ -1,5 +1,4 @@
-VER=5.3.0
-REL=1
+VER=5.3.2
 SRCS="git::commit=tags/v$VER::https://github.com/Byron/open-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=339452"


### PR DESCRIPTION
Topic Description
-----------------

- open-rs: update to 5.3.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- open-rs: 5.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit open-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
