### PR TITLE
box64: update to 0.3.9+git20251124

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,5 +1,5 @@
-VER=0.3.9+git20251122
+VER=0.3.9+git20251124
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=0c405897d366fc02d79bda7716fab6aa319098a1;copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=8a40b11574a13e8ff1173be8a966314d47f2d38f;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251124
    - Fix latest proton experimental on arm64.
    - Link: https://github.com/ptitSeb/box64/commit/7befdcf
    - Link: https://github.com/ptitSeb/box64/commit/d4f72f8
    - Link: https://github.com/ptitSeb/box64/commit/3ec07fa

Package(s) Affected
-------------------

- box64: 0.3.9+git20251124

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

