### PR TITLE
bitcomet: new, 2.20.0

### DIFF
--- a/app-web/bitcomet/autobuild/build
+++ b/app-web/bitcomet/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Unpacking .deb package ..."
+dpkg -x "$SRCDIR"/bitcomet.deb \
+    "$PKGDIR"
+
+# FIXME: This should be fixed by 2.18.1 (or later?).
+abinfo "Fixing up permissions ..."
+find -type d -not -perm 755 -exec chmod -v 755 {} ";"
+find -type f -not -perm 644 -exec chmod -v 644 {} ";"
+chmod -v 755 "$PKGDIR"/usr/bin/*

--- a/app-web/bitcomet/autobuild/defines
+++ b/app-web/bitcomet/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=bitcomet
+PKGSEC=web
+PKGDEP="cairo gcc-runtime gtk-3 libxkbcommon pango webkit2gtk"
+PKGDES="BitTorrent/HTTP/FTP download client"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPLITDBG=0
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/app-web/bitcomet/spec
+++ b/app-web/bitcomet/spec
@@ -1,8 +1,8 @@
-VER=2.18.0
+VER=2.20.0
 SRCS__AMD64="file::rename=bitcomet.deb::https://download.bitcomet.com/linux/x86_64/BitComet-${VER}-x86_64.deb"
 SRCS__ARM64="file::rename=bitcomet.deb::https://download.bitcomet.com/linux/arm64/BitComet-${VER}-arm64.deb"
 SRCS__LOONGARCH64="file::rename=bitcomet.deb::https://download.bitcomet.com/linux/loongarch64/BitComet-${VER}-loongarch64-abi2.0.deb"
-CHKSUMS__AMD64="sha256::46bfaa7deb26d3f22a020b85bdb41ed358eed800f978f8f5f1d25922504ecfe4"
-CHKSUMS__ARM64="sha256::8f9f1f6be793cc9b104e06a0e9a34d8a557df9351d74f6c87027988039e0360d"
-CHKSUMS__LOONGARCH64="sha256::7e55945352004bf35c4934fcdb1930d93c8ff7816f3e7a511bddacedcf3ec566"
+CHKSUMS__AMD64="sha256::0d4c768934d8aa8a2b2f2f2f730b689f27ab5b8b3cd73e9979ee06396619f078"
+CHKSUMS__ARM64="sha256::e6870e098dad1f26226128d119ab33aa6fa26334e68e809d400851ade943d92b"
+CHKSUMS__LOONGARCH64="sha256::907647ce96b33d846f73b743cb83a720afadb4088f9736793ee82224e3965831"
 CHKUPDATE="anitya::id=386770"

--- a/app-web/bitcomet/spec
+++ b/app-web/bitcomet/spec
@@ -1,0 +1,8 @@
+VER=2.18.0
+SRCS__AMD64="file::rename=bitcomet.deb::https://download.bitcomet.com/linux/x86_64/BitComet-${VER}-x86_64.deb"
+SRCS__ARM64="file::rename=bitcomet.deb::https://download.bitcomet.com/linux/arm64/BitComet-${VER}-arm64.deb"
+SRCS__LOONGARCH64="file::rename=bitcomet.deb::https://download.bitcomet.com/linux/loongarch64/BitComet-${VER}-loongarch64-abi2.0.deb"
+CHKSUMS__AMD64="sha256::46bfaa7deb26d3f22a020b85bdb41ed358eed800f978f8f5f1d25922504ecfe4"
+CHKSUMS__ARM64="sha256::8f9f1f6be793cc9b104e06a0e9a34d8a557df9351d74f6c87027988039e0360d"
+CHKSUMS__LOONGARCH64="sha256::7e55945352004bf35c4934fcdb1930d93c8ff7816f3e7a511bddacedcf3ec566"
+CHKUPDATE="anitya::id=386770"


### PR DESCRIPTION
Topic Description
-----------------

- bitcomet: update to 2.20.0
- bitcomet: new, 2.18.0

Package(s) Affected
-------------------

- bitcomet: 2.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitcomet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
