### PR TITLE
box64: update to 0.3.9+git20251108

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-VER=0.3.9+git20251031
-SRCS="git::commit=64a6802b5e56ae7d239d5957248290cb33928d7b::https://github.com/ptitSeb/box64.git"
+VER=0.3.9+git20251108
+SRCS="git::commit=7faeec0864849e55051fc955bc38c83b941f30f0::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251108

Package(s) Affected
-------------------

- box64: 0.3.9+git20251108

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

