### PR TITLE
darkhttpd: update to 1.17

### DIFF
--- a/app-web/darkhttpd/autobuild/build
+++ b/app-web/darkhttpd/autobuild/build
@@ -1,3 +1,5 @@
+abinfo "Building darkhttpd..."
 make 
 
+abinfo "Installing darkhttpd..."
 install -Dm755 darkhttpd $PKGDIR/usr/bin/darkhttpd

--- a/app-web/darkhttpd/autobuild/defines
+++ b/app-web/darkhttpd/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=darkhttpd
 PKGSEC=net
 PKGDEP="glibc"
-PKGDES="A small and secure web server daemon"
-
+PKGDES="Single-threaded static content webserver"

--- a/app-web/darkhttpd/spec
+++ b/app-web/darkhttpd/spec
@@ -1,4 +1,4 @@
-VER=1.16
-SRCS="tbl::https://github.com/emikulic/darkhttpd/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::ab97ea3404654af765f78282aa09cfe4226cb007d2fcc59fe1a475ba0fef1981"
+VER=1.17
+SRCS="git::commit=tags/v$VER::https://github.com/emikulic/darkhttpd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391"


### PR DESCRIPTION
Topic Description
-----------------

- darkhttpd: update to 1.17
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- darkhttpd: 1.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit darkhttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
