### PR TITLE
Virtualization Survey 20251111

### DIFF
--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,5 +1,4 @@
-VER=4.4.9
+VER=4.6.1
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::60551dc787f41e87aeaa1e9c33304f9008037e3baf9fa11aef9c2d584cc0b54b"
+CHKSUMS="sha256::5f43055db213e16aed6a064a8b4fdb56092106f18c19e8890482c058b0a1dd85"
 CHKUPDATE="anitya::id=5137"
-REL=2

--- a/app-virtualization/libvirt/autobuild/beyond
+++ b/app-virtualization/libvirt/autobuild/beyond
@@ -6,6 +6,6 @@ abinfo "Fixing permissions for PolicyKit rules ..."
 chown -v 0:27 "$PKGDIR"/usr/share/polkit-1/rules.d
 chmod -v 0750 "$PKGDIR"/usr/share/polkit-1/rules.d
 
-abinfo "Dropping unnecessary directories ..."
-rm -rv \
-    "$PKGDIR"/var/run
+abinfo "Dropping HTML documentations ..."
+# This saves 8.0MiB of disk space.
+rm -rv "$PKGDIR"/usr/share/doc/libvirt/html

--- a/app-virtualization/libvirt/autobuild/defines
+++ b/app-virtualization/libvirt/autobuild/defines
@@ -4,15 +4,10 @@ PKGDEP="avahi bridge-utils curl cyrus-sasl dbus dmidecode dnsmasq \
         e2fsprogs gcc-runtime gettext gnutls iproute2 iptables \
         libcap-ng libgcrypt libgpg-error libnl libpcap libssh2 libxml2 \
         lxc netcat netcf numactl openssl parted pm-utils polkit python-3 \
-        radvd systemd yajl x11-lib libssh qemu open-iscsi perl-xml-xpath \
+        radvd systemd x11-lib libssh qemu open-iscsi perl-xml-xpath \
         libiscsi sanlock"
-BUILDDEP="docutils qemu zfs rpcsvc-proto firewalld wireshark"
-# FIXME: LTS kernel not yet available for these architectures.
-BUILDDEP__LOONGARCH64="${BUILDDEP/zfs/}"
-BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP/zfs/}"
-BUILDDEP__LOONGSON3="${BUILDDEP/zfs/}"
-BUILDDEP__RISCV64="${BUILDDEP/zfs/}"
-PKGSUG="zfs"
+BUILDDEP="docutils qemu rpcsvc-proto firewalld wireshark"
+# NOTE: We dropped LTS kernel recently, thus ZFS support is not guranteed.
 PKGRECOM="qemu"
 PKGDES="API for controlling virtualization engines"
 
