### PR TITLE
libilbc: fix build

### DIFF
--- a/runtime-multimedia/libilbc/autobuild/defines
+++ b/runtime-multimedia/libilbc/autobuild/defines
@@ -3,3 +3,4 @@ PKGSEC=libs
 PKGDES="iLBC codec from the WebRTC project"
 
 PKGDEP="abseil-cpp"
+ABTYPE=cmakeninja

--- a/runtime-multimedia/libilbc/autobuild/patches/0001-AOSCOS-bump-CMAKE_CXX_STANDARD-to-17-to-build-with-a.patch
+++ b/runtime-multimedia/libilbc/autobuild/patches/0001-AOSCOS-bump-CMAKE_CXX_STANDARD-to-17-to-build-with-a.patch
@@ -1,0 +1,27 @@
+From 2823634c2c1aa2644b29a0b84b11ff26733fb95e Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Mon, 1 Dec 2025 22:02:51 +0800
+Subject: [PATCH] AOSCOS: bump CMAKE_CXX_STANDARD to 17 to build with
+ abseil-cpp in system
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52a12aea4b..ee4588fb80 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,7 +48,7 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+ 
+-set(CMAKE_CXX_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
+ 
+ if((CMAKE_C_COMPILER_ID STREQUAL "GNU") OR
+    (CMAKE_C_COMPILER_ID MATCHES "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "GNU"))
+-- 
+2.52.0
+

--- a/runtime-multimedia/libilbc/spec
+++ b/runtime-multimedia/libilbc/spec
@@ -1,5 +1,5 @@
 VER=3.0.4
-REL=1
-SRCS="tbl::https://github.com/TimothyGu/libilbc/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::c5ec9e3ec53a0a913f81504e202c7bfefbe9c070b7f5599c5e13a6c75d6af913"
+REL=2
+SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/TimothyGu/libilbc.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18775"


### PR DESCRIPTION
Topic Description
-----------------

- libilbc: fix build
    \`\`\`
    note: ‘std::string_view’ is only available from C++17 onwards
    \`\`\`
    C++17 is needed for this package.
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libilbc: 3.0.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libilbc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
