### PR TITLE
qhull: update to 8.0.2

### DIFF
--- a/app-creativity/superslicer/autobuild/defines
+++ b/app-creativity/superslicer/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=superslicer
 PKGDES="G-code generator for 3D printers"
 PKGSEC=graphics
-PKGDEP="dbus boost wxgtk3 tbb curl zlib eigen-3 expat libpng glew nlopt \
-        c-blosc openvdb libspnav gmp mpfr cgal opencascade qhull"
+PKGDEP="dbus boost wxgtk3 tbb curl zlib eigen-3 expat libpng glew nlopt z3 catch2 \
+        c-blosc openvdb libspnav gmp mpfr cgal opencascade qhull nlohmann-json"
 BUILDDEP="cereal libbgcode heatshrink nanosvg"
 
 ABTYPE=cmakeninja

--- a/app-creativity/superslicer/autobuild/patches/0006-AOSCOS-update-version-number.patch
+++ b/app-creativity/superslicer/autobuild/patches/0006-AOSCOS-update-version-number.patch
@@ -8,28 +8,29 @@ Subject: [PATCH 6/6] AOSCOS: update version number
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/version.inc b/version.inc
-index d127e2d899..95386c39d1 100644
+index 5eb0304..c9663dd 100644
 --- a/version.inc
 +++ b/version.inc
 @@ -10,9 +10,9 @@ set(SLIC3R_APP_CMD "superslicer")
- # id for windows registry
+ # id for windows registry ([a-z] [A-Z] [0-9] '_' and '.' only)
  set(SLIC3R_APP_PROG_ID "Slic3r.1")
  # versions
 -set(SLIC3R_VERSION "2.7-beta+UNKNOWN")
-+set(SLIC3R_VERSION "2.7.61.8+AOSC")
- set(SLIC3R_VERSION_FULL "2.7.61.8")
++set(SLIC3R_VERSION "2.7.61.10-AOSC")
+ set(SLIC3R_VERSION_FULL "2.7.61.10")
 -set(SLIC3R_BUILD_ID "${SLIC3R_APP_KEY}_${SLIC3R_VERSION_FULL}+UNKNOWN")
 +set(SLIC3R_BUILD_ID "${SLIC3R_APP_KEY}_${SLIC3R_VERSION_FULL}+AOSC")
- set(SLIC3R_RC_VERSION "2,7,61,8")
+ set(SLIC3R_RC_VERSION "2,7,61,10")
  set(SLIC3R_RC_VERSION_DOTS "${SLIC3R_VERSION_FULL}")
  
-@@ -28,4 +28,4 @@ set(SLIC3R_BASED_ON " based on PrusaSlicer")
+@@ -28,4 +28,5 @@ set(SLIC3R_BASED_ON " based on PrusaSlicer")
  set(SLIC3R_GITHUB "supermerill/SuperSlicer")
  # download url
  set(SLIC3R_DOWNLOAD "https://github.com/supermerill/SuperSlicer/releases")
 -set(SLIC3R_DOC_URL "https://manual.slic3r.org/")
 \ No newline at end of file
 +set(SLIC3R_DOC_URL "https://manual.slic3r.org/")
++
 -- 
 2.50.1
 

--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,4 +1,4 @@
-VER=2.7.61.8
+VER=2.7.61.10
 SRCS="git::commit=tags/${VER}::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370825"

--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -1,5 +1,5 @@
 VER=10.3.0
-REL=2
+REL=3
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
 CHKSUMS="sha256::68bc82885a3ae67a806debb14eb229506d2fe398c969dd42e2e38cc1c35f2aff"
 CHKUPDATE="anitya::id=2528"

--- a/app-scientific/qhull/autobuild/beyond
+++ b/app-scientific/qhull/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Deleting documents ..."
+rm -rv /usr/share/doc

--- a/app-scientific/qhull/autobuild/defines
+++ b/app-scientific/qhull/autobuild/defines
@@ -2,10 +2,11 @@ PKGNAME=qhull
 PKGSEC=math
 PKGDEP="gcc-runtime"
 BUILDDEP="cmake"
-PKGDES="A general dimension code for computing convex hulls and related structures"
+PKGDES="General dimension code for computing convex hulls and related structures"
 
 PKGBREAK="octave<=4.0.2-2 palapeli<=16.04.0 matplotlib<=1.5.1"
 PKGEPOCH=1
 
 # qhullcpp is static-only
+ABTYPE=cmakeninja
 NOSTATIC=0

--- a/app-scientific/qhull/spec
+++ b/app-scientific/qhull/spec
@@ -1,6 +1,4 @@
-VER=7.2.0
-REL=2
-YEAR=2015
-SRCS="tbl::http://www.qhull.org/download/qhull-${YEAR}-src-${VER}.tgz"
-CHKSUMS="sha256::78b010925c3b577adc3d58278787d7df08f7c8fb02c3490e375eab91bb58a436"
+VER=8.0.2
+SRCS="git::commit=tags/v${VER}::https://github.com/qhull/qhull"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21736"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,5 +1,4 @@
-VER=3.11.1
-REL=1
-SRCS="tbl::https://download.osgeo.org/gdal/$VER/gdal-$VER.tar.xz"
-CHKSUMS="sha256::21341b39a960295bd3194bcc5f119f773229b4701cd752499fbd850f3cc160fd"
+VER=3.12.0
+SRCS="git::commit=tags/v${VER}::https://github.com/OSGeo/gdal"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=881"

--- a/runtime-imaging/pcl/spec
+++ b/runtime-imaging/pcl/spec
@@ -1,4 +1,5 @@
 VER=1.15.1
+REL=1
 SRCS="git::commit=tags/pcl-$VER::https://github.com/PointCloudLibrary/pcl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141386"


### PR DESCRIPTION
Topic Description
-----------------

- superslice: update to 2.7.61.10
    Signed-off-by: stydxm <stydxm@outlook.com>
- pcl: bump REL due to qhull update
    Signed-off-by: stydxm <stydxm@outlook.com>
- octave: bump REL due to qhull update
    Signed-off-by: stydxm <stydxm@outlook.com>
- gdal: update to 3.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- qhull: update to 8.0.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit qhull gdal octave pcl superslicer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
