### PR TITLE
mesa-demos: enable vkgears

### DIFF
--- a/app-utils/mesa-demos/autobuild/defines
+++ b/app-utils/mesa-demos/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=mesa-demos
 PKGSEC=x11
-PKGDEP="freeglut glew mesa libdecor"
+PKGDEP="freeglut glew mesa libdecor vulkan-loader"
+BUILDDEP="glslang vulkan-headers"
 PKGDES="Mesa demos and tools"
 
-MESON_AFTER="-Dwith-system-data-files=true"
+MESON_AFTER="-Dwith-system-data-files=true -Dvulkan=enabled"

--- a/app-utils/mesa-demos/spec
+++ b/app-utils/mesa-demos/spec
@@ -1,4 +1,5 @@
 VER=9.0.0
+REL=1
 SRCS="tbl::https://archive.mesa3d.org/demos/mesa-demos-$VER.tar.xz"
 CHKSUMS="sha256::3046a3d26a7b051af7ebdd257a5f23bfeb160cad6ed952329cdff1e9f1ed496b"
 CHKUPDATE="anitya::id=16781"


### PR DESCRIPTION
Topic Description
-----------------

- mesa-demos: enable building vkgears
    Currently vkgears is not built because glslang builddep and
    vulkan-loader runtime dep is missing.
    Add the needed dependency and explicitly enable vulkan demos in meson
    command line.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa-demos: 9.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa-demos
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
