### PR TITLE
zhaoxin-linux-graphics-driver-dri: fix build on kernel 6.18

### DIFF
--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/build
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/build
@@ -1,35 +1,29 @@
 abinfo "Installing module sources ..."
 install -vd "$PKGDIR"/usr/src
-mv -v "$SRCDIR"/usr/src/zx-"$__UPSTREAM_VER" "$PKGDIR"/usr/src
+cp -av "$SRCDIR"/usr/src/zx-"$__UPSTREAM_VER" "$PKGDIR"/usr/src
 
-abinfo "Installing kernel interface library"
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/libkeinterface_zx.so.0.0.0 \
-                "$PKGDIR"/usr/lib/libkeinterface_zx.so.0
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib
+cp -av "$SRCDIR"/usr/lib/x86_64-linux-gnu/* \
+    -t "$PKGDIR"/usr/lib/
 
-abinfo "Installing DRI driver"
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/dri/zx_vndri.so \
-             -t "$PKGDIR"/usr/lib/dri
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/dri/zx_drv_video.so \
-             -t "$PKGDIR"/usr/lib/dri
-install -Dvm644 "$SRCDIR"/usr/lib/x86_64-linux-gnu/dri/ZXEApp.cfg \
-             -t "$PKGDIR"/usr/lib/dri
-install -Dvm644 "$SRCDIR"/usr/share/drirc.d/01-zx_drv.conf \
-             -t "$PKGDIR"/usr/share/drirc.d
+abinfo "Installing X.Org driver ..."
+cp -av "$SRCDIR"/usr/lib/xorg \
+    -t "$PKGDIR"/usr/lib/
 
-abinfo "Installing OpenGL stack"
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/libglapi_zx.so.0.0.0 \
-                "$PKGDIR"/usr/lib/libglapi_zx.so.0
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/libEGL_zx.so.0.0.0 \
-                "$PKGDIR"/usr/lib/libEGL_zx.so.0
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/libGLX_zx.so.0.0.0 \
-                "$PKGDIR"/usr/lib/libGLX_zx.so.0
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/gbm/zx_gbm.so \
-             -t "$PKGDIR"/usr/lib/gbm
-install -Dvm755 "$SRCDIR"/usr/lib/x86_64-linux-gnu/libvdpau_zx.so \
-             -t "$PKGDIR"/usr/lib
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x \
+    "$PKGDIR"/usr/lib/**/*.so*
 
-abinfo "Installing X.Org driver"
-install -Dvm755 "$SRCDIR"/usr/lib/xorg/modules/drivers/zx_drv.so \
-             -t "$PKGDIR"/usr/lib/xorg/modules/drivers
-install -Dvm755 "$SRCDIR"/usr/lib/xorg/modules/extensions/libglx_zx.so \
-             -t "$PKGDIR"/usr/lib/xorg/modules/extensions
+abinfo "Installing shared data ..."
+install -vd "$PKGDIR"/usr/share
+# Note: GLVND, X11 configurations are found in overrides as they
+# require generation via postinst in the original package.
+cp -av "$SRCDIR"/usr/share/drirc.d \
+    "$PKGDIR"/usr/share/
+
+abinfo "Running ldconfig to create missing symlinks ..."
+ldconfig \
+    -r "$PKGDIR"/ \
+    -N \
+    --verbose

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/defines
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=zhaoxin-linux-graphics-driver-dri
 PKGSEC=libs
 PKGDEP="glibc gcc-runtime dracut dkms libdrm libglvnd mesa x11-lib libxcb wayland"
-PKGDES="Graphics driver for Zhaoxin C-960 (KX-6000 series processor)"
+PKGDES="Graphics driver for Zhaoxin C-960 (KX-6000/6900 series)"
 
 # Note: Binary packaging.
 ABSTRIP=0

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,7 +1,7 @@
 From a5963cfc6208bed7e5c6f7ebd808739bf8c13fa6 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
-Subject: [PATCH 1/5] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
+Subject: [PATCH 1/6] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
 
 EXTRA_*FLAGS support was deprecated in 2007 and removed in 2025.
 
@@ -63,5 +63,5 @@ index a2b2900..277d1cf 100644
               -I${ZXGPU_FULL_PATH}/src/cbios/Device \
               -I${ZXGPU_FULL_PATH}/src/cbios/Device/Port \
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,7 +1,7 @@
 From 8e4d5357faabde017294faffeb43721416edf196 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
