### PR TITLE
telegram-desktop: update to 6.3.4

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -24,6 +24,10 @@ CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX='/usr' \
              -DQT_VERSION_MAJOR=5"
 
 ABTYPE=cmakeninja
+# FIXME: circumvent a potential race condition on ppc64el
+# /var/cache/acbs/build/acbs.xhrcc222/tdesktop-6.3.4-full/abbuild/gen/gio/_types.hpp:3: error: unterminated #ifndef
+#     3 | #ifndef _GI_GIO__TYPES_HPP_
+ABTYPE__PPC64EL=cmake
 
 # FIXME: LTO fails on riscv64
 # lto1: fatal error: LTO_symtab_tags out of range: Range is 0 to 5, value is 237

--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,7 +1,7 @@
-From 0c8413f88e9ad2ab06c1a7a3d2158c7fb5a57223 Mon Sep 17 00:00:00 2001
+From 8979e3fa60751846879cf4510de4ae2f65dabf51 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 01/13] fix(window.style): set default window width to 360px
+Subject: [PATCH 01/15] fix(window.style): set default window width to 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---
@@ -9,7 +9,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index a18a471533..a72dbf3989 100644
+index b56f520d61..37d3d1a113 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";
@@ -31,5 +31,5 @@ index a18a471533..a72dbf3989 100644
  columnMaximalWidthThird: 392px;
  
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,7 +1,7 @@
-From 62d7478f1e15632e023474e7fec5a10420596fba Mon Sep 17 00:00:00 2001
+From 8ab6b5aceba5a9dab7654e9d2d95dc1e0cb12bac Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 02/13] fix(core_settings.h): use system window decoration by
+Subject: [PATCH 02/15] fix(core_settings.h): use system window decoration by
  default
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 02/13] fix(core_settings.h): use system window decoration by
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 9ee26fea74..98f480a3c3 100644
+index 0a78d2c22c..2e59e02c6f 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1044,7 +1044,7 @@ private:
+@@ -1051,7 +1051,7 @@ private:
  	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;
@@ -22,5 +22,5 @@ index 9ee26fea74..98f480a3c3 100644
  	rpl::variable<bool> _systemDarkModeEnabled = true;
  	rpl::variable<WindowTitleContent> _windowTitleContent;
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,7 +1,7 @@
-From 57ecfccb077557aa8c2dfad908453a243b547336 Mon Sep 17 00:00:00 2001
+From 98da6dd7843d421cc18c426d748dfcc4f7cebf63 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
-Subject: [PATCH 03/13] fix(ui): fix build with Qt 5
+Subject: [PATCH 03/15] fix(ui): fix build with Qt 5
 
 Co-authored-by: Henry Chen <chenx97@aosc.io>
 ---
@@ -68,5 +68,5 @@ index 24274c3794..a57c4fab1f 100644
 +
 +#include "webview_linux_compositor.moc"
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,7 +1,7 @@
-From a949da6a9ad00303fa2b04b038e50b911e49d094 Mon Sep 17 00:00:00 2001
+From 6a82cef02c72aeb0660c4e7eef080a6bc57a10d9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
-Subject: [PATCH 04/13] fix(core/launcher.cpp): revert to old HiDPI handling
+Subject: [PATCH 04/15] fix(core/launcher.cpp): revert to old HiDPI handling
  behaviour
 
 The current implementation makes icons blurry in Qt 5 builds, whilst
