### PR TITLE
iputils: new, 20250605

### DIFF
--- a/app-utils/inetutils/autobuild/defines
+++ b/app-utils/inetutils/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=inetutils
 PKGSEC=utils
 PKGDEP="glibc iana-etc linux-pam"
+PKGRECOM="iputils"
 PKGDES="Common networking programs"
 
 AUTOTOOLS_AFTER=(
@@ -22,8 +23,8 @@ AUTOTOOLS_AFTER=(
     '--enable-ftp'
     '--enable-dnsdomainname'
     '--enable-hostname'
-    '--enable-ping'
-    '--enable-ping6'
+    '--disable-ping'
+    '--disable-ping6'
     '--enable-rcp'
     '--enable-rexec'
     '--enable-rlogin'

--- a/app-utils/inetutils/spec
+++ b/app-utils/inetutils/spec
@@ -1,5 +1,5 @@
 VER=2.6
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/inetutils/inetutils-$VER.tar.gz"
 CHKSUMS="sha256::ccaa256e0d646df7f285ff158a3291f37cd1fc8382f3774d22f7254127635da7"
 CHKUPDATE="anitya::id=13805"

--- a/app-utils/iputils/autobuild/beyond
+++ b/app-utils/iputils/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Creating a symlink from /usr/bin/ping6 to ping..."
+ln -sv ping "${PKGDIR}"/usr/bin/ping6

--- a/app-utils/iputils/autobuild/defines
+++ b/app-utils/iputils/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=iputils
+PKGSEC=utils
+PKGDEP="glibc"
+BUILDDEP="meson"
+PKGDES="Set of utilities for Linux networking"
+
+PKGBREAK="inetutils<=2.6-1"
+PKGREP="inetutils<=2.6-1"
+
+MESON_AFTER=("-DBUILD_ARPING=false")

--- a/app-utils/iputils/spec
+++ b/app-utils/iputils/spec
@@ -1,0 +1,4 @@
+VER=20250605
+SRCS="tbl::https://github.com/iputils/iputils/releases/download/$VER/iputils-$VER.tar.gz"
+CHKSUMS="sha256::475c643e5f55b302286267b97d3ce0f47ca3489ced8aa0401b1eeb1e68228d6b"
+CHKUPDATE="anitya::id=1395"

--- a/meta-bases/network-base/autobuild/defines
+++ b/meta-bases/network-base/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=network-base
 PKGSEC=Bases
 PKGRECOM="arp-scan bind bluez core-base dhcpcd dnsmasq ethtool geoip-api-c \
-          iana-etc idnkit inetutils iproute2 iptables iw lksctp-tools mtr \
-          netcat net-tools nfs-utils nghttp2 openssh ppp wpa-supplicant \
+          iana-etc idnkit inetutils iputils iproute2 iptables iw lksctp-tools \
+          mtr netcat net-tools nfs-utils nghttp2 openssh ppp wpa-supplicant \
           rsync wireless-tools tftp-hpa"
 PKGDES="Meta package for AOSC OS basic networking utilities"
 

--- a/meta-bases/network-base/spec
+++ b/meta-bases/network-base/spec
@@ -1,2 +1,2 @@
-VER=8
+VER=9
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- network-base: add new PKGRECOM \`iputils\`
- inetutils: remove inetutils-ping, use iputils-ping instead
- iputils: new, 20250605

Package(s) Affected
-------------------

- inetutils: 2.6-2
- iputils: 20250605
- network-base: 9

Security Update?
----------------

No

Build Order
-----------

```
#buildit inetutils iputils network-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
