### PR TITLE
xournalpp: update to 1.2.8

### DIFF
--- a/runtime-productivity/xournalpp/spec
+++ b/runtime-productivity/xournalpp/spec
@@ -1,5 +1,4 @@
-VER=1.2.5
-REL=1
+VER=1.2.8
 SRCS="git::commit=tags/v$VER::https://github.com/xournalpp/xournalpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57279"


### PR DESCRIPTION
Topic Description
-----------------

- xournalpp: update to 1.2.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xournalpp: 1.2.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit xournalpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
