### PR TITLE
partclone: update to 0.3.40

### DIFF
--- a/app-admin/partclone/spec
+++ b/app-admin/partclone/spec
@@ -1,4 +1,4 @@
-VER=0.3.38
+VER=0.3.40
 SRCS="tbl::https://github.com/Thomas-Tsai/partclone/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::5afd6f558e83026e9270396394bc95308fbe1543f8b963a4fb5331bc7b0ed9d9"
+CHKSUMS="sha256::c071a99afcaa327ca7cb541d0ca5d33d6564528ed6d7e803d54206d1c0218291"
 CHKUPDATE="anitya::id=141535"


### PR DESCRIPTION
Topic Description
-----------------

- partclone: update to 0.3.40
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- partclone: 0.3.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit partclone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
