### PR TITLE
glycin: add bublewrap dep

### DIFF
--- a/desktop-gnome/glycin/autobuild/defines
+++ b/desktop-gnome/glycin/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=glycin
 PKGSEC=gnome
 PKGDEP="lcms2 glib libseccomp fontconfig libjxl librsvg libheif cairo \
-        gdk-pixbuf pango libopenraw"
+        gdk-pixbuf pango libopenraw bubblewrap"
 BUILDDEP="rustc llvm gobject-introspection vala gettext python-3 tomli"
 PKGDES="Image loader library with sandboxing"
 

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,5 +1,5 @@
 VER=2.0.5
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369437"


### PR DESCRIPTION
Topic Description
-----------------

- glycin: add bublewrap dep

Package(s) Affected
-------------------

- glycin: 2.0.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit glycin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
