### PR TITLE
afpfs-ng: fix build

### DIFF
--- a/runtime-network/afpfs-ng/autobuild/patches/0006-Fedora-afpfs-ng-0.8.1-pointer2.patch
+++ b/runtime-network/afpfs-ng/autobuild/patches/0006-Fedora-afpfs-ng-0.8.1-pointer2.patch
@@ -1,0 +1,109 @@
+diff -ru afpfs-ng-0.8.1.orig/lib/loop.c afpfs-ng-0.8.1.new/lib/loop.c
+--- afpfs-ng-0.8.1.orig/lib/loop.c	2025-02-06 15:18:29.028488247 +0100
++++ afpfs-ng-0.8.1.new/lib/loop.c	2025-02-06 15:02:08.261418298 +0100
+@@ -87,7 +87,7 @@
+ static int ending=0;
+ void * just_end_it_now(void * ignore)
+ {
+-	if (ending) return;
++	if (ending) return(NULL);
+ 	ending=1;
+ 	if (libafpclient->forced_ending_hook) 
+ 		libafpclient->forced_ending_hook();
+diff -ru afpfs-ng-0.8.1.orig/lib/proto_directory.c afpfs-ng-0.8.1.new/lib/proto_directory.c
+--- afpfs-ng-0.8.1.orig/lib/proto_directory.c	2025-02-06 15:18:29.030488258 +0100
++++ afpfs-ng-0.8.1.new/lib/proto_directory.c	2025-02-06 15:17:58.862309936 +0100
+@@ -16,6 +16,19 @@
+ #include "dsi_protocol.h"
+ #include "afp_replies.h"
+ 
++typedef struct reply_entry {
++	uint8_t size;
++	uint8_t isdir;
++};
++
++typedef	struct ext2_reply_entry {
++	uint16_t size;
++	uint8_t isdir;
++	uint8_t pad;
++};
++
++
++
+ int afp_moveandrename(struct afp_volume *volume,
+ 	unsigned int src_did, 
+ 	unsigned int dst_did, 
+@@ -200,10 +213,7 @@
+ 		uint16_t reqcount;
+ 	} __attribute__((__packed__)) * reply = (void *) buf;
+ 
+-	struct {
+-		uint8_t size;
+-		uint8_t isdir;
+-	} __attribute__((__packed__)) * entry;
++	struct reply_entry __attribute__((__packed__)) * entry;
+ 	char * p = buf + sizeof(*reply);
+ 	int i;
+ 	char  *max=buf+size;
+@@ -219,7 +229,7 @@
+ 	}
+ 
+ 	for (i=0;i<ntohs(reply->reqcount);i++) {
+-		entry  = (void *) p;
++		entry = ( struct reply_entry *) p;
+ 
+ 		if (p>max) {
+ 			return -1;
+@@ -259,11 +269,7 @@
+ 		uint16_t reqcount;
+ 	} __attribute__((__packed__)) * reply = (void *) buf;
+ 
+-	struct {
+-		uint16_t size;
+-		uint8_t isdir;
+-		uint8_t pad;
+-	} __attribute__((__packed__)) * entry;
++	struct ext2_reply_entry __attribute__((__packed__)) * entry;
+ 	char * p = buf + sizeof(*reply);
+ 	int i;
+ 	char  *max=buf+size;
+@@ -293,7 +299,7 @@
+ 			filecur=new_file;
+ 		}
+ 
+-		entry = p;
++		entry = ( struct ext2_reply_entry *) p;
+ 
+ 		parse_reply_block(server,p+sizeof(*entry),
+ 			ntohs(entry->size),entry->isdir,
+diff -ru afpfs-ng-0.8.1.orig/lib/uams.c afpfs-ng-0.8.1.new/lib/uams.c
+--- afpfs-ng-0.8.1.orig/lib/uams.c	2025-02-06 15:18:29.030488258 +0100
++++ afpfs-ng-0.8.1.new/lib/uams.c	2025-02-06 15:00:32.383809018 +0100
+@@ -36,7 +36,7 @@
+ static int cleartxt_login(struct afp_server *server, char *username,
+ 				char *passwd);
+ static int cleartxt_passwd(struct afp_server *server, char *username,
+-				char *passwd);
++				char *passwd, char *newpasswd);
+ #ifdef HAVE_LIBGCRYPT
+ static int randnum_login(struct afp_server *server, char *username,
+ 		char *passwd);
+@@ -49,8 +49,7 @@
+ static struct afp_uam uam_noauth = 
+ 	{UAM_NOUSERAUTHENT,"No User Authent",&noauth_login,NULL,NULL};
+ static struct afp_uam uam_cleartxt = 
+-	{UAM_CLEARTXTPASSWRD,"Cleartxt Passwrd",&cleartxt_login,
+-		&cleartxt_passwd,NULL};
++	{UAM_CLEARTXTPASSWRD,"Cleartxt Passwrd",&cleartxt_login,&cleartxt_passwd,NULL};
+ #ifdef HAVE_LIBGCRYPT
+ static struct afp_uam uam_randnum = 
+ 	{UAM_RANDNUMEXCHANGE, "Randnum Exchange", &randnum_login,NULL,NULL};
+@@ -219,7 +218,7 @@
+  *      +------------------+
+  */
+ static int cleartxt_passwd(struct afp_server *server, 
+-	char *username, char *passwd) {
++	char *username, char *passwd, char *newpasswd) {
+ 
+ 	char *p, *ai = NULL;
+ 	int len, ret;

--- a/runtime-network/afpfs-ng/autobuild/patches/0007-Fedora-afpfs-ng-0.8.1-tests.patch
+++ b/runtime-network/afpfs-ng/autobuild/patches/0007-Fedora-afpfs-ng-0.8.1-tests.patch
@@ -1,0 +1,30 @@
+diff -ru afpfs-ng-0.8.1.old/cmdline/cmdline_testafp.c afpfs-ng-0.8.1.new/cmdline/cmdline_testafp.c
+--- afpfs-ng-0.8.1.old/cmdline/cmdline_testafp.c	2025-02-06 15:22:10.187795481 +0100
++++ afpfs-ng-0.8.1.new/cmdline/cmdline_testafp.c	2025-02-06 15:30:13.226751326 +0100
+@@ -31,7 +31,7 @@
+ 	snprintf(valid_url.path,sizeof(valid_url.path),"%s",path);
+ 	snprintf(valid_url.username,sizeof(valid_url.username),"%s",username);
+ 	snprintf(valid_url.password,sizeof(valid_url.password),"%s",password);
+-	snprintf(valid_url.uamname,(valid_url.uamname),"%s",uamname);
++	snprintf(valid_url.uamname,sizeof(valid_url.uamname),"%s",uamname);
+ 	valid_url.port=port;
+ 
+ 	if (afp_url_validate(url_string,&valid_url)) 
+@@ -42,7 +42,7 @@
+ 	return 0;
+ }
+ 
+-int test_urls(void)
++int test_urls(char * arg)
+ {
+ 
+ 	printf("Testing URL parsing\n");
+diff -ru afpfs-ng-0.8.1.old/cmdline/cmdline_testafp.h afpfs-ng-0.8.1.new/cmdline/cmdline_testafp.h
+--- afpfs-ng-0.8.1.old/cmdline/cmdline_testafp.h	2008-01-05 06:00:57.000000000 +0100
++++ afpfs-ng-0.8.1.new/cmdline/cmdline_testafp.h	2025-02-06 15:30:51.577987329 +0100
+@@ -1,4 +1,4 @@
+ #ifndef __CMDLINE_TESTAFP_H_
+-int test_urls(void);
++int test_urls(char * arg);
+ #endif
+ 

--- a/runtime-network/afpfs-ng/spec
+++ b/runtime-network/afpfs-ng/spec
@@ -1,5 +1,5 @@
 VER=0.8.1
-REL=4
+REL=5
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/afpfs-ng/afpfs-ng-$VER.tar.bz2"
 CHKSUMS="sha256::688560de1cde57ab8d9e0ef7dc6436dbf0267fe8884f9014e50ff92b297b01a8"
 CHKUPDATE="anitya::id=28"


### PR DESCRIPTION
Topic Description
-----------------

- afpfs-ng: fix build

Package(s) Affected
-------------------

- afpfs-ng: 0.8.1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit afpfs-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
