### PR TITLE
tmux: update to 3.6a

### DIFF
--- a/app-utils/tmux/spec
+++ b/app-utils/tmux/spec
@@ -1,4 +1,4 @@
-VER=3.6
+VER=3.6a
 SRCS="git::commit=tags/$VER::https://github.com/tmux/tmux"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4980"


### PR DESCRIPTION
Topic Description
-----------------

- tmux: update to 3.6a
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- tmux: 3.6a

Security Update?
----------------

No

Build Order
-----------

```
#buildit tmux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
