### PR TITLE
libarchive: change srcs to github release

### DIFF
--- a/runtime-common/libarchive/spec
+++ b/runtime-common/libarchive/spec
@@ -1,4 +1,5 @@
 VER=3.8.2
-SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
+REL=1
+SRCS="tbl::https://github.com/libarchive/libarchive/releases/download/v$VER/libarchive-$VER.tar.gz"
 CHKSUMS="sha256::5f2d3c2fde8dc44583a61165549dc50ba8a37c5947c90fc02c8e5ce7f1cfb80d"
 CHKUPDATE="anitya::id=1558"


### PR DESCRIPTION
Topic Description
-----------------

- libarchive: change srcs to github release

Package(s) Affected
-------------------

- libarchive: 1:3.8.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libarchive
```

Test Build(s) Done
------------------

