### PR TITLE
graphene: update to 1.10.8

### DIFF
--- a/runtime-imaging/graphene/autobuild/defines
+++ b/runtime-imaging/graphene/autobuild/defines
@@ -1,5 +1,12 @@
 PKGNAME=graphene
 PKGSEC=libs
-PKGDEP="glib"
+PKGDEP="glib glibc"
 BUILDDEP="gobject-introspection"
 PKGDES="A thin layer of graphic data types"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dgtk_doc=false'
+    '-Dtests=false'
+    '-Dinstalled_tests=false'
+)

--- a/runtime-imaging/graphene/spec
+++ b/runtime-imaging/graphene/spec
@@ -1,5 +1,4 @@
-VER=1.10.2
-REL=1
-SRCS="tbl::https://github.com/ebassi/graphene/releases/download/$VER/graphene-$VER.tar.xz"
-CHKSUMS="sha256::e97de8208f1aac4f913d4fa71ab73a7034e807186feb2abe55876e51c425a7f6"
+VER=1.10.8
+SRCS="git::commit=tags/$VER::https://github.com/ebassi/graphene.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12758"


### PR DESCRIPTION
Topic Description
-----------------

- graphene: update to 1.10.8

Package(s) Affected
-------------------

- graphene: 1.10.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit graphene
```

Test Build(s) Done
------------------

