### PR TITLE
gc: revert two patches to fix crash with Glycin and Inkscape

### DIFF
--- a/runtime-common/gc/autobuild/beyond
+++ b/runtime-common/gc/autobuild/beyond
@@ -1,4 +1,3 @@
-abinfo "Modifying and installing manual pages ..."
-sed -i -e 's/BDWGC 3/gc 3/' "$SRCDIR/doc/gc.man"
-install -m755 -dv "$PKGDIR/usr/share/man/man3"
-install -m644 -v doc/gc.man "$PKGDIR/usr/share/man/man3/gc.3"
+abinfo "Installing man pages ..."
+install -Dvm644 "$SRCDIR"/doc/gc.man \
+    "$PKGDIR"/usr/share/man/man3/gc.3

--- a/runtime-common/gc/autobuild/defines
+++ b/runtime-common/gc/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=gc
-PKGDEP="libatomic-ops"
-PKGDES="A garbage collector for C and C++"
 PKGSEC=libs
+PKGDEP="gcc-runtime glibc"
+PKGDES="General purpose, garbage collecting storage allocator"
 
-AUTOTOOLS_AFTER="--enable-cplusplus"
 ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--enable-cplusplus'
+)
+
+PKGPROV="bdwgc"

--- a/runtime-common/gc/autobuild/patch
+++ b/runtime-common/gc/autobuild/patch
@@ -1,2 +1,0 @@
-abinfo "Hacking docs makefile ..."
-sed -i 's#pkgdata#doc#' "$SRCDIR/doc/doc.am"

--- a/runtime-common/gc/autobuild/patches/0001-AOSCOS-fix-title-for-man-page-BDWGC-gc.patch
+++ b/runtime-common/gc/autobuild/patches/0001-AOSCOS-fix-title-for-man-page-BDWGC-gc.patch
@@ -1,0 +1,23 @@
+From 797fa3565a3982694382816d20bda7fc263d0f84 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 16 Nov 2025 12:54:39 +0800
+Subject: [PATCH 1/3] AOSCOS: fix title for man page (BDWGC => gc)
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ doc/gc.man | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/doc/gc.man b/doc/gc.man
+index c28e4b66..94b3db2a 100644
+--- a/doc/gc.man
++++ b/doc/gc.man
+@@ -1,4 +1,4 @@
+-.TH BDWGC 3 "23 Aug 2023"
++.TH gc 3 "23 Aug 2023"
+ .SH NAME
+ GC_malloc, GC_malloc_atomic, GC_free, GC_realloc, GC_enable_incremental,
+ GC_register_finalizer, GC_malloc_ignore_off_page,
+-- 
+2.51.1
+

