### PR TITLE
iosevka-fonts: update to 33.3.5

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.3.4
+VER=33.3.5
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::0944361d0ed540a0a68866120339c41c702bb6c9811d28a9920fb0a375e9a5f4 \
-         sha256::e678876033b8702444564512f71c655f271f534f19d9b9b7d6994800c28e200a \
-         sha256::da329da5460c7adcc8ff9f37bc0df300c45072984cfeb0869f00b81bfabb10e8 \
-         sha256::c8c072462a36cc69507fe65a65d74a86c7b543ca2a01e669ee79c2a7750994bb \
-         sha256::340bb8bfd6eae6b3a6af7c8600e03e5950c05bb0673ba641d21b52b0ab94b009 \
-         sha256::e8deb64015ffe3d4d5cb80adb97fb5398398f8581d1ae3bf27726bd7621544ff \
-         sha256::bb628a0fa921a000bd84f76595417fa6d5c90a41f9ed5a548e09dd47c6da3f39 \
-         sha256::e14c2792c53e9cc4c453320e1a78ed03510278505964f6f4f03f31fe7e8a68e1 \
-         sha256::74ec6f6631d45b67a5769fa13113d427baccabcb5ce261e46a25f954748e68cd \
-         sha256::209a8d2c86c01988b252384efc28cf90d3550691d820ce7cd102facf2042fa03 \
-         sha256::c98d6da68d866ace51b09a5787207cb752ecd34c19f0733ee3ce8c964389a608 \
-         sha256::783126f1f61a4846402b695e88a92d83cf503d959521c5a0741219c926e647bb \
-         sha256::e97b8f1d8e54616fedffb1d04df2842fb1587afc33ed0f996957f62f978cd525 \
-         sha256::e55b382b3eeeecf922c28976ae33bbabbe6267308c3d71aef46115890aaf3f0c \
-         sha256::178efded33d92eb035a92a711e0a3378574bfe0acc558662f9e2b481a7169842 \
-         sha256::e9073c6546a64b3cedfa4b1f84bf833c8d8298cbf0c22201cfc42c26302cedab \
-         sha256::2fdabc1e40746cd2539b16fbddeede5c024742bb62159752a26840302b03d265 \
-         sha256::71d788b98a9eb5649a9bea5e72ce959040712d49f5f4bc60332e07db8d3d6a6c \
-         sha256::be0364537c2c1f154542cc748ad7c2e7e4a7e4646b471e9f4c04d22076821341 \
-         sha256::a21566b8dc8329758c2d2073658b295d3193d5a236d55d56cdf3db7859c7f7ed \
-         sha256::376049510484ef54ca27e40c896a4a114bf6ff92a655d92a923e36255f99949c \
-         sha256::78fbe75e2c6b3d7562fa3578e0df97679fee54e9e79a5b980115c6c846c32380 \
-         sha256::d9015d81841a79cad917aba1732c149b20fbff4b17ad3afcfaee7df6fbce8f53 \
-         sha256::3279dc3c782b9b587b23c6902847b0c730d62674211a0be419a403cb790356ff \
+CHKSUMS="sha256::88b6d7e2442b39ef98ce4c352018a90906aa1eea8d54497743ffc1c0e1697981 \
+         sha256::fcc5aac4a6857801c206a2822b30ec30677e84dab40c24de64a3a308efb64d43 \
+         sha256::f2168ca681e8a973635db5a5aac41659f36dc2ef32c361296c56369f58ce82a1 \
+         sha256::1828cbf43016cdfc4b7c132c6ac022de07cd6206c023b3f707f2642e04ab71e8 \
+         sha256::8ed780b5fabbf4aef445981bf7d497b5eae68e022e52e75e0559b3909feb00c5 \
+         sha256::88f20e60aab36ccac82eb6214f630bac6f9deca3d8bb7aee0093a5157908c66d \
+         sha256::fcf55c9ab82442d21e56c432102b8e6602b99a54b491ed8c67d50afebbac4130 \
+         sha256::44e01d5a233e7146891be49709c3c3846734d8183ce70e06eeb71eed99723665 \
+         sha256::90bbb8b5f4724c1324787849f0c3590c25797f3cad2360c86fe9dc6695af94b4 \
+         sha256::b5f99d94919276a0e5290d6e23b1435ea23e2cb08222aa519266524702eb5e77 \
+         sha256::74b54d6f69178bdb4b6e39551fd09d9e21ea312f4910297871a39570e87158f0 \
+         sha256::785cb90f6ff2abe4aba377591d5e8cffc293c6a77ea22a8420ef5d4cd3a86f24 \
+         sha256::783e6094a4cbe80a23422a8a8322c77df02029c34060a823e5b68cb51756cb42 \
+         sha256::789f26a2a62f161dc0b818623159a864df862785cf944c6279b5d308913e7074 \
+         sha256::01c26abb4df7f36bdb577455b78672e8bbae72ef6f35fac65abc52cf96c9905d \
+         sha256::a38fb571b81f49cce72e609c93f13245f89e6f1396982b0662216d69ff8c66ad \
+         sha256::81043733d66b9b1a5bd00dc8848eca2d3ae7b0d6ee1f73f0ef1744649ed66284 \
+         sha256::a9c691d6054ca9f8aef85c89d6856166532448ca5a6971939c165512064a9f57 \
+         sha256::e386eb76426b9b332ae0d4505a055e25de02160e9e79ae8a3d91acec2bd04aa6 \
+         sha256::eb5eb4ba00a94389f5fe3170f3051f3d9a44f04c4bd747565716793f241d9cc2 \
+         sha256::712afa8986e5c275c374bcf3758c5d681c6357b4f260470583a88709dc85654d \
+         sha256::39860a205b0c0733157847f3734bfbc313f7857686ee18d6c2df1fc7d2bf9987 \
+         sha256::2088c746610fa0c901dfc840e24fa7d00ede13efd3d6ed91d95130e10b081925 \
+         sha256::d0bc8cfbf87a5776c663e9e59fa9e0570db3c0306c918f352db9b510458a898e \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.3.5
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 33.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
