### PR TITLE
rocm: update to 7.1.1

### DIFF
--- a/runtime-common/frugally-deep/autobuild/defines
+++ b/runtime-common/frugally-deep/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=frugally-deep
+PKGSEC=libs
+PKGDES="Header-only library for using Keras models in C++"
+# it's just headers
+PKGDEP="functional-plus eigen-3 nlohmann-json"
+BUILDDEP="cmake ninja"
+
+# just headers and cmake files
+# the building process is just to verify the headers work correctly
+ABHOST=noarch

--- a/runtime-common/frugally-deep/spec
+++ b/runtime-common/frugally-deep/spec
@@ -1,0 +1,4 @@
+VER=0.18.2
+SRCS="tbl::https://github.com/Dobiasd/frugally-deep/archive/v$VER.tar.gz"
+CHKSUMS="sha256::e4274735261c89fd312e5a23e16bfa540752d1a61a190037f63f4d2612495c64"
+CHKUPDATE="anitya::id=378969"

--- a/runtime-common/functional-plus/autobuild/defines
+++ b/runtime-common/functional-plus/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=functional-plus
+PKGSEC=libs
+PKGDES="Functional Programming Library for C++. Write concise and readable C++ code."
+# it's just headers
+PKGDEP=""
+BUILDDEP="cmake ninja"
+
+# just headers and cmake files
+# the building process is just to verify the headers work correctly
+ABHOST=noarch

--- a/runtime-common/functional-plus/spec
+++ b/runtime-common/functional-plus/spec
@@ -1,0 +1,4 @@
+VER=0.2.26
+SRCS="tbl::https://github.com/Dobiasd/FunctionalPlus/archive/v$VER.tar.gz"
+CHKSUMS="sha256::119894b4ab521d22e7dbd4692c364dc911cf206fca011071575658d4053e61f2"
+CHKUPDATE="anitya::id=378970"

--- a/runtime-rocm/rocm-aqlprofile/autobuild/defines
+++ b/runtime-rocm/rocm-aqlprofile/autobuild/defines
@@ -1,0 +1,22 @@
+PKGNAME=rocm-aqlprofile
+PKGDES="Architected Queuing Language Profiling Library"
+PKGSEC=devel
+PKGDEP="gcc-runtime rocm-core rocm-llvm rocr-runtime"
+BUILDDEP="cmake"
+
+USECLANG=1
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DCMAKE_SKIP_RPATH=OFF'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib;/usr/lib/rocm/lib/llvm/lib'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/runtime-rocm/rocm-aqlprofile/spec
+++ b/runtime-rocm/rocm-aqlprofile/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
+CHKSUMS="SKIP"
+SUBDIR="rocm-systems/projects/aqlprofile"
+CHKUPDATE="anitya::id=386527"

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems \
       git::commit=tags/rocm-${VER};rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP \

--- a/runtime-rocm/rocm-cmake/spec
+++ b/runtime-rocm/rocm-cmake/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-cmake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231446"

--- a/runtime-rocm/rocm-comgr/spec
+++ b/runtime-rocm/rocm-comgr/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/comgr"

--- a/runtime-rocm/rocm-composable-kernel/autobuild/defines
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/defines
@@ -1,0 +1,47 @@
+PKGNAME=rocm-composable-kernel
+PKGDES="High Performance Composable Kernel for AMD GPUs"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-rocfft"
+BUILDDEP="cmake"
+
+USECLANG=1
+
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+# FIXME: LTO Detecting HIP compiler ABI info
+#   LINKER_TYPE 'LLD' is unknown or not supported by this toolchain.
+NOLTO=1
+
+# FIXME: Build Fail DWARF DebugLoc
+#
+#  llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp:557
+#  bool llvm::DwarfExpression::addExpression(DIExpressionCursor &&, llvm::function_ref<bool (unsigned int, DIExpressionCursor &)>)
+#  Assertion `OffsetInBits >= FragmentOffset && "fragment offset not added?"' failed.
+ABSPLITDBG=0
+
+# Note: Keep libdevice_other_operations.a and etc...
+#  This is necessary for subsequent packages that depend on composable-kernel.
+NOSTATIC=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DDL_KERNELS=ON'
+    '-DDPP_KERNELS=ON'
+    '-DCK_USE_FP8_ON_UNSUPPORTED_ARCH=OFF'
+    '-DBUILD_DEV=OFF'
+    '-DROCM_WARN_TOOLCHAIN_VAR=OFF'
+    '-DCMAKE_BUILD_TYPE=Release'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-composable-kernel/autobuild/prepare
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Use LLD for Link ..."
+export LDFLAGS="${LDFLAGS} -fuse-ld=lld"

--- a/runtime-rocm/rocm-composable-kernel/spec
+++ b/runtime-rocm/rocm-composable-kernel/spec
@@ -1,0 +1,6 @@
+VER=7.1.1
+ENVREQ="total_mem=100"
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/composablekernel"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocm-core"

--- a/runtime-rocm/rocm-device-libs/spec
+++ b/runtime-rocm/rocm-device-libs/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/device-libs/"

