### PR TITLE
daed: update to 1.5.1

### DIFF
--- a/app-proxy/daed/autobuild/build
+++ b/app-proxy/daed/autobuild/build
@@ -1,5 +1,12 @@
+# SWC only supports amd64 and arm64, so use prebuilt frontend files.
 abinfo "Building daed ..."
-make VERSION="$PKGVER"
+pushd "$SRCDIR/wing"
+make bundle \
+    OUTPUT="../daed" \
+    APPNAME="daed" \
+    WEB_DIST="$SRCDIR/web" \
+    VERSION="$PKGVER"
+popd
 
 abinfo "Installing daed ..."
 install -Dvm755 "$SRCDIR"/daed -t "$PKGDIR"/usr/bin

--- a/app-proxy/daed/autobuild/defines
+++ b/app-proxy/daed/autobuild/defines
@@ -3,12 +3,10 @@ PKGSEC=net
 PKGDES="Transparent proxy solution based on eBPF, bundled with dashboard"
 PKGDEP="gcc-runtime v2ray-rules-dat"
 PKGCONFL="dae"
-BUILDDEP="go llvm nodejs"
+BUILDDEP="go llvm"
 
 USECLANG=1
 ABTYPE=self
 
-# FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
-ABSPLITDBG=0
-# FIXME: Missing vmlinux.h file for loongson3 and SWC only supports amd64 and arm64.
-FAIL_ARCH="!(amd64|arm64)"
+# FIXME: Missing vmlinux.h file for loongson3.
+FAIL_ARCH="(loongson3)"

--- a/app-proxy/daed/autobuild/patch
+++ b/app-proxy/daed/autobuild/patch
@@ -1,0 +1,4 @@
+abinfo "Applying patches ..."
+pushd "$SRCDIR/wing"
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.patch
+popd

