### PR TITLE
helix: update to 25.07.1

### DIFF
--- a/app-editors/helix/autobuild/defines
+++ b/app-editors/helix/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=helix
 PKGSEC=editors
 PKGDES="A Vim-like terminal-based text editor"
-BUILDDEP="rustc llvm-20"
+BUILDDEP="rustc llvm"
 
 USECLANG=1
 ABSPLITDBG=0

--- a/app-editors/helix/spec
+++ b/app-editors/helix/spec
@@ -1,5 +1,5 @@
-VER=25.07
+VER=25.07.1
 SRCS="tbl::https://github.com/helix-editor/helix/releases/download/$VER/helix-${VER}-source.tar.xz"
-CHKSUMS="sha256::22f037e8c4bbef67b7aa6db3448063f87004159fde6a9ce684082963bfeba4e5"
+CHKSUMS="sha256::2d0cf264ac77f8c25386a636e2b3a09a23dec555568cc9a5b2927f84322f544e"
 CHKUPDATE="anitya::id=219661"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- helix: update to 25.07.1
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- helix: 25.07.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit helix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
