### PR TITLE
gi-docgen: update to 2025.5

### DIFF
--- a/app-doc/gi-docgen/spec
+++ b/app-doc/gi-docgen/spec
@@ -1,4 +1,4 @@
-VER=2025.4
+VER=2025.5
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/gi-docgen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=178582"


### PR DESCRIPTION
Topic Description
-----------------

- gi-docgen: update to 2025.5
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- gi-docgen: 2025.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit gi-docgen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
