### PR TITLE
mlt: update to 7.34.1

### DIFF
--- a/runtime-multimedia/mlt/spec
+++ b/runtime-multimedia/mlt/spec
@@ -1,4 +1,4 @@
-VER=7.32.0
+VER=7.34.1
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/mlt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11007"


### PR DESCRIPTION
Topic Description
-----------------

- mlt: update to 7.34.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mlt: 7.34.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mlt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
