### PR TITLE
libspelling: update to 0.4.9

### DIFF
--- a/desktop-gnome/libspelling/spec
+++ b/desktop-gnome/libspelling/spec
@@ -1,4 +1,4 @@
-VER=0.4.6
+VER=0.4.9
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/libspelling.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369148"

--- a/runtime-editors/gtksourceview-5/autobuild/defines
+++ b/runtime-editors/gtksourceview-5/autobuild/defines
@@ -1,9 +1,15 @@
 PKGNAME=gtksourceview-5
 PKGSEC=gnome
 PKGDEP="gtk-4 libxml2 gtk-update-icon-cache"
-BUILDDEP="gobject-introspection intltool vala"
+BUILDDEP="gobject-introspection intltool sysprof vala"
 PKGDES="A text widget adding syntax highlighting and more to GNOME (version 5)"
 
-MESON_AFTER="-Dinstall-tests=false \
-             -Dvapi=true \
-             -Dsysprof=false"
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dbuild-testsuite=false'
+    '-Dinstall-tests=false'
+    '-Dintrospection=enabled'
+    '-Dvapi=true'
+    '-Ddocumentation=false'
+    '-Dsysprof=true'
+)

--- a/runtime-editors/gtksourceview-5/spec
+++ b/runtime-editors/gtksourceview-5/spec
@@ -1,5 +1,4 @@
-VER=5.14.2
-REL=1
+VER=5.18.0
 SRCS="tbl::https://download.gnome.org/sources/gtksourceview/${VER:0:4}/gtksourceview-$VER.tar.xz"
-CHKSUMS="sha256::1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264"
+CHKSUMS="sha256::051a78fe38f793328047e5bcd6d855c6425c0b480c20d9432179e356742c6ac0"
 CHKUPDATE="html::url=https://download.gnome.org/sources/gtksourceview/${VER%.*}/;pattern=gtksourceview-(.+?).tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- libspelling: update to 0.4.9
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>
- gtksourceview-5: update to 5.18.0

Package(s) Affected
-------------------

- libspelling: 0.4.9
- gtksourceview-5: 5.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gtksourceview-5 libspelling
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
