### PR TITLE
regex: update to 2025.11.3

### DIFF
--- a/lang-python/regex/spec
+++ b/lang-python/regex/spec
@@ -1,5 +1,4 @@
-VER=2019.02.21
-REL=5
+VER=2025.11.3
 SRCS="tbl::https://pypi.io/packages/source/r/regex/regex-$VER.tar.gz"
-CHKSUMS="sha256::587bd4cad11c7294f89799c45778abca271d7c6668a0e85c41a6dbfa8096f9bb"
+CHKSUMS="sha256::1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01"
 CHKUPDATE="anitya::id=5548"


### PR DESCRIPTION
Topic Description
-----------------

- regex: update to 2025.11.3
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- regex: 2025.11.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit regex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
