### PR TITLE
tokei: update to 13.0.0

### DIFF
--- a/app-devel/tokei/autobuild/patches/0001-use-fat-lto.patch
+++ b/app-devel/tokei/autobuild/patches/0001-use-fat-lto.patch
@@ -1,11 +1,24 @@
---- a/Cargo.toml	2020-08-03 17:05:07.647574224 -0600
-+++ b/Cargo.toml	2020-08-03 16:44:21.522952590 -0600
-@@ -20,7 +20,7 @@
- yaml = ["serde_yaml"]
+From 0f2357963daefc51faeb6e5bece86a13c847b75d Mon Sep 17 00:00:00 2001
+From: xffish <xffish@126.com>
+Date: Sun, 28 Dec 2025 20:09:11 +0800
+Subject: [PATCH] use fat lto
+
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 62882c8..de67be9 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -30,7 +30,7 @@ default = ["cli"]
+ yaml = ["dep:serde_yaml"]
  
  [profile.release]
 -lto = "thin"
 +lto = true
  panic = "abort"
  
- [build-dependencies]
+ [[bin]]
+-- 
+2.52.0

--- a/app-devel/tokei/spec
+++ b/app-devel/tokei/spec
@@ -1,5 +1,4 @@
-VER=12.1.2
-REL=9
+VER=13.0.0
 SRCS="tbl::https://github.com/XAMPPRocky/tokei/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::81ef14ab8eaa70a68249a299f26f26eba22f342fb8e22fca463b08080f436e50"
+CHKSUMS="sha256::b426ab03b8eedf4fe3ea70ca8379a2355981b0e9ca1d0083a66e623858e7e481"
 CHKUPDATE="anitya::id=13727"


### PR DESCRIPTION
Topic Description
-----------------

- tokei: update to 13.0.0

Package(s) Affected
-------------------

- tokei: 13.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tokei
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
