### PR TITLE
lapack: update to 3.12.1

### DIFF
--- a/app-scientific/lapack/autobuild/beyond
+++ b/app-scientific/lapack/autobuild/beyond
@@ -2,6 +2,6 @@ abinfo "Building manpages ..."
 doxygen "$SRCDIR"/DOCS/Doxyfile
 
 abinfo "Install manpages ..."
-mkdir -vp "$PKGDIR"/usr/share
-cp -vr "$SRCDIR"/DOCS/man "$PKGDIR"/usr/share
+mkdir -pv "$PKGDIR"/usr/share
+cp -av "$SRCDIR"/DOCS/man "$PKGDIR"/usr/share
 rm -v "$PKGDIR"/usr/share/man/man3l/*_acbs_*

--- a/app-scientific/lapack/autobuild/defines
+++ b/app-scientific/lapack/autobuild/defines
@@ -1,16 +1,17 @@
 PKGNAME=lapack
-PKGDES="Lapack and BLAS Linear Algebra library"
 PKGSEC=libs
 PKGDEP="gcc-runtime"
 BUILDDEP="doxygen"
+PKGDES="Fortran library to solve numerical linear algebra"
 
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON \
-             -DCMAKE_Fortran_COMPILER=gfortran \
-             -DLAPACKE=ON \
-             -DLAPACKE_WITH_TMG=ON \
-             -DCBLAS=ON \
-             -DBUILD_DEPRECATED=ON"
-AB_FLAGS_SPECS=0
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_SHARED_LIBS=ON'
+    '-DCMAKE_Fortran_COMPILER=gfortran'
+    '-DLAPACKE=ON'
+    '-DLAPACKE_WITH_TMG=ON'
+    '-DCBLAS=ON'
+    '-DBUILD_DEPRECATED=OFF'
+)
+
 AB_FLAGS_O3=1
-NOLTO=1
-ABTYPE=cmake

--- a/app-scientific/lapack/autobuild/patches/0001-UPSTREAM-ge-lq-qr-s.f-WORK-LWORK-WORK.patch
+++ b/app-scientific/lapack/autobuild/patches/0001-UPSTREAM-ge-lq-qr-s.f-WORK-LWORK-WORK.patch
@@ -1,0 +1,196 @@
+From af8912aca69583b490d1cdc6754b17dac499490d Mon Sep 17 00:00:00 2001
+From: Wouter Deconinck <wdconinc@gmail.com>
+Date: Fri, 10 Jan 2025 14:32:30 -0600
+Subject: [PATCH 1/2] UPSTREAM: ?ge(lq|qr)s.f: WORK( LWORK ) -> WORK( * )
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ SRC/DEPRECATED/cgelqs.f | 4 ++--
+ SRC/DEPRECATED/cgeqrs.f | 4 ++--
+ SRC/DEPRECATED/dgelqs.f | 4 ++--
+ SRC/DEPRECATED/dgeqrs.f | 4 ++--
+ SRC/DEPRECATED/sgelqs.f | 4 ++--
+ SRC/DEPRECATED/sgeqrs.f | 4 ++--
+ SRC/DEPRECATED/zgelqs.f | 4 ++--
+ SRC/DEPRECATED/zgeqrs.f | 4 ++--
+ 8 files changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/SRC/DEPRECATED/cgelqs.f b/SRC/DEPRECATED/cgelqs.f
+index 47e17a583..aba3632a7 100644
+--- a/SRC/DEPRECATED/cgelqs.f
++++ b/SRC/DEPRECATED/cgelqs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/cgeqrs.f b/SRC/DEPRECATED/cgeqrs.f
+index 13ac7f74f..9d0527283 100644
+--- a/SRC/DEPRECATED/cgeqrs.f
++++ b/SRC/DEPRECATED/cgeqrs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       COMPLEX            A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/dgelqs.f b/SRC/DEPRECATED/dgelqs.f
+index dc08f2398..1bab67890 100644
+--- a/SRC/DEPRECATED/dgelqs.f
++++ b/SRC/DEPRECATED/dgelqs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/dgeqrs.f b/SRC/DEPRECATED/dgeqrs.f
+index bfb7bd8bb..e3e6c4048 100644
+--- a/SRC/DEPRECATED/dgeqrs.f
++++ b/SRC/DEPRECATED/dgeqrs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/sgelqs.f b/SRC/DEPRECATED/sgelqs.f
+index 330d4d585..2b1dd44b7 100644
+--- a/SRC/DEPRECATED/sgelqs.f
++++ b/SRC/DEPRECATED/sgelqs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/sgeqrs.f b/SRC/DEPRECATED/sgeqrs.f
+index ed1148910..bdbad5dcb 100644
+--- a/SRC/DEPRECATED/sgeqrs.f
++++ b/SRC/DEPRECATED/sgeqrs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       REAL               A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/zgelqs.f b/SRC/DEPRECATED/zgelqs.f
+index 5f629f8c7..772165dfd 100644
+--- a/SRC/DEPRECATED/zgelqs.f
++++ b/SRC/DEPRECATED/zgelqs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+diff --git a/SRC/DEPRECATED/zgeqrs.f b/SRC/DEPRECATED/zgeqrs.f
+index 6583e3859..cc33a45fc 100644
+--- a/SRC/DEPRECATED/zgeqrs.f
++++ b/SRC/DEPRECATED/zgeqrs.f
+@@ -16,7 +16,7 @@
+ *       ..
+ *       .. Array Arguments ..
+ *       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
+-*      $                   WORK( LWORK )
++*      $                   WORK( * )
+ *       ..
+ *
+ *
+@@ -128,7 +128,7 @@
+ *     ..
+ *     .. Array Arguments ..
+       COMPLEX*16         A( LDA, * ), B( LDB, * ), TAU( * ),
+-     $                   WORK( LWORK )
++     $                   WORK( * )
+ *     ..
+ *
+ *  =====================================================================
+-- 
+2.52.0
+

--- a/app-scientific/lapack/autobuild/patches/0002-AOSCOS-rename-man-page-category-to-3l-to-avoid-file-.patch
+++ b/app-scientific/lapack/autobuild/patches/0002-AOSCOS-rename-man-page-category-to-3l-to-avoid-file-.patch
@@ -1,8 +1,19 @@
+From a427602cec7dcf517dfb1c60648d6354ee38b7fa Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Mon, 6 Apr 2026 22:05:41 +0800
+Subject: [PATCH 2/2] AOSCOS: rename man page category to 3l to avoid file
+ conflict
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ DOCS/Doxyfile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/DOCS/Doxyfile b/DOCS/Doxyfile
-index 1767cf5..a7bf53d 100644
+index 5cdf3208c..2ccdd3622 100644
 --- a/DOCS/Doxyfile
 +++ b/DOCS/Doxyfile
-@@ -1138,7 +1138,7 @@
+@@ -1144,7 +1144,7 @@ IGNORE_PREFIX          =
  # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
  # The default value is: YES.
  
@@ -11,7 +22,7 @@ index 1767cf5..a7bf53d 100644
  
  # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
  # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
-@@ -1975,7 +1975,7 @@
+@@ -1981,7 +1981,7 @@ RTF_SOURCE_CODE        = NO
  # classes and files.
  # The default value is: NO.
  
@@ -20,7 +31,7 @@ index 1767cf5..a7bf53d 100644
  
  # The MAN_OUTPUT tag is used to specify where the man pages will be put. If a
  # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
-@@ -1993,7 +1993,7 @@
+@@ -1999,7 +1999,7 @@ MAN_OUTPUT             = man
  # The default value is: .3.
  # This tag requires that the tag GENERATE_MAN is set to YES.
  
@@ -29,3 +40,6 @@ index 1767cf5..a7bf53d 100644
  
  # The MAN_SUBDIR tag determines the name of the directory created within
  # MAN_OUTPUT in which the man pages are placed. If defaults to man followed by
+-- 
+2.52.0
+

--- a/app-scientific/lapack/autobuild/prepare
+++ b/app-scientific/lapack/autobuild/prepare
@@ -1,9 +1,0 @@
-export CFLAGS="${CFLAGS} -frecursive -fPIC"
-export CXXFLAGS="${CXXFLAGS} -fPIC"
-export FFLAGS="${FFLAGS} -fPIC"
-export LDFLAGS="${LDFLAGS} -fPIC"
-
-if [[ "${CROSS:-$ARCH}" = "ppc64el" ]]; then
-    abinfo "Disabling x86 intrinsics to fix build on ppc64el ..."
-    export CPPFLAGS="${CPPFLAGS/-DNO_WARN_X86_INTRINSICS/}"
-fi

--- a/app-scientific/lapack/spec
+++ b/app-scientific/lapack/spec
@@ -1,4 +1,4 @@
-VER=3.12.0
+VER=3.12.1
 SRCS="git::commit=tags/v$VER::https://github.com/Reference-LAPACK/lapack"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1534"


### PR DESCRIPTION
Topic Description
-----------------

- lapack: update to 3.12.1
    - Backport a patch to fix build failure.
    - Disable deprecated modules as they no longer build.
    - Track patches at AOSC-Tracking/lapack @ aosc/v3.12.1
    \)HEAD: a427602cec7dcf517dfb1c60648d6354ee38b7fa\).
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lapack: 3.12.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lapack
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
