### PR TITLE
xdotool: update to 4.20251130.1

### DIFF
--- a/app-utils/xdotool/autobuild/defines
+++ b/app-utils/xdotool/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=xdotool
 PKGSEC=x11
 PKGDEP="glibc libxkbcommon x11-lib"
 PKGDES="X11 automation tool"
+PKGBREAK="cinnamon-screensaver<=5.8.0"
 
 ABTYPE=self

--- a/app-utils/xdotool/spec
+++ b/app-utils/xdotool/spec
@@ -1,5 +1,4 @@
-VER=3.20211022.1
-REL=1
+VER=4.20251130.1
 SRCS="git::commit=tags/v$VER::https://github.com/jordansissel/xdotool"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8648"

--- a/desktop-cinnamon/cinnamon-screensaver/spec
+++ b/desktop-cinnamon/cinnamon-screensaver/spec
@@ -1,5 +1,5 @@
 VER=5.8.0
+REL=2
 SRCS="tbl::https://github.com/linuxmint/cinnamon-screensaver/archive/$VER.tar.gz"
 CHKSUMS="sha256::7ecf9354ea0ce057fc6c4ee267393c144f06a9fb80b797d34fe5a1423c9faefc"
 CHKUPDATE="anitya::id=6385"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- cinnamon-screensaver: bump REL
    Signed-off-by: stydxm <stydxm@outlook.com>
- xdotool: update to 4.20251130.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit xdotool cinnamon-screensaver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
