### PR TITLE
git: enable libsecret credential helper

### DIFF
--- a/app-vcs/git/01-git-core/defines
+++ b/app-vcs/git/01-git-core/defines
@@ -5,7 +5,7 @@ PKGDEP="curl expat openssl pcre2 perl perl-error cvsps perl-authen-sasl \
         libwww-perl perl-mime-tools perl-net-smtp-ssl perl-term-readkey \
         python-3 tk perl-dbi subversion brotli"
 PKGRECOM="git-lfs gitk git-gui"
-BUILDDEP="gettext asciidoc xmlto emacs meson"
+BUILDDEP="gettext asciidoc xmlto emacs meson libsecret"
 
 PKGDEP__RETRO="curl expat openssl pcre2"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
@@ -31,4 +31,5 @@ MESON_AFTER=(
     '-Dcontrib=completion,contacts,subtree'
     '-Ddocs=man,html'
     '-Ddefault_editor=/usr/bin/editor'
+    '-Dcredential_helpers=libsecret'
 )

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,4 +1,5 @@
 VER=2.52.0
+REL=1
 
 # Use this for stable releases.
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"


### PR DESCRIPTION
Topic Description
-----------------

- git: enable libsecret credential helper
    This, after being configured with credential.helper, allows Git
    credentials to be stored in the system keyring.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- mesa+32: update to 25.3.0
- mesa: update to 25.3.0
- mesa+32: update to 25.3.0-rc4
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.3.0-rc4
    \(HEAD: 7ce39bc59cd9157b6aeec6796e5f85edbd831c47\).
- directx-headers+32: new, 1.618.2
- mesa: update to 25.3.0-rc4
    Track patches at AOSC-Tracking/mesa @ aosc/mesa-25.3.0-rc4
    \(HEAD: 7ce39bc59cd9157b6aeec6796e5f85edbd831c47\).

Package(s) Affected
-------------------

- git: 2.51.1-1
- git-gui: 2.51.1-1
- gitk: 2.51.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
