### PR TITLE
box64: update to 0.3.9+git20251130

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,5 +1,5 @@
-VER=0.3.9+git20251126
+VER=0.3.9+git20251130
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=d5d4cc09510687fc184ed37c3144c3a09ae3dba5;copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=c4e09fddb9e15de5d7b096af17dabc5fe0d2663c;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251130

Package(s) Affected
-------------------

- box64: 0.3.9+git20251130

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