@@ -13,7 +13,7 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
-index e844acf9ee..adb4b80fb6 100644
+index a5e98dc11e..0675ee1605 100644
 --- a/Telegram/SourceFiles/core/launcher.cpp
 +++ b/Telegram/SourceFiles/core/launcher.cpp
 @@ -342,7 +342,9 @@ void Launcher::initHighDpi() {
@@ -28,5 +28,5 @@ index e844acf9ee..adb4b80fb6 100644
  
  	if (OptionFractionalScalingEnabled.value()) {
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,14 +1,14 @@
-From 4793226eb8cfe9710e8fd027d48b2a69ed35a869 Mon Sep 17 00:00:00 2001
+From 7126598f074e8123c462ef68665b3a71edc46a3a Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 05/13] fix(settings): use system fonts by default
+Subject: [PATCH 05/15] fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 98f480a3c3..7fdf581191 100644
+index 2e59e02c6f..1331b60ceb 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
 @@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -19,7 +19,7 @@ index 98f480a3c3..7fdf581191 100644
  #include "base/flags.h"
  #include "emoji.h"
  
-@@ -1078,7 +1079,7 @@ private:
+@@ -1085,7 +1086,7 @@ private:
  	rpl::variable<bool> _storiesClickTooltipHidden = false;
  	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
  	WindowPosition _ivPosition;
@@ -29,5 +29,5 @@ index 98f480a3c3..7fdf581191 100644
  	std::optional<bool> _weatherInCelsius;
  	QByteArray _tonsiteStorageToken;
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,7 +1,7 @@
-From 7ee0e218255643e6ab4fdde85c98f5fad67dbff5 Mon Sep 17 00:00:00 2001
+From 5b5181e610d44c85339ce66c05911b257e14f2df Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 06/13] Remove the confusing "Default" option from selectable
+Subject: [PATCH 06/15] Remove the confusing "Default" option from selectable
  fonts
 
 ---
