### PR TITLE
desktop-base: Ship Zhaoxin graphics drivers

### DIFF
--- a/meta-bases/desktop-base/autobuild/defines
+++ b/meta-bases/desktop-base/autobuild/defines
@@ -1,12 +1,17 @@
 PKGNAME=desktop-base
 PKGSEC=Bases
+PKGDES="Base desktop definition and assets for AOSC OS"
 PKGDEP="x11-base"
+
 PKGRECOM="noto-fonts noto-cjk-fonts liberation-fonts"
 # Note: All useful VA-API drivers and the debugging utilities should be
 # included below.
 PKGRECOM="${PKGRECOM} intel-media-driver libva-intel-driver \
           libva-nvidia-driver libva-vdpau-driver libva-utils"
+# Zhaoxin graphics drivers are amd64-only, apparently.
+PKGRECOM__AMD64="${PKGRECOM[@]} \
+                cx4-linux-graphics-driver-dri \
+                zhaoxin-linux-graphics-driver-dri"
 PKGRECOM__LOONGARCH64="${PKGRECOM[@]} liblol"
-PKGDES="Base desktop definition and assets for AOSC OS"
 
 ABSPLITDBG=0

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,4 +1,4 @@
-VER=16
+VER=17
 SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
 # FIXME: No release would be made from this repository.


### PR DESCRIPTION
Topic Description
-----------------

- desktop-base: ship Zhaoxin graphics drivers by default
    They can be safely removed as needed since they are in PKGRECOM.

Package(s) Affected
-------------------

- desktop-base: 17

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
