### PR TITLE
pamixer: update to 1.6

### DIFF
--- a/app-multimedia/pamixer/autobuild/build
+++ b/app-multimedia/pamixer/autobuild/build
@@ -1,4 +1,0 @@
-abinfo "build: making..."
-make
-abinfo "build: installing pamixer binary to destination..."
-install -D -m755 pamixer "$PKGDIR"/usr/bin/pamixer

--- a/app-multimedia/pamixer/autobuild/defines
+++ b/app-multimedia/pamixer/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=pamixer
-PKGDES="Pulseaudio command-line mixer like amixer"
+PKGDES="Command-line mixer for PulseAudio"
 PKGSEC=utils
-PKGDEP="pulseaudio boost"
+PKGDEP="cxxopts pulseaudio"
+
+ABTYPE=meson

--- a/app-multimedia/pamixer/spec
+++ b/app-multimedia/pamixer/spec
@@ -1,5 +1,4 @@
-VER=1.4
-SRCS="tbl::https://github.com/cdemoulins/pamixer/archive/$VER.tar.gz"
-CHKSUMS="sha256::d8c7175dd844e458f4222fd24367e16d2b6cc4edb450bfa8bb9b3dec538cbdea"
-REL=2
+VER=1.6
+SRCS="git::commit=tags/$VER::https://github.com/cdemoulins/pamixer"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230946"


### PR DESCRIPTION
Topic Description
-----------------

- pamixer: update to 1.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pamixer: 1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit pamixer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
