### PR TITLE
starship: update to 1.24.1

### DIFF
--- a/app-utils/starship/spec
+++ b/app-utils/starship/spec
@@ -1,4 +1,4 @@
-VER=1.24.0
+VER=1.24.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/starship/starship"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=55456"


### PR DESCRIPTION
Topic Description
-----------------

- starship: update to 1.24.1

Package(s) Affected
-------------------

- starship: 1.24.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit starship
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
