### PR TITLE
inxi: update to 3.3.40+1

### DIFF
--- a/app-utils/inxi/spec
+++ b/app-utils/inxi/spec
@@ -1,4 +1,4 @@
-VER=3.3.37+1
+VER=3.3.40+1
 SRCS="git::commit=tags/${VER/+/-}::https://codeberg.org/smxi/inxi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10526"


### PR DESCRIPTION
Topic Description
-----------------

- inxi: update to 3.3.40-1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- inxi: 3.3.40-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit inxi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
