### PR TITLE
firejail: update to 0.9.76

### DIFF
--- a/app-admin/firejail/spec
+++ b/app-admin/firejail/spec
@@ -1,4 +1,4 @@
-VER=0.9.72
+VER=0.9.76
 SRCS="tbl::https://sourceforge.net/projects/firejail/files/firejail/firejail-${VER}.tar.xz"
-CHKSUMS="sha256::82e177c48cfc87f62b088b55efc53ff4612b9740aab5ea35cbf2395e83efe7f4"
+CHKSUMS="sha256::6bfaa57e10897f65cc1183b330974d555669d888d6897c7a8739bb1d334d9e4a"
 CHKUPDATE="anitya::id=13821"


### PR DESCRIPTION
Topic Description
-----------------

- firejail: update to 0.9.76

Package(s) Affected
-------------------

- firejail: 0.9.76

Security Update?
----------------

No

Build Order
-----------

```
#buildit firejail
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
