### PR TITLE
krb5: update to 1.22.1

### DIFF
--- a/app-network/krb5/autobuild/defines
+++ b/app-network/krb5/autobuild/defines
@@ -35,7 +35,6 @@ AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
 
 MAKE_AFTER="EXAMPLEDIR=/usr/share/doc/krb5/examples"
 ABSHADOW=0
-NOPARALLEL=1
 RECONF=0
 
 # Note: Extra Provides for Spiral (Debian compatibility).

--- a/app-network/krb5/autobuild/defines.stage2
+++ b/app-network/krb5/autobuild/defines.stage2
@@ -16,5 +16,4 @@ AUTOTOOLS_AFTER="--localstatedir=/var/lib \
 
 MAKE_AFTER="EXAMPLEDIR=/usr/share/doc/krb5/examples"
 ABSHADOW=0
-NOPARALLEL=1
 RECONF=0

--- a/app-network/krb5/autobuild/patch
+++ b/app-network/krb5/autobuild/patch
@@ -1,4 +1,0 @@
-for i in "$SRCDIR"/autobuild/patches/*; do
-    abinfo "Applying $i ..."
-    patch -Np2 -i $i
-done

--- a/app-network/krb5/spec
+++ b/app-network/krb5/spec
@@ -1,6 +1,6 @@
-UPSTREAM_VER=1.21.3-final
+UPSTREAM_VER=1.22.1-final   # "-final" to please release-monitoring.org
 VER=${UPSTREAM_VER/-final/}
 SRCS="tbl::https://web.mit.edu/kerberos/dist/krb5/${VER%.*}/krb5-$VER.tar.gz"
-CHKSUMS="sha256::b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35"
+CHKSUMS="sha256::1a8832b8cad923ebbf1394f67e2efcf41e3a49f460285a66e35adec8fa0053af"
 CHKUPDATE="anitya::id=13287"
 SUBDIR="krb5-$VER/src"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

krb5: update to 1.22.1
- Drop unused patch script.
- Drop NOPARALLEL which seems not needed now.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

krb5: `1.22.1`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit krb5
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
