### PR TITLE
gdu: update to 5.32.0

### DIFF
--- a/app-utils/gdu/autobuild/defines
+++ b/app-utils/gdu/autobuild/defines
@@ -5,10 +5,4 @@ PKGDEP="gcc-runtime"
 BUILDDEP="go"
 
 ABTYPE=gomod
-
 GO_PACKAGES=("cmd/gdu")
-GO_LDFLAGS=(
-    "-X github.com/dundee/gdu/v5/build.Version=$PKGVER"
-    "-X github.com/dundee/gdu/v5/build.Time=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")"
-    "-X github.com/dundee/gdu/v5/build.User=AOSC"
-)

--- a/app-utils/gdu/autobuild/prepare
+++ b/app-utils/gdu/autobuild/prepare
@@ -1,0 +1,6 @@
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS=(
+    "-X github.com/dundee/gdu/v5/build.Version=$PKGVER"
+    "-X github.com/dundee/gdu/v5/build.Time=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")"
+    "-X github.com/dundee/gdu/v5/build.User=AOSC"
+)

--- a/app-utils/gdu/spec
+++ b/app-utils/gdu/spec
@@ -1,5 +1,4 @@
-VER=5.31.0
-REL=2
+VER=5.32.0
 SRCS="git::commit=tags/v$VER::https://github.com/dundee/gdu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141586"


### PR DESCRIPTION
Topic Description
-----------------

- gdu: update to 5.32.0

Package(s) Affected
-------------------

- gdu: 5.32.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
