### PR TITLE
surfer: update to 0.4.0

### DIFF
--- a/app-electronics/surfer/autobuild/defines
+++ b/app-electronics/surfer/autobuild/defines
@@ -3,6 +3,7 @@ PKGDES="A waveform viewer"
 PKGSEC=electronics
 PKGDEP="openssl"
 BUILDDEP="rustc llvm openssl pkg-config pkgconf"
+ABTYPE=rust
 
 USECLANG=1
 

--- a/app-electronics/surfer/spec
+++ b/app-electronics/surfer/spec
@@ -1,4 +1,7 @@
-VER=0.3.0
+VER=0.4.0
 
 SRCS="git::commit=tags/v$VER::https://gitlab.com/surfer-project/surfer"
 CHKSUMS="SKIP"
+
+# Note: Prefer larger RAM.
+ENVREQ__ARM64="total_mem=60"


### PR DESCRIPTION
Topic Description
-----------------

- surfer: update to 0.4.0
    - Specify \`ABTYPE\` to meet the AOSC OS Package Styling Manual.

Package(s) Affected
-------------------

- surfer: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit surfer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
