### PR TITLE
networkmanager: update to 1.54.2

### DIFF
--- a/app-network/networkmanager/spec
+++ b/app-network/networkmanager/spec
@@ -1,4 +1,4 @@
-VER=1.54.1
+VER=1.54.2
 SRCS="tbl::https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/releases/$VER/downloads/NetworkManager-$VER.tar.xz"
-CHKSUMS="sha256::00f3f0be12ac4d4858ebf152430b92def1574803ff6107f7efc764a056d4c4c7"
+CHKSUMS="sha256::abcd4949509aeebe394f45761e6a6789657d4dc8979fe52d2d466145928fc7a2"
 CHKUPDATE="anitya::id=21197"


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager: update to 1.54.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- networkmanager: 1.54.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit networkmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
