### PR TITLE
freeglut: update to 3.8.0

### DIFF
--- a/runtime-display/freeglut/spec
+++ b/runtime-display/freeglut/spec
@@ -1,4 +1,4 @@
-VER=3.4.0
+VER=3.8.0
 SRCS="tbl::https://github.com/freeglut/freeglut/releases/download/v$VER/freeglut-$VER.tar.gz"
-CHKSUMS="sha256::3c0bcb915d9b180a97edaebd011b7a1de54583a838644dcd42bb0ea0c6f3eaec"
+CHKSUMS="sha256::674dcaff25010e09e450aec458b8870d9e98c46f99538db457ab659b321d9989"
 CHKUPDATE="anitya::id=846"


### PR DESCRIPTION
Topic Description
-----------------

- freeglut: update to 3.8.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- freeglut: 3.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freeglut
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
