### PR TITLE
guitarix: update to 0.47.0

### DIFF
--- a/app-multimedia/guitarix/spec
+++ b/app-multimedia/guitarix/spec
@@ -1,4 +1,4 @@
-VER=0.46.0
+VER=0.47.0
 SRCS="tbl::https://github.com/brummer10/guitarix/releases/download/V${VER}/guitarix2-${VER}.tar.xz"
-CHKSUMS="sha256::c660beb3f16cdc455d99e6f074cd6ea2b1f10c1dfc480e84210461637dc98c44"
+CHKSUMS="sha256::f18abd3bd2cb05960d00f15f36c63f97eb1759f9571977e3e42191ff16b9b467"
 CHKUPDATE="anitya::id=10599"


### PR DESCRIPTION
Topic Description
-----------------

- guitarix: update to 0.47.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- guitarix: 0.47.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit guitarix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
