### PR TITLE
nerdctl: update to 2.2.0

### DIFF
--- a/app-containers/nerdctl/autobuild/beyond
+++ b/app-containers/nerdctl/autobuild/beyond
@@ -1,4 +1,4 @@
-abinfo "Installing kind shell completions..."
+abinfo "Installing nerdctl shell completions..."
 "$PKGDIR"/usr/bin/nerdctl completion bash | \
         install -Dvm644 /dev/stdin \
         "$PKGDIR"/usr/share/bash-completion/completions/nerdctl
@@ -8,3 +8,9 @@ abinfo "Installing kind shell completions..."
 "$PKGDIR"/usr/bin/nerdctl completion fish | \
         install -Dvm644 /dev/stdin \
         "$PKGDIR"/usr/share/fish/vendor_completions.d/nerdctl.fish
+
+abinfo "Installing nerdctl rootless tools..."
+install -Dvm755 "$SRCDIR"/extras/rootless/containerd-rootless.sh \
+	"$PKGDIR"/usr/bin/containerd-rootless.sh
+install -Dvm755 "$SRCDIR"/extras/rootless/containerd-rootless-setuptool.sh \
+	"$PKGDIR"/usr/bin/containerd-rootless-setuptool.sh

--- a/app-containers/nerdctl/autobuild/defines
+++ b/app-containers/nerdctl/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=nerdctl
 PKGDES="Docker-compatible CLI for containerd"
 BUILDDEP="go"
-PKGDEP="glibc containerd cni-plugins"
+PKGDEP="glibc containerd cni-plugins rootlesskit"
 PKGSEC="admin"
 
 ABTYPE=gomod

--- a/app-containers/nerdctl/spec
+++ b/app-containers/nerdctl/spec
@@ -1,5 +1,4 @@
-VER=2.1.6
-REL=1
+VER=2.2.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/nerdctl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="aniya::id=242901"


### PR DESCRIPTION
Topic Description
-----------------

- nerdctl: update to 2.2.0
    - add containerd rootless support

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit nerdctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
