### PR TITLE
arping: update to 2.26

### DIFF
--- a/app-network/arping/spec
+++ b/app-network/arping/spec
@@ -1,4 +1,4 @@
-VER=2.25
+VER=2.26
 SRCS="tbl::http://www.habets.pp.se/synscan/files/arping-$VER.tar.gz"
-CHKSUMS="sha256::32f868e801e931033f058a614cce858f0a0b8f893331bbaddd6c5c1e46f2b1f0"
+CHKSUMS="sha256::6768d63f861945ceb7875c23b0be27c8657795317d063e004a2f7f81d26979da"
 CHKUPDATE="anitya::id=5495"


### PR DESCRIPTION
Topic Description
-----------------

- arping: update to 2.26
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- arping: 2.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit arping
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
