### PR TITLE
rmpc: update to 0.10.0

### DIFF
--- a/app-multimedia/rmpc/spec
+++ b/app-multimedia/rmpc/spec
@@ -1,4 +1,4 @@
-VER=0.9.0
+VER=0.10.0
 SRCS="git::commit=tags/v$VER::https://github.com/mierak/rmpc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376792"


### PR DESCRIPTION
Topic Description
-----------------

- rmpc: update to 0.10.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\) <self@origincode.me>

Package(s) Affected
-------------------

- rmpc: 0.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rmpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
