### PR TITLE
[PREVIEW] cmake: update to 4.1.2

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,6 +1,6 @@
-VER=4.0.3
+VER=4.1.2
 SRCS="tbl::https://github.com/Kitware/CMake/releases/download/v$VER/cmake-$VER.tar.gz"
-CHKSUMS="sha256::8d3537b7b7732660ea247398f166be892fe6131d63cc291944b45b91279f3ffb"
+CHKSUMS="sha256::643f04182b7ba323ab31f526f785134fb79cba3188a852206ef0473fee282a15"
 CHKUPDATE="anitya::id=306"
 
 # lto-wrapper: fatal error: write: No space left on device

--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,8 +1,7 @@
-VER=3.31.11
-REL=2
+VER=4.4.3
 EPOCH=1
 SRCS="tbl::https://github.com/Kitware/CMake/releases/download/v$VER/cmake-$VER.tar.gz"
-CHKSUMS="sha256::c0a3b3f2912b2166f522d5010ffb6029d8454ee635f5ad7a3247e0be7f9a15c9"
+CHKSUMS="sha256::c46400618b4f1f2b43507f24fb22f3ae830c3416cf23b776e16e1d413aa892f0"
 CHKUPDATE="anitya::id=306"
 
 # lto-wrapper: fatal error: write: No space left on device


### PR DESCRIPTION
Topic Description
-----------------

- cmake: update to 4.1.2
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- cmake: 4.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
