### PR TITLE
mtd-utils: update to 2.3.0

### DIFF
--- a/app-admin/mtd-utils/autobuild/defines
+++ b/app-admin/mtd-utils/autobuild/defines
@@ -3,13 +3,14 @@ PKGSEC=admin
 PKGDEP="lzo util-linux zstd"
 PKGDES="Utilities for MTD devices"
 
-AUTOTOOLS_AFTER="--enable-largefile \
-                 --enable-ubihealthd \
-                 --enable-lsmtd \
-                 --with-jffs \
-                 --with-ubifs \
-                 --with-xattr \
-                 --with-lzo \
-                 --with-zstd \
-                 --without-selinux \
-                 --with-crypto"
+AUTOTOOLS_AFTER=(
+    '--enable-largefile'
+    '--enable-ubihealthd'
+    '--with-jffs'
+    '--with-ubifs'
+    '--with-xattr'
+    '--with-lzo'
+    '--with-zstd'
+    '--without-selinux'
+    '--with-crypto'
+)

--- a/app-admin/mtd-utils/spec
+++ b/app-admin/mtd-utils/spec
@@ -1,5 +1,4 @@
-VER=2.1.5
-REL=2
+VER=2.3.0
 SRCS="git::commit=tags/v$VER::https://git.infraroot.at/mtd-utils.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2026"


### PR DESCRIPTION
Topic Description
-----------------

- mtd-utils: update to 2.3.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mtd-utils: 2.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mtd-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