--- a/runtime-common/gc/autobuild/patches/0002-AOSCOS-Revert-Fix-pthread-id-stored-in-key-thread_sp.patch
+++ b/runtime-common/gc/autobuild/patches/0002-AOSCOS-Revert-Fix-pthread-id-stored-in-key-thread_sp.patch
@@ -1,0 +1,154 @@
+From 57b81b139e25b25159addbf14dcb78e7df7be781 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 16 Nov 2025 12:51:43 +0800
+Subject: [PATCH 2/3] AOSCOS: Revert "Fix pthread id stored in key
+ thread_specific_data of child process"
+
+This reverts commit 2cd0f5e56718a053341d1b5e7df7a3cab9a5ceaa.
+
+Link: https://github.com/bdwgc/bdwgc/issues/783#issuecomment-3433334711
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ include/private/gc_priv.h  | 11 -----------
+ include/private/specific.h |  7 -------
+ pthread_support.c          | 31 +++++++++++++++----------------
+ specific.c                 | 27 ---------------------------
+ 4 files changed, 15 insertions(+), 61 deletions(-)
+
+diff --git a/include/private/gc_priv.h b/include/private/gc_priv.h
+index 5e14fd72..90c7f997 100644
+--- a/include/private/gc_priv.h
++++ b/include/private/gc_priv.h
+@@ -832,10 +832,6 @@ EXTERN_C_END
+ 
+ #include <setjmp.h>
+ 
+-#if defined(CAN_HANDLE_FORK) && defined(GC_PTHREADS)
+-#  include <pthread.h> /* for pthread_t */
+-#endif
+-
+ #if __STDC_VERSION__ >= 201112L
+ # include <assert.h> /* for static_assert */
+ #endif
+@@ -1556,13 +1552,6 @@ struct _GC_arrays {
+ # endif
+   size_t _ed_size;      /* Current size of above arrays.        */
+   size_t _avail_descr;  /* Next available slot.                 */
+-
+-# if defined(CAN_HANDLE_FORK) && defined(GC_PTHREADS)
+-    /* Value of pthread_self() of the thread which called fork().   */
+-#   define GC_parent_pthread_self GC_arrays._parent_pthread_self
+-    pthread_t _parent_pthread_self;
+-# endif
+-
+   typed_ext_descr_t *_ext_descriptors;  /* Points to array of extended  */
+                                         /* descriptors.                 */
+   GC_mark_proc _mark_procs[MAX_MARK_PROCS];
+diff --git a/include/private/specific.h b/include/private/specific.h
+index 029fc7f3..3ed75647 100644
+--- a/include/private/specific.h
++++ b/include/private/specific.h
+@@ -109,13 +109,6 @@ GC_INNER int GC_setspecific(tsd * key, void * value);
+                         GC_remove_specific_after_fork(key, pthread_self())
+ GC_INNER void GC_remove_specific_after_fork(tsd * key, pthread_t t);
+ 
+-#ifdef CAN_HANDLE_FORK
+-  /* Update thread-specific data for the survived thread of the child     */
+-  /* process.  Should be called once after removing thread-specific data  */
+-  /* for other threads.                                                   */
+-  GC_INNER void GC_update_specific_after_fork(tsd *key);
+-#endif
+-
+ /* An internal version of getspecific that assumes a cache miss.        */
+ GC_INNER void * GC_slow_getspecific(tsd * key, word qtid,
+                                     tse * volatile * cache_entry);
+diff --git a/pthread_support.c b/pthread_support.c
+index 937846c7..3a4b22b1 100644
+--- a/pthread_support.c
++++ b/pthread_support.c
+@@ -829,6 +829,9 @@ GC_API void GC_CALL GC_register_altstack(void *stack, GC_word stack_size,
+     GC_threads[hv] = me;
+   }
+ 
++/* Value of pthread_self() of the thread which called fork(). */
++STATIC pthread_t GC_parent_pthread_self;
++
+ /* Remove all entries from the GC_threads table, except the one for */
+ /* the current thread.  Also update thread identifiers stored in    */
+ /* the table for the current thread.  We need to do this in the     */
+@@ -892,22 +895,18 @@ STATIC void GC_remove_all_threads_but_me(void)
+     /* Put "me" back to GC_threads.     */
+     store_to_threads_table(THREAD_TABLE_INDEX(me -> id), me);
+ 
+-#   ifdef THREAD_LOCAL_ALLOC
+-#     ifdef USE_CUSTOM_SPECIFIC
+-        GC_update_specific_after_fork(GC_thread_key);
+-#     else
+-        {
+-          int res;
+-
+-          /* Some TLS implementations might be not fork-friendly, so    */
+-          /* we re-assign thread-local pointer to 'tlfs' for safety     */
+-          /* instead of the assertion check (again, it is OK to call    */
+-          /* GC_destroy_thread_local and GC_free_inner before).         */
+-          res = GC_setspecific(GC_thread_key, &me->tlfs);
+-          if (COVERT_DATAFLOW(res) != 0)
+-            ABORT("GC_setspecific failed (in child)");
+-        }
+-#     endif
++#   if defined(THREAD_LOCAL_ALLOC) && !defined(USE_CUSTOM_SPECIFIC)
++    {
++      int res;
++
++      /* Some TLS implementations might be not fork-friendly, so    */
++      /* we re-assign thread-local pointer to 'tlfs' for safety     */
++      /* instead of the assertion check (again, it is OK to call    */
++      /* GC_destroy_thread_local and GC_free_inner before).         */
++      res = GC_setspecific(GC_thread_key, &me->tlfs);
++      if (COVERT_DATAFLOW(res) != 0)
++        ABORT("GC_setspecific failed (in child)");
++    }
+ #   endif
+ }
+ #endif /* CAN_HANDLE_FORK */
+diff --git a/specific.c b/specific.c
+index 1293d40b..09387ac3 100644
+--- a/specific.c
++++ b/specific.c
+@@ -133,33 +133,6 @@ GC_INNER void GC_remove_specific_after_fork(tsd * key, pthread_t t)
+       ABORT("pthread_mutex_unlock failed (remove_specific after fork)");
+ }
+ 
+-#ifdef CAN_HANDLE_FORK
+-  GC_INNER void
+-  GC_update_specific_after_fork(tsd *key)
+-  {
+-    unsigned hash_val = HASH(GC_parent_pthread_self);
+-    tse *entry;
+-
+-    GC_ASSERT(I_HOLD_LOCK());
+-#   ifdef LINT2
+-      pthread_mutex_lock(&key->lock);
+-#   endif
+-    entry = key->hash[hash_val].p;
+-    if (EXPECT(entry != NULL, TRUE)) {
+-      GC_ASSERT(THREAD_EQUAL(entry->thread, GC_parent_pthread_self));
+-      GC_ASSERT(NULL == entry->next);
+-      /* Remove the entry from the table. */
+-      key->hash[hash_val].p = NULL;
+-      entry->thread = pthread_self();
+-      /* Then put the entry back to the table (based on new hash value). */
+-      key->hash[HASH(entry->thread)].p = entry;
+-    }
+-#   ifdef LINT2
+-      (void)pthread_mutex_unlock(&key->lock);
+-#   endif
+-  }
+-#endif
+-
+ /* Note that even the slow path doesn't lock.   */
+ GC_INNER void * GC_slow_getspecific(tsd * key, word qtid,
+                                     tse * volatile * cache_ptr)
+-- 
+2.51.1
+

