### PR TITLE
clash-verge-service-ipc: move install/uninstall binary to /usr/libexec

### DIFF
--- a/app-proxy/clash-verge-service-ipc/autobuild/beyond
+++ b/app-proxy/clash-verge-service-ipc/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Move some binaries to /usr/libexec ..."
+mkdir -pv "$PKGDIR"/usr/libexec
+mv -v "$PKGDIR"/usr/bin/clash-verge-service-install "$PKGDIR"/usr/libexec/clash-verge-install-service
+mv -v "$PKGDIR"/usr/bin/clash-verge-service-uninstall "$PKGDIR"/usr/libexec/clash-verge-uninstall-service

--- a/app-proxy/clash-verge-service-ipc/autobuild/patches/0001-AOSCOS-set-clash-verge-service-path-to-usr-bin-clash.patch
+++ b/app-proxy/clash-verge-service-ipc/autobuild/patches/0001-AOSCOS-set-clash-verge-service-path-to-usr-bin-clash.patch
@@ -1,0 +1,28 @@
+From d061a44d8be111aee79738178601c1c8c34066fb Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Sun, 23 Nov 2025 23:43:00 +0800
+Subject: [PATCH] AOSCOS: set 'clash-verge-service' path to
+ '/usr/bin/clash-verge-service'
+
+---
+ src/bin/install_service.rs | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/bin/install_service.rs b/src/bin/install_service.rs
+index b65dfa1..286b5e4 100644
+--- a/src/bin/install_service.rs
++++ b/src/bin/install_service.rs
+@@ -118,9 +118,7 @@ fn main() -> Result<(), Error> {
+ 
+     let debug = env::args().any(|arg| arg == "--debug");
+ 
+-    let service_binary_path = env::current_exe()
+-        .unwrap()
+-        .with_file_name("clash-verge-service");
++    let service_binary_path = Path::new("/usr/bin/clash-verge-service");
+ 
+     if !service_binary_path.exists() {
+         return Err(anyhow::anyhow!("clash-verge-service binary not found"));
+-- 
+2.52.0
+

--- a/app-proxy/clash-verge-service-ipc/spec
+++ b/app-proxy/clash-verge-service-ipc/spec
@@ -1,3 +1,4 @@
 VER=2.0.21
+REL=1
 SRCS="git::commit=v"$VER"::https://github.com/clash-verge-rev/clash-verge-service-ipc"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-service-ip: move install/uninstall binary to /usr/libexec
    - Track patches at AOSC-Tracking/clash-verge-service-ipc @ aosc/v2.0.21
    \(HEAD: d061a44d8be111aee79738178601c1c8c34066fb\).

Package(s) Affected
-------------------

- clash-verge-service-ipc: 2.0.21-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-service-ipc
```

Test Build(s) Done
------------------

