### PR TITLE
fcitx5-pinyin-moegirl: update to 20251109

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20251009
+VER=20251109
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::b3c8b5799aeea564929a08b9dae8472e082d9f966da0317032d25e643c3fce72
-         sha256::f1699f9e47d383ccdd30abe7dc8f808392988dd6d4a5e5a181e48411cfd652cb
+CHKSUMS="sha256::06a8a81402dad598cc5425a04fd3dd4c72b4fd8aa2a4e1623619fe3e7f9341ce
+         sha256::1817afb23a3a29177a522732d8ba4cc20649925b8de67d880ff0c089a28957be
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20251109

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20251109
- rime-pinyin-moegirl: 20251109

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