--- a/runtime-common/gc/autobuild/patches/0003-AOSCOS-Revert-Fix-pthread-id-stored-in-GC_threads-of.patch
+++ b/runtime-common/gc/autobuild/patches/0003-AOSCOS-Revert-Fix-pthread-id-stored-in-GC_threads-of.patch
@@ -1,0 +1,153 @@
+From f2ec374b22ef3e1631fc87d5dd9fb6ef10acb5e4 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sun, 16 Nov 2025 12:51:53 +0800
+Subject: [PATCH 3/3] AOSCOS: Revert "Fix pthread id stored in GC_threads of
+ child process"
+
+This reverts commit 74fc05d128c4ad9860740d73b4c7fd43ea18e74a.
+
+Link: https://github.com/bdwgc/bdwgc/issues/783#issuecomment-3433334711
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ pthread_support.c | 84 +++++++++++++++++------------------------------
+ 1 file changed, 30 insertions(+), 54 deletions(-)
+
+diff --git a/pthread_support.c b/pthread_support.c
+index 3a4b22b1..3d85bc59 100644
+--- a/pthread_support.c
++++ b/pthread_support.c
+@@ -829,28 +829,47 @@ GC_API void GC_CALL GC_register_altstack(void *stack, GC_word stack_size,
+     GC_threads[hv] = me;
+   }
+ 
+-/* Value of pthread_self() of the thread which called fork(). */
+-STATIC pthread_t GC_parent_pthread_self;
+-
+-/* Remove all entries from the GC_threads table, except the one for */
+-/* the current thread.  Also update thread identifiers stored in    */
+-/* the table for the current thread.  We need to do this in the     */
+-/* child process after a fork(), since only the current thread      */
+-/* survives in the child.                                           */
++/* Remove all entries from the GC_threads table, except the     */
++/* one for the current thread.  We need to do this in the child */
++/* process after a fork(), since only the current thread        */
++/* survives in the child.                                       */
+ STATIC void GC_remove_all_threads_but_me(void)
+ {
++    pthread_t self = pthread_self();
+     int hv;
+-    GC_thread me = NULL;
+ 
+     for (hv = 0; hv < THREAD_TABLE_SZ; ++hv) {
+       GC_thread p, next;
++      GC_thread me = NULL;
+ 
+       for (p = GC_threads[hv]; 0 != p; p = next) {
+         next = p -> next;
+-        if (THREAD_EQUAL(p -> id, GC_parent_pthread_self)
++        if (THREAD_EQUAL(p -> id, self)
+             && me == NULL) { /* ignore dead threads with the same id */
+           me = p;
+           p -> next = 0;
++#         ifdef GC_DARWIN_THREADS
++            /* Update thread Id after fork (it is OK to call    */
++            /* GC_destroy_thread_local and GC_free_inner        */
++            /* before update).                                  */
++            me -> stop_info.mach_thread = mach_thread_self();
++#         endif
++#         ifdef USE_TKILL_ON_ANDROID
++            me -> kernel_id = gettid();
++#         endif
++#         if defined(THREAD_LOCAL_ALLOC) && !defined(USE_CUSTOM_SPECIFIC)
++          {
++            int res;
++
++            /* Some TLS implementations might be not fork-friendly, so  */
++            /* we re-assign thread-local pointer to 'tlfs' for safety   */
++            /* instead of the assertion check (again, it is OK to call  */
++            /* GC_destroy_thread_local and GC_free_inner before).       */
++            res = GC_setspecific(GC_thread_key, &me->tlfs);
++            if (COVERT_DATAFLOW(res) != 0)
++              ABORT("GC_setspecific failed (in child)");
++          }
++#         endif
+         } else {
+ #         ifdef THREAD_LOCAL_ALLOC
+             if (!(p -> flags & FINISHED)) {
+@@ -870,44 +889,8 @@ STATIC void GC_remove_all_threads_but_me(void)
+ #         endif
+         }
+       }
+-      store_to_threads_table(hv, NULL);
+-    }
+-
+-#   if defined(CPPCHECK) || defined(LINT2)
+-      if (NULL == me)
+-        ABORT("Current thread is not found after fork");
+-#   else
+-      GC_ASSERT(me != NULL);
+-#   endif
+-    /* Update pthread's id as it is not guaranteed to be the same   */
+-    /* between this (child) process and the parent one.             */
+-    me -> id = pthread_self();
+-#   ifdef GC_DARWIN_THREADS
+-      /* Update thread Id after fork (it is OK to call  */
+-      /* GC_destroy_thread_local and GC_free_inner      */
+-      /* before update).                                */
+-      me -> stop_info.mach_thread = mach_thread_self();
+-#   endif
+-#   ifdef USE_TKILL_ON_ANDROID
+-      me -> kernel_id = gettid();
+-#   endif
+-
+-    /* Put "me" back to GC_threads.     */
+-    store_to_threads_table(THREAD_TABLE_INDEX(me -> id), me);
+-
+-#   if defined(THREAD_LOCAL_ALLOC) && !defined(USE_CUSTOM_SPECIFIC)
+-    {
+-      int res;
+-
+-      /* Some TLS implementations might be not fork-friendly, so    */
+-      /* we re-assign thread-local pointer to 'tlfs' for safety     */
+-      /* instead of the assertion check (again, it is OK to call    */
+-      /* GC_destroy_thread_local and GC_free_inner before).         */
+-      res = GC_setspecific(GC_thread_key, &me->tlfs);
+-      if (COVERT_DATAFLOW(res) != 0)
+-        ABORT("GC_setspecific failed (in child)");
++      store_to_threads_table(hv, me);
+     }
+-#   endif
+ }
+ #endif /* CAN_HANDLE_FORK */
+ 
+@@ -1214,7 +1197,6 @@ static void fork_prepare_proc(void)
+     /* the (one remaining thread in) the child.                         */
+       LOCK();
+       DISABLE_CANCEL(fork_cancel_state);
+-      GC_parent_pthread_self = pthread_self();
+                 /* Following waits may include cancellation points. */
+ #     if defined(PARALLEL_MARK)
+         if (GC_parallel)
+@@ -1255,9 +1237,6 @@ static void fork_parent_proc(void)
+       }
+ #   endif
+     RESTORE_CANCEL(fork_cancel_state);
+-#   ifdef GC_ASSERTIONS
+-      BZERO(&GC_parent_pthread_self, sizeof(pthread_t));
+-#   endif
+     UNLOCK();
+ }
+ 
+@@ -1305,9 +1284,6 @@ static void fork_child_proc(void)
+     /* Clean up the thread table, so that just our thread is left.      */
+     GC_remove_all_threads_but_me();
+     RESTORE_CANCEL(fork_cancel_state);
+-#   ifdef GC_ASSERTIONS
+-      BZERO(&GC_parent_pthread_self, sizeof(pthread_t));
+-#   endif
+     UNLOCK();
+     /* Even though after a fork the child only inherits the single      */
+     /* thread that called the fork(), if another thread in the parent   */
+-- 
+2.51.1
+

--- a/runtime-common/gc/spec
+++ b/runtime-common/gc/spec
@@ -1,4 +1,5 @@
 VER=8.2.10
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/bdwgc/bdwgc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=876"


### PR DESCRIPTION
Topic Description
-----------------

- gc: revert two patches to fix crash with Glycin and Inkscape
    - Clean up build scripts, replacing all sed\(1\) invocations with a patch.
    - Drop unused patch script.
    - Clean up dependencies.
    - Improve PKGDES.
    - Add PKGPROV to bdwgc.
    - Track patches at AOSC-Tracking/bdwgc @ aosc/v8.2.10
    \(HEAD: f2ec374b22ef3e1631fc87d5dd9fb6ef10acb5e4\).
    Link: https://github.com/bdwgc/bdwgc/issues/783#issuecomment-3433334711

Package(s) Affected
-------------------

- gc: 8.2.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
