### PR TITLE
gearlever: update to 4.0.3

### DIFF
--- a/app-utils/gearlever/autobuild/beyond
+++ b/app-utils/gearlever/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing get_appimage_offset command ..."
+install -Dvm755 "$SRCDIR"/build-aux/get_appimage_offset.sh \
+    "$PKGDIR"/usr/lib/gearlever/get_appimage_offset
+
+abinfo "Removing redundant files ..."
+rm -v "$PKGDIR"/usr/share/icons/hicolor/scalable/actions/meson.build
+rm -v "$PKGDIR"/usr/share/gearlever/gearlever/meson.build

--- a/app-utils/gearlever/autobuild/defines
+++ b/app-utils/gearlever/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=gearlever
 PKGSEC=utils
-PKGDEP="7-zip coreutils dbus-python gtk-4 hicolor-icon-theme libadwaita \
-        pygobject-3 python-3 pyxdg requests squashfs-tools gtk-update-icon-cache"
+PKGDEP="7-zip coreutils dbus-python desktop-entry-lib ftputil gtk-4 \
+        hicolor-icon-theme libadwaita pygobject-3 python-3 pyxdg requests \
+        squashfs-tools gtk-update-icon-cache"
 BUILDDEP="appstream desktop-file-utils gettext"
 PKGDES="A utility to manage AppImages"
 

--- a/app-utils/gearlever/autobuild/patches/0001-Direct-internally-used-script-to-its-new-location-in.patch
+++ b/app-utils/gearlever/autobuild/patches/0001-Direct-internally-used-script-to-its-new-location-in.patch
@@ -1,0 +1,25 @@
+From 9bf3b2d5a8876669241e2cd8aa9eae3667beb27f Mon Sep 17 00:00:00 2001
+From: pugaizai <i@pugai.life>
+Date: Thu, 27 Nov 2025 01:09:58 +0800
+Subject: [PATCH] Direct internally used script to its new location in lib
+
+---
+ src/providers/AppImageProvider.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/providers/AppImageProvider.py b/src/providers/AppImageProvider.py
+index cd9821e..b9fcf9f 100644
+--- a/src/providers/AppImageProvider.py
++++ b/src/providers/AppImageProvider.py
+@@ -701,7 +701,7 @@ class AppImageProvider():
+ 
+             if use_unsquashfs:
+                 logging.debug('Testing with unsquashfs')
+-                appimage_offset = terminal.sandbox_sh(['get_appimage_offset', file.get_path()])
++                appimage_offset = terminal.sandbox_sh(['/usr/lib/gearlever/get_appimage_offset', file.get_path()])
+ 
+                 try:
+                     terminal.sandbox_sh(['unsquashfs', '-o', appimage_offset, '-l', file.get_path()])
+-- 
+2.52.0
+

--- a/app-utils/gearlever/autobuild/patches/0002-Fix-DesktopEntry-type-annotation-in-AppImageProvider.patch
+++ b/app-utils/gearlever/autobuild/patches/0002-Fix-DesktopEntry-type-annotation-in-AppImageProvider.patch
@@ -1,0 +1,25 @@
+From 1b3d2d8e4a75b074f3416235d2e104b47821ea83 Mon Sep 17 00:00:00 2001
+From: pugaizai <i@pugai.life>
+Date: Thu, 27 Nov 2025 20:41:49 +0800
+Subject: [PATCH] Fix DesktopEntry type annotation in AppImageProvider
+
+---
+ src/providers/AppImageProvider.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/providers/AppImageProvider.py b/src/providers/AppImageProvider.py
+index cd9821e..26f71ad 100644
+--- a/src/providers/AppImageProvider.py
++++ b/src/providers/AppImageProvider.py
+@@ -841,7 +841,7 @@ class AppImageProvider():
+         folder = Settings.settings.get_string('appimages-default-folder')
+         return re.sub(r'^~', GLib.get_home_dir(), folder)
+ 
+-    def _get_app_version(self, extracted_appimage: Optional[ExtractedAppImage], desktop_entry: Optional[DesktopEntry] = None):
++    def _get_app_version(self, extracted_appimage: Optional[ExtractedAppImage], desktop_entry: Optional[DesktopEntry.DesktopEntry] = None):
+         if not desktop_entry:
+             desktop_entry = extracted_appimage.desktop_entry
+ 
+-- 
+2.52.0
+

--- a/app-utils/gearlever/spec
+++ b/app-utils/gearlever/spec
@@ -1,4 +1,4 @@
-VER=3.4.7
+VER=4.0.3
 SRCS="git::commit=tags/${VER}::https://github.com/mijorus/gearlever"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378021"

--- a/lang-python/desktop-entry-lib/autobuild/defines
+++ b/lang-python/desktop-entry-lib/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=desktop-entry-lib
+PKGSEC=python
+PKGDEP="desktop-file-utils jeepney python-3 xdg-user-dirs"
+BUILDDEP="setuptools"
+PKGDES="A library for working with .desktop files"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/desktop-entry-lib/spec
+++ b/lang-python/desktop-entry-lib/spec
@@ -1,0 +1,4 @@
+VER=5.0
+SRCS="pypi::version=$VER::desktop-entry-lib"
+CHKSUMS="sha256::9a621bac1819fe21021356e41fec0ac096ed56e6eb5dcfe0639cd8654914b864"
+CHKUPDATE="anitya::id=272430"

--- a/lang-python/ftputil/autobuild/defines
+++ b/lang-python/ftputil/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=ftputil
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Library for high-level FTP client"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/ftputil/spec
+++ b/lang-python/ftputil/spec
@@ -1,0 +1,4 @@
+VER=5.1.0
+SRCS="pypi::version=$VER::ftputil"
+CHKSUMS="sha256::e9e62d3fd307ef9c52e43b33fd92759fc94c04d8b5178f85f641b183906d4353"
+CHKUPDATE="anitya::id=371165"


### PR DESCRIPTION
Topic Description
-----------------

- ftputil: new, 5.1.0
- desktop-entry-lib: new, 5.0
- gearlever: update to 4.0.3
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- desktop-entry-lib: 5.0
- ftputil: 5.1.0
- gearlever: 4.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-entry-lib ftputil gearlever
```

Test Build(s) Done
------------------

