### PR TITLE
arise-linux-graphics-driver-dri: new, 25.00.45 (loongarch64: 25.00.46)

### DIFF
--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/build
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/build
@@ -1,0 +1,43 @@
+abinfo "Setting DEB_CHOST ..."
+if ab_match_arch amd64; then
+    DEB_CHOST="x86_64-linux-gnu"
+elif ab_match_arch arm64; then
+    DEB_CHOST="aarch64-linux-gnu"
+elif ab_match_arch loongarch64; then
+    DEB_CHOST="loongarch64-linux-gnu"
+fi
+
+abinfo "Installing module sources ..."
+install -vd "$PKGDIR"/usr/src
+cp -av "$SRCDIR"/usr/src/arise-"$PKGVER" "$PKGDIR"/usr/src
+
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib
+cp -av "$SRCDIR"/usr/lib/${DEB_CHOST}/* \
+    -t "$PKGDIR"/usr/lib/
+
+abinfo "Installing X.Org driver ..."
+cp -av "$SRCDIR"/usr/lib/xorg \
+    -t "$PKGDIR"/usr/lib/
+
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x \
+    "$PKGDIR"/usr/lib/**/*.so*
+
+abinfo "Installing shared data ..."
+install -vd "$PKGDIR"/usr/share
+# Note: GLVND configuration is maintained in overrides as it
+# requires generation via postinst in the original package.
+cp -av "$SRCDIR"/usr/share/{drirc.d,X11} \
+    "$PKGDIR"/usr/share/
+
+abinfo "Installing OpenCL ICD ..."
+install -vd "$PKGDIR"/etc
+cp -av "$SRCDIR"/etc/OpenCL \
+    "$PKGDIR"/etc/
+
+abinfo "Running ldconfig to create missing symlinks ..."
+ldconfig \
+    -r "$PKGDIR"/ \
+    -N \
+    --verbose

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/defines
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=arise-linux-graphics-driver-dri
+PKGSEC=libs
+PKGDEP="glibc gcc-runtime dracut dkms libdrm libglvnd mesa x11-lib libxcb wayland"
+PKGDES="Graphics driver for Glenfly Arise 1000 and 2000 series"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: Architecture-specific binaries.
+FAIL_ARCH="!(amd64|arm64|loongarch64)"
+ABSPLITDBG=0

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0001-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0001-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,0 +1,28 @@
+From bee07f9ad7cf8f5cea384b40db4e896a02e27bf1 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 12 Nov 2025 18:42:34 +0800
+Subject: [PATCH 1/9] chore: import .gitignore from loonggpu-kernel-dkms
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ .gitignore | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..223542a
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,8 @@
++*.o
++*.ko
++*.mod
++*.mod.c
++*.cmd
++*.symvers
++*.order
++conftest
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0002-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0002-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
@@ -1,0 +1,71 @@
+From dac246efaf62b1e5bbb1c2bbb7bc70c1b8372bf6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 7 Nov 2025 23:50:09 +0800
+Subject: [PATCH 2/9] AOSCOS: fix(dkms.conf): drop check_gcc_version()
+
+Not even sure why it's here. Drop it.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 47 +----------------------------------------------
+ 1 file changed, 1 insertion(+), 46 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 7e4661c..80e9d9a 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -19,50 +19,5 @@ num_cpu_cores()
+ 	fi
+ }
+ 
+-check_gcc_version()
+-{
+-local KERNEL_UNAME=`uname -r`
+-local KERNEL_MODLIB=/lib/modules/${KERNEL_UNAME}
+-local KERNEL_SOURCES=`test -d ${KERNEL_MODLIB}/source && echo ${KERNEL_MODLIB}/source || echo ${KERNEL_MODLIB}/build`
+-local KERNEL_COMPILE_H=${KERNEL_SOURCES}/include/generated/compile.h
+-
+-	if [ -f ${KERNEL_COMPILE_H} ];then
+-
+-		# Try to get all installed gcc list
+-		local SYSTEM_GCC_LIST=`ls /usr/bin/gcc-[0-9]* | xargs -n1 | sort -u`
+-
+-		# Try to get current GCC version, some GCC version string only hava major.minor
+-		local SYSTEM_GCC_VERSION=`gcc -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-		if [ -z "$SYSTEM_GCC_VERSION" ];then
+-			SYSTEM_GCC_VERSION=`gcc -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-		fi
+-
+-		# Get version string from 'compile.h', some GCC version string only hava major.minor
+-		local KERNEL_BUILT_GCC_STRING=`cat ${KERNEL_COMPILE_H} | grep LINUX_COMPILER | cut -f 2 -d '"'`
+-		local KERNEL_BUILT_GCC_VERSION=`echo "${KERNEL_BUILT_GCC_STRING}" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-		if [ -z "$KERNEL_BUILT_GCC_VERSION" ];then
+-			KERNEL_BUILT_GCC_VERSION=`echo "${KERNEL_BUILT_GCC_STRING}" | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-		fi
+-
+-		# Checking GCC version and assign gcc by 'CC=' here
+-		if [ "$KERNEL_BUILT_GCC_VERSION" != "$SYSTEM_GCC_VERSION" ];then
+-			for TARGET_GCC_PATH in $SYSTEM_GCC_LIST;
+-			do
+-				local TARGET_GCC_VERSION=`$TARGET_GCC_PATH -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-				if [ -z "$TARGET_GCC_VERSION" ];then
+-					TARGET_GCC_VERSION=`$TARGET_GCC_PATH -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-				fi
+-
+-				if [ "$KERNEL_BUILT_GCC_VERSION" = "$TARGET_GCC_VERSION" ];then
+-					echo "CC=$TARGET_GCC_PATH"
+-					break;
+-				fi
+-			done
+-		fi
+-
+-	fi
+-
+-}
+-
+-MAKE[0]="make $(check_gcc_version) -j$(num_cpu_cores) -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
++MAKE[0]="make -j$(num_cpu_cores) -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
+ #POST_REMOVE="post-remove.sh $kernelver"
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0003-AOSCOS-fix-dkms.conf-drop-unused-options.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0003-AOSCOS-fix-dkms.conf-drop-unused-options.patch
@@ -1,0 +1,26 @@
+From d43e19c47cee191687c1cad26f2f41858e50488c Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 12:30:19 +0800
+Subject: [PATCH 3/9] AOSCOS: fix(dkms.conf): drop unused options
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 80e9d9a..37d500c 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -1,8 +1,6 @@
+ PACKAGE_NAME="arise"
+ PACKAGE_VERSION=25.00.45
+ AUTOINSTALL="yes"
+-#REMAKE_INITRD="yes"
+-SKIP_IMMD_MODPROBE=1
+ 
+ BUILT_MODULE_NAME[0]="arise"
+ BUILT_MODULE_LOCATION[0]=""
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0004-AOSCOS-fix-adapt-to-timer-changes-in-6.16.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0004-AOSCOS-fix-adapt-to-timer-changes-in-6.16.patch
@@ -1,0 +1,34 @@
+From ae160903d9e77502afe525be0fc21d12c638aa52 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:48:50 +0800
+Subject: [PATCH 4/9] AOSCOS: fix: adapt to timer changes in 6.16
+
+In the 6.16 cycle, upstream renamed `from_timer()' to
+`timer_container_of()' in commit 41cb08555c41 ("treewide, timers: Rename
+from_timer() to timer_container_of()").
+
+Follow this change and rename said function.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_disp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/linux/gf_disp.c b/linux/gf_disp.c
+index 5664c3c..0e8dfe4 100644
+--- a/linux/gf_disp.c
++++ b/linux/gf_disp.c
+@@ -1347,7 +1347,9 @@ void gf_disp_state_timer_fn(struct timer_list *t)
+ void gf_disp_state_timer_fn(unsigned long data)
+ #endif
+ {
+-#if DRM_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++    disp_state_info_t *pstate_info = timer_container_of(pstate_info, t, state_timer);
++#elif DRM_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+     disp_state_info_t *pstate_info = from_timer(pstate_info, t, state_timer);
+ #else
+     disp_state_info_t *pstate_info  = (disp_state_info_t  *)data;
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0005-AOSCOS-fix-adapt-to-drm_framebuffer-changes-in-6.17.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0005-AOSCOS-fix-adapt-to-drm_framebuffer-changes-in-6.17.patch
@@ -1,0 +1,91 @@
+From 7f58d640a09b830fe9b5047d1e7ad3f64a43cb48 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:52:01 +0800
+Subject: [PATCH 5/9] AOSCOS: fix: adapt to drm_framebuffer changes in 6.17
+
+With commit 81112eaac559 ("drm: Pass the format info to .fb_create()"),
+an additional parameter format_info was added to the
+drm_helper_mode_fill_fb_struct() function call.
+
+Follow suit to fix build with kernels >= 6.17.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_drmfb.c | 14 +++++++++++++-
+ linux/gf_drmfb.h |  6 ++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/linux/gf_drmfb.c b/linux/gf_drmfb.c
+index 3769cc8..3c731ff 100644
+--- a/linux/gf_drmfb.c
++++ b/linux/gf_drmfb.c
+@@ -61,6 +61,9 @@ static const struct drm_framebuffer_funcs gf_fb_funcs =
+ struct drm_gf_framebuffer*
+ __gf_framebuffer_create(struct drm_device *dev,
+                         struct drm_mode_fb_cmd2 *mode_cmd,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                        const struct drm_format_info *format_info,
++#endif
+                         struct drm_gf_gem_object *obj)
+ {
+     int ret;
+@@ -71,8 +74,10 @@ __gf_framebuffer_create(struct drm_device *dev,
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
+     drm_helper_mode_fill_fb_struct(&gfb->base, mode_cmd);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+     drm_helper_mode_fill_fb_struct(dev, &gfb->base, mode_cmd);
++#elif DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    drm_helper_mode_fill_fb_struct(dev, &gfb->base, format_info, mode_cmd);
+ #endif
+     gfb->obj = obj;
+ 
+@@ -89,6 +94,9 @@ err_free:
+ struct drm_framebuffer *
+ gf_fb_create(struct drm_device *dev,
+               struct drm_file *file,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++              const struct drm_format_info *format_info,
++#endif
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && !defined (PHYTIUM_2000)
+               struct drm_mode_fb_cmd2 *user_mode_cmd
+ #else
+@@ -104,7 +112,11 @@ gf_fb_create(struct drm_device *dev,
+     if (!obj)
+         return ERR_PTR(-ENOENT);
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    fb = __gf_framebuffer_create(dev, &mode_cmd, format_info, obj);
++#else
+     fb = __gf_framebuffer_create(dev, &mode_cmd, obj);
++#endif
+     if (IS_ERR(fb))
+         gf_gem_object_put(obj);
+ 
+diff --git a/linux/gf_drmfb.h b/linux/gf_drmfb.h
+index e3c6304..3ae1d82 100644
+--- a/linux/gf_drmfb.h
++++ b/linux/gf_drmfb.h
+@@ -41,6 +41,9 @@ struct drm_gf_framebuffer
+ struct drm_framebuffer *
+ gf_fb_create(struct drm_device *dev,
+                               struct drm_file *file_priv,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                              const struct drm_format_info *format_info,
++#endif
+                               #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)  || defined (PHYTIUM_2000)
+                               const struct drm_mode_fb_cmd2 *mode_cmd
+                               #else
+@@ -53,5 +56,8 @@ void gf_cleanup_fb(struct drm_plane *plane,  struct drm_plane_state *old_state);
+ struct drm_gf_framebuffer*
+ __gf_framebuffer_create(struct drm_device *dev,
+                         struct drm_mode_fb_cmd2 *mode_cmd,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                        const struct drm_format_info *format_info,
++#endif
+                         struct drm_gf_gem_object *obj);
+ #endif
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0006-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0006-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
@@ -1,0 +1,33 @@
+From 94cee0e22812ca44dcda149e93a07629b7673bb5 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:52:26 +0800
+Subject: [PATCH 6/9] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
+ 6.17
+
+Follow commit 21aa65bf82a7 ("mm: remove callers of pfn_t functionality")
+and remove all usage of linux/pfn_t.h there.
+
+The rest of the code already works with >= 6.17.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_gem_priv.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/linux/gf_gem_priv.h b/linux/gf_gem_priv.h
+index e179785..4c2c64c 100644
+--- a/linux/gf_gem_priv.h
++++ b/linux/gf_gem_priv.h
+@@ -39,7 +39,8 @@
+ #include "gf_gem_debug.h"
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
+-    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && !defined(YHQILIN)
++    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && !defined(YHQILIN) && \
++    DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ #include <linux/pfn_t.h>
+ #else
+ typedef struct {
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0007-AOSCOS-fix-adapt-to-sysfs-changes-in-6.16.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0007-AOSCOS-fix-adapt-to-sysfs-changes-in-6.16.patch
@@ -1,0 +1,41 @@
+From d5167231f75e05651f0bdf37226f11f5e7a0b0f0 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:55:26 +0800
+Subject: [PATCH 7/9] AOSCOS: fix: adapt to sysfs changes in 6.16
+
+In the 6.16 cycle, upstream consified the `bin_attribute' argument of
+`bin_attribute::read/write()' in commit 97d06802d10a ("sysfs: constify
+bin_attribute argument of bin_attribute::read/write()").
+
+Follow suit and adapt to this change.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_sysfs.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/linux/gf_sysfs.c b/linux/gf_sysfs.c
+index 6331b3a..4e48221 100644
+--- a/linux/gf_sysfs.c
++++ b/linux/gf_sysfs.c
+@@ -766,7 +766,7 @@ const struct attribute *gf_os_gpu_info[] = {
+     NULL
+ };
+ 
+-static ssize_t gf_sysfs_trace_read(struct file *filp, struct kobject *kobj, struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
++static ssize_t gf_sysfs_trace_read(struct file *filp, struct kobject *kobj, const struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
+ {
+     struct pci_dev*    pdev    = to_pci_dev(container_of(kobj,struct device,kobj));
+     struct drm_device* drm_dev = pci_get_drvdata(pdev);
+@@ -785,7 +785,7 @@ static ssize_t gf_sysfs_trace_read(struct file *filp, struct kobject *kobj, stru
+     return ret;
+ }
+ 
+-static ssize_t gf_sysfs_trace_write(struct file *filp, struct kobject *kobj, struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
++static ssize_t gf_sysfs_trace_write(struct file *filp, struct kobject *kobj, const struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
+ {
+     struct pci_dev*    pdev    = to_pci_dev(container_of(kobj,struct device,kobj));
+     struct drm_device* drm_dev = pci_get_drvdata(pdev);
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0008-AOSCOS-fix-drop-TARGET_ARCH-from-Makefile.patch.amd64
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0008-AOSCOS-fix-drop-TARGET_ARCH-from-Makefile.patch.amd64
@@ -1,0 +1,24 @@
+From a268c867e6716b8b3a3b59084dc9835198c3cea6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 18:14:43 +0800
+Subject: [PATCH 8/9] AOSCOS: fix: drop TARGET_ARCH from Makefile
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 2e58807..1370eb9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,5 @@
+ CHIP?=E3k
+ DRIVER_NAME?=arise
+-TARGET_ARCH?=x86_64
+ DEBUG?=0
+ VIDEO_ONLY_FPGA?=0
+ RUN_HW_NULL?=0
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0008-AOSCOS-fix-drop-TARGET_ARCH-from-Makefile.patch.arm64
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0008-AOSCOS-fix-drop-TARGET_ARCH-from-Makefile.patch.arm64
@@ -1,0 +1,24 @@
+From a268c867e6716b8b3a3b59084dc9835198c3cea6 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 18:14:43 +0800
+Subject: [PATCH 8/9] AOSCOS: fix: drop TARGET_ARCH from Makefile
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 2e58807..1370eb9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,5 @@
+ CHIP?=E3k
+ DRIVER_NAME?=arise
+-TARGET_ARCH?=aarch64
+ DEBUG?=0
+ VIDEO_ONLY_FPGA?=0
+ RUN_HW_NULL?=0
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0009-BACKPORT-AOCSOS-chore-import-v25.00.46-changes.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.45/0009-BACKPORT-AOCSOS-chore-import-v25.00.46-changes.patch
@@ -1,0 +1,909 @@
+From 6426cec3418ce1771e4106cc9fbe14fad5691840 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 18:13:38 +0800
+Subject: [PATCH 9/9] BACKPORT: AOCSOS: chore: import v25.00.46 changes
+
+This should enable support for Glenfly Arise 10C0t/10D0.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ cbios/Device/Monitor/CBiosEDPPanel.c       |   2 +-
+ cbios/Util/CBiosEDID.c                     |   2 +-
+ core/Makefile                              |   1 -
+ core/context/context.h                     |   2 +-
+ core/e3k/vidmm/vidmm_allocate_e3k.c        |   2 -
+ core/e3k/vidsch/vidsch_engine_submit_e3k.c |   9 --
+ core/global/global.c                       |   2 +
+ core/include/gf_chip_id.h                  |   2 +
+ core/perfevent/perfevent.c                 |  14 +--
+ core/util/bit_op.h                         |  32 ++++++
+ core/vidmm/vidmm.c                         |   6 +-
+ core/vidsch/vidsch.c                       |   4 +-
+ core/vidsch/vidsch_submit.c                |   3 +-
+ core/vidsch/vidsch_workerthread.c          |  10 +-
+ dkms.conf                                  |   2 +-
+ gf_version.h                               |   6 +-
+ linux/gf_cbios.c                           |  23 ++++
+ linux/gf_cbios.h                           |   2 +
+ linux/gf_disp.c                            |  16 +--
+ linux/gf_driver.c                          |   9 ++
+ linux/gf_encoder.c                         | 128 ++++++++++++++-------
+ linux/gf_kms.h                             |   2 +-
+ linux/gf_pcie.c                            |   9 ++
+ linux/gf_splice.c                          |  17 ++-
+ linux/os_interface.c                       |  26 ++++-
+ 25 files changed, 228 insertions(+), 103 deletions(-)
+
+diff --git a/cbios/Device/Monitor/CBiosEDPPanel.c b/cbios/Device/Monitor/CBiosEDPPanel.c
+index 2e12539..f2a90a3 100644
+--- a/cbios/Device/Monitor/CBiosEDPPanel.c
++++ b/cbios/Device/Monitor/CBiosEDPPanel.c
+@@ -36,7 +36,7 @@ static PCBIOS_EDP_PANEL_DESC EDPPanelDescTbl[] =
+ 
+ static CBIOS_BOOL cbEDPPanel_GetMonitorID(CBIOS_U8 *pEDID, CBIOS_U8 *pMnitorID)
+ {
+-    CBIOS_U8 index[32] = "0ABCDEFGHIJKLMNOPQRSTUVWXYZ[/]^_";
++    CBIOS_U8 *index = "0ABCDEFGHIJKLMNOPQRSTUVWXYZ[/]^_";
+     CBIOS_U8 ProductID[3] = {0};
+     CBIOS_BOOL bRet = CBIOS_FALSE;
+     CBIOS_U8 *pMonitorIDinEDID = pEDID + 0x08;
+diff --git a/cbios/Util/CBiosEDID.c b/cbios/Util/CBiosEDID.c
+index d5db8a4..d617449 100644
+--- a/cbios/Util/CBiosEDID.c
++++ b/cbios/Util/CBiosEDID.c
+@@ -2693,7 +2693,7 @@ Return:      CBIOS_TRUE if get monitor ID successfully
+ ***************************************************************/
+ CBIOS_BOOL cbEDIDModule_GetMonitorID(CBIOS_U8 *pEDID, CBIOS_U8 *pMonitorID)
+ {
+-    CBIOS_U8 index[32] = "0ABCDEFGHIJKLMNOPQRSTUVWXYZ[/]^_";
++    CBIOS_U8 *index = "0ABCDEFGHIJKLMNOPQRSTUVWXYZ[/]^_";
+     CBIOS_U8 ProductID[3] = {0};
+     CBIOS_BOOL bRet = CBIOS_FALSE;
+     CBIOS_U8 *pMonitorIDinEDID = pEDID + MONITORIDINDEX;
+diff --git a/core/Makefile b/core/Makefile
+index 821a86b..1be2485 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -6,7 +6,6 @@ ccflags-y += \
+     -I${GFGPU_FULL_PATH}/core/vidmm \
+     -I${GFGPU_FULL_PATH}/core/vidsch \
+     -I${GFGPU_FULL_PATH}/core/util \
+-    -I${GFGPU_FULL_PATH}/core/isr \
+     -I${GFGPU_FULL_PATH}/core/perfevent \
+     -I${GFGPU_FULL_PATH}/shared
+ 
+diff --git a/core/context/context.h b/core/context/context.h
+index fd3380f..66be62b 100644
+--- a/core/context/context.h
++++ b/core/context/context.h
+@@ -32,7 +32,7 @@
+ #define SYNCOBJECTLIST_SIZE     256
+ #define ALLOCATIONLIST_SIZE     (USER_MODE_DMA_SIZE / 64) * 4   /* Set to 2KB for every 64KB of command buffer to pass MaxContexts test */
+ #define PATCHLOCATIONLIST_SIZE  (USER_MODE_DMA_SIZE / 64) * 16   /* Set to 2KB for every 64KB of command buffer to pass MaxContexts test */
+-#define MAX_SYNC_OBJECT_SIZE_PER_DEVICE  512*4
++#define MAX_SYNC_OBJECT_SIZE_PER_DEVICE  64 * 1024
+ 
+ #ifdef GFX_ONLY_FPGA
+ #define CM_DESTROY_TIMEOUT       20000
+diff --git a/core/e3k/vidmm/vidmm_allocate_e3k.c b/core/e3k/vidmm/vidmm_allocate_e3k.c
+index 809670a..0d420ef 100644
+--- a/core/e3k/vidmm/vidmm_allocate_e3k.c
++++ b/core/e3k/vidmm/vidmm_allocate_e3k.c
+@@ -544,7 +544,6 @@ static void vidmmi_calc_allocation_pitch_e3k(vidmm_allocation_t *allocation)
+     unsigned int  TileWidth, TileHeight;
+     unsigned int  UnitWidth, UnitHeight;
+     unsigned int  P2Width0, P2Height0;
+-    unsigned int  UnitSize;
+     unsigned int  Pitch;
+     unsigned int  WidthAligned;
+     unsigned int  HeightAligned;
+@@ -552,7 +551,6 @@ static void vidmmi_calc_allocation_pitch_e3k(vidmm_allocation_t *allocation)
+     BitCount   = allocation->bit_count;
+     TileWidth  = calcTileWidth_e3k(BitCount);
+     TileHeight = calcTileHeight_e3k(BitCount);
+-    UnitSize   = UNIT_SIZE_E3K;
+     UnitWidth  = calcUnitWidth_e3k(BitCount);
+     UnitHeight = calcUnitHeight_e3k(BitCount);
+ 
+diff --git a/core/e3k/vidsch/vidsch_engine_submit_e3k.c b/core/e3k/vidsch/vidsch_engine_submit_e3k.c
+index 0a13d23..3f57169 100644
+--- a/core/e3k/vidsch/vidsch_engine_submit_e3k.c
++++ b/core/e3k/vidsch/vidsch_engine_submit_e3k.c
+@@ -303,7 +303,6 @@ static int enginei_submit_to_gfx_high_e3k(engine_e3k_t *engine, task_dma_t *task
+     unsigned int * pRB1 = NULL;
+     Cmd_Blk_Cmd_Csp_Indicator_Dword1 trigger_Dw = {0};
+     Csp_Opcodes_cmd         cmd                 = {0};
+-    unsigned int dwRealRBSize;
+     RINGBUFFER_COMMANDS_E3K *pRingBufferCommands = (RINGBUFFER_COMMANDS_E3K*)share->RingBufferCommands;
+     RB_PREDEFINE_DMA        *pPredefine         = (RB_PREDEFINE_DMA*)share->begin_end_vma->virt_addr;
+     CONTEXT_RESTORE_DMA_E3K *pRestoreDMA        = &(pPredefine->RestoreDMA);
+@@ -519,14 +518,6 @@ static int enginei_submit_to_gfx_high_e3k(engine_e3k_t *engine, task_dma_t *task
+     cmd.cmd_Tbr_Indicator.Indicator_Info = TBR_INDICATOR_INDICATOR_INFO_BEGIN;
+     *pRB++ = cmd.uint;
+ 
+-    dwRealRBSize = pRB - pRB0;
+-
+-//    dwAlignRBSize = (((dwRealRBSize) + 15) & ~15);
+-//    if (dwAlignRBSize != dwRbSize)
+-//    {
+-//        *pRB++ = SEND_SKIP_E3K(dwRbSize - dwRealRBSize);
+-//    }
+-
+     gf_memcpy(pRB1, pRB0, (dwRbSize<<2));
+     //util_dump_memory(pRB1, dwRbSize<<2, "high dma in rb");
+ 
+diff --git a/core/global/global.c b/core/global/global.c
+index 61a0784..de54c27 100644
+--- a/core/global/global.c
++++ b/core/global/global.c
+@@ -90,6 +90,8 @@ void glb_init_chip_id(adapter_t *adapter, krnl_adapter_init_info_t *info)
+             adapter->chip_id = CHIP_ARISE1010;
+         else if((adapter->bus_config.device_id & CHIP_MASK) == CHIP_MASK_ARISE10C0T)
+             adapter->chip_id = CHIP_ARISE10C0T;
++        else if((adapter->bus_config.device_id & CHIP_MASK) == CHIP_MASK_ARISE10D0)
++            adapter->chip_id = CHIP_ARISE10C0T;
+         else if((adapter->bus_config.device_id & CHIP_MASK) == CHIP_MASK_ARISE2030)
+             adapter->chip_id = CHIP_ARISE2030;
+         else if((adapter->bus_config.device_id & CHIP_MASK) == CHIP_MASK_ARISE2020)
+diff --git a/core/include/gf_chip_id.h b/core/include/gf_chip_id.h
+index 7f45e40..2847f65 100644
+--- a/core/include/gf_chip_id.h
++++ b/core/include/gf_chip_id.h
+@@ -40,6 +40,7 @@
+ #define PCI_ID_ARISE1010   0x3D04 //ARISE1010
+ #define PCI_ID_ARISE2030   0x3D07 //ARISE2030
+ #define PCI_ID_ARISE2020   0x3D08 //ARISE2020
++#define PCI_ID_ARISE10D0   0x3D0E //ARISE10D0
+ 
+ #define PCI_ID_GENERIC_EXCALIBUR   PCI_ID_EXC2UMA
+ #define PCI_ID_GENERIC_ELITE       PCI_ID_ELT
+@@ -72,6 +73,7 @@
+ #define CHIP_MASK_ARISE10C0T    (PCI_ID_ARISE10C0T & CHIP_MASK)
+ #define CHIP_MASK_ARISE2030     (PCI_ID_ARISE2030 & CHIP_MASK)
+ #define CHIP_MASK_ARISE2020     (PCI_ID_ARISE2020 & CHIP_MASK)
++#define CHIP_MASK_ARISE10D0     (PCI_ID_ARISE10D0 & CHIP_MASK)
+ 
+ enum
+ {
+diff --git a/core/perfevent/perfevent.c b/core/perfevent/perfevent.c
+index 6c7760e..e77cca0 100644
+--- a/core/perfevent/perfevent.c
++++ b/core/perfevent/perfevent.c
+@@ -401,7 +401,6 @@ int perf_event_get_miu_event(adapter_t *adapter, gf_get_miu_dump_perf_event_t *g
+     perf_event_mgr_t *perf_event_mgr    = adapter->perf_event_mgr;
+     perf_event_node *event_node         = NULL;
+     perf_event_node *event_node_next    = NULL;
+-    gf_perf_event_header_t *perf_event = NULL;
+     int event_fill_num                  = 0;
+     char *dst_buf                       = get_perf_event->event_buffer;
+ 
+@@ -440,8 +439,6 @@ int perf_event_get_miu_event(adapter_t *adapter, gf_get_miu_dump_perf_event_t *g
+         gf_copy_to_user(dst_buf, &event_node->perf_event, event_node->perf_event.size);
+         dst_buf += event_node->perf_event.size;
+ 
+-        perf_event = &event_node->perf_event;
+-
+         list_del(&event_node->list_node);
+ 
+         gf_free(event_node);
+@@ -482,7 +479,6 @@ int perf_event_get_event(adapter_t *adapter, gf_get_perf_event_t *get_perf_event
+     int i = 0;
+     int ret = 0;
+     char *dst_buf = get_perf_event->event_buffer;
+-    gf_perf_event_header_t *perf_event;
+ 
+     perf_event_trace("perf_event_get_event enter\n");
+ 
+@@ -517,8 +513,6 @@ int perf_event_get_event(adapter_t *adapter, gf_get_perf_event_t *get_perf_event
+         gf_copy_to_user(dst_buf, &event_node->perf_event, event_node->perf_event.size);
+         dst_buf += event_node->perf_event.size;
+ 
+-        perf_event = &event_node->perf_event;
+-
+         list_del(&event_node->list_node);
+ 
+         gf_free(event_node);
+@@ -930,8 +924,12 @@ int hwq_process_vsync_event(adapter_t *adapter, unsigned long long time)
+             }
+             p_hwq_event->idle_time+=(e_idle_time - s_idle_time);
+         }
+-        p_hwq_event->engine_usage = 100 - gf_do_div(p_hwq_event->idle_time*100, time - hwq_event_mgr->start_time);
+-        //gf_info("\n EngineNum=%d engine_usage ALL=%llu%%\n",engine,p_hwq_event->engine_usage);
++
++        if (time != hwq_event_mgr->start_time)
++        {
++            p_hwq_event->engine_usage = 100 - gf_do_div(p_hwq_event->idle_time*100, time - hwq_event_mgr->start_time);
++            //gf_info("\n EngineNum=%d engine_usage ALL=%llu%%\n",engine,p_hwq_event->engine_usage);
++        }
+ 
+         p_hwq_event->idle_time=0;
+         p_hwq_event->engine_status.active=0;
+diff --git a/core/util/bit_op.h b/core/util/bit_op.h
+index 1519bbc..be3cc5c 100644
+--- a/core/util/bit_op.h
++++ b/core/util/bit_op.h
+@@ -31,6 +31,36 @@
+ 
+ #define VERIFY_BIT_OP 0
+ 
++#if defined(__riscv)
++static inline int ffs(int x)
++{
++    int r = 1;
++
++    if (!x)
++        return 0;
++    if (!(x & 0xffff)) {
++        x >>= 16;
++        r += 16;
++    }
++    if (!(x & 0xff)) {
++        x >>= 8;
++        r += 8;
++    }
++    if (!(x & 0xf)) {
++        x >>= 4;
++        r += 4;
++    }
++    if (!(x & 3)) {
++        x >>= 2;
++        r += 2;
++    }
++    if (!(x & 1)) {
++        x >>= 1;
++        r += 1;
++    }
++    return r;
++}
++#endif
+ 
+ static __inline__ unsigned char _BitScanForward(volatile unsigned int *Index, unsigned int Mask)
+ {
+@@ -48,6 +78,8 @@ static __inline__ unsigned char _BitScanForward(volatile unsigned int *Index, un
+        :"=r"(Mask)
+        :"r" (Mask)
+        );
++#elif defined(__riscv)
++    Mask = ffs(Mask)-1;
+ #else
+     Mask = __builtin_ffs(Mask)-1;
+ #endif
+diff --git a/core/vidmm/vidmm.c b/core/vidmm/vidmm.c
+index 78ed75a..a65ca76 100644
+--- a/core/vidmm/vidmm.c
++++ b/core/vidmm/vidmm.c
+@@ -744,9 +744,9 @@ int vidmm_save(adapter_t *adapter)
+ 
+     if (!adapter->fence_buf->reserved_memory->pages_mem)
+     {
+-        adapter->fence_buf->backup = gf_malloc(68 * 1024);
++        adapter->fence_buf->backup = gf_malloc(512 * 1024);
+         if (adapter->fence_buf->backup)
+-            gf_memcpy(adapter->fence_buf->backup, adapter->fence_buf->reserved_memory->vma->virt_addr, 68 * 1024);
++            gf_memcpy(adapter->fence_buf->backup, adapter->fence_buf->reserved_memory->vma->virt_addr, 512 * 1024);
+     }
+ 
+     return result;
+@@ -806,7 +806,7 @@ void vidmm_restore(adapter_t *adapter)
+ 
+     if (adapter->fence_buf->backup)
+     {
+-        gf_memcpy(adapter->fence_buf->reserved_memory->vma->virt_addr, adapter->fence_buf->backup, 68 * 1024);
++        gf_memcpy(adapter->fence_buf->reserved_memory->vma->virt_addr, adapter->fence_buf->backup, 512 * 1024);
+         gf_free(adapter->fence_buf->backup);
+     }
+ 
+diff --git a/core/vidsch/vidsch.c b/core/vidsch/vidsch.c
+index 34788e3..0b5e947 100644
+--- a/core/vidsch/vidsch.c
++++ b/core/vidsch/vidsch.c
+@@ -84,7 +84,7 @@ int vidsch_create(adapter_t *adapter)
+ 
+     adapter->active_engine_count = query_data.engine_count;
+ 
+-    adapter->fence_buf = vidschi_create_fence_buffer(adapter, query_data.fence_buffer_segment_id, 68*1024);
++    adapter->fence_buf = vidschi_create_fence_buffer(adapter, query_data.fence_buffer_segment_id, 512 * 1024);
+     adapter->fence_buf_local = vidschi_create_fence_buffer(adapter, 0x1, 68*1024);
+     adapter->fence_buf_snoop = vidschi_create_fence_buffer(adapter, 0x3, 68*1024);
+ 
+@@ -720,7 +720,7 @@ static vidsch_fence_buffer_t *vidschi_create_fence_buffer(adapter_t *adapter, un
+     vidsch_fence_buffer_t   *fence_buf       = gf_calloc(sizeof(vidsch_fence_buffer_t));
+     vidmm_segment_memory_t  *reserved_memory = NULL;
+     vidmm_map_flags_t        map_flags       = {0};
+-    unsigned short           total_num       = 0;
++    unsigned int           total_num       = 0;
+ 
+     reserved_memory = vidmm_allocate_segment_memory(adapter, segment_id, buffer_size, 0);
+ 
+diff --git a/core/vidsch/vidsch_submit.c b/core/vidsch/vidsch_submit.c
+index 99d8ba7..2b929dd 100644
+--- a/core/vidsch/vidsch_submit.c
++++ b/core/vidsch/vidsch_submit.c
+@@ -36,7 +36,7 @@ static int vidschi_submit_dma(vidsch_mgr_t *sch_mgr, task_dma_t *task_dma)
+     gpu_context_t           *context       = task_dma->desc.context;
+     vidmm_allocation_t      *mm_allocation = NULL;
+     vidsch_allocation_t     *sch_allocation = NULL;
+-    unsigned long long      fence_id, last_send_fence_id;
++    unsigned long long      fence_id;
+     int                      i, ret = S_OK;
+ 
+     gf_down_read(schedule->rw_lock);
+@@ -50,7 +50,6 @@ static int vidschi_submit_dma(vidsch_mgr_t *sch_mgr, task_dma_t *task_dma)
+ 
+     //gf_mutex_lock(adapter->hw_reset_lock);
+ 
+-    last_send_fence_id = sch_mgr->last_send_fence_id;
+     fence_id = vidschi_inc_send_fence_id(sch_mgr, task_dma->prepare_submit);
+ 
+     task_dma->prepare_submit = FALSE;
+diff --git a/core/vidsch/vidsch_workerthread.c b/core/vidsch/vidsch_workerthread.c
+index d04fb23..7c54d00 100644
+--- a/core/vidsch/vidsch_workerthread.c
++++ b/core/vidsch/vidsch_workerthread.c
+@@ -69,7 +69,7 @@ static int vidschi_try_submit_pending_task(vidsch_mgr_t *sch_mgr, pending_task_p
+     unsigned long long global_task_id = 0ll;
+     int submited_count = 0;
+ 
+-    int submitted = FALSE, signaled = FALSE;
++    int submitted = FALSE;
+ 
+     vidschi_init_task_pool(&schedule_pool, TRUE);
+     vidschi_init_task_pool(&unready_pool, FALSE);
+@@ -147,7 +147,6 @@ static int vidschi_try_submit_pending_task(vidsch_mgr_t *sch_mgr, pending_task_p
+ 
+             if(vidschi_try_signal(task->task_signal) == S_OK)
+             {
+-                signaled  = TRUE;
+                 submitted = TRUE;
+ 
+                 context->last_submit_to_sw = task_id;
+@@ -208,13 +207,6 @@ static int vidschi_try_submit_pending_task(vidsch_mgr_t *sch_mgr, pending_task_p
+         vidschi_splice_task_pool(pool, &unready_pool);
+     }
+ 
+-#if 0
+-    if(signaled)
+-    {
+-        /* try wakeup all thread for none fence syncobj*/
+-    }
+-#endif
+-
+     vidschi_fini_task_pool(&schedule_pool);
+     vidschi_fini_task_pool(&unready_pool);
+ 
+diff --git a/dkms.conf b/dkms.conf
+index 37d500c..080d376 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -1,5 +1,5 @@
+ PACKAGE_NAME="arise"
+-PACKAGE_VERSION=25.00.45
++PACKAGE_VERSION=25.00.46
+ AUTOINSTALL="yes"
+ 
+ BUILT_MODULE_NAME[0]="arise"
+diff --git a/gf_version.h b/gf_version.h
+index ea18af0..9a31afa 100644
+--- a/gf_version.h
++++ b/gf_version.h
+@@ -22,16 +22,16 @@
+  *
+  */
+ 
+-#define DRIVER_DATE                 "04/16/2025"
++#define DRIVER_DATE                 "05/20/2025"
+ #define DRIVER_MAJOR                0x25
+ #define DRIVER_MINOR                0x00
+-#define DRIVER_PATCHLEVEL           0x45
++#define DRIVER_PATCHLEVEL           0x46
+ #define DRIVER_CLASS                ""
+ #define DRIVER_NAME                 arise
+ #define DRIVER_VENDOR               "Glenfly Tech Co., Ltd."
+ #define DRIVER_LICENSE              "Glenfly"
+ #define DRIVER_VERSION              ((DRIVER_MAJOR<<24)|(DRIVER_MINOR<<16)|DRIVER_PATCHLEVEL)
+-#define DRIVER_VERSION_CHAR         "25.00.45"
++#define DRIVER_VERSION_CHAR         "25.00.46"
+ #define OS_VERSION                  ""
+ #define CC_VERSION                  ""
+ #define LD_VERSION                  ""
+diff --git a/linux/gf_cbios.c b/linux/gf_cbios.c
+index 726c391..dc73009 100644
+--- a/linux/gf_cbios.c
++++ b/linux/gf_cbios.c
+@@ -853,6 +853,29 @@ int disp_cbios_get_adapter_modes(disp_info_t *disp_info, void* buffer, int buf_s
+     return  real_num;
+ }
+ 
++CBiosModeInfoExt* disp_cbios_get_preferred_mode(CBiosModeInfoExt *dev_mode_list, unsigned int mode_num)
++{
++    CBiosModeInfoExt *pcbios_mode = NULL;
++    int i = 0;
++
++    for (i = 0; i < mode_num; i++)
++    {
++        pcbios_mode = dev_mode_list + i;
++
++        if (pcbios_mode->isPreferredMode)
++        {
++            break;
++        }
++    }
++
++    return pcbios_mode;
++}
++
++CBiosModeInfoExt* disp_cbios_get_maxium_mode(CBiosModeInfoExt *dev_mode_list)
++{
++    return &dev_mode_list[0];
++}
++
+ int disp_cbios_merge_modes(CBiosModeInfoExt* merge_mode_list, CBiosModeInfoExt * adapter_mode_list, unsigned int const adapter_mode_num,
+     CBiosModeInfoExt const * dev_mode_list, unsigned int const dev_mode_num)
+ {
+diff --git a/linux/gf_cbios.h b/linux/gf_cbios.h
+index 98dfbcb..da3c0c7 100644
+--- a/linux/gf_cbios.h
++++ b/linux/gf_cbios.h
+@@ -123,6 +123,8 @@ int         disp_cbios_get_adapter_modes_size(disp_info_t *disp_info);
+ int         disp_cbios_get_adapter_modes(disp_info_t *disp_info, void* buffer, int buf_size);
+ int         disp_cbios_merge_modes(CBiosModeInfoExt* merge_mode_list, CBiosModeInfoExt * adapter_mode_list, unsigned int const adapter_mode_num,
+     CBiosModeInfoExt const * dev_mode_list, unsigned int const dev_mode_num);
++CBiosModeInfoExt* disp_cbios_get_preferred_mode(CBiosModeInfoExt *dev_mode_list, unsigned int mode_num);
++CBiosModeInfoExt* disp_cbios_get_maxium_mode(CBiosModeInfoExt *dev_mode_list);
+ int         disp_cbios_cbmode_to_drmmode(disp_info_t *disp_info, int output, void* cbmode, int i, struct drm_display_mode *drm_mode);
+ int         disp_cbios_3dmode_to_drmmode(disp_info_t *disp_info, int output, void* mode, int i, struct drm_display_mode *drm_mode);
+ int         disp_cbios_get_3dmode_size(disp_info_t* disp_info, int output);
+diff --git a/linux/gf_disp.c b/linux/gf_disp.c
+index 0e8dfe4..91e3736 100644
+--- a/linux/gf_disp.c
++++ b/linux/gf_disp.c
+@@ -1170,8 +1170,8 @@ static int disp_mode_config_init(disp_info_t* disp_info)
+ 
+     drm->mode_config.max_width = 3840*4;   // 4*4k
+     drm->mode_config.max_height = 2160*4;
+-    drm->mode_config.cursor_width = 64;
+-    drm->mode_config.cursor_height = 64;
++    drm->mode_config.cursor_width = 128;
++    drm->mode_config.cursor_height = 128;
+ 
+     drm->mode_config.preferred_depth = 24;
+     drm->mode_config.prefer_shadow = 1;
+@@ -1809,12 +1809,12 @@ int gf_get_chip_fanspeed(void* dispi, int index)
+ 
+ int gf_get_chip_fanspeed_legacy(void* dispi, int index)
+ {
+-    static int fanspeed = 0,pwm = 0;
++    static int fanspeed = 0;
+     disp_info_t*  disp_info = (disp_info_t*)dispi;
+     adapter_info_t*  adp_info = disp_info->adp_info;
+     int ctrl_reg_8x000, ctrl_reg_8x008, ctrl_reg_8x014, out_8x01c;
+-    unsigned int *pRegAddr_8x000, *pRegAddr_8x004, *pRegAddr_8x008, *pRegAddr_8x00c, *pRegAddr_8x014, *pRegAddr_8x01c, *pRegAddr_d00xc;
+-    int temp = 0, fanbase = 0, pwmoffset = 0;
++    unsigned int *pRegAddr_8x000, *pRegAddr_8x004, *pRegAddr_8x008, *pRegAddr_8x014, *pRegAddr_8x01c;
++    int temp = 0, fanbase = 0;
+ 
+     if(adp_info->mmio_size < 0x8F024)
+     {
+@@ -1829,12 +1829,10 @@ int gf_get_chip_fanspeed_legacy(void* dispi, int index)
+             return fanspeed;
+ 
+         fanbase = 0x8c000;
+-        pwmoffset = 0x10;
+     }
+     else if(index == 0)
+     {
+         fanbase = 0x8d000;
+-        pwmoffset = 0x0;
+     }
+     else
+     {
+@@ -1844,10 +1842,8 @@ int gf_get_chip_fanspeed_legacy(void* dispi, int index)
+     pRegAddr_8x000   = (unsigned int*)(adp_info->mmio  + fanbase + 0x000);
+     pRegAddr_8x004   = (unsigned int*)(adp_info->mmio  + fanbase + 0x004);
+     pRegAddr_8x008   = (unsigned int*)(adp_info->mmio  + fanbase + 0x008);
+-    pRegAddr_8x00c   = (unsigned int*)(adp_info->mmio  + fanbase + 0x00c);
+     pRegAddr_8x014   = (unsigned int*)(adp_info->mmio  + fanbase + 0x014);
+     pRegAddr_8x01c   = (unsigned int*)(adp_info->mmio  + fanbase + 0x01c);
+-    pRegAddr_d00xc   = (unsigned int*)(adp_info->mmio  + pwmoffset + 0xd0000 + 0x0c);
+ 
+     if((gf_read32(pRegAddr_8x004) & 0x2) != 0)
+     {
+@@ -1871,8 +1867,6 @@ int gf_get_chip_fanspeed_legacy(void* dispi, int index)
+         fanspeed = -1;
+     }
+ 
+-    pwm = gf_read32(pRegAddr_d00xc) & 0xfff;
+-
+     ctrl_reg_8x014 = 0x7D00;
+     gf_write32(pRegAddr_8x014, ctrl_reg_8x014);
+ 
+diff --git a/linux/gf_driver.c b/linux/gf_driver.c
+index fcf6d9e..be94280 100644
+--- a/linux/gf_driver.c
++++ b/linux/gf_driver.c
+@@ -604,6 +604,15 @@ static ssize_t gf_gpuinfo_proc_read(struct file *filp, char *buf, size_t count,
+         type_dp = "/DP";
+         break;
+ 
++    case 0x3d0e:
++        hdmi_fps = 60;
++        subsystemid = 0x10D0;
++        technology = 28;
++        pixel_fillrate = 96 * eclk;
++        texture_fillrate = pixel_fillrate *2;
++        product_name = "Arise10D0";
++        break;
++
+     default:
+         hdmi_fps = 60;
+         subsystemid = 0;
+diff --git a/linux/gf_encoder.c b/linux/gf_encoder.c
+index 75ca16e..d932cc7 100644
+--- a/linux/gf_encoder.c
++++ b/linux/gf_encoder.c
+@@ -191,69 +191,105 @@ bool gf_encoder_mode_fixup_internal(disp_info_t*  disp_info,
+                                    const struct drm_display_mode *mode,
+                                    struct drm_display_mode *adjusted_mode)
+ {
+-    unsigned int dev_mode_size = 0, dev_real_num = 0, i = 0, matched = 0;
+-    void * dev_mode_buf = NULL;
++    unsigned int dev_mode_size = 0, dev_real_num = 0, i = 0;
++    unsigned int adapter_mode_size = 0, adapter_mode_num = 0;
++    void *dev_mode_buf = NULL, *adapter_mode_buf = NULL;
+     PCBiosModeInfoExt pcbios_mode = NULL, matched_mode = NULL;
++    PCBiosModeInfoExt ppreferred_mode = NULL, pmaxium_mode = NULL;
++
++    if (!adjusted_mode)
++    {
++        return FALSE;
++    }
+ 
+     dev_mode_size = disp_cbios_get_modes_size(disp_info, output_type);
+-    if(dev_mode_size)
++    if (!dev_mode_size)
++    {
++        goto End;
++    }
++
++    dev_mode_buf = gf_calloc(dev_mode_size);
++    if (!dev_mode_buf)
++    {
++        goto End;
++    }
++
++    dev_real_num = disp_cbios_get_modes(disp_info, output_type, dev_mode_buf, dev_mode_size);
++    for (i = 0; i < dev_real_num; i++)
+     {
+-        dev_mode_buf = gf_calloc(dev_mode_size);
+-        if(dev_mode_buf)
++        pcbios_mode = (PCBiosModeInfoExt)dev_mode_buf + i;
++        if ((pcbios_mode->XRes == mode->hdisplay) &&
++            (pcbios_mode->YRes == mode->vdisplay) &&
++            (pcbios_mode->RefreshRate/100 == drm_mode_vrefresh(mode)) &&
++            ((mode->flags & DRM_MODE_FLAG_INTERLACE) ? (pcbios_mode->InterlaceProgressiveCaps == 0x02) : (pcbios_mode->InterlaceProgressiveCaps == 0x01)))
+         {
+-            dev_real_num = disp_cbios_get_modes(disp_info, output_type, dev_mode_buf, dev_mode_size);
+-            for(i = 0; i < dev_real_num; i++)
+-            {
+-                pcbios_mode = (PCBiosModeInfoExt)dev_mode_buf + i;
+-                if((pcbios_mode->XRes == mode->hdisplay) &&
+-                   (pcbios_mode->YRes == mode->vdisplay) &&
+-                   (pcbios_mode->RefreshRate/100 == drm_mode_vrefresh(mode)) &&
+-                   ((mode->flags & DRM_MODE_FLAG_INTERLACE) ? (pcbios_mode->InterlaceProgressiveCaps == 0x02) : (pcbios_mode->InterlaceProgressiveCaps == 0x01)))
+-                {
+-                    matched = 1;
+-                    break;
+-                }
+-            }
++            //sw mode == hw mode
++            goto End;
+         }
+     }
+ 
+-    if(!matched && disp_info->scale_support)
++    if (!disp_info->scale_support)
++    {
++        goto End;
++    }
++
++    adapter_mode_size = disp_cbios_get_adapter_modes_size(disp_info);
++    if (!adapter_mode_size)
+     {
+-        for(i = 0; i < dev_real_num; i++)
++        goto End;
++    }
++
++    adapter_mode_buf = gf_calloc(adapter_mode_size);
++    if (!adapter_mode_buf)
++    {
++        goto End;
++    }
++
++    ppreferred_mode = disp_cbios_get_preferred_mode((PCBiosModeInfoExt)dev_mode_buf, dev_real_num);
++    pmaxium_mode = disp_cbios_get_maxium_mode((PCBiosModeInfoExt)dev_mode_buf);
++
++    adapter_mode_num = disp_cbios_get_adapter_modes(disp_info, adapter_mode_buf, adapter_mode_size);
++    for (i = 0; i < adapter_mode_num; i++)
++    {
++        pcbios_mode = (PCBiosModeInfoExt)adapter_mode_buf + i;
++
++        if (pcbios_mode->XRes == mode->hdisplay &&
++            pcbios_mode->YRes == mode->vdisplay &&
++            pcbios_mode->RefreshRate/100 == drm_mode_vrefresh(mode))
+         {
+-            pcbios_mode = (PCBiosModeInfoExt)dev_mode_buf + i;
+-            if(pcbios_mode->XRes >= mode->hdisplay && pcbios_mode->YRes >= mode->vdisplay &&
+-               pcbios_mode->RefreshRate/100 >= drm_mode_vrefresh(mode))
++            if (ppreferred_mode != NULL &&
++                ppreferred_mode->XRes >= mode->hdisplay &&
++                ppreferred_mode->YRes >= mode->vdisplay &&
++                ppreferred_mode->RefreshRate/100 >= drm_mode_vrefresh(mode))
+             {
+-                if(pcbios_mode->isPreferredMode)
+-                {
+-                    matched_mode = pcbios_mode;
+-                    break;
+-                }
+-                else if(!matched_mode)
+-                {
+-                    matched_mode = pcbios_mode;
+-                }
++                //perferred as the hw mode
++                matched_mode = ppreferred_mode;
++                break;
+             }
+-        }
+ 
+-        if(matched_mode)
+-        {
+-            if(adjusted_mode)
++            if (pmaxium_mode != NULL &&
++                pmaxium_mode->XRes >= mode->hdisplay &&
++                pmaxium_mode->YRes >= mode->vdisplay &&
++                pmaxium_mode->RefreshRate/100 >= drm_mode_vrefresh(mode))
+             {
+-                disp_cbios_cbmode_to_drmmode(disp_info, output_type, matched_mode, 0, adjusted_mode);
++                //maxium as the hw mode
++                matched_mode = pmaxium_mode;
++                break;
+             }
+-            matched = 1;
+         }
+     }
+ 
+-    if (adjusted_mode && matched)
++    if (matched_mode)
+     {
++        disp_cbios_cbmode_to_drmmode(disp_info, output_type, matched_mode, 0, adjusted_mode);
++    }
++
++End:
+ #if DRM_VERSION_CODE < KERNEL_VERSION(5,9,0)
+-        adjusted_mode->vrefresh = drm_mode_vrefresh(adjusted_mode);
++    adjusted_mode->vrefresh = drm_mode_vrefresh(adjusted_mode);
+ #endif
+-        disp_cbios_get_mode_timing(disp_info, output_type, adjusted_mode);
+-    }
++
++    disp_cbios_get_mode_timing(disp_info, output_type, adjusted_mode);
+ 
+     if (dev_mode_buf)
+     {
+@@ -261,7 +297,13 @@ bool gf_encoder_mode_fixup_internal(disp_info_t*  disp_info,
+         dev_mode_buf = NULL;
+     }
+ 
+-    return (matched)? TRUE : FALSE;
++    if (adapter_mode_buf)
++    {
++        gf_free(adapter_mode_buf);
++        adapter_mode_buf = NULL;
++    }
++
++    return TRUE;
+ }
+ 
+ static bool gf_encoder_mode_fixup(struct drm_encoder *encoder,
+diff --git a/linux/gf_kms.h b/linux/gf_kms.h
+index 37980e4..8baf4aa 100644
+--- a/linux/gf_kms.h
++++ b/linux/gf_kms.h
+@@ -48,7 +48,7 @@
+ #endif
+ 
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+-#if DRM_VERSION_CODE <= KERNEL_VERSION(6, 12, 0)
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ #include <drm/drm_aperture.h>
+ #else
+ #include <linux/aperture.h>
+diff --git a/linux/gf_pcie.c b/linux/gf_pcie.c
+index 87539e3..db7cd78 100644
+--- a/linux/gf_pcie.c
++++ b/linux/gf_pcie.c
+@@ -61,6 +61,14 @@
+ #endif
+ #endif
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
++#include <drm/drm_aperture.h>
++#else
++#include <linux/aperture.h>
++#endif
++#endif
++
+ #if defined(__loongarch__)  && defined(KYLIN) && DRM_VERSION_CODE == KERNEL_VERSION(6, 6, 0)
+ #include <linux/sysfb.h>
+ #endif
+@@ -102,6 +110,7 @@ static struct pci_device_id pciidlist[] =
+     {0x6766, 0x3D06, PCI_ANY_ID, PCI_ANY_ID, 0, 0, (kernel_ulong_t)&gf_e3k_info}, //arise10c0t
+     {0x6766, 0x3D07, PCI_ANY_ID, PCI_ANY_ID, 0, 0, (kernel_ulong_t)&gf_e3k_info},
+     {0x6766, 0x3D08, PCI_ANY_ID, PCI_ANY_ID, 0, 0, (kernel_ulong_t)&gf_e3k_info},
++    {0x6766, 0x3D0E, PCI_ANY_ID, PCI_ANY_ID, 0, 0, (kernel_ulong_t)&gf_e3k_info}, //arise10D0
+     {0, 0, 0}
+ };
+ 
+diff --git a/linux/gf_splice.c b/linux/gf_splice.c
+index 794cfe0..cffae2e 100644
+--- a/linux/gf_splice.c
++++ b/linux/gf_splice.c
+@@ -1158,9 +1158,7 @@ static int gf_splice_crtc_page_flip(struct drm_crtc *crtc,
+ 
+ static struct drm_crtc_state* gf_splice_crtc_duplicate_state(struct drm_crtc *crtc)
+ {
+-    gf_crtc_state_t* crtc_state, *cur_crtc_state;
+-
+-    cur_crtc_state = to_gf_crtc_state(crtc->state);
++    gf_crtc_state_t* crtc_state;
+ 
+     crtc_state = gf_calloc(sizeof(gf_crtc_state_t));
+     if (!crtc_state)
+@@ -1658,7 +1656,18 @@ static void gf_splice_crtc_dpms_onoff_helper(struct drm_crtc *crtc, int dpms_on)
+             continue;
+         }
+ 
+-        disp_cbios_turn_onoff_screen(disp_info, gf_source_crtc->pipe, status);
++        if(!status)
++        {
++            //turn off
++            disp_cbios_turn_onoff_screen(disp_info, gf_source_crtc->pipe, 0);
++            disp_cbios_turn_onoff_iga(disp_info, gf_source_crtc->pipe, 0);
++        }
++        else if(status)
++        {
++            //turn on
++            disp_cbios_turn_onoff_iga(disp_info, gf_source_crtc->pipe, 1);
++            disp_cbios_turn_onoff_screen(disp_info, gf_source_crtc->pipe, 1);
++        }
+     }
+ 
+     gf_crtc->crtc_dpms = status;
+diff --git a/linux/os_interface.c b/linux/os_interface.c
+index 342135b..7320d40 100644
+--- a/linux/os_interface.c
++++ b/linux/os_interface.c
+@@ -1211,8 +1211,10 @@ static void gf_flush_page_cache(struct device *dev, struct page *pages, unsigned
+ #if __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)ptr, (unsigned long)(ptr+PAGE_SIZE));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr, ptr + PAGE_SIZE);
+         outer_flush_range(page_to_phys(pages), page_to_phys(pages) + PAGE_SIZE);
++#endif
+ #endif
+         kunmap(pages);
+         pages++;
+@@ -1782,8 +1784,10 @@ void gf_flush_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memor
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)(ptr + page_start_offset), (unsigned long)(ptr + page_end_offset));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr + page_start_offset, ptr + page_end_offset);
+         outer_flush_range(page_to_phys(pages) + page_start_offset, page_to_phys(pages) + page_end_offset);
++#endif
+ #endif
+         kunmap(pages);
+     }
+@@ -1796,8 +1800,10 @@ void gf_flush_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memor
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)(ptr + page_start_offset), (unsigned long)(ptr + PAGE_SIZE));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr + page_start_offset, ptr + PAGE_SIZE);
+         outer_flush_range(page_to_phys(pages) + page_start_offset, page_to_phys(pages) + PAGE_SIZE);
++#endif
+ #endif
+         kunmap(pages);
+ 
+@@ -1808,8 +1814,10 @@ void gf_flush_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memor
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)ptr, (unsigned long)(ptr + page_end_offset));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr, ptr + PAGE_SIZE);
+         outer_flush_range(page_to_phys(pages), page_to_phys(pages) + page_end_offset);
++#endif
+ #endif
+         kunmap(pages);
+     }
+@@ -1823,8 +1831,10 @@ void gf_flush_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memor
+ #elif  __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)ptr, (unsigned long)(ptr + PAGE_SIZE));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr, ptr + PAGE_SIZE);
+         outer_flush_range(page_to_phys(pages), page_to_phys(pages) + PAGE_SIZE);
++#endif
+ #endif
+         kunmap(pages);
+     }
+@@ -1868,8 +1878,10 @@ void gf_inv_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memory,
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)(ptr + page_start_offset), (unsigned long)(ptr + page_end_offset));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr + page_start_offset, ptr + page_end_offset);
+         outer_inv_range(page_to_phys(pages) + page_start_offset, page_to_phys(pages) + page_end_offset);
++#endif
+ #endif
+         kunmap(pages);
+     }
+@@ -1882,8 +1894,10 @@ void gf_inv_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memory,
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)(ptr + page_start_offset), (unsigned long)(ptr + PAGE_SIZE));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr + page_start_offset, ptr + PAGE_SIZE);
+         outer_inv_range(page_to_phys(pages) + page_start_offset, page_to_phys(pages) + PAGE_SIZE);
++#endif
+ #endif
+         kunmap(pages);
+ 
+@@ -1894,8 +1908,10 @@ void gf_inv_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memory,
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)ptr, (unsigned long)(ptr + PAGE_SIZE));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr, ptr + PAGE_SIZE);
+         outer_inv_range(page_to_phys(pages), page_to_phys(pages) + page_end_offset);
++#endif
+ #endif
+         kunmap(pages);
+     }
+@@ -1909,8 +1925,10 @@ void gf_inv_cache(void *pdev, gf_vm_area_t *vma, struct os_pages_memory* memory,
+ #elif __ARM_ARCH >= 8
+         flush_icache_range((unsigned long)ptr, (unsigned long)(ptr + PAGE_SIZE));
+ #else
++#if !defined(__riscv)
+         dmac_flush_range(ptr, ptr + PAGE_SIZE);
+         outer_inv_range(page_to_phys(pages), page_to_phys(pages) + PAGE_SIZE);
++#endif
+ #endif
+         kunmap(pages);
+     }
+@@ -2348,7 +2366,7 @@ int gf_disp_wait_idle(void *disp_info)
+ #define gf_wmb_asm()   wmb()
+ #define gf_flush_wc_asm() mb()
+ #define gf_dsb_asm()
+-#else
++#elif defined(__aarch64__)
+ #if __ARM_ARCH >= 7
+ #define dmb(opt)        asm volatile("dmb " #opt : : : "memory")
+ #define dsb(opt)        asm volatile("dsb " #opt : : : "memory")
+@@ -2359,6 +2377,12 @@ int gf_disp_wait_idle(void *disp_info)
+ #define gf_flush_wc_asm() dsb(sy)
+ #define gf_dsb_asm()   dsb(sy)
+ #endif
++#elif defined(__riscv)
++#define gf_mb_asm()
++#define gf_rmb_asm()
++#define gf_wmb_asm()
++#define gf_flush_wc_asm()
++#define gf_dsb_asm()
+ #endif
+ 
+ void gf_mb(void)
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0001-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0001-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,0 +1,28 @@
+From e7ce1ccff2d385bd2cc8493721c6e9fcd981e8ec Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 12 Nov 2025 18:42:34 +0800
+Subject: [PATCH 1/8] chore: import .gitignore from loonggpu-kernel-dkms
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ .gitignore | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..223542a
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,8 @@
++*.o
++*.ko
++*.mod
++*.mod.c
++*.cmd
++*.symvers
++*.order
++conftest
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0002-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0002-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
@@ -1,0 +1,71 @@
+From 37b4fb73833a1f069fbc312f9c3a323d011c41ef Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 7 Nov 2025 23:50:09 +0800
+Subject: [PATCH 2/8] AOSCOS: fix(dkms.conf): drop check_gcc_version()
+
+Not even sure why it's here. Drop it.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 47 +----------------------------------------------
+ 1 file changed, 1 insertion(+), 46 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index e3b1af7..0a0ce16 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -19,50 +19,5 @@ num_cpu_cores()
+ 	fi
+ }
+ 
+-check_gcc_version()
+-{
+-local KERNEL_UNAME=`uname -r`
+-local KERNEL_MODLIB=/lib/modules/${KERNEL_UNAME}
+-local KERNEL_SOURCES=`test -d ${KERNEL_MODLIB}/source && echo ${KERNEL_MODLIB}/source || echo ${KERNEL_MODLIB}/build`
+-local KERNEL_COMPILE_H=${KERNEL_SOURCES}/include/generated/compile.h
+-
+-	if [ -f ${KERNEL_COMPILE_H} ];then
+-
+-		# Try to get all installed gcc list
+-		local SYSTEM_GCC_LIST=`ls /usr/bin/gcc-[0-9]* | xargs -n1 | sort -u`
+-
+-		# Try to get current GCC version, some GCC version string only hava major.minor
+-		local SYSTEM_GCC_VERSION=`gcc -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-		if [ -z "$SYSTEM_GCC_VERSION" ];then
+-			SYSTEM_GCC_VERSION=`gcc -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-		fi
+-
+-		# Get version string from 'compile.h', some GCC version string only hava major.minor
+-		local KERNEL_BUILT_GCC_STRING=`cat ${KERNEL_COMPILE_H} | grep LINUX_COMPILER | cut -f 2 -d '"'`
+-		local KERNEL_BUILT_GCC_VERSION=`echo "${KERNEL_BUILT_GCC_STRING}" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-		if [ -z "$KERNEL_BUILT_GCC_VERSION" ];then
+-			KERNEL_BUILT_GCC_VERSION=`echo "${KERNEL_BUILT_GCC_STRING}" | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-		fi
+-
+-		# Checking GCC version and assign gcc by 'CC=' here
+-		if [ "$KERNEL_BUILT_GCC_VERSION" != "$SYSTEM_GCC_VERSION" ];then
+-			for TARGET_GCC_PATH in $SYSTEM_GCC_LIST;
+-			do
+-				local TARGET_GCC_VERSION=`$TARGET_GCC_PATH -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1`
+-				if [ -z "$TARGET_GCC_VERSION" ];then
+-					TARGET_GCC_VERSION=`$TARGET_GCC_PATH -v 2>&1 | awk 'END{print}' | grep -o '[0-9]\+\.[0-9]\+' | head -n 1`
+-				fi
+-
+-				if [ "$KERNEL_BUILT_GCC_VERSION" = "$TARGET_GCC_VERSION" ];then
+-					echo "CC=$TARGET_GCC_PATH"
+-					break;
+-				fi
+-			done
+-		fi
+-
+-	fi
+-
+-}
+-
+-MAKE[0]="make $(check_gcc_version) -j$(num_cpu_cores) -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
++MAKE[0]="make -j$(num_cpu_cores) -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
+ #POST_REMOVE="post-remove.sh $kernelver"
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0003-AOSCOS-fix-dkms.conf-drop-unused-options.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0003-AOSCOS-fix-dkms.conf-drop-unused-options.patch
@@ -1,0 +1,26 @@
+From c48b291a28ae4a9118b958dbef979f35caed6e00 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 12:30:19 +0800
+Subject: [PATCH 3/8] AOSCOS: fix(dkms.conf): drop unused options
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 0a0ce16..080d376 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -1,8 +1,6 @@
+ PACKAGE_NAME="arise"
+ PACKAGE_VERSION=25.00.46
+ AUTOINSTALL="yes"
+-#REMAKE_INITRD="yes"
+-SKIP_IMMD_MODPROBE=1
+ 
+ BUILT_MODULE_NAME[0]="arise"
+ BUILT_MODULE_LOCATION[0]=""
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0004-AOSCOS-fix-adapt-to-timer-changes-in-6.16.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0004-AOSCOS-fix-adapt-to-timer-changes-in-6.16.patch
@@ -1,0 +1,34 @@
+From f9fc293bf1a61a6ee7c4cd468fa77dd392a845f4 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:48:50 +0800
+Subject: [PATCH 4/8] AOSCOS: fix: adapt to timer changes in 6.16
+
+In the 6.16 cycle, upstream renamed `from_timer()' to
+`timer_container_of()' in commit 41cb08555c41 ("treewide, timers: Rename
+from_timer() to timer_container_of()").
+
+Follow this change and rename said function.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_disp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/linux/gf_disp.c b/linux/gf_disp.c
+index 9296b1c..91e3736 100644
+--- a/linux/gf_disp.c
++++ b/linux/gf_disp.c
+@@ -1347,7 +1347,9 @@ void gf_disp_state_timer_fn(struct timer_list *t)
+ void gf_disp_state_timer_fn(unsigned long data)
+ #endif
+ {
+-#if DRM_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++    disp_state_info_t *pstate_info = timer_container_of(pstate_info, t, state_timer);
++#elif DRM_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+     disp_state_info_t *pstate_info = from_timer(pstate_info, t, state_timer);
+ #else
+     disp_state_info_t *pstate_info  = (disp_state_info_t  *)data;
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0005-AOSCOS-fix-adapt-to-drm_framebuffer-changes-in-6.17.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0005-AOSCOS-fix-adapt-to-drm_framebuffer-changes-in-6.17.patch
@@ -1,0 +1,91 @@
+From db6f5fc62cb8355b7142ed8d0c53995f40716f05 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:52:01 +0800
+Subject: [PATCH 5/8] AOSCOS: fix: adapt to drm_framebuffer changes in 6.17
+
+With commit 81112eaac559 ("drm: Pass the format info to .fb_create()"),
+an additional parameter format_info was added to the
+drm_helper_mode_fill_fb_struct() function call.
+
+Follow suit to fix build with kernels >= 6.17.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_drmfb.c | 14 +++++++++++++-
+ linux/gf_drmfb.h |  6 ++++++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/linux/gf_drmfb.c b/linux/gf_drmfb.c
+index 3769cc8..3c731ff 100644
+--- a/linux/gf_drmfb.c
++++ b/linux/gf_drmfb.c
+@@ -61,6 +61,9 @@ static const struct drm_framebuffer_funcs gf_fb_funcs =
+ struct drm_gf_framebuffer*
+ __gf_framebuffer_create(struct drm_device *dev,
+                         struct drm_mode_fb_cmd2 *mode_cmd,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                        const struct drm_format_info *format_info,
++#endif
+                         struct drm_gf_gem_object *obj)
+ {
+     int ret;
+@@ -71,8 +74,10 @@ __gf_framebuffer_create(struct drm_device *dev,
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
+     drm_helper_mode_fill_fb_struct(&gfb->base, mode_cmd);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+     drm_helper_mode_fill_fb_struct(dev, &gfb->base, mode_cmd);
++#elif DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    drm_helper_mode_fill_fb_struct(dev, &gfb->base, format_info, mode_cmd);
+ #endif
+     gfb->obj = obj;
+ 
+@@ -89,6 +94,9 @@ err_free:
+ struct drm_framebuffer *
+ gf_fb_create(struct drm_device *dev,
+               struct drm_file *file,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++              const struct drm_format_info *format_info,
++#endif
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && !defined (PHYTIUM_2000)
+               struct drm_mode_fb_cmd2 *user_mode_cmd
+ #else
+@@ -104,7 +112,11 @@ gf_fb_create(struct drm_device *dev,
+     if (!obj)
+         return ERR_PTR(-ENOENT);
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    fb = __gf_framebuffer_create(dev, &mode_cmd, format_info, obj);
++#else
+     fb = __gf_framebuffer_create(dev, &mode_cmd, obj);
++#endif
+     if (IS_ERR(fb))
+         gf_gem_object_put(obj);
+ 
+diff --git a/linux/gf_drmfb.h b/linux/gf_drmfb.h
+index e3c6304..3ae1d82 100644
+--- a/linux/gf_drmfb.h
++++ b/linux/gf_drmfb.h
+@@ -41,6 +41,9 @@ struct drm_gf_framebuffer
+ struct drm_framebuffer *
+ gf_fb_create(struct drm_device *dev,
+                               struct drm_file *file_priv,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                              const struct drm_format_info *format_info,
++#endif
+                               #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)  || defined (PHYTIUM_2000)
+                               const struct drm_mode_fb_cmd2 *mode_cmd
+                               #else
+@@ -53,5 +56,8 @@ void gf_cleanup_fb(struct drm_plane *plane,  struct drm_plane_state *old_state);
+ struct drm_gf_framebuffer*
+ __gf_framebuffer_create(struct drm_device *dev,
+                         struct drm_mode_fb_cmd2 *mode_cmd,
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++                        const struct drm_format_info *format_info,
++#endif
+                         struct drm_gf_gem_object *obj);
+ #endif
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0006-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0006-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
@@ -1,0 +1,33 @@
+From 2877a3098fcfa0489112c5e24026b4daaff0921f Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:52:26 +0800
+Subject: [PATCH 6/8] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
+ 6.17
+
+Follow commit 21aa65bf82a7 ("mm: remove callers of pfn_t functionality")
+and remove all usage of linux/pfn_t.h there.
+
+The rest of the code already works with >= 6.17.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_gem_priv.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/linux/gf_gem_priv.h b/linux/gf_gem_priv.h
+index e179785..4c2c64c 100644
+--- a/linux/gf_gem_priv.h
++++ b/linux/gf_gem_priv.h
+@@ -39,7 +39,8 @@
+ #include "gf_gem_debug.h"
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || \
+-    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && !defined(YHQILIN)
++    DRM_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)) && !defined(YHQILIN) && \
++    DRM_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+ #include <linux/pfn_t.h>
+ #else
+ typedef struct {
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0007-AOSCOS-fix-adapt-to-sysfs-changes-in-6.16.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0007-AOSCOS-fix-adapt-to-sysfs-changes-in-6.16.patch
@@ -1,0 +1,41 @@
+From 5f2a6e298f020b5d3e8cc85b6615911e14567360 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 16:55:26 +0800
+Subject: [PATCH 7/8] AOSCOS: fix: adapt to sysfs changes in 6.16
+
+In the 6.16 cycle, upstream consified the `bin_attribute' argument of
+`bin_attribute::read/write()' in commit 97d06802d10a ("sysfs: constify
+bin_attribute argument of bin_attribute::read/write()").
+
+Follow suit and adapt to this change.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ linux/gf_sysfs.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/linux/gf_sysfs.c b/linux/gf_sysfs.c
+index 6331b3a..4e48221 100644
+--- a/linux/gf_sysfs.c
++++ b/linux/gf_sysfs.c
+@@ -766,7 +766,7 @@ const struct attribute *gf_os_gpu_info[] = {
+     NULL
+ };
+ 
+-static ssize_t gf_sysfs_trace_read(struct file *filp, struct kobject *kobj, struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
++static ssize_t gf_sysfs_trace_read(struct file *filp, struct kobject *kobj, const struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
+ {
+     struct pci_dev*    pdev    = to_pci_dev(container_of(kobj,struct device,kobj));
+     struct drm_device* drm_dev = pci_get_drvdata(pdev);
+@@ -785,7 +785,7 @@ static ssize_t gf_sysfs_trace_read(struct file *filp, struct kobject *kobj, stru
+     return ret;
+ }
+ 
+-static ssize_t gf_sysfs_trace_write(struct file *filp, struct kobject *kobj, struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
++static ssize_t gf_sysfs_trace_write(struct file *filp, struct kobject *kobj, const struct bin_attribute *bin_attr, char *buf, loff_t pos, size_t size)
+ {
+     struct pci_dev*    pdev    = to_pci_dev(container_of(kobj,struct device,kobj));
+     struct drm_device* drm_dev = pci_get_drvdata(pdev);
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0008-AOSCOS-fix-drop-TARGET_ARCH-from-Makefile.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.46/0008-AOSCOS-fix-drop-TARGET_ARCH-from-Makefile.patch
@@ -1,0 +1,24 @@
+From f5286239636abea2a9698c5e3939cdc6bc46c635 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 17 Nov 2025 18:14:43 +0800
+Subject: [PATCH 8/8] AOSCOS: fix: drop TARGET_ARCH from Makefile
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 9a77c38..1370eb9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,5 @@
+ CHIP?=E3k
+ DRIVER_NAME?=arise
+-TARGET_ARCH?=loongarch64
+ DEBUG?=0
+ VIDEO_ONLY_FPGA?=0
+ RUN_HW_NULL?=0
+-- 
+2.51.1
+

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/overrides/usr/share/glvnd/egl_vendor.d/10_arise.json
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/overrides/usr/share/glvnd/egl_vendor.d/10_arise.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_arise.so.0"
+    }
+}

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/postinst.in
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/postinst.in
@@ -1,0 +1,16 @@
+VER="%PKGVER%"
+unset ARCH
+
+echo "Installing arise kernel modules..."
+for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+    if [ -f "/usr/lib/modules/$i/modules.dep" -a \
+         -f "/usr/lib/modules/$i/modules.order" -a \
+         -f "/usr/lib/modules/$i/modules.builtin" ]; then
+        echo -e "\033[36m**\033[0m\tBuilding arise kernel modules for $i ..."
+        dkms install arise/"$VER" -k "$i" > /dev/null
+    else
+        echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+    fi
+done
+
+update-initramfs

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/prepare
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/prepare
@@ -1,0 +1,36 @@
+# Note: Override PKGVER.
+if ab_match_arch amd64; then
+    PKGVER="${__VER__AMD64}"
+elif ab_match_arch arm64; then
+    PKGVER="${__VER__ARM64}"
+elif ab_match_arch loongarch64; then
+    PKGVER="${__VER__LOONGARCH64}"
+fi
+
+for i in postinst prerm; do
+    abinfo "Generating $i ..."
+    sed -e \
+        "s/%PKGVER%/${PKGVER}/g" \
+        "$SRCDIR/autobuild/$i.in" > \
+        "$SRCDIR/autobuild/$i"
+done
+
+if ab_match_arch amd64; then
+    GLENFLY_DEB_ARCH="$ARCH"
+elif ab_match_arch arm64; then
+    # Note: Why, Glenfy, why?
+    GLENFLY_DEB_ARCH="aarch64"
+elif ab_match_arch loongarch64; then
+    # Note: Debian uses a different architecture name than we do.
+    GLENFLY_DEB_ARCH="loong64"
+fi
+
+abinfo "Unpacking upstream deb package ..."
+dpkg-deb -X "$SRCDIR"/gf-arise-linux-graphics-driver-glvnd-dri_${PKGVER}_${GLENFLY_DEB_ARCH}.deb "$SRCDIR"
+
+abinfo "Entering kernel module sources directory"
+cd "$SRCDIR"/usr/src/arise-"$PKGVER"
+
+abinfo "Patching kernel module sources ..."
+ab_apply_patches "$SRCDIR"/autobuild/module-patches/${PKGVER}/*.patch
+ab_apply_patches "$SRCDIR"/autobuild/module-patches/${PKGVER}/*.patch.${ARCH}

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/prerm.in
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/prerm.in
@@ -1,0 +1,4 @@
+VER="%PKGVER%"
+unset ARCH
+
+dkms remove arise/"$VER" --all || true > /dev/null

--- a/runtime-display/arise-linux-graphics-driver-dri/spec
+++ b/runtime-display/arise-linux-graphics-driver-dri/spec
@@ -1,0 +1,14 @@
+VER__AMD64=25.00.45
+VER__ARM64=25.00.45
+VER__LOONGARCH64=25.00.46
+__VER__AMD64="${VER__AMD64}"
+__VER__ARM64="${VER__ARM64}"
+__VER__LOONGARCH64="${VER__LOONGARCH64}"
+SRCS__AMD64="tbl::https://www.glenfly.com/down/linux/${VER__AMD64}/${VER__AMD64}_amd64.zip"
+SRCS__ARM64="tbl::https://www.glenfly.com/down/linux/${VER__ARM64}/${VER__ARM64}_aarch64.zip"
+# Note: Rename by a pattern shared by the other two to make scripting easier.
+SRCS__LOONGARCH64="file::rename=gf-arise-linux-graphics-driver-glvnd-dri_${VER__LOONGARCH64}_loong64.deb::https://archive.openkylin.top/openkylin/pool/pty/a/arise-linux-graphics-driver-dri/arise-linux-graphics-driver-dri_${VER__LOONGARCH64}_loong64.deb"
+CHKSUMS__AMD64="sha256::44a3f5f3fc2beb99df58968b20616c995724cdb3275ef0699e3b490c89cb24df"
+CHKSUMS__ARM64="sha256::7bc8b7013ca17139cdbe5e7fd90d84f50e8079d1b8d5bf9219240c142e8350f9"
+CHKSUMS__LOONGARCH64="sha256::77f12b3db4eb386dfbff636653a0ada939db2ce4a9c9d0172eb710745a87ca13"
+# FIXME: Impossible to generate CHKUPDATE for architecture-version-pairs.


### PR DESCRIPTION
Topic Description
-----------------

- arise-linux-graphics-driver-dri: new, 25.00.45 \(loongarch64: 25.00.46\)
    Track patches at AOSC-Tracking/arise-linux-graphics-driver-dri @ ...
    - aosc/v25.00.46 \(HEAD: 6426cec3418ce1771e4106cc9fbe14fad5691840\)
    - aosc/v25.00.46 \(HEAD: f5286239636abea2a9698c5e3939cdc6bc46c635\)
- calibre: update to 8.14.0
- openmw: build with qt-6
- groups/qt6-rebuilds: drop dtk
- fcitx-qt5: rebuild for Qt 6.10.0
- quickshell: rebuild for Qt 6.10.0
- obs-studio: update to 32.0.2
- wireshark: rebuild for Qt 6.10.0
- virtualbox: rebuild for Qt 6.10.0
- texstudio: rebuild for Qt 6.10.0

... and 47 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit arise-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
