### PR TITLE
Go: update to 1.25.5

### DIFF
--- a/app-admin/conmon/spec
+++ b/app-admin/conmon/spec
@@ -1,5 +1,5 @@
 VER=2.1.13
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containers/conmon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=96793"

--- a/app-admin/gocryptfs/spec
+++ b/app-admin/gocryptfs/spec
@@ -1,5 +1,5 @@
 VER=2.6.1
-REL=2
+REL=3
 SRCS="tbl::https://github.com/rfjakob/gocryptfs/releases/download/v${VER}/gocryptfs_v${VER}_src-deps.tar.gz"
 CHKSUMS="sha256::9a966c1340a1a1d92073091643687b1205c46b57017c5da2bf7e97e3f5729a5a"
 CHKUPDATE="anitya::id=21085"

--- a/app-admin/ignition/spec
+++ b/app-admin/ignition/spec
@@ -2,4 +2,4 @@ VER=2.20.0
 SRCS="git::commit=tags/v${VER}::https://github.com/coreos/ignition.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328236"
-REL=3
+REL=4

--- a/app-admin/opentofu/spec
+++ b/app-admin/opentofu/spec
@@ -1,5 +1,5 @@
 VER=1.10.6
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER}::https://github.com/opentofu/opentofu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371292"

--- a/app-admin/prometheus-node-exporter/spec
+++ b/app-admin/prometheus-node-exporter/spec
@@ -1,5 +1,5 @@
 VER=1.9.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER}::https://github.com/prometheus/node_exporter.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=98081"

--- a/app-admin/rootlesskit/spec
+++ b/app-admin/rootlesskit/spec
@@ -1,4 +1,5 @@
 VER=2.3.5
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/rootless-containers/rootlesskit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369032"

--- a/app-admin/runc/spec
+++ b/app-admin/runc/spec
@@ -1,4 +1,5 @@
 VER=1.4.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/opencontainers/runc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7462"

--- a/app-admin/snapd/spec
+++ b/app-admin/snapd/spec
@@ -2,4 +2,4 @@ VER=2.65.1
 SRCS="tbl::https://github.com/snapcore/snapd/releases/download/$VER/snapd_$VER.vendor.tar.xz"
 CHKSUMS="sha256::826f8fa8021400326c7be40ea2d45c2d3f80288b41effba21cd5677fde5c2db0"
 CHKUPDATE="anitya::id=12370"
-REL=3
+REL=4

--- a/app-containers/buildah/spec
+++ b/app-containers/buildah/spec
@@ -1,5 +1,5 @@
 VER=1.40.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/containers/buildah"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14974"

--- a/app-containers/containerd/spec
+++ b/app-containers/containerd/spec
@@ -1,4 +1,5 @@
 VER=2.2.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/containerd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16460"

--- a/app-containers/cri-o/spec
+++ b/app-containers/cri-o/spec
@@ -1,4 +1,5 @@
 VER=1.34.2
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/cri-o/cri-o.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12687"

--- a/app-containers/docker-buildx/spec
+++ b/app-containers/docker-buildx/spec
@@ -1,5 +1,5 @@
 VER=0.22.0
-REL=3
+REL=4
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/docker/buildx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=325723"

--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,4 +1,5 @@
 VER=5.0.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/docker/compose"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6185"

--- a/app-containers/docker/spec
+++ b/app-containers/docker/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=29.1.2
+REL=1
 # Find tini version at:
 #
 # https://github.com/moby/moby/blob/v$UPSTREAM_VER/hack/dockerfile/install/tini.installer

--- a/app-containers/helm/spec
+++ b/app-containers/helm/spec
@@ -1,5 +1,5 @@
 VER=3.17.1
-REL=2
+REL=3
 SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/helm/helm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15046"

--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,5 @@
 VER=6.19.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"

--- a/app-containers/kind/spec
+++ b/app-containers/kind/spec
@@ -1,5 +1,5 @@
 VER=0.30.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/kubernetes-sigs/kind"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379132"

--- a/app-containers/kubernetes/01-kubectl/defines
+++ b/app-containers/kubernetes/01-kubectl/defines
@@ -4,4 +4,4 @@ PKGDEP="glibc"
 BUILDDEP="go"
 PKGSEC="admin"
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el)"

