### PR TITLE
gcr-4: new, 4.4.0.1

### DIFF
--- a/desktop-gnome/gcr-4/autobuild/defines
+++ b/desktop-gnome/gcr-4/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=gcr-4
+PKGSEC=libs
+PKGDEP="glib glibc gtk-4 libgcrypt libsecret openssh pango p11-kit systemd"
+BUILDDEP="gobject-introspection vala"
+PKGDES="Libraries used for displaying certificates and accessing key stores(GTK-4)"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dintrospection=true'
+    '-Dvapi=true'
+    '-Dgtk4=true'
+    '-Dgtk_doc=false'
+    '-Dcrypto=libgcrypt'
+    '-Dssh_agent=true'
+    '-Dsystemd=enabled'
+)

--- a/desktop-gnome/gcr-4/spec
+++ b/desktop-gnome/gcr-4/spec
@@ -1,0 +1,4 @@
+VER=4.4.0.1
+SRCS="https://download.gnome.org/sources/gcr/${VER:0:3}/gcr-$VER.tar.xz"
+CHKSUMS="sha256::0c3c341e49f9f4f2532a4884509804190a0c2663e6120360bb298c5d174a8098"
+CHKUPDATE="anitya::id=11801"

--- a/desktop-gnome/gcr/autobuild/defines
+++ b/desktop-gnome/gcr/autobuild/defines
@@ -1,12 +1,15 @@
 PKGNAME=gcr
 PKGSEC=libs
-PKGDEP="dconf desktop-file-utils gtk-3 hicolor-icon-theme libgcrypt \
-        p11-kit python-3 libsecret"
-BUILDDEP="gi-docgen gobject-introspection gtk-doc intltool libxslt vala vim"
+PKGDEP="cairo dconf desktop-file-utils gdk-pixbuf glib glibc gtk-3 \
+        hicolor-icon-theme libgcrypt libsecret pango p11-kit python-3"
+BUILDDEP="gobject-introspection libxslt vala"
 PKGDES="Libraries used for displaying certificates and accessing key stores"
 
-MESON_AFTER="-Dintrospection=true \
-             -Dgtk=true \
-             -Dgtk_doc=true \
-             -Dsystemd=enabled"
 ABTYPE=meson
+MESON_AFTER=(
+    '-Dintrospection=true'
+    '-Dgtk=true'
+    '-Dgtk_doc=false'
+    '-Dssh_agent=false'
+    '-Dsystemd=enabled'
+)

--- a/desktop-gnome/gcr/spec
+++ b/desktop-gnome/gcr/spec
@@ -1,5 +1,4 @@
-VER=3.41.1
-REL=2
+VER=3.41.2
 SRCS="https://download.gnome.org/sources/gcr/${VER:0:4}/gcr-$VER.tar.xz"
-CHKSUMS="sha256::bb7128a3c2febbfee9c03b90d77d498d0ceb237b0789802d60185c71c4bea24f"
-CHKUPDATE="anitya::id=11801"
+CHKSUMS="sha256::bad10f3c553a0e1854649ab59c5b2434da22ca1a54ae6138f1f53961567e1ab7"
+CHKUPDATE="anitya::id=369445"

--- a/desktop-gnome/gnome-keyring/autobuild/defines
+++ b/desktop-gnome/gnome-keyring/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=gnome-keyring
 PKGSEC=gnome
-PKGDEP="gcc-runtime gcr glib glibc libcap-ng libgcrypt linux-pam systemd"
+PKGDEP="gcc-runtime gcr gcr-4 glib glibc libcap-ng libgcrypt linux-pam systemd"
 BUILDDEP="gtk-doc meson"
 PKGDES="GNOME password management daemon"
 

