### PR TITLE
glycin: disable gtk-4

### DIFF
--- a/desktop-gnome/glycin/autobuild/defines
+++ b/desktop-gnome/glycin/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=glycin
 PKGSEC=gnome
-PKGDEP="lcms2 glib gtk-4 libseccomp fontconfig libjxl librsvg libheif cairo \
+PKGDEP="lcms2 glib libseccomp fontconfig libjxl librsvg libheif cairo \
         gdk-pixbuf pango libopenraw"
 BUILDDEP="rustc llvm gobject-introspection vala gettext python-3 tomli"
-PKGDES="Sass compiler written in Rust"
+PKGDES="Image loader library with sandboxing"
 
 ABTYPE=meson
 USECLANG=1
@@ -15,7 +15,7 @@ MESON_AFTER=(
     '-Dloaders=glycin-heif,glycin-image-rs,glycin-jxl,glycin-svg,glycin-raw'
     '-Dtests=false'
     '-Dlibglycin=true'
-    '-Dlibglycin-gtk4=true'
+    '-Dlibglycin-gtk4=false'
     '-Dintrospection=true'
     '-Dvapi=true'
     '-Dcapi_docs=false'

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,4 +1,5 @@
 VER=2.0.5
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369437"


### PR DESCRIPTION
Topic Description
-----------------

- glycin: disable gtk-4
    This library is not used by anything yet and it bloats our Base
    distribution way too much.

Package(s) Affected
-------------------

- glycin: 2.0.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit glycin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
