### PR TITLE
steam: adjust PKGDEP PKGRECOM PKGSUG

### DIFF
--- a/app-games/steam/autobuild/defines
+++ b/app-games/steam/autobuild/defines
@@ -1,10 +1,16 @@
 PKGNAME=steam
 PKGSEC=non-free/games
 PKGDEP="curl dbus freetype gdk-pixbuf hicolor-icon-theme 32subsystem zenity liberation-fonts"
-PKGDEP__with_emulator="curl dbus freetype gdk-pixbuf hicolor-icon-theme box64 zenity liberation-fonts"
+PKGDEP__with_emulator="curl dbus freetype gdk-pixbuf hicolor-icon-theme zenity liberation-fonts"
 PKGDEP__ARM64="${PKGDEP__with_emulator}"
 PKGDEP__LOONGARCH64="${PKGDEP__with_emulator}"
 PKGDEP__RISCV64="${PKGDEP__with_emulator}"
+PKGRECOM__with_emulator="box64"
+PKGRECOM__ARM64="${PKGRECOM__with_emulator}"
+PKGRECOM__LOONGARCH64="${PKGRECOM__with_emulator}"
+PKGRECOM__RISCV64="${PKGRECOM__with_emulator}"
+PKGSUG__ARM64="fex"
+PKGSUG__LOONGARCH64="latx"
 PKGDES="Official Steam client for Linux"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/app-games/steam/spec
+++ b/app-games/steam/spec
@@ -1,5 +1,5 @@
 VER=1.0.0.85
-REL=2
+REL=3
 SRCS="tbl::https://repo.steampowered.com/steam/pool/steam/s/steam/steam_$VER.tar.gz"
 CHKSUMS="sha256::7f2d374a2fb413ced5b8125151456219d918a255872b4bb77016cbccf38bb7f1"
 CHKUPDATE="anitya::id=12318"


### PR DESCRIPTION
Topic Description
-----------------

- steam: adjust PKGDEP PKGRECOM PKGSUG on emulator-supported architectures
    - Move box64 to PKGRECOM.
    - Add fex to PKGSUG on arm64.
    - Add latx to PKGSUG on loongarch64.

Package(s) Affected
-------------------

- steam: 1.0.0.85-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit steam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