--- a/app-containers/kubernetes/02-kubeadm/defines
+++ b/app-containers/kubernetes/02-kubeadm/defines
@@ -4,4 +4,4 @@ PKGDEP="glibc"
 BUILDDEP="go"
 PKGSEC="admin"
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el)"

--- a/app-containers/kubernetes/03-kubelet/defines
+++ b/app-containers/kubernetes/03-kubelet/defines
@@ -4,4 +4,4 @@ PKGDEP="containerd cni-plugins"
 BUILDDEP="go"
 PKGSEC="admin"
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el)"

--- a/app-containers/kubernetes/spec
+++ b/app-containers/kubernetes/spec
@@ -1,5 +1,5 @@
 VER=1.34.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/kubernetes/kubernetes"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10954"

--- a/app-containers/minikube/spec
+++ b/app-containers/minikube/spec
@@ -1,5 +1,5 @@
 VER=1.35.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/kubernetes/minikube"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=320530"

--- a/app-containers/nerdctl/spec
+++ b/app-containers/nerdctl/spec
@@ -1,4 +1,5 @@
 VER=2.2.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/nerdctl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="aniya::id=242901"

--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=5.7.0
+REL=1
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile

--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,5 +1,5 @@
 VER=1.19.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9216"

--- a/app-containers/talosctl/spec
+++ b/app-containers/talosctl/spec
@@ -1,5 +1,5 @@
 VER=1.10.5
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/siderolabs/talos"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379061"

--- a/app-devel/buf/spec
+++ b/app-devel/buf/spec
@@ -1,4 +1,5 @@
 VER=1.61.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/bufbuild/buf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328143"

--- a/app-devel/cf-tool/spec
+++ b/app-devel/cf-tool/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
-REL=11
+REL=12
 SRCS="git::commit=tags/v$VER::https://github.com/xalanq/cf-tool"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235020"

--- a/app-devel/gh/spec
+++ b/app-devel/gh/spec
@@ -1,4 +1,5 @@
 VER=2.83.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/cli/cli"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235195"

--- a/app-devel/git-lfs/spec
+++ b/app-devel/git-lfs/spec
@@ -1,5 +1,5 @@
 VER=3.6.1
-REL=2
+REL=3
 SRCS=git::commit=tags/v${VER}::https://github.com/git-lfs/git-lfs.git
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11551"

--- a/app-devel/glab/spec
+++ b/app-devel/glab/spec
@@ -1,4 +1,5 @@
 VER=1.76.0
+REL=1
 # Note: copy-repo is required to generate docs
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://gitlab.com/gitlab-org/cli.git"
 CHKSUMS="SKIP"

--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,4 +1,5 @@
 VER=18.0.0
+REL=1
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
 CHKSUMS="sha256::c773b74114d1fbca66c81b8fb799892827e7e1542491ed459aaad279e0253973"
 CHKUPDATE="anitya::id=4136"

--- a/app-devel/tea/spec
+++ b/app-devel/tea/spec
@@ -1,5 +1,5 @@
 VER=0.10.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://gitea.com/gitea/tea"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377482"

--- a/app-devel/yq/spec
+++ b/app-devel/yq/spec
@@ -1,4 +1,5 @@
 VER=4.49.2
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/mikefarah/yq.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=303696"

--- a/app-devices/android-platform-tools/spec
+++ b/app-devices/android-platform-tools/spec
@@ -1,5 +1,5 @@
 VER=35.0.2
-REL=5
+REL=6
 SRCS="tbl::https://github.com/nmeum/android-tools/releases/download/$VER/android-tools-$VER.tar.xz"
 CHKSUMS="sha256::d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097"
 CHKUPDATE="anitya::id=226905"

--- a/app-doc/go-md2man/spec
+++ b/app-doc/go-md2man/spec
@@ -1,5 +1,5 @@
 VER=2.0.6
-REL=2
+REL=3
 SRCS="git::commit=tags/v${VER}::https://github.com/cpuguy83/go-md2man"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14461"

--- a/app-editors/liteide/spec
+++ b/app-editors/liteide/spec
@@ -1,5 +1,5 @@
 VER=38.3
-REL=6
+REL=7
 SRCS="git::commit=tags/x$VER::https://github.com/visualfc/liteide.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227233"

--- a/app-editors/micro/spec
+++ b/app-editors/micro/spec
@@ -2,4 +2,4 @@ VER=2.0.14
 SRCS="git::commit=tags/v$VER::https://github.com/zyedidia/micro"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19017"
