### PR TITLE
graphviz: update to 14.0.4

### DIFF
--- a/app-doc/graphviz/autobuild/defines
+++ b/app-doc/graphviz/autobuild/defines
@@ -13,13 +13,8 @@ ABSHADOW=0
 
 PKGBREAK="kdsme<=1.2.8-7 vala<=0.56.18"
 
-# FIXME: FTBFS with LTO
-NOLTO=1
-
-# FIXME: FTBFS
-AUTOTOOLS_AFTER="--disable-ocaml \
-                 --disable-php"
+# FIXME: configure: error: unrecognized options: --enable-php
+AUTOTOOLS_AFTER=(
+    '--enable-php=no'
+)
 AUTOTOOLS_STRICT=0
-
-# Installation fails with parallelism.
-NOPARALLEL=1

--- a/app-doc/graphviz/autobuild/patches/0002-chore-workaround-lua-5.1-pkg-config-suffix.patch
+++ b/app-doc/graphviz/autobuild/patches/0002-chore-workaround-lua-5.1-pkg-config-suffix.patch
@@ -1,0 +1,26 @@
+From 4701665477ab0baadc721d849cfd245dce3994a3 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <self@origincode.me>
+Date: Sun, 23 Nov 2025 05:19:37 -0800
+Subject: [PATCH] chore: workaround lua 5.1 pkg-config suffix
+
+Signed-off-by: Kaiyang Wu <self@origincode.me>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index ce9529b79..57e633fb3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -737,7 +737,7 @@ else
+             if test "$PKG_CONFIG" != ""; then
+ 	        AC_MSG_CHECKING(for Lua headers and libraries with pkg-config)
+ 	        echo
+-	        for l in "$lua_suffix" "" "54" "5.4" "53" "5.3" "52" "5.2" "51" "5.1" ; do
++	        for l in "$lua_suffix" "" "54" "5.4" "53" "5.3" "52" "5.2" "51" "5.1" "-5.1" ; do
+ 	            pkgconfig_lua_found=`$PKG_CONFIG --exists lua$l 2>/dev/null`
+ 	            if test "$?" = "0" ; then
+                         LUA_INCLUDES="$LUA_CFLAGS "`$PKG_CONFIG --cflags-only-I lua$l`
+-- 
+2.52.0
+

--- a/app-doc/graphviz/spec
+++ b/app-doc/graphviz/spec
@@ -1,4 +1,4 @@
-VER=14.0.2
+VER=14.0.4
 SRCS="git::commit=tags/$VER::https://gitlab.com/graphviz/graphviz"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1249"


### PR DESCRIPTION
Topic Description
-----------------

- graphviz: update to 14.0.4
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- graphviz: 14.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit graphviz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