--- a/desktop-gnome/gnome-keyring/autobuild/patches/0001-ARCHLINUX-daemon-Add-Cinnamon-to-autostart-files.patch
+++ b/desktop-gnome/gnome-keyring/autobuild/patches/0001-ARCHLINUX-daemon-Add-Cinnamon-to-autostart-files.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Sat, 21 May 2022 18:47:23 +0000
+Subject: [PATCH] daemon: Add Cinnamon to autostart files
+
+Cinnamon also wants to use gnome-keyring-daemon.
+---
+ daemon/gnome-keyring-pkcs11.desktop.in.in  | 2 +-
+ daemon/gnome-keyring-secrets.desktop.in.in | 2 +-
+ daemon/gnome-keyring-ssh.desktop.in.in     | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/daemon/gnome-keyring-pkcs11.desktop.in.in b/daemon/gnome-keyring-pkcs11.desktop.in.in
+index 3e36603fac70..bb729caddfd1 100644
+--- a/daemon/gnome-keyring-pkcs11.desktop.in.in
++++ b/daemon/gnome-keyring-pkcs11.desktop.in.in
+@@ -3,7 +3,7 @@ Type=Application
+ Name=Certificate and Key Storage
+ Comment=GNOME Keyring: PKCS#11 Component
+ Exec=@bindir@/gnome-keyring-daemon --start --components=pkcs11
+-OnlyShowIn=GNOME;Unity;MATE;
++OnlyShowIn=GNOME;Unity;MATE;Cinnamon;
+ NoDisplay=true
+ X-GNOME-Autostart-Phase=PreDisplayServer
+ X-GNOME-AutoRestart=false
+diff --git a/daemon/gnome-keyring-secrets.desktop.in.in b/daemon/gnome-keyring-secrets.desktop.in.in
+index 799caeea4306..6c836a2a7ec9 100644
+--- a/daemon/gnome-keyring-secrets.desktop.in.in
++++ b/daemon/gnome-keyring-secrets.desktop.in.in
+@@ -3,7 +3,7 @@ Type=Application
+ Name=Secret Storage Service
+ Comment=GNOME Keyring: Secret Service
+ Exec=@bindir@/gnome-keyring-daemon --start --components=secrets
+-OnlyShowIn=GNOME;Unity;MATE;
++OnlyShowIn=GNOME;Unity;MATE;Cinnamon;
+ NoDisplay=true
+ X-GNOME-Autostart-Phase=PreDisplayServer
+ X-GNOME-AutoRestart=false
+diff --git a/daemon/gnome-keyring-ssh.desktop.in.in b/daemon/gnome-keyring-ssh.desktop.in.in
+index fd7657a4d0cc..8f9847033507 100644
+--- a/daemon/gnome-keyring-ssh.desktop.in.in
++++ b/daemon/gnome-keyring-ssh.desktop.in.in
+@@ -3,7 +3,7 @@ Type=Application
+ Name=SSH Key Agent
+ Comment=GNOME Keyring: SSH Agent
+ Exec=@bindir@/gnome-keyring-daemon --start --components=ssh
+-OnlyShowIn=GNOME;Unity;MATE;
++OnlyShowIn=GNOME;Unity;MATE;Cinnamon;
+ X-GNOME-Autostart-Phase=PreDisplayServer
+ X-GNOME-AutoRestart=false
+ X-GNOME-Autostart-Notify=true

--- a/desktop-gnome/gnome-keyring/spec
+++ b/desktop-gnome/gnome-keyring/spec
@@ -1,4 +1,5 @@
 VER=48.0
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/gnome-keyring/${VER%.*}/gnome-keyring-$VER.tar.xz"
 CHKSUMS="sha256::f20518c920e9ea3f9c9b8b44be8c50d8d7feecd0dd5624960f77bd2ca4fbeb9d"
 CHKUPDATE="anitya::id=13133"


### PR DESCRIPTION
Topic Description
-----------------

- gnome-keyring: daemon add cinnamon to autostart files
- gcr-4: new, 4.4.0.1
- gcr: update to 3.14.2
ssh_agent move to gcr-4

Package(s) Affected
-------------------

- gcr: 3.41.2
- gcr-4: 4.4.0.1
- gnome-keyring: 48.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcr gcr-4 gnome-keyring
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
