### PR TITLE
YT-DLP external javascript solver via deno

### DIFF
--- a/app-multimedia/yt-dlp/autobuild/defines
+++ b/app-multimedia/yt-dlp/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=yt-dlp
 PKGSEC=web
 PKGDEP="atomicparsley brotlicffi certifi curl ffmpeg mutagen pycryptodomex \
-        python-3 quickjs requests rtmpdump secretstorage urllib3 websockets"
+        python-3 quickjs requests rtmpdump secretstorage urllib3 websockets \
+        yt-dlp-ejs"
+PKGRECOM="deno"
 BUILDDEP="hatchling python-build python-installer wheel"
 PKGDES="Command-line media stream downloader for YouTube and other streaming sites"
 

--- a/app-multimedia/yt-dlp/spec
+++ b/app-multimedia/yt-dlp/spec
@@ -1,4 +1,5 @@
 VER=2025.11.12
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/yt-dlp/yt-dlp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=143399"

--- a/lang-python/yt-dlp-ejs/autobuild/defines
+++ b/lang-python/yt-dlp-ejs/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=yt-dlp-ejs
+PKGSEC=python
+PKGDES="External JavaScript for yt-dlp supporting many runtimes"
+PKGDEP="python-3"
+# Note: deno only used for generating js bundle
+BUILDDEP="hatchling hatch-vcs deno"
+
+ABTYPE=pep517
+NOPYTHON2=1
+ABHOST=noarch

--- a/lang-python/yt-dlp-ejs/spec
+++ b/lang-python/yt-dlp-ejs/spec
@@ -1,0 +1,4 @@
+VER=0.3.1
+SRCS="pypi::version=$VER::yt-dlp-ejs"
+CHKSUMS="sha256::7f2119eb02864800f651fa33825ddfe13d152a1f730fa103d9864f091df24227"
+CHKUPDATE="anitya::id=386809"


### PR DESCRIPTION
Topic Description
-----------------

- yt-dlp: depend on yt-dlp-ejs
- yt-dlp-ejs: new, 0.3.1

Package(s) Affected
-------------------

- yt-dlp: 2025.11.12-1
- yt-dlp-ejs: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yt-dlp-ejs yt-dlp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
