### PR TITLE
qt-4: fix build on loongarch64_nosimd

### DIFF
--- a/runtime-desktop/qt-4/autobuild/build
+++ b/runtime-desktop/qt-4/autobuild/build
@@ -22,7 +22,8 @@ if [[ "${CROSS:-$ARCH}" = "armv4" || \
 fi
 
 # FIXME: No WebKit support for loongarch64.
-if ab_match_arch loongarch64; then
+if ab_match_arch loongarch64 || \
+   ab_match_arch loongarch64_nosimd; then
     export WEBKIT="-no-webkit"
 fi
 

--- a/runtime-desktop/qt-4/autobuild/build.stage2
+++ b/runtime-desktop/qt-4/autobuild/build.stage2
@@ -22,7 +22,8 @@ if [[ "${CROSS:-$ARCH}" = "armv4" || \
 fi
 
 # FIXME: No WebKit support for loongarch64.
-if ab_match_arch loongarch64; then
+if ab_match_arch loongarch64 || \
+   ab_match_arch loongarch64_nosimd; then
     export WEBKIT="-no-webkit"
 fi
 

--- a/runtime-desktop/qt-4/spec
+++ b/runtime-desktop/qt-4/spec
@@ -1,5 +1,5 @@
 VER=4.8.7
-REL=23
+REL=24
 SRCS="tbl::https://download.qt.io/archive/qt/${VER:0:3}/$VER/qt-everywhere-opensource-src-$VER.tar.gz"
 CHKSUMS="sha256::e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
 CHKUPDATE="html::url=https://download.qt.io/archive/qt/${VER:0:3}/$VER/;pattern=qt-everywhere-opensource-src-(.+?).tar.gz"


### PR DESCRIPTION
Topic Description
-----------------

- qt-4: fix build on loongarch64_nosimd

Package(s) Affected
-------------------

- qt-4: 4.8.7-24

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-4:+stage2 qt-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
