### PR TITLE
libotr: fix implicit function declaration

### DIFF
--- a/runtime-web/libotr/autobuild/patches/0001-FEDORA-be-liberal-in-what-version-to-accept.patch
+++ b/runtime-web/libotr/autobuild/patches/0001-FEDORA-be-liberal-in-what-version-to-accept.patch
@@ -1,0 +1,37 @@
+From 8d21389323d2a7f0587e4f6efe6aa99457ec933a Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Mon, 24 Nov 2025 05:09:43 +0800
+Subject: [PATCH 1/2] be liberal in what version to accept
+
+---
+ src/proto.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/proto.c b/src/proto.c
+index 8d82dc1..15eb0de 100644
+--- a/src/proto.c
++++ b/src/proto.c
+@@ -54,6 +54,12 @@ gcry_error_t otrl_init(unsigned int ver_major, unsigned int ver_minor,
+ {
+     unsigned int api_version;
+ 
++/* See:
++ * https://bugzilla.redhat.com/show_bug.cgi?id=1634321
++ * https://github.com/psi-im/plugins/issues/7#issuecomment-423048948
++ */
++#if 0
++
+     /* The major versions have to match, and you can't be using a newer
+      * minor version than we expect. */
+     if (ver_major != OTRL_VERSION_MAJOR || ver_minor > OTRL_VERSION_MINOR) {
+@@ -63,6 +69,7 @@ gcry_error_t otrl_init(unsigned int ver_major, unsigned int ver_minor,
+ 		OTRL_VERSION_MAJOR, OTRL_VERSION_MINOR, OTRL_VERSION_SUB);
+ 	return gcry_error(GPG_ERR_INV_VALUE);
+     }
++#endif
+ 
+     /* Set the API version.  If we get called multiple times for some
+      * reason, take the smallest value. */
+-- 
+2.51.1
+

--- a/runtime-web/libotr/autobuild/patches/0002-FEDORA-fix-implicit-function-declaration.patch
+++ b/runtime-web/libotr/autobuild/patches/0002-FEDORA-fix-implicit-function-declaration.patch
@@ -1,0 +1,24 @@
+From bf588e0df5cbcdad0965a043cbcefe1b98e5d20b Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Mon, 24 Nov 2025 05:13:09 +0800
+Subject: [PATCH 2/2] fix implicit function declaration
+
+---
+ tests/regression/client/client.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/regression/client/client.c b/tests/regression/client/client.c
+index e72b661..908b875 100644
+--- a/tests/regression/client/client.c
++++ b/tests/regression/client/client.c
+@@ -27,6 +27,7 @@
+ #include <syscall.h>
+ #include <sys/epoll.h>
+ #include <sys/types.h>
++#include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+ 
+-- 
+2.51.1
+

--- a/runtime-web/libotr/spec
+++ b/runtime-web/libotr/spec
@@ -1,5 +1,5 @@
 VER=4.1.1
-REL=1
+REL=2
 SRCS="tbl::https://otr.cypherpunks.ca/libotr-$VER.tar.gz"
 CHKSUMS="sha256::8b3b182424251067a952fb4e6c7b95a21e644fbb27fbd5f8af2b2ed87ca419f5"
 CHKUPDATE="anitya::id=13303"


### PR DESCRIPTION
Topic Description
-----------------

- libotr: fix implicit function declaration

Package(s) Affected
-------------------

- libotr: 4.1.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libotr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
