### PR TITLE
llama.cpp: update to 7164

### DIFF
--- a/runtime-creativity/llama.cpp/spec
+++ b/runtime-creativity/llama.cpp/spec
@@ -1,4 +1,4 @@
-VER=7091
+VER=7164
 # The build system uses git tags to determine version number
 SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggerganov/llama.cpp.git"
 CHKSUMS="SKIP"

--- a/runtime-scientific/ggml/spec
+++ b/runtime-scientific/ggml/spec
@@ -1,4 +1,4 @@
-VER=0.9.4+git20251117
-SRCS="git::commit=c23776f22d616d8cb635145381cad365bac675e7;copy-repo=true::https://github.com/ggml-org/ggml"
+VER=0.9.4+git20251124
+SRCS="git::commit=55bc9320a4aae82af18e23eefd5de319a755d7b9;copy-repo=true::https://github.com/ggml-org/ggml"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383765"


### PR DESCRIPTION
Topic Description
-----------------

- llama.cpp: update to 7164
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- llama.cpp: 7164

Security Update?
----------------

No

Build Order
-----------

```
#buildit ggml llama.cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
