### PR TITLE
groups: adjust fmt-rebuild build order

### DIFF
--- a/groups/fmt-rebuilds
+++ b/groups/fmt-rebuilds
@@ -8,7 +8,6 @@ app-multimedia/easyeffects
 app-multimedia/kodi
 app-multimedia/ncmpc
 app-multimedia/wiliwili
-app-utils/watchman
 app-utils/waybar
 runtime-database/tiledb
 runtime-common/folly
@@ -17,5 +16,6 @@ runtime-network/mvfst
 runtime-network/wangle
 app-network/fbthrift
 runtime-network/fb303
+app-utils/watchman
 runtime-web/ada
 app-admin/cryfs


### PR DESCRIPTION
Topic Description
-----------------

- groups: adjust fmt-rebuild build order

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
