### PR TITLE
dart-sdk: update to 3.10.3

### DIFF
--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -1,5 +1,5 @@
-VER=3.10.1
+VER=3.10.3
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/dart-sdk-${VER}.tar.zst"
-CHKSUMS="sha256::b29b6876439a39ea1fcddadce8d1aa45844c599689b19cf56fdc719282517ebd"
+CHKSUMS="sha256::833f34f56bf199251953cf11af5cfa5dddaab308531685833619477e1c27188e"
 CHKUPDATE="anitya::id=14718"
 SUBDIR="dart-sdk-${VER}"

--- a/lang-dart/fvm/spec
+++ b/lang-dart/fvm/spec
@@ -1,4 +1,4 @@
-VER=4.0.1
-SRCS="git::commit=tags/${VER}::https://github.com/leoafarias/fvm"
+VER=4.0.4
+SRCS="git::commit=tags/$VER::https://github.com/leoafarias/fvm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379051"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sdk: update to 3.10.3
- gourps: add dart-sdk-rebuilds
- fvm: update to 4.0.4
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- dart-sdk: 3.10.3
- dartaotruntime: 3.10.3
- fvm: 4.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk fvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
