### PR TITLE
goreleaser: update to 2.12.7

### DIFF
--- a/app-containers/docker/autobuild/build
+++ b/app-containers/docker/autobuild/build
@@ -15,8 +15,8 @@ case "$VERSION" in
 	refs/pull/*) VERSION=pr-$(echo "$VERSION" | grep -o '[0-9]\+') ;;
 esac
 
-DOCKER_CE_GO_LDFLAGS="-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" -X \"github.com/docker/docker/dockerversion.Version=${VERSION}\""
-DOCKER_CLI_GO_LDFLAGS="-X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\" -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
+DOCKER_CE_GO_LDFLAGS="-X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" -X \"github.com/docker/docker/dockerversion.Version=${PKGVER}\""
+DOCKER_CLI_GO_LDFLAGS="-X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\" -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\" -X \"github.com/docker/cli/cli/version.Version=${PKGVER}\""
 
 # Fedora: Build docker-proxy (libnetwork).
 abinfo "docker-proxy (libnetwork): Building ..."

--- a/lang-golang/goreleaser/autobuild/defines
+++ b/lang-golang/goreleaser/autobuild/defines
@@ -4,5 +4,7 @@ PKGDEP="glibc"
 BUILDDEP="go"
 PKGDES="A tool for building and releasing Go projects"
 
+ABTYPE=gomod
+GO_LDFLAGS=("-X main.version=$PKGVER -X main.builtBy=AOSC")
 # FIXME: Autobuild does not yet support splitting out debug symbol from Go executables
 ABSPLITDBG=0

--- a/lang-golang/goreleaser/spec
+++ b/lang-golang/goreleaser/spec
@@ -1,5 +1,4 @@
-VER=2.8.2
-REL=2
-SRCS="git::commit=tags/v$VER::https://github.com/goreleaser/goreleaser.git"
+VER=2.12.7
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/goreleaser/goreleaser.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374129"


### PR DESCRIPTION
Topic Description
-----------------

- goreleaser: update to 2.12.7
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- goreleaser: 2.12.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit goreleaser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
