### PR TITLE
libplacebo: update to 7.351.0

### DIFF
--- a/app-devel/shaderc/autobuild/defines
+++ b/app-devel/shaderc/autobuild/defines
@@ -1,8 +1,12 @@
 PKGNAME=shaderc
 PKGSEC=devel
-PKGDEP="gcc-runtime glslang spirv-tools"
-BUILDDEP="spirv-headers python-3"
+PKGDEP="gcc-runtime glibc glslang"
+BUILDDEP="asciidoctor python-3 spirv-headers spirv-tools"
 PKGDES="A collection of tools, libraries and tests for shader compilation"
 
-CMAKE_AFTER="-DSHADERC_SKIP_TESTS=ON \
-             -DPYTHON_EXE=/usr/bin/python${ABPY3VER}"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DSHADERC_SKIP_COPYRIGHT_CHECK=ON'
+    '-DSHADERC_SKIP_EXAMPLES=ON'
+    '-DSHADERC_SKIP_TESTS=ON'
+)

--- a/app-devel/shaderc/spec
+++ b/app-devel/shaderc/spec
@@ -1,4 +1,4 @@
-VER=2025.3
+VER=2025.4
 SRCS="git::commit=tags/v$VER::https://github.com/google/shaderc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19047"

--- a/app-imaging/glslang/autobuild/defines
+++ b/app-imaging/glslang/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=glslang
 PKGSEC=graphics
-PKGDEP="glibc"
+PKGDEP="gcc-runtime glibc"
 BUILDDEP="python-3 spirv-tools"
 PKGDES="An OpenGL and OpenGL ES shader front end and validator."
 
 NOSTATIC=0
 
 CMAKE_AFTER=(
-    -DALLOW_EXTERNAL_SPIRV_TOOLS=ON
+    '-DALLOW_EXTERNAL_SPIRV_TOOLS=ON'
 )

--- a/app-imaging/glslang/spec
+++ b/app-imaging/glslang/spec
@@ -1,5 +1,4 @@
-VER=15.3.0
+VER=16.0.0
 SRCS="git::commit=tags/$VER::https://github.com/KhronosGroup/glslang"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205796"
-REL=1

--- a/app-multimedia/mpv/autobuild/defines
+++ b/app-multimedia/mpv/autobuild/defines
@@ -163,7 +163,7 @@ MESON_AFTER=(
 # FIXME: No LuaJIT for these architectures.
 MESON_AFTER__NOLUAJIT=(
     "${MESON_AFTER[@]}"
-    '-Dlua=lua'
+    '-Dlua=lua-5.1'
 )
 MESON_AFTER__PPC64EL=(
     "${MESON_AFTER__NOLUAJIT[@]}"

--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,5 +1,5 @@
 VER=0.40.0
-REL=3
+REL=4
 SRCS="git::commit=tags/v$VER::https://github.com/mpv-player/mpv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5348"

--- a/runtime-i18n/uchardet/autobuild/defines
+++ b/runtime-i18n/uchardet/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=uchardet
 PKGSEC=libs
-PKGDEP="gcc-runtime"
+PKGDEP="gcc-runtime glibc"
 PKGDES="An encoding detector library ported from Mozilla"
+
+ABTYPE=cmakeninja

--- a/runtime-i18n/uchardet/spec
+++ b/runtime-i18n/uchardet/spec
@@ -1,5 +1,4 @@
-VER=0.0.5
-SRCS="tbl::https://github.com/BYVoid/uchardet/archive/v$VER.tar.gz"
-CHKSUMS="sha256::7c5569c8ee1a129959347f5340655897e6a8f81ec3344de0012a243f868eabd1"
-REL=1
+VER=0.0.8
+SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/uchardet/uchardet.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9265"

--- a/runtime-multimedia/libplacebo/autobuild/defines
+++ b/runtime-multimedia/libplacebo/autobuild/defines
@@ -1,4 +1,8 @@
 PKGNAME=libplacebo
 PKGDES="Core rendering algorithms of mpv as a library"
 PKGSEC=video
-PKGDEP="gcc-runtime libunwind xz zlib"
+PKGDEP="ffmpeg gcc-runtime glfw glibc lcms2 libunwind sdl2 shaderc \
+        vulkan-loader"
+BUILDDEP="sdl2-image spirv-headers spirv-tools vulkan-headers xz zlib"
+
+ABTYPE=meson

--- a/runtime-multimedia/libplacebo/spec
+++ b/runtime-multimedia/libplacebo/spec
@@ -1,4 +1,4 @@
-VER=6.338.2
+VER=7.351.0
 SRCS="git::commit=tags/v$VER::https://github.com/haasn/libplacebo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20101"

--- a/runtime-optenv32/glslang+32/spec
+++ b/runtime-optenv32/glslang+32/spec
@@ -1,4 +1,4 @@
-VER=15.3.0
+VER=16.0.0
 SRCS="git::commit=tags/$VER::https://github.com/KhronosGroup/glslang"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205796"


### PR DESCRIPTION
Topic Description
-----------------

- uchardet: update to 0.0.8
- mpv: rebuild for libplacebo 7.351.0
- glslang: update to 16.0.0
- glslang+32: update to 16.0.0
- shaderc: update to 2025.4
- libplacebo: update to 7.351.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- glslang: 16.0.0
- libplacebo: 7.351.0
- mpv: 0.40.0-4
- shaderc: 2025.4
- uchardet: 0.0.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit glslang shaderc libplacebo uchardet mpv
```

Test Build(s) Done
------------------