--- a/runtime-rocm/rocm-half/spec
+++ b/runtime-rocm/rocm-half/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/half"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378431"

--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas-common"

--- a/runtime-rocm/rocm-hipblas/spec
+++ b/runtime-rocm/rocm-hipblas/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas"

--- a/runtime-rocm/rocm-hipblaslt/autobuild/defines
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipblas-common rocm-roctracer rocm-or
 
 # FIXME: Undefined symbol: cblas_dgemm. Build-time dependency to lapack
 # was removed.
-BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib gtest pyyaml"
+BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib gtest pyyaml blis"
 
 USECLANG=1
 
@@ -42,8 +42,9 @@ CMAKE_AFTER=(
     '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
     '-DCMAKE_LINKER_TYPE=LLD'
-    # FIXME: Need flame/blis
-    '-DHIPBLASLT_ENABLE_BLIS=OFF'
+    '-DHIPBLASLT_ENABLE_BLIS=ON'
+    '-DBLIS_ROOT=/usr'
+    '-DBLIS_LIB=/usr/lib/libblis.so'
     # FIXME: ld.lld: error: undefined symbol: cblas_dgemm
     '-DHIPBLASLT_ENABLE_CLIENT=OFF'
     '-DORIGAMI_ENABLE_INSTALL=OFF'

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblaslt"

--- a/runtime-rocm/rocm-hipcub/spec
+++ b/runtime-rocm/rocm-hipcub/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipcub"

--- a/runtime-rocm/rocm-hipfft/spec
+++ b/runtime-rocm/rocm-hipfft/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipfft"

--- a/runtime-rocm/rocm-hipfort/spec
+++ b/runtime-rocm/rocm-hipfort/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipfort.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378520"

--- a/runtime-rocm/rocm-hipify/spec
+++ b/runtime-rocm/rocm-hipify/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/HIPIFY.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378519"

--- a/runtime-rocm/rocm-hiprand/spec
+++ b/runtime-rocm/rocm-hiprand/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hiprand"

--- a/runtime-rocm/rocm-hipsolver/autobuild/defines
+++ b/runtime-rocm/rocm-hipsolver/autobuild/defines
@@ -1,0 +1,28 @@
+PKGNAME=rocm-hipsolver
+PKGDES="Radeon Open Compute LAPACK marshalling library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocblas rocm-rocsolver rocm-hipblas rocm-hipsparse"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+# Note: Depends on architecture-specific runtime. Treat as ELF-less.
+ABSPLITDBG=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-hipsolver/autobuild/prepare
+++ b/runtime-rocm/rocm-hipsolver/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-hipsolver/spec
+++ b/runtime-rocm/rocm-hipsolver/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/hipsolver"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipsparse/spec
+++ b/runtime-rocm/rocm-hipsparse/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipsparse"

--- a/runtime-rocm/rocm-llvm/autobuild/patches/0006-llvm-fix-compile-fail.patch
+++ b/runtime-rocm/rocm-llvm/autobuild/patches/0006-llvm-fix-compile-fail.patch
@@ -1,0 +1,8 @@
+--- a/llvm/lib/Transforms/Scalar/CMakeLists.txt    2025-11-27 02:34:27.033183750 +0000
++++ b/llvm/lib/Transforms/Scalar/CMakeLists.txt    2025-11-27 02:34:32.887916250 +0000
+@@ -97,4 +97,5 @@
+   InstCombine
+   Support
+   TransformUtils
++  TargetParser
+   )

--- a/runtime-rocm/rocm-llvm/spec
+++ b/runtime-rocm/rocm-llvm/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/llvm"

--- a/runtime-rocm/rocm-miopen/autobuild/defines
+++ b/runtime-rocm/rocm-miopen/autobuild/defines
@@ -1,0 +1,32 @@
+PKGNAME=rocm-miopen
+PKGDES="AMD DNN Library"
+PKGSEC=devel
+PKGDEP="frugally-deep rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-rocblas rocm-hipblas rocm-rocmlir rocm-hipblaslt rocm-rocrand rocm-half rocm-composable-kernel"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_HIP_COMPILER=/usr/lib/rocm/lib/llvm/bin/amdclang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_BUILD_TYPE=Release'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DMIOPEN_BACKEND=HIP'
+    '-DBUILD_DEV=OFF'
+    '-DBUILD_TESTING=OFF'
+    '-DBoost_USE_STATIC_LIBS=OFF'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-miopen/autobuild/prepare
+++ b/runtime-rocm/rocm-miopen/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-miopen/spec
+++ b/runtime-rocm/rocm-miopen/spec
@@ -1,0 +1,6 @@
+VER=7.1.1
+ENVREQ="total_mem=100"
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/miopen"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-origami/spec
+++ b/runtime-rocm/rocm-origami/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/shared/origami"

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -1,5 +1,4 @@
-VER=7.1.0
-REL=1
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rccl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241714"

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocblas"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocfft"

