### PR TITLE
docutils: update to 0.22.3

### DIFF
--- a/lang-python/docutils/spec
+++ b/lang-python/docutils/spec
@@ -1,6 +1,5 @@
 EPOCH=2
-VER=0.21.2
-REL="2"
+VER=0.22.3
 SRCS="tbl::https://pypi.io/packages/source/d/docutils/docutils-$VER.tar.gz"
-CHKSUMS="sha256::3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"
+CHKSUMS="sha256::21486ae730e4ca9f622677b1412b879af1791efcfba517e4c6f60be543fc8cdd"
 CHKUPDATE="anitya::id=3849"


### PR DESCRIPTION
Topic Description
-----------------

- docutils: update to 0.22.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- docutils: 2:0.22.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit docutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
