### PR TITLE
zed: update to 0.213.8

### DIFF
--- a/app-editors/zed/autobuild/defines
+++ b/app-editors/zed/autobuild/defines
@@ -1,5 +1,5 @@
-PKGNAME="zed"
-PKGDES="A general-purpose, multiplayer code editor"
+PKGNAME=zed
+PKGDES="General-purpose, multiplayer code editor"
 PKGSEC=devel
 PKGDEP="alsa-lib gcc-runtime glibc libxcb libxkbcommon x11-lib zlib"
 BUILDDEP="rustc llvm mold"

--- a/app-editors/zed/spec
+++ b/app-editors/zed/spec
@@ -1,4 +1,4 @@
-VER=0.213.3
+VER=0.213.8
 SRCS="git::commit=v$VER::https://github.com/zed-industries/zed"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373275"


### PR DESCRIPTION
Topic Description
-----------------

- zed: update to 0.213.8
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- zed: 0.213.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit zed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
