### PR TITLE
bash-completion: update to 2.17.0

### DIFF
--- a/app-shells/bash-completion/spec
+++ b/app-shells/bash-completion/spec
@@ -1,4 +1,4 @@
-VER=2.16.0
+VER=2.17.0
 SRCS="git::commit=tags/$VER::https://github.com/scop/bash-completion"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5667"


### PR DESCRIPTION
Topic Description
-----------------

- bash-completion: update to 2.17.0
    Co-authored-by: wxiwnd \(@wxiwnd\)

Package(s) Affected
-------------------

- bash-completion: 1:2.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-completion
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
