### PR TITLE
imv: update to 5.0.0

### DIFF
--- a/app-imaging/imv/autobuild/defines
+++ b/app-imaging/imv/autobuild/defines
@@ -2,9 +2,11 @@ PKGNAME=imv
 PKGSEC=x11
 PKGDEP="wayland xorg-server glu libxcb libxkbcommon pango inih \
     cairo egl-wayland eglexternalplatform librsvg libheif libtiff \
-    libjxl libpng libjpeg-turbo libnsgif glibc"
-BUILDDEP="meson ninja asciidoc"
-PKGDES="A command-line image viewer"
+    libjxl libpng libjpeg-turbo libnsgif glibc libnsbmp libwebp"
+BUILDDEP="meson ninja asciidoc qoi"
+PKGDES="Command-line image viewer"
 
 ABTYPE=meson
-MESON_AFTER="-Dman=enabled"
+MESON_AFTER=(
+    '-Dman=enabled'
+)

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,5 +1,4 @@
-VER=4.5.0
-REL=6
+VER=5.0.0
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"

--- a/runtime-common/qoi/autobuild/build
+++ b/runtime-common/qoi/autobuild/build
@@ -1,0 +1,3 @@
+abinfo "Installing qoi.h header ..."
+install -Dvm644 "$SRCDIR"/qoi.h \
+    -t "$PKGDIR"/usr/include/

--- a/runtime-common/qoi/autobuild/defines
+++ b/runtime-common/qoi/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=qoi
+PKGSEC=libs
+PKGDES="Header for \"Quite OK Image Format\" lossless image compression"
+# it's just header
+PKGDEP=""
+
+# just header
+ABHOST=noarch

--- a/runtime-common/qoi/spec
+++ b/runtime-common/qoi/spec
@@ -1,0 +1,5 @@
+VER=0+git20251113
+SRCS="git::commit=44b233a95eda82fbd2e39a269199b73af0f4c4c3::https://github.com/phoboslab/qoi.git"
+CHKSUMS="SKIP"
+# FIXME: Upstream did not release any version
+# CHKUPDATE=""


### PR DESCRIPTION
Topic Description
-----------------

- imv: update to 5.0.0
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- imv: 5.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qoi imv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
