### PR TITLE
nvidia-settings: new, 580.95.05

### DIFF
--- a/app-admin/nvidia-settings/autobuild/beyond
+++ b/app-admin/nvidia-settings/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing application icon ..."
+install -Dvm644 "$SRCDIR"/doc/nvidia-settings.png \
+    -t "$PKGDIR"/usr/share/pixmaps/

--- a/app-admin/nvidia-settings/autobuild/build
+++ b/app-admin/nvidia-settings/autobuild/build
@@ -1,0 +1,12 @@
+abinfo "Building nvidia-settings ..."
+make
+
+abinfo "Installing nvidia-settings ..."
+cd "$SRCDIR"/src
+make DESTDIR="$PKGDIR" PREFIX=/usr install
+
+cd "$SRCDIR"/doc
+make DESTDIR="$PKGDIR" PREFIX=/usr install
+
+abinfo "Fixing permission ..."
+chmod -v 755 "$PKGDIR"/usr/lib/*

--- a/app-admin/nvidia-settings/autobuild/defines
+++ b/app-admin/nvidia-settings/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=nvidia-settings
+PKGSEC=libs
+PKGDEP="x11-lib cairo pango gtk-3 gtk-2 fontconfig harfbuzz freetype glib \
+        at-spi2-core gdk-pixbuf wayland vulkan"
+PKGDES="NVIDIA driver control panel"
+
+FAIL_ARCH="!(amd64|arm64)"
+
+PKGBREAK="nvidia<=580.95.05"
+PKGREP="nvidia<=580.95.05"

--- a/app-admin/nvidia-settings/spec
+++ b/app-admin/nvidia-settings/spec
@@ -1,0 +1,4 @@
+VER=580.95.05
+SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=5435"

--- a/runtime-display/nvidia-open/autobuild/defines
+++ b/runtime-display/nvidia-open/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=nvidia-open
 PKGSEC=x11
 PKGDEP="libcl zlib opencl-registry-api xorg-server dkms \
-        libglvnd egl-wayland gtk-3 jansson libvdpau \
+        libglvnd egl-wayland gtk-3 jansson libvdpau nvidia-settings \
         libxnvctrl vulkan nvidia-firmware nvidia-utils libva-nvidia-driver"
 PKGDES="The open-source drivers suite for NVIDIA cards"
 BUILDDEP="inetutils"

--- a/runtime-display/nvidia-open/autobuild/overrides/usr/lib/modprobe.d/nvidia.conf
+++ b/runtime-display/nvidia-open/autobuild/overrides/usr/lib/modprobe.d/nvidia.conf
@@ -1,1 +1,3 @@
 blacklist nouveau
+blacklist nova_core
+blacklist nova_drm

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,4 +1,5 @@
 VER=580.95.05
+REL=1
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/01-utils/build
+++ b/runtime-display/nvidia/01-utils/build
@@ -46,7 +46,7 @@ sanity_check() {
     # The regex glob matching so that should not be installed, due to
     #  - Incompatibility with with GLVND, or
     #  - A separate package containing this so.
-    BLACKLIST="(EGL|GL|GLESv1_CM|GLESv2|GLX|OpenGL|OpenCL|GLdispatch|nvidia-egl-wayland|libnvidia-gtk3|libnvidia-wayland-client).so."
+    BLACKLIST="(EGL|GL|GLESv1_CM|GLESv2|GLX|OpenGL|OpenCL|GLdispatch|nvidia-egl-wayland|libnvidia-gtk2|libnvidia-gtk3|libnvidia-wayland-client).so."
     # Assuming pwd is in NVIDIA-Linux-${NV_ARCH}
     abinfo "Checking whether all the .so provided has been installed"
     _PROVIDED=$(find -maxdepth 1 -name "*.so.*" -exec basename {} \; | sort | sed -E "/${BLACKLIST}/d")
@@ -231,9 +231,6 @@ install -Dvm644 nvidia-application-profiles-$PKGVER-rc \
     "$PKGDIR"/usr/share/nvidia/nvidia-application-profiles-$PKGVER-rc
 install -Dvm644 nvidia-application-profiles-$PKGVER-key-documentation \
     "$PKGDIR"/usr/share/nvidia/nvidia-application-profiles-$PKGVER-key-documentation
-
-abinfo "NVIDIA Control Panel..."
-install_for_all 755 libnvidia-gtk2.so.$PKGVER "$PKGDIR"/usr/lib
 
 abinfo "Power management services"
 for i in suspend hibernate resume; do

--- a/runtime-display/nvidia/03-kernel/build
+++ b/runtime-display/nvidia/03-kernel/build
@@ -92,9 +92,6 @@ abinfo "Installing kernel sources ..."
 install -dm 755 "$PKGDIR"/usr/src
 cp -dr --no-preserve='ownership' kernel "$PKGDIR"/usr/src/nvidia-$PKGVER
 
-abinfo "Wayland support libraries and platform files ..."
-install_if_amd64 755 "libnvidia-wayland-client.so.$PKGVER" "$PKGDIR"/usr/lib
-
 abinfo "NVIDIA X configurator ..."
 install -Dvm755 nvidia-xconfig \
     "$PKGDIR"/usr/bin/nvidia-xconfig
@@ -112,12 +109,6 @@ install -Dvm644 \
     "$PKGDIR"/usr/lib/systemd/system/nvidia-persistenced.service
 sed -e 's/__USER__/nvidia-persistenced/' \
     -i "$PKGDIR"/usr/lib/systemd/system/nvidia-persistenced.service
-
-abinfo "NVIDIA Control Panel..."
-install_for_all 755 nvidia-settings "$PKGDIR"/usr/bin
-install_for_all 644 nvidia-settings.1.gz "$PKGDIR"/usr/share/man/man1
-install_for_all 644 nvidia-settings.png "$PKGDIR"/usr/share/pixmaps
-install_for_all 755 libnvidia-gtk3.so.$PKGVER "$PKGDIR"/usr/lib
 
 if ((NEED_FIX)); then
     aberr "Additional files should be installed. See errors above."

--- a/runtime-display/nvidia/03-kernel/defines
+++ b/runtime-display/nvidia/03-kernel/defines
@@ -1,6 +1,6 @@
 PKGNAME=nvidia
 PKGSEC=x11
-PKGDEP="libcl zlib opencl-registry-api xorg-server gtk-2 dkms \
+PKGDEP="libcl zlib opencl-registry-api xorg-server gtk-2 dkms nvidia-settings \
         libglvnd egl-wayland nvidia-firmware nvidia-utils libva-nvidia-driver"
 PKGDES="The proprietary drivers suite for NVIDIA cards"
 

--- a/runtime-display/nvidia/03-kernel/overrides/usr/lib/modprobe.d/nvidia.conf
+++ b/runtime-display/nvidia/03-kernel/overrides/usr/lib/modprobe.d/nvidia.conf
@@ -1,1 +1,3 @@
 blacklist nouveau
+blacklist nova_core
+blacklist nova_drm

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,4 +1,5 @@
 VER=580.95.05
+REL=1
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
 CHKSUMS__AMD64="sha256::849ef0ef8e842b9806b2cde9f11c1303d54f1a9a769467e4e5d961b2fe1182a7"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-open: use packaged nvidia-settings
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: use packaged nvidia-settings
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-settings: new, 580.95.05
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- nvidia: 580.95.05-1
- nvidia-firmware: 580.95.05-1
- nvidia-open: 580.95.05-1
- nvidia-settings: 580.65.06
- nvidia-utils: 580.95.05-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia-settings nvidia nvidia-open
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
