### PR TITLE
gnome-disk-utility: rebuild for upgrade failed

### DIFF
--- a/app-admin/udisks-2/autobuild/beyond
+++ b/app-admin/udisks-2/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing api docs ..."
+rm -rv "$PKGDIR"/usr/share/gtk-doc

--- a/app-admin/udisks-2/autobuild/defines
+++ b/app-admin/udisks-2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=udisks-2
 PKGSEC=admin
-PKGDEP="acl libatasmart lvm2 polkit systemd glib util-linux libblockdev \
+PKGDEP="acl libatasmart lvm2 polkit systemd glib glibc util-linux libblockdev \
         libconfig libstoragemgmt libiscsi bcache-tools parted gptfdisk \
         ntfs-3g dosfstools libgudev"
 PKGDEP__RETRO=" \
@@ -26,11 +26,18 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="Storage media interface"
 
-AUTOTOOLS_AFTER="--with-systemdsystemunitdir=/usr/lib/systemd/system \
-                 --localstatedir=/var \
-                 --libexecdir=/usr/lib \
-                 --disable-iscsi"
+AUTOTOOLS_AFTER=(
+    '--with-systemdsystemunitdir=/usr/lib/systemd/system'
+    '--localstatedir=/var'
+    '--libexecdir=/usr/libexec'
+    '--enable-btrfs'
+    '--enable-lvm2'
+    '--enable-lsm'
+    '--enable-smart'
+    '--disable-gtk-doc'
+    '--disable-iscsi'
+)
 
-MAKE_AFTER="bash_completiondir=/usr/share/bash-completion/completions"
+MAKE_AFTER=('bash_completiondir=/usr/share/bash-completion/completions')
 ABSHADOW=0
 RECONF=0

--- a/app-admin/udisks-2/spec
+++ b/app-admin/udisks-2/spec
@@ -1,4 +1,4 @@
-VER=2.10.2
+VER=2.11.0
 SRCS="tbl::https://github.com/storaged-project/udisks/releases/download/udisks-$VER/udisks-$VER.tar.bz2"
-CHKSUMS="sha256::6401c715d287ec84fe605e0cb90579e8da6c395bce5f42e419f205dd297e261f"
+CHKSUMS="sha256::0bf30151fe8d9d2fb59b57f6630739dfbbd16417dee69ec57d43b37335bd649a"
 CHKUPDATE="anitya::id=5028"

--- a/desktop-gnome/gnome-disk-utility/autobuild/defines
+++ b/desktop-gnome/gnome-disk-utility/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=gnome-disk-utility
 PKGSEC=gnome
-PKGDEP="desktop-file-utils gtk-3 libcanberra libdvdread libhandy libnotify \
-        libpwquality libsecret parted udisks-2"
+PKGDEP="at-spi2-core atk cairo desktop-file-utils gcc-runtime gdk-pixbuf glib \
+        glibc gtk-3 libcanberra libdvdread libhandy libpwquality libsecret \
+        pango systemd udisks-2 xz"
 BUILDDEP="docbook-xsl glade gnome-settings-daemon gtk-doc intltool vala"
 PKGDES="Disk management utility for GNOME"
 
-MESON_AFTER="-Dlogind=libsystemd \
-             -Dgsd_plugin=true \
-             -Dman=true"
+MESON_AFTER=(
+    '-Dlogind=libsystemd'
+    '-Dgsd_plugin=true'
+    '-Dman=true'
+)

--- a/desktop-gnome/gnome-disk-utility/spec
+++ b/desktop-gnome/gnome-disk-utility/spec
@@ -1,4 +1,4 @@
-VER=42.0
+VER=46.1
 SRCS="https://download.gnome.org/sources/gnome-disk-utility/${VER%.*}/gnome-disk-utility-$VER.tar.xz"
-CHKSUMS="sha256::1b6564454d67426322cb3bfc5a5558653bfc7dfeea2ae0825b1d08629f01090b"
+CHKSUMS="sha256::c24e9439a04d70bcfae349ca134c7005435fe2b6f452114df878bff0b89bbffe"
 CHKUPDATE="anitya::id=5398"

--- a/runtime-devices/libblockdev/autobuild/defines
+++ b/runtime-devices/libblockdev/autobuild/defines
@@ -1,10 +1,12 @@
 PKGNAME=libblockdev
 PKGSEC=libs
-PKGDEP="btrfs-progs dosfstools gptfdisk libbytesize lvm2 mdadm volume-key \
-        xfsprogs bcache-tools yaml ndctl parted libatasmart json-glib"
-PKGDEP__RETRO=" \
-        btrfs-progs dosfstools gptfdisk libbytesize lvm2 mdadm volume-key \
-        xfsprogs yaml parted libatasmart json-glib"
+PKGDEP="bcache-tools btrfs-progs cryptsetup dosfstools gcc-runtime glib glibc \
+        gptfdisk json-glib keyutils kmod libatasmart libbytesize lvm2 mdadm \
+        ndctl nspr nss parted systemd util-linux-runtime volume-key xfsprogs \
+        yaml"
+PKGDEP__RETRO="btrfs-progs cryptsetup dosfstools gcc-runtime glib glibc \
+        gptfdisk json-glib keyutils kmod libatasmart libbytesize lvm2 mdadm \
+        nspr nss parted systemd util-linux-runtime volume-key xfsprogs yaml"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
@@ -25,17 +27,18 @@ BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="A library for manipulating block devices"
 
-AUTOTOOLS_AFTER="--with-dm=no"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-nvdimm"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=('--with-dm=no')
+AUTOTOOLS_AFTER__RETRO=(
+                 "${AUTOTOOLS_AFTER[@]}"
+                 '--without-nvdimm'
+)
+AUTOTOOLS_AFTER__ARMV4=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__ARMV6HF=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__ARMV7HF=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__I486=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__LOONGSON2F=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__M68K=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__POWERPC=("${AUTOTOOLS_AFTER__RETRO[@]}")
+AUTOTOOLS_AFTER__PPC64=("${AUTOTOOLS_AFTER__RETRO[@]}")
 
 ABSHADOW=0

--- a/runtime-devices/libblockdev/spec
+++ b/runtime-devices/libblockdev/spec
@@ -1,4 +1,4 @@
-VER=3.3.1
+VER=3.4.0
 SRCS="tbl::https://github.com/storaged-project/libblockdev/releases/download/${VER}/libblockdev-${VER}.tar.gz"
-CHKSUMS="sha256::a2e2e448a19d420480b8cce5e0752197482a65cb62a9ed55d88b237da36600d1"
+CHKSUMS="sha256::65ef9a37babd44b85b8ff9b273f90f9f7d5f8ff7b0c76a8edb69240325fd83f4"
 CHKUPDATE="anitya::id=9397"


### PR DESCRIPTION
Topic Description
-----------------

- libblockdev: update to 3.4.0
- udisks-2: update to 2.11.0
- gnome-disk-utility: update to 46.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gnome-disk-utility: 46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-disk-utility
```

Test Build(s) Done
------------------

