### PR TITLE
sarasa-gothic-fonts: update to 1.0.35

### DIFF
--- a/desktop-fonts/sarasa-gothic-fonts/spec
+++ b/desktop-fonts/sarasa-gothic-fonts/spec
@@ -1,7 +1,7 @@
-VER=1.0.34
+VER=1.0.35
 SRCS="tbl::https://github.com/be5invis/Sarasa-Gothic/releases/download/v$VER/Sarasa-TTC-$VER.7z \
       git::commit=tags/v$VER::https://github.com/be5invis/Sarasa-Gothic"
-CHKSUMS="sha256::71a0341a7186bdcf7ba01f653760c6838326fe39c0d88f759ef3fc4b3be32b64 \
+CHKSUMS="sha256::3fe41f6ff2c4cdb4e4c80f725cf012aecdfdf1ecca577648b5c202932df352d3 \
          SKIP"
 CHKUPDATE="anitya::id=227599"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- sarasa-gothic-fonts: update to 1.0.35
    Co-authored-by: Kaiyang Wu \(@OriginCode\)

Package(s) Affected
-------------------

- sarasa-gothic-fonts: 1.0.35

Security Update?
----------------

No

Build Order
-----------

```
#buildit sarasa-gothic-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
