### PR TITLE
openvpn: update to 2.6.16

### DIFF
--- a/app-network/openvpn/spec
+++ b/app-network/openvpn/spec
@@ -1,4 +1,4 @@
-VER=2.6.15
+VER=2.6.16
 SRCS="tbl::https://swupdate.openvpn.net/community/releases/openvpn-$VER.tar.gz"
-CHKSUMS="sha256::e35513ee15995e3c71adfd8891b9f33522896c70b3baa2ed9a23c7a42c4d7bde"
+CHKSUMS="sha256::05cb5fdf1ea33fcba719580b31a97feaa019c4a3050563e88bc3b34675e6fed4"
 CHKUPDATE="anitya::id=2567"


### PR DESCRIPTION
Topic Description
-----------------

- openvpn: update to 2.6.16
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- openvpn: 2.6.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit openvpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
