### PR TITLE
Libvirt Survey November 2025

### DIFF
--- a/app-virtualization/libvirt/autobuild/beyond
+++ b/app-virtualization/libvirt/autobuild/beyond
@@ -5,7 +5,3 @@ chmod -v 0770 "$PKGDIR"/var/lib/libvirt/qemu
 abinfo "Fixing permissions for PolicyKit rules ..."
 chown -v 0:27 "$PKGDIR"/usr/share/polkit-1/rules.d
 chmod -v 0750 "$PKGDIR"/usr/share/polkit-1/rules.d
-
-abinfo "Dropping unnecessary directories ..."
-rm -rv \
-    "$PKGDIR"/var/run

--- a/app-virtualization/libvirt/autobuild/defines
+++ b/app-virtualization/libvirt/autobuild/defines
@@ -59,7 +59,6 @@ MESON_AFTER=(
     -Dselinux_mount=disabled
     -Dudev=enabled
     -Dwireshark_dissector=enabled
-    -Dyajl=enabled
     -Ddriver_bhyve=disabled
     -Ddriver_esx=enabled
     -Ddriver_hyperv=disabled

--- a/app-virtualization/libvirt/autobuild/patches/0001-Add-bios-path-for-loongarch.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0001-Add-bios-path-for-loongarch.patch
@@ -16,7 +16,7 @@ diff --git a/src/qemu/qemu.conf.in b/src/qemu/qemu.conf.in
 index f406df8749..6449beb84b 100644
 --- a/src/qemu/qemu.conf.in
 +++ b/src/qemu/qemu.conf.in
-@@ -843,7 +843,8 @@
+@@ -1005,7 +1005,8 @@
  #   "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd",
  #   "/usr/share/OVMF/OVMF_CODE.secboot.fd:/usr/share/OVMF/OVMF_VARS.fd",
  #   "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd",
@@ -25,7 +25,7 @@ index f406df8749..6449beb84b 100644
 +#   "/usr/share/qemu/edk2-loongarch64-code.fd:/usr/share/qemu/edk2-loongarch64-vars.fd"
  #]
  
- # The backend to use for handling stdout/stderr output from
+
 diff --git a/src/qemu/qemu_conf.c b/src/qemu/qemu_conf.c
 index 4050a82341..07dd509f13 100644
 --- a/src/qemu/qemu_conf.c

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,5 +1,4 @@
-VER=10.5.0
-REL=1
-SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
-CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
+VER=11.9.0
+SRCS="tbl::https://download.libvirt.org/libvirt-$VER.tar.xz"
+CHKSUMS="sha256::104f70ee591e72989d4f8c6caa79ed9dacd5dc84efdb0125b848afe544ad0c2d"
 CHKUPDATE="anitya::id=13830"

--- a/app-virtualization/qemu/01-shared/build
+++ b/app-virtualization/qemu/01-shared/build
@@ -1,5 +1,4 @@
-if ! ab_match_arch loongarch64 && \
-   ! ab_match_arch loongson3 && \
+if ! ab_match_arch loongson3 && \
    ! ab_match_arch riscv64; then
     COMMON_CONFIGURE_FLAGS="
 	--prefix=/usr

--- a/app-virtualization/qemu/01-shared/defines
+++ b/app-virtualization/qemu/01-shared/defines
@@ -13,18 +13,12 @@ BUILDDEP="spice-protocol xmlto doxygen dtc sphinx jack glib-static \
 PKGDES="A KVM based virtualization client"
 
 AB_FLAGS_SPECS=0
+
+# FIXME: Relocation overflow.
+#
+# loongson3: relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
+# riscv64: relocation truncated to fit: R_RISCV_JAL against symbol `safe_syscall_set_errno_tail' defined in .text section
 NOLTO__LOONGSON3=1
-
-# FIXME: /tcg/tcg-op-vec.c:244:(.text+0x3e6da8): relocation truncated to fit:
-# R_LARCH_PCREL20_S2 against `.LANCHOR21'
-# /usr/bin/ld: final link failed: bad value
-# collect2: error: ld returned 1 exit status
-NOLTO__LOONGARCH64=1
-
-# FIXME: relocation truncated to fit: R_RISCV_JAL against symbol
-# `safe_syscall_set_errno_tail' defined in .text section in
-# /tmp/cca5hLTf.ltrans0.ltrans.o
-ABSPLITDBG__RISCV64=0
 NOLTO__RISCV64=1
 
 # Note: Used to be debundled, now bundled.

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,4 @@
-VER=9.2.2
-REL=3
+VER=10.0.6
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf"
+CHKSUMS="sha256::c7c40c4b166871e775804e97fce4da65665d1cc93a5c6c9e2ede9d9ee992e7a0"
 CHKUPDATE="anitya::id=13607"

--- a/app-virtualization/virglrenderer/autobuild/defines
+++ b/app-virtualization/virglrenderer/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=virglrenderer
 PKGSEC=libs
-PKGDEP="libdrm libepoxy mesa x11-lib"
+PKGDEP="libdrm libepoxy mesa x11-lib vulkan-loader libva"
+BUILDDEP="pyyaml"
 PKGDES="Virtual 3D GPU library"
 
 ABTYPE=meson
@@ -16,14 +17,18 @@ PKGBREAK="qemu<=5.1.0"
 # 7887 |       gr->size += gbm_bo_get_plane_size(bo, plane);
 #      |                   ^~~~~~~~~~~~~~~~~~~~~
 #      |                   gbm_bo_get_plane_count
-MESON_AFTER="-Dplatforms=auto \
-             -Dminigbm_allocation=false \
-             -Dvenus-validate=false \
-             -Dcheck-gl-errors=true \
-             -Ddrm-msm-experimental=false \
-             -Drender-server=false \
-             -Drender-server-worker=process \
-             -Dvideo=true \
-             -Dfuzzer=false \
-             -Dvalgrind=false \
-             -Dtracing=none"
+MESON_AFTER=(
+	-Dcheck-gl-errors=true
+	-Ddrm-renderers=amdgpu-experimental,asahi,msm
+	-Dfuzzer=false
+	-Dminigbm_allocation=false
+	-Dplatforms=auto
+	-Drender-server-worker=process
+	-Dtests=false
+	-Dtracing=none
+	-Dunstable-apis=false
+	-Dvalgrind=false
+	-Dvenus=true
+	-Dvenus-validate=true
+	-Dvideo=true
+)

--- a/app-virtualization/virglrenderer/spec
+++ b/app-virtualization/virglrenderer/spec
@@ -1,4 +1,4 @@
-VER=0.10.4
+VER=1.2.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/virgl/virglrenderer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15968"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: upgrade to 11.9.0
    Co-authored-by: Tianhao Chai <cth451@gmail.com>
- qemu: update to 10.0.6
    Co-authored-by: Tianhao Chai <cth451@gmail.com>
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
- virglrenderer: update to 1.2.0
    Co-authored-by: Tianhao Chai <cth451@gmail.com>

Package(s) Affected
-------------------

- libvirt: 11.9.0
- qemu: 10.0.6
- qemu-aarch64-static: 10.0.6
- qemu-alpha-static: 10.0.6
- qemu-arm-static: 10.0.6
- qemu-armeb-static: 10.0.6
- qemu-guest-agent: 10.0.6
- qemu-i386-static: 10.0.6
- qemu-loongarch64-static: 10.0.6
- qemu-m68k-static: 10.0.6
- qemu-microblaze-static: 10.0.6
- qemu-microblazeel-static: 10.0.6
- qemu-mips-static: 10.0.6
- qemu-mips64-static: 10.0.6
- qemu-mips64el-static: 10.0.6
- qemu-mipsel-static: 10.0.6
- qemu-mipsn32-static: 10.0.6
- qemu-mipsn32el-static: 10.0.6
- qemu-or32-static: 10.0.6
- qemu-ppc-static: 10.0.6
- qemu-ppc64-static: 10.0.6
- qemu-ppc64le-static: 10.0.6
- qemu-riscv32-static: 10.0.6
- qemu-riscv64-static: 10.0.6
- qemu-s390x-static: 10.0.6
- qemu-sh4-static: 10.0.6
- qemu-sh4eb-static: 10.0.6
- qemu-sparc-static: 10.0.6
- qemu-sparc32plus-static: 10.0.6
- qemu-sparc64-static: 10.0.6
- qemu-user-static: 10.0.6
- qemu-x86-64-static: 10.0.6
- virglrenderer: 1.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit virglrenderer qemu libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
