### PR TITLE
cmake: downgrade to 3.31.6

### DIFF
--- a/app-devel/cmake/spec
+++ b/app-devel/cmake/spec
@@ -1,6 +1,7 @@
-VER=4.0.3
+VER=3.31.6
+EPOCH=1
 SRCS="tbl::https://github.com/Kitware/CMake/releases/download/v$VER/cmake-$VER.tar.gz"
-CHKSUMS="sha256::8d3537b7b7732660ea247398f166be892fe6131d63cc291944b45b91279f3ffb"
+CHKSUMS="sha256::653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0"
 CHKUPDATE="anitya::id=306"
 
 # lto-wrapper: fatal error: write: No space left on device


### PR DESCRIPTION
Topic Description
-----------------

- cmake: downgrade to 3.31.6
    Retreat, retreat! It broke everything!

Package(s) Affected
-------------------

- cmake: 3.31.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit cmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
