### PR TITLE
box64: update to 0.3.9+git20251126

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,5 +1,5 @@
-VER=0.3.9+git20251124
+VER=0.3.9+git20251126
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=8a40b11574a13e8ff1173be8a966314d47f2d38f;copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=d5d4cc09510687fc184ed37c3144c3a09ae3dba5;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251126

Package(s) Affected
-------------------

- box64: 0.3.9+git20251126

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

