### PR TITLE
gost: update to 3.2.6

### DIFF
--- a/app-proxy/gost/spec
+++ b/app-proxy/gost/spec
@@ -1,5 +1,4 @@
-VER=3.2.5
-REL=1
+VER=3.2.6
 SRCS="git::commit=tags/v$VER::https://github.com/go-gost/gost"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230972"


### PR DESCRIPTION
Topic Description
-----------------

- gost: update to 3.2.6
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gost: 3.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit gost
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
