### PR TITLE
weechat: update to 4.8.1

### DIFF
--- a/app-web/weechat/autobuild/defines
+++ b/app-web/weechat/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=weechat
 PKGSEC=net
 PKGDEP="gnutls curl libgcrypt cjson"
 BUILDDEP="asciidoctor source-highlight cmake pkg-config zstd gettext ca-certs \
-          perl python-3 lua tcl aspell guile php argon2 libxml2 libsodium"
+          perl python-3 lua-5.4 tcl aspell guile php argon2 libxml2 libsodium"
 PKGDES="A fast, light and extensible chat client"
 
 ABTYPE=cmakeninja

--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,4 @@
-VER=4.7.2
+VER=4.8.1
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::66624bd905a6db58a0893bfbdddbb8fa417b97aab4a9af8c140e0b29ceba2569"
+CHKSUMS="sha256::e7ac1fbcc71458ed647aada8747990905cb5bfb93fd8ccccbc2a969673a4285a"
 CHKUPDATE="anitya::id=5122"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.8.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- weechat: 4.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