-Subject: [PATCH 2/5] chore: dkms: remove useless variables
+Subject: [PATCH 2/6] chore: dkms: remove useless variables
 
 REMAKE_INITRD was deprecated. SKIP_IMMD_MODPROBE is not standard.
 
@@ -37,5 +37,5 @@ index ebd645e..0c366b0 100644
  MAKE[0]="make -j$(num_cpu_cores) LINUXDIR=$kernel_source_dir -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
 -#POST_REMOVE="post-remove.sh $kernelver"
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,7 +1,7 @@
 From 3a384c2fafe324402aa95fa9c704c9077ca4ee30 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 3/5] fix: kernel: 6.15
+Subject: [PATCH 3/6] fix: kernel: 6.15
 
 Make it compatible with Linux kernel 6.15.
 
@@ -43,5 +43,5 @@ index 89a7819..48706c2 100644
      .fb_dirty           = zxfb_dirty,
  #endif
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,7 +1,7 @@
 From f1e1314b6ce3f541b7da43c839978c7acce44ce4 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 4/5] fix: kernel: 6.16
+Subject: [PATCH 4/6] fix: kernel: 6.16
 
 Make it compatible with Linux kernel 6.16.
 
@@ -39,5 +39,5 @@ index 84ff1da..4e91f71 100644
      struct pci_dev*    pdev    = to_pci_dev(kobj_to_dev(kobj));
      struct drm_device* drm_dev = pci_get_drvdata(pdev);
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,7 +1,7 @@
 From e170a0eb554203120c8356bdc1f27db33d55b379 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
-Subject: [PATCH 5/5] fix: kernel: 6.17
+Subject: [PATCH 5/6] fix: kernel: 6.17
 
 Make it compatible with Linux kernel 6.17.
 
@@ -134,5 +134,5 @@ index 6acc810..1f49859 100644
  #else
  typedef struct {
 -- 
-2.51.2
+2.51.1
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,0 +1,46 @@
+From 4a49d7b148cf57ae0044875796e1e6594b728e3f Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 8 Nov 2025 23:49:24 +0800
+Subject: [PATCH 6/6] fix: kernel: 6.18
+
+In the 6.18 cycle, Intel moved `struct_mutex' from the public `drm_device'
+struct to `drm_i915_private'. As this was really only used by Intel to
+replace the BKL (Big Kernel Lock), I think it would not be out of the
+realm of reason to assume that this code was not needed at all.
+
+Guard invocations to `struct_mutex' out on kernels >= 6.17.
+
+Tests pending on KX-6000/6900.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/zx_fbdev.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 6eecac4..b55023e 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -129,7 +129,9 @@ static int zxfb_create(struct drm_fb_helper *helper, struct drm_fb_helper_surfac
+     DRM_DEBUG_KMS("fb_width=%d,fb_height=%d,surface_width=%d,surface_height=%d,surface_bpp=%d,surface_depth=%d\n",
+             sizes->fb_width, sizes->fb_height, sizes->surface_width, sizes->surface_height, sizes->surface_bpp, sizes->surface_depth);
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+     mutex_lock(&dev->struct_mutex);
++#endif
+ 
+     if (fb && (sizes->fb_width > fb->base.width || sizes->fb_height > fb->base.height))
+     {
+@@ -243,7 +245,9 @@ static int zxfb_create(struct drm_fb_helper *helper, struct drm_fb_helper_surfac
+     DRM_DEBUG_KMS("screen_base=0x%p,screen_size=0x%lx,smem_start=0x%lx,smem_len=0x%x,xres=%d,yres=%d\n",
+             info->screen_base, info->screen_size, info->fix.smem_start, info->fix.smem_len, info->var.xres, info->var.yres);
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+     mutex_unlock(&dev->struct_mutex);
++#endif
+     return 0;
+ }
+ 
+-- 
+2.51.1
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=21.00.79
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
+REL=1
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3418&tag=0&ref=qdxz&pre=0&t=83e1707a341d4e51"
 CHKSUMS="sha256::5d2f466b20e47c1814bdea3b07fe73ed81ff42b58d7e9805660a85ed1d27ca23"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- zhaoxin-linux-graphics-driver-dri: fix build on kernel 6.18
    Also improve PKGDES and note that it is compatible with KX-6900.
- rootlesskit: new, 2.3.5

Package(s) Affected
-------------------

- zhaoxin-linux-graphics-driver-dri: 21.00.79-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit zhaoxin-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
