### PR TITLE
navidrome: update to 0.58.5

### DIFF
--- a/app-multimedia/navidrome/spec
+++ b/app-multimedia/navidrome/spec
@@ -1,5 +1,4 @@
-VER=0.58.0
-REL=2
+VER=0.58.5
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/navidrome/navidrome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326646"


### PR DESCRIPTION
Topic Description
-----------------

- navidrome: update to 0.58.5
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- navidrome: 0.58.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit navidrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
