### PR TITLE
supercollider: update to 3.14.1

### DIFF
--- a/app-creativity/supercollider/autobuild/defines
+++ b/app-creativity/supercollider/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=supercollider
 PKGSEC=sound
-PKGDES="An audio server, programming language, and IDE for sound synthesis and algorithmic composition"
 PKGDEP="qt-5 emacs"
+PKGDES="Audio server, programming language, and IDE for sound synthesis and algorithmic composition"
 
-# FIXME: qt5-webengine
+# FIXME: Qt5WebEngine
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-creativity/supercollider/spec
+++ b/app-creativity/supercollider/spec
@@ -1,4 +1,5 @@
-VER=3.13.0
-SRCS="git::commit=tags/Version-$VER::https://github.com/supercollider/supercollider.git"
+VER=3.14.1
+# Note: copy-repo=true for version information.
+SRCS="git::commit=tags/Version-$VER;copy-repo=true::https://github.com/supercollider/supercollider.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16290"


### PR DESCRIPTION
Topic Description
-----------------

- supercollider: update to 3.14.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- supercollider: 3.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit supercollider
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
