### PR TITLE
libarchive: update to 3.8.2

### DIFF
--- a/runtime-common/libarchive/autobuild/defines
+++ b/runtime-common/libarchive/autobuild/defines
@@ -7,28 +7,30 @@ PKGSEC=libs
 # Note: Mutually exclusive feature sets.
 #     (1) mbedtls, nettle, or openssl for cryptography support.
 #     (2) [lib]xml2 or expat for xar support.
-AUTOTOOLS_AFTER="--enable-bsdtar=shared \
-                 --enable-bsdcat=shared \
-                 --enable-bsdcpio=shared \
-                 --disable-rpath \
-                 --enable-posix-regex-lib=libc \
-                 --enable-xattr \
-                 --enable-acl \
-                 --enable-largefile \
-                 --with-zlib \
-                 --with-bz2lib \
-                 --with-libb2 \
-                 --with-iconv \
-                 --with-lz4 \
-                 --with-zstd \
-                 --with-lzma \
-                 --with-lzo2 \
-                 --with-cng \
-                 --without-mbedtls \
-                 --without-nettle \
-                 --with-openssl \
-                 --without-xml2 \
-                 --with-expat"
+AUTOTOOLS_AFTER=(
+    '--enable-bsdtar=shared'
+    '--enable-bsdcat=shared'
+    '--enable-bsdcpio=shared'
+    '--disable-rpath'
+    '--enable-posix-regex-lib=libc'
+    '--enable-xattr'
+    '--enable-acl'
+    '--enable-largefile'
+    '--with-zlib'
+    '--with-bz2lib'
+    '--with-libb2'
+    '--with-iconv'
+    '--with-lz4'
+    '--with-zstd'
+    '--with-lzma'
+    '--with-lzo2'
+    '--with-cng'
+    '--without-mbedtls'
+    '--without-nettle'
+    '--with-openssl'
+    '--without-xml2'
+    '--with-expat'
+)
 
 ABSHADOW=0
 AB_FLAGS_O3=1

--- a/runtime-common/libarchive/spec
+++ b/runtime-common/libarchive/spec
@@ -1,4 +1,4 @@
-VER=3.7.8
+VER=3.8.2
 SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
-CHKSUMS="sha256::a123d87b1bd8adb19e8c187da17ae2d957c7f9596e741b929e6b9ceefea5ad0f"
+CHKSUMS="sha256::5f2d3c2fde8dc44583a61165549dc50ba8a37c5947c90fc02c8e5ce7f1cfb80d"
 CHKUPDATE="anitya::id=1558"


### PR DESCRIPTION
Topic Description
-----------------

- libarchive: update to 3.8.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- libarchive: 1:3.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libarchive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