@@ -59,7 +54,6 @@ MESON_AFTER=(
     -Dselinux_mount=disabled
     -Dudev=enabled
     -Dwireshark_dissector=enabled
-    -Dyajl=enabled
     -Ddriver_bhyve=disabled
     -Ddriver_esx=enabled
     -Ddriver_hyperv=disabled
@@ -67,7 +61,7 @@ MESON_AFTER=(
     -Ddriver_libvirtd=enabled
     -Ddriver_libxl=disabled
     -Ddriver_lxc=enabled
-    -Ddriver_ch=enabled
+    -Ddriver_ch=disabled
     -Ddriver_network=enabled
     -Ddriver_openvz=enabled
     -Ddriver_qemu=enabled
@@ -92,7 +86,7 @@ MESON_AFTER=(
     -Dstorage_rbd=disabled
     -Dstorage_scsi=enabled
     -Dstorage_vstorage=enabled
-    -Dstorage_zfs=enabled
+    -Dstorage_zfs=disabled
     -Ddtrace=disabled
     -Dfirewalld=enabled
     -Dfirewalld_zone=enabled
@@ -103,4 +97,11 @@ MESON_AFTER=(
     -Dnumad=disabled
     -Dpm_utils=enabled
     -Dsysctl_config=enabled
+)
+# Note: meson.build:1579:6: ERROR: Problem encountered: linux on x86_64 or aarch64 is required to build Cloud-Hypervisor driver
+MESON_AFTER__AMD64=(
+    -Ddriver_ch=disabled
+)
+MESON_AFTER__ARM64=(
+    -Ddriver_ch=disabled
 )

--- a/app-virtualization/libvirt/autobuild/patches/0001-Add-bios-path-for-loongarch.patch
+++ b/app-virtualization/libvirt/autobuild/patches/0001-Add-bios-path-for-loongarch.patch
@@ -16,7 +16,7 @@ diff --git a/src/qemu/qemu.conf.in b/src/qemu/qemu.conf.in
 index f406df8749..6449beb84b 100644
 --- a/src/qemu/qemu.conf.in
 +++ b/src/qemu/qemu.conf.in
-@@ -843,7 +843,8 @@
+@@ -1005,7 +1005,8 @@
  #   "/usr/share/OVMF/OVMF_CODE.fd:/usr/share/OVMF/OVMF_VARS.fd",
  #   "/usr/share/OVMF/OVMF_CODE.secboot.fd:/usr/share/OVMF/OVMF_VARS.fd",
  #   "/usr/share/AAVMF/AAVMF_CODE.fd:/usr/share/AAVMF/AAVMF_VARS.fd",
@@ -25,7 +25,7 @@ index f406df8749..6449beb84b 100644
 +#   "/usr/share/qemu/edk2-loongarch64-code.fd:/usr/share/qemu/edk2-loongarch64-vars.fd"
  #]
  
- # The backend to use for handling stdout/stderr output from
+ 
 diff --git a/src/qemu/qemu_conf.c b/src/qemu/qemu_conf.c
 index 4050a82341..07dd509f13 100644
 --- a/src/qemu/qemu_conf.c

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,5 +1,4 @@
-VER=10.5.0
-REL=1
+VER=11.9.0
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
-CHKSUMS="sha256::8e853a9c91c9029b9019cf5fdf2b5fea36d501d563e43254efc20e12c00557e8"
+CHKSUMS="sha256::104f70ee591e72989d4f8c6caa79ed9dacd5dc84efdb0125b848afe544ad0c2d"
 CHKUPDATE="anitya::id=13830"

--- a/app-virtualization/open-vm-tools/spec
+++ b/app-virtualization/open-vm-tools/spec
@@ -1,8 +1,6 @@
-VER=13.0.0
-BUILDNBR=24696409
+VER=13.0.5
+BUILDNBR=24915695
 SRCS="tbl::https://github.com/vmware/open-vm-tools/releases/download/stable-${VER}/open-vm-tools-${VER}-${BUILDNBR}.tar.gz"
-CHKSUMS="sha256::ce855a7d9a0a6561e6009784eb2a34f6a1d98b2a883afce5290cd426f78e7a6d"
+CHKSUMS="sha256::2b8ad0f916ed4c85dd69736cf7d3cd57d444c2d14c1361c1ba71e7698d2740ba"
 SUDDIR="open-vm-tools-${VER}-${BUILDNBR}"
 CHKUPDATE="anitya::id=10998"
-
-REL=1

--- a/app-virtualization/virglrenderer/autobuild/defines
+++ b/app-virtualization/virglrenderer/autobuild/defines
@@ -2,28 +2,28 @@ PKGNAME=virglrenderer
 PKGSEC=libs
 PKGDEP="libdrm libepoxy mesa x11-lib"
 PKGDES="Virtual 3D GPU library"
-
+BUILDDEP="pyyaml"
 ABTYPE=meson
 PKGBREAK="qemu<=5.1.0"
 
 # Note: -Dplatforms: Platforms support, set to auto to enable all.
-# Note: Venus and render server are still experimental.
+MESON_AFTER=(
+	"-Dplatforms=auto"
+# FIXME:
 #
-# FIXME: minigbm_allocation breaks build at src/vrend_renderer.c
-# ../src/vrend_renderer.c:7887:19: error: implicit declaration of function
-# ‘gbm_bo_get_plane_size’; did you mean ‘gbm_bo_get_plane_count’?
-# [-Werror=implicit-function-declaration]
-# 7887 |       gr->size += gbm_bo_get_plane_size(bo, plane);
-#      |                   ^~~~~~~~~~~~~~~~~~~~~
-#      |                   gbm_bo_get_plane_count
-MESON_AFTER="-Dplatforms=auto \
-             -Dminigbm_allocation=false \
-             -Dvenus-validate=false \
-             -Dcheck-gl-errors=true \
-             -Ddrm-msm-experimental=false \
-             -Drender-server=false \
-             -Drender-server-worker=process \
-             -Dvideo=true \
-             -Dfuzzer=false \
-             -Dvalgrind=false \
-             -Dtracing=none"
+# "Broken SPICE screen with minigbm_allocation enabled on my computer (AMD
+# 7840HS with Radeon 780M).
+#
+# "This option is now deprecated in the main branch of virglrenderer
+# (though not in the 1.2.0 release)."
+#
+# Link: https://github.com/AOSC-Dev/aosc-os-abbs/pull/13825#discussion_r2573308089
+	"-Dminigbm_allocation=false"
+	"-Dvenus-validate=true"
+	"-Dcheck-gl-errors=true"
+	"-Drender-server-worker=process"
+	"-Dvideo=true"
+	"-Dfuzzer=false"
+	"-Dvalgrind=false"
+	"-Dtracing=none"
+)

--- a/app-virtualization/virglrenderer/autobuild/prepare
+++ b/app-virtualization/virglrenderer/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Appending -ldrm linkage ..."
-export LDFLAGS="${LDFLAGS} -ldrm"

--- a/app-virtualization/virglrenderer/spec
+++ b/app-virtualization/virglrenderer/spec
@@ -1,4 +1,4 @@
-VER=0.10.4
+VER=1.2.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/virgl/virglrenderer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15968"

--- a/app-virtualization/virt-manager/01-virt-install/patches/0001-Add-more-keywords-to-desktop-file.patch
+++ b/app-virtualization/virt-manager/01-virt-install/patches/0001-Add-more-keywords-to-desktop-file.patch
@@ -1,317 +1,860 @@
-From e1e61c7a3c1970a9f38609619d45d2926e560b97 Mon Sep 17 00:00:00 2001
+From dd7cc8f4d1943a09c65400ed786bc836d673e1a0 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Sat, 12 Apr 2025 18:51:11 +0800
+Date: Tue, 18 Nov 2025 15:57:19 +0800
 Subject: [PATCH] Add more keywords to desktop file
 
 ---
  data/virt-manager.desktop.in | 2 +-
- po/ar.po                     | 2 +-
- po/cs.po                     | 2 +-
- po/de.po                     | 2 +-
- po/en_GB.po                  | 2 +-
- po/es.po                     | 2 +-
- po/fi.po                     | 2 +-
- po/fur.po                    | 2 +-
- po/hu.po                     | 2 +-
- po/id.po                     | 2 +-
- po/it.po                     | 2 +-
- po/ka.po                     | 2 +-
- po/ko.po                     | 2 +-
- po/pl.po                     | 2 +-
- po/pt_BR.po                  | 2 +-
- po/ro.po                     | 2 +-
- po/ru.po                     | 2 +-
- po/sv.po                     | 2 +-
- po/tr.po                     | 2 +-
- po/uk.po                     | 2 +-
- po/zh_CN.po                  | 2 +-
- po/zh_TW.po                  | 2 +-
- 22 files changed, 22 insertions(+), 22 deletions(-)
+ po/ar.po                     | 4 ++--
+ po/as.po                     | 4 ++--
+ po/bg.po                     | 4 ++--
+ po/bn_IN.po                  | 4 ++--
+ po/bs.po                     | 4 ++--
+ po/ca.po                     | 4 ++--
+ po/cs.po                     | 4 ++--
+ po/da.po                     | 4 ++--
+ po/de.po                     | 4 ++--
+ po/en_GB.po                  | 4 ++--
+ po/es.po                     | 4 ++--
+ po/fa.po                     | 2 +-
+ po/fi.po                     | 4 ++--
+ po/fr.po                     | 4 ++--
+ po/fur.po                    | 4 ++--
+ po/gl.po                     | 2 +-
+ po/gu.po                     | 4 ++--
+ po/hi.po                     | 4 ++--
+ po/hr.po                     | 4 ++--
+ po/hu.po                     | 4 ++--
+ po/id.po                     | 4 ++--
+ po/ie.po                     | 4 ++--
+ po/is.po                     | 4 ++--
+ po/it.po                     | 4 ++--
+ po/ja.po                     | 4 ++--
+ po/ka.po                     | 4 ++--
+ po/kab.po                    | 2 +-
+ po/kn.po                     | 4 ++--
+ po/ko.po                     | 4 ++--
+ po/ml.po                     | 4 ++--
+ po/mr.po                     | 4 ++--
+ po/ms.po                     | 4 ++--
+ po/nb.po                     | 4 ++--
+ po/nl.po                     | 4 ++--
+ po/or.po                     | 4 ++--
+ po/pa.po                     | 4 ++--
+ po/pl.po                     | 4 ++--
+ po/pt.po                     | 4 ++--
+ po/pt_BR.po                  | 4 ++--
+ po/ro.po                     | 4 ++--
+ po/ru.po                     | 4 ++--
+ po/si.po                     | 2 +-
+ po/sk.po                     | 4 ++--
+ po/sr.po                     | 4 ++--
+ po/sr@latin.po               | 4 ++--
+ po/sv.po                     | 4 ++--
+ po/ta.po                     | 4 ++--
+ po/te.po                     | 4 ++--
+ po/tr.po                     | 4 ++--
+ po/uk.po                     | 4 ++--
+ po/vi.po                     | 2 +-
+ po/zh_CN.po                  | 4 ++--
+ po/zh_TW.po                  | 4 ++--
+ 54 files changed, 102 insertions(+), 102 deletions(-)
 
 diff --git a/data/virt-manager.desktop.in b/data/virt-manager.desktop.in
-index f237c657b..332052b65 100644
+index 0229a835a..2ea472f04 100644
 --- a/data/virt-manager.desktop.in
 +++ b/data/virt-manager.desktop.in
-@@ -5,5 +5,5 @@ Icon=virt-manager
- Exec=virt-manager
+@@ -7,4 +7,4 @@ Exec=virt-manager
  Type=Application
  Terminal=false
--Keywords=vmm;
-+Keywords=bhyve;kvm;libvirt;lxc;qemu;virt;virt-manager;virtuozzo;vm;vmm;xen;
- Categories=System;
+ Categories=System;Emulator;GTK;
+-Keywords=virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;
++Keywords=virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;
 diff --git a/po/ar.po b/po/ar.po
-index e77cc573d..a0a21d870 100644
+index abcc1570e..d7bbae274 100644
 --- a/po/ar.po
 +++ b/po/ar.po
-@@ -77,7 +77,7 @@ msgstr "إدارة الآلات الافتراضية"
+@@ -83,8 +83,8 @@ msgstr "إدارة الآلات الافتراضية"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualization;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/as.po b/po/as.po
+index 9b8f2e66a..6a94471b1 100644
+--- a/po/as.po
++++ b/po/as.po
+@@ -84,8 +84,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "ভাৰছুৱেলাইজেষণ ধৰণ '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/bg.po b/po/bg.po
+index 9b5be85b8..d217cf1e6 100644
+--- a/po/bg.po
++++ b/po/bg.po
+@@ -83,8 +83,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Виртуална _Машина"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/bn_IN.po b/po/bn_IN.po
+index 4fcbc5797..fe91f9561 100644
+--- a/po/bn_IN.po
++++ b/po/bn_IN.po
+@@ -85,8 +85,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "ভার্টুয়ালাইজেশন ধরন '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/bs.po b/po/bs.po
+index 6529c11ba..e32858cdd 100644
+--- a/po/bs.po
++++ b/po/bs.po
+@@ -83,8 +83,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Virtualno _računalo"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/ca.po b/po/ca.po
+index da5c083f1..0f50aecb0 100644
+--- a/po/ca.po
++++ b/po/ca.po
+@@ -103,8 +103,8 @@ msgstr "Gestioneu les màquines virtuals"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "tipus de virtualització «%s»"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/cs.po b/po/cs.po
-index 4f94ff8fa..59ce03840 100644
+index 4d3f75014..52217fd55 100644
 --- a/po/cs.po
 +++ b/po/cs.po
-@@ -88,7 +88,7 @@ msgstr "Spravovat virtuální stroje"
+@@ -93,8 +93,8 @@ msgstr "Spravovat virtuální stroje"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualizace;libvirt;vm,vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/da.po b/po/da.po
+index 227904b13..4d7d7752c 100644
+--- a/po/da.po
++++ b/po/da.po
+@@ -91,8 +91,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Virtuel maskine"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/de.po b/po/de.po
-index d976b338c..fdc6e74d5 100644
+index f63d2fe87..02c716580 100644
 --- a/po/de.po
 +++ b/po/de.po
-@@ -103,7 +103,7 @@ msgstr "Virtuelle Maschinen verwalten"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -112,8 +112,8 @@ msgstr "Virtuelle Maschinen verwalten"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Virtualisierung;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/en_GB.po b/po/en_GB.po
-index 4b7a87a98..6454291bc 100644
+index 99ce2fc92..6a7c21959 100644
 --- a/po/en_GB.po
 +++ b/po/en_GB.po
-@@ -82,7 +82,7 @@ msgstr "Manage virtual machines"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -89,8 +89,8 @@ msgstr "Manage virtual machines"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualisation"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/es.po b/po/es.po
-index 1d6084314..7d5ef565f 100644
+index fc303b1cc..2f87ae9a2 100644
 --- a/po/es.po
 +++ b/po/es.po
-@@ -104,7 +104,7 @@ msgstr "Gestionar máquinas virtuales"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -112,8 +112,8 @@ msgstr "Gestione máquinas virtuales"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualización;libvirt;mv;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/fa.po b/po/fa.po
+index d808d5efc..5fd2d4f9a 100644
+--- a/po/fa.po
++++ b/po/fa.po
+@@ -75,7 +75,7 @@ msgid "Manage virtual machines"
+ msgstr ""
+ 
+ #: data/virt-manager.desktop.in:10
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
+ msgstr ""
+ 
+ #: ui/about.ui:10
 diff --git a/po/fi.po b/po/fi.po
-index fc4d5f087..a2626e02c 100644
+index 325525cd6..5f4467de3 100644
 --- a/po/fi.po
 +++ b/po/fi.po
-@@ -84,7 +84,7 @@ msgstr "Hallitse virtuaalikoneita"
+@@ -89,8 +89,8 @@ msgstr "Hallitse virtuaalikoneita"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualisointi;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/fr.po b/po/fr.po
+index 0ea39804d..6dd7b7cb7 100644
+--- a/po/fr.po
++++ b/po/fr.po
+@@ -110,8 +110,8 @@ msgstr "Gérer des machines virtuelles"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "type de virtualisation « %s »"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/fur.po b/po/fur.po
-index 708d8ba07..83361e349 100644
+index da7f34030..6c986d5f2 100644
 --- a/po/fur.po
 +++ b/po/fur.po
-@@ -73,7 +73,7 @@ msgstr "Gjestìs machinis virtuâls"
+@@ -80,8 +80,8 @@ msgstr "Gjestìs machinis virtuâls"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualizazion"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/gl.po b/po/gl.po
+index d17627a0e..1da53cbaa 100644
+--- a/po/gl.po
++++ b/po/gl.po
+@@ -80,7 +80,7 @@ msgid "Manage virtual machines"
+ msgstr ""
+ 
+ #: data/virt-manager.desktop.in:10
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
+ msgstr ""
+ 
+ #: ui/about.ui:10
+diff --git a/po/gu.po b/po/gu.po
+index 9fd8fa546..51f43fa5d 100644
+--- a/po/gu.po
++++ b/po/gu.po
+@@ -87,8 +87,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "વર્ચ્યુઅલાઇઝેશન પ્રકાર '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/hi.po b/po/hi.po
+index 04ef22f6f..c3eff047c 100644
+--- a/po/hi.po
++++ b/po/hi.po
+@@ -87,8 +87,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "वर्चुअलाइजेशन प्रकार '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/hr.po b/po/hr.po
+index ac9df46bb..e41f0b229 100644
+--- a/po/hr.po
++++ b/po/hr.po
+@@ -91,8 +91,8 @@ msgstr "Upravljajte virtualnim računalima"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Choose virtualization type"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Odaberi vrstu virtualizacije"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/hu.po b/po/hu.po
-index 0c0197b08..75844d021 100644
+index 53b26b33b..877f4f9c6 100644
 --- a/po/hu.po
 +++ b/po/hu.po
-@@ -97,7 +97,7 @@ msgstr "Virtuális gépek menedzselése"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -104,8 +104,8 @@ msgstr "Virtuális gépek menedzselése"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualizáció típusa '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/id.po b/po/id.po
-index d40531c66..b688c2eb0 100644
+index c6ecc2200..e3d9446dd 100644
 --- a/po/id.po
 +++ b/po/id.po
-@@ -74,7 +74,7 @@ msgstr "Mengelola mesin virtual"
+@@ -81,8 +81,8 @@ msgstr "Mengelola mesin virtual"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualisasi"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/ie.po b/po/ie.po
+index 61c0d2bf8..1725d6a9a 100644
+--- a/po/ie.po
++++ b/po/ie.po
+@@ -81,8 +81,8 @@ msgstr "Gerentie de virtual machines"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Choose virtualization type"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Selecter un tip de virtualisation"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/is.po b/po/is.po
+index 93852039e..841cc3669 100644
+--- a/po/is.po
++++ b/po/is.po
+@@ -82,8 +82,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Sýndar_vél"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/it.po b/po/it.po
-index a24dfb3dd..8fa89935d 100644
+index c5da83153..9411b1820 100644
 --- a/po/it.po
 +++ b/po/it.po
-@@ -88,7 +88,7 @@ msgstr "Gestisci macchine virtuali"
+@@ -94,8 +94,8 @@ msgstr "Gestisci macchine virtuali"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualizzazione;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/ja.po b/po/ja.po
+index d2fa93e53..52e4b8039 100644
+--- a/po/ja.po
++++ b/po/ja.po
+@@ -102,8 +102,8 @@ msgstr "仮想マシンの管理"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualization;仮想化;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/ka.po b/po/ka.po
-index f6e5837f6..f86dbc4be 100644
+index e7903ce67..4fba90bcd 100644
 --- a/po/ka.po
 +++ b/po/ka.po
-@@ -76,7 +76,7 @@ msgstr "ვირტუალური მანქანების მარ
+@@ -81,8 +81,8 @@ msgstr "ვირტუალური მანქანების მარ
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "ვირტუალიზაცია;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/kab.po b/po/kab.po
+index 0c8ba8c62..431ded8da 100644
+--- a/po/kab.po
++++ b/po/kab.po
+@@ -76,7 +76,7 @@ msgid "Manage virtual machines"
+ msgstr ""
+ 
+ #: data/virt-manager.desktop.in:10
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
+ msgstr ""
+ 
+ #: ui/about.ui:10
+diff --git a/po/kn.po b/po/kn.po
+index f20dddadf..5537d9566 100644
+--- a/po/kn.po
++++ b/po/kn.po
+@@ -89,8 +89,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "'%s' ವರ್ಚುವಲೈಸೇಶನ್ ಬಗೆ"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/ko.po b/po/ko.po
-index a90f30049..eefa823e3 100644
+index 0247c95f0..976c6ed8a 100644
 --- a/po/ko.po
 +++ b/po/ko.po
-@@ -85,7 +85,7 @@ msgstr "가상 장비 관리"
+@@ -90,8 +90,8 @@ msgstr "가상 장비 관리"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualization;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/ml.po b/po/ml.po
+index f76b561a0..3b16ddd01 100644
+--- a/po/ml.po
++++ b/po/ml.po
+@@ -86,8 +86,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "വിര്‍ച്ച്വലൈസേഷന്‍ തരം '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/mr.po b/po/mr.po
+index 9664981ac..3dba707f0 100644
+--- a/po/mr.po
++++ b/po/mr.po
+@@ -86,8 +86,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "वर्च्युअलाइजेशन प्रकार '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/ms.po b/po/ms.po
+index 3643d52f9..f56145bec 100644
+--- a/po/ms.po
++++ b/po/ms.po
+@@ -82,8 +82,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Mesin _Maya"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/nb.po b/po/nb.po
+index 1f81817f8..e5b2d772e 100644
+--- a/po/nb.po
++++ b/po/nb.po
+@@ -82,8 +82,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Virtuell _maskin"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/nl.po b/po/nl.po
+index b4fead437..9cce172d7 100644
+--- a/po/nl.po
++++ b/po/nl.po
+@@ -92,8 +92,8 @@ msgstr "Beheer virtuele machines"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualisatie type '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/or.po b/po/or.po
+index 51d18dedc..2066428f5 100644
+--- a/po/or.po
++++ b/po/or.po
+@@ -86,8 +86,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "ଆଭାସୀ କରଣ ପ୍ରକାର'%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/pa.po b/po/pa.po
+index 1adf3892f..adea42063 100644
+--- a/po/pa.po
++++ b/po/pa.po
+@@ -88,8 +88,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "ਵਰਚੁਅਲਾਈਜ਼ੇਸ਼ਨ ਕਿਸਮ '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/pl.po b/po/pl.po
-index dfcf225f1..06557695e 100644
+index 9402619b6..4e03354c1 100644
 --- a/po/pl.po
 +++ b/po/pl.po
-@@ -88,7 +88,7 @@ msgstr "Zarządzanie maszynami wirtualnymi"
+@@ -93,8 +93,8 @@ msgstr "Zarządzanie maszynami wirtualnymi"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "wirtualizacja;libvirt;vm;vmm;maszyna wirtualna;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/pt.po b/po/pt.po
+index 4f9642870..54d541064 100644
+--- a/po/pt.po
++++ b/po/pt.po
+@@ -93,8 +93,8 @@ msgstr "Gerir máquinas virtuais"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "tipo de virtualização '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/pt_BR.po b/po/pt_BR.po
-index 5d088fca9..c033c3bc8 100644
+index 4a3696442..d04f1a8d2 100644
 --- a/po/pt_BR.po
 +++ b/po/pt_BR.po
-@@ -97,7 +97,7 @@ msgstr "Gerenciar máquinas virtuais"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -102,8 +102,8 @@ msgstr "Gerenciar máquinas virtuais"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualização;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/ro.po b/po/ro.po
-index bf7fad86d..a3284ebc9 100644
+index 59676f95d..c5e58bb0b 100644
 --- a/po/ro.po
 +++ b/po/ro.po
-@@ -82,7 +82,7 @@ msgstr "Gestionează mașini virtuale"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -87,8 +87,8 @@ msgstr "Gestionează mașini virtuale"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualizare;libvirt;vm;vmm;mv;mmmv;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/ru.po b/po/ru.po
-index 726dca8d8..e51784cf9 100644
+index c74671da4..da6bdc9a2 100644
 --- a/po/ru.po
 +++ b/po/ru.po
-@@ -101,7 +101,7 @@ msgstr "Управление виртуальными машинами"
+@@ -107,8 +107,8 @@ msgstr "Управление виртуальными машинами"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualization;libvirt;vm;vmm;виртуализация;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/si.po b/po/si.po
+index 5de7a37a9..e6993ae22 100644
+--- a/po/si.po
++++ b/po/si.po
+@@ -73,7 +73,7 @@ msgid "Manage virtual machines"
+ msgstr ""
+ 
+ #: data/virt-manager.desktop.in:10
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
+ msgstr ""
+ 
+ #: ui/about.ui:10
+diff --git a/po/sk.po b/po/sk.po
+index 690b51e19..d79d32b43 100644
+--- a/po/sk.po
++++ b/po/sk.po
+@@ -87,8 +87,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Virtuálny počítač"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/sr.po b/po/sr.po
+index 747fa94ad..8247a884f 100644
+--- a/po/sr.po
++++ b/po/sr.po
+@@ -89,8 +89,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Виртуелна _машина"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/sr@latin.po b/po/sr@latin.po
+index e055a6254..27c7bf80e 100644
+--- a/po/sr@latin.po
++++ b/po/sr@latin.po
+@@ -84,8 +84,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "Virtual _Machine"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "Virtuelna _mašina"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/sv.po b/po/sv.po
-index 92c27f413..c345006a9 100644
+index b850b0d31..4073eec06 100644
 --- a/po/sv.po
 +++ b/po/sv.po
-@@ -87,7 +87,7 @@ msgstr "Hantera virtuella maskiner"
+@@ -92,8 +92,8 @@ msgstr "Hantera virtuella maskiner"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualisering;libvirt;vm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
  
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/ta.po b/po/ta.po
+index a3f2f1d48..5f1335399 100644
+--- a/po/ta.po
++++ b/po/ta.po
+@@ -88,8 +88,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "மெய்நிகராக்க வகை '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
++msgstr ""
+ 
+ #: ui/about.ui:10
+ msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/te.po b/po/te.po
+index 29be4b51d..0b917a550 100644
+--- a/po/te.po
++++ b/po/te.po
+@@ -86,8 +86,8 @@ msgstr ""
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization type '%s'"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "వర్చ్యులైజేషన్ రకం '%s'"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/tr.po b/po/tr.po
-index b06b1962a..f9f01857f 100644
+index a3a655596..89a5b645a 100644
 --- a/po/tr.po
 +++ b/po/tr.po
-@@ -88,7 +88,7 @@ msgstr "Sanal makineleri yönet"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -94,8 +94,8 @@ msgstr "Sanal makineleri yönet"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "sanallaştırma;libvirt;sm;vmm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/uk.po b/po/uk.po
-index 97f344c14..73da974c0 100644
+index 6e88ac30b..5687258a7 100644
 --- a/po/uk.po
 +++ b/po/uk.po
-@@ -90,7 +90,7 @@ msgstr "Керування віртуальними машинами"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -95,8 +95,8 @@ msgstr "Керування віртуальними машинами"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization;libvirt;vm;vmm;"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "virtualization;libvirt;vm;vmm;віртуалізація;лібвірт;вм;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
+diff --git a/po/vi.po b/po/vi.po
+index fd1cf7ed2..40463392b 100644
+--- a/po/vi.po
++++ b/po/vi.po
+@@ -73,7 +73,7 @@ msgid "Manage virtual machines"
+ msgstr ""
+ 
+ #: data/virt-manager.desktop.in:10
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
+ msgstr ""
+ 
+ #: ui/about.ui:10
 diff --git a/po/zh_CN.po b/po/zh_CN.po
-index 7daf576ea..684991f7b 100644
+index 4df09acdf..df127efc6 100644
 --- a/po/zh_CN.po
 +++ b/po/zh_CN.po
-@@ -99,7 +99,7 @@ msgstr "管理虚拟系统"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -107,8 +107,8 @@ msgstr "管理虚拟系统"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "虚拟化类型"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 diff --git a/po/zh_TW.po b/po/zh_TW.po
-index c28a90411..a40618d13 100644
+index 3b96d00de..1fd7c82bf 100644
 --- a/po/zh_TW.po
 +++ b/po/zh_TW.po
-@@ -90,7 +90,7 @@ msgstr "管理虛擬系統"
- 
- #: data/virt-manager.desktop.in:9
- msgid "vmm;"
--msgstr "vmm;"
+@@ -98,8 +98,8 @@ msgstr "管理虛擬系統"
+ #: data/virt-manager.desktop.in:10
+ #, fuzzy
+ #| msgid "virtualization"
+-msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;"
+-msgstr "虛擬化"
++msgid "virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;bhyve;kvm;libvirt;virt;virt-manager;virtuozzo;"
 +msgstr ""
  
  #: ui/about.ui:10
  msgid "Copyright (C) 2006-2020 Red Hat Inc."
 -- 
-2.49.0
+2.51.1
 

--- a/app-virtualization/virt-manager/spec
+++ b/app-virtualization/virt-manager/spec
@@ -1,5 +1,4 @@
-VER=5.0.0
-REL=3
+VER=5.1.0
 SRCS="tbl::https://releases.pagure.org/virt-manager/virt-manager-$VER.tar.xz"
-CHKSUMS="sha256::bc89ae46e0c997bd754ed62a419ca39c6aadec27e3d8b850cea5282f0083f84a"
+CHKSUMS="sha256::ccfc44b6c1c0be8398beb687c675d9ea4ca1c721dfb67bd639209a7b0dec11b1"
 CHKUPDATE="anitya::id=8183"

--- a/app-virtualization/virtiofsd/spec
+++ b/app-virtualization/virtiofsd/spec
@@ -1,4 +1,4 @@
-VER=1.13.0
+VER=1.13.2
 SRCS="git::commit=tags/v${VER}::https://gitlab.com/virtio-fs/virtiofsd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=347345"

--- a/runtime-virtualization/libvirt-python/autobuild/build
+++ b/runtime-virtualization/libvirt-python/autobuild/build
@@ -1,3 +1,0 @@
-abinfo "Installing LibVirt-Python ..."
-python3 setup.py clean
-python3 setup.py install --root="$PKGDIR"

--- a/runtime-virtualization/libvirt-python/autobuild/defines
+++ b/runtime-virtualization/libvirt-python/autobuild/defines
@@ -2,3 +2,6 @@ PKGNAME=libvirt-python
 PKGSEC=python
 PKGDEP="python-3 libvirt"
 PKGDES="Python bindings for libvirt"
+
+ABTYPE=pep517
+NOPYTHON2=1

--- a/runtime-virtualization/libvirt-python/spec
+++ b/runtime-virtualization/libvirt-python/spec
@@ -1,4 +1,4 @@
-VER=10.5.0
-SRCS="tbl::https://libvirt.org/sources/python/libvirt-python-$VER.tar.gz"
-CHKSUMS="sha256::785023500f58d3e8e829af98647d43eee97e517aacc9d9e7ded43594ea52d032"
+VER=11.9.0
+SRCS="pypi::version=$VER::libvirt-python"
+CHKSUMS="sha256::dc54b8ab3581118af1bd64c5847d03c946e2f19b6cf8bf9d18fd8b75d7a70181"
 CHKUPDATE="anitya::id=13829"


### PR DESCRIPTION
Topic Description
-----------------

- open-vm-tools: update to 13.0.5
- virt-manager: update to 5.1.0
    \* Refresh patches.
- libvirt-python: update to 11.9.0
    - Use PyPI source and correct Anitya \(the old ID references a file server
    that does not seem to sync with new releases reliably\).
    - Use pep517 ABTYPE.
- libvirt: update to 11.9.0
    \* Strip out HTML documentation.
    \* Refresh patches.
- virglrenderer: update to 1.2.0
    \* Enable Venus \(Vulkan\) renderer.
    \* Disable minigbm_allocation due to reports of "broken SPICE screen" with
    AMD graphics cards \(see link\).
    \* Clean up Meson options and comments.
    \* Add pyyaml as build dependency.
    \* Convert MESON_AFTER to array.
    Link: https://github.com/AOSC-Dev/aosc-os-abbs/pull/13825#discussion_r2573308089
- wireshark: update to 4.6.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
- virtiofsd: update to 1.13.2

Package(s) Affected
-------------------

- libvirt: 11.9.0
- open-vm-tools: 13.0.5
- virglrenderer: 1.2.0
- virtiofsd: 1.13.2
- wireshark: 4.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit virtiofsd wireshark virglrenderer libvirt libvirt-python virt-manager open-vm-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
