### PR TITLE
tealdeer: update to 1.8.1

### DIFF
--- a/app-doc/tealdeer/spec
+++ b/app-doc/tealdeer/spec
@@ -1,4 +1,4 @@
-VER=1.8.0
+VER=1.8.1
 SRCS="git::commit=tags/v$VER::https://github.com/dbrgn/tealdeer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=84521"


### PR DESCRIPTION
Topic Description
-----------------

- tealdeer: update to 1.8.1

Package(s) Affected
-------------------

- tealdeer: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tealdeer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
