### PR TITLE
libssh2: update to 1.11.1

### DIFF
--- a/runtime-network/libssh2/autobuild/defines
+++ b/runtime-network/libssh2/autobuild/defines
@@ -3,4 +3,4 @@ PKGSEC=libs
 PKGDEP="openssl zlib"
 PKGDES="A client-side C library implementing the SSH2 protocol"
 
-RECONF=0
+ABTYPE=cmakeninja

--- a/runtime-network/libssh2/spec
+++ b/runtime-network/libssh2/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
-REL=2
-SRCS="tbl::https://www.libssh2.org/download/libssh2-$VER.tar.gz"
-CHKSUMS="sha256::d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
+VER=1.11.1
+SRCS="git::commit=tags/libssh2-${VER}::https://github.com/libssh2/libssh2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1730"

--- a/runtime-optenv32/libssh2+32/autobuild/defines
+++ b/runtime-optenv32/libssh2+32/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="aosc-aaa+32 openssl+32 zlib+32"
 BUILDDEP="autoconf-archive devel-base+32"
 PKGDES="A client-side C library implementing the SSH2 protocol (32-bit x86 runtime)"
 
+ABTYPE=cmakeninja
 ABHOST=optenv32

--- a/runtime-optenv32/libssh2+32/spec
+++ b/runtime-optenv32/libssh2+32/spec
@@ -1,5 +1,4 @@
-VER=1.9.0
-REL=3
-SRCS="tbl::https://www.libssh2.org/download/libssh2-$VER.tar.gz"
-CHKSUMS="sha256::d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
+VER=1.11.1
+SRCS="git::commit=tags/libssh2-${VER}::https://github.com/libssh2/libssh2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1730"


### PR DESCRIPTION
Topic Description
-----------------

- libssh2+32: update to 1.11.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- libssh2: update to 1.11.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libssh2: 1.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libssh2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
