### PR TITLE
bitwarden:update to 2025.11.0

### DIFF
--- a/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-prefer-glibc-instead-of-musl-libc.patch
@@ -1,4 +1,4 @@
-From 0264dde6456f8b1f28dbe6adbef1a2932013e3d1 Mon Sep 17 00:00:00 2001
+From cc53e30aefc222431304307ea0e1a457a4469e21 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:16 -0700
 Subject: [PATCH 1/4] napi: prefer glibc instead of musl libc
@@ -36,5 +36,5 @@ index acfd0dffb8..bfb0e4aa69 100644
          );
          localFileExisted = existsSync(join(__dirname, "desktop_napi.linux-arm-gnueabihf.node"));
 -- 
-2.51.0
+2.51.1
 

--- a/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
+++ b/app-utils/bitwarden/autobuild/patches/0002-napi-enable-lto.patch
@@ -1,4 +1,4 @@
-From 175d1a5871a9ae28e22b43dc024b9f6c02b069ab Mon Sep 17 00:00:00 2001
+From 2fea1f519cf190102dac3ec5778c42eb8ef61967 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
 Subject: [PATCH 2/4] napi: enable lto
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index 5e2e42b463..7b9528229c 100644
+index 4198baa4b5..b59dae9f46 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
 @@ -39,3 +39,9 @@ napi-build = { workspace = true }
@@ -23,5 +23,5 @@ index 5e2e42b463..7b9528229c 100644
 +strip = false
 +incremental = false
 -- 
-2.51.0
+2.51.1
 

--- a/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
+++ b/app-utils/bitwarden/autobuild/patches/0003-napi-add-loongarch64-support.patch.loongarch64
@@ -1,4 +1,4 @@
-From 58418833b01b4fea6ffa169153a116e5e0022175 Mon Sep 17 00:00:00 2001
+From fc3f84c8c5848734d13fc138f0db68619e455708 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Sat, 20 Sep 2025 14:59:50 +0800
 Subject: [PATCH 3/4] napi: add loongarch64 support
@@ -27,14 +27,14 @@ index bfb0e4aa69..03d8a4ffc5 100644
          nativeBinding = loadFirstAvailable(
            ["desktop_napi.linux-arm-gnu.node", "desktop_napi.linux-arm-musl.node"],
 diff --git a/apps/desktop/electron-builder.json b/apps/desktop/electron-builder.json
-index 2e780bf6b1..ba9cc55f58 100644
+index eaa299db50..317ccdd3c3 100644
 --- a/apps/desktop/electron-builder.json
 +++ b/apps/desktop/electron-builder.json
 @@ -20,7 +20,7 @@
      "**/node_modules/@bitwarden/desktop-napi/index.js",
      "**/node_modules/@bitwarden/desktop-napi/desktop_napi.${platform}-${arch}*.node"
    ],
--  "electronVersion": "36.9.3",
+-  "electronVersion": "37.7.0",
 +  "electronVersion": "37.2.5",
    "generateUpdatesFilesForAllChannels": true,
    "publish": {
@@ -53,5 +53,5 @@ index 5fc42f31ac..fc36766e02 100644
  
  exports.default = run;
 -- 
-2.51.0
+2.51.1
 

--- a/app-utils/bitwarden/autobuild/patches/0004-fix-use-system-libsqlite3.so.patch
+++ b/app-utils/bitwarden/autobuild/patches/0004-fix-use-system-libsqlite3.so.patch
@@ -1,18 +1,18 @@
-From 558b527369c1c9028cb8764f2a6f0d10019e77bd Mon Sep 17 00:00:00 2001
+From 636d25ee289edf0a1c0d742ac6e55477c837e091 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Mon, 22 Sep 2025 16:09:53 +0800
 Subject: [PATCH 4/4] fix: use  system libsqlite3.so
 
 ---
- .../desktop_native/bitwarden_chromium_importer/Cargo.toml       | 2 +-
+ apps/desktop/desktop_native/chromium_importer/Cargo.toml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml b/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
-index d1efbd006f..779b55fee5 100644
---- a/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
-+++ b/apps/desktop/desktop_native/bitwarden_chromium_importer/Cargo.toml
-@@ -16,7 +16,7 @@ hex = { workspace = true }
- homedir = { workspace = true }
+diff --git a/apps/desktop/desktop_native/chromium_importer/Cargo.toml b/apps/desktop/desktop_native/chromium_importer/Cargo.toml
+index 51ad450a6f..89fe2ec2ba 100644
+--- a/apps/desktop/desktop_native/chromium_importer/Cargo.toml
++++ b/apps/desktop/desktop_native/chromium_importer/Cargo.toml
+@@ -16,7 +16,7 @@ dirs = { workspace = true }
+ hex = { workspace = true }
  pbkdf2 = "=0.12.2"
  rand = { workspace = true }
 -rusqlite = { version = "=0.37.0", features = ["bundled"] }
@@ -21,5 +21,5 @@ index d1efbd006f..779b55fee5 100644
  serde_json = { workspace = true }
  sha1 = "=0.10.6"
 -- 
-2.51.0
+2.51.1
 

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,4 @@
-VER=2025.10.0
+VER=2025.11.0
 SRCS="git::commit=tags/desktop-v$VER::https://github.com/bitwarden/clients"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=179174"


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: update to 2025.11.0

Package(s) Affected
-------------------

- bitwarden: 2025.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
