### PR TITLE
gnome-disk-utility: rebuild for upgrade failed

### DIFF
--- a/desktop-gnome/gnome-disk-utility/autobuild/defines
+++ b/desktop-gnome/gnome-disk-utility/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-disk-utility
 PKGSEC=gnome
-PKGDEP="at-spi2-core atk cairo desktop-file-utils gcc-runtime gdk-pixbuf glib \
+PKGDEP="at-spi2-core cairo desktop-file-utils gcc-runtime gdk-pixbuf glib \
         glibc gtk-3 libcanberra libdvdread libhandy libpwquality libsecret \
         pango systemd udisks-2 xz"
 BUILDDEP="docbook-xsl glade gnome-settings-daemon gtk-doc intltool vala"
@@ -11,3 +11,5 @@ MESON_AFTER=(
     '-Dgsd_plugin=true'
     '-Dman=true'
 )
+
+PKGBREAK="gnome-disk-utility<=46.1"

--- a/desktop-gnome/gnome-disk-utility/spec
+++ b/desktop-gnome/gnome-disk-utility/spec
@@ -1,4 +1,5 @@
 VER=46.1
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-disk-utility/${VER%.*}/gnome-disk-utility-$VER.tar.xz"
 CHKSUMS="sha256::c24e9439a04d70bcfae349ca134c7005435fe2b6f452114df878bff0b89bbffe"
 CHKUPDATE="anitya::id=5398"


### PR DESCRIPTION
Topic Description
-----------------

- gnome-disk-utility: rebuild for upgrade failed

Package(s) Affected
-------------------

- gnome-disk-utility: 46.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnome-disk-utility
```

Test Build(s) Done
------------------

