### PR TITLE
box64: update to 0.3.9+git20251113

### DIFF
--- a/app-emulation/box64/autobuild/triggers
+++ b/app-emulation/box64/autobuild/triggers
@@ -1,0 +1,1 @@
+activate-noawait systemd-binfmt

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-VER=0.3.9+git20251109
-SRCS="git::commit=1fab6582d7d70cfb3ab55e90cc5c3fc45e915d7a::https://github.com/ptitSeb/box64.git"
+VER=0.3.9+git20251113
+SRCS="git::commit=b6fb4865fb80dd754caabe1c3895aa70e4b9a813::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251113
    - Add a trigger to reload binfmt config.

Package(s) Affected
-------------------

- box64: 0.3.9+git20251113

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

