### PR TITLE
deploykit-gui: update to 0.10.3

### DIFF
--- a/app-admin/deploykit-gui/spec
+++ b/app-admin/deploykit-gui/spec
@@ -1,7 +1,7 @@
-VER=0.10.0
+VER=0.10.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AOSC-Dev/deploykit-gui.git \
       tbl::https://github.com/AOSC-Dev/deploykit-gui/releases/download/v$VER/dist.tar.xz"
 CHKSUMS="SKIP \
-         sha256::69eb9ee7cf8cd399b50d9a1e537de151570ce1d61a36c5321038e5b0084fcb77"
+         sha256::dbadad5ffbd001c6279c6e45fcb7ac7b4950b12907d416cdda3bd06e49f25d4e"
 SUBDIR="deploykit-gui/src-tauri"
 CHKUPDATE="anitya::id=371971"


### PR DESCRIPTION
Topic Description
-----------------

- deploykit-gui: update to 0.10.3
    Fix a bug in the user creation UI where it fails to check if the
    username field is empty, when only the two password fields are filled.

Package(s) Affected
-------------------

- deploykit-gui: 0.10.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit deploykit-gui
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
