### PR TITLE
coreutils: update to 9.9

### DIFF
--- a/app-utils/coreutils/spec
+++ b/app-utils/coreutils/spec
@@ -1,4 +1,4 @@
-VER=9.8
+VER=9.9
 SRCS="tbl::https://ftp.gnu.org/gnu/coreutils/coreutils-$VER.tar.xz"
-CHKSUMS="sha256::e6d4fd2d852c9141a1c2a18a13d146a0cd7e45195f72293a4e4c044ec6ccca15"
+CHKSUMS="sha256::19bcb6ca867183c57d77155eae946c5eced88183143b45ca51ad7d26c628ca75"
 CHKUPDATE="anitya::id=343"


### PR DESCRIPTION
Topic Description
-----------------

- coreutils: update to 9.9
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreutils: 9.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
