### PR TITLE
.NET SDK 8.0.416 rework

### DIFF
--- a/lang-dotnet/dotnet-apphost-pack-8.0/spec
+++ b/lang-dotnet/dotnet-apphost-pack-8.0/spec
@@ -1,16 +1,17 @@
 VER=8.0.22
+REL=1
 
 # Note: For use inside autobuild/.
 __VER="${VER}"
 
-SDKVER=8.0.403
+SDKVER=8.0.416
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha256::f7c31f1397444aab91afbef8d8a46e36531443faced60fa9d4070cf15a81b256"
+CHKSUMS__AMD64="sha256::5a306ca2f114da1641f5c70596de6ba64a771237f4e7dd1957c99b7b476c1e85"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha256::e6b539de634b5c40d86631e5e35488af6dbe682229e367375261c635ad5e8cb0"
+CHKSUMS__ARM64="sha256::08477f9d40cb1e7cc713bdb7df5ddd9213a724facfdfdc929cab5bcbe2e0a1c1"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha256::2244b19913c32aa0b60ae91def84528ddd7ec031cb9f3e78db4857088749eeec"
+CHKSUMS__ARMV7HF="sha256::d2a83a23d65a2207d9ebc77bd6acd39f5b17a431158366a1e47832b10689227b"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(8\..+?)\""

--- a/lang-dotnet/dotnet-sdk-8.0/autobuild/postinst
+++ b/lang-dotnet/dotnet-sdk-8.0/autobuild/postinst
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 first_run() {
-    /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/8.0.403/dotnet.dll internal-reportinstallsuccess "aoscpackage" > /dev/null 2>&1 || true
+    /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/8.0.416/dotnet.dll internal-reportinstallsuccess "aoscpackage" > /dev/null 2>&1 || true
 }
 
 source /etc/profile.d/dotnet-cli-telemetry-optout.sh

--- a/lang-dotnet/dotnet-sdk-8.0/spec
+++ b/lang-dotnet/dotnet-sdk-8.0/spec
@@ -1,4 +1,5 @@
 VER=8.0.416
+REL=1
 
 # Note: For use inside autobuild/.
 __VER="${VER}"

--- a/lang-dotnet/dotnet-targeting-pack-8.0/spec
+++ b/lang-dotnet/dotnet-targeting-pack-8.0/spec
@@ -1,16 +1,17 @@
 VER=8.0.22
+REL=1
 
 # Note: For use inside autobuild/.
 __VER="${VER}"
 
-SDKVER=8.0.403
+SDKVER=8.0.416
 
 SRCS__AMD64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-x64.tar.gz"
-CHKSUMS__AMD64="sha256::f7c31f1397444aab91afbef8d8a46e36531443faced60fa9d4070cf15a81b256"
+CHKSUMS__AMD64="sha256::5a306ca2f114da1641f5c70596de6ba64a771237f4e7dd1957c99b7b476c1e85"
 SRCS__ARM64="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm64.tar.gz"
-CHKSUMS__ARM64="sha256::e6b539de634b5c40d86631e5e35488af6dbe682229e367375261c635ad5e8cb0"
+CHKSUMS__ARM64="sha256::08477f9d40cb1e7cc713bdb7df5ddd9213a724facfdfdc929cab5bcbe2e0a1c1"
 SRCS__ARMV7HF="https://dotnetcli.azureedge.net/dotnet/Sdk/$SDKVER/dotnet-sdk-$SDKVER-linux-arm.tar.gz"
-CHKSUMS__ARMV7HF="sha256::2244b19913c32aa0b60ae91def84528ddd7ec031cb9f3e78db4857088749eeec"
+CHKSUMS__ARMV7HF="sha256::d2a83a23d65a2207d9ebc77bd6acd39f5b17a431158366a1e47832b10689227b"
 
 SUBDIR=.
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-runtime\": \"(8\..+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- dotnet-targeting-pack-8.0: use sdk 8.0.416
- dotnet-apphost-pack-8.0: use sdk 8.0.416
- dotnet-sdk-8.0: use correct sdk version when first run

Package(s) Affected
-------------------

- dotnet-apphost-pack-8.0: 1:8.0.22-1
- dotnet-sdk-8.0: 8.0.416-1
- dotnet-targeting-pack-8.0: 1:8.0.22-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-targeting-pack-8.0 dotnet-apphost-pack-8.0 dotnet-sdk-8.0
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
