### PR TITLE
openssh: add a patch for allowing uname(3)

### DIFF
--- a/app-network/openssh/autobuild/patches/0003-FROMLIST-seccomp-sandbox-allow-uname-3.patch
+++ b/app-network/openssh/autobuild/patches/0003-FROMLIST-seccomp-sandbox-allow-uname-3.patch
@@ -1,0 +1,33 @@
+From 589f824ab93dfa5e602ecc6991131a74646d26dd Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Fri, 7 Nov 2025 14:27:35 +0800
+Subject: [PATCH] seccomp sandbox: allow uname(3)
+
+The uname(3) syscall is utilized by zlib-ng on RISC-V to decide whether
+the kernel handles VILL bit of V extension properly (by checking the
+kernel version against 6.5).
+
+Allow it in the seccomp sandbox.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ sandbox-seccomp-filter.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sandbox-seccomp-filter.c b/sandbox-seccomp-filter.c
+index a0692dd2f..b3da8d587 100644
+--- a/sandbox-seccomp-filter.c
++++ b/sandbox-seccomp-filter.c
+@@ -435,6 +435,9 @@ static const struct sock_filter preauth_insns[] = {
+ #ifdef __NR_getpeername
+ 	SC_ALLOW(__NR_getpeername),
+ #endif
++#ifdef __NR_uname
++	SC_ALLOW(__NR_uname),
++#endif
+ #ifdef __NR_setsockopt
+ 	SC_ALLOW_SETSOCKOPT(IPPROTO_IPV6, IPV6_TCLASS),
+ 	SC_ALLOW_SETSOCKOPT(IPPROTO_IP, IP_TOS),
+-- 
+2.51.1
+

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -2,3 +2,4 @@ VER=10.2p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2"
 CHKUPDATE="anitya::id=2565"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- openssh: add a patch for allowing uname\(3\)
    Fixes SIGSYS on RISC-V with zlib-ng.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- openssh: 10.2p1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
