### PR TITLE
clamav: update to 1.5.1

### DIFF
--- a/app-admin/clamav/autobuild/defines
+++ b/app-admin/clamav/autobuild/defines
@@ -35,7 +35,8 @@ CMAKE_AFTER="-DAPP_CONFIG_DIRECTORY=/etc/clamav \
              -DENABLE_STATIC_LIB=OFF \
              -DENABLE_SHARED_LIB=ON \
              -DENABLE_UNRAR=ON \
-             -DENABLE_SYSTEMD=ON"
+             -DENABLE_SYSTEMD=ON \
+             -DVENDOR_DEPENDENCIES=ON"
 CMAKE_AFTER__RETRO=" \
              ${CMAKE_AFTER} \
              -DENABLE_DOXYGEN=OFF \

--- a/app-admin/clamav/autobuild/patches/0001-Update-Rust-dependency-to-fix-build-errors-on-LoongA.patch
+++ b/app-admin/clamav/autobuild/patches/0001-Update-Rust-dependency-to-fix-build-errors-on-LoongA.patch
@@ -1,0 +1,30 @@
+From f320eeb064f2f2526df787bd39cd0339f38f2994 Mon Sep 17 00:00:00 2001
+From: Felix Yan <felixonmars@archlinux.org>
+Date: Tue, 2 Dec 2025 07:22:45 +0800
+Subject: [PATCH] Update Rust dependency to fix build errors on LoongArch
+
+The new version contains fix from
+https://github.com/VoidStarKat/half-rs/pull/136
+---
+ Cargo.lock | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 37226169b..e5a808ea4 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -862,9 +862,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+ 
+ [[package]]
+ name = "half"
+-version = "2.7.0"
++version = "2.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e54c115d4f30f52c67202f079c5f9d8b49db4691f460fdb0b4c2e838261b2ba5"
++checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+ dependencies = [
+  "cfg-if",
+  "crunchy",
+-- 
+2.52.0
+

--- a/app-admin/clamav/spec
+++ b/app-admin/clamav/spec
@@ -1,4 +1,4 @@
-VER=1.4.3
+VER=1.5.1
 SRCS="tbl::https://www.clamav.net/downloads/production/clamav-$VER.tar.gz"
-CHKSUMS="sha256::d874cabf3d4765b35b518ef535658a1e6ec74802006a1d613f9f124aa1343210"
+CHKSUMS="sha256::64fe4a16a5622c1d71efe9ed7f2c2fbd37f8f237da9f11ff66b73038df71db91"
 CHKUPDATE="anitya::id=291"


### PR DESCRIPTION
Topic Description
-----------------

- clamav: update to 1.5.1
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- clamav: 1.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clamav
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
