### PR TITLE
libcap: update to 2.77

### DIFF
--- a/runtime-common/libcap/autobuild/beyond
+++ b/runtime-common/libcap/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Fixing the permission of the shared library ..."
-chmod -v 0755 "$PKGDIR"/usr/lib/libcap.so.2.*

--- a/runtime-common/libcap/autobuild/build
+++ b/runtime-common/libcap/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Building libcap ..."
-make GOLANG=no
+make prefix=/usr lib=lib GOLANG=no
 make prefix=/usr \
      lib=lib \
      GOLANG=no \
@@ -10,6 +10,3 @@ make prefix=/usr \
 abinfo "Installing example capability.conf ..."
 install -Dvm644 "$SRCDIR"/pam_cap/capability.conf \
     "$PKGDIR"/usr/share/doc/libcap/capability.conf.example
-
-abinfo "Setting executable bits for /usr/lib/*.so.* ..."
-chmod -v +x "$PKGDIR"/usr/lib/*.so.*

--- a/runtime-common/libcap/autobuild/defines
+++ b/runtime-common/libcap/autobuild/defines
@@ -3,5 +3,4 @@ PKGSEC=libs
 PKGDES="POSIX 1003.1e capabilities"
 PKGDEP="attr glibc"
 
-NOPARALLEL=1
 PKGEPOCH_SPIRAL=1

--- a/runtime-common/libcap/autobuild/prepare
+++ b/runtime-common/libcap/autobuild/prepare
@@ -1,4 +1,0 @@
-abinfo "Arch Linux: use distribution build flags ..."
-sed -e "s/CFLAGS :=/CFLAGS += \$(CPPFLAGS) \$(CFLAGS) /" \
-    -e "s/LDFLAGS :=/LDFLAGS +=/" \
-    -i "$SRCDIR"/Make.Rules

--- a/runtime-common/libcap/spec
+++ b/runtime-common/libcap/spec
@@ -1,4 +1,4 @@
-VER=2.73
+VER=2.77
 SRCS="tbl::https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-$VER.tar.xz"
-CHKSUMS="sha256::6405f6089cf4cdd8c271540cd990654d78dd0b1989b2d9bda20f933a75a795a5"
+CHKSUMS="sha256::897bc18b44afc26c70e78cead3dbb31e154acc24bee085a5a09079a88dbf6f52"
 CHKUPDATE="anitya::id=1569"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

libcap: update to 2.77
- Drop unneeded permission change for shared libraries, the build system already does that.
- Drop sed to "use distribution build flags": I'm pretty sure the build flags in environment are pick even without the change.
- Add prefix= and libdir= for make, or libcap.pc and libpsl.pc will have incorrect libdir.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

libcap: `2.77`

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit libcap
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
