### PR TITLE
apt: add asahi to kernel handler

### DIFF
--- a/app-admin/apt/autobuild/overrides/etc/kernel/postinst.d/apt-auto-removal
+++ b/app-admin/apt/autobuild/overrides/etc/kernel/postinst.d/apt-auto-removal
@@ -18,7 +18,7 @@ config_file="${APT_CONF_D}/01autoremove-kernels"
 eval $(apt-config shell DPKG Dir::bin::dpkg/f)
 test -n "$DPKG" || DPKG="/usr/bin/dpkg"
 
-list="$("${DPKG}" -l | awk '/^[ih][^nc][ ]+linux-kernel+(|-lts|-rc|-sunxi64)+-[0-9]+\./ { print $2,$3; }' | sed -e 's#^linux-kernel\+\(\|-lts\|-rc\|-sunxi64\)\+-##' -e 's#:[^:]\+ # #')"
+list="$("${DPKG}" -l | awk '/^[ih][^nc][ ]+linux-kernel+(|-lts|-rc|-sunxi64|-asahi)+-[0-9]+\./ { print $2,$3; }' | sed -e 's#^linux-kernel\+\(\|-lts\|-rc\|-sunxi64\|-asahi\)\+-##' -e 's#:[^:]\+ # #')"
 debverlist="$(echo "$list" | cut -d' ' -f 2 | sort --unique --reverse --version-sort)"
 
 if [ -n "$1" ]; then
@@ -50,7 +50,8 @@ generateconfig() {
 APT::NeverAutoRemove
 {
 EOF
-	for package in linux-kernel linux-kernel-lts linux-kernel-rc linux-kernel-sunxi64; do
+	for package in	linux-kernel linux-kernel-lts linux-kernel-rc \
+			linux-kernel-sunxi64 linux-kernel-asahi; do
 		for kernel in $kernels; do
 			echo "   \"^${package}-${kernel}$\";"
 		done

--- a/app-admin/apt/spec
+++ b/app-admin/apt/spec
@@ -1,4 +1,5 @@
 VER=3.0.3
+REL=1
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/apt-team/apt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7208"


### PR DESCRIPTION
Topic Description
-----------------

- apt: add asahi to kernel handler

Package(s) Affected
-------------------

- apt: 2:3.0.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit apt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