-REL=3
+REL=4

--- a/app-multimedia/musicfox/spec
+++ b/app-multimedia/musicfox/spec
@@ -1,4 +1,5 @@
 VER=4.7.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/go-musicfox/go-musicfox"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376106"

--- a/app-multimedia/navidrome/spec
+++ b/app-multimedia/navidrome/spec
@@ -1,4 +1,5 @@
 VER=0.59.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/navidrome/navidrome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326646"

--- a/app-network/ayano/spec
+++ b/app-network/ayano/spec
@@ -1,5 +1,5 @@
 VER=0.1.4
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/taoky/ayano.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378730"

--- a/app-network/chisel/spec
+++ b/app-network/chisel/spec
@@ -1,5 +1,5 @@
 VER=1.10.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/jpillora/chisel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=135401"

--- a/app-network/dnscontrol/spec
+++ b/app-network/dnscontrol/spec
@@ -1,5 +1,5 @@
 VER=4.26.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/StackExchange/dnscontrol.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375553"

--- a/app-network/dnscrypt/spec
+++ b/app-network/dnscrypt/spec
@@ -1,5 +1,5 @@
 VER=2.1.7
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/DNSCrypt/dnscrypt-proxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15546"

--- a/app-network/doggo/spec
+++ b/app-network/doggo/spec
@@ -1,4 +1,5 @@
 VER=1.1.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mr-karan/doggo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373317"

--- a/app-network/geoipupdate/spec
+++ b/app-network/geoipupdate/spec
@@ -1,5 +1,5 @@
 VER=7.1.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/maxmind/geoipupdate"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230971"

--- a/app-network/mosdns/spec
+++ b/app-network/mosdns/spec
@@ -1,5 +1,5 @@
 VER=5.3.3
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/IrineSistiana/mosdns.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377076"

--- a/app-network/nali/spec
+++ b/app-network/nali/spec
@@ -2,4 +2,4 @@ VER=0.8.1
 SRCS="git::commit=tags/v$VER::https://github.com/zu1k/nali.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376443"
-REL=3
+REL=4

--- a/app-network/netbird/spec
+++ b/app-network/netbird/spec
@@ -1,4 +1,5 @@
 VER=0.59.10
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/netbirdio/netbird.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383363"

--- a/app-network/nexttrace/spec
+++ b/app-network/nexttrace/spec
@@ -1,4 +1,5 @@
 VER=1.5.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/nxtrace/NTrace-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=356726"

--- a/app-network/popub/spec
+++ b/app-network/popub/spec
@@ -1,5 +1,5 @@
 VER=0+git20210814
-REL=9
+REL=10
 SRCS="git::commit=a96c877dbf168309d73525a7987dd0d26e5c03cc::https://github.com/m13253/popub"
 CHKSUMS="SKIP"
 # FIXME: Upstream has no tag.

--- a/app-network/q/spec
+++ b/app-network/q/spec
@@ -1,4 +1,5 @@
 VER=0.19.11
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/natesales/q.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376437"

--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,4 +1,5 @@
 VER=2.0.11
+REL=1
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
 CHKSUMS="sha256::a9656cded5048bac4937e7046b1b4d5fb6d78bca01df2eed495335be6d4ab643"
 CHKUPDATE="anitya::id=11814"

--- a/app-network/tailscale/spec
+++ b/app-network/tailscale/spec
@@ -1,4 +1,5 @@
 VER=1.90.9
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/tailscale/tailscale"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141585"

--- a/app-proxy/clash/spec
+++ b/app-proxy/clash/spec
@@ -1,5 +1,5 @@
 VER=1.18.0
-REL=8
+REL=9
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/clash-1.18.0.tar.gz"
 CHKSUMS="sha256::139794f50d3d94f438bab31a993cf25d7cbdf8ca8e034f3071e0dd0014069692"
 CHKUPDATE="anitya::id=211719"

--- a/app-proxy/cloudflared/spec
+++ b/app-proxy/cloudflared/spec
@@ -1,4 +1,5 @@
 VER=2025.11.1
+REL=1
 # copy repo required by auto version detection logic in makefile
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/cloudflare/cloudflared"
 CHKSUMS="SKIP"

--- a/app-proxy/dae/spec
+++ b/app-proxy/dae/spec
@@ -1,5 +1,5 @@
 VER=1.0.0
