### PR TITLE
libpaper: update to 2.2.6

### DIFF
--- a/runtime-productivity/libpaper/spec
+++ b/runtime-productivity/libpaper/spec
@@ -1,4 +1,4 @@
-VER=2.2.5
+VER=2.2.6
 SRCS="tbl::https://github.com/rrthomas/libpaper/releases/download/v$VER/libpaper-$VER.tar.gz"
-CHKSUMS="sha256::7be50974ce0df0c74e7587f10b04272cd53fd675cb6a1273ae1cc5c9cc9cab09"
+CHKSUMS="sha256::500d39dc58768ee09688738c8b5bfe07640ba2fd6c25a6dc78810eb69c719e93"
 CHKUPDATE="anitya::id=15136"


### PR DESCRIPTION
Topic Description
-----------------

- libpaper: update to 2.2.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libpaper: 2.2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpaper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
