### PR TITLE
lxcfs: update to 6.0.5

### DIFF
--- a/app-admin/lxcfs/autobuild/defines
+++ b/app-admin/lxcfs/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=lxcfs
 PKGSEC=libs
-PKGDEP="dbus-glib fuse libnih lxc"
-BUILDDEP="help2man"
+PKGDEP="dbus-glib fuse-3 libnih lxc"
+BUILDDEP="help2man jinja2"
 PKGDES="FUSE module for LXC containers"
 
 ABSHADOW=0

--- a/app-admin/lxcfs/spec
+++ b/app-admin/lxcfs/spec
@@ -1,5 +1,4 @@
-VER=3.0.3
-REL=2
-SRCS="tbl::https://linuxcontainers.org/downloads/lxcfs/lxcfs-$VER.tar.gz"
-CHKSUMS="sha256::890aa30d960d9b1e53b0c0712bf645c1f1924f750e32cd090f368c1338bd462f"
+VER=6.0.5
+SRCS="tbl::https://linuxcontainers.org/downloads/lxcfs/lxcfs-v$VER.tar.gz"
+CHKSUMS="sha256::91ce19087147791361115f3c8d3c647d5b0a36d386cd050ee0175bb75cc5d918"
 CHKUPDATE="anitya::id=17098"


### PR DESCRIPTION
Topic Description
-----------------

- lxcfs: update to 6.0.5
    - lxcfs: add jinja2 building dependency
    - lxcfs: switching fuse to fuse-3

Package(s) Affected
-------------------

- lxcfs: 6.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxcfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
