### PR TITLE
box64: update to 0.3.9+git20251119

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-VER=0.3.9+git20251113
-SRCS="git::commit=b6fb4865fb80dd754caabe1c3895aa70e4b9a813::https://github.com/ptitSeb/box64.git"
+VER=0.3.9+git20251119
+SRCS="git::commit=0a37916aa316b777251da685a4c7bdf6f7332610::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251119
    - Fix the latest Linux Steam.
    - Link: https://github.com/ptitSeb/box64/commit/82fbf9d

Package(s) Affected
-------------------

- box64: 0.3.9+git20251119

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

