### PR TITLE
db: improve build scripts

### DIFF
--- a/app-database/db/autobuild/build
+++ b/app-database/db/autobuild/build
@@ -1,4 +1,4 @@
-pushd build_unix
+pushd "$SRCDIR"/build_unix
 
 # The following configuration:
 #
@@ -7,29 +7,26 @@ pushd build_unix
 # 3. Enables CXX programs (disable --enable-cxx if you do think it is necessary);
 # 4. Enables shared libraries (if you need static libraries, add --enable-static);
 # 5. Disables Tcl bindings (it is not necessary so far, at least in AOSC OS);
-abinfo "Configuring Berkeley DB..."
-../dist/configure --prefix=/usr      \
-                  --enable-compat185 \
-                  --enable-dbm       \
-                  --enable-cxx       \
-                  --enable-shared    \
-                  --disable-tcl      \
-                  --with-mutex=POSIX/pthreads/library
+abinfo "Configuring Berkeley DB ..."
+"$SRCDIR"/dist/configure \
+    --prefix=/usr \
+    --enable-compat185 \
+    --enable-dbm \
+    --enable-cxx \
+    --enable-shared \
+    --disable-tcl \
+    --with-mutex=POSIX/pthreads/library
 
-# Enables POSIX thread library linkage (in GLibC, no need to remove).
-abinfo "Building threaded runtime libraries..."
+# Enables POSIX thread library linkage (in glibc, no need to remove).
+abinfo "Building threaded runtime libraries ..."
 make LIBSO_LIBS="-lpthread"
-make DESTDIR="$PKGDIR" install
 
-if [[ "${CROSS:-$ARCH}" = "i486" || "${CROSS:-$ARCH}" = "powerpc" ]]; then
-    abinfo "Removing HTML documentation..."
-    rm -rv "$PKGDIR"/usr/docs
-else
-    abinfo "Moving documentations..."
-    mkdir -pv "$PKGDIR"/usr/share/doc/db
-    mv -v "$PKGDIR"/usr/docs/* \
-        "$PKGDIR"/usr/share/doc/db/
-    rm -rv "$PKGDIR"/usr/docs
-fi
+abinfo "Installing Berkeley DB ..."
+make install \
+    DESTDIR="$PKGDIR"
+
+# Note: Per the Styling Manual.
+abinfo "Removing HTML documentation..."
+rm -rv "$PKGDIR"/usr/docs
 
 popd

--- a/app-database/db/autobuild/defines
+++ b/app-database/db/autobuild/defines
@@ -5,7 +5,6 @@ PKGDEP="glibc"
 
 PKGEPOCH=1
 
-NOLTO=1
 AB_FLAGS_O3=1
 
 PKGBREAK="libical<=3.0.8 librcc<=0.2.12-1 ruby<=2.6.6 apr-util<=1.6.1-2 iproute2<=5.4.0-1 \

--- a/app-database/db/spec
+++ b/app-database/db/spec
@@ -1,5 +1,5 @@
 VER=5.3.28
-REL=4
+REL=5
 SRCS="https://download.oracle.com/berkeley-db/db-$VER.tar.gz"
 CHKSUMS="sha256::e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628"
 CHKUPDATE="anitya::id=64941"


### PR DESCRIPTION
Topic Description
-----------------

- db: improve build scripts
    - Drop documentation per the Styling Manual.
    - Clean up build scripts.

Package(s) Affected
-------------------

- db: 1:5.3.28-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit db
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
