### PR TITLE
gping: new, 1.20.1

### DIFF
--- a/app-web/gping/autobuild/beyond
+++ b/app-web/gping/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/gping.1 \
+    "$PKGDIR"/usr/share/man/man1/gping.1

--- a/app-web/gping/autobuild/defines
+++ b/app-web/gping/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="gping"
+PKGDES="Graph the ping time for multiple hosts"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="rustc llvm"
+PKGSEC=net
+
+ABTYPE=rust
+
+USECLANG=1

--- a/app-web/gping/spec
+++ b/app-web/gping/spec
@@ -1,0 +1,4 @@
+VER=1.20.1
+SRCS="git::commit=tags/gping-v${VER}::https://github.com/orf/gping"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242646"


### PR DESCRIPTION
Topic Description
-----------------

- gping: new, 1.20.1

Package(s) Affected
-------------------

- gping: 1.20.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gping
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
