### PR TITLE
aosc-os-feature-data: update to 20251123

### DIFF
--- a/runtime-data/aosc-os-feature-data/spec
+++ b/runtime-data/aosc-os-feature-data/spec
@@ -1,4 +1,4 @@
-VER=20241017.1
+VER=20251123
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-os-feature-data"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375022"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-os-feature-data: update to 20251123
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aosc-os-feature-data: 20251123

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-os-feature-data
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
