### PR TITLE
optipng: update to 7.9.1

### DIFF
--- a/app-utils/optipng/spec
+++ b/app-utils/optipng/spec
@@ -1,5 +1,4 @@
-VER=0.7.7
-REL=1
+VER=7.9.1
 SRCS="tbl::https://sourceforge.net/projects/optipng/files/OptiPNG/optipng-$VER/optipng-$VER.tar.gz"
-CHKSUMS="sha256::4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452"
+CHKSUMS="sha256::c2579be58c2c66dae9d63154edcb3d427fef64cb00ec0aff079c9d156ec46f29"
 CHKUPDATE="anitya::id=2571"

--- a/topics/optipng-7.9.1.toml
+++ b/topics/optipng-7.9.1.toml
@@ -1,0 +1,12 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OptiPNG 7.9.1"
+
+[caution]
+default = "Fixes a Buffer Overflow vulnerability - CVE-2023-43907 (Severity: High)"
+zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2023-43907（严重性：高）"
+
+[packages-v2]
+"optipng" = "< 7.9.1"


### PR DESCRIPTION
Topic Description
-----------------

- optipng: update to 7.9.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- optipng: 7.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit optipng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
