### PR TITLE
fmt: rework rebuilds

### DIFF
--- a/groups/fmt-rebuilds
+++ b/groups/fmt-rebuilds
@@ -4,12 +4,14 @@ runtime-common/spdlog
 app-devel/bear
 app-editors/imhex
 app-games/0ad
+app-multimedia/mpd
 app-multimedia/easyeffects
 app-multimedia/kodi
 app-multimedia/ncmpc
 app-multimedia/wiliwili
 app-utils/waybar
 runtime-database/tiledb
+runtime-common/edencommon
 runtime-common/folly
 app-network/fizz
 runtime-network/mvfst
@@ -19,3 +21,4 @@ runtime-network/fb303
 app-utils/watchman
 runtime-web/ada
 app-admin/cryfs
+runtime-rocm/rocm-rccl

--- a/runtime-common/edencommon/autobuild/defines
+++ b/runtime-common/edencommon/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=edencommon
 PKGSEC=libs
-PKGDEP="fb303 folly gflags glog"
+PKGDEP="fb303 fmt folly gflags glog"
 BUILDDEP="gtest"
 PKGDES="Support library for Watchman and Eden projects"
 

--- a/runtime-common/edencommon/spec
+++ b/runtime-common/edencommon/spec
@@ -1,5 +1,5 @@
 VER=2025.09.01.00
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/facebookexperimental/edencommon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375630"

--- a/runtime-rocm/rocm-rccl/autobuild/defines
+++ b/runtime-rocm/rocm-rccl/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=rocm-rccl
 PKGDES="ROCm Communication Collectives Library (RCCL)"
 PKGSEC=devel
-PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-smi-lib rocm-hipify"
-BUILDDEP="cmake fmt"
+PKGDEP="fmt rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-smi-lib \
+        rocm-hipify"
+BUILDDEP="cmake ninja"
 
 # FIXME unsupported LLD, and BFD without gold
 #

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -1,4 +1,5 @@
 VER=7.1.0
+REL=1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rccl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241714"


### PR DESCRIPTION
Topic Description
-----------------

- groups/fmt-rebuilds: add more packages
- rocm-rccl: bump REL for fmt 12.1.0
- edencommon: bump REL for fmt 12.1.0

Package(s) Affected
-------------------

- edencommon: 2025.09.01.00-2
- rocm-rccl: 7.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit edencommon rocm-rccl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
