### PR TITLE
pktstat: update to 1.8.5

### DIFF
--- a/app-network/pktstat/autobuild/defines
+++ b/app-network/pktstat/autobuild/defines
@@ -2,3 +2,4 @@ PKGNAME=pktstat
 PKGSEC=net
 PKGDEP="ncurses libpcap"
 PKGDES="Real-time network interface traffic viewer"
+ABTYPE=autotools

--- a/app-network/pktstat/spec
+++ b/app-network/pktstat/spec
@@ -1,4 +1,5 @@
-VER=20160317
-SRCS="git::commit=2070e5e1f3aeb0f260122e3b3fb1058f29a11c30::https://github.com/dleonard0/pktstat"
+VER=1.8.5
+EPOCH=1
+SRCS="git::commit=v"$VER"::https://github.com/dleonard0/pktstat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230984"


### PR DESCRIPTION
Topic Description
-----------------

- pktstat: update to 1.8.5
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pktstat: 1.8.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit pktstat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