-REL=2
+REL=3
 SRCS="tbl::https://github.com/daeuniverse/dae/releases/download/v$VER/dae-full-src.zip"
 CHKSUMS="sha256::d933b93fc30cb4e9941cbb1be23557bd6caa2a33af212883505fec435d06fc13"
 CHKUPDATE="anitya::id=369479"

--- a/app-proxy/daed/spec
+++ b/app-proxy/daed/spec
@@ -1,4 +1,5 @@
 VER=1.5.1
+REL=1
 SRCS="tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/daed-full-src.zip \
       tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/web.zip"
 CHKSUMS="sha256::557157d5e95142aad4ec7f5127f75ad797cd94755678fa24990ccfdf38a9ed81 \

--- a/app-proxy/flclash/spec
+++ b/app-proxy/flclash/spec
@@ -2,4 +2,4 @@ VER=0.8.90
 SRCS="git::commit=tags/aosc/v$VER::https://github.com/AOSC-Tracking/FlClash"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383523"
-REL=2
+REL=3

--- a/app-proxy/frp/spec
+++ b/app-proxy/frp/spec
@@ -1,5 +1,5 @@
 VER=0.65.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/fatedier/frp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230969"

--- a/app-proxy/gost/spec
+++ b/app-proxy/gost/spec
@@ -1,4 +1,5 @@
 VER=3.2.6
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/go-gost/gost"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230972"

--- a/app-proxy/graftcp/spec
+++ b/app-proxy/graftcp/spec
@@ -2,4 +2,4 @@ VER=0.7.4
 SRCS="git::commit=v$VER::https://github.com/hmgle/graftcp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230973"
-REL=3
+REL=4

--- a/app-proxy/hysteria/spec
+++ b/app-proxy/hysteria/spec
@@ -1,5 +1,5 @@
 VER=2.6.3
-REL=1
+REL=2
 SRCS="git::commit=tags/app/v$VER::https://github.com/apernet/hysteria"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371975"

--- a/app-proxy/kcptun/spec
+++ b/app-proxy/kcptun/spec
@@ -1,5 +1,5 @@
 VER=20241227
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/xtaci/kcptun"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14970"

--- a/app-proxy/kubo/spec
+++ b/app-proxy/kubo/spec
@@ -1,4 +1,5 @@
 VER=0.38.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ipfs/kubo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328587"

--- a/app-proxy/mihomo/spec
+++ b/app-proxy/mihomo/spec
@@ -1,4 +1,5 @@
 VER=1.19.16
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/MetaCubeX/mihomo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371845"

--- a/app-proxy/obfs4proxy/spec
+++ b/app-proxy/obfs4proxy/spec
@@ -1,5 +1,5 @@
 VER=0.0.14
-REL=7
+REL=8
 SRCS="git::commit=tags/obfs4proxy-$VER::https://gitlab.com/yawning/obfs4.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=195186"

--- a/app-proxy/sing-box/spec
+++ b/app-proxy/sing-box/spec
@@ -1,4 +1,5 @@
 VER=1.12.12
+REL=1
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"

--- a/app-proxy/v2ray/spec
+++ b/app-proxy/v2ray/spec
@@ -1,5 +1,5 @@
 VER=5.41.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/v2fly/v2ray-core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=134851"

--- a/app-proxy/v2raya/spec
+++ b/app-proxy/v2raya/spec
@@ -1,5 +1,5 @@
 VER=2.2.7.3
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/v2rayA/v2rayA.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326097"

--- a/app-proxy/xray-plugin/spec
+++ b/app-proxy/xray-plugin/spec
@@ -2,4 +2,4 @@ VER=1.8.24
 SRCS="git::commit=tags/v$VER::https://github.com/teddysun/xray-plugin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372439"
-REL=4
+REL=5

--- a/app-proxy/xray/spec
+++ b/app-proxy/xray/spec
@@ -1,5 +1,5 @@
 VER=25.8.31
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/XTLS/Xray-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231005"

--- a/app-utils/automatic-component-toolkit/spec
+++ b/app-utils/automatic-component-toolkit/spec
@@ -1,5 +1,5 @@
 VER="1.6.0"
-REL=8
+REL=9
 SRCS="git::commit=tags/v$VER::https://github.com/Autodesk/AutomaticComponentToolkit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376780"

--- a/app-utils/chezmoi/spec
+++ b/app-utils/chezmoi/spec
@@ -1,4 +1,5 @@
 VER=2.68.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/twpayne/chezmoi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232604"

