### PR TITLE
chrony: update to 4.8

### DIFF
--- a/app-admin/chrony/spec
+++ b/app-admin/chrony/spec
@@ -1,5 +1,4 @@
-VER=4.5
-REL=1
+VER=4.8
 SRCS="https://chrony-project.org/releases/chrony-$VER.tar.gz"
-CHKSUMS="sha256::19fe1d9f4664d445a69a96c71e8fdb60bcd8df24c73d1386e02287f7366ad422"
+CHKSUMS="sha256::33ea8eb2a4daeaa506e8fcafd5d6d89027ed6f2f0609645c6f149b560d301706"
 CHKUPDATE="anitya::id=8810"


### PR DESCRIPTION
Topic Description
-----------------

- chrony: update to 4.8
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- chrony: 4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit chrony
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
