### PR TITLE
vte: update to 0.82.2

### DIFF
--- a/runtime-common/fast-float/spec
+++ b/runtime-common/fast-float/spec
@@ -1,4 +1,4 @@
-VER=7.0.0
+VER=8.1.0
 SRCS="git::commit=tags/v$VER::https://github.com/fastfloat/fast_float.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=214353"

--- a/runtime-common/simdutf/autobuild/defines
+++ b/runtime-common/simdutf/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=simdutf
+PKGSEC=libs
+PKGDEP="gcc-runtime glibc"
+PKGDES="SIMD accelerated Unicode validation, transcoding and processing"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_SHARED_LIBS=ON'
+    '-DSIMDUTF_TESTS=OFF'
+    '-DSIMDUTF_BENCHMARKS=OFF'
+    '-DSIMDUTF_TOOLS=OFF'
+)

--- a/runtime-common/simdutf/spec
+++ b/runtime-common/simdutf/spec
@@ -1,0 +1,4 @@
+VER=7.7.0
+SRCS="git::commit=tags/v$VER::https://github.com/simdutf/simdutf.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378662"

--- a/runtime-desktop/vte/autobuild/beyond
+++ b/runtime-desktop/vte/autobuild/beyond
@@ -1,7 +1,0 @@
-abinfo "Creating symbolic link from bashrc.d for shell integration"
-mkdir -pv "${PKGDIR}/etc/bashrc.d"
-ln -sv ../profile.d/vte.sh "${PKGDIR}/etc/bashrc.d/vte.sh"
-
-abinfo "Creating symbolic link from zshrc.d for shell integration"
-mkdir -pv "${PKGDIR}/etc/zsh/zshrc.d"
-ln -sv ../../profile.d/vte.sh "${PKGDIR}/etc/zsh/zshrc.d/vte.sh"

--- a/runtime-desktop/vte/autobuild/defines
+++ b/runtime-desktop/vte/autobuild/defines
@@ -1,23 +1,27 @@
 PKGNAME=vte
 PKGSEC=gnome
-PKGDEP="fribidi gtk-3 icu pcre2"
-BUILDDEP="glade gobject-introspection gtk-doc intltool vala gperf"
+PKGDEP="at-spi2-core cairo fribidi gcc-runtime gdk-pixbuf glib glibc gnutls \
+        graphene gtk-3 gtk-4 icu lz4 pango pcre2 simdutf systemd"
+BUILDDEP="fast-float fmt glade gobject-introspection gperf gtk-doc vala"
 PKGDES="VTE widget for use with GTK"
 
-# FIXME: GTK 4 is not yet supported.
-MESON_AFTER="-D_b_symbolic_functions=true \
-             -Da11y=true \
-             -Ddebugg=false \
-             -Ddocs=true \
-             -Dgir=true \
-             -Dfribidi=true \
-             -Dglade=true \
-             -Dgnutls=true \
-             -Dgtk3=true \
-             -Dgtk4=false \
-             -Dicu=true \
-             -D_systemd=true \
-             -Dvapi=true"
+ABTYPE=meson
+MESON_AFTER=(
+    '-D_b_symbolic_functions=true'
+    '-Da11y=true'
+    '-Dapp=false'
+    '-Ddbg=false'
+    '-Ddocs=false'
+    '-Dgir=true'
+    '-Dfribidi=true'
+    '-Dglade=true'
+    '-Dgnutls=true'
+    '-Dgtk3=true'
+    '-Dgtk4=true'
+    '-Dicu=true'
+    '-D_systemd=true'
+    '-Dvapi=true'
+)
 
 PKGBREAK="vte-gtk3<=0.62.1"
 PKGREP="vte-gtk3<=0.62.1"

--- a/runtime-desktop/vte/autobuild/prepare
+++ b/runtime-desktop/vte/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Guarantee we don't accidentally use subprojects if a new subproject is added"
+rm -rv "$SRCDIR"/subprojects

--- a/runtime-desktop/vte/spec
+++ b/runtime-desktop/vte/spec
@@ -1,5 +1,4 @@
-VER=0.68.0
-REL=2
+VER=0.82.2
 SRCS="https://download.gnome.org/sources/vte/${VER%.*}/vte-$VER.tar.xz"
-CHKSUMS="sha256::13e7d4789ca216a33780030d246c9b13ddbfd04094c6316eea7ff92284dd1749"
+CHKSUMS="sha256::e1295aafc4682b3b550f1235dc2679baa0f71570d8ed543c001c1283d530be91"
 CHKUPDATE="anitya::id=10895"


### PR DESCRIPTION
Topic Description
-----------------

- fast-float: update to 8.1.0
- simdutf: new, 7.7.0
- vte: update to 0.82.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- fast-float: 8.1.0
- simdutf: 7.7.0
- vte: 0.82.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fast-float simdutf vte
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
