### PR TITLE
vscode: update to 1.106.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.105.1
+VER=1.106.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::456acb8c6f2b146098e486ae4b4e9e50a4f344dbd168da60c10d6ac12bcab29b"
-CHKSUMS__ARM64="sha256::0e0f7b5d8340abc0ffaa2a15a44461d59d0eef36d95825e18e07868b804453e8"
+CHKSUMS__AMD64="sha256::2ab9c5fc3c99afcaa0a973ec870d652aa4610926536a1dab282b6d6e6ccee89d"
+CHKSUMS__ARM64="sha256::371d7b87f3d83fd5b519df7cc9db6c78496d5fd3e5feac8c4f1a12bb0fe8ee7a"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.106.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.106.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
