### PR TITLE
iperf3: update to 3.20

### DIFF
--- a/app-network/iperf3/spec
+++ b/app-network/iperf3/spec
@@ -1,4 +1,4 @@
-VER=3.19.1
+VER=3.20
 SRCS="git::commit=tags/$VER::https://github.com/esnet/iperf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1389"


### PR DESCRIPTION
Topic Description
-----------------

- iperf3: update to 3.20
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- iperf3: 3.20

Security Update?
----------------

No

Build Order
-----------

```
#buildit iperf3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
