### PR TITLE
nss: update to 3.117

### DIFF
--- a/runtime-cryptography/nss/autobuild/defines
+++ b/runtime-cryptography/nss/autobuild/defines
@@ -6,11 +6,6 @@ PKGDES="Netscape security library"
 NOSTATIC=0
 NOSTATIC__RETRO=1
 
-# FIXME: re-enable LTO after fixing ld
-# ld: relocation R_LARCH_PCREL20_S2 overflow 0x200374
-NOLTO__LOONGARCH64=1
-NOLTO__LOONGARCH64_NOSIMD=${NOLTO__LOONGARCH64}
-
 # Note: Debian's NSS is currently at 2:.
 PKGEPOCH_SPIRAL=2
 

--- a/runtime-cryptography/nss/spec
+++ b/runtime-cryptography/nss/spec
@@ -1,4 +1,4 @@
-VER=3.116
+VER=3.117
 SRCS="https://archive.mozilla.org/pub/security/nss/releases/NSS_${VER//./_}_RTM/src/nss-$VER.tar.gz"
-CHKSUMS="sha256::3938611de4ad1e3b71f27f3cd5ea717a5b5f83bffc9cd427e6d929dc67f2bb73"
+CHKSUMS="sha256::5786b523a2f2e9295ed10d711960d2e33cd620bb80d6288443eda43553a51996"
 CHKUPDATE="anitya::id=2503"


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

nss: update to 3.117
- Drop NOLTO for LoongArch: now it builds fine on YuanBao with LTO, meaning the linker bug is likely already fixed.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

nss: `3.117`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit nss
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
