### PR TITLE
zfs: update to 2.3.5

### DIFF
--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,5 +1,4 @@
-VER=2.3.4
-REL=2
+VER=2.3.5
 SRCS="git::commit=tags/zfs-$VER::https://github.com/openzfs/zfs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: update to 2.3.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- zfs: 2.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
