### PR TITLE
gnutls: update to 3.8.11

### DIFF
--- a/runtime-cryptography/gnutls/spec
+++ b/runtime-cryptography/gnutls/spec
@@ -1,4 +1,4 @@
-VER=3.8.10
+VER=3.8.11
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
-CHKSUMS="sha256::db7fab7cce791e7727ebbef2334301c821d79a550ec55c9ef096b610b03eb6b7"
+CHKSUMS="sha256::91bd23c4a86ebc6152e81303d20cf6ceaeb97bc8f84266d0faec6e29f17baa20"
 CHKUPDATE="anitya::id=1221"

--- a/runtime-optenv32/gnutls+32/spec
+++ b/runtime-optenv32/gnutls+32/spec
@@ -1,4 +1,4 @@
-VER=3.8.7
+VER=3.8.11
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
-CHKSUMS="sha256::fe302f2b6ad5a564bcb3678eb61616413ed5277aaf8e7bf7cdb9a95a18d9f477"
+CHKSUMS="sha256::91bd23c4a86ebc6152e81303d20cf6ceaeb97bc8f84266d0faec6e29f17baa20"
 CHKUPDATE="anitya::id=1221"


### PR DESCRIPTION
Topic Description
-----------------

- gnutls+32: update to 3.8.11
- gnutls: update to 3.8.11

Package(s) Affected
-------------------

- gnutls: 3.8.11

Security Update?
----------------

Yes, #13687

Build Order
-----------

```
#buildit gnutls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
