### PR TITLE
wezterm: update to 20240203+110809+5046fc22+git20251123

### DIFF
--- a/app-utils/wezterm/autobuild/patches/0002-fix-procinfo-fix-can_close_without_prompting-check-s.patch
+++ b/app-utils/wezterm/autobuild/patches/0002-fix-procinfo-fix-can_close_without_prompting-check-s.patch
@@ -1,0 +1,42 @@
+From 5fbf16062e0d8ecd7e97a3d5ae6ad6780a31a4e1 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Mon, 24 Nov 2025 14:07:17 +0800
+Subject: [PATCH] fix(procinfo): fix `can_close_without_prompting` check `sudo`
+ program always return true
+
+When reading /proc/SUDO_PID/exe (say SUDO_PID is a PID running with elevated privileges,
+e.g., with sudo(1)) without elevated privileges, it will be read without privileges, whereas
+`exe_for_pid` function will always return an empty path. The final set of processes returned
+will then only include the shell that the user is running, making Wezterm fail to detect a
+running process with can_close_without_prompting (tab closes without a prompt asit would always
+return true).
+
+Fix this by implementing a fallback logic where, when Wezterm sees such a process, it would attempt
+to read argv0, making process detection work again in this case.
+---
+ procinfo/src/lib.rs | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/procinfo/src/lib.rs b/procinfo/src/lib.rs
+index 08f042364..7c76d4b8e 100644
+--- a/procinfo/src/lib.rs
++++ b/procinfo/src/lib.rs
+@@ -70,9 +70,12 @@ impl LocalProcessInfo {
+         let mut names = HashSet::new();
+ 
+         fn flatten(item: &LocalProcessInfo, names: &mut HashSet<String>) {
+-            if let Some(exe) = item.executable.file_name() {
+-                names.insert(exe.to_string_lossy().into_owned());
+-            }
++            match item.executable.file_name() {
++                Some(exe) if !exe.is_empty() => names.insert(exe.to_string_lossy().into_owned()),
++                // Handle no permission to read executable path program, like 'sudo'
++                _ => names.insert(item.name.clone()),
++            };
++
+             for proc in item.children.values() {
+                 flatten(proc, names);
+             }
+-- 
+2.52.0
+

--- a/app-utils/wezterm/spec
+++ b/app-utils/wezterm/spec
@@ -1,6 +1,6 @@
-VER=20240203+110809+5046fc22+git20250909
+VER=20240203+110809+5046fc22+git20251123
 REL=1
-SRCS="git::commit=bf9a2aeebacec19fd07b55234d626f006b22d369;copy-repo=true::https://github.com/wez/wezterm"
+SRCS="git::commit=ac08cdf6d72afd726cc1591c1ec9d80aa883ea41;copy-repo=true::https://github.com/wez/wezterm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235427"
 


### PR DESCRIPTION
Topic Description
-----------------

- wezterm: update to 20240203+110809+5046fc22+git20251123
    - Add patch https://github.com/wezterm/wezterm/pull/7398

Package(s) Affected
-------------------

- wezterm: 20240203+110809+5046fc22+git20251123-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wezterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
