### PR TITLE
musescore: update to 4.6.4

### DIFF
--- a/app-creativity/musescore/autobuild/beyond
+++ b/app-creativity/musescore/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing bundled files ..."
-rm -rv "$PKGDIR"/usr/{include,lib}

--- a/app-creativity/musescore/autobuild/defines
+++ b/app-creativity/musescore/autobuild/defines
@@ -4,20 +4,22 @@ PKGDEP="lame portaudio pulseaudio qt-5 shared-mime-info flac freetype"
 BUILDDEP="doxygen gtk-2"
 PKGDES="Create, play and print beautiful sheet music"
 
-CMAKE_AFTER="-DMUSESCORE_BUILD_MODE=release \
-             -DMUE_ENABLE_AUDIO_JACK=ON \
-             -DMUE_DOWNLOAD_SOUNDFONT=OFF \
-             -DMUE_COMPILE_USE_SYSTEM_FLAC=ON \
-             -DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON \
-             -DMUE_BUILD_UNIT_TESTS=OFF \
-             -DMUE_BUILD_CRASHPAD_CLIENT=OFF"
+CMAKE_AFTER=(
+    "-DMUSESCORE_BUILD_MODE=release"
+    "-DMUE_ENABLE_AUDIO_JACK=ON"
+    "-DMUE_ENABLE_FILE_ASSOCIATION=ON"
+    "-DMUE_DOWNLOAD_SOUNDFONT=OFF"
+    "-DMUE_COMPILE_USE_SYSTEM_FLAC=ON"
+    "-DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON"
+    "-DMUE_BUILD_UNIT_TESTS=OFF"
+    "-DMUE_BUILD_CRASHPAD_CLIENT=OFF"
+    "-DMUE_INSTALL_SOUNDFONT=ON"
+)
 
 # FIXME: No data signature found in rcc
 # See https://bugreports.qt.io/browse/QTBUG-73834
 # & https://bugs.gentoo.org/908808
 NOLTO=1
 
-# FIXME: Even with NOLTO it will still error.
-# {standard input}: Assembler messages:
-# {standard input}: 134111: Error: branch out of range
-FAIL_ARCH="loongson3"
+# FIXME: https://github.com/musescore/MuseScore/blob/master/buildscripts/cmake/GetPlatformInfo.cmake#L45
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd)"

--- a/app-creativity/musescore/autobuild/patches/0001-Disable-self-update.patch
+++ b/app-creativity/musescore/autobuild/patches/0001-Disable-self-update.patch
@@ -1,43 +1,24 @@
-From 1c6ceca69f81b08cd5c0954338e0ceddc8578cb6 Mon Sep 17 00:00:00 2001
-From: Jiajie Chen <c@jia.je>
-Date: Mon, 13 May 2024 10:38:32 +0800
-Subject: [PATCH] Disable self update
-
----
- src/update/internal/updatescenario.cpp | 15 ++++++---------
- 1 file changed, 6 insertions(+), 9 deletions(-)
-
-diff --git a/src/update/internal/updatescenario.cpp b/src/update/internal/updatescenario.cpp
-index 666b581f44..fc6942b925 100644
---- a/src/update/internal/updatescenario.cpp
-+++ b/src/update/internal/updatescenario.cpp
-@@ -41,20 +41,17 @@ using namespace mu::framework;
+diff --git a/src/framework/update/internal/updatescenario.cpp b/src/framework/update/internal/updatescenario.cpp
+index 23b54be0c1..b3e67ac053 100644
+--- a/src/framework/update/internal/updatescenario.cpp
++++ b/src/framework/update/internal/updatescenario.cpp
+@@ -69,7 +69,7 @@ muse::async::Promise<Ret> UpdateScenario::checkForUpdate(bool manual)
+                 (void)resolve(ret);
+             };
  
- void UpdateScenario::delayedInit()
+-            const bool noUpdate = res.ret.code() == static_cast<int>(Err::NoUpdate);
++            const bool noUpdate = true;
+             if (!noUpdate && !res.ret) {
+                 LOGE() << "Unable to check for app update, error: " << res.ret.toString();
+                 ret = muse::make_ret(Ret::Code::UnknownError);
+@@ -221,8 +221,8 @@ void UpdateScenario::downloadRelease()
+ 
+ void UpdateScenario::askToCloseAndCompleteInstall(const muse::io::path_t& installerPath)
  {
--    if (configuration()->needCheckForUpdate() && multiInstancesProvider()->instances().size() == 1) {
--        QTimer::singleShot(AUTO_CHECK_UPDATE_INTERVAL, [this]() {
--            doCheckForUpdate(false);
--        });
--    }
- }
- 
- void UpdateScenario::checkForUpdate()
- {
--    if (isCheckStarted()) {
--        return;
--    }
-+    QString str = qtrc("update", "Self-update is disabled by AOSC OS. Please update via oma/apt.");
- 
--    doCheckForUpdate(true);
-+    IInteractive::Text text(str.toStdString(), IInteractive::TextFormat::RichText);
-+    IInteractive::ButtonData okBtn = interactive()->buttonData(IInteractive::Button::Ok);
-+
-+    interactive()->info(trc("update", "Self-update disabled"), text, { okBtn }, okBtn.btn,
-+                        IInteractive::Option::WithIcon);
- }
- 
- bool UpdateScenario::isCheckStarted() const
--- 
-2.45.0
-
+-    const std::string info = muse::trc("update", "MuseScore Studio needs to close to complete the installation. "
+-                                                 "If you have any unsaved changes, you will be prompted to save them before MuseScore Studio closes.");
++    const std::string info = muse::trc("update", "Update is disabled."
++                                                 "Please update MuseScore with oma.");
+     const int closeBtn = int(IInteractive::Button::CustomButton) + 1;
+     const IInteractive::Result res = interactive()->infoSync("", info,
+                                                              { interactive()->buttonData(IInteractive::Button::Cancel),

--- a/app-creativity/musescore/spec
+++ b/app-creativity/musescore/spec
@@ -1,5 +1,4 @@
-VER=4.3.2
-REL=2
-SRCS="git::commit=tags/v$VER::https://github.com/musescore/MuseScore"
+VER=4.6.4
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/musescore/MuseScore"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6093"


### PR DESCRIPTION
Topic Description
-----------------

- musescore: update to 4.6.4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- musescore: 4.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit musescore
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