--- a/app-utils/cliphist/spec
+++ b/app-utils/cliphist/spec
@@ -1,5 +1,5 @@
 VER=0.7.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/sentriz/cliphist.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242870"

--- a/app-utils/croc/spec
+++ b/app-utils/croc/spec
@@ -1,4 +1,5 @@
 VER=10.2.7
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/schollz/croc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=350834"

--- a/app-utils/crush/spec
+++ b/app-utils/crush/spec
@@ -1,4 +1,5 @@
 VER=0.19.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/crush"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=382294"

--- a/app-utils/direnv/spec
+++ b/app-utils/direnv/spec
@@ -2,4 +2,4 @@ VER=2.35.0
 SRCS="git::commit=tags/v$VER::https://github.com/direnv/direnv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11598"
-REL=3
+REL=4

--- a/app-utils/dive/spec
+++ b/app-utils/dive/spec
@@ -2,4 +2,4 @@ VER=0.13.1
 SRCS="git::commit=tags/v$VER::https://github.com/wagoodman/dive"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=385450"
-REL=2
+REL=3

--- a/app-utils/duf/spec
+++ b/app-utils/duf/spec
@@ -1,4 +1,5 @@
 VER=0.9.1
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/muesli/duf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138143"

--- a/app-utils/fan2go-tui/spec
+++ b/app-utils/fan2go-tui/spec
@@ -1,5 +1,5 @@
 VER=0.2.1
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/markusressel/fan2go-tui.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376895"

--- a/app-utils/fan2go/spec
+++ b/app-utils/fan2go/spec
@@ -1,4 +1,5 @@
 VER=0.11.1
+REL=1
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/markusressel/fan2go.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376893"

--- a/app-utils/fscan/spec
+++ b/app-utils/fscan/spec
@@ -2,4 +2,4 @@ VER=2.0.0
 SRCS="git::commit=tags/$VER::https://github.com/shadow1ng/fscan.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375841"
-REL=3
+REL=4

--- a/app-utils/fzf/spec
+++ b/app-utils/fzf/spec
@@ -1,5 +1,5 @@
 VER=0.66.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/junegunn/fzf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15856"

--- a/app-utils/gdu/spec
+++ b/app-utils/gdu/spec
@@ -1,4 +1,5 @@
 VER=5.32.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/dundee/gdu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141586"

--- a/app-utils/glow/spec
+++ b/app-utils/glow/spec
@@ -1,5 +1,5 @@
 VER=2.1.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/glow"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376121"

--- a/app-utils/gum/spec
+++ b/app-utils/gum/spec
@@ -1,5 +1,5 @@
 VER=0.16.2
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/gum"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=290984"

--- a/app-utils/httpx-go/spec
+++ b/app-utils/httpx-go/spec
@@ -1,5 +1,5 @@
 VER=1.7.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/httpx.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328160"

--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,5 @@
 VER=0.43.1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
 CHKSUMS="sha256::44a875e34e6a5f9b8f599b25b0796c07a1506fec2b2310573e03077ef1ae159f"
 CHKUPDATE="anitya::id=17405"

--- a/app-utils/miller/spec
+++ b/app-utils/miller/spec
@@ -1,5 +1,5 @@
 VER=6.15.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/johnkerl/miller"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20574"

--- a/app-utils/mods/spec
+++ b/app-utils/mods/spec
@@ -1,5 +1,5 @@
 VER=1.8.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/mods"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=382296"

--- a/app-utils/nuclei/spec
+++ b/app-utils/nuclei/spec
@@ -1,5 +1,5 @@
 VER=3.4.2
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/nuclei.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=106029"

--- a/app-utils/nwg-look/spec
+++ b/app-utils/nwg-look/spec
@@ -1,5 +1,5 @@
 VER=1.0.6
-REL=3
+REL=4
 SRCS="git::commit=tags/v${VER}::https://github.com/nwg-piotr/nwg-look.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378332"

--- a/app-utils/pcstat/spec
+++ b/app-utils/pcstat/spec
@@ -1,5 +1,5 @@
 VER=0.0.2
-REL=8
+REL=9
 SRCS="git::commit=tags/v${VER}::https://github.com/tobert/pcstat.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231629"

--- a/app-utils/restic/spec
+++ b/app-utils/restic/spec
@@ -1,5 +1,5 @@
 VER=0.17.3
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/restic/restic"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16643"

