### PR TITLE
netctl: update to 1.29

### DIFF
--- a/app-network/netctl/spec
+++ b/app-network/netctl/spec
@@ -1,4 +1,4 @@
-VER=1.23
+VER=1.29
 SRCS="tbl::https://sources.archlinux.org/other/packages/netctl/netctl-$VER.tar.xz"
-CHKSUMS="sha256::c8cb017d573136e995e4becb3e352fd9db5ec9d320b73cc0d7b16c75ff44ab26"
+CHKSUMS="sha256::27f91ad21a8fe8cb1e14b5a816580167da36e8ef056de40c87b3975d86b76932"
 CHKUPDATE="anitya::id=138134"


### PR DESCRIPTION
Topic Description
-----------------

- netctl: update to 1.29
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- netctl: 1.29

Security Update?
----------------

No

Build Order
-----------

```
#buildit netctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
