### PR TITLE
nim: new, 2.2.6

### DIFF
--- a/lang-nim/nim/autobuild/build
+++ b/lang-nim/nim/autobuild/build
@@ -1,0 +1,35 @@
+cd $SRCDIR
+abinfo "Building nim ..."
+sh ./build.sh
+abinfo "Building koch ..."
+./bin/nim c -d:release koch
+./koch boot -d:release -d:nativeStacktrace -d:useGnuReadline
+abinfo "Building tools ..."
+./koch tools
+abinfo "Building niminst ..."
+./bin/nim compile ./tools/niminst/niminst.nim
+
+abinfo "Installing nim ..."
+./koch install "$PKGDIR/usr/lib"
+mkdir -pv "$PKGDIR/usr/bin"
+ln -sv ../lib/nim/bin/nim "$PKGDIR/usr/bin/nim"
+
+local exe=""
+while read -r exe ; do
+	abinfo "Installing nim support tool: ${exe}"
+	install -Dvm755 "${exe}" "$PKGDIR/usr/bin/"
+done < \
+	 <(find ./bin -type f -not -iname nim)
+
+abinfo "Installing nim bash completion ..."
+install -Dvm644 ./tools/nim.bash-completion /usr/share/bash-completion/nim
+abinfo "Installing nim zsh completion ..."
+install -Dvm644 ./tools/nim.zsh-completion /usr/share/zsh/site-functions/_nim
+abinfo "Installing nimble bash completion ..."
+install -Dvm644 ./dist/nimble/nimble.bash-completion /usr/share/bash-completion/nimble
+abinfo "Installing nimble zsh completion ..."
+install -Dvm644 ./dist/nimble/nimble.zsh-completion /usr/share/zsh/site-functions/_nimble
+
+abinfo "Installing LICENSE ..."
+mkdir -pv /usr/share/doc/nim
+install -Dvm644 copying.txt "$PKGDIR/usr/share/doc/nim/LICENSE"

--- a/lang-nim/nim/autobuild/defines
+++ b/lang-nim/nim/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME="nim"
+PKGSEC=devel
+PKGDES="A general-purpose, multi-paradigm, statically typed, compiled high-level system programming language."
+PKGDEP="gcc pcre openssl readline"
+ABTYPE=self

--- a/lang-nim/nim/spec
+++ b/lang-nim/nim/spec
@@ -1,0 +1,4 @@
+VER=2.2.6
+SRCS="tbl::https://nim-lang.org/download/nim-$VER.tar.xz"
+CHKSUMS="sha256::657b0e3d5def788148d2a87fa6123fa755b2d92cad31ef60fd261e451785528b"
+CHKUPDATE="anitya::id=16496"


### PR DESCRIPTION
Topic Description
-----------------
nim: new, 2.2.6

Package(s) Affected
-------------------

nim

Security Update?
----------------
No

Build Order
-----------
```
#buildit nim
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
