### PR TITLE
mpd: fix dependencies, disable html doc

### DIFF
--- a/app-multimedia/mpd/autobuild/defines
+++ b/app-multimedia/mpd/autobuild/defines
@@ -7,9 +7,8 @@ PKGDEP="libao ffmpeg libmodplug audiofile libshout libmad curl openmpt opus \
         libmpdclient icu libupnp libnfs sndio bzip2 flac lame libsamplerate \
         chromaprint libcdio-paranoia zziplib openal-soft libcdio dbus pcre2 \
         fluidsynth game-music-emu libmpcdec libmikmod mpg123 zlib expat adplug \
-        libsidplayfp twolame wildmidi soxr liburing udisks-2"
-BUILDDEP="alsa-lib jack pipewire pulseaudio fmt sphinx sphinx-rtd-theme \
-          doxygen nlohmann-json"
+        libsidplayfp twolame wildmidi soxr liburing udisks-2 fmt"
+BUILDDEP="alsa-lib jack pipewire pulseaudio nlohmann-json"
 PKGSUG="jack pipewire pulseaudio"
 PKGDES="Server-side application for playing music"
 
@@ -20,10 +19,10 @@ ABTYPE=meson
 # https://github.com/MusicPlayerDaemon/MPD/blob/1caeb9b4183740250739739c6e76d1734bc3891d/meson_options.txt#L101
 # Ref: https://bugzilla.samba.org/show_bug.cgi?id=11413
 MESON_AFTER=(
-    '-Ddocumentation=enabled'
-    '-Dhtml_manual=true'
+    '-Ddocumentation=disabled'
+    '-Dhtml_manual=false'
     '-Dmanpages=true'
-    '-Ddoxygen=true'
+    '-Ddoxygen=false'
     '-Dsyslog=enabled'
     '-Dinotify=true'
     '-Dio_uring=enabled'

--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,5 @@
 VER=0.24.6
+REL=1
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
 CHKSUMS="sha256::8ce34a010577feb42999a96d867325c6d38bf7ae1b7a57f878d7e548c1fd1fa9"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: fix dependencies, disable html doc
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- mpd: 0.24.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
