### PR TITLE
units: update to 2.24

### DIFF
--- a/app-utils/units/spec
+++ b/app-utils/units/spec
@@ -1,4 +1,4 @@
-VER=2.23
+VER=2.24
 SRCS="tbl::https://ftp.gnu.org/gnu/units/units-$VER.tar.gz"
-CHKSUMS="sha256::d957b451245925c9e614c4513397449630eaf92bd62b8495ba09bbe351a17370"
+CHKSUMS="sha256::1e502c4edfacf20b29284716c72e5ddb51a495a2365d7b03e7960494c4a0c902"
 CHKUPDATE="anitya::id=5048"


### PR DESCRIPTION
Topic Description
-----------------

- units: update to 2.24
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- units: 2.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit units
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
