### PR TITLE
go: update to 1.25.4+tools0.34.0+net0.41.0

### DIFF
--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.25.3
+UPSTREAM_VER=1.25.4
 # Versions of Golang, net library and Go tools
 GO_VER=${UPSTREAM_VER/\~/}
 TOOLS_VER=0.34.0
@@ -8,7 +8,7 @@ VER="${UPSTREAM_VER}+tools${TOOLS_VER}+net${NET_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools \
       git::commit=tags/v${NET_VER};rename=net::https://github.com/golang/net"
-CHKSUMS="sha256::a81a4ba593d0015e10c51e267de3ff07c7ac914dfca037d9517d029517097795 \
+CHKSUMS="sha256::160043b7f17b6d60b50369436917fda8d5034640ba39ae2431c6b95a889cc98c \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1227"


### PR DESCRIPTION
Topic Description
-----------------

- go: update to 1.25.4+tools0.34.0+net0.41.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- go: 1.25.4+tools0.34.0+net0.41.0
- go-runtime: 1.25.4+tools0.34.0+net0.41.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
