### PR TITLE
soteria: new, 0.2.2

### DIFF
--- a/app-admin/soteria/autobuild/beyond
+++ b/app-admin/soteria/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Moving soteria to the correct folder ..."
+install -dvm755 "$PKGDIR"/usr/lib/soteria-polkit
+mv -v "$PKGDIR"/usr/bin/soteria "$PKGDIR"/usr/lib/soteria-polkit
+rm -rv "$PKGDIR"/usr/bin

--- a/app-admin/soteria/autobuild/defines
+++ b/app-admin/soteria/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=soteria
+PKGSEC=admin
+PKGDEP="gcc-runtime glib glibc gtk-4 polkit"
+BUILDDEP="rustc llvm"
+PKGDES="GTK-based polkit authentication agent"
+
+ABTYPE=rust

--- a/app-admin/soteria/spec
+++ b/app-admin/soteria/spec
@@ -1,0 +1,4 @@
+VER=0.2.2
+SRCS="git::commit=tags/v$VER::https://github.com/imvaskel/soteria.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=387428"


### PR DESCRIPTION
Topic Description
-----------------

- soteria: new, 0.2.2

Package(s) Affected
-------------------

- soteria: 0.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit soteria
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
