### PR TITLE
difftastic: update to 0.65.0

### DIFF
--- a/app-utils/difftastic/autobuild/beyond
+++ b/app-utils/difftastic/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/difft.1 -t "$PKGDIR"/usr/share/man/man1/

--- a/app-utils/difftastic/autobuild/defines
+++ b/app-utils/difftastic/autobuild/defines
@@ -4,5 +4,5 @@ PKGSEC="utils"
 PKGDEP="glibc"
 BUILDDEP="rustc llvm"
 
-# FIXME: ld.lld: error: undefined symbol: mi_free
-NOLTO=1
+ABTYPE=rust
+USECLANG=1

--- a/app-utils/difftastic/spec
+++ b/app-utils/difftastic/spec
@@ -1,4 +1,4 @@
-VER=0.64.0
+VER=0.65.0
 # URL not found for submodule in .gitmodules.
 SRCS="git::commit=tags/$VER;submodule=false::https://github.com/Wilfred/difftastic"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- difftastic: update to 0.65.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- difftastic: 0.65.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit difftastic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
