### PR TITLE
docker-compose: update to 5.0.0

### DIFF
--- a/app-containers/docker-compose/autobuild/build
+++ b/app-containers/docker-compose/autobuild/build
@@ -1,6 +1,6 @@
 # Translated from Makefile
 abinfo "Gathering info..."
-GO_LDFLAGS="$GO_LDFLAGS -w -X github.com/docker/compose/v2/internal.Version=${PKGVER}"
+GO_LDFLAGS="$GO_LDFLAGS -w -X github.com/docker/compose/v${PKGVER%%.*}/internal.Version=${PKGVER}"
 GO_BUILDTAGS=e2e
 
 abinfo "Building docker-compose..."
@@ -10,4 +10,3 @@ env GO111MODULE=on \
 
 abinfo "Installing $PKGNAME ..."
 install -Dvm755 "$SRCDIR"/bin/build/docker-compose "$PKGDIR"/usr/lib/docker/cli-plugins/docker-compose
-install -Dvm644 "$SRCDIR"/packaging/LICENSE "$PKGDIR"/usr/share/doc/docker-compose/LICENSE

--- a/app-containers/docker-compose/spec
+++ b/app-containers/docker-compose/spec
@@ -1,5 +1,4 @@
-VER=2.35.0
-REL=3
+VER=5.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/docker/compose"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6185"


### PR DESCRIPTION
Topic Description
-----------------

- docker-compose: update to 5.0.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- docker-compose: 5.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker-compose
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
