### PR TITLE
libsixel: update to 1.8.7

### DIFF
--- a/runtime-imaging/libsixel/autobuild/defines
+++ b/runtime-imaging/libsixel/autobuild/defines
@@ -16,4 +16,6 @@ AUTOTOOLS_AFTER=(
     '--with-jpeg'
     '--with-png'
     'PYTHON=/usr/bin/python3'
+    '--with-bashcompletiondir='${PKGDIR}'/usr/share/bash-completion/completions'
+    '--with-zshcompletiondir='${PKGDIR}'/usr/share/zsh/site-functions'
 )

--- a/runtime-imaging/libsixel/spec
+++ b/runtime-imaging/libsixel/spec
@@ -1,4 +1,4 @@
-VER=1.8.6
+VER=1.8.7
 SRCS="git::commit=tags/v$VER::https://github.com/saitoha/libsixel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243242"


### PR DESCRIPTION
Topic Description
-----------------

- libsixel: update to 1.8.7
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libsixel: 1.8.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsixel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
