### PR TITLE
bfs: new, 4.1

### DIFF
--- a/app-utils/bfs/autobuild/build
+++ b/app-utils/bfs/autobuild/build
@@ -1,0 +1,16 @@
+echo "Configuring bfs..."
+"$SRCDIR"/configure \
+    --enable-release \
+    --with-libacl \
+    --with-libcap \
+    --with-liburing \
+    --with-oniguruma \
+    --prefix=/usr \
+    --mandir=/usr/share/man \
+    V=1
+
+echo "Building bfs..."
+make V=1
+
+echo "Installing bfs..."
+make install DESTDIR="$PKGDIR"

--- a/app-utils/bfs/autobuild/defines
+++ b/app-utils/bfs/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=bfs
+PKGSEC=utils
+PKGDEP="glibc acl libcap liburing onig"
+PKGDES="Breadth-first version of the UNIX find command"
+# Note: bfs uses a handcrafted, autotools-incompatible configure script.
+ABTYPE=self

--- a/app-utils/bfs/spec
+++ b/app-utils/bfs/spec
@@ -1,0 +1,4 @@
+VER=4.1
+SRCS="git::commit=tags/$VER;submodule=false::https://github.com/tavianator/bfs"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=276209"


### PR DESCRIPTION
Topic Description
-----------------

- bfs: new, 4.1

Package(s) Affected
-------------------

- bfs: 4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
