### PR TITLE
ed: update to 1.22.3

### DIFF
--- a/app-editors/ed/spec
+++ b/app-editors/ed/spec
@@ -1,4 +1,4 @@
-VER=1.22.2
+VER=1.22.3
 SRCS="tbl::https://ftp.gnu.org/gnu/ed/ed-$VER.tar.lz"
-CHKSUMS="sha256::f58d15242056e15af76f13f34c60d890fa2a2d5cb0abef91c115e4d83794ffe3"
+CHKSUMS="sha256::47a55ddfc52d4a1ff6f7559fbd00cf948a16b6cf151ec520392761aeae4e97be"
 CHKUPDATE="anitya::id=659"


### PR DESCRIPTION
Topic Description
-----------------

- ed: update to 1.22.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ed: 1.22.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
