### PR TITLE
ninja: update to 1.13.2

### DIFF
--- a/app-devel/ninja/spec
+++ b/app-devel/ninja/spec
@@ -1,4 +1,4 @@
-VER=1.13.1
+VER=1.13.2
 SRCS="git::commit=tags/v$VER::https://github.com/ninja-build/ninja"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2089"


### PR DESCRIPTION
Topic Description
-----------------

- ninja: update to 1.13.2
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- ninja: 1.13.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ninja
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
