### PR TITLE
vscode: update to 1.106.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.106.0
+VER=1.106.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::2ab9c5fc3c99afcaa0a973ec870d652aa4610926536a1dab282b6d6e6ccee89d"
-CHKSUMS__ARM64="sha256::371d7b87f3d83fd5b519df7cc9db6c78496d5fd3e5feac8c4f1a12bb0fe8ee7a"
+CHKSUMS__AMD64="sha256::de283e44b54ff3c5eccaba5c237b70e9a44840e39f00b45c60f252b65ccdfe5e"
+CHKSUMS__ARM64="sha256::0abf5a3425003a5feff4bbb630066d9018ca86b544cf37221f1374617660afa8"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.106.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.106.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
