### PR TITLE
ddcutil: update to 2.2.2

### DIFF
--- a/app-utils/ddcutil/spec
+++ b/app-utils/ddcutil/spec
@@ -1,4 +1,4 @@
-VER=2.2.1
+VER=2.2.2
 SRCS="git::commit=tags/v$VER::https://github.com/rockowitz/ddcutil"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242390"


### PR DESCRIPTION
Topic Description
-----------------

- ddcutil: update to 2.2.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ddcutil: 2.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddcutil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