--- a/app-proxy/daed/autobuild/patches/0001-update-modernc.org-sqlite-to-support-loongarch64.patch
+++ b/app-proxy/daed/autobuild/patches/0001-update-modernc.org-sqlite-to-support-loongarch64.patch
@@ -1,0 +1,89 @@
+From 607351a0a9fcce4517057d48d58147dc010ab7f0 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 30 Nov 2025 18:49:34 +0800
+Subject: [PATCH] update modernc.org/sqlite to support loongarch64
+
+---
+ go.mod |  7 +++++--
+ go.sum | 30 ++++++++++++++++++++++++------
+ 2 files changed, 29 insertions(+), 8 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 0ba2997..046d51c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -74,6 +74,7 @@ require (
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+ 	github.com/modern-go/reflect2 v1.0.2 // indirect
+ 	github.com/mzz2017/disk-bloom v1.0.1 // indirect
++	github.com/ncruces/go-strftime v0.1.9 // indirect
+ 	github.com/nwaples/rardecode v1.1.3 // indirect
+ 	github.com/nxadm/tail v1.4.8 // indirect
+ 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd // indirect
+@@ -106,12 +107,14 @@ require (
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d // indirect
+ 	google.golang.org/grpc v1.65.0 // indirect
+ 	google.golang.org/protobuf v1.36.1 // indirect
+-	modernc.org/libc v1.24.1 // indirect
++	modernc.org/libc v1.50.9 // indirect
+ 	modernc.org/mathutil v1.6.0 // indirect
+-	modernc.org/memory v1.6.0 // indirect
++	modernc.org/memory v1.8.0 // indirect
+ 	modernc.org/sqlite v1.23.1 // indirect
+ )
+ 
+ replace github.com/daeuniverse/dae => ./dae-core
+ 
+ // replace github.com/daeuniverse/dae => ../dae
++
++replace modernc.org/sqlite => modernc.org/sqlite v1.30.0
+diff --git a/go.sum b/go.sum
+index a283bad..c1cb6cb 100644
+--- a/go.sum
++++ b/go.sum
+@@ -143,6 +143,8 @@ github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B
+ github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
+ github.com/mzz2017/softwind v0.0.0-20230803152605-5f1f6bc06934 h1:IAaVbSfNiYP/TuJ4n686SeAwcs+PMvKdzJM5R4Y1rhM=
+ github.com/mzz2017/softwind v0.0.0-20230803152605-5f1f6bc06934/go.mod h1:TopiWHnL2ty4V4AkNM1nNVdbLlASWdQqploagf4tcKc=
++github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
++github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+ github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+ github.com/nwaples/rardecode v1.1.3 h1:cWCaZwfM5H7nAD6PyEdcVnczzV8i/JtotnyW/dD9lEc=
+ github.com/nwaples/rardecode v1.1.3/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+@@ -303,11 +305,27 @@ gorm.io/driver/sqlite v1.5.2 h1:TpQ+/dqCY4uCigCFyrfnrJnrW9zjpelWVoEVNy5qJkc=
+ gorm.io/driver/sqlite v1.5.2/go.mod h1:qxAuCol+2r6PannQDpOP1FP6ag3mKi4esLnB/jHed+4=
+ gorm.io/gorm v1.25.2 h1:gs1o6Vsa+oVKG/a9ElL3XgyGfghFfkKA2SInQaCyMho=
+ gorm.io/gorm v1.25.2/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
+-modernc.org/libc v1.24.1 h1:uvJSeCKL/AgzBo2yYIPPTy82v21KgGnizcGYfBHaNuM=
+-modernc.org/libc v1.24.1/go.mod h1:FmfO1RLrU3MHJfyi9eYYmZBfi/R+tqZ6+hQ3yQQUkak=
++modernc.org/cc/v4 v4.21.2 h1:dycHFB/jDc3IyacKipCNSDrjIC0Lm1hyoWOZTRR20Lk=
++modernc.org/cc/v4 v4.21.2/go.mod h1:HM7VJTZbUCR3rV8EYBi9wxnJ0ZBRiGE5OeGXNA0IsLQ=
++modernc.org/ccgo/v4 v4.17.8 h1:yyWBf2ipA0Y9GGz/MmCmi3EFpKgeS7ICrAFes+suEbs=
++modernc.org/ccgo/v4 v4.17.8/go.mod h1:buJnJ6Fn0tyAdP/dqePbrrvLyr6qslFfTbFrCuaYvtA=
++modernc.org/fileutil v1.3.0 h1:gQ5SIzK3H9kdfai/5x41oQiKValumqNTDXMvKo62HvE=
++modernc.org/fileutil v1.3.0/go.mod h1:XatxS8fZi3pS8/hKG2GH/ArUogfxjpEKs3Ku3aK4JyQ=
++modernc.org/gc/v2 v2.4.1 h1:9cNzOqPyMJBvrUipmynX0ZohMhcxPtMccYgGOJdOiBw=
++modernc.org/gc/v2 v2.4.1/go.mod h1:wzN5dK1AzVGoH6XOzc3YZ+ey/jPgYHLuVckd62P0GYU=
++modernc.org/libc v1.50.9 h1:hIWf1uz55lorXQhfoEoezdUHjxzuO6ceshET/yWjSjk=
++modernc.org/libc v1.50.9/go.mod h1:15P6ublJ9FJR8YQCGy8DeQ2Uwur7iW9Hserr/T3OFZE=
+ modernc.org/mathutil v1.6.0 h1:fRe9+AmYlaej+64JsEEhoWuAYBkOtQiMEU7n/XgfYi4=
+ modernc.org/mathutil v1.6.0/go.mod h1:Ui5Q9q1TR2gFm0AQRqQUaBWFLAhQpCwNcuhBOSedWPo=
+-modernc.org/memory v1.6.0 h1:i6mzavxrE9a30whzMfwf7XWVODx2r5OYXvU46cirX7o=
+-modernc.org/memory v1.6.0/go.mod h1:PkUhL0Mugw21sHPeskwZW4D6VscE/GQJOnIpCnW6pSU=
+-modernc.org/sqlite v1.23.1 h1:nrSBg4aRQQwq59JpvGEQ15tNxoO5pX/kUjcRNwSAGQM=
+-modernc.org/sqlite v1.23.1/go.mod h1:OrDj17Mggn6MhE+iPbBNf7RGKODDE9NFT0f3EwDzJqk=
++modernc.org/memory v1.8.0 h1:IqGTL6eFMaDZZhEWwcREgeMXYwmW83LYW8cROZYkg+E=
++modernc.org/memory v1.8.0/go.mod h1:XPZ936zp5OMKGWPqbD3JShgd/ZoQ7899TUuQqxY+peU=
++modernc.org/opt v0.1.3 h1:3XOZf2yznlhC+ibLltsDGzABUGVx8J6pnFMS3E4dcq4=
++modernc.org/opt v0.1.3/go.mod h1:WdSiB5evDcignE70guQKxYUl14mgWtbClRi5wmkkTX0=
++modernc.org/sortutil v1.2.0 h1:jQiD3PfS2REGJNzNCMMaLSp/wdMNieTbKX920Cqdgqc=
++modernc.org/sortutil v1.2.0/go.mod h1:TKU2s7kJMf1AE84OoiGppNHJwvB753OYfNl2WRb++Ss=
++modernc.org/sqlite v1.30.0 h1:8YhPUs/HTnlEgErn/jSYQTwHN/ex8CjHHjg+K9iG7LM=
++modernc.org/sqlite v1.30.0/go.mod h1:cgkTARJ9ugeXSNaLBPK3CqbOe7Ec7ZhWPoMFGldEYEw=
++modernc.org/strutil v1.2.0 h1:agBi9dp1I+eOnxXeiZawM8F4LawKv4NzGWSaLfyeNZA=
++modernc.org/strutil v1.2.0/go.mod h1:/mdcBmfOibveCTBxUl5B5l6W+TTH1FXPLHZE6bTosX0=
++modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
++modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+-- 
+2.52.0
+

--- a/app-proxy/daed/spec
+++ b/app-proxy/daed/spec
@@ -1,6 +1,7 @@
-VER=1.0.0
-REL=2
-SRCS="tbl::https://github.com/daeuniverse/daed/releases/download/v0.9.0/daed-full-src.zip"
-CHKSUMS="sha256::4ad31c5b3640906a6ef301ee06f94162cb2f5e577b1bd579f47476cae4b2dbf8"
+VER=1.5.1
+SRCS="tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/daed-full-src.zip \
+      tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/web.zip"
+CHKSUMS="sha256::557157d5e95142aad4ec7f5127f75ad797cd94755678fa24990ccfdf38a9ed81 \
+         sha256::92c77aa820e3434606ef0912aa30311b052b4319672f9394ad0aa9f2b8d8a2b8"
 CHKUPDATE="anitya::id=375373"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- daed: update to 1.5.1
    - Correct SRCS urls.
    - Use prebuilt frontend files to support more architectures.

Package(s) Affected
-------------------

- daed: 1.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit daed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
