### PR TITLE
libwacom: update to 2.17.0

### DIFF
--- a/runtime-devices/libwacom/spec
+++ b/runtime-devices/libwacom/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.17.0
 SRCS="tbl::https://github.com/linuxwacom/libwacom/releases/download/libwacom-$VER/libwacom-$VER.tar.xz"
-CHKSUMS="sha256::d0d022761e3f9ab23e329583b7d2bd470b0450dfb077caeb22c5a0d66c2bd414"
+CHKSUMS="sha256::41a0f239841567b101904df8ced81e1e0115334ccfd82a024412aa0903dae5a7"
 CHKUPDATE="anitya::id=16887"


### PR DESCRIPTION
Topic Description
-----------------

- libwacom: update to 2.17.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libwacom: 2.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libwacom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
