### PR TITLE
gapless: update to 4.6

### DIFF
--- a/app-multimedia/gapless/spec
+++ b/app-multimedia/gapless/spec
@@ -1,4 +1,4 @@
-VER=4.5
+VER=4.6
 SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/neithern/g4music.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370413"


### PR DESCRIPTION
Topic Description
-----------------

- gapless: update to 4.6
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gapless: 4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit gapless
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
