### PR TITLE
systemd: remove OSC 8003 components to fix extraneous PROMPT_COMMAND output

### DIFF
--- a/app-admin/systemd/autobuild/beyond
+++ b/app-admin/systemd/autobuild/beyond
@@ -45,3 +45,18 @@ fi
 # In order to reduce confusion, create symlink to align the behavior
 abinfo "Creating symlink for systemd-sysctl to read /etc/sysctl.conf ..."
 ln -svf ../sysctl.conf "$PKGDIR"/etc/sysctl.d/99-sysctl.conf
+
+# FIXME: OSC;8003, as implemented in systemd 258, is known to cause
+# extraneous "garbage" output via systemd-osc-context on SecureCRT,
+# FinalShell, etc. This is a bug on those clients, but for the sake of
+# compatibility and for the current buggy versions to flush out, and that
+# there is "no terminal application is known that consumes these
+# sequences"... strip this feature for now.
+#
+# FIXME: There is no Meson option to disable OSC;8003.
+#
+# Link: https://systemd.io/OSC_CONTEXT/
+# Link: https://github.com/systemd/systemd/issues/39114
+abinfo "Removing OSC;8003 components that causes extraneous command prompt outputs with SecureCRT and more ..."
+rm -v "${PKGDIR}"/etc/profile.d/80-systemd-osc-context.sh
+rm -v "${PKGDIR}"/usr/lib/tmpfiles.d/20-systemd-osc-context.conf

--- a/app-admin/systemd/autobuild/patches/0001-AOSCOS-sleep.conf-AllowHibernation-no-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0001-AOSCOS-sleep.conf-AllowHibernation-no-by-default.patch
@@ -1,7 +1,7 @@
 From b8b069ac1c9114b4e857f477c217d0c7e289283d Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Tue, 11 Apr 2023 18:04:25 -0700
-Subject: [PATCH 1/4] AOSCOS: sleep.conf: AllowHibernation=no by default
+Subject: [PATCH 1/5] AOSCOS: sleep.conf: AllowHibernation=no by default
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---

--- a/app-admin/systemd/autobuild/patches/0002-AOSCOS-fix-do-not-tint-terminal-by-default.patch
+++ b/app-admin/systemd/autobuild/patches/0002-AOSCOS-fix-do-not-tint-terminal-by-default.patch
@@ -1,7 +1,7 @@
 From d8d9838f2355db420a49fbd8c1f022a5b4c81f85 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 12 Aug 2024 22:19:25 +0800
-Subject: [PATCH 2/4] AOSCOS: fix: do not tint terminal by default
+Subject: [PATCH 2/5] AOSCOS: fix: do not tint terminal by default
 
 Let's face it, it's weird and we have much better ways to notify the user
 about a system running in a container. Change the default behavior (tint by

--- a/app-admin/systemd/autobuild/patches/0003-AOSCOS-exec-credential-try-forking-again-without-CLO.patch
+++ b/app-admin/systemd/autobuild/patches/0003-AOSCOS-exec-credential-try-forking-again-without-CLO.patch
@@ -1,7 +1,8 @@
-From 916ea12432b853856d4781d8a8f9ff47dbf326e2 Mon Sep 17 00:00:00 2001
+From 0367e930a02a80e934f94247aa3dac13ba59a7e9 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 28 Dec 2024 16:06:22 +0800
-Subject: [PATCH 3/4] exec-credential: try forking again without CLONE_NEWNS
+Subject: [PATCH 3/5] AOSCOS: exec-credential: try forking again without
+ CLONE_NEWNS
 
 QEMU user emulation currently does not support CLONE_NEWS, fork()ing
 with it will result in an EINVAL, rendering the system unbootable with

--- a/app-admin/systemd/autobuild/patches/0004-AOSCOS-allow-all-sysrq-keys-except-memory-dump.patch
+++ b/app-admin/systemd/autobuild/patches/0004-AOSCOS-allow-all-sysrq-keys-except-memory-dump.patch
@@ -1,7 +1,7 @@
-From 7e1f363f4a0540cfbab63f5704f67573804fa621 Mon Sep 17 00:00:00 2001
+From 3d8db0697d3808949c56d9427b293b4bd6a4ed66 Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Tue, 2 Sep 2025 03:33:38 +0000
-Subject: [PATCH 4/4] AOSCOS: allow all sysrq keys except memory dump
+Subject: [PATCH 4/5] AOSCOS: allow all sysrq keys except memory dump
 
 so our user can debug and recover from a broken system even when they didn't know the system would break.
 ---

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,8 +1,7 @@
 VER=258.2
 
 # Use this for stable/main branch releases.
-#REL=2
-# Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- systemd: remove OSC;8003 components to fix extraneous PROMPT_COMMAND output
    Link: https://github.com/systemd/systemd/issues/39114

Package(s) Affected
-------------------

- systemd: 1:258.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
