### PR TITLE
gifsicle: update to 1.96

### DIFF
--- a/app-utils/gifsicle/spec
+++ b/app-utils/gifsicle/spec
@@ -1,4 +1,4 @@
-VER=1.95
+VER=1.96
 SRCS="git::commit=tags/v$VER::https://github.com/kohler/gifsicle"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1159"


### PR DESCRIPTION
Topic Description
-----------------

- gifsicle: update to 1.96
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gifsicle: 1.96

Security Update?
----------------

No

Build Order
-----------

```
#buildit gifsicle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
