### PR TITLE
xorg-server: revert upstrema GLAMOR changes to fix regression

### DIFF
--- a/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0001-Use-intel-ddx-only-on-pre-gen4-hw-newer-ones-will-fa.patch
@@ -1,7 +1,7 @@
 From 3e1f0cb0072cf0cf3fdaaecdafa0fec256c8ca92 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:06:28 +0800
-Subject: [PATCH 1/7] Use intel ddx only on pre-gen4 hw, newer ones will fall
+Subject: [PATCH 01/12] Use intel ddx only on pre-gen4 hw, newer ones will fall
  back to modesetting
 
 Co-authored-by: Timo Aaltonen <tjaalton@debian.org>
@@ -40,5 +40,5 @@ index aeeed8be6..db705bf72 100644
  			break;
          }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0002-xfree86-use-modesetting-driver-by-default-on-GeForce.patch
@@ -1,7 +1,7 @@
 From 365b982603f0e5aa81186880f10adac48fcab46e Mon Sep 17 00:00:00 2001
 From: Ben Skeggs <bskeggs@redhat.com>
 Date: Sat, 22 Apr 2017 02:26:28 +1000
-Subject: [PATCH 2/7] xfree86: use modesetting driver by default on GeForce 8
+Subject: [PATCH 02/12] xfree86: use modesetting driver by default on GeForce 8
  and newer
 
 Signed-off-by: Ben Skeggs <bskeggs@redhat.com>
@@ -49,5 +49,5 @@ index db705bf72..d2e78acaa 100644
  #endif
          driverList[idx++] = "nv";
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0003-hw-xfree86-re-calculate-the-clock-and-refresh-rate.patch
@@ -1,7 +1,7 @@
 From 76254188831b1074eb54805ce9f9bfe972ee87c9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:18:25 +0800
-Subject: [PATCH 3/7] hw/xfree86: re-calculate the clock and refresh rate
+Subject: [PATCH 03/12] hw/xfree86: re-calculate the clock and refresh rate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -85,5 +85,5 @@ index ad01b87ec..561087717 100644
      MODE_ERROR = -1             /* error condition */
  } ModeStatus;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0004-xf86-Accept-devices-with-the-hyperv_drm-driver.patch
@@ -1,7 +1,7 @@
 From 51e9941fd6718419c2d30045d4b7f23545807574 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Fri, 30 Aug 2024 14:27:59 +0800
-Subject: [PATCH 4/7] xf86: Accept devices with the 'hyperv_drm' driver
+Subject: [PATCH 04/12] xf86: Accept devices with the 'hyperv_drm' driver
 
 Put in a workaround to accept devices of the kernel's hyperv_drm
 driver. Makes Xorg work on HyperV Gen 1/2 with the DRM graphics
@@ -28,5 +28,5 @@ index 45028f7a6..071f44b2a 100644
                      if (strcmp(xf86_platform_devices[j].attribs->driver, "simpledrm") == 0)
                          break;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0005-Allows-X-to-work-on-the-Lemote-Yeeloong-laptop.patch
@@ -1,7 +1,7 @@
 From 06559e8ebe009564c300b257abb0e1f5c9beff79 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 15 Aug 2020 01:32:42 -0600
-Subject: [PATCH 5/7] Allows X to work on the Lemote Yeeloong laptop
+Subject: [PATCH 05/12] Allows X to work on the Lemote Yeeloong laptop
 
 ---
  hw/xfree86/common/compiler.h            | 64 ++++++++++++++++++++++++-