--- a/app-utils/skate/spec
+++ b/app-utils/skate/spec
@@ -1,5 +1,5 @@
 VER=1.0.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/skate"
 CHKSUMS="SKIP"
 CHKUPDATE="anitay::id=382298"

--- a/app-utils/vhs/spec
+++ b/app-utils/vhs/spec
@@ -1,5 +1,5 @@
 VER=0.10.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/vhs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377764"

--- a/app-vcs/git-credential-oauth/spec
+++ b/app-vcs/git-credential-oauth/spec
@@ -1,5 +1,5 @@
 VER=0.16.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/hickford/git-credential-oauth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301894"

--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,4 +1,5 @@
 VER=1.25.1
+REL=1
 SRCS="tbl::https://github.com/go-gitea/gitea/releases/download/v$VER/gitea-src-$VER.tar.gz"
 CHKSUMS="sha256::127f9d6efce69cc9cbe92b6cf84b98709b458407f9b21c6d15b007d68b656148"
 CHKUPDATE="anitya::id=13537"

--- a/app-vcs/lazygit/spec
+++ b/app-vcs/lazygit/spec
@@ -1,4 +1,5 @@
 VER=0.56.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/jesseduffield/lazygit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268930"

--- a/app-web/adguardhome/spec
+++ b/app-web/adguardhome/spec
@@ -1,4 +1,5 @@
 VER=0.107.69
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301521"

--- a/app-web/anubis/spec
+++ b/app-web/anubis/spec
@@ -1,5 +1,5 @@
 VER=1.21.3
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/TecharoHQ/anubis"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377999"

--- a/app-web/caddy/spec
+++ b/app-web/caddy/spec
@@ -1,5 +1,5 @@
 VER=2.10.2
-REL=2
+REL=3
 SRCS="tbl::https://github.com/caddyserver/caddy/releases/download/v${VER}/caddy_${VER}_buildable-artifact.tar.gz"
 CHKSUMS="sha256::f25ba47638690436a15b9f60b22c95deb560ab16105eb7382fb2dacd77fb819d"
 CHKUPDATE="anitya::id=15601"

--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,5 +1,5 @@
 VER=11.0.0
-REL=2
+REL=3
 # Note: copy-repo required by auto version detection
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://codeberg.org/forgejo/forgejo"
 CHKSUMS="SKIP"

--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -1,4 +1,5 @@
 VER=0.152.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/gohugoio/hugo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12959"

--- a/app-web/lego/spec
+++ b/app-web/lego/spec
@@ -1,4 +1,5 @@
 VER=4.28.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/go-acme/lego"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20764"

--- a/app-web/openlist/spec
+++ b/app-web/openlist/spec
@@ -1,5 +1,5 @@
 VER=4.1.4
-REL=1
+REL=2
 SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/OpenListTeam/OpenList \
       tbl::https://github.com/OpenListTeam/OpenList-Frontend/releases/download/v4.1.4/openlist-frontend-dist-v4.1.4.tar.gz"
 CHKSUMS="SKIP \

--- a/app-web/proton-bridge/spec
+++ b/app-web/proton-bridge/spec
@@ -1,5 +1,5 @@
 VER=3.21.2
-REL=5
+REL=6
 SRCS="git::copy-repo=true;submodule=false;commit=tags/v$VER::https://github.com/ProtonMail/proton-bridge"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231962"

--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -1,4 +1,5 @@
 VER=1.72.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"

--- a/app-web/xcaddy/spec
+++ b/app-web/xcaddy/spec
@@ -1,5 +1,5 @@
 VER=0.4.5
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/caddyserver/xcaddy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376781"

--- a/groups/go-rebuilds
+++ b/groups/go-rebuilds
@@ -3,10 +3,12 @@ app-admin/gocryptfs
 app-admin/ignition
 app-admin/opentofu
 app-admin/prometheus-node-exporter
+app-admin/rootlesskit
 app-admin/runc
 app-admin/snapd
 app-containers/buildah
 app-containers/containerd
+app-containers/cri-o
 app-containers/docker
 app-containers/docker-buildx
 app-containers/docker-compose
@@ -72,6 +74,7 @@ app-utils/croc
 app-utils/crush
 app-utils/direnv
 app-utils/dive
+app-utils/duf
 app-utils/fan2go
 app-utils/fan2go-tui
 app-utils/fscan

