### PR TITLE
vdeplug4: replace and break vde2<=1:2.3.3

### DIFF
--- a/app-network/vde2/autobuild/defines
+++ b/app-network/vde2/autobuild/defines
@@ -5,3 +5,7 @@ PKGDES="Virtual Distributed Ethernet for emulators like QEMU"
 
 ABTYPE=cmake
 PKGEPOCH=1
+
+CMAKE_AFTER=(
+    "-DWITH_VDEPLUG4=ON"
+)

--- a/app-network/vde2/spec
+++ b/app-network/vde2/spec
@@ -1,4 +1,5 @@
 VER=2.3.3+git20250918
+REL=1
 SRCS="git::commit=6023871235cc5eec0fc359f031105b59d01c2075::https://github.com/virtualsquare/vde-2.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13642"

--- a/app-network/vdeplug4/autobuild/defines
+++ b/app-network/vdeplug4/autobuild/defines
@@ -3,3 +3,6 @@ PKGSEC=net
 PKGDEP="glibc s2argv-execs"
 PKGDES="Virtual Distributed Ethernet - Plug library"
 ABTYPE=cmake
+
+PKGBREAK="vde2<=1:2.3.3"
+PKGREP="vde2<=1:2.3.3"

--- a/app-network/vdeplug4/spec
+++ b/app-network/vdeplug4/spec
@@ -1,4 +1,5 @@
 VER=4.0.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/rd235/vdeplug4.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=rd235/vdeplug4"


### PR DESCRIPTION
Topic Description
-----------------

- vdeplug4: replace and break vde2<=1:2.3.3
- vde2: explicit require vdeplug4 in cmake options

Package(s) Affected
-------------------

- vde2: 1:2.3.3+git20250918-1
- vdeplug4: 4.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vdeplug4 vde2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
