### PR TITLE
kcptun: update to 20251124

### DIFF
--- a/app-proxy/kcptun/spec
+++ b/app-proxy/kcptun/spec
@@ -1,5 +1,4 @@
-VER=20241227
-REL=2
+VER=20251124
 SRCS="git::commit=tags/v$VER::https://github.com/xtaci/kcptun"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14970"


### PR DESCRIPTION
Topic Description
-----------------

- kcptun: update to 20251124
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kcptun: 20251124

Security Update?
----------------

No

Build Order
-----------

```
#buildit kcptun
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
