### PR TITLE
getdns: update to 1.7.3

### DIFF
--- a/app-network/getdns/autobuild/defines
+++ b/app-network/getdns/autobuild/defines
@@ -1,8 +1,15 @@
 PKGNAME=getdns
 PKGSEC=net
-PKGDEP="gnutls libev libevent libuv libidn2 openssl unbound"
+PKGDEP="gnutls libev libevent libuv libidn2 openssl unbound gmp"
 BUILDDEP="check"
 PKGDES="An implementation of a modern asynchronous DNS API"
 
-CMAKE_AFTER="-DUSE_GNUTLS=ON \
-             -DBUILD_STUBBY=OFF"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DBUILD_TESTING=OFF"
+    "-DUSE_GNUTLS=ON"
+    "-DBUILD_STUBBY=OFF"
+    "-DCMAKE_EXE_LINKER_FLAGS=\"-lgmp\""
+    "-DCMAKE_SHARED_LINKER_FLAGS=\"-lgmp\""
+    )
+NOLTO=1

--- a/app-network/getdns/spec
+++ b/app-network/getdns/spec
@@ -1,5 +1,4 @@
-VER=1.6.0
-REL=2
-SRCS="tbl::https://getdnsapi.net/releases/getdns-${VER//./-}/getdns-$VER.tar.gz"
-CHKSUMS="sha256::40e5737471a3902ba8304b0fd63aa7c95802f66ebbc6eae53c487c8e8a380f4a"
+VER=1.7.3
+SRCS="git::commit=tags/v$VER::https://github.com/getdnsapi/getdns"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10324"

--- a/app-network/stubby/autobuild/defines
+++ b/app-network/stubby/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=stubby
 PKGSEC=net
 PKGDEP="getdns yaml"
-PKGDES="A local DNS Privacy stub resolver (using DNS-over-TLS)"
+PKGDES="DNS-over-TLS based local DNS Privacy stub resolver"

--- a/app-network/stubby/spec
+++ b/app-network/stubby/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
-SRCS="tbl::https://github.com/getdnsapi/stubby/archive/v$VER.tar.gz"
-CHKSUMS="sha256::b37a0e0ec2b7cfcdcb596066a6fd6109e91a2766b17a42c47d3703d9be41d000"
+VER=0.4.3
+SRCS="git::commit=tags/v$VER::https://github.com/getdnsapi/stubby"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15913"


### PR DESCRIPTION
Topic Description
-----------------

- getdns: update to 1.7.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- getdns: 1.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit getdns stubby
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