--- a/lang-golang/delve/spec
+++ b/lang-golang/delve/spec
@@ -1,5 +1,5 @@
 VER=1.24.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/go-delve/delve"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=40149"

--- a/lang-golang/dep/spec
+++ b/lang-golang/dep/spec
@@ -1,5 +1,5 @@
 VER=0.5.4
-REL=24
+REL=25
 SRCS="git::commit=v$VER::https://github.com/golang/dep"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18652"

--- a/lang-golang/glide/spec
+++ b/lang-golang/glide/spec
@@ -1,5 +1,5 @@
 VER=0.13.3
-REL=24
+REL=25
 SRCS="git::commit=tags/v$VER::https://github.com/Masterminds/glide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11625"

--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.25.4
+UPSTREAM_VER=1.25.5
 # Versions of Golang, net library and Go tools
 GO_VER=${UPSTREAM_VER/\~/}
 TOOLS_VER=0.34.0
@@ -8,7 +8,7 @@ VER="${UPSTREAM_VER}+tools${TOOLS_VER}+net${NET_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools \
       git::commit=tags/v${NET_VER};rename=net::https://github.com/golang/net"
-CHKSUMS="sha256::160043b7f17b6d60b50369436917fda8d5034640ba39ae2431c6b95a889cc98c \
+CHKSUMS="sha256::22a5fd0a91efcd28a1b0537106b9959b2804b61f59c3758b51e8e5429c1a954f \
          SKIP \
          SKIP"
 CHKUPDATE="anitya::id=1227"

--- a/lang-golang/goreleaser/spec
+++ b/lang-golang/goreleaser/spec
@@ -1,4 +1,5 @@
 VER=2.12.7
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/goreleaser/goreleaser.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374129"

--- a/lang-ziglang/zvm/spec
+++ b/lang-ziglang/zvm/spec
@@ -1,5 +1,5 @@
 VER=0.8.10
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/tristanisham/zvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=363557"

--- a/runtime-containers/cni-plugins/spec
+++ b/runtime-containers/cni-plugins/spec
@@ -1,5 +1,5 @@
 VER=1.7.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/containernetworking/plugins.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=96794"

--- a/runtime-containers/cri-tools/spec
+++ b/runtime-containers/cri-tools/spec
@@ -1,5 +1,5 @@
 # follow kubernetes
-REL=1
+REL=2
 VER=1.34.0
 SRCS="git::commit=tags/v$VER::https://github.com/kubernetes-sigs/cri-tools"
 CHKSUMS="SKIP"

--- a/runtime-virtualization/libguestfs/spec
+++ b/runtime-virtualization/libguestfs/spec
@@ -1,5 +1,5 @@
 VER=1.54.1
-REL=3
+REL=4
 SRCS="tbl::https://download.libguestfs.org/${VER%.*}-stable/libguestfs-$VER.tar.gz"
 CHKSUMS="sha256::6e3fc6ac192675f7bc2840a561bb36a36d3d5a8dfa7f88ea2f53f8cf602a177e"
 CHKUPDATE="anitya::id=229572"

--- a/topics/go-1.25.5.toml
+++ b/topics/go-1.25.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Go 1.25.5"
+
+[caution]
+default = "Fixes 2 security vulnerabilities in the crypto/x509 package"
+zh_CN = "修复 crypto/x509 软件包中的 2 个安全漏洞"
+
+[packages-v2]
+go = "< 1.25.5+tools0.34.0+net0.41.0"


### PR DESCRIPTION
Topic Description
-----------------

- zvm: bump REL due to go update to 1.25.5
- yq: bump REL due to go update to 1.25.5
- xray-plugin: bump REL due to go update to 1.25.5
- xray: bump REL due to go update to 1.25.5
- xcaddy: bump REL due to go update to 1.25.5
- vhs: bump REL due to go update to 1.25.5
- v2raya: bump REL due to go update to 1.25.5
- v2ray: bump REL due to go update to 1.25.5
- tea: bump REL due to go update to 1.25.5
- talosctl: bump REL due to go update to 1.25.5

... and 107 more commits

Package(s) Affected
-------------------

