### PR TITLE
mission-center: update to 1.1.0

### DIFF
--- a/app-utils/mission-center/spec
+++ b/app-utils/mission-center/spec
@@ -1,5 +1,4 @@
-VER=1.0.2
-REL=1
+VER=1.1.0
 SRCS="git::commit=tags/v$VER::https://gitlab.com/mission-center-devs/mission-center"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377664"


### PR DESCRIPTION
Topic Description
-----------------

- mission-center: update to 1.1.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- mission-center: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mission-center
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
