### PR TITLE
86box: update to 5.2

### DIFF
--- a/app-emulation/86box-roms/spec
+++ b/app-emulation/86box-roms/spec
@@ -1,5 +1,5 @@
-VER=5.1+git20250926
-SRCS="git::commit=983cd7fcd7216d217828e6ee7ac9d525caf6f190::https://github.com/86Box/roms"
+VER=5.2+git20251113
+SRCS="git::commit=e550378d005cc5318159470a6b7e527aabc944ba::https://github.com/86Box/roms"
 CHKSUMS="SKIP"
 # Note: We will just follow master, there is no point in following tags.
 #CHKUPDATE="anitya::id=268433"

--- a/app-emulation/86box/autobuild/defines
+++ b/app-emulation/86box/autobuild/defines
@@ -31,5 +31,6 @@ CMAKE_AFTER__AMD64=(
 # Upstream advised to use "new" dynamic recompiler for arm64.
 CMAKE_AFTER__ARM64=(
     "${CMAKE_AFTER[@]}"
+    '-DDYNAREC=ON'
     '-DNEW_DYNAREC=ON'
 )

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,5 +1,4 @@
-VER=5.1
-REL=1
+VER=5.2
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
Topic Description
-----------------

- 86box-roms: update to 5.2+git20251113
- 86box: update to 5.2

Package(s) Affected
-------------------

- 86box: 5.2
- 86box-roms: 5.2+git20251113

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box 86box-roms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
