### PR TITLE
libpng: update to 1.6.52

### DIFF
--- a/runtime-imaging/libpng/spec
+++ b/runtime-imaging/libpng/spec
@@ -1,4 +1,4 @@
-VER=1.6.44
+VER=1.6.52
 SRCS="git::commit=tags/v$VER::https://github.com/pnggroup/libpng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1705"


### PR DESCRIPTION
Topic Description
-----------------

- libpng: update to 1.6.52
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libpng: 1.6.52

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
