### PR TITLE
openvpn: update to 2.6.17

### DIFF
--- a/app-network/openvpn/spec
+++ b/app-network/openvpn/spec
@@ -1,4 +1,4 @@
-VER=2.6.16
+VER=2.6.17
 SRCS="tbl::https://swupdate.openvpn.net/community/releases/openvpn-$VER.tar.gz"
-CHKSUMS="sha256::05cb5fdf1ea33fcba719580b31a97feaa019c4a3050563e88bc3b34675e6fed4"
+CHKSUMS="sha256::4cc8e63f710d3001493b13d8a32cf22a214d5e4f71dd37d93831e2fd3208b370"
 CHKUPDATE="anitya::id=2567"


### PR DESCRIPTION
Topic Description
-----------------

- openvpn: update to 2.6.17

Package(s) Affected
-------------------

- openvpn: 2.6.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit openvpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
