### PR TITLE
xrdp: update to 0.10.4.1

### DIFF
--- a/app-network/xrdp/spec
+++ b/app-network/xrdp/spec
@@ -1,4 +1,4 @@
-VER=0.10.3
+VER=0.10.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231006"


### PR DESCRIPTION
Topic Description
-----------------

- xrdp: update to 0.10.4.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xrdp: 0.10.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xrdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
