### PR TITLE
topics: fix version range for linux-kernel-6.17.y.toml

### DIFF
--- a/topics/linux-kernel-6.17.y.toml
+++ b/topics/linux-kernel-6.17.y.toml
@@ -9,4 +9,4 @@ default = "Includes support for new devices and functionality fixes, improves th
 zh_CN = "包含大量新设备支持及功能修复，改善内核崩溃 (Kernel Panic) 界面的实用性"
 
 [packages-v2]
-"linux+kernel" = ">= 3:6.17.0 && < 3:6.18.0"
+"linux+kernel" = "< 3:6.17.0"


### PR DESCRIPTION
Topic Description
-----------------

- topics: fix version range for linux-kernel-6.17.y.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
