### PR TITLE
qgis: update to 3.44.5

### DIFF
--- a/app-gis/qgis/autobuild/defines
+++ b/app-gis/qgis/autobuild/defines
@@ -1,13 +1,16 @@
 PKGNAME=qgis
 PKGSEC=science
 PKGDEP="proj geos gdal libzip exiv2 pdal qtkeychain qca gsl sip jinja2 psycopg2 \
-		pyqt5 pyqt-builder qwt5 qscintilla libspatialindex postgresql-runtime-17 \
+		pyqt5 pyqt-builder qwt5 qscintilla postgresql-runtime-17 \
 		owslib"
 PKGDES="Geographic Information System (GIS) software"
 
+# System libspatialindex is too new:
+# https://github.com/libspatialindex/libspatialindex/issues/276
 CMAKE_AFTER=(
 	"-DPostgreSQL_INCLUDE_DIR=/usr/lib/postgresql-17/include/"
 	"-DQGIS_MANUAL_SUBDIR=share/man"
+    "-DWITH_INTERNAL_SPATIALINDEX=TRUE"
 )
 
 # FIXME: elocation truncated to fit: R_MIPS_TLS_LDM against 

--- a/app-gis/qgis/spec
+++ b/app-gis/qgis/spec
@@ -1,4 +1,4 @@
-VER=3.44.3
+VER=3.44.5
 SRCS="git::commit=tags/final-${VER//./_}::https://github.com/qgis/QGIS.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5779"


### PR DESCRIPTION
Topic Description
-----------------

- qgis: update to 3.44.5
    Co-authored-by: Felix Yan \(@felixonmars\) <felixonmars@archlinux.org>

Package(s) Affected
-------------------

- qgis: 3.44.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit qgis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
