### PR TITLE
mate-terminal: add missing PKGDEP

### DIFF
--- a/desktop-mate/mate-terminal/autobuild/defines
+++ b/desktop-mate/mate-terminal/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=mate-terminal
 PKGSEC=MATE
-PKGDEP="dbus dconf vte"
+PKGDEP="at-spi2-core atk cairo dbus dconf gdk-pixbuf glib glibc gtk-3 \
+        mate-desktop pango vte x11-lib"
 BUILDDEP="intltool itstool mate-common yelp-tools"
 PKGDES="The MATE terminal emulator"
 

--- a/desktop-mate/mate-terminal/spec
+++ b/desktop-mate/mate-terminal/spec
@@ -1,5 +1,5 @@
 VER=1.28.1
-REL=1
+REL=2
 SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-terminal-$VER.tar.xz"
 CHKSUMS="sha256::f135eb1a9e2ae22798ecb2dc1914fdb4cfd774e6bb65c0152be37cc6c9469e92"
 CHKUPDATE="anitya::id=198702"


### PR DESCRIPTION
Topic Description
-----------------

- mate-terminal: add missing PKGDEP

Package(s) Affected
-------------------

- mate-terminal: 1:1.28.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mate-terminal
```

Test Build(s) Done
------------------

