### PR TITLE
dill: update to 0.4.0

### DIFF
--- a/lang-python/dill/spec
+++ b/lang-python/dill/spec
@@ -1,4 +1,4 @@
-VER=0.3.8
+VER=0.4.0
 SRCS="tbl::https://pypi.io/packages/source/d/dill/dill-$VER.tar.gz"
-CHKSUMS="sha256::3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"
+CHKSUMS="sha256::0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0"
 CHKUPDATE="anitya::id=7687"


### PR DESCRIPTION
Topic Description
-----------------

- dill: update to 0.4.0
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- dill: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dill
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
