### PR TITLE
box64: update to 0.3.9+git20251122

### DIFF
--- a/app-emulation/box64/autobuild/defines
+++ b/app-emulation/box64/autobuild/defines
@@ -36,4 +36,8 @@ CMAKE_AFTER__RISCV64=(
     "-DRV64_DYNAREC=ON"
 )
 
-FAIL_ARCH="!(arm64|loongarch64|ppc64el|riscv64)"
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER__LOONGARCH64[@]}"
+)
+
+FAIL_ARCH="!(arm64|loongarch64|ppc64el|riscv64|loongarch64_nosimd)"

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,5 @@
-VER=0.3.9+git20251121
-SRCS="git::commit=a170660a81a09f488cecdcd954e43c1ce4473dd4::https://github.com/ptitSeb/box64.git"
+VER=0.3.9+git20251122
+# Note: copy-repo is required for "box64 -v" to show the commit hash
+SRCS="git::commit=0c405897d366fc02d79bda7716fab6aa319098a1;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251122
    - Enable building for loongarch64_nosimd
    - Add copy-repo=true for "box64 -v".

Package(s) Affected
-------------------

- box64: 0.3.9+git20251122

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

