### PR TITLE
python-dbusmock: update to 0.37.1

### DIFF
--- a/lang-python/python-dbusmock/autobuild/defines
+++ b/lang-python/python-dbusmock/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=python-dbusmock
 PKGSEC=python
-PKGDEP="linux-pam python-2 python-3"
-BUILDDEP="setuptools setuptools-python2"
+PKGDEP="dbus-python python-3"
+BUILDDEP="setuptools-scm"
 PKGDES="Mock D-Bus objects"
 
 ABHOST=noarch

--- a/lang-python/python-dbusmock/spec
+++ b/lang-python/python-dbusmock/spec
@@ -1,5 +1,4 @@
-VER=0.22.0
-SRCS="tbl::https://pypi.io/packages/source/p/python-dbusmock/python-dbusmock-$VER.tar.gz"
-CHKSUMS="sha256::2191919cc411fb94953b36e46bfd55ee5ad4162432ee0d0892bc2c4770ff5d7c"
+VER=0.37.1
+SRCS="pypi::version=$VER::python-dbusmock"
+CHKSUMS="sha256::a65aeedc17d8bbc1f0bf3f0b295988914c48619882d77b9afa4117eed95fc594"
 CHKUPDATE="anitya::id=19778"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- python-dbusmock: update to 0.37.1

Package(s) Affected
-------------------

- python-dbusmock: 0.37.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-dbusmock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
