### PR TITLE
openssh: use a more conservative warning prompt about leaked SSH keys

### DIFF
--- a/app-network/openssh/autobuild/templates
+++ b/app-network/openssh/autobuild/templates
@@ -1,14 +1,14 @@
 Template: openssh/leaked_keys_20240913
 Type: note
-Description: WARNING - POSSIBLY LEAKED OPENSSH HOST KEYS
- AOSC OS has detected leaked SSH host key(s) on your system, which should be considered vulnerable and untrusted. These keys may have shipped with previously published AOSC OS installation media, system images, and tarballs.
+Description: Warning: Leaked OpenSSH Host Keys
+ Certain versions of AOSC OS installation media contains accidentally leaked SSH host key(s), which should be considered vulnerable and untrusted.
  .
- This update will remove all SSH host keys from your system and replace them with newly generated ones.
+ This update will remove any leaked SSH host keys found in your system and replace them with newly generated ones.
  .
- Note: AOSC OS will restart your SSH daemon after this update. However, this will not affect currently active SSH connections. In case you are running AOSC OS on a server, you would need to inform your SSH/SCP/SFTP users regarding possible SSH errors and should remove the previous key records from their trust store.
-Description-zh_CN.UTF-8: 警告 - 系统可能包含已泄漏的 OpenSSH 主机密钥
- AOSC OS 在您的系统中发现了遭意外泄漏的 SSH 主机密钥，这些密钥不可信且可能带来潜在安全风险。这些密钥是随先前发布的 AOSC OS 安装盘、系统镜像和系统包泄漏的。
+ Should key removal be necessary, AOSC OS will restart your SSH daemon. This will not affect currently active SSH connections. However, If you are running AOSC OS on a server, please inform your SSH/SCP/SFTP users regarding possible SSH errors and that they should remove the previous key records from their trust store.
+Description-zh_CN.UTF-8: 警告 - OpenSSH 主机密钥泄漏
+ 某些版本的 AOSC OS 安装介质包含遭意外泄漏的 SSH 主机密钥，这些密钥不可信且可能带来潜在安全风险。
  .
- 本更新将删除在您系统上的所有 SSH 主机密钥并重新生成替代密钥。
+ 本更新将探测并删除在您系统中存在的已泄漏密钥，并重新生成替代密钥。
  .
- 请注意：更新完成后，AOSC OS 将重启 SSH 服务守护程序，但不会影响当前已经建立的 SSH 连接。如果您对外提供 SSH 服务，您的用户在连接该设备上运行的 SSH/SCP/SFTP 服务时可能会遇到连接错误。因此，您可能需要将有关情况告知您的用户，并引导其删除先前信任的 SSH 主机密钥记录。
+ 如探测到已泄漏密钥，AOSC OS 将重启 SSH 服务守护程序。本操作不会影响当前已经建立的 SSH 连接，但如果您对外提供 SSH 服务，您的用户在连接该设备上运行的 SSH/SCP/SFTP 服务时可能会遇到连接错误。因此，您可能需要将有关情况告知您的用户，并引导其删除先前信任的 SSH 主机密钥记录。

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -2,4 +2,4 @@ VER=10.2p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2"
 CHKUPDATE="anitya::id=2565"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- openssh: use a more conservative warning prompt about leaked SSH keys
    High priority debconf templates seems to disregard if-conditions in
    postinst and prompts users erroneously about leaked OpenSSH keys. Until
    we find a better solution, make this prompt more "conditional" to make it
    make sense.

Package(s) Affected
-------------------

- openssh: 10.2p1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
