### PR TITLE
guvcview: update to 2.2.2

### DIFF
--- a/app-devices/guvcview/spec
+++ b/app-devices/guvcview/spec
@@ -1,5 +1,4 @@
-VER=2.1.0
-REL=1
+VER=2.2.2
 SRCS="tbl::https://sourceforge.net/projects/guvcview/files/source/guvcview-src-$VER.tar.bz2"
-CHKSUMS="sha256::3d93e4c9fab8d1a7a9bde1a6dbbf04d6cf9d347c134b5128b4586a1d90b63cfb"
+CHKSUMS="sha256::6a1b1348b99e79da957a0d9e237395a54757a09db7e0c0809f6c30668b69da3b"
 CHKUPDATE="anitya::id=10680"


### PR DESCRIPTION
Topic Description
-----------------

- guvcview: update to 2.2.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- guvcview: 2.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit guvcview
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
