### PR TITLE
xorg-server: update to 21.1.21

### DIFF
--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/X11/xorg.conf.d/10-cx4gpu.conf
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/overrides/usr/share/X11/xorg.conf.d/10-cx4gpu.conf
@@ -2,4 +2,5 @@ Section "OutputClass"
 	Identifier "cx4"
 	MatchDriver "cx4"
 	Driver "cx4"
+	Option "GlxVendorLibrary" "cx4"
 EndSection

--- a/runtime-display/cx4-linux-graphics-driver-dri/spec
+++ b/runtime-display/cx4-linux-graphics-driver-dri/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=26.00.41
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
+REL=1
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3419&tag=0&ref=qdxz&pre=0&t=20ce3b68fe29466a"
 CHKSUMS="sha256::1cdf4d00309fbd34350beda1d2c3caaf863941040450c56786229a102232e2a6"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.19
+VER=21.1.21
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: update to 21.1.21
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xorg-server: 21.1.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit xorg-server cx4-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
