### PR TITLE
cppcheck: update to 2.18.3

### DIFF
--- a/app-devel/cppcheck/spec
+++ b/app-devel/cppcheck/spec
@@ -1,4 +1,4 @@
-VER=2.18.0
-SRCS="tbl::https://sourceforge.net/projects/cppcheck/files/cppcheck/${VER:0:4}/cppcheck-${VER}.tar.gz"
-CHKSUMS="sha256::dc74e300ac59f2ef9f9c05c21d48ae4c8dd1ce17f08914dd30c738ff482e748f"
+VER=2.18.3
+SRCS="git::commit=tags/$VER::https://github.com/danmar/cppcheck"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=357"


### PR DESCRIPTION
Topic Description
-----------------

- cppcheck: update to 2.18.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- cppcheck: 2.18.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit cppcheck
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
