### PR TITLE
gpsd: update to 3.27

### DIFF
--- a/app-scientific/gpsd/spec
+++ b/app-scientific/gpsd/spec
@@ -1,5 +1,4 @@
-VER=3.25
-REL=1
+VER=3.27
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/gpsd/gpsd-$VER.tar.gz"
-CHKSUMS="sha256::b368b6a305e3f7a6382d23a0cbfc1d78923060b6b7f54cf7987a73c7b4a9afc2"
+CHKSUMS="sha256::6195292dd7910be68cb7018d45166283eaefd3f9db9773fcd6e9a78d49eac999"
 CHKUPDATE="anitya::id=6846"


### PR DESCRIPTION
Topic Description
-----------------

- gpsd: update to 3.27
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gpsd: 3.27

Security Update?
----------------

No

Build Order
-----------

```
#buildit gpsd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
