### PR TITLE
fan2go: update to 0.11.1

### DIFF
--- a/app-utils/fan2go/autobuild/defines
+++ b/app-utils/fan2go/autobuild/defines
@@ -4,6 +4,5 @@ PKGDES="A daemon providing dynamic fan speed control based on temperature sensor
 PKGDEP="glibc lm-sensors"
 BUILDDEP="go"
 
-# FIXME: Autobuild does not yet support splitting debug symbols out of
-# Go executables.
-ABSPLITDBG=0
+ABTYPE=gomod
+GO_BUILD_AFTER=("-tags" "netgo,disable_nvml")

--- a/app-utils/fan2go/spec
+++ b/app-utils/fan2go/spec
@@ -1,5 +1,4 @@
-VER=0.9.0
-REL=2
-SRCS="git::commit=tags/$VER::https://github.com/markusressel/fan2go.git"
+VER=0.11.1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/markusressel/fan2go.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376893"


### PR DESCRIPTION
Topic Description
-----------------

- fan2go: update to 0.11.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- fan2go: 0.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fan2go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
