### PR TITLE
rdfind: update to 1.7.0

### DIFF
--- a/app-utils/rdfind/spec
+++ b/app-utils/rdfind/spec
@@ -1,4 +1,4 @@
-VER=1.6.0
+VER=1.7.0
 SRCS="tbl::https://rdfind.pauldreik.se/rdfind-$VER.tar.gz"
-CHKSUMS="sha256::7a406e8ef1886a5869655604618dd98f672f12c6a6be4926d053be65070f3279"
+CHKSUMS="sha256::78c463152e1d9e4fd1bfeb83b9c92df5e7fc4c5f93c7d426fb1f7efa2be4df29"
 CHKUPDATE="anitya::id=231641"


### PR DESCRIPTION
Topic Description
-----------------

- rdfind: update to 1.7.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rdfind: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rdfind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
