### PR TITLE
cinny-desktop: update to 4.10.2

### DIFF
--- a/app-web/cinny-desktop/autobuild/overrides/usr/share/applications/cinny.desktop
+++ b/app-web/cinny-desktop/autobuild/overrides/usr/share/applications/cinny.desktop
@@ -3,7 +3,7 @@ Name=Cinny
 Comment=A Matrix client for desktop
 Comment[zh_CN]=桌面 Matrix 客户端
 Comment[zh_TW]=桌面 Matrix 用户端
-Exec=/usr/bin/cinny %u
+Exec=/usr/bin/env WEBKIT_DISABLE_DMABUF_RENDERER=1 /usr/bin/cinny %u
 Terminal=false
 Type=Application
 Icon=cinny

--- a/app-web/cinny-desktop/spec
+++ b/app-web/cinny-desktop/spec
@@ -1,4 +1,4 @@
-VER=4.10.1
+VER=4.10.2
 SRCS="git::commit=tags/v$VER::https://github.com/cinnyapp/cinny-desktop"
 CHKSUMS="SKIP"
 SUBDIR="cinny-desktop/src-tauri"


### PR DESCRIPTION
Topic Description
-----------------

- cinny-desktop: update to 4.10.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- cinny-desktop: 4.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinny-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
