### PR TITLE
remmina: update to 1.4.41

### DIFF
--- a/app-network/remmina/spec
+++ b/app-network/remmina/spec
@@ -1,4 +1,4 @@
-VER=1.4.40
+VER=1.4.41
 SRCS="tbl::https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUMS="sha256::a1881003474211368fa18ec2a46f29ce55458932faedc6dca02a28e713470b73"
+CHKSUMS="sha256::4214b5eb8755b9409e7216aa29019c026163204c4919293b858178f590e8c570"
 CHKUPDATE="anitya::id=4188"


### PR DESCRIPTION
Topic Description
-----------------

- remmina: update to 1.4.41
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- remmina: 1.4.41

Security Update?
----------------

No

Build Order
-----------

```
#buildit remmina
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
