### PR TITLE
libsoundio: update to 2.0.1+7

### DIFF
--- a/app-creativity/lmms/spec
+++ b/app-creativity/lmms/spec
@@ -1,4 +1,4 @@
-VER=1.2.2+git20251014
-SRCS="git::commit=a809c03f87afc6d17b5b2e180c6f6d993247418c::https://github.com/LMMS/lmms"
+VER=1.2.2+git20251129
+SRCS="git::commit=f50b047684a07b6836735cf47984fc27f54b845d::https://github.com/LMMS/lmms"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1832"

--- a/runtime-multimedia/libsoundio/spec
+++ b/runtime-multimedia/libsoundio/spec
@@ -1,5 +1,4 @@
-VER=1.1.0
-REL=1
-SRCS="tbl::https://github.com/andrewrk/libsoundio/archive/$VER.tar.gz"
-CHKSUMS="sha256::ba0b21397cb3e29dc8f51ed213ae27625f05398c01aefcfbaa860fab42a84281"
+VER=2.0.1+7
+SRCS="git::commit=tags/${VER//+/-}::https://github.com/andrewrk/libsoundio"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=102867"


### PR DESCRIPTION
Topic Description
-----------------

- lmms: update to 1.2.2+git20251129
    Signed-off-by: stydxm <stydxm@outlook.com>
- libsoundio: update to 2.0.1+7
    Signed-off-by: stydxm <stydxm@outlook.com>
- jujutsu: new, 0.35.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libsoundio lmms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
