### PR TITLE
simh: update to 3.12-2

### DIFF
--- a/app-emulation/simh/autobuild/build
+++ b/app-emulation/simh/autobuild/build
@@ -1,12 +1,11 @@
 abinfo "Building SimH ..."
 mkdir -pv "$SRCDIR"/BIN
 make \
-    USE_NETWORK=1 \
-    NETWORK_OPT='-DUSE_NETWORK -isystem /usr/include -lpcap' \
     CFLAGS_O="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
 
 abinfo "Installing SimH ..."
-for i in "$SRCDIR"/BIN/*; do
+shopt -s extglob
+for i in "$SRCDIR"/BIN/!(buildtools); do
     install -Dvm755 $i \
         "$PKGDIR/usr/bin/simh-$(basename "$i")"
 done

--- a/app-emulation/simh/autobuild/defines
+++ b/app-emulation/simh/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=simh
 PKGSEC=utils
-PKGDEP="libpcap"
-PKGDES="A portable multi-system emulator for historical computers"
-
+PKGDEP="glibc vde2"
+PKGDES="Portable multi-system emulator for historical computers"

--- a/app-emulation/simh/autobuild/prepare
+++ b/app-emulation/simh/autobuild/prepare
@@ -1,7 +1,6 @@
-abinfo "Removing SIM_INLINE from VAX binaries ..."
-find "$SRCDIR"/VAX \
-    -type f \
-    -exec sed -i 's/SIM_INLINE//' {} +
-
+# FIXME:
+#
+# /usr/bin/ld: /tmp/cc0EPKAi.o (symbol from plugin): in function `cpu_set_hist':
+# (.text+0x0): multiple definition of `uc15_memsize'; /tmp/ccsuEpik.o (symbol from plugin):(.text+0x0): first defined here
 abinfo "Appending -fcommon to fix build with GCC 10 ..."
 export CFLAGS="${CFLAGS} -fcommon"

--- a/app-emulation/simh/spec
+++ b/app-emulation/simh/spec
@@ -1,5 +1,5 @@
-VER=3.11+1
-REL=2
-SRCS="tbl::https://github.com/simh/simh/archive/v${VER/+/-}.tar.gz"
-CHKSUMS="sha256::c8a2fc62bfa9369f75935950512a4cac204fd813ce6a9a222b2c6a76503befdb"
+UPSTREAM_VER=3.12-2
+VER=${UPSTREAM_VER/\-/+}
+SRCS="tbl::https://github.com/simh/simh/archive/v${UPSTREAM_VER}.tar.gz"
+CHKSUMS="sha256::bd8b01c24e62d9ba930f41a7ae7c87bf0c1e5794e27ff689c1b058ed75ebc3e8"
 CHKUPDATE="anitya::id=9653"


### PR DESCRIPTION
Topic Description
-----------------

- simh: update to 3.12-2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- simh: 3.12-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit simh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
