### PR TITLE
clit: fix build errors

### DIFF
--- a/app-utils/clit/autobuild/build
+++ b/app-utils/clit/autobuild/build
@@ -1,8 +1,8 @@
-pushd lib
-make
-popd
+abinfo "Building clit lib ..."
+make -C "$SRCDIR"/lib
 
-pushd clit18
-make
-install -Dm755 clit $PKGDIR/usr/bin/clit
-popd
+abinfo "Building clit18 ..."
+make -C "$SRCDIR"/clit18
+
+abinfo "Install clit ..."
+install -Dvm755 "$SRCDIR"/clit18/clit "$PKGDIR"/usr/bin/clit

--- a/app-utils/clit/autobuild/patches/0003-fix-implicit-declaration.patch
+++ b/app-utils/clit/autobuild/patches/0003-fix-implicit-declaration.patch
@@ -1,0 +1,67 @@
+From 132a574450d8083266e6d0f274e4ab38174dd2db Mon Sep 17 00:00:00 2001
+From: pch666777 <1005100717@qq.com>
+Date: Wed, 19 Nov 2025 21:36:14 +0800
+Subject: [PATCH] fix implicit declaration
+
+- Supplement the missing standard header files.
+- Provide the accurate path for lzx.h.
+---
+ clit18/explode.c  | 1 +
+ clit18/hexdump.c  | 1 +
+ lib/litlib.h      | 2 ++
+ lib/litsections.c | 2 +-
+ 4 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/clit18/explode.c b/clit18/explode.c
+index 82bd81b..b8297eb 100644
+--- a/clit18/explode.c
++++ b/clit18/explode.c
+@@ -24,6 +24,7 @@
+ #include <stdio.h>
+ #include <stdlib.h> 
+ #include <string.h>
++#include <sys/stat.h>
+ #include "clit.h"
+ #include "litlib.h"
+ #include "manifest.h"
+diff --git a/clit18/hexdump.c b/clit18/hexdump.c
+index 18155a1..f14c960 100644
+--- a/clit18/hexdump.c
++++ b/clit18/hexdump.c
+@@ -16,6 +16,7 @@
+ #include <ctype.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ typedef unsigned char byte;
+ 
+diff --git a/lib/litlib.h b/lib/litlib.h
+index 096c6d7..ac5d1bb 100644
+--- a/lib/litlib.h
++++ b/lib/litlib.h
+@@ -24,6 +24,8 @@
+ #ifndef LITLIB_H
+ #define LITLIB_H
+ 
++#include <string.h>
++#include <ctype.h>
+ #include "littypes.h"
+ 
+ 
+diff --git a/lib/litsections.c b/lib/litsections.c
+index 78e2ef6..6a38dec 100644
+--- a/lib/litsections.c
++++ b/lib/litsections.c
+@@ -31,7 +31,7 @@
+ #include <string.h>
+ #include "litlib.h"
+ #include "litinternal.h"
+-#include "lzx.h"
++#include "lzx/lzx.h"
+ 
+ static int decompress_section(lit_file * litfile, char * section_name,
+     U8 * pControl, int sizeControl, U8 * pContent, int sizeContent, 
+-- 
+2.51.1
+

--- a/app-utils/clit/spec
+++ b/app-utils/clit/spec
@@ -1,5 +1,5 @@
 VER=1.8
-REL=7
+REL=8
 SRCS="tbl::http://www.convertlit.com/clit18src.zip"
 CHKSUMS="sha256::d70a85f5b945104340d56f48ec17bcf544e3bb3c35b1b3d58d230be699e557ba"
 SUBDIR=.


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- Include the missing standard header files.
- Provide the accurate path for lzx.h.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- clit: 1.8-7
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit clit
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
