### PR TITLE
mesa: update to 25.2.7

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -38,6 +38,9 @@ PKGEPOCH=1
 
 # Note: -Dwrap_mode=default is used for Crate dependencies.
 MESON_AFTER=(
+# Note: For stable-bound updates, use the following to disable assert().
+    '-Db_ndebug=true'
+# Note: Comment out line above for preview (RC or x.y.0) releases.
     '-Dsplit-debug=disabled'
     '-Dplatforms=x11,wayland'
     '-Degl-native-platform=auto'

--- a/runtime-display/mesa/autobuild/defines.stage2
+++ b/runtime-display/mesa/autobuild/defines.stage2
@@ -8,6 +8,9 @@ PKGEPOCH=1
 
 # Note: -Dwrap_mode=default is used for Crate dependencies.
 MESON_AFTER=(
+# Note: For stable-bound updates, use the following to disable assert().
+    '-Db_ndebug=true'
+# Note: Comment out line above for preview (RC or x.y.0) releases.
     '-Dsplit-debug=disabled'
     '-Dplatforms=x11'
     '-Degl-native-platform=auto'

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,4 +1,4 @@
-VER=25.2.6
+VER=25.2.7
 SRCS="tbl::https://archive.mesa3d.org/mesa-${VER}.tar.xz"
-CHKSUMS="sha256::361c97e8afa5fe20141c5362c5b489040751e12861c186a16c621a2fb182fc42"
+CHKSUMS="sha256::b40232a642011820211aab5a9cdf754e106b0bce15044bc4496b0ac9615892ad"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa+32: update to 25.2.7
    Disable assert\(\) for stable-bound updates, end-users can live without
    assert\(\).
- mesa: update to 25.2.7
    Disable assert\(\) for stable-bound updates, end-users can live without
    assert\(\).

Package(s) Affected
-------------------

- mesa: 1:25.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
