### PR TITLE
malcontent: update to 0.13.1

### DIFF
--- a/runtime-desktop/malcontent/spec
+++ b/runtime-desktop/malcontent/spec
@@ -1,4 +1,4 @@
-VER=0.13.0
+VER=0.13.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pwithnall/malcontent.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230451"


### PR DESCRIPTION
Topic Description
-----------------

- malcontent: update to 0.13.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- malcontent: 0.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit malcontent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
