### PR TITLE
openslp: use new upstream url

### DIFF
--- a/runtime-gis/openslp/spec
+++ b/runtime-gis/openslp/spec
@@ -1,5 +1,5 @@
 VER=2.0.0
-REL=9
-SRCS="tbl::https://fossies.org/linux/privat/openslp-$VER.tar.gz"
+REL=10
+SRCS="tbl::https://fossies.org/linux/privat/old/openslp-$VER.tar.gz"
 CHKSUMS="sha256::924337a2a8e5be043ebaea2a78365c7427ac6e9cee24610a0780808b2ba7579b"
 CHKUPDATE="anitya::id=230482"


### PR DESCRIPTION
Topic Description
-----------------

- openslp: use new upstream url

Package(s) Affected
-------------------

- openslp: 2.0.0-10

Security Update?
----------------

No

Build Order
-----------

```
#buildit openslp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
