### PR TITLE
lm-sensors: minimise loongarch64_nosimd dependencies

### DIFF
--- a/app-utils/lm-sensors/autobuild/build
+++ b/app-utils/lm-sensors/autobuild/build
@@ -7,7 +7,8 @@ MAKE_OPTS=(
     'MANDIR=/usr/share/man'
     'BUILD_STATIC_LIB=0'
 )
-if ! ab_match_archgroup retro; then
+if ! ab_match_archgroup retro && \
+   ! ab_match_arch loongarch64_nosimd; then
     MAKE_OPTS+=(
         'PROG_EXTRA=sensord'
     )

--- a/app-utils/lm-sensors/autobuild/defines
+++ b/app-utils/lm-sensors/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=lm-sensors
 PKGSEC=utils
 PKGDEP="perl sysfsutils rrdtool"
+# Note: Most LoongArch64 (No SIMD) devices are not meant to run desktop
+# software and probably will no benefit from the extra graphing features
+# as found in sensord, which pulls in desktop dependencies.
+PKGDEP__LOONGARCH64_NOSIMD="${PKGDEP/rrdtool/}"
 PKGDEP__RETRO="sysfsutils"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"

--- a/app-utils/lm-sensors/spec
+++ b/app-utils/lm-sensors/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=3-6-0
 VER=${UPSTREAM_VER//-/.}
-REL=3
+REL=4
 SRCS="git::commit=tags/V${UPSTREAM_VER}::https://github.com/lm-sensors/lm-sensors"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1831"


### PR DESCRIPTION
Topic Description
-----------------

- lm-sensors: minimise loongarch64_nosimd dependencies
    Note: Most LoongArch64 \(No SIMD\) devices are not meant to run desktop
    software and probably will no benefit from the extra graphing features
    as found in sensord, which pulls in desktop dependencies.

Package(s) Affected
-------------------

- lm-sensors: 3.6.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit lm-sensors
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
