### PR TITLE
baobab: update to 49.1

### DIFF
--- a/desktop-gnome/baobab/autobuild/defines
+++ b/desktop-gnome/baobab/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=baobab
 PKGSEC=gnome
-PKGDEP="dconf desktop-file-utils gsettings-desktop-schemas gtk-4 \
-        hicolor-icon-theme libadwaita librsvg"
-BUILDDEP="appstream-glib gobject-introspection gtk-doc intltool itstool vala"
-PKGDES="A graphical directory tree analyzer"
+PKGDEP="cairo glib glibc graphene gtk-4 libadwaita pango"
+BUILDDEP="vala"
+PKGDES="Graphical directory tree analyzer"
+
+ABTYPE=meson

--- a/desktop-gnome/baobab/spec
+++ b/desktop-gnome/baobab/spec
@@ -1,4 +1,4 @@
-VER=42.0
+VER=49.1
 SRCS="https://download.gnome.org/sources/baobab/${VER%.*}/baobab-$VER.tar.xz"
-CHKSUMS="sha256::4b1aabe6bab1582b3fea79a2829bce7f2415bb6e5062f25357aeedd5317a50dc"
+CHKSUMS="sha256::6243c92002be7e91f5decd249612face2a4a12d3742afd88b086a94b875dffe0"
 CHKUPDATE="anitya::id=10907"


### PR DESCRIPTION
Topic Description
-----------------

- baobab: update to 49.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- baobab: 49.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit baobab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
