### PR TITLE
cri-o: update to 1.34.2

### DIFF
--- a/app-containers/cri-o/spec
+++ b/app-containers/cri-o/spec
@@ -1,4 +1,4 @@
-VER=1.34.1
+VER=1.34.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/cri-o/cri-o.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12687"


### PR DESCRIPTION
Topic Description
-----------------

- cri-o: update to 1.34.2

Package(s) Affected
-------------------

- cri-o: 1.34.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cri-o
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
