### PR TITLE
mergiraf: new, 0.16.1

### DIFF
--- a/app-devel/mergiraf/autobuild/defines
+++ b/app-devel/mergiraf/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="mergiraf"
+PKGDES="Syntax-aware Git merge driver for various programming languages and file formats"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="rustc llvm"
+PKGSEC="devel"
+
+ABTYPE="rust"
+
+USECLANG=1

--- a/app-devel/mergiraf/spec
+++ b/app-devel/mergiraf/spec
@@ -1,0 +1,4 @@
+VER=0.16.1
+SRCS="git::commit=tags/v$VER::https://codeberg.org/mergiraf/mergiraf.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=386476"


### PR DESCRIPTION
Topic Description
-----------------

- mergiraf: new, 0.16.1

Package(s) Affected
-------------------

- mergiraf: 0.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mergiraf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