@@ -133,5 +133,5 @@ index fd83022f6..bacbe010b 100644
      if (ioBase == NULL) {
          ioBase = (volatile unsigned char *) mmap(0, 0x20000,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0006-modesetting-match-against-Multimedia-Video-Controlle.patch
@@ -1,7 +1,7 @@
 From a555a066b6b52b0848aabea2edb03ce9229a427e Mon Sep 17 00:00:00 2001
 From: "Liu, Chang" <cl91tp@gmail.com>
 Date: Wed, 8 Nov 2023 13:02:10 +0800
-Subject: [PATCH 6/7] modesetting: match against Multimedia Video Controllers
+Subject: [PATCH 06/12] modesetting: match against Multimedia Video Controllers
  as well
 
 Some GPU devices such as those found in the Loongson 7A2000 bridge
@@ -28,5 +28,5 @@ index fe3315a9c..01b3f505b 100644
      {0, 0, 0},
  };
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0007-hw-xfree86-workaround-bad-firmware-boot-VGA-reportin.patch
@@ -1,8 +1,8 @@
 From c18393b1e3e5b0f592c709737a060866fe1f3f0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 17:38:44 +0800
-Subject: [PATCH 7/7] hw/xfree86: workaround bad firmware boot VGA reporting on
- MIPS Loongson devices
+Subject: [PATCH 07/12] hw/xfree86: workaround bad firmware boot VGA reporting
+ on MIPS Loongson devices
 
 Loongson (MIPS) platforms based on (at least) the 7A bridge chip has
 faulty firmware that does not export the correct boot VGA device to the
@@ -74,5 +74,5 @@ index fd144dbe7..a95096736 100644
          return;
  #endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/xorg-server/autobuild/patches/0008-Revert-glamor-reject-configs-using-unsupported-rgbBi.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0008-Revert-glamor-reject-configs-using-unsupported-rgbBi.patch
@@ -1,0 +1,76 @@
+From 374322f977a691c08c08f32d97118536b2f33243 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Wed, 19 Nov 2025 16:23:46 +0100
+Subject: [PATCH 08/12] Revert "glamor: reject configs using unsupported
+ rgbBits size"
+
+This reverts commit b89a563882f234f6949a874770d3ca075d2d2fdc.
+
+This is a fix for a code path that we are about to remove with the next
+few reverts, so start by reverting this change.
+
+See-also: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1848
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2104>
+---
+ glamor/glamor_glx_provider.c | 21 +++------------------
+ 1 file changed, 3 insertions(+), 18 deletions(-)
+
+diff --git a/glamor/glamor_glx_provider.c b/glamor/glamor_glx_provider.c
+index c27141c7c..77ccc3c8b 100644
+--- a/glamor/glamor_glx_provider.c
++++ b/glamor/glamor_glx_provider.c
+@@ -140,14 +140,12 @@ egl_create_glx_drawable(ClientPtr client, __GLXscreen *screen,
+  * - drawable type masks is suspicious
+  */
+ static struct egl_config *
+-translate_eglconfig(ScreenPtr pScreen, struct egl_screen *screen, EGLConfig hc,
++translate_eglconfig(struct egl_screen *screen, EGLConfig hc,
+                     struct egl_config *chain, Bool direct_color,
+                     Bool double_buffer, Bool duplicate_for_composite,
+                     Bool srgb_only)
+ {
+     EGLint value;
+-    bool valid_depth;
+-    int i;
+     struct egl_config *c = calloc(1, sizeof *c);
+ 
+     if (!c)
+@@ -220,19 +218,6 @@ translate_eglconfig(ScreenPtr pScreen, struct egl_screen *screen, EGLConfig hc,
+     }
+ #undef GET
+ 
+-    /* Only expose this config if rgbBits matches a supported
+-     * depth value.
+-     */
+-    valid_depth = false;
+-    for (i = 0; i < pScreen->numDepths && !valid_depth; i++) {
+-        if (pScreen->allowedDepths[i].depth == c->base.rgbBits)
+-            valid_depth = true;
+-    }
+-    if (!valid_depth) {
+-        free(c);
+-        return chain;
+-    }
+-
+     /* derived state: config caveats */
+     eglGetConfigAttrib(screen->display, hc, EGL_CONFIG_CAVEAT, &value);
+     if (value == EGL_NONE)
+@@ -355,13 +340,13 @@ egl_mirror_configs(ScreenPtr pScreen, struct egl_screen *screen)
+         for (j = 0; j < 3; j++) /* direct_color */
+             for (k = 0; k < 2; k++) /* double_buffer */ {
+                 if (can_srgb)
+-                    c = translate_eglconfig(pScreen, screen, host_configs[i], c,
++                    c = translate_eglconfig(screen, host_configs[i], c,
+                                             /* direct_color */ j == 1,
+                                             /* double_buffer */ k > 0,
+                                             /* duplicate_for_composite */ j == 0,
+                                             /* srgb_only */ true);
+ 
+-                c = translate_eglconfig(pScreen, screen, host_configs[i], c,
++                c = translate_eglconfig(screen, host_configs[i], c,
+                                         /* direct_color */ j == 1,
+                                         /* double_buffer */ k > 0,
+                                         /* duplicate_for_composite */ j == 0,
+-- 
+2.52.0
+

--- a/runtime-display/xorg-server/autobuild/patches/0009-Revert-glamor_egl-add-support-of-GlxVendorLibrary-op.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0009-Revert-glamor_egl-add-support-of-GlxVendorLibrary-op.patch
@@ -1,0 +1,88 @@
+From ec62d04798da48e9d1e817a654f924fcdaccb09c Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Wed, 19 Nov 2025 16:23:53 +0100
+Subject: [PATCH 09/12] Revert "glamor_egl: add support of GlxVendorLibrary
+ option"
+
+This reverts commit 062d39977094c89ef34168b78b9c9e9fc85483ff.
+
+There is an issue with this code in GLAMOR EGL and using this option in
+the "xorg.conf" would lead to a segmentation fault in the Xserver.
+
+Instead of fixing the code for that option in GLAMOR EGL, let's revert
+the commit in the stable branch, since we are to revert support for
+glamor GLX, this options will no longer be needed.
+
+See-also: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1848
+See-also: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2096
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2104>
+---
+ glamor/glamor_egl.c | 20 ++++----------------
+ 1 file changed, 4 insertions(+), 16 deletions(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index d1896340f..a3ea4c3d5 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -59,7 +59,6 @@ struct glamor_egl_screen_private {
+     int fd;
+     struct gbm_device *gbm;
+     int dmabuf_capable;
+-    Bool force_vendor; /* if GLVND vendor is forced from options */
+ 
+     CloseScreenProcPtr saved_close_screen;
+     DestroyPixmapProcPtr saved_destroy_pixmap;
+@@ -914,13 +913,10 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
+ 
+     glamor_ctx->make_current = glamor_egl_make_current;
+ 
+-    /* Use dynamic logic only if vendor is not forced via xorg.conf */
+-    if (!glamor_egl->force_vendor) {
+-        gbm_backend_name = gbm_device_get_backend_name(glamor_egl->gbm);
+-        /* Mesa uses "drm" as backend name, in that case, just do nothing */
+-        if (gbm_backend_name && strcmp(gbm_backend_name, "drm") != 0)
+-            glamor_set_glvnd_vendor(screen, gbm_backend_name);
+-    }
++    gbm_backend_name = gbm_device_get_backend_name(glamor_egl->gbm);
++    /* Mesa uses "drm" as backend name, in that case, just do nothing */
++    if (gbm_backend_name && strcmp(gbm_backend_name, "drm") != 0)
++        glamor_set_glvnd_vendor(screen, gbm_backend_name);
+ #ifdef DRI3
+     /* Tell the core that we have the interfaces for import/export
+      * of pixmaps.
+@@ -1074,12 +1070,10 @@ glamor_egl_try_gles_api(ScrnInfoPtr scrn)
+ 
+ enum {
+     GLAMOREGLOPT_RENDERING_API,
+-    GLAMOREGLOPT_VENDOR_LIBRARY
+ };
+ 
+ static const OptionInfoRec GlamorEGLOptions[] = {
+     { GLAMOREGLOPT_RENDERING_API, "RenderingAPI", OPTV_STRING, {0}, FALSE },
+-    { GLAMOREGLOPT_VENDOR_LIBRARY, "GlxVendorLibrary", OPTV_STRING, {0}, FALSE },
+     { -1, NULL, OPTV_NONE, {0}, FALSE },
+ };
+ 
+@@ -1092,7 +1086,6 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+     const char *api = NULL;
+     Bool es_allowed = TRUE;
+     Bool force_es = FALSE;
+-    const char *glvnd_vendor = NULL;
+ 
+     glamor_egl = calloc(sizeof(*glamor_egl), 1);
+     if (glamor_egl == NULL)
+@@ -1103,11 +1096,6 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
+     options = xnfalloc(sizeof(GlamorEGLOptions));
+     memcpy(options, GlamorEGLOptions, sizeof(GlamorEGLOptions));
+     xf86ProcessOptions(scrn->scrnIndex, scrn->options, options);
+-    glvnd_vendor = xf86GetOptValString(options, GLAMOREGLOPT_VENDOR_LIBRARY);
+-    if (glvnd_vendor) {
+-        glamor_set_glvnd_vendor(xf86ScrnToScreen(scrn), glvnd_vendor);
+-        glamor_egl->force_vendor = TRUE;
+-    }
+     api = xf86GetOptValString(options, GLAMOREGLOPT_RENDERING_API);
+     if (api && !strncasecmp(api, "es", 2))
+         force_es = TRUE;
+-- 
+2.52.0
+

--- a/runtime-display/xorg-server/autobuild/patches/0010-Revert-xorg-initialize-glamor-provider.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0010-Revert-xorg-initialize-glamor-provider.patch
@@ -1,0 +1,76 @@
+From ba7101b681f95bf8106513e2a0ffe1622f816ff0 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Wed, 19 Nov 2025 16:24:02 +0100
+Subject: [PATCH 10/12] Revert "xorg: initialize glamor provider"
+
+This reverts commit 0a1ee643b26fd53074ec90c95a14c12c8f5166b3.
+
+This is causing a number of regressions on existing setups:
+
+ * Reverse PRIME with the NVIDIA proprietary driver, where software
+   rendering is used instead of the NVIDIA GLX library with hardware
+   acceleration
+ * Performance issues with AMDGPU
+ * Rendering with 10-bit output with AMDGPU
+
+Revert the change that is causing these regressions in the stable branch.
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1848
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2104>
+---
+ glamor/glamor_egl.c               | 11 -----------
+ hw/xfree86/glamor_egl/meson.build |  2 +-
+ 2 files changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index a3ea4c3d5..dc31c1650 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -46,7 +46,6 @@
+ 
+ #include "glamor.h"
+ #include "glamor_priv.h"
+-#include "glamor_glx_provider.h"
+ #include "dri3.h"
+ 
+ struct glamor_egl_screen_private {
+@@ -896,9 +895,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
+         glamor_egl_get_screen_private(scrn);
+ #ifdef DRI3
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+-#endif
+-#ifdef GLXEXT
+-    static Bool vendor_initialized = FALSE;
+ #endif
+     const char *gbm_backend_name;
+ 
+@@ -940,13 +936,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
+         }
+     }
+ #endif
+-#ifdef GLXEXT
+-    if (!vendor_initialized) {
+-        GlxPushProvider(&glamor_provider);
+-        xorgGlxCreateVendor();
+-        vendor_initialized = TRUE;
+-    }
+-#endif
+ }
+ 
+ static void glamor_egl_cleanup(struct glamor_egl_screen_private *glamor_egl)
+diff --git a/hw/xfree86/glamor_egl/meson.build b/hw/xfree86/glamor_egl/meson.build
+index dd1cafcd9..7eae05812 100644
+--- a/hw/xfree86/glamor_egl/meson.build
++++ b/hw/xfree86/glamor_egl/meson.build
+@@ -15,7 +15,7 @@ shared_module(
+         dependency('libdrm', version: '>= 2.4.46'),
+         gbm_dep,
+     ],
+-    link_with: [glamor, libxserver_glx],
++    link_with: glamor,
+ 
+     install: true,
+     install_dir: module_dir,
+-- 
+2.52.0
+

--- a/runtime-display/xorg-server/autobuild/patches/0011-Revert-glamor-Lift-the-GLX-EGL-backend-from-Xwayland.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0011-Revert-glamor-Lift-the-GLX-EGL-backend-from-Xwayland.patch
@@ -1,0 +1,549 @@
+From 95624a0b1d37b4c9212e76f981aff2688bf7e4a7 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Wed, 19 Nov 2025 16:24:11 +0100
+Subject: [PATCH 11/12] Revert "glamor: Lift the GLX EGL backend from Xwayland"
+
+This reverts commit ed1ec1350269fb91c2c276680d614653a021ee98.
+This reverts commit 3837159a3f6f3f8915c55e282ea545eed3f1dfdc.
+
+We no longer use GLX provider for glamor, so we can remove that code.
+
+See-also: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1848
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2104>
+---
+ glamor/Makefile.am                |   7 -
+ glamor/glamor_glx_provider.c      | 422 ------------------------------
+ glamor/glamor_glx_provider.h      |  37 ---
+ glamor/meson.build                |   5 +-
+ hw/xfree86/glamor_egl/Makefile.am |   1 -
+ 5 files changed, 1 insertion(+), 471 deletions(-)
+ delete mode 100644 glamor/glamor_glx_provider.c
+ delete mode 100644 glamor/glamor_glx_provider.h
+
+diff --git a/glamor/Makefile.am b/glamor/Makefile.am
+index 847daa2a8..aaf0aab17 100644
+--- a/glamor/Makefile.am
++++ b/glamor/Makefile.am
+@@ -49,13 +49,6 @@ libglamor_la_SOURCES = \
+ 	glamor_sync.c \
+ 	glamor.h
+ 
+-if GLX
+-AM_CFLAGS += -I$(top_srcdir)/glx
+-libglamor_la_SOURCES += \
+-	glamor_glx_provider.c \
+-	glamor_glx_provider.h
+-endif
+-
+ if XV
+ libglamor_la_SOURCES += \
+ 	glamor_xv.c
+diff --git a/glamor/glamor_glx_provider.c b/glamor/glamor_glx_provider.c
+deleted file mode 100644
+index 77ccc3c8b..000000000
+--- a/glamor/glamor_glx_provider.c
++++ /dev/null
+@@ -1,422 +0,0 @@
+-/*
+- * Copyright © 2019 Red Hat, Inc.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice (including the next
+- * paragraph) shall be included in all copies or substantial portions of the
+- * Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+- * DEALINGS IN THE SOFTWARE.
+- *
+- * Authors:
+- *	Adam Jackson <ajax@redhat.com>
+- */
+-
+-/*
+- * Sets up GLX capabilities based on the EGL capabilities of the glamor
+- * renderer for the screen. Without this you will get whatever swrast
+- * can do, which often does not include things like multisample visuals.
+- */
+-
+-#include <dix-config.h>
+-
+-#define MESA_EGL_NO_X11_HEADERS
+-#define EGL_NO_X11
+-#include <epoxy/egl.h>
+-#include "glxserver.h"
+-#include "glxutil.h"
+-#include "compint.h"
+-#include <X11/extensions/composite.h>
+-#include "glamor_priv.h"
+-#include "glamor.h"
+-
+-/* Can't get these from <GL/glx.h> since it pulls in client headers */
+-#define GLX_RGBA_BIT		0x00000001
+-#define GLX_WINDOW_BIT		0x00000001
+-#define GLX_PIXMAP_BIT		0x00000002
+-#define GLX_PBUFFER_BIT		0x00000004
+-#define GLX_NONE                0x8000
+-#define GLX_SLOW_CONFIG         0x8001
+-#define GLX_TRUE_COLOR		0x8002
+-#define GLX_DIRECT_COLOR	0x8003
+-#define GLX_NON_CONFORMANT_CONFIG 0x800D
+-#define GLX_DONT_CARE           0xFFFFFFFF
+-#define GLX_RGBA_FLOAT_BIT_ARB  0x00000004
+-#define GLX_SWAP_UNDEFINED_OML  0x8063
+-
+-struct egl_config {
+-    __GLXconfig base;
+-    EGLConfig config;
+-};
+-
+-struct egl_screen {
+-    __GLXscreen base;
+-    EGLDisplay display;
+-    EGLConfig *configs;
+-};
+-
+-static void
+-egl_screen_destroy(__GLXscreen *_screen)
+-{
+-    struct egl_screen *screen = (struct egl_screen *)_screen;
+-
+-    /* XXX do we leak the fbconfig list? */
+-
+-    free(screen->configs);
+-    __glXScreenDestroy(_screen);
+-    free(_screen);
+-}
+-
+-static void
+-egl_drawable_destroy(__GLXdrawable *draw)
+-{
+-    free(draw);
+-}
+-
+-static GLboolean
+-egl_drawable_swap_buffers(ClientPtr client, __GLXdrawable *draw)
+-{
+-    return GL_FALSE;
+-}
+-
+-static void
+-egl_drawable_copy_sub_buffer(__GLXdrawable *draw, int x, int y, int w, int h)
+-{
+-}
+-
+-static void
+-egl_drawable_wait_x(__GLXdrawable *draw)
+-{
+-    glamor_block_handler(draw->pDraw->pScreen);
+-}
+-
+-static void
+-egl_drawable_wait_gl(__GLXdrawable *draw)
+-{
+-}
+-
+-static __GLXdrawable *
+-egl_create_glx_drawable(ClientPtr client, __GLXscreen *screen,
+-                        DrawablePtr draw, XID drawid, int type,
+-                        XID glxdrawid, __GLXconfig *modes)
+-{
+-    __GLXdrawable *ret;
+-
+-    ret = calloc(1, sizeof *ret);
+-    if (!ret)
+-        return NULL;
+-
+-    if (!__glXDrawableInit(ret, screen, draw, type, glxdrawid, modes)) {
+-        free(ret);
+-        return NULL;
+-    }
+-
+-    ret->destroy = egl_drawable_destroy;
+-    ret->swapBuffers = egl_drawable_swap_buffers;
+-    ret->copySubBuffer = egl_drawable_copy_sub_buffer;
+-    ret->waitX = egl_drawable_wait_x;
+-    ret->waitGL = egl_drawable_wait_gl;
+-
+-    return ret;
+-}
+-
+-/*
+- * TODO:
+- *
+- * - bindToTextureTargets is suspicious
+- * - better channel mask setup
+- * - drawable type masks is suspicious
+- */
+-static struct egl_config *
+-translate_eglconfig(struct egl_screen *screen, EGLConfig hc,
+-                    struct egl_config *chain, Bool direct_color,
+-                    Bool double_buffer, Bool duplicate_for_composite,
+-                    Bool srgb_only)
+-{
+-    EGLint value;
+-    struct egl_config *c = calloc(1, sizeof *c);
+-
+-    if (!c)
+-        return chain;
+-
+-    /* constants.  changing these requires (at least) new EGL extensions */
+-    c->base.stereoMode = GL_FALSE;
+-    c->base.numAuxBuffers = 0;
+-    c->base.level = 0;
+-    c->base.transparentAlpha = 0;
+-    c->base.transparentIndex = 0;
+-    c->base.transparentPixel = GLX_NONE;
+-    c->base.visualSelectGroup = 0;
+-    c->base.indexBits = 0;
+-    c->base.optimalPbufferWidth = 0;
+-    c->base.optimalPbufferHeight = 0;
+-    c->base.bindToMipmapTexture = 0;
+-    c->base.bindToTextureTargets = GLX_DONT_CARE;
+-    c->base.swapMethod = GLX_SWAP_UNDEFINED_OML;
+-
+-    /* this is... suspect */
+-    c->base.drawableType = GLX_WINDOW_BIT | GLX_PIXMAP_BIT | GLX_PBUFFER_BIT;
+-
+-    /* hmm */
+-    c->base.bindToTextureRgb = GL_TRUE;
+-    c->base.bindToTextureRgba = GL_TRUE;
+-
+-    /*
+-     * glx conformance failure: there's no such thing as accumulation
+-     * buffers in EGL.  they should be emulable with shaders and fbos,
+-     * but i'm pretty sure nobody's using this feature since it's
+-     * entirely software.  note that glx conformance merely requires
+-     * that an accum buffer _exist_, not a minimum bitness.
+-     */
+-    c->base.accumRedBits = 0;
+-    c->base.accumGreenBits = 0;
+-    c->base.accumBlueBits = 0;
+-    c->base.accumAlphaBits = 0;
+-
+-    /* parametric state */
+-    if (direct_color)
+-        c->base.visualType = GLX_DIRECT_COLOR;
+-    else
+-        c->base.visualType = GLX_TRUE_COLOR;
+-
+-    if (double_buffer)
+-        c->base.doubleBufferMode = GL_TRUE;
+-    else
+-        c->base.doubleBufferMode = GL_FALSE;
+-
+-    /* direct-mapped state */
+-#define GET(attr, slot) \
+-    eglGetConfigAttrib(screen->display, hc, attr, &c->base.slot)
+-    GET(EGL_RED_SIZE, redBits);
+-    GET(EGL_GREEN_SIZE, greenBits);
+-    GET(EGL_BLUE_SIZE, blueBits);
+-    GET(EGL_ALPHA_SIZE, alphaBits);
+-    GET(EGL_BUFFER_SIZE, rgbBits);
+-    GET(EGL_DEPTH_SIZE, depthBits);
+-    GET(EGL_STENCIL_SIZE, stencilBits);
+-    GET(EGL_TRANSPARENT_RED_VALUE, transparentRed);
+-    GET(EGL_TRANSPARENT_GREEN_VALUE, transparentGreen);
+-    GET(EGL_TRANSPARENT_BLUE_VALUE, transparentBlue);
+-    GET(EGL_SAMPLE_BUFFERS, sampleBuffers);
+-    GET(EGL_SAMPLES, samples);
+-    if (c->base.renderType & GLX_PBUFFER_BIT) {
+-        GET(EGL_MAX_PBUFFER_WIDTH, maxPbufferWidth);
+-        GET(EGL_MAX_PBUFFER_HEIGHT, maxPbufferHeight);
+-        GET(EGL_MAX_PBUFFER_PIXELS, maxPbufferPixels);
+-    }
+-#undef GET
+-
+-    /* derived state: config caveats */
+-    eglGetConfigAttrib(screen->display, hc, EGL_CONFIG_CAVEAT, &value);
+-    if (value == EGL_NONE)
+-        c->base.visualRating = GLX_NONE;
+-    else if (value == EGL_SLOW_CONFIG)
+-        c->base.visualRating = GLX_SLOW_CONFIG;
+-    else if (value == EGL_NON_CONFORMANT_CONFIG)
+-        c->base.visualRating = GLX_NON_CONFORMANT_CONFIG;
+-    /* else panic */
+-
+-    /* derived state: float configs */
+-    c->base.renderType = GLX_RGBA_BIT;
+-    if (eglGetConfigAttrib(screen->display, hc, EGL_COLOR_COMPONENT_TYPE_EXT,
+-                           &value) == EGL_TRUE) {
+-        if (value == EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT) {
+-            c->base.renderType = GLX_RGBA_FLOAT_BIT_ARB;
+-        }
+-        /* else panic */
+-    }
+-
+-    /* derived state: sRGB. EGL doesn't put this in the fbconfig at all,
+-     * it's a property of the surface specified at creation time, so we have
+-     * to infer it from the GL's extensions. only makes sense at 8bpc though.
+-     */
+-    if (srgb_only) {
+-        if (c->base.redBits == 8) {
+-            c->base.sRGBCapable = GL_TRUE;
+-        } else {
+-            free(c);
+-            return chain;
+-        }
+-    }
+-
+-    /* map to the backend's config */
+-    c->config = hc;
+-
+-    /*
+-     * XXX do something less ugly
+-     */
+-    if (c->base.renderType == GLX_RGBA_BIT) {
+-        if (c->base.redBits == 5 &&
+-            (c->base.rgbBits == 15 || c->base.rgbBits == 16)) {
+-            c->base.blueMask  = 0x0000001f;
+-            if (c->base.alphaBits) {
+-                c->base.greenMask = 0x000003e0;
+-                c->base.redMask   = 0x00007c00;
+-                c->base.alphaMask = 0x00008000;
+-            } else {
+-                c->base.greenMask = 0x000007e0;
+-                c->base.redMask   = 0x0000f800;
+-                c->base.alphaMask = 0x00000000;
+-            }
+-        }
+-        else if (c->base.redBits == 8 &&
+-            (c->base.rgbBits == 24 || c->base.rgbBits == 32)) {
+-            c->base.blueMask  = 0x000000ff;
+-            c->base.greenMask = 0x0000ff00;
+-            c->base.redMask   = 0x00ff0000;
+-            if (c->base.alphaBits)
+-                /* assume all remaining bits are alpha */
+-                c->base.alphaMask = 0xff000000;
+-        }
+-        else if (c->base.redBits == 10 &&
+-            (c->base.rgbBits == 30 || c->base.rgbBits == 32)) {
+-            c->base.blueMask  = 0x000003ff;
+-            c->base.greenMask = 0x000ffc00;
+-            c->base.redMask   = 0x3ff00000;
+-            if (c->base.alphaBits)
+-                /* assume all remaining bits are alpha */
+-                c->base.alphaMask = 0xc000000;
+-        }
+-    }
+-
+-    /*
+-     * Here we decide which fbconfigs will be duplicated for compositing.
+-     * fgbconfigs marked with duplicatedForComp will be reserved for
+-     * compositing visuals.
+-     * It might look strange to do this decision this late when translation
+-     * from an EGLConfig is already done, but using the EGLConfig
+-     * accessor functions becomes worse both with respect to code complexity
+-     * and CPU usage.
+-     */
+-    if (duplicate_for_composite &&
+-        (c->base.renderType == GLX_RGBA_FLOAT_BIT_ARB ||
+-         c->base.rgbBits != 32 ||
+-         c->base.redBits != 8 ||
+-         c->base.greenBits != 8 ||
+-         c->base.blueBits != 8 ||
+-         c->base.visualRating != GLX_NONE ||
+-         c->base.sampleBuffers != 0)) {
+-        free(c);
+-        return chain;
+-    }
+-    c->base.duplicatedForComp = duplicate_for_composite;
+-
+-    c->base.next = chain ? &chain->base : NULL;
+-    return c;
+-}
+-
+-static __GLXconfig *
+-egl_mirror_configs(ScreenPtr pScreen, struct egl_screen *screen)
+-{
+-    int i, j, k, nconfigs;
+-    struct egl_config *c = NULL;
+-    EGLConfig *host_configs = NULL;
+-    bool can_srgb = epoxy_has_gl_extension("GL_ARB_framebuffer_sRGB") ||
+-                    epoxy_has_gl_extension("GL_EXT_framebuffer_sRGB") ||
+-                    epoxy_has_gl_extension("GL_EXT_sRGB_write_control");
+-
+-    eglGetConfigs(screen->display, NULL, 0, &nconfigs);
+-    if (!(host_configs = calloc(nconfigs, sizeof *host_configs)))
+-        return NULL;
+-
+-    eglGetConfigs(screen->display, host_configs, nconfigs, &nconfigs);
+-
+-    /* We walk the EGL configs backwards to make building the
+-     * ->next chain easier.
+-     */
+-    for (i = nconfigs - 1; i >= 0; i--)
+-        for (j = 0; j < 3; j++) /* direct_color */
+-            for (k = 0; k < 2; k++) /* double_buffer */ {
+-                if (can_srgb)
+-                    c = translate_eglconfig(screen, host_configs[i], c,
+-                                            /* direct_color */ j == 1,
+-                                            /* double_buffer */ k > 0,
+-                                            /* duplicate_for_composite */ j == 0,
+-                                            /* srgb_only */ true);
+-
+-                c = translate_eglconfig(screen, host_configs[i], c,
+-                                        /* direct_color */ j == 1,
+-                                        /* double_buffer */ k > 0,
+-                                        /* duplicate_for_composite */ j == 0,
+-                                        /* srgb_only */ false);
+-            }
+-
+-    screen->configs = host_configs;
+-    return c ? &c->base : NULL;
+-}
+-
+-static __GLXscreen *
+-egl_screen_probe(ScreenPtr pScreen)
+-{
+-    struct egl_screen *screen;
+-    glamor_screen_private *glamor_screen;
+-    __GLXscreen *base;
+-
+-    if (enableIndirectGLX)
+-        return NULL; /* not implemented */
+-
+-    glamor_screen = glamor_get_screen_private(pScreen);
+-    if (!glamor_screen)
+-        return NULL;
+-
+-    if (!(screen = calloc(1, sizeof *screen)))
+-        return NULL;
+-
+-    base = &screen->base;
+-    base->destroy = egl_screen_destroy;
+-    base->createDrawable = egl_create_glx_drawable;
+-    /* base.swapInterval = NULL; */
+-
+-    screen->display = glamor_screen->ctx.display;
+-
+-    __glXInitExtensionEnableBits(screen->base.glx_enable_bits);
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_ARB_context_flush_control");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_ARB_create_context");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_ARB_create_context_no_error");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_ARB_create_context_profile");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_ARB_create_context_robustness");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_ARB_fbconfig_float");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_EXT_create_context_es2_profile");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_EXT_create_context_es_profile");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_EXT_fbconfig_packed_float");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_EXT_framebuffer_sRGB");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_EXT_no_config_context");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_EXT_texture_from_pixmap");
+-    __glXEnableExtension(base->glx_enable_bits, "GLX_MESA_copy_sub_buffer");
+-    // __glXEnableExtension(base->glx_enable_bits, "GLX_SGI_swap_control");
+-
+-    base->fbconfigs = egl_mirror_configs(pScreen, screen);
+-    if (!base->fbconfigs) {
+-        free(screen);
+-        return NULL;
+-    }
+-
+-    if (!screen->base.glvnd && glamor_screen->glvnd_vendor)
+-        screen->base.glvnd = strdup(glamor_screen->glvnd_vendor);
+-
+-    if (!screen->base.glvnd)
+-        screen->base.glvnd = strdup("mesa");
+-
+-    __glXScreenInit(base, pScreen);
+-    __glXsetGetProcAddress(eglGetProcAddress);
+-
+-    return base;
+-}
+-
+-__GLXprovider glamor_provider = {
+-    egl_screen_probe,
+-    "glamor",
+-    NULL
+-};
+diff --git a/glamor/glamor_glx_provider.h b/glamor/glamor_glx_provider.h
+deleted file mode 100644
+index b0db90e47..000000000
+--- a/glamor/glamor_glx_provider.h
++++ /dev/null
+@@ -1,37 +0,0 @@
+-/*
+- * Copyright © 2019 Red Hat, Inc.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice (including the next
+- * paragraph) shall be included in all copies or substantial portions of the
+- * Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+- * DEALINGS IN THE SOFTWARE.
+- *
+- * Authors:
+- *	Adam Jackson <ajax@redhat.com>
+- */
+-
+-#ifndef XWAYLAND_GLX_H
+-#define XWAYLAND_GLX_H
+-
+-#include <dix-config.h>
+-
+-#ifdef GLXEXT
+-#include "glx_extinit.h"
+-extern _X_EXPORT __GLXprovider glamor_provider;
+-#endif
+-
+-#endif /* XWAYLAND_GLX_H */
+diff --git a/glamor/meson.build b/glamor/meson.build
+index 1bd2c744f..268af593e 100644
+--- a/glamor/meson.build
++++ b/glamor/meson.build
+@@ -34,9 +34,6 @@ srcs_glamor = [
+     'glamor_sync.c',
+ ]
+ 
+-if build_glx
+-    srcs_glamor += 'glamor_glx_provider.c'
+-endif
+ if build_xv
+     srcs_glamor += 'glamor_xv.c'
+ endif
+@@ -45,7 +42,7 @@ epoxy_dep = dependency('epoxy')
+ 
+ glamor = static_library('glamor',
+     srcs_glamor,
+-    include_directories: [inc, glx_inc],
++    include_directories: inc,
+     dependencies: [
+         common_dep,
+         epoxy_dep,
+diff --git a/hw/xfree86/glamor_egl/Makefile.am b/hw/xfree86/glamor_egl/Makefile.am
+index 741eb11d5..e697c8296 100644
+--- a/hw/xfree86/glamor_egl/Makefile.am
++++ b/hw/xfree86/glamor_egl/Makefile.am
+@@ -33,7 +33,6 @@ libglamoregl_la_LDFLAGS = \
+ 	$()
+ 
+ libglamoregl_la_LIBADD = \
+-	$(top_builddir)/glx/libglx.la \
+ 	$(top_builddir)/glamor/libglamor.la \
+ 	$()
+ 
+-- 
+2.52.0
+

--- a/runtime-display/xorg-server/autobuild/patches/0012-Revert-glamor-add-glvnd_vendor-private.patch
+++ b/runtime-display/xorg-server/autobuild/patches/0012-Revert-glamor-add-glvnd_vendor-private.patch
@@ -1,0 +1,118 @@
+From 990162bedb0b817cdcb9dc1b5e11703e5dea5386 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Wed, 19 Nov 2025 16:24:19 +0100
+Subject: [PATCH 12/12] Revert "glamor: add glvnd_vendor private"
+
+This reverts commit a6145198bc1d4f535c3105f8352e420c7c59382f.
+
+We no longer need to store the glvnd vendor, so we can also drop that
+change.
+
+See-also: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1848
+Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2104>
+---
+ glamor/glamor.c      | 26 --------------------------
+ glamor/glamor.h      |  6 ------
+ glamor/glamor_egl.c  |  5 -----
+ glamor/glamor_priv.h |  1 -
+ 4 files changed, 38 deletions(-)
+
+diff --git a/glamor/glamor.c b/glamor/glamor.c
+index b42345f8e..5e8f6aaad 100644
+--- a/glamor/glamor.c
++++ b/glamor/glamor.c
+@@ -941,7 +941,6 @@ glamor_close_screen(ScreenPtr screen)
+     glamor_priv = glamor_get_screen_private(screen);
+     glamor_sync_close(screen);
+     glamor_composite_glyphs_fini(screen);
+-    glamor_set_glvnd_vendor(screen, NULL);
+     screen->CloseScreen = glamor_priv->saved_procs.close_screen;
+ 
+     screen->CreateGC = glamor_priv->saved_procs.create_gc;
+@@ -974,31 +973,6 @@ glamor_fini(ScreenPtr screen)
+     /* Do nothing currently. */
+ }
+ 
+-void
+-glamor_set_glvnd_vendor(ScreenPtr screen, const char *vendor_name)
+-{
+-    glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+-
+-    if (!glamor_priv)
+-        return;
+-
+-    if (glamor_priv->glvnd_vendor)
+-        free(glamor_priv->glvnd_vendor);
+-
+-    glamor_priv->glvnd_vendor = xnfstrdup(vendor_name);
+-}
+-
+-const char *
+-glamor_get_glvnd_vendor(ScreenPtr screen)
+-{
+-    glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+-
+-    if (!glamor_priv)
+-        return NULL;
+-
+-    return glamor_priv->glvnd_vendor;
+-}
+-
+ void
+ glamor_enable_dri3(ScreenPtr screen)
+ {
+diff --git a/glamor/glamor.h b/glamor/glamor.h
+index f5634b7e7..31157471d 100644
+--- a/glamor/glamor.h
++++ b/glamor/glamor.h
+@@ -120,12 +120,6 @@ extern _X_EXPORT void glamor_clear_pixmap(PixmapPtr pixmap);
+ 
+ extern _X_EXPORT void glamor_block_handler(ScreenPtr screen);
+ 
+-/* This function should be called after glamor_init,
+- * but before adding a glamor GLX provider */
+-extern _X_EXPORT void glamor_set_glvnd_vendor(ScreenPtr screen,
+-                                              const char *vendor);
+-extern _X_EXPORT const char *glamor_get_glvnd_vendor(ScreenPtr screen);
+-
+ extern _X_EXPORT PixmapPtr glamor_create_pixmap(ScreenPtr screen, int w, int h,
+                                                 int depth, unsigned int usage);
+ extern _X_EXPORT Bool glamor_destroy_pixmap(PixmapPtr pixmap);
+diff --git a/glamor/glamor_egl.c b/glamor/glamor_egl.c
+index dc31c1650..503aeb239 100644
+--- a/glamor/glamor_egl.c
++++ b/glamor/glamor_egl.c
+@@ -896,7 +896,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
+ #ifdef DRI3
+     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
+ #endif
+-    const char *gbm_backend_name;
+ 
+     glamor_egl->saved_close_screen = screen->CloseScreen;
+     screen->CloseScreen = glamor_egl_close_screen;
+@@ -909,10 +908,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
+ 
+     glamor_ctx->make_current = glamor_egl_make_current;
+ 
+-    gbm_backend_name = gbm_device_get_backend_name(glamor_egl->gbm);
+-    /* Mesa uses "drm" as backend name, in that case, just do nothing */
+-    if (gbm_backend_name && strcmp(gbm_backend_name, "drm") != 0)
+-        glamor_set_glvnd_vendor(screen, gbm_backend_name);
+ #ifdef DRI3
+     /* Tell the core that we have the interfaces for import/export
+      * of pixmaps.
+diff --git a/glamor/glamor_priv.h b/glamor/glamor_priv.h
+index 4c2f4691c..ac166102c 100644
+--- a/glamor/glamor_priv.h
++++ b/glamor/glamor_priv.h
+@@ -336,7 +336,6 @@ typedef struct glamor_screen_private {
+     int flags;
+     ScreenPtr screen;
+     int dri3_enabled;
+-    char *glvnd_vendor;
+ 
+     Bool suppress_gl_out_of_memory_logging;
+     Bool logged_any_fbo_allocation_failure;
+-- 
+2.52.0
+

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,5 @@
 VER=21.1.19
+REL=1
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: revert upstrema GLAMOR changes to fix regression
    - We observed that Glenfly/Zhaoxin GPU drivers causes X server to SIGABRT
    with this round of changes between 21.1.18 and 21.1.19.
    - Upstream complains that it broke NVIDIA.
    - Good, let's revert - there is consensus.
    - Track patches at AOSC-Tracking/xserver @ aosc/xorg-server-21.1.19
    \(HEAD: 990162bedb0b817cdcb9dc1b5e11703e5dea5386\).
    Link: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2104

Package(s) Affected
-------------------

- xorg-server: 21.1.19-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
