### PR TITLE
osu-lazer: update to 2025.1029.1

### DIFF
--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=2025.816.0-lazer
+UPSTREAM_VER=2025.1029.1-lazer
 VER=${UPSTREAM_VER/-lazer/}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/ppy/osu"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2025.1029.1
    Co-authored-by: 董冠泽 \(@grayawa\)

Package(s) Affected
-------------------

- osu-lazer: 2025.1029.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
