### PR TITLE
seahorse: update to 47.0.1

### DIFF
--- a/desktop-gnome/seahorse/autobuild/defines
+++ b/desktop-gnome/seahorse/autobuild/defines
@@ -1,16 +1,19 @@
 PKGNAME=seahorse
 PKGSEC=gnome
-PKGDEP="dconf desktop-file-utils gcr gpgme gtk-3 hicolor-icon-theme libhandy \
-        libsecret libsoup openldap"
-BUILDDEP="appstream-glib gobject-introspection intltool vala yelp-tools"
-PKGDES="A GPG key manager for GNOME"
+PKGDEP="avahi dconf desktop-file-utils gcc-runtime gcr gdk-pixbuf glib glibc \
+        gpgme gtk-3 libhandy libpwquality libsecret libsoup-3 openldap"
+BUILDDEP="appstream appstream-glib gobject-introspection intltool vala \
+          yelp-tools"
+PKGDES="GPG key manager for GNOME"
 
-MESON_AFTER="-Dhelp=true \
-             -Dpgp-support=true \
-             -Dcheck-compatible-gpg=false \
-             -Dpkcs11-support=true \
-             -Dkeyservers-support=true \
-             -Dhkp-support=true \
-             -Dldap-support=true \
-             -Dkey-sharing=true \
-             -Dmanpage=true"
+MESON_AFTER=(
+    '-Dhelp=true'
+    '-Dpgp-support=true'
+    '-Dcheck-compatible-gpg=false'
+    '-Dpkcs11-support=true'
+    '-Dkeyservers-support=true'
+    '-Dhkp-support=true'
+    '-Dldap-support=true'
+    '-Dkey-sharing=true'
+    '-Dmanpage=true'
+)

--- a/desktop-gnome/seahorse/spec
+++ b/desktop-gnome/seahorse/spec
@@ -1,5 +1,4 @@
-VER=42.0
-REL=1
+VER=47.0.1
 SRCS="https://download.gnome.org/sources/seahorse/${VER:0:2}/seahorse-${VER/\~/.}.tar.xz"
-CHKSUMS="sha256::c50cacebf8de7a7e2e5f1dae0b98232114741296abe8d543e3923d62a153d630"
+CHKSUMS="sha256::9c1917e4a61f7febb787849ce36ce717fce706c346880b991d056d54dadbcacc"
 CHKUPDATE="anitya::id=9548"


### PR DESCRIPTION
Topic Description
-----------------

- seahorse: update to 47.0.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- seahorse: 47.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit seahorse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
