### PR TITLE
qutebrowser: update to 3.6.3+pdfjs5.4.296

### DIFF
--- a/app-web/qutebrowser/autobuild/defines
+++ b/app-web/qutebrowser/autobuild/defines
@@ -10,4 +10,4 @@ PKGDES="A keyboard-driven, vim-like browser based on PyQt"
 # Mark this package as non-noarch and instruct Autobuild to ignore automatic debug
 # symbol stripping.
 ABSPLITDBG=0
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd)"

--- a/app-web/qutebrowser/spec
+++ b/app-web/qutebrowser/spec
@@ -1,11 +1,11 @@
-UPSTREAM_VER=3.6.1
+UPSTREAM_VER=3.6.3
 # NOTE: Find the latest pdf.js version in
 # https://github.com/mozilla/pdf.js/releases
-PDFJS_VER=5.4.296
+PDFJS_VER=5.4.449
 VER=${UPSTREAM_VER}+pdfjs${PDFJS_VER}
 SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$UPSTREAM_VER/qutebrowser-$UPSTREAM_VER.tar.gz \
       file::rename=pdfjs.zip::https://github.com/mozilla/pdf.js/releases/download/v$PDFJS_VER/pdfjs-$PDFJS_VER-dist.zip"
-CHKSUMS="sha256::f5bdf550f2739ac1825e608021bfbc5cc1232a7bc52043b4328cd696e1d86d90 \
-         sha256::c00128ab92dfc73249cdf276ef7b34a0d8403e40ecbfcc7b9344411e33dd43e4"
+CHKSUMS="sha256::6dbe2889e61ebd63003ae40b319e1e81f306e924e8316c6795ae4884021c2faf \
+         sha256::8afd631c5f062d2ef160e1fb362d4ccce9ae8157f246b6da91a95a257326e34d"
 SUBDIR="qutebrowser-$UPSTREAM_VER"
 CHKUPDATE="anitya::id=9759"


### PR DESCRIPTION
Topic Description
-----------------

- qutebrowser: update to 3.6.3+pdfjs5.4.296
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- qutebrowser: 3.6.3+pdfjs5.4.296

Security Update?
----------------

No

Build Order
-----------

```
#buildit qutebrowser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