--- a/runtime-rocm/rocm-rocmlir/spec
+++ b/runtime-rocm/rocm-rocmlir/spec
@@ -1,4 +1,4 @@
-VER=7.1
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocMLIR"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378515"

--- a/runtime-rocm/rocm-rocprim/spec
+++ b/runtime-rocm/rocm-rocprim/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocprim"

--- a/runtime-rocm/rocm-rocprofiler-register/spec
+++ b/runtime-rocm/rocm-rocprofiler-register/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocprofiler-register"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocrand"

--- a/runtime-rocm/rocm-rocsolver/spec
+++ b/runtime-rocm/rocm-rocsolver/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsolver"

--- a/runtime-rocm/rocm-rocsparse/spec
+++ b/runtime-rocm/rocm-rocsparse/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsparse"

--- a/runtime-rocm/rocm-rocthrust/autobuild/defines
+++ b/runtime-rocm/rocm-rocthrust/autobuild/defines
@@ -1,0 +1,28 @@
+PKGNAME=rocm-rocthrust
+PKGDES="Radeon Open Compute Thrust library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocprim"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+# Note: Depends on architecture-specific runtime. Treat as ELF-less.
+ABSPLITDBG=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-rocthrust/autobuild/prepare
+++ b/runtime-rocm/rocm-rocthrust/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-rocthrust/spec
+++ b/runtime-rocm/rocm-rocthrust/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/rocthrust"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-roctracer/spec
+++ b/runtime-rocm/rocm-roctracer/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/roctracer"

--- a/runtime-rocm/rocm-smi-lib/spec
+++ b/runtime-rocm/rocm-smi-lib/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocm-smi-lib"

--- a/runtime-rocm/rocminfo/spec
+++ b/runtime-rocm/rocminfo/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocminfo"

--- a/runtime-rocm/rocr-runtime/autobuild/defines
+++ b/runtime-rocm/rocr-runtime/autobuild/defines
@@ -7,6 +7,8 @@ BUILDDEP="cmake vim"
 PKGBREAK="roct-thunk-interface<=6.0.2"
 PKGREP="roct-thunk-interface<=6.0.2"
 USECLANG=1
+# Note: Keep libhsakmt.a, rocprofiler-sdk dependency ...
+NOSTATIC=0
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocr-runtime"


### PR DESCRIPTION
Topic Description
-----------------

- frugally-deep: add, 0.18.2
- functional-plus: add, 0.2.25
- rocm-hipsolver: add, 7.1.1
- rocm-rocthrust: add, 7.1.1
- rocm-miopen: add, 7.1.1
- rocm-composable-kernel: add, 7.1.1
- rocm-aqlprofile: add, 7.1.1
- rocm-hipify: upgrade to 7.1.1
- rocm-rocmlir: upgrade to 7.1.1
- rocm-hiprand: upgrade to 7.1.1

... and 27 more commits

Package(s) Affected
-------------------

- frugally-deep: 0.18.2
- functional-plus: 0.2.26
- rocm-aqlprofile: 7.1.1
- rocm-clr: 7.1.1
- rocm-cmake: 7.1.1
- rocm-comgr: 7.1.1
- rocm-composable-kernel: 7.1.1
- rocm-core: 7.1.1
- rocm-device-libs: 7.1.1
- rocm-half: 7.1.1
- rocm-hipblas: 7.1.1
- rocm-hipblas-common: 7.1.1
- rocm-hipblaslt: 7.1.1
- rocm-hipcub: 7.1.1
- rocm-hipfft: 7.1.1
- rocm-hipfort: 7.1.1
- rocm-hipify: 7.1.1
- rocm-hiprand: 7.1.1
- rocm-hipsolver: 7.1.1
- rocm-hipsparse: 7.1.1
- rocm-llvm: 7.1.1
- rocm-miopen: 7.1.1
- rocm-origami: 7.1.1
- rocm-rccl: 7.1.1
- rocm-rocblas: 7.1.1
- rocm-rocfft: 7.1.1
- rocm-rocmlir: 7.1.1
- rocm-rocprim: 7.1.1
- rocm-rocprofiler-register: 7.1.1
- rocm-rocrand: 7.1.1
- rocm-rocsolver: 7.1.1
- rocm-rocsparse: 7.1.1
- rocm-rocthrust: 7.1.1
- rocm-roctracer: 7.1.1
- rocm-smi-lib: 7.1.1
- rocminfo: 7.1.1
- rocr-runtime: 7.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocm-llvm rocm-device-libs rocm-comgr rocm-cmake rocm-rocprofiler-register rocr-runtime rocminfo rocm-clr rocm-half rocm-smi-lib rocm-hipify rocm-hipfort rocm-roctracer rocm-hipblas-common rocm-origami rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand rocm-rccl rocm-rocprim rocm-rocsparse rocm-hipfft rocm-hipsparse rocm-rocsolver rocm-hipblas rocm-hipcub rocm-hiprand rocm-rocmlir rocm-aqlprofile rocm-composable-kernel functional-plus frugally-deep rocm-miopen rocm-rocthrust rocm-hipsolver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
