### PR TITLE
cx4-linux-graphics-driver-dri: new, 26.00.41

### DIFF
--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/build
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/build
@@ -1,0 +1,34 @@
+abinfo "Installing module sources ..."
+install -vd "$PKGDIR"/usr/src
+cp -av "$SRCDIR"/usr/src/cx4-"$__UPSTREAM_VER" "$PKGDIR"/usr/src
+
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib
+cp -av "$SRCDIR"/usr/lib/x86_64-linux-gnu/* \
+    -t "$PKGDIR"/usr/lib/
+
+abinfo "Installing X.Org driver ..."
+cp -av "$SRCDIR"/usr/lib/xorg \
+    -t "$PKGDIR"/usr/lib/
+
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x \
+    "$PKGDIR"/usr/lib/**/*.so*
+
+abinfo "Installing shared data ..."
+install -vd "$PKGDIR"/usr/share
+# Note: GLVND, Vulkan, X11 configurations are found in overrides as they
+# require generation via postinst in the original package.
+cp -av "$SRCDIR"/usr/share/drirc.d \
+    "$PKGDIR"/usr/share/
+
+abinfo "Installing OpenCL ICD ..."
+install -vd "$PKGDIR"/etc
+cp -av "$SRCDIR"/etc/OpenCL \
+    "$PKGDIR"/etc/
+
+abinfo "Running ldconfig to create missing symlinks ..."
+ldconfig \
+    -r "$PKGDIR"/ \
+    -N \
+    --verbose

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/defines
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=cx4-linux-graphics-driver-dri
+PKGSEC=libs
+PKGDEP="glibc gcc-runtime dracut dkms libdrm libglvnd mesa x11-lib libxcb wayland"
+PKGDES="Graphics driver for Zhaoxin C-1080/1190 (KX-6000G/7000 series)"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: amd64-specific.
+FAIL_ARCH="!(amd64)"
+ABSPLITDBG=0

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
@@ -1,0 +1,71 @@
+From 5780dca6ee33f54c003bf9ba2db46ab82bbcaf26 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 7 Nov 2025 23:50:09 +0800
+Subject: [PATCH 1/4] AOSCOS: fix(dkms.conf): drop check_gcc_version()
+
+Not even sure why it's here. Drop it.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 47 +----------------------------------------------
+ 1 file changed, 1 insertion(+), 46 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 74fb58c..3ead229 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -19,50 +19,5 @@ num_cpu_cores()
+ 	fi
+ }
+ 
+-check_gcc_version()
+-{
+-local KERNEL_UNAME=`uname -r`
+-local KERNEL_MODLIB=/lib/modules/${KERNEL_UNAME}
+-local KERNEL_SOURCES=`test -d ${KERNEL_MODLIB}/source && echo ${KERNEL_MODLIB}/source || echo ${KERNEL_MODLIB}/build`
+-local KERNEL_COMPILE_H=${KERNEL_SOURCES}/include/generated/compile.h
+-
+-	if [ -f ${KERNEL_COMPILE_H} ];then
+-
+-		# Try to get all installed gcc list
+-		local SYSTEM_GCC_LIST=`ls /usr/bin/gcc-[0-9]* | xargs -n1 | sort -u`
+-
+-		# Try to get current GCC version, some GCC version string only hava major.minor
+-		local SYSTEM_GCC_VERSION=`gcc -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-		if [ -z "$SYSTEM_GCC_VERSION" ];then
+-			SYSTEM_GCC_VERSION=`gcc -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-		fi
+-
+-		# Get version string from 'compile.h', some GCC version string only hava major.minor
+-		local KERNEL_BUILT_GCC_STRING=`cat ${KERNEL_COMPILE_H} | grep LINUX_COMPILER | cut -f 2 -d '"'`
+-		local KERNEL_BUILT_GCC_VERSION=`echo "${KERNEL_BUILT_GCC_STRING}" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-		if [ -z "$KERNEL_BUILT_GCC_VERSION" ];then
+-			KERNEL_BUILT_GCC_VERSION=`echo "${KERNEL_BUILT_GCC_STRING}" | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-		fi
+-
+-		# Checking GCC version and assign gcc by 'CC=' here
+-		if [ "$KERNEL_BUILT_GCC_VERSION" != "$SYSTEM_GCC_VERSION" ];then
+-			for TARGET_GCC_PATH in $SYSTEM_GCC_LIST;
+-			do
+-				local TARGET_GCC_VERSION=`$TARGET_GCC_PATH -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-				if [ -z "$TARGET_GCC_VERSION" ];then
+-					TARGET_GCC_VERSION=`$TARGET_GCC_PATH -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-				fi
+-
+-				if [ "$KERNEL_BUILT_GCC_VERSION" = "$TARGET_GCC_VERSION" ];then
+-					echo "CC=$TARGET_GCC_PATH"
+-					break;
+-				fi
+-			done
+-		fi
+-
+-	fi
+-
+-}
+-
+-MAKE[0]="make $(check_gcc_version) -j$(num_cpu_cores) -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
++MAKE[0]="make -j$(num_cpu_cores) -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
+ #POST_REMOVE="post-remove.sh $kernelver"
+-- 
+2.51.1
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
@@ -1,0 +1,26 @@
+From 226f417350c86a0855fc20c967c7a6ad31d9134a Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 7 Nov 2025 23:50:49 +0800
+Subject: [PATCH 2/4] AOSCOS: fix(dkms.conf): drop unused options
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 3ead229..e1ef5d3 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -1,8 +1,6 @@
+ PACKAGE_NAME="cx4"
+ PACKAGE_VERSION=26.00.41
+ AUTOINSTALL="yes"
+-#REMAKE_INITRD="yes"
+-SKIP_IMMD_MODPROBE=1
+ 
+ BUILT_MODULE_NAME[0]="cx4"
+ BUILT_MODULE_LOCATION[0]=""
+-- 
+2.51.1
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
@@ -1,0 +1,71 @@
+From b537e7566c2301b0ac09696651ce598f5f7134bf Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 8 Nov 2025 22:45:52 +0800
+Subject: [PATCH 3/4] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
+ 6.17
+
+Follow commit 21aa65bf82a7 ("mm: remove callers of pfn_t functionality")
+and remove all usage of linux/pfn_t.h there.
+
+The rest of the code already works with >= 6.17.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/zx_gem.h      |  7 ++++---
+ linux/zx_gem_priv.h | 14 ++++++++------
+ 2 files changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/linux/zx_gem.h b/linux/zx_gem.h
+index 9a3274f..522758f 100644
+--- a/linux/zx_gem.h
++++ b/linux/zx_gem.h
+@@ -38,10 +38,11 @@
+ #include "zx_gem_debug.h"
+ #include "zx_version.h"
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
+-    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
++     DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && \
++     DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ #include <linux/pfn_t.h>
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+ typedef struct {
+     u64 val;
+ } pfn_t;
+diff --git a/linux/zx_gem_priv.h b/linux/zx_gem_priv.h
+index 05d92ea..7f6d444 100644
+--- a/linux/zx_gem_priv.h
++++ b/linux/zx_gem_priv.h
+@@ -31,19 +31,21 @@
+ #include "os_interface.h"
+ #include "zx_gem_debug.h"
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
+-    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
++     DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && \
++     DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ #include <linux/pfn_t.h>
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+ typedef struct {
+     u64 val;
+ } pfn_t;
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
+-    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
++     DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && \
++     DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ #include <linux/pfn_t.h>
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+ typedef struct {
+     u64 val;
+ } pfn_t;
+-- 
+2.51.1
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0004-AOSCOS-fix-adapt-to-drm_framebuffer-changes-in-6.17.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0004-AOSCOS-fix-adapt-to-drm_framebuffer-changes-in-6.17.patch
@@ -1,0 +1,120 @@
+From c659918326cdf710386e2940f4a95b82f4952c37 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 8 Nov 2025 23:09:29 +0800
+Subject: [PATCH 4/4] AOSCOS: fix: adapt to drm_framebuffer changes in 6.17
+
+With commit 81112eaac559 ("drm: Pass the format info to .fb_create()"),
+an additional parameter format_info was added to the
+drm_helper_mode_fill_fb_struct() function call.
+
+Follow suit to fix build with kernels >= 6.17.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/zx_drm_helper.h | 11 ++++++++++-
+ linux/zx_drmfb.c      | 14 ++++++++++++++
+ linux/zx_drmfb.h      |  6 ++++++
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/linux/zx_drm_helper.h b/linux/zx_drm_helper.h
+index 2c5eb93..d0e85b7 100644
+--- a/linux/zx_drm_helper.h
++++ b/linux/zx_drm_helper.h
+@@ -76,13 +76,22 @@
+ #endif
+ 
+ static inline
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++void zx_drm_helper_mode_fill_fb_struct(struct drm_device *dev,
++                                       struct drm_framebuffer *fb,
++                                       const struct drm_format_info *format_info,
++                                       struct drm_mode_fb_cmd2 *mode_cmd)
++#else
+ void zx_drm_helper_mode_fill_fb_struct(struct drm_device *dev, struct drm_framebuffer *fb,
+                                        struct drm_mode_fb_cmd2 *mode_cmd)
++#endif
+ {
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
+     drm_helper_mode_fill_fb_struct(fb, mode_cmd);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+     drm_helper_mode_fill_fb_struct(dev, fb, mode_cmd);
++#else
++    drm_helper_mode_fill_fb_struct(dev, fb, format_info, mode_cmd);
+ #endif
+ 
+ }
+diff --git a/linux/zx_drmfb.c b/linux/zx_drmfb.c
+index 6df61bb..696cac3 100644
+--- a/linux/zx_drmfb.c
++++ b/linux/zx_drmfb.c
+@@ -61,6 +61,9 @@ static const struct drm_framebuffer_funcs zx_fb_funcs =
+ struct drm_zx_framebuffer*
+ __zx_framebuffer_create(struct drm_device *dev,
+                         struct drm_mode_fb_cmd2 *mode_cmd,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                        const struct drm_format_info *format_info,
++#endif
+                         struct drm_zx_gem_object *obj)
+ {
+     int ret;
+@@ -76,7 +79,11 @@ __zx_framebuffer_create(struct drm_device *dev,
+     if (!zxfb)
+         return ERR_PTR(-ENOMEM);
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+     zx_drm_helper_mode_fill_fb_struct(dev, &zxfb->base, mode_cmd);
++#else
++    zx_drm_helper_mode_fill_fb_struct(dev, &zxfb->base, format_info, mode_cmd);
++#endif
+     zxfb->obj = obj;
+ 
+     // map gpuva
+@@ -111,6 +118,9 @@ err_free:
+ struct drm_framebuffer *
+ zx_fb_create(struct drm_device *dev,
+               struct drm_file *file,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++              const struct drm_format_info *format_info,
++#endif
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+               struct drm_mode_fb_cmd2 *user_mode_cmd
+ #else
+@@ -126,7 +136,11 @@ zx_fb_create(struct drm_device *dev,
+     if (!obj)
+         return ERR_PTR(-ENOENT);
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    fb = __zx_framebuffer_create(dev, &mode_cmd, format_info, obj);
++#else
+     fb = __zx_framebuffer_create(dev, &mode_cmd, obj);
++#endif
+     if (IS_ERR(fb))
+         zx_gem_object_put(obj);
+ 
+diff --git a/linux/zx_drmfb.h b/linux/zx_drmfb.h
+index ecbe3e3..cfcafc5 100644
+--- a/linux/zx_drmfb.h
++++ b/linux/zx_drmfb.h
+@@ -32,6 +32,9 @@ struct drm_zx_framebuffer
+ struct drm_framebuffer *
+ zx_fb_create(struct drm_device *dev,
+                               struct drm_file *file_priv,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                              const struct drm_format_info *format_info,
++#endif
+                               #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+                               const struct drm_mode_fb_cmd2 *mode_cmd
+                               #else
+@@ -44,5 +47,8 @@ void zx_cleanup_fb(struct drm_plane *plane,  struct drm_plane_state *old_state);
+ struct drm_zx_framebuffer*
+ __zx_framebuffer_create(struct drm_device *dev,
+                         struct drm_mode_fb_cmd2 *mode_cmd,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                        const struct drm_format_info *format_info,
++#endif
+                         struct drm_zx_gem_object *obj);
+ #endif
+-- 
+2.51.1
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/X11/xorg.conf.d/10-cx4gpu.conf
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/X11/xorg.conf.d/10-cx4gpu.conf
@@ -1,0 +1,5 @@
+Section "OutputClass"
+	Identifier "cx4"
+	MatchDriver "cx4"
+	Driver "cx4"
+EndSection

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/glvnd/egl_vendor.d/10_cx4.json
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/glvnd/egl_vendor.d/10_cx4.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_cx4.so.0"
+    }
+}

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/vulkan/icd.d/cx4_icd.x86_64.json
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/vulkan/icd.d/cx4_icd.x86_64.json
@@ -1,0 +1,7 @@
+{
+    "ICD": {
+        "api_version": "1.1.107",
+        "library_path": "/usr/lib/libvulkan_cx4.so"
+    },
+    "file_format_version": "1.0.0"
+}

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/postinst.in
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/postinst.in
@@ -1,0 +1,16 @@
+VER="%PKGVER%"
+unset ARCH
+
+echo "Installing cx4 kernel modules..."
+for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+    if [ -f "/usr/lib/modules/$i/modules.dep" -a \
+         -f "/usr/lib/modules/$i/modules.order" -a \
+         -f "/usr/lib/modules/$i/modules.builtin" ]; then
+        echo -e "\033[36m**\033[0m\tBuilding cx4 kernel modules for $i ..."
+        dkms install cx4/"$VER" -k "$i" > /dev/null
+    else
+        echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+    fi
+done
+
+update-initramfs

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
@@ -1,0 +1,16 @@
+for i in postinst prerm; do
+    abinfo "Generating $i ..."
+    sed -e \
+        "s/%PKGVER%/$__UPSTREAM_VER/g" \
+        "$SRCDIR/autobuild/$i.in" > \
+        "$SRCDIR/autobuild/$i"
+done
+
+abinfo "Unpacking upstream deb package ..."
+dpkg-deb -X "$SRCDIR"/KX-6000G-KOS_x64-26.00.41/cx4-linux-graphics-driver-dri-glvnd-"$__UPSTREAM_VER"_amd64.deb "$SRCDIR"
+
+abinfo "Entering kernel module sources directory"
+cd "$SRCDIR"/usr/src/cx4-"$__UPSTREAM_VER"
+
+abinfo "Patching kernel module sources ..."
+ab_apply_patches "$SRCDIR"/autobuild/module-patches/*.patch

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prerm.in
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prerm.in
@@ -1,0 +1,4 @@
+VER="%PKGVER%"
+unset ARCH
+
+dkms remove cx4/"$VER" --all || true > /dev/null

--- a/runtime-display/cx4-linux-graphics-driver-dri/spec
+++ b/runtime-display/cx4-linux-graphics-driver-dri/spec
@@ -1,0 +1,6 @@
+UPSTREAM_VER=26.00.41
+__UPSTREAM_VER="$UPSTREAM_VER"
+VER="$UPSTREAM_VER"
+SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3419&tag=0&ref=qdxz&pre=0&t=20ce3b68fe29466a"
+CHKSUMS="sha256::1cdf4d00309fbd34350beda1d2c3caaf863941040450c56786229a102232e2a6"
+# FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- cx4-linux-graphics-driver-dri: new, 26.00.41
    - Compatible with kernels up to 6.18.
    - Track patches at AOSC-Tracking/cx4-kernel-dkms @ aosc/v26.00.41
    \(HEAD: 226f417350c86a0855fc20c967c7a6ad31d9134a\).

Package(s) Affected
-------------------

- cx4-linux-graphics-driver-dri: 26.00.41

Security Update?
----------------

No

Build Order
-----------

```
#buildit cx4-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