- adguardhome: 0.107.69-1
- android-platform-tools: 35.0.2-6
- anubis: 1.21.3-3
- automatic-component-toolkit: 1.6.0-9
- ayano: 0.1.4-3
- buf: 1.60.0-1
- buildah: 1.40.1-3
- caddy: 2.10.2-3
- cf-tool: 1.0.0-12
- chezmoi: 2.67.1-1
- chisel: 1.10.1-3
- clash: 1.18.0-9
- cliphist: 0.7.0-2
- cloudflared: 1:2025.11.1-1
- cni-plugins: 1.7.1-2
- conmon: 2.1.13-2
- containerd: 2.1.4-2
- cri-o: 1.34.2-1
- cri-tools: 1.34.0-2
- croc: 10.2.7-1
- crush: 0.19.0-1
- dae: 1.0.0-3
- daed: 1.5.1-1
- delve: 1.24.0-3
- dep: 0.5.4-25
- direnv: 2.35.0-4
- dive: 0.13.1-3
- dnscontrol: 4.26.0-2
- dnscrypt: 2.1.7-3
- docker: 28.5.1+tini0.19.0-2
- docker-buildx: 0.22.0-4
- docker-compose: 2.35.0-4
- doggo: 1.1.2-1
- duf: 0.9.1-1
- fan2go: 0.11.1-1
- fan2go-tui: 0.2.1-3
- flclash: 0.8.90-3
- forgejo: 11.0.0-3
- frp: 0.65.0-2
- fscan: 2.0.0-4
- fzf: 0.66.0-2
- gdu: 5.32.0-1
- geoipupdate: 7.1.0-3
- gh: 2.83.0-1
- git-credential-oauth: 0.16.0-2
- git-lfs: 3.6.1-3
- gitea: 1.25.1-1
- glab: 1.76.0-1
- glide: 0.13.3-25
- glow: 2.1.1-3
- go: 1.25.5+tools0.34.0+net0.41.0
- go-md2man: 2.0.6-3
- go-runtime: 1.25.5+tools0.34.0+net0.41.0
- gocryptfs: 2.6.1-3
- goreleaser: 2.12.7-1
- gost: 3.2.6-1
- graftcp: 1:0.7.4-4
- gum: 0.16.2-3
- helm: 3.17.1-3
- httpx-go: 1.7.1-3
- hugo: 0.152.0-1
- hysteria: 2.6.3-2
- ignition: 2.20.0-4
- incus: 6.19.1-1
- incus-agent: 6.19.1-1
- kcptun: 20241227-3
- kind: 0.30.0-3
- kitty: 0.43.1-2
- kubeadm: 1.34.1-2
- kubectl: 1.34.1-2
- kubelet: 1.34.1-2
- kubo: 0.38.2-1
- lazygit: 0.56.0-1
- lego: 4.28.0-1
- libguestfs: 1.54.1-4
- liteide: 38.3-7
- micro: 2.0.14-4
- mihomo: 1.19.16-1
- miller: 6.15.0-3
- minikube: 1.35.0-3
- mods: 1.8.1-3
- mosdns: 5.3.3-3
- musicfox: 4.7.1-1
- nali: 0.8.1-4
- navidrome: 0.58.5-1
- nerdctl: 2.2.0-1
- netbird: 0.59.7-2
- nexttrace: 1.5.0-1
- nuclei: 3.4.2-3
- nwg-look: 1.0.6-4
- obfs4proxy: 0.0.14-8
- openlist: 4.1.4-2
- opentofu: 1.10.6-2
- pcstat: 1:0.0.2-9
- podman: 5.7.0+vsock0.8.7-1
- popub: 1:0+git20210814-10
- prometheus-node-exporter: 1.9.1-2
- proton-bridge: 3.21.2-6
- q: 0.19.11-1
- qtcreator: 18.0.0-1
- rclone: 1.72.0-1
- restic: 0.17.3-3
- rootlesskit: 2.3.5-1
- runc: 1.3.1-2
- sing-box: 1.12.12-1
- skate: 1.0.1-3
- skopeo: 1.19.0-3
- snapd: 2.65.1-4
- syncthing: 2.0.11-1
- tailscale: 1.90.9-1
- talosctl: 1.10.5-3
- tea: 0.10.1-3
- v2ray: 5.41.0-2
- v2raya: 2.2.7.3-2
- vhs: 0.10.0-3
- xcaddy: 0.4.5-3
- xray: 25.8.31-3
- xray-plugin: 1.8.24-5
- yq: 4.49.2-1
- zvm: 0.8.10-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit go groups/go-rebuilds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
