### PR TITLE
bash-pinyin-completion-rs: update to 1.0.2

### DIFF
--- a/app-shells/bash-pinyin-completion-rs/spec
+++ b/app-shells/bash-pinyin-completion-rs/spec
@@ -1,4 +1,4 @@
-VER=1.0.1
+VER=1.0.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/bash-pinyin-completion-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376526"


### PR DESCRIPTION
Topic Description
-----------------

- bash-pinyin-completion-rs: update to 1.0.2
    Co-authored-by: wxiwnd \(@wxiwnd\)

Package(s) Affected
-------------------

- bash-pinyin-completion-rs: 1.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-pinyin-completion-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
