### PR TITLE
etckeeper: update to 1.18.23

### DIFF
--- a/app-admin/etckeeper/spec
+++ b/app-admin/etckeeper/spec
@@ -1,5 +1,4 @@
-VER=1.18.21
-SRCS="tbl::https://git.joeyh.name/index.cgi/etckeeper.git/snapshot/etckeeper-$VER.tar.gz"
-CHKSUMS="sha256::a87c5e9c847c29f761da933c1cd907779545c7ddf92fb75de8ef692b90fc9e5d"
+VER=1.18.23
+SRCS="git::commit=tags/$VER::https://git.joeyh.name/git/etckeeper.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=761"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- etckeeper: update to 1.18.23
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- etckeeper: 1.18.23

Security Update?
----------------

No

Build Order
-----------

```
#buildit etckeeper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
