### PR TITLE
unixbench: add -std=gnuc17 to fix Dhrystone 2

### DIFF
--- a/app-benchmarks/unixbench/autobuild/build
+++ b/app-benchmarks/unixbench/autobuild/build
@@ -1,4 +1,4 @@
-make -C UnixBench/ OPTON="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+make -C UnixBench/ OPTON="${CPPFLAGS} ${CFLAGS} -std=gnu17 ${LDFLAGS}"
 
 mkdir -p "$PKGDIR"/usr/{bin,lib/unixbench}
 cp -av "$SRCDIR"/UnixBench/{pgms,results,testdir,tmp,Run} "$PKGDIR"/usr/lib/unixbench

--- a/app-benchmarks/unixbench/spec
+++ b/app-benchmarks/unixbench/spec
@@ -1,4 +1,5 @@
 VER=6.0.0
+REL=1
 SRCS="tbl::https://github.com/kdlucas/byte-unixbench/archive/v$VER.tar.gz"
 CHKSUMS="sha256::c151d28b6f4f3f40faad19e877c1ab06fbd4b3da006ccfa26b36200c741fc3ba"
 CHKUPDATE="anitya::id=226943"


### PR DESCRIPTION
Topic Description
-----------------

- unixbench: add -std=gnuc17 to fix Dhrystone 2
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- unixbench: 6.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit unixbench
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
