### PR TITLE
OS Release survey 20251110

### DIFF
--- a/app-admin/deploykit-backend/autobuild/beyond
+++ b/app-admin/deploykit-backend/autobuild/beyond
@@ -5,3 +5,8 @@ install -Dvm644 "$SRCDIR"/deploykit-backend.service \
 abinfo "Installing D-Bus configuration ..."
 install -Dvm644 "$SRCDIR"/deploykit-dbus.conf \
     "$PKGDIR"/usr/share/dbus-1/system.d/deploykit-dbus.conf
+
+abinfo "Installing quirk data ..."
+mkdir -pv "$PKGDIR"/usr/share/deploykit-backend
+cp -rv "$SRCDIR"/data/quirks \
+	"$PKGDIR"/usr/share/deploykit-backend/

--- a/app-admin/deploykit-backend/spec
+++ b/app-admin/deploykit-backend/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
-SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
+VER=0.9.0
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/AOSC-Dev/deploykit-backend/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371972"

--- a/meta-bases/desktop-base/autobuild/defines
+++ b/meta-bases/desktop-base/autobuild/defines
@@ -1,12 +1,17 @@
 PKGNAME=desktop-base
 PKGSEC=Bases
+PKGDES="Base desktop definition and assets for AOSC OS"
 PKGDEP="x11-base"
+
 PKGRECOM="noto-fonts noto-cjk-fonts liberation-fonts"
 # Note: All useful VA-API drivers and the debugging utilities should be
 # included below.
 PKGRECOM="${PKGRECOM} intel-media-driver libva-intel-driver \
           libva-nvidia-driver libva-vdpau-driver libva-utils"
-PKGRECOM__LOONGARCH64="${PKGRECOM[@]} liblol"
-PKGDES="Base desktop definition and assets for AOSC OS"
+# Zhaoxin graphics drivers are amd64-only, apparently.
+PKGRECOM__AMD64="${PKGRECOM[@]} \
+                cx4-linux-graphics-driver-dri \
+                zhaoxin-linux-graphics-driver-dri"
+PKGRECOM__LOONGARCH64="${PKGRECOM[@]} liblol loonggpu-driver"
 
 ABSPLITDBG=0

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,4 +1,4 @@
-VER=16
+VER=17
 SRCS="git::rename=logo;commit=aa0462d91c4cee125961d5bb29eea8aa9c574359::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
 # FIXME: No release would be made from this repository.

--- a/meta-bases/x11-base/autobuild/defines
+++ b/meta-bases/x11-base/autobuild/defines
@@ -5,8 +5,6 @@ PKGRECOM="xf86-input-wacom xf86-video-amdgpu xf86-video-ati \
           xf86-video-nouveau xf86-input-libinput"
 PKGRECOM__AMD64=" \
           ${PKGRECOM} xf86-input-vmmouse xf86-video-vesa"
-PKGRECOM__LOONGARCH64=" \
-          ${PKGRECOM} loonggpu-driver"
 
 PKGDEP__ARMV4="${PKGDEP} xf86-input-evdev"
 PKGDEP__ARMV6HF="${PKGDEP} xf86-input-evdev"

--- a/meta-bases/x11-base/spec
+++ b/meta-bases/x11-base/spec
@@ -1,2 +1,2 @@
-VER=4
+VER=5
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-backend: update to 0.9.0
- x11-base: remove loonggpu from PKGRECOM
    This dependency will be moved to desktop-base.
- aoscbootstrap: update to 0.10.3
- desktop-base: ship Zhaoxin graphics drivers by default
    They can be safely removed as needed since they are in PKGRECOM.

Package(s) Affected
-------------------

- aoscbootstrap: 0.10.3
- deploykit-backend: 0.9.0
- desktop-base: 17
- x11-base: 5

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base aoscbootstrap x11-base deploykit-backend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
