### PR TITLE
aosc-os-repository-data: update to 20251115

### DIFF
--- a/runtime-data/aosc-os-repository-data/spec
+++ b/runtime-data/aosc-os-repository-data/spec
@@ -1,4 +1,4 @@
-VER=20250831
+VER=20251115
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-os-repository-data"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230634"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-repository-data: update to 20251115

Package(s) Affected
-------------------

- aosc-os-repository-data: 20251115

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-repository-data
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
