### PR TITLE
ptyxis: new, 49.2

### DIFF
--- a/desktop-gnome/ptyxis/autobuild/defines
+++ b/desktop-gnome/ptyxis/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=ptyxis
+PKGSEC=gnome
+PKGDEP="cairo gcc-runtime glib glibc gtk-4 json-glib libadwaita libportal \
+        pango vte"
+PKGDES="Terminal emulator with built-in container management support"
+
+MESON_AFTER=(
+    '-Dgeneric=ptyxis'
+)

--- a/desktop-gnome/ptyxis/autobuild/prepare
+++ b/desktop-gnome/ptyxis/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Ensure the use of the system vte package ..."
+rm -rv "$SRCDIR"/subprojects

--- a/desktop-gnome/ptyxis/spec
+++ b/desktop-gnome/ptyxis/spec
@@ -1,0 +1,4 @@
+VER=49.2
+SRCS="https://download.gnome.org/sources/ptyxis/${VER%%.*}/ptyxis-$VER.tar.xz"
+CHKSUMS="sha256::16d37e122fb7c0a25147e8297c959eda17b887ee1d812ddc7bcca5314309a5b3"
+CHKUPDATE="anitya::id=371673"


### PR DESCRIPTION
Topic Description
-----------------

- ptyxis: new, 49.2

Package(s) Affected
-------------------

- ptyxis: 49.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ptyxis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
