### PR TITLE
hatch-vcs: update to 0.5.0

### DIFF
--- a/lang-python/hatch-vcs/spec
+++ b/lang-python/hatch-vcs/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.5.0
 SRCS="tbl::https://github.com/ofek/hatch-vcs/archive/refs/tags/v${VER}.tar.gz"
-CHKSUMS="sha256::08d52088c3cc97a719e2530f42a05829cf442c63ea735e63e4d152e75966c4f1"
+CHKSUMS="sha256::a74465d21bb60eef75f01b3c189b73181f152a5eef2b26bd95de039e224953a7"
 CHKUPDATE="anitya::id=301800"


### PR DESCRIPTION
Topic Description
-----------------

- hatch-vcs: update to 0.5.0
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- hatch-vcs: 0.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit hatch-vcs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
