### PR TITLE
ostree: fix missing dependencies

### DIFF
--- a/app-admin/ostree/autobuild/defines
+++ b/app-admin/ostree/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=ostree
 PKGSEC=admin
-PKGDEP="avahi curl fuse gpgme libarchive util-linux"
+PKGDEP="avahi curl fuse gpgme libarchive util-linux xz zlib libsodium openssl \
+        glib"
 BUILDDEP="bison dracut docbook-xsl"
 PKGDES="Tool for managing bootable, immutable filesystem trees"
 

--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,5 @@
 VER=2025.7
+REL=1
 SRCS="tbl::https://github.com/ostreedev/ostree/releases/download/v$VER/libostree-$VER.tar.xz"
 CHKSUMS="sha256::af8d080b9585e7fd1faba8f022967e1c268ae62e20ecf32ee7b364c1e307570b"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: fix missing dependencies
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- ostree: 2025.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
