### PR TITLE
git: update to 2.52.0

### DIFF
--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,4 @@
-VER=2.51.1
+VER=2.52.0
 
 # Use this for stable releases.
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
@@ -7,5 +7,5 @@ SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 #RC=2
 ##SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::b049d79e6a6cb3d81334bf689af6301f4d4c884191dfae65d2bb314a90384831"
+CHKSUMS="sha256::6880cb1e737e26f81cf7db9957ab2b5bb2aa1490d87619480b860816e0c10c32"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.52.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- git: 2.52.0
- git-gui: 2.52.0
- gitk: 2.52.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