@@ -45,5 +45,5 @@ index a891c422f1..585c3a7934 100644
  		std::swap(result[2], *nowIt);
  		++skip;
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,7 +1,7 @@
-From b880e72810976d4b494996690339d0f231d36de5 Mon Sep 17 00:00:00 2001
+From 5cf367a8de78f83ac32997ea406faaba7d45698b Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
-Subject: [PATCH 07/13] fix(lib_tl): add missing cstring include
+Subject: [PATCH 07/15] fix(lib_tl): add missing cstring include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -21,5 +21,5 @@ index 5eadf62a93..961f7febe0 100644
  
  namespace tl {
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,7 +1,7 @@
-From a7185b55867aecd93643594c19ca5435b9ebee0a Mon Sep 17 00:00:00 2001
+From 1c0ed089e514fecf325e0b3b1e89b0c114c00c07 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
-Subject: [PATCH 08/13] fix(lib_webview): add missing cstdint include
+Subject: [PATCH 08/15] fix(lib_webview): add missing cstdint include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/lib_webview/webview/webview_interface.h b/Telegram/lib_webview/webview/webview_interface.h
-index 4a92fe3020..3cf6125358 100644
+index 7477811ad4..a175bd69aa 100644
 --- a/Telegram/lib_webview/webview/webview_interface.h
 +++ b/Telegram/lib_webview/webview/webview_interface.h
 @@ -12,6 +12,7 @@
@@ -21,5 +21,5 @@ index 4a92fe3020..3cf6125358 100644
  #include <rpl/never.h>
  #include <rpl/producer.h>
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,7 +1,7 @@
-From 1efab5d4513d335888a930ca31820c90d0cf87cf Mon Sep 17 00:00:00 2001
+From 0393c3defe28ce83b17f4b8280830119a72449bd Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
-Subject: [PATCH 09/13] fix(current_geo_location_linux): add missing
+Subject: [PATCH 09/15] fix(current_geo_location_linux): add missing
  QGuiApplication include
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -22,5 +22,5 @@ index 7015af7398..d48fc7025a 100644
  namespace Platform {
  namespace {
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,7 +1,7 @@
-From aecdd037f9241d98475c3492f50bb5e9e60313a9 Mon Sep 17 00:00:00 2001
+From b48ee65dc78b6068799f82900b546a8e52bd3599 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
-Subject: [PATCH 10/13] fix(core_settings.h): enable video hardware
+Subject: [PATCH 10/15] fix(core_settings.h): enable video hardware
  acceleration by default
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -10,10 +10,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 7fdf581191..0b6386477a 100644
+index 1331b60ceb..7b1d6dc3a0 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1060,11 +1060,7 @@ private:
+@@ -1067,11 +1067,7 @@ private:
  	rpl::variable<Media::OrderMode> _playerOrderMode;
  	bool _macWarnBeforeQuit = true;
  	std::vector<uint64> _accountsOrder;
@@ -26,5 +26,5 @@ index 7fdf581191..0b6386477a 100644
  		= HistoryView::DoubleClickQuickAction();
  	bool _translateButtonEnabled = false;
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,7 +1,7 @@
-From 7c96df63ffd37d362e6c28cb8959b37f9125924d Mon Sep 17 00:00:00 2001
+From ce670f7600f77437a26617e308542b1ae401d982 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
-Subject: [PATCH 11/13] fix(cmake): disable CMP0160 to workaround KF5 cmake
+Subject: [PATCH 11/15] fix(cmake): disable CMP0160 to workaround KF5 cmake
  errors
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
@@ -27,5 +27,5 @@ index fc7b239b03..d9f278a357 100644
  
  include(cmake/validate_special_target.cmake)
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
@@ -1,7 +1,7 @@
-From 0daca95d120c41ed75950d9398c8b2bc5289ae5b Mon Sep 17 00:00:00 2001
+From f81c30c19ef812aa4ecd900177aab8a616c2eef8 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 3 Jul 2025 19:04:36 -0700
-Subject: [PATCH 12/13] fix(credits_amount.h): include cmath for std::floor
+Subject: [PATCH 12/15] fix(credits_amount.h): include cmath for std::floor
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
@@ -22,5 +22,5 @@ index 098266d887..a5d329c417 100644
  #include "base/basic_types.h"
  
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
@@ -1,32 +1,38 @@
-From c1271847216ea61e19b5794601629e7f8d1acb63 Mon Sep 17 00:00:00 2001
+From bfe151bf126c0a7f91e6c6c1ab01bbfe83399bc0 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 28 Aug 2025 02:08:09 -0700
-Subject: [PATCH 13/13] fix(lib_webview): fix build with Qt 5
+Subject: [PATCH 13/15] fix(lib_webview): fix build with Qt 5
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
- .../linux/webview_linux_http_server.cpp       | 20 +++++++++++++++++++
- .../linux/webview_linux_webkitgtk.cpp         | 16 +++++++++++++++
- 2 files changed, 36 insertions(+)
+ .../linux/webview_linux_http_server.cpp       | 25 +++++++++++++++++++
+ .../linux/webview_linux_webkitgtk.cpp         | 16 ++++++++++++
+ 2 files changed, 41 insertions(+)
 
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
-index 77fd81908a..072c98ab8d 100644
+index 5439d2bb42..038d64a22b 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
-@@ -126,7 +126,12 @@ bool HttpServer::Private::processRedirect(
+@@ -128,8 +128,18 @@ bool HttpServer::Private::processRedirect(
  	request.setRawHeader("Referer", "http://desktop-app-resource/page.html");
  
  	const auto reply = manager.get(request);
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
- 	QObject::connect(reply, &QNetworkReply::finished, socket, [
+ 	connect(socket, &QObject::destroyed, reply, &QObject::deleteLater);
+ 	connect(reply, &QNetworkReply::finished, socket, [=] {
 +#else
 +	QMetaObject::Connection * const connection = new QMetaObject::Connection;
 +	*connection = QObject::connect(reply, &QNetworkReply::finished, socket, [
++		=,
++		replyGuard = std::make_unique<Guard>(crl::guard(reply, [=] {
++			reply->deleteLater();
++		}))
++	] {
 +#endif
- 		=, 
- 		replyGuard = std::make_unique<Guard>(crl::guard(reply, [=] {
- 			reply->deleteLater();
-@@ -155,7 +160,13 @@ bool HttpServer::Private::processRedirect(
+ 		(void) guard;
+ 		const auto input = reply->readAll();
+ 		socket->write("HTTP/1.1 200 OK\r\n");
+@@ -153,7 +163,13 @@ bool HttpServer::Private::processRedirect(
  		socket->write("Cache-Control: no-store\r\n");
  		socket->write("\r\n");
  		socket->write(input);
@@ -40,12 +46,12 @@ index 77fd81908a..072c98ab8d 100644
  
  	return true;
  }
-@@ -179,9 +190,18 @@ HttpServer::HttpServer(
+@@ -177,9 +193,18 @@ HttpServer::HttpServer(
  				socket,
  				&QObject::deleteLater);
  
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
- 			QObject::connect(socket, &QIODevice::readyRead, socket, [=] {
+ 			connect(socket, &QIODevice::readyRead, this, [=] {
  				_private->handleRequest(socket);
  			}, Qt::SingleShotConnection);
 +#else
@@ -60,10 +66,10 @@ index 77fd81908a..072c98ab8d 100644
  	});
  }
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
-index 5027a4c0db..44ab526918 100644
+index 7f88a2a21d..776eefce6b 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
-@@ -716,21 +716,37 @@ void Instance::dataRequest(
+@@ -751,21 +751,37 @@ void Instance::dataRequest(
  		socket->write("HTTP/1.1 ");
  		socket->write(partial ? "206 Partial Content\r\n" : "200 OK\r\n");
  
@@ -102,5 +108,5 @@ index 5027a4c0db..44ab526918 100644
  		}
  
 -- 
-2.51.0
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0014-Fix-desktop-file-name-on-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0014-Fix-desktop-file-name-on-Qt-5.patch
@@ -1,7 +1,7 @@
-From 0034f9f12ad34c108d8c031da993a8389e2d8d24 Mon Sep 17 00:00:00 2001
+From 056e8434e4c57cc788881d532aeb528e063fa0a1 Mon Sep 17 00:00:00 2001
 From: Kirikaze Chiyuki <me@chyk.ink>
 Date: Mon, 4 Aug 2025 09:53:59 +0800
-Subject: [PATCH] Fix desktop file name on Qt 5
+Subject: [PATCH 14/15] Fix desktop file name on Qt 5
 
 The target Qt version of Telegram Desktop code is Qt 6. commit 0534a2f aligns the behavior of desktopFileName to Qt 6. However, AOSC OS is still using Qt 5 to compile Telegram Desktop, so conditional compilation fixes are introduced in this patch.
 ---
@@ -12,7 +12,7 @@ The target Qt version of Telegram Desktop code is Qt 6. commit 0534a2f aligns th
  4 files changed, 54 insertions(+)
 
 diff --git a/Telegram/SourceFiles/platform/linux/integration_linux.cpp b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
-index 0bb06f550..1a223a122 100644
+index 9ea29d6ba8..c39ddf5fd1 100644
 --- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
 @@ -17,6 +17,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -36,7 +36,7 @@ index 0bb06f550..1a223a122 100644
  		set_application_id(appId);
  	}
 diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
-index f70a8959f..3e673314b 100644
+index 77f668fc71..7ad50f1135 100644
 --- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
 @@ -35,6 +35,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -63,10 +63,10 @@ index f70a8959f..3e673314b 100644
  	const auto counterSlice = std::min(Core::App().unreadBadge(), 9999);
  
 diff --git a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
-index f73fceab0..ca06e0b2f 100644
+index 176eb1de43..ff493c960c 100644
 --- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
-@@ -26,6 +26,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+@@ -25,6 +25,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
  #include "base/weak_ptr.h"
  #include "window/notifications_utilities.h"
  
@@ -74,7 +74,7 @@ index f73fceab0..ca06e0b2f 100644
  #include <QtCore/QBuffer>
  #include <QtCore/QVersionNumber>
  #include <QtGui/QGuiApplication>
-@@ -676,8 +677,13 @@ void Manager::Private::showNotification(
+@@ -680,8 +681,13 @@ void Manager::Private::showNotification(
  			"category",
  			GLib::Variant::new_string("im.received"));
  
@@ -89,18 +89,18 @@ index f73fceab0..ca06e0b2f 100644
  
  	const auto imageKey = GetImageKey();
 diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
-index 171080535..bc68355c0 100644
+index cc9e032979..275f906995 100644
 --- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
-@@ -27,6 +27,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+@@ -26,6 +26,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
  #include "base/platform/linux/base_linux_xcb_utilities.h"
  #endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION
  
 +#include <QtGlobal>
  #include <QtWidgets/QApplication>
  #include <QtWidgets/QSystemTrayIcon>
- #include <QtCore/QStandardPaths>
-@@ -236,9 +237,14 @@ bool GenerateDesktopFile(
+ #include <QtGui/QDesktopServices>
+@@ -235,9 +236,14 @@ bool GenerateDesktopFile(
  	if (!QDir(targetPath).exists()) QDir().mkpath(targetPath);
  
  	const auto sourceFile = u":/misc/org.telegram.desktop.desktop"_q;
@@ -115,7 +115,7 @@ index 171080535..bc68355c0 100644
  
  	const auto sourceText = [&] {
  		QFile source(sourceFile);
-@@ -400,9 +406,15 @@ bool GenerateServiceFile(bool silent = false) {
+@@ -399,9 +405,15 @@ bool GenerateServiceFile(bool silent = false) {
  	const auto targetPath = QStandardPaths::writableLocation(
  		QStandardPaths::GenericDataLocation) + u"/dbus-1/services/"_q;
  
@@ -131,7 +131,7 @@ index 171080535..bc68355c0 100644
  
  	DEBUG_LOG(("App Info: placing D-Bus service file to %1").arg(targetPath));
  	if (!QDir(targetPath).exists()) QDir().mkpath(targetPath);
-@@ -410,10 +422,18 @@ bool GenerateServiceFile(bool silent = false) {
+@@ -409,10 +421,18 @@ bool GenerateServiceFile(bool silent = false) {
  	auto target = GLib::KeyFile::new_();
  	constexpr auto group = "D-BUS Service";
  
@@ -150,7 +150,7 @@ index 171080535..bc68355c0 100644
  
  	QStringList exec;
  	exec.append(executable);
-@@ -583,10 +603,16 @@ void AutostartToggle(bool enabled, Fn<void(bool)> done) {
+@@ -631,10 +651,16 @@ void AutostartToggle(bool enabled, Fn<void(bool)> done) {
  			+ u"/autostart/"_q;
  
  		if (!enabled) {
@@ -167,7 +167,7 @@ index 171080535..bc68355c0 100644
  		}
  
  		return GenerateDesktopFile(
-@@ -694,7 +720,11 @@ void start() {
+@@ -742,7 +768,11 @@ void start() {
  				Core::Launcher::Instance().instanceHash().constData());
  		}
  
@@ -179,7 +179,7 @@ index 171080535..bc68355c0 100644
  	}());
  
  	LOG(("App ID: %1").arg(QGuiApplication::desktopFileName()));
-@@ -779,10 +809,17 @@ QImage DefaultApplicationIcon() {
+@@ -826,10 +856,17 @@ QImage DefaultApplicationIcon() {
  }
  
  QString ApplicationIconName() {
@@ -198,5 +198,5 @@ index 171080535..bc68355c0 100644
  }
  
 -- 
-2.50.1
+2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0015-fix-main_window_linux-include-QScreen-for-qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0015-fix-main_window_linux-include-QScreen-for-qt-5.patch
@@ -1,0 +1,24 @@
+From a3de6b504b6afd4d12546f2389c184d6b4967840 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Tue, 2 Dec 2025 16:46:34 +0800
+Subject: [PATCH 15/15] fix(main_window_linux): include QScreen for qt-5
+
+---
+ Telegram/SourceFiles/platform/linux/main_window_linux.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+index 7ad50f1135..b303a1b191 100644
+--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
++++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+@@ -39,6 +39,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include <QtCore/QSize>
+ #include <QtCore/QMimeData>
+ #include <QtGui/QWindow>
++#include <QtGui/QScreen>
+ #include <QtWidgets/QMenuBar>
+ #include <QtWidgets/QLineEdit>
+ #include <QtWidgets/QTextEdit>
+-- 
+2.52.0
+

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=6.1.3
+VER=6.3.4
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
-OWTVER=5c5c71258777d0196dbb3a09cc37d2f56ead28ab
-TDLIBVER=6dca40bdaac8b5e66c7a793727bf3f81e9711f70
+OWTVER=d067233a845e387e63d480d0d846da5fcb6a40cb
+TDLIBVER=f0d04d357c4ab2d4a7288e52dbeec3c2d9dd0a2d
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::1c6a531abf106d5f4b6d9179fc802f93cb8ab62630cc07e73d64688780125869 \
+CHKSUMS="sha256::7943671e3242bbc714c260e910333c5731ebef37e2c0310a563d4de6329fbfdd \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.3.4
    Track patches at AOSC-Tracking/telegram-desktop @ aosc/v6.3.4
    \(HEAD: a3de6b504b6afd4d12546f2389c184d6b4967840\).

Package(s) Affected
-------------------

- telegram-desktop: 6.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
