### PR TITLE
box64: update to 0.3.9+git20251121

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-VER=0.3.9+git20251119
-SRCS="git::commit=0a37916aa316b777251da685a4c7bdf6f7332610::https://github.com/ptitSeb/box64.git"
+VER=0.3.9+git20251121
+SRCS="git::commit=a170660a81a09f488cecdcd954e43c1ce4473dd4::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251121

Package(s) Affected
-------------------

- box64: 0.3.9+git20251121

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

