### PR TITLE
docker: update to 29.0.3+tini0.19.0

### DIFF
--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -15,7 +15,7 @@ case "$VERSION" in
 	refs/pull/*) VERSION=pr-$(echo "$VERSION" | grep -o '[0-9]\+') ;;
 esac
 
-DOCKER_CE_GO_LDFLAGS="-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" -X \"github.com/docker/docker/dockerversion.Version=${VERSION}\""
+DOCKER_CE_GO_LDFLAGS="-X \"github.com/moby/moby/dockerversion.GitCommit=${GITCOMMIT}\" -X \"github.com/moby/moby/dockerversion.BuildTime=${BUILDTIME}\" -X \"github.com/moby/moby/dockerversion.Version=${VERSION}\""
 DOCKER_CLI_GO_LDFLAGS="-X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\" -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
 
 # Fedora: Build docker-proxy (libnetwork).
@@ -23,12 +23,12 @@ abinfo "docker-proxy (libnetwork): Building ..."
 export GOPATH="$SRCDIR"
 export GO111MODULE=auto
 
-mkdir -pv "$SRCDIR"/src/github.com/docker
-ln -vfns ../../.. src/github.com/docker/docker
+mkdir -pv "$SRCDIR"/src/github.com/moby
+ln -vfns ../../.. src/github.com/moby/moby
 
-go build \
+go build -mod=mod\
     -o "$BLDDIR"/bin/docker-proxy \
-    github.com/docker/docker/cmd/docker-proxy
+    github.com/moby/moby/cmd/docker-proxy
 
 # Fedora: Build tini (installed as docker-init).
 abinfo "tini: Building ..."
@@ -47,15 +47,15 @@ abinfo "Docker Engine: Building ..."
 go build \
     -o abbuild/bin/dockerd \
     -ldflags "${DOCKER_CE_GO_LDFLAGS}" \
-    github.com/docker/docker/cmd/dockerd
-	
+    github.com/moby/moby/cmd/dockerd
+
 # Fedora: Build cli.
 abinfo "docker-cli: Preparing sources and build environment ..."
 cd "$SRCDIR"/../cli
 mkdir -pv src/github.com/docker
 
 ln -vfns ../../.. src/github.com/docker/cli
-	
+
 export GOPATH="${PWD}"
 export GO111MODULE=off
 export BUILDTAGS="pkcs11"
@@ -91,10 +91,6 @@ install -Dvm755 \
     "$BLDDIR"/bin/docker-proxy \
     "$SRCDIR"/tini-static \
     -t "$PKGDIR"/usr/libexec/docker/
-
-abinfo "Installing UDev rules ..."
-install -Dvm644 "$SRCDIR"/contrib/udev/80-docker.rules \
-    -t "$PKGDIR"/usr/lib/udev/rules.d/80-docker.rules
 
 abinfo "Installing docker.socket ..."
 install -Dvm644 "$SRCDIR"/contrib/init/systemd/docker.socket \

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,5 +1,4 @@
-UPSTREAM_VER=28.5.1
-REL=1
+UPSTREAM_VER=29.0.3
 # Find tini version at:
 #
 # https://github.com/moby/moby/blob/v$UPSTREAM_VER/hack/dockerfile/install/tini.installer
@@ -7,7 +6,7 @@ TINI_VER=0.19.0
 
 VER=${UPSTREAM_VER}+tini${TINI_VER}
 SRCS="git::commit=tags/v${UPSTREAM_VER};rename=cli::https://github.com/docker/cli \
-      git::commit=tags/v${UPSTREAM_VER};rename=moby;copy-repo=true::https://github.com/moby/moby \
+      git::commit=tags/docker-v${UPSTREAM_VER};rename=moby;copy-repo=true::https://github.com/moby/moby \
       git::commit=tags/v${TINI_VER};rename=tini::https://github.com/krallin/tini"
 CHKSUMS="SKIP \
          SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- docker: update to 29.0.3+tini0.19.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- docker: 29.0.3+tini0.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
