### PR TITLE
osc: new, 1.22.0

### DIFF
--- a/app-devel/osc/autobuild/defines
+++ b/app-devel/osc/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=osc
+PKGDES="Command-line interface to Open Build Service"
+PKGSEC=devel
+PKGDEP="python-3 ruamel-yaml cryptography urllib3 rpm"
+BUILDDEP="setuptools"
+
+ABTYPE=python
+NOPYTHON2=1
+ABHOST=noarch

--- a/app-devel/osc/spec
+++ b/app-devel/osc/spec
@@ -1,0 +1,3 @@
+VER=1.22.0
+SRCS="git::commit=tags/${VER}::https://github.com/openSUSE/osc.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- osc: new, 1.22.0
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- osc: 1.22.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit osc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
