### PR TITLE
nspr: update to 4.38

### DIFF
--- a/runtime-common/nspr/spec
+++ b/runtime-common/nspr/spec
@@ -1,6 +1,5 @@
-VER=4.35
-REL=1
+VER=4.38
 SRCS="tbl::https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$VER/src/nspr-$VER.tar.gz"
-CHKSUMS="sha256::7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f"
+CHKSUMS="sha256::72ee73ffcc6ef5e706965f855ecf470ec3986c3e188e12a8a8006e76f6b31a6f"
 SUBDIR="nspr-$VER/nspr"
 CHKUPDATE="anitya::id=7953"


### PR DESCRIPTION
Topic Description
-----------------

- nspr: update to 4.38
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nspr: 4.38

Security Update?
----------------

No

Build Order
-----------

```
#buildit nspr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
