### PR TITLE
zhaoxin-linux-graphics-driver-dri: fix framebuffer enablement/switching

### DIFF
--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,7 +1,7 @@
 From a5963cfc6208bed7e5c6f7ebd808739bf8c13fa6 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
-Subject: [PATCH 1/6] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
+Subject: [PATCH 1/9] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
 
 EXTRA_*FLAGS support was deprecated in 2007 and removed in 2025.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,7 +1,7 @@
 From 8e4d5357faabde017294faffeb43721416edf196 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
-Subject: [PATCH 2/6] chore: dkms: remove useless variables
+Subject: [PATCH 2/9] chore: dkms: remove useless variables
 
 REMAKE_INITRD was deprecated. SKIP_IMMD_MODPROBE is not standard.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,7 +1,7 @@
 From 3a384c2fafe324402aa95fa9c704c9077ca4ee30 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 3/6] fix: kernel: 6.15
+Subject: [PATCH 3/9] fix: kernel: 6.15
 
 Make it compatible with Linux kernel 6.15.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,7 +1,7 @@
 From f1e1314b6ce3f541b7da43c839978c7acce44ce4 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 4/6] fix: kernel: 6.16
+Subject: [PATCH 4/9] fix: kernel: 6.16
 
 Make it compatible with Linux kernel 6.16.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,7 +1,7 @@
 From e170a0eb554203120c8356bdc1f27db33d55b379 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
-Subject: [PATCH 5/6] fix: kernel: 6.17
+Subject: [PATCH 5/9] fix: kernel: 6.17
 
 Make it compatible with Linux kernel 6.17.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,7 +1,7 @@
 From 4a49d7b148cf57ae0044875796e1e6594b728e3f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
-Subject: [PATCH 6/6] fix: kernel: 6.18
+Subject: [PATCH 6/9] fix: kernel: 6.18
 
 In the 6.18 cycle, Intel moved `struct_mutex' from the public `drm_device'
 struct to `drm_i915_private'. As this was really only used by Intel to

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,0 +1,28 @@
+From d4a86def62bc8f02dcb384d4667d716edff41989 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 12 Nov 2025 18:42:34 +0800
+Subject: [PATCH 7/9] chore: import .gitignore from loonggpu-kernel-dkms
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ .gitignore | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..223542a
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,8 @@
++*.o
++*.ko
++*.mod
++*.mod.c
++*.cmd
++*.symvers
++*.order
++conftest
+-- 
+2.51.1
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,0 +1,37 @@
+From fb992beebfeca0d47a2c0d4d7ee3eba84d00ac84 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 12 Nov 2025 18:42:48 +0800
+Subject: [PATCH 8/9] refactor (NFC): rename zxfb_create to zx_fbdev_probe
+
+Make it more similar to reference implementations.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index b55023e..96a1456 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -114,7 +114,7 @@ static void zx_crtc_fb_gamma_get(struct drm_crtc *crtc, u16 *red, u16 *green, u1
+ }
+ #endif
+ 
+-static int zxfb_create(struct drm_fb_helper *helper, struct drm_fb_helper_surface_size *sizes)
++static int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_size *sizes)
+ {
+     int ret = 0;
+     struct fb_info *info;
+@@ -273,7 +273,7 @@ static const struct drm_fb_helper_funcs zx_fb_helper_funcs = {
+     .gamma_get          = zx_crtc_fb_gamma_get,
+ #endif
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+-    .fb_probe           = zxfb_create,
++    .fb_probe           = zx_fbdev_probe,
+ #endif
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+     .fb_dirty           = zxfb_dirty,
+-- 
+2.51.1
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,0 +1,97 @@
+From 64e92f64e09b35bb9d1025c0f0cb65696b0403e2 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 12 Nov 2025 19:07:04 +0800
+Subject: [PATCH 9/9] fix: run DRM default client setup on Linux >= 6.15
+
+Call drm_client_setup() to run the kernel's default client setup
+for DRM. Set fbdev_probe in struct drm_driver, so that the client
+setup can start the common fbdev client.
+
+Following the reference implementation change.
+
+Link: https://github.com/AOSC-Tracking/loonggpu-kernel-dkms/commit/5d470d0074d8
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c |  7 ++++++-
+ src/zx_fbdev.h |  1 +
+ src/zx_pcie.c  | 15 +++++++++++++++
+ 3 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 96a1456..58d5edf 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -114,7 +114,9 @@ static void zx_crtc_fb_gamma_get(struct drm_crtc *crtc, u16 *red, u16 *green, u1
+ }
+ #endif
+ 
+-static int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_size *sizes)
++static const struct drm_fb_helper_funcs zx_fb_helper_funcs;
++
++int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_size *sizes)
+ {
+     int ret = 0;
+     struct fb_info *info;
+@@ -219,6 +221,9 @@ static int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_sur
+ 
+     info->skip_vt_switch = true;
+     fbdev->helper.fb = &fb->base;
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    fbdev->helper.funcs = &zx_fb_helper_funcs,
++#endif
+     zx_vsprintf(info->fix.id, "%s", "zxfb");
+ 
+     if (obj)
+diff --git a/src/zx_fbdev.h b/src/zx_fbdev.h
+index 704d624..6c56455 100644
+--- a/src/zx_fbdev.h
++++ b/src/zx_fbdev.h
+@@ -19,4 +19,5 @@ int zx_fbdev_init(zx_card_t *zx);
+ int zx_fbdev_deinit(zx_card_t *zx);
+ void zx_fbdev_set_suspend(zx_card_t *zx, int state);
+ void zx_fbdev_poll_changed(struct drm_device *dev);
++int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_size *sizes);
+ #endif
+diff --git a/src/zx_pcie.c b/src/zx_pcie.c
+index a989f9a..8fe5d35 100644
+--- a/src/zx_pcie.c
++++ b/src/zx_pcie.c
+@@ -41,6 +41,14 @@
+ #endif
+ #endif
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++#if __has_include(<drm/clients/drm_client_setup.h>)
++#include <drm/clients/drm_client_setup.h>
++#else
++#include <drm/drm_client_setup.h>
++#endif
++#endif
++
+ #define DRIVER_NAME         "zx"
+ #define DRIVER_DESC         "ZX DRM Pro"
+ 
+@@ -634,6 +642,9 @@ static struct drm_zx_driver zx_drm_driver = {
+         .major              = DRIVER_MAJOR,
+         .minor              = DRIVER_MINOR,
+         .patchlevel         = DRIVER_PATCHLEVEL,
++    #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++        .fbdev_probe        = zx_fbdev_probe,
++    #endif
+     }
+ };
+ 
+@@ -671,6 +682,10 @@ static int zx_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+     if (ret)
+             goto err_pci;
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6,15,0)
++    drm_client_setup(dev, NULL);
++#endif
++
+     return 0;
+ 
+ err_pci:
+-- 
+2.51.1
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,7 +1,7 @@
 UPSTREAM_VER=21.00.79
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
-REL=1
+REL=2
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3418&tag=0&ref=qdxz&pre=0&t=83e1707a341d4e51"
 CHKSUMS="sha256::5d2f466b20e47c1814bdea3b07fe73ed81ff42b58d7e9805660a85ed1d27ca23"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- zhaoxin-linux-graphics-driver-dri: fix framebuffer enablement/switching
    Track DKMS patches at AOSC-Tracking/zx-kernel-dkms @ aosc/v21.00.79
    \(HEAD: 64e92f64e09b35bb9d1025c0f0cb65696b0403e2\).

Package(s) Affected
-------------------

- zhaoxin-linux-graphics-driver-dri: 21.00.79-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zhaoxin-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
