### PR TITLE
xwayland-satellite: update to 0.8

### DIFF
--- a/runtime-display/xwayland-satellite/autobuild/defines
+++ b/runtime-display/xwayland-satellite/autobuild/defines
@@ -6,8 +6,3 @@ PKGDES="Rootless Xwayland integration for compositors supporting xdg_wm_base"
 USECLANG=1
 CARGO_AFTER="--features systemd"
 ABTYPE=rust
-
-# FIXME: ld.lld is not yet available for loongson3.
-# ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; 
-# recompile with -fPIC
-NOLTO__LOONGSON3=1

--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -1,4 +1,4 @@
-VER=0.7
-SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite"
+VER=0.8
+SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377600"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland-satellite: update to 0.8

Package(s) Affected
-------------------

- xwayland-satellite: 0.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
