### PR TITLE
linux-kernel: add Wodposit NVMe SSD to nvme_id_table and apply NVME_QUIRK_NO_SECONDARY_TEMP_THRESH

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-riscv-mmap-use-unsigned-offset-type-in-risc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-riscv-mmap-use-unsigned-offset-type-in-risc.patch
@@ -1,7 +1,7 @@
 From d71b76e1e1fac6f42f015579fc766d628ffd4665 Mon Sep 17 00:00:00 2001
 From: Jessica Liu <liu.xuemei1@zte.com.cn>
 Date: Fri, 1 Aug 2025 10:49:48 +0800
-Subject: [PATCH 001/344] UPSTREAM: riscv: mmap(): use unsigned offset type in
+Subject: [PATCH 001/345] UPSTREAM: riscv: mmap(): use unsigned offset type in
  riscv_sys_mmap
 
 The variable type of offset should be consistent with the relevant
@@ -24,7 +24,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/riscv/kernel/sys_riscv.c b/arch/riscv/kernel/sys_riscv.c
-index d77afe05578f2..795b2e815ac92 100644
+index d77afe05578f..795b2e815ac9 100644
 --- a/arch/riscv/kernel/sys_riscv.c
 +++ b/arch/riscv/kernel/sys_riscv.c
 @@ -10,7 +10,7 @@
@@ -37,5 +37,5 @@ index d77afe05578f2..795b2e815ac92 100644
  {
  	if (unlikely(offset & (~PAGE_MASK >> page_shift_offset)))
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-riscv-introduce-ioremap_wc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-riscv-introduce-ioremap_wc.patch
@@ -1,7 +1,7 @@
 From 13f062a9dc97162eb1aa7c456bb97214f797574b Mon Sep 17 00:00:00 2001
 From: Yunhui Cui <cuiyunhui@bytedance.com>
 Date: Tue, 22 Jul 2025 17:15:04 +0800
-Subject: [PATCH 002/344] UPSTREAM: riscv: introduce ioremap_wc()
+Subject: [PATCH 002/345] UPSTREAM: riscv: introduce ioremap_wc()
 
 Compared with IO attributes, NC attributes can improve performance,
 specifically in these aspects: Relaxed Order, Gathering, Supports Read
@@ -20,7 +20,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  2 files changed, 5 insertions(+)
 
 diff --git a/arch/riscv/include/asm/io.h b/arch/riscv/include/asm/io.h
-index a0e51840b9db4..09bb5f57a9d34 100644
+index a0e51840b9db..09bb5f57a9d3 100644
 --- a/arch/riscv/include/asm/io.h
 +++ b/arch/riscv/include/asm/io.h
 @@ -28,6 +28,10 @@
@@ -35,7 +35,7 @@ index a0e51840b9db4..09bb5f57a9d34 100644
  
  /*
 diff --git a/arch/riscv/include/asm/pgtable.h b/arch/riscv/include/asm/pgtable.h
-index 4355e8f3670bb..e7a4b0ab76bd7 100644
+index 4355e8f3670b..e7a4b0ab76bd 100644
 --- a/arch/riscv/include/asm/pgtable.h
 +++ b/arch/riscv/include/asm/pgtable.h
 @@ -203,6 +203,7 @@ extern struct pt_alloc_ops pt_ops __meminitdata;
@@ -47,5 +47,5 @@ index 4355e8f3670bb..e7a4b0ab76bd7 100644
  #define PAGE_KERNEL_IO		__pgprot(_PAGE_IOREMAP)
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-irqchip-sifive-plic-Respect-mask-state-when.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-irqchip-sifive-plic-Respect-mask-state-when.patch
@@ -1,7 +1,7 @@
 From 5195b68cd82b244bff9c534af895cab4c2a576e1 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Mon, 11 Aug 2025 08:26:32 +0800
-Subject: [PATCH 003/344] UPSTREAM: irqchip/sifive-plic: Respect mask state
+Subject: [PATCH 003/345] UPSTREAM: irqchip/sifive-plic: Respect mask state
  when setting affinity
 
 plic_set_affinity() always calls plic_irq_enable(), which clears up the
@@ -27,7 +27,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/irqchip/irq-sifive-plic.c b/drivers/irqchip/irq-sifive-plic.c
-index 9c4af7d588463..c0cf4fed13e09 100644
+index 9c4af7d58846..c0cf4fed13e0 100644
 --- a/drivers/irqchip/irq-sifive-plic.c
 +++ b/drivers/irqchip/irq-sifive-plic.c
 @@ -179,12 +179,14 @@ static int plic_set_affinity(struct irq_data *d,
@@ -48,5 +48,5 @@ index 9c4af7d588463..c0cf4fed13e09 100644
  	return IRQ_SET_MASK_OK_DONE;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-irqchip-sg2042-msi-Set-MSI_FLAG_MULTI_PCI_M.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-irqchip-sg2042-msi-Set-MSI_FLAG_MULTI_PCI_M.patch
@@ -1,7 +1,7 @@
 From 8637c0710b28e5fdc8ed6a779637d3378ca1c019 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 14 Aug 2025 07:28:34 +0800
-Subject: [PATCH 004/344] UPSTREAM: irqchip/sg2042-msi: Set
+Subject: [PATCH 004/345] UPSTREAM: irqchip/sg2042-msi: Set
  MSI_FLAG_MULTI_PCI_MSI flags for SG2044
 
 The MSI controller on SG2044 has the ability to allocate multiple PCI MSI
@@ -24,7 +24,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/irqchip/irq-sg2042-msi.c b/drivers/irqchip/irq-sg2042-msi.c
-index 2fd4d94f9bd76..3b13dbbfdb51c 100644
+index 2fd4d94f9bd7..3b13dbbfdb51 100644
 --- a/drivers/irqchip/irq-sg2042-msi.c
 +++ b/drivers/irqchip/irq-sg2042-msi.c
 @@ -212,6 +212,7 @@ static const struct msi_parent_ops sg2042_msi_parent_ops = {
@@ -36,5 +36,5 @@ index 2fd4d94f9bd76..3b13dbbfdb51c 100644
  
  static const struct msi_parent_ops sg2044_msi_parent_ops = {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-riscv-Move-vendor-errata-definitions-to-new.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-riscv-Move-vendor-errata-definitions-to-new.patch
@@ -1,7 +1,7 @@
 From 32bd3d7c9fe28a4d95bb32f77de4fa033d2d1b1b Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:20 -0400
-Subject: [PATCH 005/344] UPSTREAM: riscv: Move vendor errata definitions to
+Subject: [PATCH 005/345] UPSTREAM: riscv: Move vendor errata definitions to
  new header
 
 Move vendor errata definitions into errata_list_vendors.h.
@@ -21,7 +21,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  create mode 100644 arch/riscv/include/asm/errata_list_vendors.h
 
 diff --git a/arch/riscv/include/asm/errata_list.h b/arch/riscv/include/asm/errata_list.h
-index 6e426ed7919a4..18c9f7ee9b7c4 100644
+index 6e426ed7919a..18c9f7ee9b7c 100644
 --- a/arch/riscv/include/asm/errata_list.h
 +++ b/arch/riscv/include/asm/errata_list.h
 @@ -10,24 +10,7 @@
@@ -52,7 +52,7 @@ index 6e426ed7919a4..18c9f7ee9b7c4 100644
  
 diff --git a/arch/riscv/include/asm/errata_list_vendors.h b/arch/riscv/include/asm/errata_list_vendors.h
 new file mode 100644
-index 0000000000000..d448b9ce7c7c5
+index 000000000000..d448b9ce7c7c
 --- /dev/null
 +++ b/arch/riscv/include/asm/errata_list_vendors.h
 @@ -0,0 +1,24 @@
@@ -81,5 +81,5 @@ index 0000000000000..d448b9ce7c7c5
 +
 +#endif /* ASM_ERRATA_LIST_VENDORS_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-dts-sophgo-sg2042-added-numa-id-description.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-dts-sophgo-sg2042-added-numa-id-description.patch
@@ -1,7 +1,7 @@
 From e373171e9d6b57f0a74a4a4afc0af06f3e493a34 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 10 Sep 2025 18:55:31 +0800
-Subject: [PATCH 006/344] UPSTREAM: dts: sophgo: sg2042: added numa id
+Subject: [PATCH 006/345] UPSTREAM: dts: sophgo: sg2042: added numa id
  description
 
 According to the description of [1], sg2042 is divided into 4 numa.
@@ -37,7 +37,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  2 files changed, 84 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-cpus.dtsi b/arch/riscv/boot/dts/sophgo/sg2042-cpus.dtsi
-index 77ded53042728..94a4b71acad32 100644
+index 77ded5304272..94a4b71acad3 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-cpus.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-cpus.dtsi
 @@ -272,6 +272,7 @@ cpu0: cpu@0 {
@@ -553,7 +553,7 @@ index 77ded53042728..94a4b71acad32 100644
  			cpu63_intc: interrupt-controller {
  				compatible = "riscv,cpu-intc";
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042.dtsi b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
-index b3e4d3c18fdcf..029561b6ad813 100644
+index b3e4d3c18fdc..029561b6ad81 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 @@ -19,6 +19,26 @@ / {
@@ -584,5 +584,5 @@ index b3e4d3c18fdcf..029561b6ad813 100644
  		serial0 = &uart0;
  	};
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-dt-bindings-pci-Add-Sophgo-SG2042-PCIe-host.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-dt-bindings-pci-Add-Sophgo-SG2042-PCIe-host.patch
@@ -1,7 +1,7 @@
 From 2dd422a19e1fc0f55f6acf0573fbbcf3bf5418ba Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:35:32 +0800
-Subject: [PATCH 007/344] UPSTREAM: dt-bindings: pci: Add Sophgo SG2042 PCIe
+Subject: [PATCH 007/345] UPSTREAM: dt-bindings: pci: Add Sophgo SG2042 PCIe
  host
 
 Add binding for Sophgo SG2042 PCIe host controller.
@@ -19,7 +19,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
 
 diff --git a/Documentation/devicetree/bindings/pci/sophgo,sg2042-pcie-host.yaml b/Documentation/devicetree/bindings/pci/sophgo,sg2042-pcie-host.yaml
 new file mode 100644
-index 0000000000000..f8b7ca57fff14
+index 000000000000..f8b7ca57fff1
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pci/sophgo,sg2042-pcie-host.yaml
 @@ -0,0 +1,64 @@
@@ -88,5 +88,5 @@ index 0000000000000..f8b7ca57fff14
 +      msi-parent = <&msi>;
 +    };
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-PCI-cadence-Check-for-the-existence-of-cdns.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-PCI-cadence-Check-for-the-existence-of-cdns.patch
@@ -1,7 +1,7 @@
 From 3d20eb1809ae42f735ff679e37ffbfc60a340d05 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:36:01 +0800
-Subject: [PATCH 008/344] UPSTREAM: PCI: cadence: Check for the existence of
+Subject: [PATCH 008/345] UPSTREAM: PCI: cadence: Check for the existence of
  cdns_pcie::ops before using it
 
 cdns_pcie::ops might not be populated by all the Cadence glue drivers. This
@@ -23,7 +23,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  3 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-host.c b/drivers/pci/controller/cadence/pcie-cadence-host.c
-index 59a4631de79fe..fffd63d6665e8 100644
+index 59a4631de79f..fffd63d6665e 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence-host.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence-host.c
 @@ -531,7 +531,7 @@ static int cdns_pcie_host_init_address_translation(struct cdns_pcie_rc *rc)
@@ -36,7 +36,7 @@ index 59a4631de79fe..fffd63d6665e8 100644
  
  	addr0 = CDNS_PCIE_AT_OB_REGION_CPU_ADDR0_NBITS(12) |
 diff --git a/drivers/pci/controller/cadence/pcie-cadence.c b/drivers/pci/controller/cadence/pcie-cadence.c
-index 70a19573440ee..61806bbd8aa32 100644
+index 70a19573440e..61806bbd8aa3 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence.c
 @@ -92,7 +92,7 @@ void cdns_pcie_set_outbound_region(struct cdns_pcie *pcie, u8 busnr, u8 fn,
@@ -58,7 +58,7 @@ index 70a19573440ee..61806bbd8aa32 100644
  
  	addr0 = CDNS_PCIE_AT_OB_REGION_CPU_ADDR0_NBITS(17) |
 diff --git a/drivers/pci/controller/cadence/pcie-cadence.h b/drivers/pci/controller/cadence/pcie-cadence.h
-index 1d81c4bf6c6db..2f07ba661bda7 100644
+index 1d81c4bf6c6d..2f07ba661bda 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence.h
 +++ b/drivers/pci/controller/cadence/pcie-cadence.h
 @@ -468,7 +468,7 @@ static inline u32 cdns_pcie_ep_fn_readl(struct cdns_pcie *pcie, u8 fn, u32 reg)
@@ -87,5 +87,5 @@ index 1d81c4bf6c6db..2f07ba661bda7 100644
  
  	return true;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-PCI-sg2042-Add-Sophgo-SG2042-PCIe-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-PCI-sg2042-Add-Sophgo-SG2042-PCIe-driver.patch
@@ -1,7 +1,7 @@
 From 126f81bdd23087303530dbd50f96f44b4b57b53d Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:36:31 +0800
-Subject: [PATCH 009/344] UPSTREAM: PCI: sg2042: Add Sophgo SG2042 PCIe driver
+Subject: [PATCH 009/345] UPSTREAM: PCI: sg2042: Add Sophgo SG2042 PCIe driver
 
 Add support for PCIe controller in Sophgo SG2042 SoC. The controller uses
 the Cadence PCIe core programmed by pcie-cadence* common driver. The PCIe
@@ -22,7 +22,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  create mode 100644 drivers/pci/controller/cadence/pcie-sg2042.c
 
 diff --git a/drivers/pci/controller/cadence/Kconfig b/drivers/pci/controller/cadence/Kconfig
-index 666e16b6367f1..02a639e55fd8c 100644
+index 666e16b6367f..02a639e55fd8 100644
 --- a/drivers/pci/controller/cadence/Kconfig
 +++ b/drivers/pci/controller/cadence/Kconfig
 @@ -42,6 +42,15 @@ config PCIE_CADENCE_PLAT_EP
@@ -48,7 +48,7 @@ index 666e16b6367f1..02a639e55fd8c 100644
 +
  endmenu
 diff --git a/drivers/pci/controller/cadence/Makefile b/drivers/pci/controller/cadence/Makefile
-index 9bac5fb2f13da..5e23f8539ecc1 100644
+index 9bac5fb2f13d..5e23f8539ecc 100644
 --- a/drivers/pci/controller/cadence/Makefile
 +++ b/drivers/pci/controller/cadence/Makefile
 @@ -4,3 +4,4 @@ obj-$(CONFIG_PCIE_CADENCE_HOST) += pcie-cadence-host.o
@@ -58,7 +58,7 @@ index 9bac5fb2f13da..5e23f8539ecc1 100644
 +obj-$(CONFIG_PCIE_SG2042_HOST) += pcie-sg2042.o
 diff --git a/drivers/pci/controller/cadence/pcie-sg2042.c b/drivers/pci/controller/cadence/pcie-sg2042.c
 new file mode 100644
-index 0000000000000..a077b28d48949
+index 000000000000..a077b28d4894
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-sg2042.c
 @@ -0,0 +1,134 @@
@@ -197,5 +197,5 @@ index 0000000000000..a077b28d48949
 +MODULE_DESCRIPTION("PCIe controller driver for SG2042 SoCs");
 +MODULE_AUTHOR("Chen Wang <unicorn_wang@outlook.com>");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-irqchip-sg2042-msi-Set-irq-type-according-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-irqchip-sg2042-msi-Set-irq-type-according-t.patch
@@ -1,7 +1,7 @@
 From 50e3a246e833155584471ee1bb85068b2bd935ba Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Thu, 4 Sep 2025 11:01:19 +0800
-Subject: [PATCH 010/344] UPSTREAM: irqchip/sg2042-msi: Set irq type according
+Subject: [PATCH 010/345] UPSTREAM: irqchip/sg2042-msi: Set irq type according
  to DT configuration
 
 Read the device tree configuration and use it to set the interrupt type.
@@ -17,7 +17,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/irqchip/irq-sg2042-msi.c b/drivers/irqchip/irq-sg2042-msi.c
-index 3b13dbbfdb51c..f7cf0dc72eabb 100644
+index 3b13dbbfdb51..f7cf0dc72eab 100644
 --- a/drivers/irqchip/irq-sg2042-msi.c
 +++ b/drivers/irqchip/irq-sg2042-msi.c
 @@ -30,6 +30,7 @@ struct sg204x_msi_chip_info {
@@ -62,5 +62,5 @@ index 3b13dbbfdb51c..f7cf0dc72eabb 100644
  
  	mutex_init(&data->msi_map_lock);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-riscv-sophgo-dts-sg2042-Change-msi-irq-type.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-riscv-sophgo-dts-sg2042-Change-msi-irq-type.patch
@@ -1,7 +1,7 @@
 From 10525dd490ca78399a54eb3a6dd63867d69212e1 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Thu, 4 Sep 2025 11:00:37 +0800
-Subject: [PATCH 011/344] UPSTREAM: riscv: sophgo: dts: sg2042: Change msi irq
+Subject: [PATCH 011/345] UPSTREAM: riscv: sophgo: dts: sg2042: Change msi irq
  type to IRQ_TYPE_EDGE_RISING
 
 Fix msi irq type to be the correct type, although this field is not used yet.
@@ -17,7 +17,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042.dtsi b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
-index 029561b6ad813..c5e49709b3088 100644
+index 029561b6ad81..c5e49709b308 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 @@ -210,7 +210,7 @@ msi: msi-controller@7030010304 {
@@ -30,5 +30,5 @@ index 029561b6ad813..c5e49709b3088 100644
  
  		rpgate: clock-controller@7030010368 {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-riscv-sophgo-dts-sg2044-Change-msi-irq-type.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-riscv-sophgo-dts-sg2044-Change-msi-irq-type.patch
@@ -1,7 +1,7 @@
 From aa72c6ffcc2ffc5f1e1b5efb4cbf383affda84dd Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Thu, 4 Sep 2025 11:00:59 +0800
-Subject: [PATCH 012/344] UPSTREAM: riscv: sophgo: dts: sg2044: Change msi irq
+Subject: [PATCH 012/345] UPSTREAM: riscv: sophgo: dts: sg2044: Change msi irq
  type to IRQ_TYPE_EDGE_RISING
 
 Fix msi irq type to be the correct type, although this field is not used yet.
@@ -18,7 +18,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2044.dtsi b/arch/riscv/boot/dts/sophgo/sg2044.dtsi
-index 6ec955744b0cb..320c4d1d08e69 100644
+index 6ec955744b0c..320c4d1d08e6 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2044.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2044.dtsi
 @@ -214,7 +214,7 @@ msi: msi-controller@6d50000000 {
@@ -31,5 +31,5 @@ index 6ec955744b0cb..320c4d1d08e69 100644
  		};
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-riscv-acpi-avoid-errors-caused-by-probing-D.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-riscv-acpi-avoid-errors-caused-by-probing-D.patch
@@ -1,7 +1,7 @@
 From 531726d7e04cdcfea0693fbb109832449d3a27fb Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 10 Sep 2025 19:24:01 +0800
-Subject: [PATCH 013/344] UPSTREAM: riscv: acpi: avoid errors caused by probing
+Subject: [PATCH 013/345] UPSTREAM: riscv: acpi: avoid errors caused by probing
  DT devices when ACPI is used
 
 Similar to the ARM64 commit 3505f30fb6a9s ("ARM64 / ACPI: If we chose
@@ -20,7 +20,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/arch/riscv/kernel/setup.c b/arch/riscv/kernel/setup.c
-index f90cce7a3acea..d7ee62837aa4f 100644
+index f90cce7a3ace..d7ee62837aa4 100644
 --- a/arch/riscv/kernel/setup.c
 +++ b/arch/riscv/kernel/setup.c
 @@ -330,11 +330,14 @@ void __init setup_arch(char **cmdline_p)
@@ -41,5 +41,5 @@ index f90cce7a3acea..d7ee62837aa4f 100644
  
  	init_resources();
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 4bf28caa232333e6f9133fe0735aa4810923c04e Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 014/344] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 014/345] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/phy/phy-tegra-usb.c b/drivers/usb/phy/phy-tegra-usb.c
-index fb9031628d397..5374aa99cca48 100644
+index fb9031628d39..5374aa99cca4 100644
 --- a/drivers/usb/phy/phy-tegra-usb.c
 +++ b/drivers/usb/phy/phy-tegra-usb.c
 @@ -174,7 +174,7 @@ struct tegra_xtal_freq {
@@ -47,5 +47,5 @@ index fb9031628d397..5374aa99cca48 100644
  
  static inline struct tegra_usb_phy *to_tegra_usb_phy(struct usb_phy *u_phy)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
@@ -1,7 +1,7 @@
 From 9c19aacf9ef83f45b382c048f01d4287f1b540d4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 015/344] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
+Subject: [PATCH 015/345] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
  before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
@@ -39,7 +39,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/Makefile b/drivers/gpu/drm/Makefile
-index 4dafbdc8f86ac..84bf661a2a87a 100644
+index 4dafbdc8f86a..84bf661a2a87 100644
 --- a/drivers/gpu/drm/Makefile
 +++ b/drivers/gpu/drm/Makefile
 @@ -168,6 +168,7 @@ obj-y			+= clients/
@@ -59,5 +59,5 @@ index 4dafbdc8f86ac..84bf661a2a87a 100644
  obj-$(CONFIG_DRM_TVE200) += tve200/
  obj-$(CONFIG_DRM_ADP) += adp/
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From 422e9745744f286f9806af99b0aabee3f31fa61c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 016/344] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 016/345] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of
@@ -51,7 +51,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 581ae20c46e4b..346f0e49bb2ea 100644
+index 581ae20c46e4..346f0e49bb2e 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,6 +185,7 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,
@@ -63,5 +63,5 @@ index 581ae20c46e4b..346f0e49bb2ea 100644
  
  /**
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From db0980ed67372c458e1be1646d61c88d83d082df Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 017/344] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 017/345] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/mm/cache.c b/arch/loongarch/mm/cache.c
-index 6be04d36ca076..89eeb9a97dd5d 100644
+index 6be04d36ca07..89eeb9a97dd5 100644
 --- a/arch/loongarch/mm/cache.c
 +++ b/arch/loongarch/mm/cache.c
 @@ -63,6 +63,27 @@ static void flush_cache_leaf(unsigned int leaf)
@@ -58,5 +58,5 @@ index 6be04d36ca076..89eeb9a97dd5d 100644
  	}
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
@@ -1,7 +1,7 @@
 From f9fb98b86bd8f01aa707f4e85f959bde1ab3ae6f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:47 +0800
-Subject: [PATCH 018/344] FROMLIST: dt-bindings: serial: 8250: Add Loongson
+Subject: [PATCH 018/345] FROMLIST: dt-bindings: serial: 8250: Add Loongson
  uart compatible
 
 The Loongson family have a mostly NS16550A-compatible UART and
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 14 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/serial/8250.yaml b/Documentation/devicetree/bindings/serial/8250.yaml
-index b243afa69a1ae..167ddcbd88005 100644
+index b243afa69a1a..167ddcbd8800 100644
 --- a/Documentation/devicetree/bindings/serial/8250.yaml
 +++ b/Documentation/devicetree/bindings/serial/8250.yaml
 @@ -125,6 +125,8 @@ properties:
@@ -52,5 +52,5 @@ index b243afa69a1ae..167ddcbd88005 100644
    reg:
      maxItems: 1
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
@@ -1,7 +1,7 @@
 From 6c7b0acd1a091183b611c27bfea329c023fef9f9 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:48 +0800
-Subject: [PATCH 019/344] FROMLIST: serial: 8250: Add Loongson uart driver
+Subject: [PATCH 019/345] FROMLIST: serial: 8250: Add Loongson uart driver
  support
 
 Add the driver for on-chip UART used on Loongson family chips.
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/drivers/tty/serial/8250/8250_loongson.c b/drivers/tty/serial/8250/8250_loongson.c
 new file mode 100644
-index 0000000000000..53153a116c011
+index 000000000000..53153a116c01
 --- /dev/null
 +++ b/drivers/tty/serial/8250/8250_loongson.c
 @@ -0,0 +1,238 @@
@@ -272,7 +272,7 @@ index 0000000000000..53153a116c011
 +MODULE_AUTHOR("Loongson Technology Corporation Limited.");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/tty/serial/8250/Kconfig b/drivers/tty/serial/8250/Kconfig
-index f64ef0819cd4e..98236b3bec102 100644
+index f64ef0819cd4..98236b3bec10 100644
 --- a/drivers/tty/serial/8250/Kconfig
 +++ b/drivers/tty/serial/8250/Kconfig
 @@ -468,6 +468,16 @@ config SERIAL_8250_OMAP_TTYO_FIXUP
@@ -293,7 +293,7 @@ index f64ef0819cd4e..98236b3bec102 100644
  	tristate "NXP LPC18xx/43xx serial port support"
  	depends on SERIAL_8250 && OF && (ARCH_LPC18XX || COMPILE_TEST)
 diff --git a/drivers/tty/serial/8250/Makefile b/drivers/tty/serial/8250/Makefile
-index 513a0941c284f..e318a32407898 100644
+index 513a0941c284..e318a3240789 100644
 --- a/drivers/tty/serial/8250/Makefile
 +++ b/drivers/tty/serial/8250/Makefile
 @@ -38,6 +38,7 @@ obj-$(CONFIG_SERIAL_8250_HP300)		+= 8250_hp300.o
@@ -305,5 +305,5 @@ index 513a0941c284f..e318a32407898 100644
  obj-$(CONFIG_SERIAL_8250_LPSS)		+= 8250_lpss.o
  obj-$(CONFIG_SERIAL_8250_MEN_MCB)	+= 8250_men_mcb.o
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
@@ -1,7 +1,7 @@
 From 42ca55085242438974c65fc24283f5e2a8cd7c5c Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:49 +0800
-Subject: [PATCH 020/344] FROMLIST: LoongArch: dts: Add uart new compatible
+Subject: [PATCH 020/345] FROMLIST: LoongArch: dts: Add uart new compatible
  string
 
 Add loongson,ls2k*-uart compatible string on uarts.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/boot/dts/loongson-2k0500.dtsi b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
-index 588ebc3bded40..357de4ca75550 100644
+index 588ebc3bded4..357de4ca7555 100644
 --- a/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 @@ -380,7 +380,7 @@ tsensor: thermal-sensor@1fe11500 {
@@ -32,7 +32,7 @@ index 588ebc3bded40..357de4ca75550 100644
  			clock-frequency = <100000000>;
  			interrupt-parent = <&eiointc>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k1000.dtsi b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
-index d8e01e2534dde..60ab425f793fe 100644
+index d8e01e2534dd..60ab425f793f 100644
 --- a/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 @@ -297,7 +297,7 @@ dma-controller@1fe00c40 {
@@ -45,7 +45,7 @@ index d8e01e2534dde..60ab425f793fe 100644
  			clock-frequency = <125000000>;
  			interrupt-parent = <&liointc0>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k2000.dtsi b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
-index 00cc485b753b1..6c77b86ee06c8 100644
+index 00cc485b753b..6c77b86ee06c 100644
 --- a/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 @@ -250,7 +250,7 @@ i2c@1fe00130 {
@@ -58,5 +58,5 @@ index 00cc485b753b1..6c77b86ee06c8 100644
  			clock-frequency = <100000000>;
  			interrupt-parent = <&liointc>;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From 0042fef8abc6260296e8f937eddb339a8da78ed3 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Wed, 23 Oct 2024 16:38:05 +0800
-Subject: [PATCH 021/344] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 021/345] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/input/mouse/pixart_ps2.h
 
 diff --git a/drivers/input/mouse/Kconfig b/drivers/input/mouse/Kconfig
-index 833b643f06164..8a27a20d04b01 100644
+index 833b643f0616..8a27a20d04b0 100644
 --- a/drivers/input/mouse/Kconfig
 +++ b/drivers/input/mouse/Kconfig
 @@ -69,6 +69,18 @@ config MOUSE_PS2_LOGIPS2PP
@@ -54,7 +54,7 @@ index 833b643f06164..8a27a20d04b01 100644
  	bool "Synaptics PS/2 mouse protocol extension" if EXPERT
  	default y
 diff --git a/drivers/input/mouse/Makefile b/drivers/input/mouse/Makefile
-index a1336d5bee6f3..5630295515291 100644
+index a1336d5bee6f..563029551529 100644
 --- a/drivers/input/mouse/Makefile
 +++ b/drivers/input/mouse/Makefile
 @@ -32,6 +32,7 @@ psmouse-$(CONFIG_MOUSE_PS2_ELANTECH)	+= elantech.o
@@ -67,7 +67,7 @@ index a1336d5bee6f3..5630295515291 100644
  psmouse-$(CONFIG_MOUSE_PS2_TOUCHKIT)	+= touchkit_ps2.o
 diff --git a/drivers/input/mouse/pixart_ps2.c b/drivers/input/mouse/pixart_ps2.c
 new file mode 100644
-index 0000000000000..d5cd009361716
+index 000000000000..d5cd00936171
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.c
 @@ -0,0 +1,310 @@
@@ -383,7 +383,7 @@ index 0000000000000..d5cd009361716
 +}
 diff --git a/drivers/input/mouse/pixart_ps2.h b/drivers/input/mouse/pixart_ps2.h
 new file mode 100644
-index 0000000000000..47a1d040f2d10
+index 000000000000..47a1d040f2d1
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.h
 @@ -0,0 +1,36 @@
@@ -424,7 +424,7 @@ index 0000000000000..47a1d040f2d10
 +
 +#endif  /* _PIXART_PS2_H */
 diff --git a/drivers/input/mouse/psmouse-base.c b/drivers/input/mouse/psmouse-base.c
-index 77ea7da3b1c50..f708b75eb91b4 100644
+index 77ea7da3b1c5..f708b75eb91b 100644
 --- a/drivers/input/mouse/psmouse-base.c
 +++ b/drivers/input/mouse/psmouse-base.c
 @@ -36,6 +36,7 @@
@@ -466,7 +466,7 @@ index 77ea7da3b1c50..f708b75eb91b4 100644
  		if (psmouse_try_protocol(psmouse, PSMOUSE_GENPS,
  					 &max_proto, set_properties, true))
 diff --git a/drivers/input/mouse/psmouse.h b/drivers/input/mouse/psmouse.h
-index 4d8acfe0d82aa..23f7fa7243cb5 100644
+index 4d8acfe0d82a..23f7fa7243cb 100644
 --- a/drivers/input/mouse/psmouse.h
 +++ b/drivers/input/mouse/psmouse.h
 @@ -69,6 +69,7 @@ enum psmouse_type {
@@ -487,5 +487,5 @@ index 4d8acfe0d82aa..23f7fa7243cb5 100644
  	unsigned char pktcnt;
  	unsigned char pktsize;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From 513b2eaa0f3cd120b22fb36214b5a0d1e310d477 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 022/344] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 022/345] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index caf508f6e9ec8..a580a9cc0f1eb 100644
+index caf508f6e9ec..a580a9cc0f1e 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2904,9 +2904,6 @@ config ARCH_SUPPORTS_KEXEC
@@ -35,5 +35,5 @@ index caf508f6e9ec8..a580a9cc0f1eb 100644
  	hex "Physical address where the kernel is loaded"
  	default "0xffffffff84000000"
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 09b6119d237e6525e06e14fa65d4484bb28f85e3 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 023/344] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 023/345] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/fpu/xstate.h b/arch/x86/kernel/fpu/xstate.h
-index 52ce192899892..fb5ea65a70ca9 100644
+index 52ce19289989..fb5ea65a70ca 100644
 --- a/arch/x86/kernel/fpu/xstate.h
 +++ b/arch/x86/kernel/fpu/xstate.h
 @@ -93,6 +93,9 @@ static inline int update_pkru_in_sigframe(struct xregs_state __user *buf, u32 pk
@@ -49,5 +49,5 @@ index 52ce192899892..fb5ea65a70ca9 100644
  
  	lmask = mask;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From 16c7cea973d1b5770f76cd38f751b7c158a2cf3f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 024/344] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 024/345] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 256fe8c86828d..390f82b4845df 100644
+index 256fe8c86828..390f82b4845d 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3522,6 +3522,7 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)
@@ -45,5 +45,5 @@ index 256fe8c86828d..390f82b4845df 100644
  
  		/* System sleep transitions should never fail */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
@@ -1,7 +1,7 @@
 From ee27619509391ad208fbcc13d7ce909f2b7be36b Mon Sep 17 00:00:00 2001
 From: WangYuli <wangyuli@uniontech.com>
 Date: Tue, 18 Mar 2025 14:11:25 +0800
-Subject: [PATCH 025/344] FROMLIST: scsi: Bypass certain SCSI commands on disks
+Subject: [PATCH 025/345] FROMLIST: scsi: Bypass certain SCSI commands on disks
  with "use_192_bytes_for_3f" attribute
 
 On some external USB hard drives, mounting can fail if "lshw" is
@@ -122,7 +122,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/drivers/scsi/scsi_lib.c b/drivers/scsi/scsi_lib.c
-index 0c65ecfedfbd6..c38c79fe9ca2d 100644
+index 0c65ecfedfbd..c38c79fe9ca2 100644
 --- a/drivers/scsi/scsi_lib.c
 +++ b/drivers/scsi/scsi_lib.c
 @@ -1568,6 +1568,7 @@ static void scsi_complete(struct request *rq)
@@ -152,5 +152,5 @@ index 0c65ecfedfbd6..c38c79fe9ca2d 100644
  		cmd->result = (DID_NO_CONNECT << 16);
  		goto done;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
@@ -1,7 +1,7 @@
 From 162fcb33ba02d52c0b2559bab571e3d073af3954 Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Sun, 11 May 2025 16:34:12 +0800
-Subject: [PATCH 026/344] FROMLIST: PCI: Use local_pci_probe() when best
+Subject: [PATCH 026/345] FROMLIST: PCI: Use local_pci_probe() when best
  selected cpu is offline
 
 When the best selected CPU is offline, work_on_cpu() will stuck forever.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 6405acdb5d0f3..829ddeada7797 100644
+index 6405acdb5d0f..829ddeada779 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -386,7 +386,7 @@ static int pci_call_probe(struct pci_driver *drv, struct pci_dev *dev,
@@ -33,5 +33,5 @@ index 6405acdb5d0f3..829ddeada7797 100644
  	else
  		error = local_pci_probe(&ddi);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From 66250d44df3e9f312ed27183855938a976530ec8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 11 May 2025 16:34:13 +0800
-Subject: [PATCH 027/344] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 027/345] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 829ddeada7797..2c60f5c490216 100644
+index 829ddeada779..2c60f5c49021 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -517,7 +517,7 @@ static void pci_device_shutdown(struct device *dev)
@@ -41,5 +41,5 @@ index 829ddeada7797..2c60f5c490216 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
@@ -1,7 +1,7 @@
 From 0cc02b17b05aece244a30f107d7e9f634bf811b8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 17 Aug 2025 22:19:09 +0800
-Subject: [PATCH 028/344] REVERT: Revert "Mark xe driver as BROKEN if kernel
+Subject: [PATCH 028/345] REVERT: Revert "Mark xe driver as BROKEN if kernel
  page size is not 4kB"
 
 This reverts commit 022906afdf90327bce33d52fb4fb41b6c7d618fb.
@@ -12,7 +12,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
-index 714d5702dfd78..2bb2bc052120d 100644
+index 714d5702dfd7..2bb2bc052120 100644
 --- a/drivers/gpu/drm/xe/Kconfig
 +++ b/drivers/gpu/drm/xe/Kconfig
 @@ -5,7 +5,6 @@ config DRM_XE
@@ -24,5 +24,5 @@ index 714d5702dfd78..2bb2bc052120d 100644
  	# we need shmfs for the swappable backing store, and in particular
  	# the shmem_readpage() which depends upon tmpfs
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
@@ -1,7 +1,7 @@
 From 8e3bd9b75a6d902924fa72769d2602fd61631b1e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 029/344] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
+Subject: [PATCH 029/345] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
  non-4K kernel page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU
@@ -104,7 +104,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
-index 50c79049ccea0..65121ddc431a4 100644
+index 50c79049ccea..65121ddc431a 100644
 --- a/drivers/gpu/drm/xe/xe_bo.c
 +++ b/drivers/gpu/drm/xe/xe_bo.c
 @@ -1863,9 +1863,9 @@ struct xe_bo *___xe_bo_create_locked(struct xe_device *xe, struct xe_bo *bo,
@@ -129,5 +129,5 @@ index 50c79049ccea0..65121ddc431a4 100644
  	if (resv) {
  		ctx.allow_res_evict = !(flags & XE_BO_FLAG_NO_RESV_EVICT);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From 487c9767ebff75af2e437831aefc15dcfae9a63d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 030/344] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
+Subject: [PATCH 030/345] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
  alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -69,7 +69,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  6 files changed, 26 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
-index 270fc37924936..4804c5eb6998a 100644
+index 270fc3792493..4804c5eb6998 100644
 --- a/drivers/gpu/drm/xe/xe_guc.c
 +++ b/drivers/gpu/drm/xe/xe_guc.c
 @@ -91,7 +91,7 @@ static u32 guc_ctl_feature_flags(struct xe_guc *guc)
@@ -91,7 +91,7 @@ index 270fc37924936..4804c5eb6998a 100644
  
  	return flags;
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index 131cfc56be00a..59e6eba03fd53 100644
+index 131cfc56be00..59e6eba03fd5 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -144,17 +144,17 @@ static size_t guc_ads_regset_size(struct xe_guc_ads *ads)
@@ -214,7 +214,7 @@ index 131cfc56be00a..59e6eba03fd53 100644
  
  		xe_map_memcpy_to(xe, ads_to_map(ads), offset,
 diff --git a/drivers/gpu/drm/xe/xe_guc_capture.c b/drivers/gpu/drm/xe/xe_guc_capture.c
-index 243dad3e24185..548bf778d8003 100644
+index 243dad3e2418..548bf778d800 100644
 --- a/drivers/gpu/drm/xe/xe_guc_capture.c
 +++ b/drivers/gpu/drm/xe/xe_guc_capture.c
 @@ -591,8 +591,8 @@ guc_capture_getlistsize(struct xe_guc *guc, u32 owner, u32 type,
@@ -247,7 +247,7 @@ index 243dad3e24185..548bf778d8003 100644
  
  static int guc_capture_output_size_est(struct xe_guc *guc)
 diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
-index 3f4e6a46ff163..961f7c6608c11 100644
+index 3f4e6a46ff16..961f7c6608c1 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ct.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ct.c
 @@ -219,7 +219,7 @@ int xe_guc_ct_init_noalloc(struct xe_guc_ct *ct)
@@ -260,7 +260,7 @@ index 3f4e6a46ff163..961f7c6608c11 100644
  	ct->g2h_wq = alloc_ordered_workqueue("xe-g2h-wq", WQ_MEM_RECLAIM);
  	if (!ct->g2h_wq)
 diff --git a/drivers/gpu/drm/xe/xe_guc_log.c b/drivers/gpu/drm/xe/xe_guc_log.c
-index c01ccb35dc752..0f40286bc7fb7 100644
+index c01ccb35dc75..0f40286bc7fb 100644
 --- a/drivers/gpu/drm/xe/xe_guc_log.c
 +++ b/drivers/gpu/drm/xe/xe_guc_log.c
 @@ -58,7 +58,7 @@ static size_t guc_log_size(void)
@@ -282,7 +282,7 @@ index c01ccb35dc752..0f40286bc7fb7 100644
  	for (i = GUC_LOG_BUFFER_CRASH_DUMP; i < GUC_LOG_BUFFER_TYPE_MAX; ++i) {
  		if (i == type)
 diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
-index 68b192fe3b32e..e9a7ac5aa646d 100644
+index 68b192fe3b32..e9a7ac5aa646 100644
 --- a/drivers/gpu/drm/xe/xe_guc_pc.c
 +++ b/drivers/gpu/drm/xe/xe_guc_pc.c
 @@ -1190,7 +1190,7 @@ int xe_guc_pc_start(struct xe_guc_pc *pc)
@@ -304,5 +304,5 @@ index 68b192fe3b32e..e9a7ac5aa646d 100644
  
  	if (xe->info.skip_guc_pc)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
 From 95a5e86a1e09d7f7c3e1397b82be5a0b8ed93343 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 031/344] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 031/345] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),
@@ -86,7 +86,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
-index 7ade41e2b7b3b..a7608c50c907e 100644
+index 7ade41e2b7b3..a7608c50c907 100644
 --- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 @@ -56,7 +56,7 @@
@@ -99,5 +99,5 @@ index 7ade41e2b7b3b..a7608c50c907e 100644
  #define RING_START_UDW(base)			XE_REG((base) + 0x48)
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From f909073e8c65726bc7f2a3250d7b9ac06e0186ea Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 032/344] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 032/345] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 
@@ -95,7 +95,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index 13e287e037096..5407da7ac55a7 100644
+index 13e287e03709..5407da7ac55a 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
 @@ -595,7 +595,7 @@ static void emit_pte(struct xe_migrate *m,
@@ -117,5 +117,5 @@ index 13e287e037096..5407da7ac55a7 100644
  		}
  	}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From 112059f0c685a4f7610262160e37475a0ad93539 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 033/344] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 033/345] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_query.c b/drivers/gpu/drm/xe/xe_query.c
-index f2a3d4ced068c..35821e9c46487 100644
+index f2a3d4ced068..35821e9c4648 100644
 --- a/drivers/gpu/drm/xe/xe_query.c
 +++ b/drivers/gpu/drm/xe/xe_query.c
 @@ -344,7 +344,7 @@ static int query_config(struct xe_device *xe, struct drm_xe_device_query *query)
@@ -42,7 +42,7 @@ index f2a3d4ced068c..35821e9c46487 100644
  	config->info[DRM_XE_QUERY_CONFIG_MAX_EXEC_QUEUE_PRIORITY] =
  		xe_exec_queue_device_get_max_priority(xe);
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index e2426413488fe..84715d5bab248 100644
+index e2426413488f..84715d5bab24 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -398,7 +398,7 @@ struct drm_xe_query_mem_regions {
@@ -55,5 +55,5 @@ index e2426413488fe..84715d5bab248 100644
   *  - %DRM_XE_QUERY_CONFIG_MAX_EXEC_QUEUE_PRIORITY - Value of the highest
   *    available exec queue priority
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-BACKPORT-FROMLIST-mfd-ls2kbmc-Introduce-Loongson-2K-.patch
@@ -1,7 +1,7 @@
 From d8a179c6e1194b7dd1df296af48828c200bc5b11 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 4 Sep 2025 20:35:05 +0800
-Subject: [PATCH 034/344] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
+Subject: [PATCH 034/345] BACKPORT: FROMLIST: mfd: ls2kbmc: Introduce
  Loongson-2K BMC core driver
 
 The Loongson-2K Board Management Controller provides an PCIe interface
@@ -32,7 +32,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/mfd/ls2k-bmc-core.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 97d958c945e4f..44753852a63ea 100644
+index 97d958c945e4..44753852a63e 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -14423,6 +14423,12 @@ S:	Maintained
@@ -49,7 +49,7 @@ index 97d958c945e4f..44753852a63ea 100644
  M:	Zhao Qunqin <zhaoqunqin@loongson.cn>
  L:	linux-edac@vger.kernel.org
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 425c5fba6cb1e..55fbeba2ca33b 100644
+index 425c5fba6cb1..55fbeba2ca33 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2428,6 +2428,19 @@ config MFD_INTEL_M10_BMC_PMCI
@@ -73,7 +73,7 @@ index 425c5fba6cb1e..55fbeba2ca33b 100644
  	tristate "QNAP microcontroller unit core driver"
  	depends on SERIAL_DEV_BUS
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index f7bdedd5a66d1..a950e670efbae 100644
+index f7bdedd5a66d..a950e670efba 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -286,6 +286,8 @@ obj-$(CONFIG_MFD_INTEL_M10_BMC_CORE)   += intel-m10-bmc-core.o
@@ -87,7 +87,7 @@ index f7bdedd5a66d1..a950e670efbae 100644
  
 diff --git a/drivers/mfd/ls2k-bmc-core.c b/drivers/mfd/ls2k-bmc-core.c
 new file mode 100644
-index 0000000000000..39cc481d9ba12
+index 000000000000..39cc481d9ba1
 --- /dev/null
 +++ b/drivers/mfd/ls2k-bmc-core.c
 @@ -0,0 +1,189 @@
@@ -281,5 +281,5 @@ index 0000000000000..39cc481d9ba12
 +MODULE_AUTHOR("Loongson Technology Corporation Limited");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMLIST-mfd-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-FROMLIST-mfd-ls2kbmc-Add-Loongson-2K-BMC-reset-funct.patch
@@ -1,7 +1,7 @@
 From 186f2ad1271c53c05d1834f34b943aa6de29a5d0 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 4 Sep 2025 20:35:06 +0800
-Subject: [PATCH 035/344] FROMLIST: mfd: ls2kbmc: Add Loongson-2K BMC reset
+Subject: [PATCH 035/345] FROMLIST: mfd: ls2kbmc: Add Loongson-2K BMC reset
  function support
 
 Since the display is a sub-function of the Loongson-2K BMC, when the
@@ -42,7 +42,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 339 insertions(+)
 
 diff --git a/drivers/mfd/ls2k-bmc-core.c b/drivers/mfd/ls2k-bmc-core.c
-index 39cc481d9ba12..e162b3c7c9f82 100644
+index 39cc481d9ba1..e162b3c7c9f8 100644
 --- a/drivers/mfd/ls2k-bmc-core.c
 +++ b/drivers/mfd/ls2k-bmc-core.c
 @@ -10,8 +10,12 @@
@@ -429,5 +429,5 @@ index 39cc481d9ba12..e162b3c7c9f82 100644
  	if (ret)
  		goto disable_pci;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-FROMLIST-ipmi-Add-Loongson-2K-BMC-support.patch
@@ -1,7 +1,7 @@
 From 8ad8627a44918ab804b2d9a934318a529e483150 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 4 Sep 2025 20:35:07 +0800
-Subject: [PATCH 036/344] FROMLIST: ipmi: Add Loongson-2K BMC support
+Subject: [PATCH 036/345] FROMLIST: ipmi: Add Loongson-2K BMC support
 
 This patch adds Loongson-2K BMC IPMI support.
 
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/char/ipmi/ipmi_si_ls2k.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 44753852a63ea..960252b6987c1 100644
+index 44753852a63e..960252b6987c 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -14427,6 +14427,7 @@ LOONGSON-2K Board Management Controller (BMC) DRIVER
@@ -53,7 +53,7 @@ index 44753852a63ea..960252b6987c1 100644
  
  LOONGSON EDAC DRIVER
 diff --git a/drivers/char/ipmi/Kconfig b/drivers/char/ipmi/Kconfig
-index f4adc6feb3b22..92bed266d07cd 100644
+index f4adc6feb3b2..92bed266d07c 100644
 --- a/drivers/char/ipmi/Kconfig
 +++ b/drivers/char/ipmi/Kconfig
 @@ -84,6 +84,13 @@ config IPMI_IPMB
@@ -71,7 +71,7 @@ index f4adc6feb3b22..92bed266d07cd 100644
  	depends on PPC_POWERNV
  	tristate 'POWERNV (OPAL firmware) IPMI interface'
 diff --git a/drivers/char/ipmi/Makefile b/drivers/char/ipmi/Makefile
-index e0944547c9d0e..4ea450a82242f 100644
+index e0944547c9d0..4ea450a82242 100644
 --- a/drivers/char/ipmi/Makefile
 +++ b/drivers/char/ipmi/Makefile
 @@ -8,6 +8,7 @@ ipmi_si-y := ipmi_si_intf.o ipmi_kcs_sm.o ipmi_smic_sm.o ipmi_bt_sm.o \
@@ -83,7 +83,7 @@ index e0944547c9d0e..4ea450a82242f 100644
  
  obj-$(CONFIG_IPMI_HANDLER) += ipmi_msghandler.o
 diff --git a/drivers/char/ipmi/ipmi_si.h b/drivers/char/ipmi/ipmi_si.h
-index 508c3fd458776..687835b53da58 100644
+index 508c3fd45877..687835b53da5 100644
 --- a/drivers/char/ipmi/ipmi_si.h
 +++ b/drivers/char/ipmi/ipmi_si.h
 @@ -101,6 +101,13 @@ void ipmi_si_pci_shutdown(void);
@@ -101,7 +101,7 @@ index 508c3fd458776..687835b53da58 100644
  void ipmi_si_parisc_init(void);
  void ipmi_si_parisc_shutdown(void);
 diff --git a/drivers/char/ipmi/ipmi_si_intf.c b/drivers/char/ipmi/ipmi_si_intf.c
-index 8b5524069c15a..cc7033e7f5508 100644
+index 8b5524069c15..cc7033e7f550 100644
 --- a/drivers/char/ipmi/ipmi_si_intf.c
 +++ b/drivers/char/ipmi/ipmi_si_intf.c
 @@ -2120,6 +2120,8 @@ static int __init init_ipmi_si(void)
@@ -124,7 +124,7 @@ index 8b5524069c15a..cc7033e7f5508 100644
  	ipmi_si_platform_shutdown();
 diff --git a/drivers/char/ipmi/ipmi_si_ls2k.c b/drivers/char/ipmi/ipmi_si_ls2k.c
 new file mode 100644
-index 0000000000000..45442c257efdb
+index 000000000000..45442c257efd
 --- /dev/null
 +++ b/drivers/char/ipmi/ipmi_si_ls2k.c
 @@ -0,0 +1,189 @@
@@ -318,5 +318,5 @@ index 0000000000000..45442c257efdb
 +		platform_driver_unregister(&ipmi_ls2k_platform_driver);
 +}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMLIST-PCI-Override-PCIe-bridge-supported-speeds-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-FROMLIST-PCI-Override-PCIe-bridge-supported-speeds-f.patch
@@ -1,7 +1,7 @@
 From 525125004d1998704229caff86bbc88aa84d4d91 Mon Sep 17 00:00:00 2001
 From: Ziyao <liziyao@uniontech.com>
 Date: Fri, 22 Aug 2025 17:15:58 +0800
-Subject: [PATCH 037/344] FROMLIST: PCI: Override PCIe bridge supported speeds
+Subject: [PATCH 037/345] FROMLIST: PCI: Override PCIe bridge supported speeds
  for older Loongson 3C6000 series steppings
 
 Older steppings of the Loongson 3C6000 series incorrectly report the
@@ -34,7 +34,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index d97335a401930..8d29b130f4585 100644
+index d97335a40193..8d29b130f458 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -1956,6 +1956,30 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL,	PCI_DEVICE_ID_INTEL_E7525_MCH,	quir
@@ -69,5 +69,5 @@ index d97335a401930..8d29b130f4585 100644
   * HiSilicon KunPeng920 and KunPeng930 have devices appear as PCI but are
   * actually on the AMBA bus. These fake PCI devices can support SVA via
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
@@ -1,7 +1,7 @@
 From 7ecdebe4e86ac4799f71af3b2ba672227afa8eab Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Aug 2025 11:21:36 +0800
-Subject: [PATCH 038/344] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
+Subject: [PATCH 038/345] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
  LoongArch and AArch64
 
 While testing my ROCm port for LoongArch and AArch64 (patches pending) on
@@ -132,7 +132,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/amd/amdkfd/Kconfig b/drivers/gpu/drm/amd/amdkfd/Kconfig
-index 16e12c9913f94..5d2fa86f60bf8 100644
+index 16e12c9913f9..5d2fa86f60bf 100644
 --- a/drivers/gpu/drm/amd/amdkfd/Kconfig
 +++ b/drivers/gpu/drm/amd/amdkfd/Kconfig
 @@ -14,7 +14,7 @@ config HSA_AMD
@@ -145,5 +145,5 @@ index 16e12c9913f94..5d2fa86f60bf8 100644
  	select HMM_MIRROR
  	select MMU_NOTIFIER
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMLIST-drm-ttm-add-pgprot-handling-for-RISC-V.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-FROMLIST-drm-ttm-add-pgprot-handling-for-RISC-V.patch
@@ -1,7 +1,7 @@
 From 50e25ee0f06854c0360fa4d8dae72f83d2214ee0 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 22 Jul 2025 19:20:50 +0800
-Subject: [PATCH 039/344] FROMLIST: drm/ttm: add pgprot handling for RISC-V
+Subject: [PATCH 039/345] FROMLIST: drm/ttm: add pgprot handling for RISC-V
 
 The RISC-V Svpbmt privileged extension provides support for overriding
 page memory coherency attributes, and, along with vendor extensions like
@@ -20,7 +20,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_module.c b/drivers/gpu/drm/ttm/ttm_module.c
-index b3fffe7b5062a..aa137ead5cc59 100644
+index b3fffe7b5062..aa137ead5cc5 100644
 --- a/drivers/gpu/drm/ttm/ttm_module.c
 +++ b/drivers/gpu/drm/ttm/ttm_module.c
 @@ -74,7 +74,8 @@ pgprot_t ttm_prot_from_caching(enum ttm_caching caching, pgprot_t tmp)
@@ -34,5 +34,5 @@ index b3fffe7b5062a..aa137ead5cc59 100644
  		tmp = pgprot_writecombine(tmp);
  	else
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
@@ -1,7 +1,7 @@
 From 2beac68b89225e3770143c838a1275e33c9e8091 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:46 +0800
-Subject: [PATCH 040/344] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
+Subject: [PATCH 040/345] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
  coherency status in ttm_device
 
 Currently TTM utilizes cached memory regardless of whether the device
@@ -22,7 +22,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  2 files changed, 15 insertions(+)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_device.c b/drivers/gpu/drm/ttm/ttm_device.c
-index c3e2fcbdd2cc6..1758d94b3d445 100644
+index c3e2fcbdd2cc..1758d94b3d44 100644
 --- a/drivers/gpu/drm/ttm/ttm_device.c
 +++ b/drivers/gpu/drm/ttm/ttm_device.c
 @@ -246,6 +246,12 @@ int ttm_device_init(struct ttm_device *bdev, const struct ttm_device_funcs *func
@@ -39,7 +39,7 @@ index c3e2fcbdd2cc6..1758d94b3d445 100644
  }
  EXPORT_SYMBOL(ttm_device_init);
 diff --git a/include/drm/ttm/ttm_device.h b/include/drm/ttm/ttm_device.h
-index 592b5f8028599..c2e61312a43a2 100644
+index 592b5f802859..c2e61312a43a 100644
 --- a/include/drm/ttm/ttm_device.h
 +++ b/include/drm/ttm/ttm_device.h
 @@ -225,6 +225,15 @@ struct ttm_device {
@@ -59,5 +59,5 @@ index 592b5f8028599..c2e61312a43a2 100644
  	 * @sysman: Resource manager for the system domain.
  	 * Access via ttm_manager_type.
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
@@ -1,7 +1,7 @@
 From 89568f8258fff99a68c1ba82c3d3e2bce329b784 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:47 +0800
-Subject: [PATCH 041/344] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
+Subject: [PATCH 041/345] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
  write_combined when snooping not available
 
 As we can now acquire the presence of the full DMA coherency (snooping
@@ -19,7 +19,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  3 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_bo_util.c b/drivers/gpu/drm/ttm/ttm_bo_util.c
-index acbbca9d5c92f..b31b22ee03e9c 100644
+index acbbca9d5c92..b31b22ee03e9 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo_util.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo_util.c
 @@ -307,6 +307,14 @@ pgprot_t ttm_io_prot(struct ttm_buffer_object *bo, struct ttm_resource *res,
@@ -38,7 +38,7 @@ index acbbca9d5c92f..b31b22ee03e9c 100644
  }
  EXPORT_SYMBOL(ttm_io_prot);
 diff --git a/drivers/gpu/drm/ttm/ttm_tt.c b/drivers/gpu/drm/ttm/ttm_tt.c
-index 506e257dfba85..8338deb3330f6 100644
+index 506e257dfba8..8338deb3330f 100644
 --- a/drivers/gpu/drm/ttm/ttm_tt.c
 +++ b/drivers/gpu/drm/ttm/ttm_tt.c
 @@ -154,6 +154,14 @@ static void ttm_tt_init_fields(struct ttm_tt *ttm,
@@ -57,7 +57,7 @@ index 506e257dfba85..8338deb3330f6 100644
  	ttm->page_flags = page_flags;
  	ttm->dma_address = NULL;
 diff --git a/include/drm/ttm/ttm_caching.h b/include/drm/ttm/ttm_caching.h
-index a18f43e93abab..f92d7911f50e4 100644
+index a18f43e93aba..f92d7911f50e 100644
 --- a/include/drm/ttm/ttm_caching.h
 +++ b/include/drm/ttm/ttm_caching.h
 @@ -47,7 +47,8 @@ enum ttm_caching {
@@ -71,5 +71,5 @@ index a18f43e93abab..f92d7911f50e4 100644
  	ttm_cached
  };
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMLIST-drm-amd-display-dml2-Guard-dml21_map_dc_sta.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-FROMLIST-drm-amd-display-dml2-Guard-dml21_map_dc_sta.patch
@@ -1,7 +1,7 @@
 From 12a97c03b957bf9b67234feddbe4a66c85ed7303 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 25 Aug 2025 16:52:11 +0800
-Subject: [PATCH 042/344] FROMLIST: drm/amd/display/dml2: Guard
+Subject: [PATCH 042/345] FROMLIST: drm/amd/display/dml2: Guard
  dml21_map_dc_state_into_dml_display_cfg with DC_FP_START
 
 dml21_map_dc_state_into_dml_display_cfg calls (the call is usually
@@ -38,7 +38,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
-index 03de3cf06ae59..059ede6ff2561 100644
+index 03de3cf06ae5..059ede6ff256 100644
 --- a/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
 +++ b/drivers/gpu/drm/amd/display/dc/dml2/dml21/dml21_wrapper.c
 @@ -224,7 +224,9 @@ static bool dml21_mode_check_and_programming(const struct dc *in_dc, struct dc_s
@@ -62,5 +62,5 @@ index 03de3cf06ae59..059ede6ff2561 100644
  	DC_FP_START();
  	is_supported = dml2_check_mode_supported(mode_support);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMLIST-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-FROMLIST-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
@@ -1,7 +1,7 @@
 From 383cb5491497e0b21b97984f0e723a034ae0067f Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:36:50 +0800
-Subject: [PATCH 043/344] FROMLIST: riscv: sophgo: dts: add PCIe controllers
+Subject: [PATCH 043/345] FROMLIST: riscv: sophgo: dts: add PCIe controllers
  for SG2042
 
 Add PCIe controller nodes in DTS for Sophgo SG2042.
@@ -16,7 +16,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 88 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042.dtsi b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
-index c5e49709b3088..e3497b5cad1df 100644
+index c5e49709b308..e3497b5cad1d 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 @@ -240,6 +240,94 @@ clkgen: clock-controller@7030012000 {
@@ -115,5 +115,5 @@ index c5e49709b3088..e3497b5cad1df 100644
  			compatible = "sophgo,sg2042-aclint-mswi", "thead,c900-aclint-mswi";
  			reg = <0x00000070 0x94000000 0x00000000 0x00004000>;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
@@ -1,7 +1,7 @@
 From 6b4ea4d36cf736e2f897d0eea351d4c325c40e5f Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:37:13 +0800
-Subject: [PATCH 044/344] FROMLIST: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 044/345] FROMLIST: riscv: sophgo: dts: enable PCIe for
  PioneerBox
 
 Enable PCIe controllers for PioneerBox, which uses SG2042 SoC.
@@ -14,7 +14,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
-index ef3a602172b1e..c4d5f8d7d4ad3 100644
+index ef3a602172b1..c4d5f8d7d4ad 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 @@ -128,6 +128,18 @@ uart0-rx-pins {
@@ -37,5 +37,5 @@ index ef3a602172b1e..c4d5f8d7d4ad3 100644
  	pinctrl-0 = <&sd_cfg>;
  	pinctrl-names = "default";
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 8cfbc67b31534ee2ba18f8c603084710a77cf2f5 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:37:35 +0800
-Subject: [PATCH 045/344] FROMLIST: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 045/345] FROMLIST: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V1.X
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V1.X board,
@@ -15,7 +15,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
-index 3320bc1dd2c66..a186d036cf360 100644
+index 3320bc1dd2c6..a186d036cf36 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 @@ -164,6 +164,18 @@ phy0: phy@0 {
@@ -38,5 +38,5 @@ index 3320bc1dd2c66..a186d036cf360 100644
  	emmc_cfg: sdhci-emmc-cfg {
  		sdhci-emmc-wp-pins {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-FROMLIST-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 599ad4d7a3fd6c675bc0210225a8dedf0f93bf72 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Fri, 12 Sep 2025 10:37:54 +0800
-Subject: [PATCH 046/344] FROMLIST: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 046/345] FROMLIST: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V2.0
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V2.0 board,
@@ -15,7 +15,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
-index 46980e41b886c..0cd0dc0f537c1 100644
+index 46980e41b886..0cd0dc0f537c 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 @@ -152,6 +152,18 @@ phy0: phy@0 {
@@ -38,5 +38,5 @@ index 46980e41b886c..0cd0dc0f537c1 100644
  	emmc_cfg: sdhci-emmc-cfg {
  		sdhci-emmc-wp-pins {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMLIST-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-FROMLIST-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
@@ -1,7 +1,7 @@
 From d11dfcbc0f65f2baac542caae6d8ef6838efb821 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:50 +0800
-Subject: [PATCH 047/344] FROMLIST: riscv: dts: sophgo: Add SPI NOR node for
+Subject: [PATCH 047/345] FROMLIST: riscv: dts: sophgo: Add SPI NOR node for
  SG2042
 
 Add SPI NOR controller node for SG2042
@@ -16,7 +16,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042.dtsi b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
-index e3497b5cad1df..e0e805c86b32a 100644
+index e3497b5cad1d..e0e805c86b32 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 @@ -68,6 +68,30 @@ soc: soc {
@@ -51,5 +51,5 @@ index e3497b5cad1df..e0e805c86b32a 100644
  			compatible = "snps,designware-i2c";
  			reg = <0x70 0x30005000 0x0 0x1000>;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
@@ -1,7 +1,7 @@
 From b9d1cb29fa6ef2044ffcda324d240ea6be9dbd3e Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:51 +0800
-Subject: [PATCH 048/344] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 048/345] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
  PioneerBox
 
 Enable SPI NOR node for PioneerBox device tree
@@ -19,7 +19,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
-index c4d5f8d7d4ad3..54d8386bf9c0f 100644
+index c4d5f8d7d4ad..54d8386bf9c0 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 @@ -150,6 +150,30 @@ &sd {
@@ -54,5 +54,5 @@ index c4d5f8d7d4ad3..54d8386bf9c0f 100644
  	pinctrl-0 = <&uart0_cfg>;
  	pinctrl-names = "default";
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 917e6e26bd8908809ba1dc2ae35dd99f07b5e2ac Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:52 +0800
-Subject: [PATCH 049/344] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 049/345] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V1
 
 Enable SPI NOR node for SG2042_EVB_V1 device tree
@@ -17,7 +17,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
-index a186d036cf360..b116dfa904cd9 100644
+index a186d036cf36..b116dfa904cd 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 @@ -250,6 +250,30 @@ &sd {
@@ -52,5 +52,5 @@ index a186d036cf360..b116dfa904cd9 100644
  	pinctrl-0 = <&uart0_cfg>;
  	pinctrl-names = "default";
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-FROMLIST-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 9fd871a12e381c7acbe479f63d93b328a577de1b Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:53 +0800
-Subject: [PATCH 050/344] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 050/345] FROMLIST: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V2
 
 Enable SPI NOR node for SG2042_EVB_V2 device tree
@@ -17,7 +17,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
-index 0cd0dc0f537c1..b2ceae2d8829e 100644
+index 0cd0dc0f537c..b2ceae2d8829 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 @@ -238,6 +238,18 @@ &sd {
@@ -40,5 +40,5 @@ index 0cd0dc0f537c1..b2ceae2d8829e 100644
  	pinctrl-0 = <&uart0_cfg>;
  	pinctrl-names = "default";
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
@@ -1,7 +1,7 @@
 From 1949ee57e78bb483e85315699430c9b028b9ee60 Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:21 -0400
-Subject: [PATCH 051/344] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
+Subject: [PATCH 051/345] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
  fixup
 
 The early version of XuanTie C910 core has a store merge buffer
@@ -38,7 +38,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  create mode 100644 arch/riscv/include/asm/rwonce.h
 
 diff --git a/arch/riscv/Kconfig.errata b/arch/riscv/Kconfig.errata
-index e318119d570de..d2c982ba53730 100644
+index e318119d570d..d2c982ba5373 100644
 --- a/arch/riscv/Kconfig.errata
 +++ b/arch/riscv/Kconfig.errata
 @@ -130,4 +130,21 @@ config ERRATA_THEAD_GHOSTWRITE
@@ -64,7 +64,7 @@ index e318119d570de..d2c982ba53730 100644
 +
  endmenu # "CPU errata selection"
 diff --git a/arch/riscv/errata/thead/errata.c b/arch/riscv/errata/thead/errata.c
-index 0b942183f708f..fbe46f2fa8fbb 100644
+index 0b942183f708..fbe46f2fa8fb 100644
 --- a/arch/riscv/errata/thead/errata.c
 +++ b/arch/riscv/errata/thead/errata.c
 @@ -168,6 +168,23 @@ static bool errata_probe_ghostwrite(unsigned int stage,
@@ -102,7 +102,7 @@ index 0b942183f708f..fbe46f2fa8fbb 100644
  }
  
 diff --git a/arch/riscv/include/asm/errata_list_vendors.h b/arch/riscv/include/asm/errata_list_vendors.h
-index d448b9ce7c7c5..d29d33ce2197d 100644
+index d448b9ce7c7c..d29d33ce2197 100644
 --- a/arch/riscv/include/asm/errata_list_vendors.h
 +++ b/arch/riscv/include/asm/errata_list_vendors.h
 @@ -18,7 +18,8 @@
@@ -117,7 +117,7 @@ index d448b9ce7c7c5..d29d33ce2197d 100644
  #endif /* ASM_ERRATA_LIST_VENDORS_H */
 diff --git a/arch/riscv/include/asm/rwonce.h b/arch/riscv/include/asm/rwonce.h
 new file mode 100644
-index 0000000000000..081793d4d772d
+index 000000000000..081793d4d772
 --- /dev/null
 +++ b/arch/riscv/include/asm/rwonce.h
 @@ -0,0 +1,34 @@
@@ -156,7 +156,7 @@ index 0000000000000..081793d4d772d
 +
 +#endif	/* __ASM_RWONCE_H */
 diff --git a/include/asm-generic/rwonce.h b/include/asm-generic/rwonce.h
-index 52b969c7cef93..4e2d941f15a11 100644
+index 52b969c7cef9..4e2d941f15a1 100644
 --- a/include/asm-generic/rwonce.h
 +++ b/include/asm-generic/rwonce.h
 @@ -50,10 +50,12 @@
@@ -173,5 +173,5 @@ index 52b969c7cef93..4e2d941f15a11 100644
  #define WRITE_ONCE(x, val)						\
  do {									\
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
@@ -1,7 +1,7 @@
 From 743c26a9c6555be3f240f2ba2351905db3038481 Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sat, 11 Oct 2025 11:57:46 -0400
-Subject: [PATCH 052/344] FROMLIST: riscv: Add pgprot_dmacoherent definition
+Subject: [PATCH 052/345] FROMLIST: riscv: Add pgprot_dmacoherent definition
 
 RISC-V Svpbmt Standard Extension for Page-Based Memory Types
 defines three modes:
@@ -29,7 +29,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/arch/riscv/include/asm/pgtable.h b/arch/riscv/include/asm/pgtable.h
-index e7a4b0ab76bd7..e790d869c793a 100644
+index e7a4b0ab76bd..e790d869c793 100644
 --- a/arch/riscv/include/asm/pgtable.h
 +++ b/arch/riscv/include/asm/pgtable.h
 @@ -656,6 +656,15 @@ static inline pgprot_t pgprot_writecombine(pgprot_t _prot)
@@ -49,5 +49,5 @@ index e7a4b0ab76bd7..e790d869c793a 100644
   * Both Svade and Svadu control the hardware behavior when the PTE A/D bits need to be set. By
   * default the M-mode firmware enables the hardware updating scheme when only Svadu is present in
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
@@ -1,7 +1,7 @@
 From 7bf21c387e304f58fba7f7e9b2679cb99fd4d396 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ilpo=20J=C3=A4rvinen?= <ilpo.jarvinen@linux.intel.com>
 Date: Thu, 18 Sep 2025 13:58:56 -0700
-Subject: [PATCH 053/344] FROMLIST: PCI: Release BAR0 of an integrated bridge
+Subject: [PATCH 053/345] FROMLIST: PCI: Release BAR0 of an integrated bridge
  to allow GPU BAR resize
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -48,7 +48,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 23 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 8d29b130f4585..b497a9e8118f4 100644
+index 8d29b130f458..b497a9e8118f 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -6362,3 +6362,26 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)
@@ -79,5 +79,5 @@ index 8d29b130f4585..b497a9e8118f4 100644
 +DECLARE_PCI_FIXUP_ENABLE(PCI_VENDOR_ID_INTEL, 0x4fa1, pci_release_bar0);
 +DECLARE_PCI_FIXUP_ENABLE(PCI_VENDOR_ID_INTEL, 0xe2ff, pci_release_bar0);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-FROMLIST-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
@@ -1,7 +1,7 @@
 From a832d4c87d3221867f9de8e6210d4ff3d2dc56d0 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 14 Oct 2025 09:48:29 +0800
-Subject: [PATCH 054/344] FROMLIST: perf vendor events riscv: add T-HEAD C920V2
+Subject: [PATCH 054/345] FROMLIST: perf vendor events riscv: add T-HEAD C920V2
  JSON support
 
 T-HEAD C920 has a V2 iteration, which supports Sscompmf. The V2
@@ -17,7 +17,7 @@ Signed-off-by: Han Gao <rabenda.cn@gmail.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/tools/perf/pmu-events/arch/riscv/mapfile.csv b/tools/perf/pmu-events/arch/riscv/mapfile.csv
-index 0a7e7dcc81be4..d5eea7f9aa9a4 100644
+index 0a7e7dcc81be..d5eea7f9aa9a 100644
 --- a/tools/perf/pmu-events/arch/riscv/mapfile.csv
 +++ b/tools/perf/pmu-events/arch/riscv/mapfile.csv
 @@ -20,5 +20,6 @@
@@ -28,5 +28,5 @@ index 0a7e7dcc81be4..d5eea7f9aa9a4 100644
  0x67e-0x80000000db0000[89]0-0x[[:xdigit:]]+,v1,starfive/dubhe-80,core
  0x31e-0x8000000000008a45-0x[[:xdigit:]]+,v1,andes/ax45,core
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From caa2134a4bcba42c6e69c38ba16e7786c96404e0 Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia.pukngae@linux.dev>
 Date: Wed, 22 Oct 2025 18:40:42 +0800
-Subject: [PATCH 055/344] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 055/345] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 6c999d89ee4bd..422e28ad1e8e2 100644
+index 6c999d89ee4b..422e28ad1e8e 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -1937,6 +1937,13 @@ static const struct dmi_system_id atkbd_dmi_quirk_table[] __initconst = {
@@ -45,5 +45,5 @@ index 6c999d89ee4bd..422e28ad1e8e2 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-rust-Add-fno-isolate-erroneous-paths-derefe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-FROMLIST-rust-Add-fno-isolate-erroneous-paths-derefe.patch
@@ -1,7 +1,7 @@
 From c9bcab5531624eae66a1fe97f07a590db100a27d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 15 Oct 2025 10:20:37 +0800
-Subject: [PATCH 056/344] FROMLIST: rust: Add
+Subject: [PATCH 056/345] FROMLIST: rust: Add
  -fno-isolate-erroneous-paths-dereference to bindgen_skip_c_flags
 
 It's used to work around an objtool issue since commit abb2a5572264
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rust/Makefile b/rust/Makefile
-index bfa915b0e5885..1a4ca25d5d7bf 100644
+index bfa915b0e588..1a4ca25d5d7b 100644
 --- a/rust/Makefile
 +++ b/rust/Makefile
 @@ -290,7 +290,7 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
@@ -32,5 +32,5 @@ index bfa915b0e5885..1a4ca25d5d7bf 100644
  # Derived from `scripts/Makefile.clang`.
  BINDGEN_TARGET_x86	:= x86_64-linux-gnu
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From e8004645f9ea8837f63ae6088f47481f60e49912 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 057/344] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 057/345] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index a580a9cc0f1eb..c972f8448bf3b 100644
+index a580a9cc0f1e..c972f8448bf3 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -529,6 +529,7 @@ config MACH_LOONGSON64
@@ -21,5 +21,5 @@ index a580a9cc0f1eb..c972f8448bf3b 100644
  	  This enables the support of Loongson-2/3 family of machines.
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From c26fef19b9a7869b25a22cfebf492c0e42af2d26 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 058/344] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 058/345] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/scsi/lpfc/lpfc_compat.h b/drivers/scsi/lpfc/lpfc_compat.h
-index 43cf46a3a71fe..0cd1e3c82d875 100644
+index 43cf46a3a71f..0cd1e3c82d87 100644
 --- a/drivers/scsi/lpfc/lpfc_compat.h
 +++ b/drivers/scsi/lpfc/lpfc_compat.h
 @@ -91,8 +91,8 @@ lpfc_memcpy_to_slim( void __iomem *dest, void *src, unsigned int bytes)
@@ -44,5 +44,5 @@ index 43cf46a3a71fe..0cd1e3c82d875 100644
  
  #endif	/* __BIG_ENDIAN */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From 390755d8277f37d99682e271c186bfa8106e969d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 059/344] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 059/345] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 32 insertions(+)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index c89e70df43d82..cc0360e8dd62c 100644
+index c89e70df43d8..cc0360e8dd62 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,6 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)
@@ -97,5 +97,5 @@ index c89e70df43d82..cc0360e8dd62c 100644
  		      dcoptop:
  			DPFROMREG(fr, MIPSInst_FR(ir));
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 72698fcf4f3ac962aec2f3dba3e2b1de587cfc96 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 060/344] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 060/345] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it
@@ -48,7 +48,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  9 files changed, 51 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/include/asm/cpu-info.h b/arch/mips/include/asm/cpu-info.h
-index fd60837ce50bc..ec34bcb9953e5 100644
+index fd60837ce50b..ec34bcb9953e 100644
 --- a/arch/mips/include/asm/cpu-info.h
 +++ b/arch/mips/include/asm/cpu-info.h
 @@ -126,7 +126,9 @@ extern void cpu_report(void);
@@ -62,7 +62,7 @@ index fd60837ce50bc..ec34bcb9953e5 100644
  struct seq_file;
  struct notifier_block;
 diff --git a/arch/mips/include/asm/mach-loongson64/boot_param.h b/arch/mips/include/asm/mach-loongson64/boot_param.h
-index 3a11ce85762be..943c576220732 100644
+index 3a11ce85762b..943c57622073 100644
 --- a/arch/mips/include/asm/mach-loongson64/boot_param.h
 +++ b/arch/mips/include/asm/mach-loongson64/boot_param.h
 @@ -66,6 +66,7 @@ struct efi_cpuinfo_loongson {
@@ -74,7 +74,7 @@ index 3a11ce85762be..943c576220732 100644
  
  #define MAX_UARTS 64
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index 5e7193b759f33..93f8cd52e3d47 100644
+index 5e7193b759f3..93f8cd52e3d4 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -22,6 +22,8 @@ extern spinlock_t rtc_lock;
@@ -87,7 +87,7 @@ index 5e7193b759f33..93f8cd52e3d47 100644
   * mips_hpt_frequency - must be set if you intend to use an R4k-compatible
   * counter as a timer interrupt source.
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index 04dc9ab555244..ae0a4849e80e6 100644
+index 04dc9ab55524..ae0a4849e80e 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -1250,32 +1250,44 @@ static inline void cpu_probe_legacy(struct cpuinfo_mips *c, unsigned int cpu)
@@ -180,7 +180,7 @@ index 04dc9ab555244..ae0a4849e80e6 100644
  const char *__elf_base_platform;
  
 diff --git a/arch/mips/kernel/proc.c b/arch/mips/kernel/proc.c
-index 8f0a0001540c7..9b2e85a2a932e 100644
+index 8f0a0001540c..9b2e85a2a932 100644
 --- a/arch/mips/kernel/proc.c
 +++ b/arch/mips/kernel/proc.c
 @@ -15,6 +15,7 @@
@@ -204,7 +204,7 @@ index 8f0a0001540c7..9b2e85a2a932e 100644
  		      cpu_data[n].udelay_val / (500000/HZ),
  		      (cpu_data[n].udelay_val / (5000/HZ)) % 100);
 diff --git a/arch/mips/kernel/time.c b/arch/mips/kernel/time.c
-index ed339d7979f3f..849c6be53b296 100644
+index ed339d7979f3..849c6be53b29 100644
 --- a/arch/mips/kernel/time.c
 +++ b/arch/mips/kernel/time.c
 @@ -120,6 +120,8 @@ EXPORT_SYMBOL(perf_irq);
@@ -217,7 +217,7 @@ index ed339d7979f3f..849c6be53b296 100644
  EXPORT_SYMBOL_GPL(mips_hpt_frequency);
  
 diff --git a/arch/mips/loongson64/env.c b/arch/mips/loongson64/env.c
-index be8d2ad10750f..c15a68c72dd46 100644
+index be8d2ad10750..c15a68c72dd4 100644
 --- a/arch/mips/loongson64/env.c
 +++ b/arch/mips/loongson64/env.c
 @@ -18,6 +18,7 @@
@@ -271,7 +271,7 @@ index be8d2ad10750f..c15a68c72dd46 100644
  	id = readl(HOST_BRIDGE_CONFIG_ADDR);
  	vendor = id & 0xffff;
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 147acd972a07b..69c1e77e6bfc7 100644
+index 147acd972a07..69c1e77e6bfc 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -418,6 +418,7 @@ static void loongson3_init_secondary(void)
@@ -283,7 +283,7 @@ index 147acd972a07b..69c1e77e6bfc7 100644
  
  static void loongson3_smp_finish(void)
 diff --git a/arch/mips/loongson64/smp.h b/arch/mips/loongson64/smp.h
-index 957bde81e0e4e..6112d9d7dd226 100644
+index 957bde81e0e4..6112d9d7dd22 100644
 --- a/arch/mips/loongson64/smp.h
 +++ b/arch/mips/loongson64/smp.h
 @@ -3,6 +3,7 @@
@@ -295,5 +295,5 @@ index 957bde81e0e4e..6112d9d7dd226 100644
  
  /* 4 groups(nodes) in maximum in numa case */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From c7b0548b4cac97bffd89f01e2d3315db0424f480 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 061/344] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 061/345] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six
@@ -54,7 +54,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.c
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index c972f8448bf3b..0b970d67e67c7 100644
+index c972f8448bf3..0b970d67e67c 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -28,6 +28,7 @@ config MIPS
@@ -106,7 +106,7 @@ index c972f8448bf3b..0b970d67e67c7 100644
  	  Select this option if you want to run n32 binaries.  These are
  	  64-bit binaries using 32-bit quantities for addressing and certain
 diff --git a/arch/mips/include/asm/abi.h b/arch/mips/include/asm/abi.h
-index dba7f4b6bebfa..6e717a4a13ceb 100644
+index dba7f4b6bebf..6e717a4a13ce 100644
 --- a/arch/mips/include/asm/abi.h
 +++ b/arch/mips/include/asm/abi.h
 @@ -21,6 +21,7 @@ struct mips_abi {
@@ -118,7 +118,7 @@ index dba7f4b6bebfa..6e717a4a13ceb 100644
  	unsigned	off_sc_fpregs;
  	unsigned	off_sc_fpc_csr;
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index ba83d3fb0a848..1c054e3096db8 100644
+index ba83d3fb0a84..1c054e3096db 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,4 +64,14 @@
@@ -137,7 +137,7 @@ index ba83d3fb0a848..1c054e3096db8 100644
 +
  #endif /* _ASM_UNISTD_H */
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index 4abe387549ad2..b501ea16ccd40 100644
+index 4abe387549ad..b501ea16ccd4 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,34 +6,37 @@
@@ -188,7 +188,7 @@ index 4abe387549ad2..b501ea16ccd40 100644
  
  #endif /* _UAPI_ASM_UNISTD_H */
 diff --git a/arch/mips/kernel/Makefile b/arch/mips/kernel/Makefile
-index 95a1e674fd678..b9786a289592c 100644
+index 95a1e674fd67..b9786a289592 100644
 --- a/arch/mips/kernel/Makefile
 +++ b/arch/mips/kernel/Makefile
 @@ -105,6 +105,10 @@ obj-$(CONFIG_HW_PERF_EVENTS)	+= perf_event_mipsxx.o
@@ -204,7 +204,7 @@ index 95a1e674fd678..b9786a289592c 100644
  
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
 new file mode 100644
-index 0000000000000..2248badc3acb6
+index 000000000000..2248badc3acb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -0,0 +1,58 @@
@@ -268,7 +268,7 @@ index 0000000000000..2248badc3acb6
 +__initcall(audit_classes_n32_init);
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
 new file mode 100644
-index 0000000000000..09ae3dbcfecbc
+index 000000000000..09ae3dbcfecb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-native.c
 @@ -0,0 +1,97 @@
@@ -371,7 +371,7 @@ index 0000000000000..09ae3dbcfecbc
 +__initcall(audit_classes_init);
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
 new file mode 100644
-index 0000000000000..e8b9b50f7d267
+index 000000000000..e8b9b50f7d26
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -0,0 +1,60 @@
@@ -436,7 +436,7 @@ index 0000000000000..e8b9b50f7d267
 +
 +__initcall(audit_classes_o32_init);
 diff --git a/arch/mips/kernel/signal.c b/arch/mips/kernel/signal.c
-index 4a10f18a88060..c803c39f5cbe5 100644
+index 4a10f18a8806..c803c39f5cbe 100644
 --- a/arch/mips/kernel/signal.c
 +++ b/arch/mips/kernel/signal.c
 @@ -8,6 +8,7 @@
@@ -472,7 +472,7 @@ index 4a10f18a88060..c803c39f5cbe5 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_n32.c b/arch/mips/kernel/signal_n32.c
-index 139d2596b0d40..fb9ddefae9648 100644
+index 139d2596b0d4..fb9ddefae964 100644
 --- a/arch/mips/kernel/signal_n32.c
 +++ b/arch/mips/kernel/signal_n32.c
 @@ -2,6 +2,7 @@
@@ -498,7 +498,7 @@ index 139d2596b0d40..fb9ddefae9648 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_o32.c b/arch/mips/kernel/signal_o32.c
-index 4f04584596507..ea3f280a18aa0 100644
+index 4f0458459650..ea3f280a18aa 100644
 --- a/arch/mips/kernel/signal_o32.c
 +++ b/arch/mips/kernel/signal_o32.c
 @@ -8,6 +8,7 @@
@@ -524,7 +524,7 @@ index 4f04584596507..ea3f280a18aa0 100644
  	.off_sc_fpregs = offsetof(struct sigcontext32, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext32, sc_fpc_csr),
 diff --git a/include/uapi/linux/audit.h b/include/uapi/linux/audit.h
-index 9a4ecc9f6dc5b..cc6b2d751225a 100644
+index 9a4ecc9f6dc5..cc6b2d751225 100644
 --- a/include/uapi/linux/audit.h
 +++ b/include/uapi/linux/audit.h
 @@ -191,7 +191,11 @@
@@ -553,7 +553,7 @@ index 9a4ecc9f6dc5b..cc6b2d751225a 100644
   * are currently used in an audit field constant understood by the kernel.
   * If you are adding a new #define AUDIT_<whatever>, please ensure that
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index eb98cd6fe91fb..e3a6a37e5e40a 100644
+index eb98cd6fe91f..e3a6a37e5e40 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -189,6 +189,19 @@ static int audit_match_perm(struct audit_context *ctx, int mask)
@@ -577,5 +577,5 @@ index eb98cd6fe91fb..e3a6a37e5e40a 100644
  		return 0;
  	}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 38e91a7022f949162417a509827debaa886974c5 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 062/344] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 062/345] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are
@@ -36,7 +36,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/arch/mips/loongson64/init.c b/arch/mips/loongson64/init.c
-index b9f90f33fc9a6..21cd12ec24e27 100644
+index b9f90f33fc9a..21cd12ec24e2 100644
 --- a/arch/mips/loongson64/init.c
 +++ b/arch/mips/loongson64/init.c
 @@ -22,6 +22,16 @@
@@ -65,5 +65,5 @@ index b9f90f33fc9a6..21cd12ec24e27 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From 42aa7c97d7967124208eab03b1dd5f50af8fb79a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 063/344] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 063/345] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 11b9b6b63e19f..36ae7c5ff48b9 100644
+index 11b9b6b63e19..36ae7c5ff48b 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -357,8 +357,10 @@ static int __init early_parse_mem(char *p)
@@ -36,5 +36,5 @@ index 11b9b6b63e19f..36ae7c5ff48b9 100644
  	start = 0;
  	size = memparse(p, &p);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From 89243fdc59ab4eaabda112919a706497d3d6986a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 064/344] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 064/345] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 62 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 36ae7c5ff48b9..22f4f9158413d 100644
+index 36ae7c5ff48b..22f4f9158413 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -54,6 +54,10 @@ struct cpuinfo_mips cpu_data[NR_CPUS] __read_mostly;
@@ -121,5 +121,5 @@ index 36ae7c5ff48b9..22f4f9158413d 100644
  
  	/*
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 4638db5d982d421cae8ed63e650525b80f73b29d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 065/344] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 065/345] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 33 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 0b970d67e67c7..50493cfcda3a7 100644
+index 0b970d67e67c..50493cfcda3a 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -18,6 +18,7 @@ config MIPS
@@ -36,7 +36,7 @@ index 0b970d67e67c7..50493cfcda3a7 100644
  	select ARCH_USE_BUILTIN_BSWAP
  	select ARCH_USE_CMPXCHG_LOCKREF if 64BIT
 diff --git a/arch/mips/include/asm/pgtable-64.h b/arch/mips/include/asm/pgtable-64.h
-index 6e854bb11f37d..1f2c3e5d0ad43 100644
+index 6e854bb11f37..1f2c3e5d0ad4 100644
 --- a/arch/mips/include/asm/pgtable-64.h
 +++ b/arch/mips/include/asm/pgtable-64.h
 @@ -260,7 +260,7 @@ static inline int pmd_present(pmd_t pmd)
@@ -49,7 +49,7 @@ index 6e854bb11f37d..1f2c3e5d0ad43 100644
  
  	return pmd_val(pmd) != (unsigned long) invalid_pte_table;
 diff --git a/arch/mips/include/asm/pgtable-bits.h b/arch/mips/include/asm/pgtable-bits.h
-index 088623ba7b8b1..9ee6e189d329f 100644
+index 088623ba7b8b..9ee6e189d329 100644
 --- a/arch/mips/include/asm/pgtable-bits.h
 +++ b/arch/mips/include/asm/pgtable-bits.h
 @@ -52,6 +52,9 @@ enum pgtable_bits {
@@ -105,7 +105,7 @@ index 088623ba7b8b1..9ee6e189d329f 100644
  # define _PAGE_SPECIAL		(1 << _PAGE_SPECIAL_SHIFT)
  #else
 diff --git a/arch/mips/include/asm/pgtable.h b/arch/mips/include/asm/pgtable.h
-index ae73ecf4c41aa..c061e5ed295ad 100644
+index ae73ecf4c41a..c061e5ed295a 100644
 --- a/arch/mips/include/asm/pgtable.h
 +++ b/arch/mips/include/asm/pgtable.h
 @@ -160,7 +160,7 @@ static inline void pte_clear(struct mm_struct *mm, unsigned long addr, pte_t *pt
@@ -146,5 +146,5 @@ index ae73ecf4c41aa..c061e5ed295ad 100644
  #define pmd_leaf(pmd)	((pmd_val(pmd) & _PAGE_HUGE) != 0)
  #define pud_leaf(pud)	((pud_val(pud) & _PAGE_HUGE) != 0)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From eb654b97e23bdae9d25d18082152a1d651546364 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 066/344] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 066/345] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/numa.c b/arch/mips/loongson64/numa.c
-index 95d5f553ce198..d7771472b5673 100644
+index 95d5f553ce19..d7771472b567 100644
 --- a/arch/mips/loongson64/numa.c
 +++ b/arch/mips/loongson64/numa.c
 @@ -60,7 +60,7 @@ static int __init compute_node_distance(int row, int col)
@@ -31,5 +31,5 @@ index 95d5f553ce198..d7771472b5673 100644
  
  static void __init init_topology_matrix(void)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From bdbbdf74fd69b877aef3b569a9baa700f96d5245 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 067/344] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 067/345] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid
@@ -36,7 +36,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 12 insertions(+), 15 deletions(-)
 
 diff --git a/arch/mips/mm/tlbex.c b/arch/mips/mm/tlbex.c
-index 69ea54bdc0c36..33f613d6665b8 100644
+index 69ea54bdc0c3..33f613d6665b 100644
 --- a/arch/mips/mm/tlbex.c
 +++ b/arch/mips/mm/tlbex.c
 @@ -676,13 +676,12 @@ static void build_huge_tlb_write_entry(u32 **p, struct uasm_label **l,
@@ -132,5 +132,5 @@ index 69ea54bdc0c36..33f613d6665b8 100644
  #ifdef CONFIG_SMP
  	uasm_l_smp_pgtable_change(l, *p);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 7577fcd71855a74891a9b43836fc46ef74df0e24 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 068/344] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 068/345] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 50493cfcda3a7..a36bb567d66e1 100644
+index 50493cfcda3a..a36bb567d66e 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -532,7 +532,6 @@ config MACH_LOONGSON64
@@ -21,5 +21,5 @@ index 50493cfcda3a7..a36bb567d66e1 100644
  	  This enables the support of Loongson-2/3 family of machines.
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From d04da184a5c0604a1f74b52204a0a6fd1b6c82fa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 069/344] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 069/345] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 27 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/irqchip/irq-loongson-eiointc.c b/drivers/irqchip/irq-loongson-eiointc.c
-index b2860eb2d32c5..8d253ac2931a2 100644
+index b2860eb2d32c..8d253ac2931a 100644
 --- a/drivers/irqchip/irq-loongson-eiointc.c
 +++ b/drivers/irqchip/irq-loongson-eiointc.c
 @@ -129,21 +129,46 @@ static void veiointc_set_irq_route(unsigned int vector, unsigned int cpu)
@@ -83,5 +83,5 @@ index b2860eb2d32c5..8d253ac2931a2 100644
  	regaddr = EIOINTC_REG_ENABLE_VEC(vector);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From cad4c2cecaae1384a447111b309e9a081cc4ee7b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 070/344] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 070/345] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/loongarch/cpu_hwmon.c
 
 diff --git a/drivers/platform/loongarch/Kconfig b/drivers/platform/loongarch/Kconfig
-index 447528797d07a..b87f51c4e4b66 100644
+index 447528797d07..b87f51c4e4b6 100644
 --- a/drivers/platform/loongarch/Kconfig
 +++ b/drivers/platform/loongarch/Kconfig
 @@ -16,6 +16,14 @@ menuconfig LOONGARCH_PLATFORM_DEVICES
@@ -37,7 +37,7 @@ index 447528797d07a..b87f51c4e4b66 100644
  	tristate "Generic Loongson-3 Laptop Driver"
  	depends on ACPI_EC
 diff --git a/drivers/platform/loongarch/Makefile b/drivers/platform/loongarch/Makefile
-index f43ab03db1a2d..8038291bae3aa 100644
+index f43ab03db1a2..8038291bae3a 100644
 --- a/drivers/platform/loongarch/Makefile
 +++ b/drivers/platform/loongarch/Makefile
 @@ -1 +1,2 @@
@@ -45,7 +45,7 @@ index f43ab03db1a2d..8038291bae3aa 100644
  obj-$(CONFIG_LOONGSON_LAPTOP) += loongson-laptop.o
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
 new file mode 100644
-index 0000000000000..93a05993745aa
+index 000000000000..93a05993745a
 --- /dev/null
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -0,0 +1,194 @@
@@ -244,5 +244,5 @@ index 0000000000000..93a05993745aa
 +MODULE_DESCRIPTION("Loongson CPU Hwmon driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From 7fcddb1bcc5635fae6d5f534338f09e05990798e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 071/344] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 071/345] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:
@@ -43,7 +43,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/firmware/sysfb.c b/drivers/firmware/sysfb.c
-index 889e5b05c739c..8988df462ef08 100644
+index 889e5b05c739..8988df462ef0 100644
 --- a/drivers/firmware/sysfb.c
 +++ b/drivers/firmware/sysfb.c
 @@ -221,4 +221,4 @@ static __init int sysfb_init(void)
@@ -53,5 +53,5 @@ index 889e5b05c739c..8988df462ef08 100644
 -device_initcall(sysfb_init);
 +fs_initcall(sysfb_init);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 0ae27290fea17b2ecfffeb678ca09a514bb3046c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 072/344] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 072/345] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 51a3e0fc2f56b..0b804e951b7b6 100644
+index 51a3e0fc2f56..0b804e951b7b 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -8093,6 +8093,7 @@ int cik_irq_process(struct radeon_device *rdev)
@@ -33,7 +33,7 @@ index 51a3e0fc2f56b..0b804e951b7b6 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index bc4ab71613a55..1ce165c627a6c 100644
+index bc4ab71613a5..1ce165c627a6 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -4919,6 +4919,7 @@ int evergreen_irq_process(struct radeon_device *rdev)
@@ -45,7 +45,7 @@ index bc4ab71613a55..1ce165c627a6c 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 8b62f7faa5b99..88e38fb3f3476 100644
+index 8b62f7faa5b9..88e38fb3f347 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -4328,6 +4328,7 @@ int r600_irq_process(struct radeon_device *rdev)
@@ -57,7 +57,7 @@ index 8b62f7faa5b99..88e38fb3f3476 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 26197aceb001c..2d7eeb781969d 100644
+index 26197aceb001..2d7eeb781969 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -6423,6 +6423,7 @@ int si_irq_process(struct radeon_device *rdev)
@@ -69,5 +69,5 @@ index 26197aceb001c..2d7eeb781969d 100644
  
  	/* make sure wptr hasn't changed while processing */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
@@ -1,7 +1,7 @@
 From e7119dfc84a16da933ba2cefd7ffdbe0edefd3f0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 May 2025 20:08:26 +0800
-Subject: [PATCH 073/344] LOONGSON: drm/ast: Restore vaddr field to struct
+Subject: [PATCH 073/345] LOONGSON: drm/ast: Restore vaddr field to struct
  ast_plane
 
 Revert "drm/ast: Remove vaddr field from struct ast_plane".
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 14 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/ast_cursor.c b/drivers/gpu/drm/ast/ast_cursor.c
-index 2d3ad7610c2e9..5ee724bfd682a 100644
+index 2d3ad7610c2e..5ee724bfd682 100644
 --- a/drivers/gpu/drm/ast/ast_cursor.c
 +++ b/drivers/gpu/drm/ast/ast_cursor.c
 @@ -91,7 +91,7 @@ static u32 ast_cursor_calculate_checksum(const void *src, unsigned int width, un
@@ -58,7 +58,7 @@ index 2d3ad7610c2e9..5ee724bfd682a 100644
  			     ast_cursor_plane_formats, ARRAY_SIZE(ast_cursor_plane_formats),
  			     NULL, DRM_PLANE_TYPE_CURSOR);
 diff --git a/drivers/gpu/drm/ast/ast_drv.h b/drivers/gpu/drm/ast/ast_drv.h
-index e37a55295ed71..b8bf495e0243e 100644
+index e37a55295ed7..b8bf495e0243 100644
 --- a/drivers/gpu/drm/ast/ast_drv.h
 +++ b/drivers/gpu/drm/ast/ast_drv.h
 @@ -122,6 +122,7 @@ enum ast_config_mode {
@@ -84,7 +84,7 @@ index e37a55295ed71..b8bf495e0243e 100644
  
  #endif
 diff --git a/drivers/gpu/drm/ast/ast_mode.c b/drivers/gpu/drm/ast/ast_mode.c
-index b4e8edc7c7678..6353e9b78b92e 100644
+index b4e8edc7c767..6353e9b78b92 100644
 --- a/drivers/gpu/drm/ast/ast_mode.c
 +++ b/drivers/gpu/drm/ast/ast_mode.c
 @@ -473,7 +473,7 @@ static void ast_wait_for_vretrace(struct ast_device *ast)
@@ -157,5 +157,5 @@ index b4e8edc7c7678..6353e9b78b92e 100644
  			     ast_primary_plane_formats, ARRAY_SIZE(ast_primary_plane_formats),
  			     NULL, DRM_PLANE_TYPE_PRIMARY);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From 7c7e970687b4b503abfe527db6e68c475dfc096d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 28 Feb 2025 20:28:08 +0800
-Subject: [PATCH 074/344] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 074/345] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  6 files changed, 131 insertions(+), 38 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/Kconfig b/drivers/gpu/drm/ast/Kconfig
-index 242fbccdf8443..1f1c24c58663a 100644
+index 242fbccdf844..1f1c24c58663 100644
 --- a/drivers/gpu/drm/ast/Kconfig
 +++ b/drivers/gpu/drm/ast/Kconfig
 @@ -5,6 +5,9 @@ config DRM_AST
@@ -42,7 +42,7 @@ index 242fbccdf8443..1f1c24c58663a 100644
  	select I2C_ALGOBIT
  	help
 diff --git a/drivers/gpu/drm/ast/ast_cursor.c b/drivers/gpu/drm/ast/ast_cursor.c
-index 5ee724bfd682a..54c0d4e3ed81f 100644
+index 5ee724bfd682..54c0d4e3ed81 100644
 --- a/drivers/gpu/drm/ast/ast_cursor.c
 +++ b/drivers/gpu/drm/ast/ast_cursor.c
 @@ -28,6 +28,7 @@
@@ -150,7 +150,7 @@ index 5ee724bfd682a..54c0d4e3ed81f 100644
  			     ast_cursor_plane_formats, ARRAY_SIZE(ast_cursor_plane_formats),
  			     NULL, DRM_PLANE_TYPE_CURSOR);
 diff --git a/drivers/gpu/drm/ast/ast_drv.c b/drivers/gpu/drm/ast/ast_drv.c
-index 473faa92d08c3..5678f53eea654 100644
+index 473faa92d08c..5678f53eea65 100644
 --- a/drivers/gpu/drm/ast/ast_drv.c
 +++ b/drivers/gpu/drm/ast/ast_drv.c
 @@ -33,9 +33,12 @@
@@ -222,7 +222,7 @@ index 473faa92d08c3..5678f53eea654 100644
  	if (ret)
  		return ret;
 diff --git a/drivers/gpu/drm/ast/ast_drv.h b/drivers/gpu/drm/ast/ast_drv.h
-index b8bf495e0243e..ec438510fca82 100644
+index b8bf495e0243..ec438510fca8 100644
 --- a/drivers/gpu/drm/ast/ast_drv.h
 +++ b/drivers/gpu/drm/ast/ast_drv.h
 @@ -29,6 +29,7 @@
@@ -263,7 +263,7 @@ index b8bf495e0243e..ec438510fca82 100644
  		   const uint32_t *formats, unsigned int format_count,
  		   const uint64_t *format_modifiers,
 diff --git a/drivers/gpu/drm/ast/ast_mm.c b/drivers/gpu/drm/ast/ast_mm.c
-index 0bc1403194649..b68bea7b5dec8 100644
+index 0bc140319464..b68bea7b5dec 100644
 --- a/drivers/gpu/drm/ast/ast_mm.c
 +++ b/drivers/gpu/drm/ast/ast_mm.c
 @@ -28,6 +28,7 @@
@@ -292,7 +292,7 @@ index 0bc1403194649..b68bea7b5dec8 100644
  	ast->vram_base = base;
  	ast->vram_size = vram_size;
 diff --git a/drivers/gpu/drm/ast/ast_mode.c b/drivers/gpu/drm/ast/ast_mode.c
-index 6353e9b78b92e..877afa6c1c3b9 100644
+index 6353e9b78b92..877afa6c1c3b 100644
 --- a/drivers/gpu/drm/ast/ast_mode.c
 +++ b/drivers/gpu/drm/ast/ast_mode.c
 @@ -41,6 +41,7 @@
@@ -455,5 +455,5 @@ index 6353e9b78b92e..877afa6c1c3b9 100644
  	if (ast->support_fullhd) {
  		dev->mode_config.max_width = 1920;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-LOONGSON-LoongArch-Allow-specify-SIMD-width-via-kern.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-LOONGSON-LoongArch-Allow-specify-SIMD-width-via-kern.patch
@@ -1,7 +1,7 @@
 From e8b2bce538a81685093a554a3162c99cc8858234 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 4 Sep 2025 15:13:41 +0800
-Subject: [PATCH 075/344] LOONGSON: LoongArch: Allow specify SIMD width via
+Subject: [PATCH 075/345] LOONGSON: LoongArch: Allow specify SIMD width via
  kernel parameters
 
 For power saving or debugging purpose, we usually want to limit the SIMD
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 44 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/kernel/cpu-probe.c b/arch/loongarch/kernel/cpu-probe.c
-index fedaa67cde410..cbfce2872d716 100644
+index fedaa67cde41..cbfce2872d71 100644
 --- a/arch/loongarch/kernel/cpu-probe.c
 +++ b/arch/loongarch/kernel/cpu-probe.c
 @@ -52,6 +52,48 @@ static inline void cpu_set_fpu_fcsr_mask(struct cpuinfo_loongarch *c)
@@ -92,5 +92,5 @@ index fedaa67cde410..cbfce2872d716 100644
  		elf_hwcap |= HWCAP_LOONGARCH_LASX;
  	}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-LOONGSON-LoongArch-Add-struct-loongarch_image_header.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-LOONGSON-LoongArch-Add-struct-loongarch_image_header.patch
@@ -1,7 +1,7 @@
 From 4b43ca575e7ecc38aafa1d757ab9cb442cd24ae2 Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 3 Sep 2025 11:00:54 +0800
-Subject: [PATCH 076/344] LOONGSON: LoongArch: Add struct
+Subject: [PATCH 076/345] LOONGSON: LoongArch: Add struct
  loongarch_image_header for kernel
 
 Define a dedicated image header structure for LoongArch architecture to
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/arch/loongarch/include/asm/image.h b/arch/loongarch/include/asm/image.h
 new file mode 100644
-index 0000000000000..f2d738439160f
+index 000000000000..f2d738439160
 --- /dev/null
 +++ b/arch/loongarch/include/asm/image.h
 @@ -0,0 +1,38 @@
@@ -70,5 +70,5 @@ index 0000000000000..f2d738439160f
 +
 +#endif /* __ASM_IMAGE_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-LOONGSON-LoongArch-Add-preparatory-infrastructure-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-LOONGSON-LoongArch-Add-preparatory-infrastructure-fo.patch
@@ -1,7 +1,7 @@
 From 2d6c80eb83849f021c3b115695aa1e67a4de9a1f Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 3 Sep 2025 11:00:55 +0800
-Subject: [PATCH 077/344] LOONGSON: LoongArch: Add preparatory infrastructure
+Subject: [PATCH 077/345] LOONGSON: LoongArch: Add preparatory infrastructure
  for kexec_file
 
 Add some preparatory infrastructure:
@@ -35,7 +35,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/loongarch/kernel/machine_kexec_file.c
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index 0631a6b11281b..aa1cb1fd3c525 100644
+index 0631a6b11281..aa1cb1fd3c52 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -633,6 +633,15 @@ config CPU_HAS_PREFETCH
@@ -55,7 +55,7 @@ index 0631a6b11281b..aa1cb1fd3c525 100644
  	def_bool y
  
 diff --git a/arch/loongarch/include/asm/kexec.h b/arch/loongarch/include/asm/kexec.h
-index cf95cd3eb2dea..9442c7a1c3a60 100644
+index cf95cd3eb2de..9442c7a1c3a6 100644
 --- a/arch/loongarch/include/asm/kexec.h
 +++ b/arch/loongarch/include/asm/kexec.h
 @@ -41,6 +41,16 @@ struct kimage_arch {
@@ -76,7 +76,7 @@ index cf95cd3eb2dea..9442c7a1c3a60 100644
  			   unsigned long cmdline_ptr,
  			   unsigned long systable_ptr,
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index 6f5a4574a911d..67b9b214d212d 100644
+index 6f5a4574a911..67b9b214d212 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -62,6 +62,7 @@ obj-$(CONFIG_MAGIC_SYSRQ)	+= sysrq.o
@@ -88,7 +88,7 @@ index 6f5a4574a911d..67b9b214d212d 100644
  
  obj-$(CONFIG_UNWINDER_GUESS)	+= unwind_guess.o
 diff --git a/arch/loongarch/kernel/machine_kexec.c b/arch/loongarch/kernel/machine_kexec.c
-index f9381800e291c..e4b2bbc47e623 100644
+index f9381800e291..e4b2bbc47e62 100644
 --- a/arch/loongarch/kernel/machine_kexec.c
 +++ b/arch/loongarch/kernel/machine_kexec.c
 @@ -70,18 +70,28 @@ int machine_kexec_prepare(struct kimage *kimage)
@@ -146,7 +146,7 @@ index f9381800e291c..e4b2bbc47e623 100644
  
 diff --git a/arch/loongarch/kernel/machine_kexec_file.c b/arch/loongarch/kernel/machine_kexec_file.c
 new file mode 100644
-index 0000000000000..8e99d2f7165e7
+index 000000000000..8e99d2f7165e
 --- /dev/null
 +++ b/arch/loongarch/kernel/machine_kexec_file.c
 @@ -0,0 +1,122 @@
@@ -273,5 +273,5 @@ index 0000000000000..8e99d2f7165e7
 +	return ret;
 +}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-LOONGSON-LoongArch-Add-EFI-binary-support-for-kexec_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-LOONGSON-LoongArch-Add-EFI-binary-support-for-kexec_.patch
@@ -1,7 +1,7 @@
 From 64e7827e6c44d92129bd3e859936b4d6b938a5b3 Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 3 Sep 2025 11:00:56 +0800
-Subject: [PATCH 078/344] LOONGSON: LoongArch: Add EFI binary support for
+Subject: [PATCH 078/345] LOONGSON: LoongArch: Add EFI binary support for
  kexec_file
 
 This patch creates kexec_efi_ops to load EFI binary file for
@@ -42,7 +42,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/loongarch/kernel/kexec_efi.c
 
 diff --git a/arch/loongarch/include/asm/image.h b/arch/loongarch/include/asm/image.h
-index f2d738439160f..d585314494f02 100644
+index f2d738439160..d585314494f0 100644
 --- a/arch/loongarch/include/asm/image.h
 +++ b/arch/loongarch/include/asm/image.h
 @@ -33,6 +33,20 @@ struct loongarch_image_header {
@@ -67,7 +67,7 @@ index f2d738439160f..d585314494f02 100644
  
  #endif /* __ASM_IMAGE_H */
 diff --git a/arch/loongarch/include/asm/kexec.h b/arch/loongarch/include/asm/kexec.h
-index 9442c7a1c3a60..054b69d3eec96 100644
+index 9442c7a1c3a6..054b69d3eec9 100644
 --- a/arch/loongarch/include/asm/kexec.h
 +++ b/arch/loongarch/include/asm/kexec.h
 @@ -42,6 +42,7 @@ struct kimage_arch {
@@ -79,7 +79,7 @@ index 9442c7a1c3a60..054b69d3eec96 100644
  int arch_kimage_file_post_load_cleanup(struct kimage *image);
  #define arch_kimage_file_post_load_cleanup arch_kimage_file_post_load_cleanup
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index 67b9b214d212d..dd6183f353e61 100644
+index 67b9b214d212..dd6183f353e6 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -62,7 +62,7 @@ obj-$(CONFIG_MAGIC_SYSRQ)	+= sysrq.o
@@ -93,7 +93,7 @@ index 67b9b214d212d..dd6183f353e61 100644
  obj-$(CONFIG_UNWINDER_GUESS)	+= unwind_guess.o
 diff --git a/arch/loongarch/kernel/kexec_efi.c b/arch/loongarch/kernel/kexec_efi.c
 new file mode 100644
-index 0000000000000..107e753eec781
+index 000000000000..107e753eec78
 --- /dev/null
 +++ b/arch/loongarch/kernel/kexec_efi.c
 @@ -0,0 +1,113 @@
@@ -211,7 +211,7 @@ index 0000000000000..107e753eec781
 +	.load = efi_kexec_load,
 +};
 diff --git a/arch/loongarch/kernel/machine_kexec_file.c b/arch/loongarch/kernel/machine_kexec_file.c
-index 8e99d2f7165e7..9dfdea0a4d8a3 100644
+index 8e99d2f7165e..9dfdea0a4d8a 100644
 --- a/arch/loongarch/kernel/machine_kexec_file.c
 +++ b/arch/loongarch/kernel/machine_kexec_file.c
 @@ -21,6 +21,7 @@
@@ -223,5 +223,5 @@ index 8e99d2f7165e7..9dfdea0a4d8a3 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-LOONGSON-LoongArch-Add-ELF-binary-support-for-kexec_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-LOONGSON-LoongArch-Add-ELF-binary-support-for-kexec_.patch
@@ -1,7 +1,7 @@
 From 92bf3d6b6802eeaee5df959a7d889e94fa425cd7 Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 3 Sep 2025 11:00:57 +0800
-Subject: [PATCH 079/344] LOONGSON: LoongArch: Add ELF binary support for
+Subject: [PATCH 079/345] LOONGSON: LoongArch: Add ELF binary support for
  kexec_file
 
 This patch creates kexec_elf_ops to load ELF binary file for
@@ -63,7 +63,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/loongarch/kernel/kexec_elf.c
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index aa1cb1fd3c525..0f1f53b3c58bf 100644
+index aa1cb1fd3c52..0f1f53b3c58b 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -639,6 +639,7 @@ config ARCH_SUPPORTS_KEXEC_FILE
@@ -75,7 +75,7 @@ index aa1cb1fd3c525..0f1f53b3c58bf 100644
  	select HAVE_IMA_KEXEC if IMA
  
 diff --git a/arch/loongarch/include/asm/kexec.h b/arch/loongarch/include/asm/kexec.h
-index 054b69d3eec96..209fa43222e1c 100644
+index 054b69d3eec9..209fa43222e1 100644
 --- a/arch/loongarch/include/asm/kexec.h
 +++ b/arch/loongarch/include/asm/kexec.h
 @@ -43,6 +43,7 @@ struct kimage_arch {
@@ -87,7 +87,7 @@ index 054b69d3eec96..209fa43222e1c 100644
  int arch_kimage_file_post_load_cleanup(struct kimage *image);
  #define arch_kimage_file_post_load_cleanup arch_kimage_file_post_load_cleanup
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index dd6183f353e61..001924877772f 100644
+index dd6183f353e6..001924877772 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -62,7 +62,7 @@ obj-$(CONFIG_MAGIC_SYSRQ)	+= sysrq.o
@@ -101,7 +101,7 @@ index dd6183f353e61..001924877772f 100644
  obj-$(CONFIG_UNWINDER_GUESS)	+= unwind_guess.o
 diff --git a/arch/loongarch/kernel/kexec_elf.c b/arch/loongarch/kernel/kexec_elf.c
 new file mode 100644
-index 0000000000000..97b2f049801a8
+index 000000000000..97b2f049801a
 --- /dev/null
 +++ b/arch/loongarch/kernel/kexec_elf.c
 @@ -0,0 +1,105 @@
@@ -211,7 +211,7 @@ index 0000000000000..97b2f049801a8
 +	.load  = elf_kexec_load,
 +};
 diff --git a/arch/loongarch/kernel/machine_kexec_file.c b/arch/loongarch/kernel/machine_kexec_file.c
-index 9dfdea0a4d8a3..fbb94da953225 100644
+index 9dfdea0a4d8a..fbb94da95322 100644
 --- a/arch/loongarch/kernel/machine_kexec_file.c
 +++ b/arch/loongarch/kernel/machine_kexec_file.c
 @@ -22,6 +22,7 @@
@@ -223,5 +223,5 @@ index 9dfdea0a4d8a3..fbb94da953225 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-LOONGSON-LoongArch-Add-crash-dump-support-for-kexec_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-LOONGSON-LoongArch-Add-crash-dump-support-for-kexec_.patch
@@ -1,7 +1,7 @@
 From 515b2e6f28972819c17a691246df01d13cfc75db Mon Sep 17 00:00:00 2001
 From: Youling Tang <tangyouling@kylinos.cn>
 Date: Wed, 3 Sep 2025 11:00:58 +0800
-Subject: [PATCH 080/344] LOONGSON: LoongArch: Add crash dump support for
+Subject: [PATCH 080/345] LOONGSON: LoongArch: Add crash dump support for
  kexec_file
 
 Enabling crash dump (kdump) includes:
@@ -36,7 +36,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 115 insertions(+)
 
 diff --git a/arch/loongarch/kernel/machine_kexec_file.c b/arch/loongarch/kernel/machine_kexec_file.c
-index fbb94da953225..dda236b51a881 100644
+index fbb94da95322..dda236b51a88 100644
 --- a/arch/loongarch/kernel/machine_kexec_file.c
 +++ b/arch/loongarch/kernel/machine_kexec_file.c
 @@ -55,6 +55,81 @@ static void cmdline_add_initrd(struct kimage *image, unsigned long *cmdline_tmpl
@@ -169,5 +169,5 @@ index fbb94da953225..dda236b51a881 100644
  	if (initrd) {
  		kbuf.buffer = initrd;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
@@ -1,7 +1,7 @@
 From b3994c5b34ec90e5d3acd86d8365b82a52b10aeb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 26 Aug 2025 19:01:09 +0800
-Subject: [PATCH 081/344] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
+Subject: [PATCH 081/345] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
 
 If I read the upstream commit 62e1e11a4916
 ("drm/client: Do not pin in drm_client_buffer_vmap()") correctly, we
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/ast_cursor.c b/drivers/gpu/drm/ast/ast_cursor.c
-index 54c0d4e3ed81f..9921bd6c0d28b 100644
+index 54c0d4e3ed81..9921bd6c0d28 100644
 --- a/drivers/gpu/drm/ast/ast_cursor.c
 +++ b/drivers/gpu/drm/ast/ast_cursor.c
 @@ -285,7 +285,6 @@ static void ast_cursor_plane_destroy(struct drm_plane *plane)
@@ -35,5 +35,5 @@ index 54c0d4e3ed81f..9921bd6c0d28b 100644
  		offset = drm_gem_vram_offset(gbo);
  		ast_cursor_plane->base.gbo = gbo;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From 1149d027d104e3aa003a99d12fa142568a3b533f Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 082/344] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 082/345] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
-index a88f5ad9328c2..9eb929cf68244 100644
+index a88f5ad9328c..9eb929cf6824 100644
 --- a/arch/arm64/Kconfig.platforms
 +++ b/arch/arm64/Kconfig.platforms
 @@ -281,6 +281,14 @@ config ARCH_PENSANDO
@@ -36,5 +36,5 @@ index a88f5ad9328c2..9eb929cf68244 100644
  	bool "Qualcomm Platforms"
  	select GPIOLIB
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From 0696ce71d8f45dd015d871ef440e851bcb6d1ceb Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 083/344] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 083/345] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 92ffc4373f6de..91385152ea450 100644
+index 92ffc4373f6d..91385152ea45 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -3255,4 +3255,6 @@
@@ -26,5 +26,5 @@ index 92ffc4373f6de..91385152ea450 100644
 +
  #endif /* _LINUX_PCI_IDS_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From ebf0737da08f051dc5de606d8cab0d64edda98ab Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 084/344] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 084/345] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 960252b6987c1..8495ead186e86 100644
+index 960252b6987c..8495ead186e8 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -3103,6 +3103,12 @@ S:	Maintained
@@ -42,7 +42,7 @@ index 960252b6987c1..8495ead186e86 100644
  R:	cros-qcom-dts-watchers@chromium.org
  F:	arch/arm64/boot/dts/qcom/sc7180*
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 67fa879b1e521..dd0bd696440e4 100644
+index 67fa879b1e52..dd0bd696440e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -122,6 +122,16 @@ config DWMAC_MESON
@@ -63,7 +63,7 @@ index 67fa879b1e521..dd0bd696440e4 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index b591d93f85033..ca28d74ee7f12 100644
+index b591d93f8503..ca28d74ee7f1 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
@@ -76,7 +76,7 @@ index b591d93f85033..ca28d74ee7f12 100644
  obj-$(CONFIG_DWMAC_ROCKCHIP)	+= dwmac-rk.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 new file mode 100644
-index 0000000000000..db1672deae824
+index 000000000000..db1672deae82
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -0,0 +1,229 @@
@@ -310,5 +310,5 @@ index 0000000000000..db1672deae824
 +MODULE_DESCRIPTION("Phytium DWMAC specific glue layer");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From a31e233600141316a1670e421b7e8c7eb5bfcff8 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 085/344] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 085/345] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index cbffccb3b9af0..37858d81324d6 100644
+index cbffccb3b9af..37858d81324d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -51,10 +51,10 @@
@@ -38,7 +38,7 @@ index cbffccb3b9af0..37858d81324d6 100644
  
  #undef FRAME_FILTER_DEBUG
 diff --git a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
-index 68a7cfcb1d8f3..40088a390f7b3 100644
+index 68a7cfcb1d8f..40088a390f7b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 @@ -200,6 +200,10 @@ static void ndesc_prepare_tx_desc(struct dma_desc *p, int is_fs, int len,
@@ -53,5 +53,5 @@ index 68a7cfcb1d8f3..40088a390f7b3 100644
  		p->des0 |= cpu_to_le32(TDES0_OWN);
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From 50be6aab34e59f672adbaaf02e196aa3a2bd9670 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 086/344] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 086/345] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index db1672deae824..86f491ea569e6 100644
+index db1672deae82..86f491ea569e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -73,14 +73,14 @@ static int phytium_dwmac_probe(struct platform_device *pdev)
@@ -75,5 +75,5 @@ index db1672deae824..86f491ea569e6 100644
  		.name		= "phytium-dwmac",
  		.of_match_table	= of_match_ptr(phytium_dwmac_of_match),
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From 0cebc494175314660ad3e9b45170df640214703a Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 087/344] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 087/345] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
@@ -113,7 +113,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 86f491ea569e6..a930cea6280b6 100644
+index 86f491ea569e..a930cea6280b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -2,7 +2,7 @@
@@ -126,5 +126,5 @@ index 86f491ea569e6..a930cea6280b6 100644
   * Chen Baozi <chenbaozi@phytium.com.cn>
   */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From 04cdc33f0f35638b901a33f4585ecf71693e4cc4 Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 088/344] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 088/345] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 8495ead186e86..0783504c02366 100644
+index 8495ead186e8..0783504c0236 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -3103,12 +3103,6 @@ S:	Maintained
@@ -52,5 +52,5 @@ index 8495ead186e86..0783504c02366 100644
  M:	Giovanni Cabiddu <giovanni.cabiddu@intel.com>
  L:	qat-linux@intel.com
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From 22da99dce022612319765b657318487a4678fced Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 089/344] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 089/345] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 16 insertions(+), 22 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 0783504c02366..cbe331f40ab2a 100644
+index 0783504c0236..cbe331f40ab2 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -20460,6 +20460,7 @@ ARM/PHYTIUM SOC SUPPORT
@@ -32,7 +32,7 @@ index 0783504c02366..cbe331f40ab2a 100644
  QAT DRIVER
  M:	Giovanni Cabiddu <giovanni.cabiddu@intel.com>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index a930cea6280b6..d31b8e870f647 100644
+index a930cea6280b..d31b8e870f64 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -37,8 +37,7 @@ static int phytium_get_mac_mode(struct fwnode_handle *fwnode)
@@ -140,5 +140,5 @@ index a930cea6280b6..d31b8e870f647 100644
  		.name		= "phytium-dwmac",
  		.of_match_table	= of_match_ptr(phytium_dwmac_of_match),
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From 33cb80b745052319994dc5313051b5993beff176 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 090/344] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 090/345] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index d31b8e870f647..6e8e44730bec6 100644
+index d31b8e870f64..6e8e44730bec 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -209,6 +209,7 @@ static struct platform_driver phytium_dwmac_driver = {
@@ -33,5 +33,5 @@ index d31b8e870f647..6e8e44730bec6 100644
  		.acpi_match_table = ACPI_PTR(phytium_dwmac_acpi_ids),
  	},
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From a4c4d3986b62334f52d2e2b2dbd265e878ed8ad4 Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 091/344] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 091/345] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.
@@ -47,7 +47,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/phytium/phytmac_v2.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index cbe331f40ab2a..73ab3c5389ce3 100644
+index cbe331f40ab2..73ab3c5389ce 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -20460,6 +20460,9 @@ ARM/PHYTIUM SOC SUPPORT
@@ -61,7 +61,7 @@ index cbe331f40ab2a..73ab3c5389ce3 100644
  
  QAT DRIVER
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index f86d4557d8d77..9702db7bcc680 100644
+index f86d4557d8d7..9702db7bcc68 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -173,6 +173,7 @@ config OA_TC6
@@ -73,7 +73,7 @@ index f86d4557d8d77..9702db7bcc680 100644
  source "drivers/net/ethernet/brocade/Kconfig"
  source "drivers/net/ethernet/qualcomm/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 67182339469a0..96ba43e005a87 100644
+index 67182339469a..96ba43e005a8 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -77,6 +77,7 @@ obj-$(CONFIG_NET_VENDOR_OKI) += oki-semi/
@@ -86,7 +86,7 @@ index 67182339469a0..96ba43e005a87 100644
  obj-$(CONFIG_NET_VENDOR_REALTEK) += realtek/
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
 new file mode 100644
-index 0000000000000..14a77adbfdc12
+index 000000000000..14a77adbfdc1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -0,0 +1,58 @@
@@ -150,7 +150,7 @@ index 0000000000000..14a77adbfdc12
 +endif # NET_VENDOR_PHYTIUM
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
 new file mode 100644
-index 0000000000000..6e710d4d54b66
+index 000000000000..6e710d4d54b6
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -0,0 +1,17 @@
@@ -173,7 +173,7 @@ index 0000000000000..6e710d4d54b66
 +phytmac-pci-objs := phytmac_pci.o
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
 new file mode 100644
-index 0000000000000..b90e1551499ef
+index 000000000000..b90e1551499e
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -0,0 +1,591 @@
@@ -770,7 +770,7 @@ index 0000000000000..b90e1551499ef
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 new file mode 100644
-index 0000000000000..592d2d9dc6d4b
+index 000000000000..592d2d9dc6d4
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -0,0 +1,544 @@
@@ -1320,7 +1320,7 @@ index 0000000000000..592d2d9dc6d4b
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
 new file mode 100644
-index 0000000000000..b0977f5cae755
+index 000000000000..b0977f5cae75
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -0,0 +1,2236 @@
@@ -3562,7 +3562,7 @@ index 0000000000000..b0977f5cae755
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
 new file mode 100644
-index 0000000000000..fd21bf80f1388
+index 000000000000..fd21bf80f138
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -0,0 +1,318 @@
@@ -3886,7 +3886,7 @@ index 0000000000000..fd21bf80f1388
 +MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
 new file mode 100644
-index 0000000000000..305ff5866e2fe
+index 000000000000..305ff5866e2f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -0,0 +1,255 @@
@@ -4147,7 +4147,7 @@ index 0000000000000..305ff5866e2fe
 +MODULE_ALIAS("platform:phytmac");
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
 new file mode 100644
-index 0000000000000..26b1b75edbde1
+index 000000000000..26b1b75edbde
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -0,0 +1,304 @@
@@ -4457,7 +4457,7 @@ index 0000000000000..26b1b75edbde1
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
 new file mode 100644
-index 0000000000000..72c8b7c674137
+index 000000000000..72c8b7c67413
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -0,0 +1,55 @@
@@ -4518,7 +4518,7 @@ index 0000000000000..72c8b7c674137
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
 new file mode 100644
-index 0000000000000..2d9f67c82050c
+index 000000000000..2d9f67c82050
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -0,0 +1,1370 @@
@@ -5894,7 +5894,7 @@ index 0000000000000..2d9f67c82050c
 +EXPORT_SYMBOL_GPL(phytmac_1p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
 new file mode 100644
-index 0000000000000..6f2b521aaebdb
+index 000000000000..6f2b521aaebd
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -0,0 +1,453 @@
@@ -6353,7 +6353,7 @@ index 0000000000000..6f2b521aaebdb
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
 new file mode 100644
-index 0000000000000..df142aa6797f6
+index 000000000000..df142aa6797f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -0,0 +1,1254 @@
@@ -7613,7 +7613,7 @@ index 0000000000000..df142aa6797f6
 +EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
 new file mode 100644
-index 0000000000000..92e4806ac2c1f
+index 000000000000..92e4806ac2c1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -0,0 +1,362 @@
@@ -7980,5 +7980,5 @@ index 0000000000000..92e4806ac2c1f
 +
 +#endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From a79ec7b86a1c8d1f586cbe3fc2c165f40f0a6441 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 092/344] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 092/345] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 19 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index b0977f5cae755..da4e067362803 100644
+index b0977f5cae75..da4e06736280 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1508,7 +1508,7 @@ int phytmac_mdio_register(struct phytmac *pdata)
@@ -111,5 +111,5 @@ index b0977f5cae755..da4e067362803 100644
  }
  EXPORT_SYMBOL_GPL(phytmac_drv_probe);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From d9eebd92ca3b3339c38535053434720ff3c73159 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 093/344] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 093/345] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 2d9f67c82050c..79df9a7f981f1 100644
+index 2d9f67c82050..79df9a7f981f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -357,8 +357,11 @@ static int phytmac_init_hw(struct phytmac *pdata)
@@ -35,5 +35,5 @@ index 2d9f67c82050c..79df9a7f981f1 100644
  	config |= PHYTMAC_BIT(PAUSE_EN);
  	/* Rx Fcs remove */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From 7a037bda4839c0bef12faa33e783f24ee7092b5b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 094/344] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 094/345] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index da4e067362803..c172103a97362 100644
+index da4e06736280..c172103a9736 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1560,6 +1560,7 @@ static void phytmac_validate(struct phylink_config *config,
@@ -30,7 +30,7 @@ index da4e067362803..c172103a97362 100644
  	    state->interface != PHY_INTERFACE_MODE_5GBASER &&
  	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 79df9a7f981f1..ec95c6c79b066 100644
+index 79df9a7f981f..ec95c6c79b06 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -161,6 +161,20 @@ static int phytmac_enable_autoneg(struct phytmac *pdata, int enable)
@@ -105,7 +105,7 @@ index 79df9a7f981f1..ec95c6c79b066 100644
  		return PHYTMAC_READ_BITS(pdata, PHYTMAC_NSTATUS, PCS_LINK);
  	else if (interface == PHY_INTERFACE_MODE_USXGMII ||
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 6f2b521aaebdb..d8de2c26cab4b 100644
+index 6f2b521aaebd..d8de2c26cab4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -228,6 +228,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;
@@ -118,5 +118,5 @@ index 6f2b521aaebdb..d8de2c26cab4b 100644
  /* DEFAULT1 register */
  #define PHYTMAC_DBW_INDEX			25
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From 52665e0c308c011a0b6420b94b9efdbf6d3cac44 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 095/344] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 095/345] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 74 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c172103a97362..07f8476946bc6 100644
+index c172103a9736..07f8476946bc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -46,6 +46,7 @@ MODULE_PARM_DESC(debug, "Debug level (0=none,...,16=all)");
@@ -208,5 +208,5 @@ index c172103a97362..07f8476946bc6 100644
  			       const struct phylink_link_state *state)
  {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From 92102b021ca8480cd9f75243c5f53d6186dbc5ba Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 096/344] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 096/345] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 07f8476946bc6..ca1a03fa35526 100644
+index 07f8476946bc..ca1a03fa3552 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1416,10 +1416,12 @@ void phytmac_pcs_link_up(struct phylink_pcs *pcs, unsigned int mode,
@@ -46,7 +46,7 @@ index 07f8476946bc6..ca1a03fa35526 100644
  		goto reset_hw;
  	}
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index ec95c6c79b066..4a690b6a96cfe 100644
+index ec95c6c79b06..4a690b6a96cf 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -414,7 +414,7 @@ static int phytmac_init_hw(struct phytmac *pdata)
@@ -68,7 +68,7 @@ index ec95c6c79b066..4a690b6a96cfe 100644
  	if (pdata->capacities & PHYTMAC_CAPS_START)
  		PHYTMAC_WRITE(pdata, PHYTMAC_NCTRL,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index d8de2c26cab4b..2cabadfed2f11 100644
+index d8de2c26cab4..2cabadfed2f1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -356,6 +356,14 @@ extern struct phytmac_hw_if phytmac_1p0_hw;
@@ -87,5 +87,5 @@ index d8de2c26cab4b..2cabadfed2f11 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From f455d8958440b2571ed8397893724de429d4cdc6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 097/344] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 097/345] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index ca1a03fa35526..058f9647b8551 100644
+index ca1a03fa3552..058f9647b855 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1843,7 +1843,7 @@ static int phytmac_close(struct net_device *ndev)
@@ -31,5 +31,5 @@ index ca1a03fa35526..058f9647b8551 100644
  	if (!netif_running(dev))
  		return -EINVAL;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From 06a40241606ce3a3b7303f2012aa8629c18bc615 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 098/344] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 098/345] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 19 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 592d2d9dc6d4b..7cddb01802f21 100644
+index 592d2d9dc6d4..7cddb01802f2 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -382,43 +382,32 @@ static int phytmac_get_link_ksettings(struct net_device *ndev,
@@ -88,7 +88,7 @@ index 592d2d9dc6d4b..7cddb01802f21 100644
  
  		ethtool_convert_legacy_u32_to_link_mode(kset->link_modes.supported,
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index fd21bf80f1388..af69329fe06de 100644
+index fd21bf80f138..af69329fe06d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -225,7 +225,7 @@ struct phytmac_data phytmac_1000basex = {
@@ -101,7 +101,7 @@ index fd21bf80f1388..af69329fe06de 100644
  };
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index df142aa6797f6..41e5df41226e9 100644
+index df142aa6797f..41e5df41226e 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -842,6 +842,7 @@ static int phytmac_pcs_linkdown(struct phytmac *pdata)
@@ -113,5 +113,5 @@ index df142aa6797f6..41e5df41226e9 100644
  		return PHYTMAC_READ_BITS(pdata, PHYTMAC_NETWORK_STATUS, LINK);
  	else if (interface == PHY_INTERFACE_MODE_USXGMII ||
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From f9a55f35e4c89ef9fffcb33523da470d289762af Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 099/344] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 099/345] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 26 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 058f9647b8551..28b6dc86f6688 100644
+index 058f9647b855..28b6dc86f668 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1732,12 +1732,6 @@ static int phytmac_open(struct net_device *ndev)
@@ -51,7 +51,7 @@ index 058f9647b8551..28b6dc86f6688 100644
  		dev_dbg(pdata->dev, "probe successfully! Phytium %s at 0x%08lx irq %d (%pM)\n",
  			"MAC", ndev->base_addr, ndev->irq, ndev->dev_addr);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 4a690b6a96cfe..b96547e54d822 100644
+index 4a690b6a96cf..b96547e54d82 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -489,6 +489,15 @@ static int phytmac_set_wake(struct phytmac *pdata, int wake)
@@ -71,7 +71,7 @@ index 4a690b6a96cfe..b96547e54d822 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 2cabadfed2f11..1f49d4ec79a04 100644
+index 2cabadfed2f1..1f49d4ec79a0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -140,6 +140,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;
@@ -100,5 +100,5 @@ index 2cabadfed2f11..1f49d4ec79a04 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From c00ec8b2a2a0f498a464235301137b616c262696 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 100/344] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 100/345] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 16 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index b90e1551499ef..33c0fc78415b2 100644
+index b90e1551499e..33c0fc78415b 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -38,7 +38,6 @@
@@ -39,7 +39,7 @@ index b90e1551499ef..33c0fc78415b2 100644
  	void (*restart)(struct phytmac *pdata);
  	int (*tx_complete)(const struct phytmac_dma_desc *desc);
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 28b6dc86f6688..0053412c2632c 100644
+index 28b6dc86f668..0053412c2632 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -793,16 +793,12 @@ static void phytmac_rx_clean(struct phytmac_queue *queue)
@@ -107,7 +107,7 @@ index 28b6dc86f6688..0053412c2632c 100644
  	unsigned int offset, size, count = 0;
  	unsigned int f, nr_frags = skb_shinfo(skb)->nr_frags;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index b96547e54d822..b823a07a731b6 100644
+index b96547e54d82..b823a07a731b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -927,22 +927,14 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,
@@ -149,5 +149,5 @@ index b96547e54d822..b823a07a731b6 100644
  	.rx_single_buffer = phytmac_rx_single_buffer,
  	.rx_pkt_start = phytmac_rx_sof,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From f3a2db4a43e0700ad8d34850c9ff0c436565e92a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 101/344] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 101/345] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 341 insertions(+), 137 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 33c0fc78415b2..363bc65c72d47 100644
+index 33c0fc78415b..363bc65c72d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -307,6 +307,13 @@ struct phytmac_tx_ts {
@@ -80,7 +80,7 @@ index 33c0fc78415b2..363bc65c72d47 100644
  					  unsigned int index);
  inline struct phytmac_dma_desc *phytmac_get_tx_desc(struct phytmac_queue *queue,
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 0053412c2632c..a2b3ed84e895a 100644
+index 0053412c2632..a2b3ed84e895 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -36,6 +36,8 @@
@@ -715,7 +715,7 @@ index 0053412c2632c..a2b3ed84e895a 100644
  
  	ret = phytmac_phylink_connect(pdata);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index b823a07a731b6..9582b587342bb 100644
+index b823a07a731b..9582b587342b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -986,16 +986,6 @@ static int phytmac_rx_pkt_len(struct phytmac *pdata, const struct phytmac_dma_de
@@ -744,7 +744,7 @@ index b823a07a731b6..9582b587342bb 100644
  	.rx_map = phytmac_rx_map_desc,
  	.rx_checksum = phytmac_rx_checksum,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 41e5df41226e9..bcfc8ad68edc1 100644
+index 41e5df41226e..bcfc8ad68edc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -952,16 +952,6 @@ static int phytmac_rx_pkt_len(struct phytmac *pdata, const struct phytmac_dma_de
@@ -773,5 +773,5 @@ index 41e5df41226e9..bcfc8ad68edc1 100644
  	.rx_map = phytmac_rx_map_desc,
  	.rx_checksum = phytmac_rx_checksum,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From fd91780b247bdfd844809e97a3834ab03c2d18b6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 102/344] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 102/345] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index a2b3ed84e895a..72b5a15870a08 100644
+index a2b3ed84e895..72b5a15870a0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -298,9 +298,9 @@ static struct net_device_stats *phytmac_get_stats(struct net_device *dev)
@@ -35,5 +35,5 @@ index a2b3ed84e895a..72b5a15870a08 100644
  
  inline struct phytmac_dma_desc *phytmac_get_rx_desc(struct phytmac_queue *queue,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From 8190ebc91a566a5caaa5511d5dbd9cb25b5bceda Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 103/344] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 103/345] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 363bc65c72d47..7e6cf22d7b4f7 100644
+index 363bc65c72d4..7e6cf22d7b4f 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -37,7 +37,7 @@ index 363bc65c72d47..7e6cf22d7b4f7 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 7cddb01802f21..4f632591142fc 100644
+index 7cddb01802f2..4f632591142f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -2,6 +2,8 @@
@@ -78,7 +78,7 @@ index 7cddb01802f21..4f632591142fc 100644
  
  void phytmac_set_ethtool_ops(struct net_device *ndev)
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 72b5a15870a08..79170097fd830 100644
+index 72b5a15870a0..79170097fd83 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2488,4 +2488,5 @@ MODULE_LICENSE("GPL");
@@ -88,7 +88,7 @@ index 72b5a15870a08..79170097fd830 100644
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index af69329fe06de..60bd296d8f0b6 100644
+index af69329fe06d..60bd296d8f0b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -316,3 +316,4 @@ module_pci_driver(phytmac_driver);
@@ -97,7 +97,7 @@ index af69329fe06de..60bd296d8f0b6 100644
  MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 305ff5866e2fe..9390056fdc7a9 100644
+index 305ff5866e2f..9390056fdc7a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -253,3 +253,4 @@ MODULE_LICENSE("GPL");
@@ -106,5 +106,5 @@ index 305ff5866e2fe..9390056fdc7a9 100644
  MODULE_ALIAS("platform:phytmac");
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From ac0888631df83ee9c299e9ce325b7511635e4ae5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 104/344] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 104/345] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 56 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 7e6cf22d7b4f7..6eb1d7d1b8293 100644
+index 7e6cf22d7b4f..6eb1d7d1b829 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -54,7 +54,7 @@ index 7e6cf22d7b4f7..6eb1d7d1b8293 100644
  	void (*clear_tx_desc)(struct phytmac_queue *queue);
  	/* ptp */
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 79170097fd830..d932d011b261f 100644
+index 79170097fd83..d932d011b261 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -442,6 +442,7 @@ static int phytmac_alloc_tx_resource(struct phytmac *pdata)
@@ -133,7 +133,7 @@ index 79170097fd830..d932d011b261f 100644
  		if (offset + frag_len > total_len) {
  			if (unlikely(frag != last_frag)) {
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 9582b587342bb..1d7c2e1759178 100644
+index 9582b587342b..1d7c2e175917 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -940,6 +940,14 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,
@@ -191,7 +191,7 @@ index 9582b587342bb..1d7c2e1759178 100644
  	.init_ts_hw = phytmac_ptp_init_hw,
  	.set_time = phytmac_set_time,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 1f49d4ec79a04..32bb129491096 100644
+index 1f49d4ec79a0..32bb12949109 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -374,7 +374,6 @@ extern struct phytmac_hw_if phytmac_1p0_hw;
@@ -203,7 +203,7 @@ index 1f49d4ec79a04..32bb129491096 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index bcfc8ad68edc1..25f1ba6c1d6ef 100644
+index bcfc8ad68edc..25f1ba6c1d6e 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -934,14 +934,32 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue, u32 index,
@@ -259,5 +259,5 @@ index bcfc8ad68edc1..25f1ba6c1d6ef 100644
  	/* ptp */
  	.init_ts_hw = phytmac_ptp_init_hw,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From dd7d297d1907eff2bed5beb87bb7e7183224c2d2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 105/344] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 105/345] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 6eb1d7d1b8293..cb9359c7bd4db 100644
+index 6eb1d7d1b829..cb9359c7bd4d 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -33,7 +33,7 @@ index 6eb1d7d1b8293..cb9359c7bd4db 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index d932d011b261f..732358ea40afe 100644
+index d932d011b261..732358ea40af 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2208,7 +2208,6 @@ static int phytmac_init(struct phytmac *pdata)
@@ -45,5 +45,5 @@ index d932d011b261f..732358ea40afe 100644
  	if (ndev->hw_features & NETIF_F_NTUPLE) {
  		INIT_LIST_HEAD(&pdata->rx_fs_list.list);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 538bddb20f841a2f7e982fb839ff77533573f2ec Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 106/344] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 106/345] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index cb9359c7bd4db..bc0d2670c2f59 100644
+index cb9359c7bd4d..bc0d2670c2f5 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -34,7 +34,7 @@ index cb9359c7bd4db..bc0d2670c2f59 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 4f632591142fc..a97a4c28c04fe 100644
+index 4f632591142f..a97a4c28c04f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -429,7 +429,7 @@ static int phytmac_set_link_ksettings(struct net_device *ndev,
@@ -47,7 +47,7 @@ index 4f632591142fc..a97a4c28c04fe 100644
  	} else {
  		phy_ethtool_set_link_ksettings(ndev, kset);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 1d7c2e1759178..20595aca17834 100644
+index 1d7c2e175917..20595aca1783 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -182,7 +182,7 @@ static int phytmac_mac_linkup(struct phytmac *pdata, phy_interface_t interface,
@@ -60,5 +60,5 @@ index 1d7c2e1759178..20595aca17834 100644
  	if (speed == SPEED_100)
  		config |= PHYTMAC_BIT(SPEED);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From a1fc6d7f8da15b58b1dabae61cfe743dcf52116c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 107/344] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 107/345] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 23 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index bc0d2670c2f59..a4e0d4e4fa1f3 100644
+index bc0d2670c2f5..a4e0d4e4fa1f 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -32,7 +32,7 @@ index bc0d2670c2f59..a4e0d4e4fa1f3 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 732358ea40afe..43c15b8baf0b7 100644
+index 732358ea40af..43c15b8baf0b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1726,6 +1726,9 @@ static void phytmac_mac_link_up(struct phylink_config *config,
@@ -62,7 +62,7 @@ index 732358ea40afe..43c15b8baf0b7 100644
  		phylink_set(mask, 10baseT_Half);
  		phylink_set(mask, 10baseT_Full);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 20595aca17834..72a6eeaec3563 100644
+index 20595aca1783..72a6eeaec356 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1078,12 +1078,15 @@ static void phytmac_mac_interface_config(struct phytmac *pdata, unsigned int mod
@@ -106,5 +106,5 @@ index 20595aca17834..72a6eeaec3563 100644
  
  static unsigned int phytmac_pcs_get_link(struct phytmac *pdata,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From 18a301d1c13c59b174bdba8a186b560eaad62e11 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 108/344] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 108/345] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index a4e0d4e4fa1f3..df4ec49a08512 100644
+index a4e0d4e4fa1f..df4ec49a0851 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -40,7 +40,7 @@ index a4e0d4e4fa1f3..df4ec49a08512 100644
 +void phytmac_set_bios_wol_enable(struct phytmac *pdata, u32 wol);
  #endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index a97a4c28c04fe..306a9934deabd 100644
+index a97a4c28c04f..306a9934deab 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -131,6 +131,7 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)
@@ -52,7 +52,7 @@ index a97a4c28c04fe..306a9934deabd 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 43c15b8baf0b7..fd29c647e2775 100644
+index 43c15b8baf0b..fd29c647e277 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -111,6 +111,8 @@ static int phytmac_set_mac_address(struct net_device *netdev, void *addr)
@@ -111,5 +111,5 @@ index 43c15b8baf0b7..fd29c647e2775 100644
  {
  	int ret = 0;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From c5f1bb15abb25903dbac20a42d076be66c753593 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 109/344] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 109/345] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 306a9934deabd..8bba0af005be8 100644
+index 306a9934deab..8bba0af005be 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -116,7 +116,8 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)
@@ -27,5 +27,5 @@ index 306a9934deabd..8bba0af005be8 100644
  
  	pdata->wol = 0;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From f598e01c6d9b10e1318f37f9c1e3ad30e0777118 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 110/344] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 110/345] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 8bba0af005be8..e1698fa10b095 100644
+index 8bba0af005be..e1698fa10b09 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -89,23 +89,23 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol
@@ -50,5 +50,5 @@ index 8bba0af005be8..e1698fa10b095 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
@@ -1,7 +1,7 @@
 From e782a82629696d950ea1f0e6e02508fc6bf50cd3 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 15 Aug 2024 17:06:59 +0800
-Subject: [PATCH 111/344] PHYTIUM: net/phytmac: Add support for phytmac v2.0
+Subject: [PATCH 111/345] PHYTIUM: net/phytmac: Add support for phytmac v2.0
 
 This patch Adds support for phtymac v2.0,including acpi description,
 rx tail pointer supporting, power management and other functions.
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  12 files changed, 796 insertions(+), 340 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
-index 6e710d4d54b66..debaed63e4538 100644
+index 6e710d4d54b6..debaed63e453 100644
 --- a/drivers/net/ethernet/phytium/Makefile
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -1,9 +1,9 @@
@@ -44,7 +44,7 @@ index 6e710d4d54b66..debaed63e4538 100644
  obj-$(CONFIG_PHYTMAC) += phytmac.o
  
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index df4ec49a08512..3806e09bc1220 100644
+index df4ec49a0851..3806e09bc122 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -1,4 +1,6 @@
@@ -195,7 +195,7 @@ index df4ec49a08512..3806e09bc1220 100644
  void phytmac_free_pdata(struct phytmac *pdata);
  int phytmac_reset_ringsize(struct phytmac *pdata, u32 rx_size, u32 tx_size);
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index e1698fa10b095..e05274b961e4b 100644
+index e1698fa10b09..e05274b961e4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -1,4 +1,5 @@
@@ -205,7 +205,7 @@ index e1698fa10b095..e05274b961e4b 100644
  #include <linux/ethtool.h>
  #include <linux/phy.h>
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index fd29c647e2775..dcede058512c6 100644
+index fd29c647e277..dcede058512c 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2,6 +2,8 @@
@@ -536,7 +536,7 @@ index fd29c647e2775..dcede058512c6 100644
  MODULE_DESCRIPTION("Phytium Ethernet driver");
  MODULE_AUTHOR("Wenting Song");
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index 60bd296d8f0b6..62766c49d1a62 100644
+index 60bd296d8f0b..62766c49d1a6 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -2,6 +2,9 @@
@@ -558,7 +558,7 @@ index 60bd296d8f0b6..62766c49d1a62 100644
  	int			speed;
  	bool			duplex;
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 9390056fdc7a9..95509711894b0 100644
+index 9390056fdc7a..95509711894b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -2,6 +2,9 @@
@@ -803,7 +803,7 @@ index 9390056fdc7a9..95509711894b0 100644
  
  module_platform_driver(phytmac_driver);
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
-index 26b1b75edbde1..4803842bd7c17 100644
+index 26b1b75edbde..4803842bd7c1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ptp.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -2,6 +2,9 @@
@@ -817,7 +817,7 @@ index 26b1b75edbde1..4803842bd7c17 100644
  #include <linux/kernel.h>
  #include <linux/types.h>
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
-index 72c8b7c674137..e9497a172d25e 100644
+index 72c8b7c67413..e9497a172d25 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ptp.h
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -2,6 +2,7 @@
@@ -829,7 +829,7 @@ index 72c8b7c674137..e9497a172d25e 100644
   * This program is free software; you can redistribute it and/or modify
   * it under the terms of the GNU General Public License version 2 as
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 72a6eeaec3563..4fc0bfa2f696e 100644
+index 72a6eeaec356..4fc0bfa2f696 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1,4 +1,5 @@
@@ -1094,7 +1094,7 @@ index 72a6eeaec3563..4fc0bfa2f696e 100644
  	.init_ts_hw = phytmac_ptp_init_hw,
  	.set_time = phytmac_set_time,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 32bb129491096..e0ca0ab835474 100644
+index 32bb12949109..e0ca0ab83547 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -1,4 +1,6 @@
@@ -1150,7 +1150,7 @@ index 32bb129491096..e0ca0ab835474 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 25f1ba6c1d6ef..b8af75b3d9341 100644
+index 25f1ba6c1d6e..b8af75b3d934 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -1,4 +1,6 @@
@@ -2494,7 +2494,7 @@ index 25f1ba6c1d6ef..b8af75b3d9341 100644
  };
  EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 92e4806ac2c1f..d2da4acb69a7d 100644
+index 92e4806ac2c1..d2da4acb69a7 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -1,11 +1,15 @@
@@ -2641,5 +2641,5 @@ index 92e4806ac2c1f..d2da4acb69a7d 100644
 +
  #endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
@@ -1,7 +1,7 @@
 From f68854eb7e4e642eb8f1606288161ba17d7fcce1 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 112/344] PHYTIUM: net/phytmac: Slove left-shift out of bound
+Subject: [PATCH 112/345] PHYTIUM: net/phytmac: Slove left-shift out of bound
  issue
 
 When the value of the bd_prefetch is equal to 0, subtracting 1 and
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 3806e09bc1220..4d66ae498b88f 100644
+index 3806e09bc122..4d66ae498b88 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -32,7 +32,7 @@ index 3806e09bc1220..4d66ae498b88f 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index b8af75b3d9341..9bab3d2a5ca4d 100644
+index b8af75b3d934..9bab3d2a5ca4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -342,10 +342,13 @@ static int phytmac_v2_get_feature_all(struct phytmac *pdata)
@@ -54,5 +54,5 @@ index b8af75b3d9341..9bab3d2a5ca4d 100644
  	if (netif_msg_hw(pdata)) {
  		netdev_info(pdata->ndev, "feature qnum=%d, daw=%d, dbw=%d, rxfs=%d, rxbd=%d, txbd=%d\n",
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
@@ -1,7 +1,7 @@
 From 93b29db6dd307f6507b953616daf2eec15eec7f0 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:29:38 +0800
-Subject: [PATCH 113/344] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
+Subject: [PATCH 113/345] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
  PHY supports WOL"
 
 This reverts commit 94967211afe596a9e9c5d80ca9d54e915de3a335.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index e05274b961e4b..7e0c749477914 100644
+index e05274b961e4..7e0c74947791 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -117,8 +117,7 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)
@@ -28,5 +28,5 @@ index e05274b961e4b..7e0c749477914 100644
  
  	pdata->wol = 0;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
@@ -1,7 +1,7 @@
 From 317990f85676089e0149c262ff988fa655ab65ce Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:36:36 +0800
-Subject: [PATCH 114/344] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
+Subject: [PATCH 114/345] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
  issue"
 
 This reverts commit 3161ed880479e35c7759e127c62c37d2d722edee.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 7e0c749477914..23c46bd91f263 100644
+index 7e0c74947791..23c46bd91f26 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -90,23 +90,23 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol
@@ -46,5 +46,5 @@ index 7e0c749477914..23c46bd91f263 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 0f13e63680bc73d4385befae4653f7fcf88d6175 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 115/344] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 115/345] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
  supports WOL feature
 
 Don't manage WoL on MAC, if PHY sets wol fails, So modify if
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 4d66ae498b88f..2c9f2966071c1 100644
+index 4d66ae498b88..2c9f2966071c 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -31,5 +31,5 @@ index 4d66ae498b88f..2c9f2966071c1 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
@@ -1,7 +1,7 @@
 From fd048eaebf878bfd6a4c29ba861038993a9f7bd4 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 116/344] PHYTIUM: net/phytmac: Fixed the PTP test failure
+Subject: [PATCH 116/345] PHYTIUM: net/phytmac: Fixed the PTP test failure
  issue
 
 The bit of RX_TS_VALID should be retained in the process of zero RX
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 2c9f2966071c1..1351f8f7a8953 100644
+index 2c9f2966071c..1351f8f7a895 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -33,7 +33,7 @@ index 2c9f2966071c1..1351f8f7a8953 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 4fc0bfa2f696e..a9cd9cb9a2f57 100644
+index 4fc0bfa2f696..a9cd9cb9a2f5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1003,7 +1003,7 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,
@@ -46,7 +46,7 @@ index 4fc0bfa2f696e..a9cd9cb9a2f57 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 9bab3d2a5ca4d..3eb4b0424bf75 100644
+index 9bab3d2a5ca4..3eb4b0424bf7 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -1038,7 +1038,7 @@ static unsigned int phytmac_v2_rx_map_desc(struct phytmac_queue *queue, u32 inde
@@ -59,5 +59,5 @@ index 9bab3d2a5ca4d..3eb4b0424bf75 100644
  	return 0;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
@@ -1,7 +1,7 @@
 From eda8dc69f0bfcf0d44df05ea5071eb9355fc134a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 117/344] PHYTIUM: net/phytmac: Cancels the power-on/off
+Subject: [PATCH 117/345] PHYTIUM: net/phytmac: Cancels the power-on/off
  capability
 
 The MAC register is powered on by default in the firmware
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 1351f8f7a8953..c53277e566318 100644
+index 1351f8f7a895..c53277e56631 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -32,7 +32,7 @@ index 1351f8f7a8953..c53277e566318 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 95509711894b0..eb3cc7d8f4290 100644
+index 95509711894b..eb3cc7d8f429 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -30,7 +30,6 @@ static const struct phytmac_config phytium_2p0_config = {
@@ -44,5 +44,5 @@ index 95509711894b0..eb3cc7d8f4290 100644
  			| PHYTMAC_CAPS_MSG
  			| PHYTMAC_CAPS_JUMBO,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
@@ -1,7 +1,7 @@
 From 4efa9185fe7672f58efbf56bc42a26a2ff0aed66 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 118/344] PHYTIUM: net/phytmac: Exit probe when MDIO times out
+Subject: [PATCH 118/345] PHYTIUM: net/phytmac: Exit probe when MDIO times out
 
 Exit early to avoid system stuck due to MDIO timeout.
 We have added a callback function for mdio_idle and improved
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 30 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index c53277e566318..98f2cd1ba0299 100644
+index c53277e56631..98f2cd1ba029 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -52,7 +52,7 @@ index c53277e566318..98f2cd1ba0299 100644
  	int (*mdio_write_c45)(struct phytmac *pdata, int mii_id, int devad,
  			      int regnum, u16 data);
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index dcede058512c6..80d3495362ad4 100644
+index dcede058512c..80d3495362ad 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1776,6 +1776,12 @@ int phytmac_mdio_register(struct phytmac *pdata)
@@ -69,7 +69,7 @@ index dcede058512c6..80d3495362ad4 100644
  	pdata->mii_bus->read = &phytmac_mdio_read_c22;
  	pdata->mii_bus->write = &phytmac_mdio_write_c22;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index a9cd9cb9a2f57..e7ac69753dd19 100644
+index a9cd9cb9a2f5..e7ac69753dd1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -558,16 +558,18 @@ static int phytmac_set_wake(struct phytmac *pdata, int wake)
@@ -106,7 +106,7 @@ index a9cd9cb9a2f57..e7ac69753dd19 100644
  	.mdio_write = phytmac_mdio_data_write_c22,
  	.mdio_read_c45 = phytmac_mdio_data_read_c45,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 3eb4b0424bf75..7b337d13329fa 100644
+index 3eb4b0424bf7..7b337d13329f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -421,16 +421,18 @@ static void phytmac_v2_get_hw_stats(struct phytmac *pdata)
@@ -143,7 +143,7 @@ index 3eb4b0424bf75..7b337d13329fa 100644
  	.mdio_write = phytmac_v2_mdio_data_write_c22,
  	.mdio_read_c45 = phytmac_v2_mdio_data_read_c45,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index d2da4acb69a7d..57594732fab98 100644
+index d2da4acb69a7..57594732fab9 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -237,6 +237,8 @@ extern struct phytmac_hw_if phytmac_2p0_hw;
@@ -156,5 +156,5 @@ index d2da4acb69a7d..57594732fab98 100644
  	PHYTMAC_MSG_CMD_DEFAULT = 0,
  	PHYTMAC_MSG_CMD_SET,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
@@ -1,7 +1,7 @@
 From c18b3d614c929d65993e909f43b3b123c1053a0d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 119/344] PHYTIUM: net/phytmac: Add XDP feature support
+Subject: [PATCH 119/345] PHYTIUM: net/phytmac: Add XDP feature support
 
 Add XDP feature support to the phytmac driver.XDP by optimizing
 the data processing flow provided significant performance improvements
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 452 insertions(+), 36 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 98f2cd1ba0299..1d89c9bd023de 100644
+index 98f2cd1ba029..1d89c9bd023d 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -12,6 +12,7 @@
@@ -124,7 +124,7 @@ index 98f2cd1ba0299..1d89c9bd023de 100644
  #define PHYTMAC_RXBUFFER_2048	2048
  #define PHYTMAC_MAX_FRAME_BUILD_SKB \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 80d3495362ad4..26d70d9ccaef9 100644
+index 80d3495362ad..26d70d9ccaef 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -40,6 +40,8 @@
@@ -720,5 +720,5 @@ index 80d3495362ad4..26d70d9ccaef9 100644
  
  static void phytmac_ncsi_handler(struct ncsi_dev *nd)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
@@ -1,7 +1,7 @@
 From ded4451e1736a4bdc54f60d33072d240d57b1e04 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 120/344] PHYTIUM: net/phytmac: Clear RX descriptor address
+Subject: [PATCH 120/345] PHYTIUM: net/phytmac: Clear RX descriptor address
  after the skb construction
 
 If the skb build failed, the descriptor address has been cleared,
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 1d89c9bd023de..5ea2a383c1074 100644
+index 1d89c9bd023d..5ea2a383c107 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -16,7 +16,7 @@
@@ -33,7 +33,7 @@ index 1d89c9bd023de..5ea2a383c1074 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 26d70d9ccaef9..df0aea0de7a41 100644
+index 26d70d9ccaef..df0aea0de7a4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -972,8 +972,6 @@ static struct sk_buff *phytmac_rx_xdp_single(struct phytmac_queue *queue,
@@ -86,5 +86,5 @@ index 26d70d9ccaef9..df0aea0de7a41 100644
  
  	for (frag = first_frag + 1; ; frag++) {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
@@ -1,7 +1,7 @@
 From 2fc721459282816f33cd5ae8f78979f69698a5ea Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 121/344] PHYTIUM: net/phytmac: Enable the tail pointer by the
+Subject: [PATCH 121/345] PHYTIUM: net/phytmac: Enable the tail pointer by the
  driver
 
 It is need to enable the RX/TX tail pointer to ensure the NIC
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 16 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 5ea2a383c1074..abe43324cd6aa 100644
+index 5ea2a383c107..abe43324cd6a 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -16,7 +16,7 @@
@@ -33,7 +33,7 @@ index 5ea2a383c1074..abe43324cd6aa 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 7b337d13329fa..2e9d14dcb9f31 100644
+index 7b337d13329f..2e9d14dcb9f3 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -159,8 +159,16 @@ static int phytmac_v2_init_hw(struct phytmac *pdata)
@@ -54,7 +54,7 @@ index 7b337d13329fa..2e9d14dcb9f31 100644
  		cmd_id = PHYTMAC_MSG_CMD_SET;
  		cmd_subid = PHYTMAC_MSG_CMD_SET_ENABLE_MDIO;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 57594732fab98..1303bde7cff05 100644
+index 57594732fab9..1303bde7cff0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -17,6 +17,7 @@ extern struct phytmac_hw_if phytmac_2p0_hw;
@@ -79,5 +79,5 @@ index 57594732fab98..1303bde7cff05 100644
  #define PHYTMAC_MEM_SIZE_INDEX				0
  #define PHYTMAC_MEM_SIZE_WIDTH				4
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
@@ -1,7 +1,7 @@
 From 4685c326a8e2424d8c63dd5d469a8704a7b0ff87 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 122/344] PHYTIUM: net/phytmac: Modify cmd processing function
+Subject: [PATCH 122/345] PHYTIUM: net/phytmac: Modify cmd processing function
 
 Change the para size in the msg struct from 64 to 56
 and add mutux to avoid race.
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 114 insertions(+), 96 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index abe43324cd6aa..e8a640de47a69 100644
+index abe43324cd6a..e8a640de47a6 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -75,7 +75,8 @@
@@ -45,7 +45,7 @@ index abe43324cd6aa..e8a640de47a69 100644
  	u32			rx_msg_tail;
  	/*use msg_mutex to protect msg */
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 23c46bd91f263..2c0bbb8f27720 100644
+index 23c46bd91f26..2c0bbb8f2772 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -70,7 +70,7 @@ static void phytmac_get_ethtool_strings(struct net_device *ndev, u32 sset, u8 *p
@@ -67,7 +67,7 @@ index 23c46bd91f263..2c0bbb8f27720 100644
  	hw_if->get_regs(pdata, regs_buff);
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index e7ac69753dd19..515825627fedc 100644
+index e7ac69753dd1..515825627fed 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1226,15 +1226,15 @@ static void phytmac_clear_tx_desc(struct phytmac_queue *queue)
@@ -90,7 +90,7 @@ index e7ac69753dd19..515825627fedc 100644
  			val = (u64)stats[i + 1] << 32 | stats[i];
  			*p += val;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 2e9d14dcb9f31..e43a55fe47700 100644
+index 2e9d14dcb9f3..e43a55fe4770 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -20,44 +20,64 @@
@@ -446,7 +446,7 @@ index 2e9d14dcb9f31..e43a55fe47700 100644
  	struct phytmac_dma_desc *desc;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 1303bde7cff05..4e195dcef04fe 100644
+index 1303bde7cff0..4e195dcef04f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -6,10 +6,11 @@
@@ -508,5 +508,5 @@ index 1303bde7cff05..4e195dcef04fe 100644
 +
  #endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From c5620c0c58269a6dc202f3359e84431f63a95b03 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 123/344] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 123/345] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 2c0bbb8f27720..bac59327087fc 100644
+index 2c0bbb8f2772..bac59327087f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -90,24 +90,20 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol
@@ -54,5 +54,5 @@ index 2c0bbb8f27720..bac59327087fc 100644
  
  static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
@@ -1,7 +1,7 @@
 From ec7f474769171e81addb507ef6bdb2b43e022a18 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 124/344] PHYTIUM: net/phytmac: Bugfix invalid wait context
+Subject: [PATCH 124/345] PHYTIUM: net/phytmac: Bugfix invalid wait context
 
 After the spinlock is called, the mutex should no longer to be
 invoked, which will lead to unnecessary sleep.
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 7 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index e8a640de47a69..7acfc97d3fc29 100644
+index e8a640de47a6..7acfc97d3fc2 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -434,8 +434,8 @@ struct phytmac_msg {
@@ -43,7 +43,7 @@ index e8a640de47a69..7acfc97d3fc29 100644
  	u32				tx_ring_size;
  	u32				dma_data_width;
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index df0aea0de7a41..765b01503c1f4 100644
+index df0aea0de7a4..765b01503c1f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2725,8 +2725,6 @@ int phytmac_drv_probe(struct phytmac *pdata)
@@ -74,7 +74,7 @@ index df0aea0de7a41..765b01503c1f4 100644
  	pdata->msg_enable = netif_msg_init(debug, PHYTMAC_DEFAULT_MSG_ENABLE);
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index e43a55fe47700..65db2c0d15dea 100644
+index e43a55fe4770..65db2c0d15de 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -27,7 +27,7 @@ static int phytmac_v2_msg_send(struct phytmac *pdata, u16 cmd_id,
@@ -127,5 +127,5 @@ index e43a55fe47700..65db2c0d15dea 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
@@ -1,7 +1,7 @@
 From b926f202ce9556ee68f9c224286d9e40940c21a6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 125/344] PHYTIUM: net/phytmac: Change the requested resource
+Subject: [PATCH 125/345] PHYTIUM: net/phytmac: Change the requested resource
  type from nRE to nRnE
 
 The resource type is changed from nRE to nRnE to avoid interrupt
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 70 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 7acfc97d3fc29..6b72b45bc0d4a 100644
+index 7acfc97d3fc2..6b72b45bc0d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -680,6 +680,8 @@ struct phytmac_hw_if {
@@ -33,7 +33,7 @@ index 7acfc97d3fc29..6b72b45bc0d4a 100644
  					  unsigned int index);
  inline struct phytmac_dma_desc *phytmac_get_tx_desc(struct phytmac_queue *queue,
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 765b01503c1f4..c32dd959cca55 100644
+index 765b01503c1f..c32dd959cca5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2933,6 +2933,72 @@ void phytmac_drv_shutdown(struct phytmac *pdata)
@@ -110,7 +110,7 @@ index 765b01503c1f4..c32dd959cca55 100644
  MODULE_DESCRIPTION("Phytium Ethernet driver");
  MODULE_AUTHOR("Wenting Song");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index eb3cc7d8f4290..540159f8fc3a8 100644
+index eb3cc7d8f429..540159f8fc3a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -203,7 +203,8 @@ static int phytmac_plat_probe(struct platform_device *pdev)
@@ -124,5 +124,5 @@ index eb3cc7d8f4290..540159f8fc3a8 100644
  		dev_err(&pdev->dev, "mac_regs ioremap failed\n");
  		ret = PTR_ERR(pdata->mac_regs);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
@@ -1,7 +1,7 @@
 From 515fdf19ce608061dcc872e374be98687455c75e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 126/344] PHYTIUM: net/phytmac: BugFix Memory leak when
+Subject: [PATCH 126/345] PHYTIUM: net/phytmac: BugFix Memory leak when
  releasing resource
 
 The size of the memory released in the dma_free_coherent is smaller
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 6b72b45bc0d4a..09e3c99232d35 100644
+index 6b72b45bc0d4..09e3c99232d3 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -114,9 +114,6 @@
@@ -34,7 +34,7 @@ index 6b72b45bc0d4a..09e3c99232d35 100644
  #define LSO_TSO		2
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c32dd959cca55..eeaf60a6e9cde 100644
+index c32dd959cca5..eeaf60a6e9cd 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -391,6 +391,7 @@ static int phytmac_free_tx_resource(struct phytmac *pdata)
@@ -78,5 +78,5 @@ index c32dd959cca55..eeaf60a6e9cde 100644
  	}
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
@@ -1,7 +1,7 @@
 From df420792ace08eef8b190d258bde103b2c85436b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 127/344] PHYTIUM: net/phytmac: Limit the number of retries to
+Subject: [PATCH 127/345] PHYTIUM: net/phytmac: Limit the number of retries to
  avoid deadlock
 
 It is need to limit retries that messages are processed
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 20 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 65db2c0d15dea..20c49bf5f4b86 100644
+index 65db2c0d15de..20c49bf5f4b8 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -25,6 +25,7 @@ static int phytmac_v2_msg_send(struct phytmac *pdata, u16 cmd_id,
@@ -68,7 +68,7 @@ index 65db2c0d15dea..20c49bf5f4b86 100644
  
  		memcpy(&msg_rx, pdata->msg_regs + PHYTMAC_MSG(pdata->msg_ring.tx_msg_rd_tail),
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 4e195dcef04fe..b32044d696ae2 100644
+index 4e195dcef04f..b32044d696ae 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -246,6 +246,8 @@ extern struct phytmac_hw_if phytmac_2p0_hw;
@@ -81,5 +81,5 @@ index 4e195dcef04fe..b32044d696ae2 100644
  
  enum phytmac_msg_cmd_id {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-update-to-1.0.47.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-PHYTIUM-net-phytmac-update-to-1.0.47.patch
@@ -1,7 +1,7 @@
 From 4c113a0a79426ac4c5bab488aba8537bf00f9415 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 11:41:46 +0800
-Subject: [PATCH 128/344] PHYTIUM: net: phytmac: update to 1.0.47
+Subject: [PATCH 128/345] PHYTIUM: net: phytmac: update to 1.0.47
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
 
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  8 files changed, 31 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 09e3c99232d35..ee22cda030e94 100644
+index 09e3c99232d3..ee22cda030e9 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -14,9 +14,10 @@
@@ -53,7 +53,7 @@ index 09e3c99232d35..ee22cda030e94 100644
  
  /* phytmac_desc_unused - calculate if we have unused descriptors */
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index bac59327087fc..26478b090ced0 100644
+index bac59327087f..26478b090ced 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -506,13 +506,16 @@ static void phytmac_get_drvinfo(struct net_device *ndev, struct ethtool_drvinfo
@@ -77,7 +77,7 @@ index bac59327087fc..26478b090ced0 100644
  
  static const struct ethtool_ops phytmac_ethtool_ops = {
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index eeaf60a6e9cde..9ed5ec09523b3 100644
+index eeaf60a6e9cd..9ed5ec09523b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -62,7 +62,7 @@ MODULE_PARM_DESC(debug, "Debug level (0=none,...,16=all)");
@@ -127,7 +127,7 @@ index eeaf60a6e9cde..9ed5ec09523b3 100644
  
  	return 0;
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index 62766c49d1a62..fac5d717ad766 100644
+index 62766c49d1a6..fac5d717ad76 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -74,7 +74,7 @@ static int phytmac_pci_probe(struct pci_dev *pdev, const struct pci_device_id *i
@@ -149,7 +149,7 @@ index 62766c49d1a62..fac5d717ad766 100644
  	.probe = phytmac_pci_probe,
  	.remove = phytmac_pci_remove,
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 540159f8fc3a8..2f2170cf0775a 100644
+index 540159f8fc3a..2f2170cf0775 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -356,7 +356,7 @@ static struct platform_driver phytmac_driver = {
@@ -162,7 +162,7 @@ index 540159f8fc3a8..2f2170cf0775a 100644
  		.acpi_match_table = phytmac_acpi_ids,
  		.pm = &phytmac_plat_pm_ops,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 515825627fedc..870f07edc58fc 100644
+index 515825627fed..870f07edc58f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -564,7 +564,7 @@ static int phytmac_mdio_idle(struct phytmac *pdata)
@@ -175,7 +175,7 @@ index 515825627fedc..870f07edc58fc 100644
  	if (ret)
  		netdev_err(pdata->ndev, "mdio wait for idle time out!");
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 20c49bf5f4b86..1afff67d625d9 100644
+index 20c49bf5f4b8..1afff67d625d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -453,7 +453,7 @@ static int phytmac_v2_mdio_idle(struct phytmac *pdata)
@@ -188,7 +188,7 @@ index 20c49bf5f4b86..1afff67d625d9 100644
  	if (ret)
  		netdev_err(pdata->ndev, "mdio wait for idle time out!");
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index b32044d696ae2..c9e159b1eb9b6 100644
+index b32044d696ae..c9e159b1eb9b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -248,7 +248,7 @@ extern struct phytmac_hw_if phytmac_2p0_hw;
@@ -201,5 +201,5 @@ index b32044d696ae2..c9e159b1eb9b6 100644
  enum phytmac_msg_cmd_id {
  	PHYTMAC_MSG_CMD_DEFAULT = 0,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From b89177e9d55f4892323733d9e9399b239635c489 Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 129/344] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 129/345] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/kernel/fpu-probe.c b/arch/mips/kernel/fpu-probe.c
-index 6bf3f19b1c335..404d753120582 100644
+index 6bf3f19b1c33..404d75312058 100644
 --- a/arch/mips/kernel/fpu-probe.c
 +++ b/arch/mips/kernel/fpu-probe.c
 @@ -144,7 +144,12 @@ static void cpu_set_fpu_2008(struct cpuinfo_mips *c)
@@ -41,5 +41,5 @@ index 6bf3f19b1c335..404d753120582 100644
  /*
   * Set the IEEE 754 NaN encodings and the ABS.fmt/NEG.fmt execution modes
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 05e6a175f9c79b24c4005be66b4638181f135f71 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 130/344] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 130/345] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hwmon/hwmon-aaeon.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 9d28fcf7cd2a6..597538bfe2f83 100644
+index 9d28fcf7cd2a..597538bfe2f8 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -38,6 +38,18 @@ config HWMON_DEBUG_CHIP
@@ -49,7 +49,7 @@ index 9d28fcf7cd2a6..597538bfe2f83 100644
  	tristate "Abit uGuru (rev 1 & 2)"
  	depends on (X86 && DMI) || COMPILE_TEST && HAS_IOPORT
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index cd8bc4752b4db..5ef7c156cc76c 100644
+index cd8bc4752b4d..5ef7c156cc76 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -15,6 +15,7 @@ obj-$(CONFIG_SENSORS_HP_WMI)	+= hp-wmi-sensors.o
@@ -62,7 +62,7 @@ index cd8bc4752b4db..5ef7c156cc76c 100644
  obj-$(CONFIG_SENSORS_W83773G)	+= w83773g.o
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
 new file mode 100644
-index 0000000000000..146da10309bbb
+index 000000000000..146da10309bb
 --- /dev/null
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -0,0 +1,568 @@
@@ -635,5 +635,5 @@ index 0000000000000..146da10309bbb
 +MODULE_AUTHOR("Kunyang Fan <kunyang_fan@aaeon.com.tw>");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 3d1a4a4ac710846f01dc43230a1f62a64204ef37 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 131/344] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 131/345] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/leds/leds-aaeon.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 6e3dce7e35a49..84d66b7d7a17d 100644
+index 6e3dce7e35a4..84d66b7d7a17 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -72,6 +72,18 @@ config LEDS_88PM860X
@@ -49,7 +49,7 @@ index 6e3dce7e35a49..84d66b7d7a17d 100644
  	tristate "LED support for Panasonic AN30259A"
  	depends on LEDS_CLASS && I2C && OF
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 9a0333ec1a861..cbb759e92d55a 100644
+index 9a0333ec1a86..cbb759e92d55 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -10,6 +10,7 @@ obj-$(CONFIG_LEDS_KUNIT_TEST)		+= led-test.o
@@ -62,7 +62,7 @@ index 9a0333ec1a861..cbb759e92d55a 100644
  obj-$(CONFIG_LEDS_AN30259A)		+= leds-an30259a.o
 diff --git a/drivers/leds/leds-aaeon.c b/drivers/leds/leds-aaeon.c
 new file mode 100644
-index 0000000000000..10090a4bff654
+index 000000000000..10090a4bff65
 --- /dev/null
 +++ b/drivers/leds/leds-aaeon.c
 @@ -0,0 +1,142 @@
@@ -209,5 +209,5 @@ index 0000000000000..10090a4bff654
 +MODULE_AUTHOR("Kunyang Fan <kunyang_fan@asus.com>");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From dca7f182490925e8f676d6e701d22f3cc85ffb35 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 132/344] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 132/345] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpio/gpio-aaeon.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index d8ac40d0eb6fb..3636fa0bfe6b4 100644
+index d8ac40d0eb6f..3636fa0bfe6b 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1716,6 +1716,18 @@ endmenu
@@ -49,7 +49,7 @@ index d8ac40d0eb6fb..3636fa0bfe6b4 100644
  	tristate "AMD 8111 GPIO driver"
  	depends on X86 || COMPILE_TEST
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index 379f55e9ed1e6..3d8b2a1606d57 100644
+index 379f55e9ed1e..3d8b2a1606d5 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -28,6 +28,7 @@ obj-$(CONFIG_GPIO_104_IDI_48)		+= gpio-104-idi-48.o
@@ -62,7 +62,7 @@ index 379f55e9ed1e6..3d8b2a1606d57 100644
  obj-$(CONFIG_GPIO_ADP5585)		+= gpio-adp5585.o
 diff --git a/drivers/gpio/gpio-aaeon.c b/drivers/gpio/gpio-aaeon.c
 new file mode 100644
-index 0000000000000..3183c45dd1946
+index 000000000000..3183c45dd194
 --- /dev/null
 +++ b/drivers/gpio/gpio-aaeon.c
 @@ -0,0 +1,205 @@
@@ -272,5 +272,5 @@ index 0000000000000..3183c45dd1946
 +MODULE_AUTHOR("Edward Lin <edward1_lin@aaeon.com.tw>");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From b83d3a44c005ee99d856efa3e989742238f7238f Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 133/344] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 133/345] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
@@ -37,7 +37,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/mfd/mfd-aaeon.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 73ab3c5389ce3..f6a8258e6a9bb 100644
+index 73ab3c5389ce..f6a8258e6a9b 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -199,6 +199,18 @@ M:	Linus Walleij <linus.walleij@linaro.org>
@@ -60,7 +60,7 @@ index 73ab3c5389ce3..f6a8258e6a9bb 100644
  L:	linux-api@vger.kernel.org
  F:	include/linux/syscalls.h
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 55fbeba2ca33b..0b3691ec4949c 100644
+index 55fbeba2ca33..0b3691ec4949 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2341,6 +2341,18 @@ config MFD_QCOM_PM8008
@@ -83,7 +83,7 @@ index 55fbeba2ca33b..0b3691ec4949c 100644
  	depends on ARCH_SA1100
  
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index a950e670efbae..89d601f346550 100644
+index a950e670efba..89d601f34655 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -290,6 +290,7 @@ obj-$(CONFIG_MFD_LS2K_BMC_CORE)		+= ls2k-bmc-core.o
@@ -96,7 +96,7 @@ index a950e670efbae..89d601f346550 100644
  
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
 new file mode 100644
-index 0000000000000..9d2efde53cad3
+index 000000000000..9d2efde53cad
 --- /dev/null
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -0,0 +1,77 @@
@@ -178,5 +178,5 @@ index 0000000000000..9d2efde53cad3
 +MODULE_DESCRIPTION("AAEON Board WMI driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From 0347413d701079a2089876c898c4a2abddf5a394 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 134/344] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 134/345] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
-index 9d2efde53cad3..74211d01ce656 100644
+index 9d2efde53cad..74211d01ce65 100644
 --- a/drivers/mfd/mfd-aaeon.c
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -16,12 +16,17 @@
@@ -78,5 +78,5 @@ index 9d2efde53cad3..74211d01ce656 100644
  	priv = (struct aaeon_wmi_priv *)context;
  	dev_set_drvdata(&wdev->dev, priv);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From 4b787896a437d54aabae97e8e12293ac0e9cfe90 Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 135/344] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 135/345] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
-index 146da10309bbb..80bf4d1224f3f 100644
+index 146da10309bb..80bf4d1224f3 100644
 --- a/drivers/hwmon/hwmon-aaeon.c
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -49,7 +49,7 @@ static ssize_t name_show(struct device *dev, struct device_attribute *devattr,
@@ -54,5 +54,5 @@ index 146da10309bbb..80bf4d1224f3f 100644
  
  static int aaeon_get_version(void)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
@@ -1,7 +1,7 @@
 From 39d0aa4f1e2e6ddf9428adb123a3b67b212b7733 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 12 Aug 2024 14:28:31 +0800
-Subject: [PATCH 136/344] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 136/345] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for SKL integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2062951
@@ -34,7 +34,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 27 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index e236c7ec221f4..ed32ebd8ec65d 100644
+index e236c7ec221f..ed32ebd8ec65 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -4553,6 +4553,33 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
@@ -72,5 +72,5 @@ index e236c7ec221f4..ed32ebd8ec65d 100644
  {
  	if (risky_device(dev))
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
@@ -1,7 +1,7 @@
 From 6195844f28ea17e516da6887b589b60bd1eb51c7 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 18 Nov 2024 09:28:40 +0800
-Subject: [PATCH 137/344] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 137/345] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for KBL and CML integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2086587
@@ -33,7 +33,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 41 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index ed32ebd8ec65d..a5ecb62bfddef 100644
+index ed32ebd8ec65..a5ecb62bfdde 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -4580,6 +4580,47 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x193A, quirk_iommu_igfx);
@@ -85,5 +85,5 @@ index ed32ebd8ec65d..a5ecb62bfddef 100644
  {
  	if (risky_device(dev))
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From 451ff04415ca17051868dbc4d55d91e1c0dfc800 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 138/344] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 138/345] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 6e8e44730bec6..078e3ee52bdcb 100644
+index 6e8e44730bec..078e3ee52bdc 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -198,6 +198,7 @@ MODULE_DEVICE_TABLE(of, phytium_dwmac_of_match);
@@ -29,5 +29,5 @@ index 6e8e44730bec6..078e3ee52bdcb 100644
  	{ }
  };
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From 8929c81d12b83cae823dcf1705d515222459f440 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 139/344] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 139/345] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise
@@ -30,7 +30,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 7b16d1207b80c..6ac3373aab2ee 100644
+index 7b16d1207b80..6ac3373aab2e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -2027,13 +2027,18 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv,
@@ -68,5 +68,5 @@ index 7b16d1207b80c..6ac3373aab2ee 100644
  
  static void free_dma_tx_desc_resources(struct stmmac_priv *priv,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From 3ade1e8e7c0908429c4b358445fd283122675ef3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 140/344] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 140/345] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 078e3ee52bdcb..ba86b6bb047dc 100644
+index 078e3ee52bdc..ba86b6bb047d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -68,6 +68,21 @@ static int phytium_dwmac_probe(struct platform_device *pdev)
@@ -71,5 +71,5 @@ index 078e3ee52bdcb..ba86b6bb047dc 100644
  	plat->axi->axi_xit_frm = false;
  	plat->axi->axi_wr_osr_lmt = 7;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-BACKPORT-DEEPIN-ethernet-Add-motorcomm-yt6801-suppor.patch
@@ -1,7 +1,7 @@
 From 92e8a1733cf4c7f098a630dfe2036e293ccdfcc8 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Wed, 17 Jul 2024 18:25:37 +0800
-Subject: [PATCH 141/344] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
+Subject: [PATCH 141/345] BACKPORT: DEEPIN: ethernet: Add motorcomm yt6801
  support
 
 - The Asus XC-LS3A6M motherboard(Loongson 3A6000),CE720Z2,CE720Z... uses
@@ -69,7 +69,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 
 diff --git a/arch/loongarch/configs/loongson3_defconfig b/arch/loongarch/configs/loongson3_defconfig
-index 34eaee0384c92..f54246ab15dc1 100644
+index 34eaee0384c9..f54246ab15dc 100644
 --- a/arch/loongarch/configs/loongson3_defconfig
 +++ b/arch/loongarch/configs/loongson3_defconfig
 @@ -591,6 +591,7 @@ CONFIG_IXGBE=y
@@ -81,7 +81,7 @@ index 34eaee0384c92..f54246ab15dc1 100644
  # CONFIG_NET_VENDOR_ROCKER is not set
  # CONFIG_NET_VENDOR_SAMSUNG is not set
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index 9702db7bcc680..aaae1ac6205bb 100644
+index 9702db7bcc68..aaae1ac6205b 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -126,6 +126,7 @@ source "drivers/net/ethernet/mellanox/Kconfig"
@@ -93,7 +93,7 @@ index 9702db7bcc680..aaae1ac6205bb 100644
  source "drivers/net/ethernet/microsoft/Kconfig"
  source "drivers/net/ethernet/moxa/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 96ba43e005a87..bc90ef0b39523 100644
+index 96ba43e005a8..bc90ef0b3952 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -63,6 +63,7 @@ obj-$(CONFIG_NET_VENDOR_MELLANOX) += mellanox/
@@ -106,7 +106,7 @@ index 96ba43e005a87..bc90ef0b39523 100644
  obj-$(CONFIG_NET_VENDOR_MYRI) += myricom/
 diff --git a/drivers/net/ethernet/motorcomm/Kconfig b/drivers/net/ethernet/motorcomm/Kconfig
 new file mode 100644
-index 0000000000000..2d058928936f0
+index 000000000000..2d058928936f
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Kconfig
 @@ -0,0 +1,27 @@
@@ -139,7 +139,7 @@ index 0000000000000..2d058928936f0
 +endif # NET_VENDOR_MOTORCOMM
 diff --git a/drivers/net/ethernet/motorcomm/Makefile b/drivers/net/ethernet/motorcomm/Makefile
 new file mode 100644
-index 0000000000000..af0a439d54a16
+index 000000000000..af0a439d54a1
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/Makefile
 @@ -0,0 +1,4 @@
@@ -149,7 +149,7 @@ index 0000000000000..af0a439d54a16
 +obj-$(CONFIG_YT6801) += yt6801/
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/Makefile b/drivers/net/ethernet/motorcomm/yt6801/Makefile
 new file mode 100644
-index 0000000000000..93b5c4510eb05
+index 000000000000..93b5c4510eb0
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/Makefile
 @@ -0,0 +1,15 @@
@@ -170,7 +170,7 @@ index 0000000000000..93b5c4510eb05
 +	fuxi-gmac-debugfs.o
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h
 new file mode 100644
-index 0000000000000..24282f8e22303
+index 000000000000..24282f8e2230
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-dbg.h
 @@ -0,0 +1,15 @@
@@ -192,7 +192,7 @@ index 0000000000000..24282f8e22303
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c
 new file mode 100644
-index 0000000000000..ae4ca3d59ac4c
+index 000000000000..ae4ca3d59ac4
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.c
 @@ -0,0 +1,1344 @@
@@ -1543,7 +1543,7 @@ index 0000000000000..ae4ca3d59ac4c
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h
 new file mode 100644
-index 0000000000000..fa0446958719c
+index 000000000000..fa0446958719
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-efuse.h
 @@ -0,0 +1,25 @@
@@ -1575,7 +1575,7 @@ index 0000000000000..fa0446958719c
 \ No newline at end of file
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c
 new file mode 100644
-index 0000000000000..63cbf948cbfa2
+index 000000000000..63cbf948cbfa
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-common.c
 @@ -0,0 +1,939 @@
@@ -2520,7 +2520,7 @@ index 0000000000000..63cbf948cbfa2
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c
 new file mode 100644
-index 0000000000000..4596d91b6e282
+index 000000000000..4596d91b6e28
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-debugfs.c
 @@ -0,0 +1,787 @@
@@ -3313,7 +3313,7 @@ index 0000000000000..4596d91b6e282
 +#endif /* HAVE_XLGMAC_DEBUG_FS */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c
 new file mode 100644
-index 0000000000000..969d84eb44e2a
+index 000000000000..969d84eb44e2
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-desc.c
 @@ -0,0 +1,601 @@
@@ -3920,7 +3920,7 @@ index 0000000000000..969d84eb44e2a
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 new file mode 100644
-index 0000000000000..05aa42f90ad83
+index 000000000000..05aa42f90ad8
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 @@ -0,0 +1,1114 @@
@@ -5040,7 +5040,7 @@ index 0000000000000..05aa42f90ad83
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c
 new file mode 100644
-index 0000000000000..0517968365d74
+index 000000000000..0517968365d7
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-hw.c
 @@ -0,0 +1,6256 @@
@@ -11302,7 +11302,7 @@ index 0000000000000..0517968365d74
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c
 new file mode 100644
-index 0000000000000..b8734efb36426
+index 000000000000..b8734efb3642
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-net.c
 @@ -0,0 +1,2329 @@
@@ -13637,7 +13637,7 @@ index 0000000000000..b8734efb36426
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c
 new file mode 100644
-index 0000000000000..f6f8f4f6a5e9b
+index 000000000000..f6f8f4f6a5e9
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-pci.c
 @@ -0,0 +1,250 @@
@@ -13893,7 +13893,7 @@ index 0000000000000..f6f8f4f6a5e9b
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c
 new file mode 100644
-index 0000000000000..88066a110f410
+index 000000000000..88066a110f41
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-phy.c
 @@ -0,0 +1,256 @@
@@ -14155,7 +14155,7 @@ index 0000000000000..88066a110f410
 +}
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h
 new file mode 100644
-index 0000000000000..65d6288e6869a
+index 000000000000..65d6288e6869
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-reg.h
 @@ -0,0 +1,1894 @@
@@ -16055,7 +16055,7 @@ index 0000000000000..65d6288e6869a
 +#endif /* __FUXI_GMAC_REG_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h
 new file mode 100644
-index 0000000000000..ea01ebdadc4e3
+index 000000000000..ea01ebdadc4e
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac.h
 @@ -0,0 +1,934 @@
@@ -16995,7 +16995,7 @@ index 0000000000000..ea01ebdadc4e3
 +#endif /* __FUXI_GMAC_H__ */
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h b/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 new file mode 100644
-index 0000000000000..1a40267e1fa2e
+index 000000000000..1a40267e1fa2
 --- /dev/null
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-os.h
 @@ -0,0 +1,515 @@
@@ -17515,5 +17515,5 @@ index 0000000000000..1a40267e1fa2e
 +
 +#endif /* __FUXI_OS_H__ */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
@@ -1,7 +1,7 @@
 From 9c15ab5801f1c8d642400d83ad33f9487612328e Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 142/344] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
+Subject: [PATCH 142/345] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
  transition of devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 31 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index b497a9e8118f4..76afe49aeddcd 100644
+index b497a9e8118f..76afe49aeddc 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -399,6 +399,36 @@ static void quirk_tigerpoint_bm_sts(struct pci_dev *dev)
@@ -61,7 +61,7 @@ index b497a9e8118f4..76afe49aeddcd 100644
  static void quirk_nopcipci(struct pci_dev *dev)
  {
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index 59876de13860d..41b9f92d64632 100644
+index 59876de13860..41b9f92d6463 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -247,6 +247,7 @@ enum pci_dev_flags {
@@ -73,5 +73,5 @@ index 59876de13860d..41b9f92d64632 100644
  
  enum pci_irq_reroute_variant {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-DEEPIN-ethernet-yt6801-fix-build-on-6.8.patch
@@ -1,7 +1,7 @@
 From 6860272ac4a57ea91925bce5f442973627e45ddc Mon Sep 17 00:00:00 2001
 From: root <baimingcong@uniontech.com>
 Date: Tue, 23 Jul 2024 11:00:20 +0800
-Subject: [PATCH 143/344] DEEPIN: ethernet: yt6801: fix build on >= 6.8
+Subject: [PATCH 143/345] DEEPIN: ethernet: yt6801: fix build on >= 6.8
 
 Adapt to ethtool.h changes introduced in 6.8.
 
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 18 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
-index 05aa42f90ad83..d0989eac966ac 100644
+index 05aa42f90ad8..d0989eac966a 100644
 --- a/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 +++ b/drivers/net/ethernet/motorcomm/yt6801/fuxi-gmac-ethtool.c
 @@ -262,8 +262,8 @@ static void fxgmac_get_reta(struct fxgmac_pdata *pdata, u32 *indir)
@@ -106,5 +106,5 @@ index 05aa42f90ad83..d0989eac966ac 100644
  	return 0;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From 901f67d79bab4057b40d3f16d934bf9ef31b36b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 144/344] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 144/345] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index ba86b6bb047dc..eea8421955134 100644
+index ba86b6bb047d..eea842195513 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)
@@ -28,5 +28,5 @@ index ba86b6bb047dc..eea8421955134 100644
  	struct net_device *ndev = platform_get_drvdata(pdev);
  	struct stmmac_priv *priv = netdev_priv(ndev);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 731b1893313c1868e88e79fcff23bd16a1822f7e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 145/344] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 145/345] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 2f2170cf0775a..ce6271ac52cd0 100644
+index 2f2170cf0775..ce6271ac52cd 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -17,6 +17,8 @@
@@ -28,5 +28,5 @@ index 2f2170cf0775a..ce6271ac52cd0 100644
  	.hw_if = &phytmac_1p0_hw,
  	.caps = PHYTMAC_CAPS_TAILPTR
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From b76af59ec10f0b60b19496fb73cc81454cf7b8fa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 146/344] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 146/345] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 9ed5ec09523b3..6ef55093d6d4a 100644
+index 9ed5ec09523b..6ef55093d6d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1848,7 +1848,7 @@ static int phytmac_phylink_connect(struct phytmac *pdata)
@@ -59,7 +59,7 @@ index 9ed5ec09523b3..6ef55093d6d4a 100644
  	struct net_device *ndev = pdata->ndev;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index ce6271ac52cd0..cf628a4517284 100644
+index ce6271ac52cd..cf628a451728 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -168,7 +168,6 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)
@@ -71,5 +71,5 @@ index ce6271ac52cd0..cf628a4517284 100644
  	struct phytmac *pdata;
  	int ret, i;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From bd9bf851b825016923b629f314f4c53422b9ab7e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 147/344] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 147/345] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -24,7 +24,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index cf628a4517284..d958ca1f168bb 100644
+index cf628a451728..d958ca1f168b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -168,6 +168,7 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)
@@ -36,5 +36,5 @@ index cf628a4517284..d958ca1f168bb 100644
  	struct phytmac *pdata;
  	int ret, i;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From 4dd766f8bb1a41ba0ed4cc466bd26630c5f8a7c1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 148/344] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 148/345] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 6 insertions(+), 65 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 6ef55093d6d4a..2a0caf15671d5 100644
+index 6ef55093d6d4..2a0caf15671d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2063,72 +2063,7 @@ static void phytmac_pcs_get_state(struct phylink_config *config,
@@ -117,5 +117,5 @@ index 6ef55093d6d4a..2a0caf15671d5 100644
  					pdata->phy_interface, &phytmac_phylink_ops);
  	if (IS_ERR(pdata->phylink)) {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From 71cfc51b0a796128a5b159d575379b881a5592df Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 149/344] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 149/345] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index 8b72ae6449c91..5f607e83dd44c 100644
+index 8b72ae6449c9..5f607e83dd44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 @@ -300,7 +300,7 @@ &gmac {
@@ -27,5 +27,5 @@ index 8b72ae6449c91..5f607e83dd44c 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
@@ -1,7 +1,7 @@
 From 95f7741ab36ec48598f966d26a837395dbc6351b Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
-Subject: [PATCH 150/344] SURFACE: (surface3-oemb) add DMI matches for Surface
+Subject: [PATCH 150/345] SURFACE: (surface3-oemb) add DMI matches for Surface
  3 with broken DMI table
 
 On some Surface 3, the DMI table gets corrupted for unknown reasons
@@ -43,7 +43,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 24 insertions(+)
 
 diff --git a/drivers/platform/surface/surface3-wmi.c b/drivers/platform/surface/surface3-wmi.c
-index 6c8fb7a4dde44..22797a53f4d8f 100644
+index 6c8fb7a4dde4..22797a53f4d8 100644
 --- a/drivers/platform/surface/surface3-wmi.c
 +++ b/drivers/platform/surface/surface3-wmi.c
 @@ -37,6 +37,13 @@ static const struct dmi_system_id surface3_dmi_table[] = {
@@ -61,7 +61,7 @@ index 6c8fb7a4dde44..22797a53f4d8f 100644
  	{ }
  };
 diff --git a/sound/soc/codecs/rt5645.c b/sound/soc/codecs/rt5645.c
-index 29a403526cd9e..986f32132c3d8 100644
+index 29a403526cd9..986f32132c3d 100644
 --- a/sound/soc/codecs/rt5645.c
 +++ b/sound/soc/codecs/rt5645.c
 @@ -3792,6 +3792,15 @@ static const struct dmi_system_id dmi_platform_data[] = {
@@ -81,7 +81,7 @@ index 29a403526cd9e..986f32132c3d8 100644
  		/*
  		 * Match for the GPDwin which unfortunately uses somewhat
 diff --git a/sound/soc/intel/common/soc-acpi-intel-cht-match.c b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
-index e4c3492a0c282..0b930c91bccb3 100644
+index e4c3492a0c28..0b930c91bccb 100644
 --- a/sound/soc/intel/common/soc-acpi-intel-cht-match.c
 +++ b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
 @@ -27,6 +27,14 @@ static const struct dmi_system_id cht_table[] = {
@@ -100,5 +100,5 @@ index e4c3492a0c282..0b930c91bccb3 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
@@ -1,7 +1,7 @@
 From 04023d39ec12db3cf91d3a566bd39737bb7a739e Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
-Subject: [PATCH 151/344] SURFACE: surface3-spi: workaround: disable DMA mode
+Subject: [PATCH 151/345] SURFACE: surface3-spi: workaround: disable DMA mode
  to avoid crash by default
 
 On Arch Linux kernel at least after 4.19, touch input is broken after suspend
@@ -81,7 +81,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/drivers/input/touchscreen/surface3_spi.c b/drivers/input/touchscreen/surface3_spi.c
-index 6074b7730e862..6aa3e1d6f160a 100644
+index 6074b7730e86..6aa3e1d6f160 100644
 --- a/drivers/input/touchscreen/surface3_spi.c
 +++ b/drivers/input/touchscreen/surface3_spi.c
 @@ -25,6 +25,12 @@
@@ -132,5 +132,5 @@ index 6074b7730e862..6aa3e1d6f160a 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From ae31e6a373357289c06737c5ca6b733f0ed65f03 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 152/344] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 152/345] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 
 The most recent firmware of the 88W8897 card reports a hardcoded LTR
@@ -35,7 +35,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 31 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index a760de191fce7..db9b203226a89 100644
+index a760de191fce..db9b203226a8 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -1702,9 +1702,21 @@ mwifiex_pcie_send_boot_cmd(struct mwifiex_adapter *adapter, struct sk_buff *skb)
@@ -61,7 +61,7 @@ index a760de191fce7..db9b203226a89 100644
  	mwifiex_write_reg(adapter, reg->rx_rdptr, card->rxbd_rdptr | tx_wrap);
  }
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index dd6d21f1dbfd7..f46b06f8d6435 100644
+index dd6d21f1dbfd..f46b06f8d643 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -13,7 +13,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -154,7 +154,7 @@ index dd6d21f1dbfd7..f46b06f8d6435 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index d6ff964aec5bf..5d30ae39d65ec 100644
+index d6ff964aec5b..5d30ae39d65e 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -4,6 +4,7 @@
@@ -166,5 +166,5 @@ index d6ff964aec5bf..5d30ae39d65ec 100644
  void mwifiex_initialize_quirks(struct pcie_service_card *card);
  int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From b887f714aa2aa45cc40632ff2da42ecfa075fcf1 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 153/344] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 153/345] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 27 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index db9b203226a89..ffd0c1fe92239 100644
+index db9b203226a8..ffd0c1fe9223 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -377,6 +377,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
@@ -49,7 +49,7 @@ index db9b203226a89..ffd0c1fe92239 100644
  }
  
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index f46b06f8d6435..99b024ecbadea 100644
+index f46b06f8d643..99b024ecbade 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -14,7 +14,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -143,7 +143,7 @@ index f46b06f8d6435..99b024ecbadea 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index 5d30ae39d65ec..c14eb56eb9118 100644
+index 5d30ae39d65e..c14eb56eb911 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -5,6 +5,7 @@
@@ -155,5 +155,5 @@ index 5d30ae39d65ec..c14eb56eb9118 100644
  void mwifiex_initialize_quirks(struct pcie_service_card *card);
  int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-SURFACE-Bluetooth-btusb-Lower-passive-lescan-interva.patch
@@ -1,7 +1,7 @@
 From c05380560dd6f34d0da75ffea570c7a87bdab431 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 154/344] SURFACE: Bluetooth: btusb: Lower passive lescan
+Subject: [PATCH 154/345] SURFACE: Bluetooth: btusb: Lower passive lescan
  interval on Marvell 88W8897
 
 The Marvell 88W8897 combined wifi and bluetooth card (pcie+usb version)
@@ -37,7 +37,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 3595a8bad6bdf..e7a0c60286d5f 100644
+index 3595a8bad6bd..e7a0c60286d5 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -66,6 +66,7 @@ static struct usb_driver btusb_driver;
@@ -77,5 +77,5 @@ index 3595a8bad6bdf..e7a0c60286d5f 100644
  	    (id->driver_info & BTUSB_MEDIATEK)) {
  		hdev->setup = btusb_mtk_setup;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
@@ -1,7 +1,7 @@
 From 024d6769aa78572f1570b73951dc2bfa3ae30c52 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
-Subject: [PATCH 155/344] SURFACE: ath10k: Add module parameters to override
+Subject: [PATCH 155/345] SURFACE: ath10k: Add module parameters to override
  board files
 
 Some Surface devices, specifically the Surface Go and AMD version of the
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 57 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
-index 6f78f1752cd6f..8f7be9cf8a9d3 100644
+index 6f78f1752cd6..8f7be9cf8a9d 100644
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
 @@ -42,6 +42,9 @@ static bool fw_diag_log;
@@ -120,5 +120,5 @@ index 6f78f1752cd6f..8f7be9cf8a9d3 100644
  		snprintf(filename, sizeof(filename), "%s/%s/%s",
  			 dir, ar->board_name, file);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From f4938cb7cd2af6b5299c3717b0f10cb03456b71b Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 156/344] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 156/345] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 2 insertions(+)
 
 diff --git a/drivers/misc/mei/hw-me-regs.h b/drivers/misc/mei/hw-me-regs.h
-index a4f75dc369292..e4a561b257d7a 100644
+index a4f75dc36929..e4a561b257d7 100644
 --- a/drivers/misc/mei/hw-me-regs.h
 +++ b/drivers/misc/mei/hw-me-regs.h
 @@ -92,6 +92,7 @@
@@ -26,7 +26,7 @@ index a4f75dc369292..e4a561b257d7a 100644
  
  #define MEI_DEV_ID_JSP_N      0x4DE0  /* Jasper Lake Point N */
 diff --git a/drivers/misc/mei/pci-me.c b/drivers/misc/mei/pci-me.c
-index bc0fc584a8e46..51a91ef66cdae 100644
+index bc0fc584a8e4..51a91ef66cda 100644
 --- a/drivers/misc/mei/pci-me.c
 +++ b/drivers/misc/mei/pci-me.c
 @@ -97,6 +97,7 @@ static const struct pci_device_id mei_me_pci_tbl[] = {
@@ -38,5 +38,5 @@ index bc0fc584a8e46..51a91ef66cdae 100644
  
  	{MEI_PCI_DEVICE(MEI_DEV_ID_TGP_LP, MEI_ME_PCH15_CFG)},
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
@@ -1,7 +1,7 @@
 From 8921f55907c6eddd77c60331bad70cdfd33955f5 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 157/344] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
+Subject: [PATCH 157/345] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
  for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 29 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index a5ecb62bfddef..d94f84bb68602 100644
+index a5ecb62bfdde..d94f84bb6860 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -39,6 +39,11 @@
@@ -110,5 +110,5 @@ index a5ecb62bfddef..d94f84bb68602 100644
  {
  	if (risky_device(dev))
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
@@ -1,7 +1,7 @@
 From 7b0b38f0010637730e8f771017f5a91c88edc201 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 158/344] SURFACE: hid: Add support for Intel Precise Touch and
+Subject: [PATCH 158/345] SURFACE: hid: Add support for Intel Precise Touch and
  Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268
@@ -69,7 +69,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/hid/ipts/thread.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index b934523593d95..b2cc5db65f5b0 100644
+index b934523593d9..b2cc5db65f5b 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -1428,6 +1428,8 @@ source "drivers/hid/surface-hid/Kconfig"
@@ -82,7 +82,7 @@ index b934523593d95..b2cc5db65f5b0 100644
  
  # USB support may be used with HID disabled
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 10ae5dedbd847..7ba7d26391e91 100644
+index 10ae5dedbd84..7ba7d26391e9 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
 @@ -175,3 +175,5 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
@@ -93,7 +93,7 @@ index 10ae5dedbd847..7ba7d26391e91 100644
 +obj-$(CONFIG_HID_IPTS)          += ipts/
 diff --git a/drivers/hid/ipts/Kconfig b/drivers/hid/ipts/Kconfig
 new file mode 100644
-index 0000000000000..297401bd388dd
+index 000000000000..297401bd388d
 --- /dev/null
 +++ b/drivers/hid/ipts/Kconfig
 @@ -0,0 +1,14 @@
@@ -113,7 +113,7 @@ index 0000000000000..297401bd388dd
 +	  module will be called ipts.
 diff --git a/drivers/hid/ipts/Makefile b/drivers/hid/ipts/Makefile
 new file mode 100644
-index 0000000000000..883896f68e6ad
+index 000000000000..883896f68e6a
 --- /dev/null
 +++ b/drivers/hid/ipts/Makefile
 @@ -0,0 +1,16 @@
@@ -135,7 +135,7 @@ index 0000000000000..883896f68e6ad
 +ipts-objs += thread.o
 diff --git a/drivers/hid/ipts/cmd.c b/drivers/hid/ipts/cmd.c
 new file mode 100644
-index 0000000000000..63a4934bbc5fa
+index 000000000000..63a4934bbc5f
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.c
 @@ -0,0 +1,61 @@
@@ -202,7 +202,7 @@ index 0000000000000..63a4934bbc5fa
 +}
 diff --git a/drivers/hid/ipts/cmd.h b/drivers/hid/ipts/cmd.h
 new file mode 100644
-index 0000000000000..2b4079075b642
+index 000000000000..2b4079075b64
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.h
 @@ -0,0 +1,60 @@
@@ -268,7 +268,7 @@ index 0000000000000..2b4079075b642
 +#endif /* IPTS_CMD_H */
 diff --git a/drivers/hid/ipts/context.h b/drivers/hid/ipts/context.h
 new file mode 100644
-index 0000000000000..ba33259f1f7c5
+index 000000000000..ba33259f1f7c
 --- /dev/null
 +++ b/drivers/hid/ipts/context.h
 @@ -0,0 +1,52 @@
@@ -326,7 +326,7 @@ index 0000000000000..ba33259f1f7c5
 +#endif /* IPTS_CONTEXT_H */
 diff --git a/drivers/hid/ipts/control.c b/drivers/hid/ipts/control.c
 new file mode 100644
-index 0000000000000..5360842d260ba
+index 000000000000..5360842d260b
 --- /dev/null
 +++ b/drivers/hid/ipts/control.c
 @@ -0,0 +1,486 @@
@@ -818,7 +818,7 @@ index 0000000000000..5360842d260ba
 +}
 diff --git a/drivers/hid/ipts/control.h b/drivers/hid/ipts/control.h
 new file mode 100644
-index 0000000000000..26629c5144edb
+index 000000000000..26629c5144ed
 --- /dev/null
 +++ b/drivers/hid/ipts/control.h
 @@ -0,0 +1,126 @@
@@ -950,7 +950,7 @@ index 0000000000000..26629c5144edb
 +#endif /* IPTS_CONTROL_H */
 diff --git a/drivers/hid/ipts/desc.h b/drivers/hid/ipts/desc.h
 new file mode 100644
-index 0000000000000..307438c7c80cd
+index 000000000000..307438c7c80c
 --- /dev/null
 +++ b/drivers/hid/ipts/desc.h
 @@ -0,0 +1,80 @@
@@ -1036,7 +1036,7 @@ index 0000000000000..307438c7c80cd
 +#endif /* IPTS_DESC_H */
 diff --git a/drivers/hid/ipts/eds1.c b/drivers/hid/ipts/eds1.c
 new file mode 100644
-index 0000000000000..7b9f54388a9f6
+index 000000000000..7b9f54388a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.c
 @@ -0,0 +1,104 @@
@@ -1146,7 +1146,7 @@ index 0000000000000..7b9f54388a9f6
 +}
 diff --git a/drivers/hid/ipts/eds1.h b/drivers/hid/ipts/eds1.h
 new file mode 100644
-index 0000000000000..eeeb6575e3e89
+index 000000000000..eeeb6575e3e8
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.h
 @@ -0,0 +1,35 @@
@@ -1187,7 +1187,7 @@ index 0000000000000..eeeb6575e3e89
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/eds2.c b/drivers/hid/ipts/eds2.c
 new file mode 100644
-index 0000000000000..639940794615d
+index 000000000000..639940794615
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.c
 @@ -0,0 +1,145 @@
@@ -1338,7 +1338,7 @@ index 0000000000000..639940794615d
 +}
 diff --git a/drivers/hid/ipts/eds2.h b/drivers/hid/ipts/eds2.h
 new file mode 100644
-index 0000000000000..064e3716907ab
+index 000000000000..064e3716907a
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.h
 @@ -0,0 +1,35 @@
@@ -1379,7 +1379,7 @@ index 0000000000000..064e3716907ab
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/hid.c b/drivers/hid/ipts/hid.c
 new file mode 100644
-index 0000000000000..e34a1a4f9fa77
+index 000000000000..e34a1a4f9fa7
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.c
 @@ -0,0 +1,225 @@
@@ -1610,7 +1610,7 @@ index 0000000000000..e34a1a4f9fa77
 +}
 diff --git a/drivers/hid/ipts/hid.h b/drivers/hid/ipts/hid.h
 new file mode 100644
-index 0000000000000..1ebe77447903a
+index 000000000000..1ebe77447903
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.h
 @@ -0,0 +1,24 @@
@@ -1640,7 +1640,7 @@ index 0000000000000..1ebe77447903a
 +#endif /* IPTS_HID_H */
 diff --git a/drivers/hid/ipts/main.c b/drivers/hid/ipts/main.c
 new file mode 100644
-index 0000000000000..fb5b5c13ee3ea
+index 000000000000..fb5b5c13ee3e
 --- /dev/null
 +++ b/drivers/hid/ipts/main.c
 @@ -0,0 +1,126 @@
@@ -1772,7 +1772,7 @@ index 0000000000000..fb5b5c13ee3ea
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/ipts/mei.c b/drivers/hid/ipts/mei.c
 new file mode 100644
-index 0000000000000..1e0395ceae4a4
+index 000000000000..1e0395ceae4a
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.c
 @@ -0,0 +1,188 @@
@@ -1966,7 +1966,7 @@ index 0000000000000..1e0395ceae4a4
 +}
 diff --git a/drivers/hid/ipts/mei.h b/drivers/hid/ipts/mei.h
 new file mode 100644
-index 0000000000000..973bade6b0fdd
+index 000000000000..973bade6b0fd
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.h
 @@ -0,0 +1,66 @@
@@ -2038,7 +2038,7 @@ index 0000000000000..973bade6b0fdd
 +#endif /* IPTS_MEI_H */
 diff --git a/drivers/hid/ipts/receiver.c b/drivers/hid/ipts/receiver.c
 new file mode 100644
-index 0000000000000..977724c728c3e
+index 000000000000..977724c728c3
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.c
 @@ -0,0 +1,251 @@
@@ -2295,7 +2295,7 @@ index 0000000000000..977724c728c3e
 +}
 diff --git a/drivers/hid/ipts/receiver.h b/drivers/hid/ipts/receiver.h
 new file mode 100644
-index 0000000000000..3de7da62d40c1
+index 000000000000..3de7da62d40c
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.h
 @@ -0,0 +1,16 @@
@@ -2317,7 +2317,7 @@ index 0000000000000..3de7da62d40c1
 +#endif /* IPTS_RECEIVER_H */
 diff --git a/drivers/hid/ipts/resources.c b/drivers/hid/ipts/resources.c
 new file mode 100644
-index 0000000000000..cc14653b2a9f5
+index 000000000000..cc14653b2a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.c
 @@ -0,0 +1,131 @@
@@ -2454,7 +2454,7 @@ index 0000000000000..cc14653b2a9f5
 +}
 diff --git a/drivers/hid/ipts/resources.h b/drivers/hid/ipts/resources.h
 new file mode 100644
-index 0000000000000..2068e13285f0e
+index 000000000000..2068e13285f0
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.h
 @@ -0,0 +1,41 @@
@@ -2501,7 +2501,7 @@ index 0000000000000..2068e13285f0e
 +#endif /* IPTS_RESOURCES_H */
 diff --git a/drivers/hid/ipts/spec-data.h b/drivers/hid/ipts/spec-data.h
 new file mode 100644
-index 0000000000000..e8dd98895a7ee
+index 000000000000..e8dd98895a7e
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-data.h
 @@ -0,0 +1,100 @@
@@ -2607,7 +2607,7 @@ index 0000000000000..e8dd98895a7ee
 +#endif /* IPTS_SPEC_DATA_H */
 diff --git a/drivers/hid/ipts/spec-device.h b/drivers/hid/ipts/spec-device.h
 new file mode 100644
-index 0000000000000..41845f9d90257
+index 000000000000..41845f9d9025
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-device.h
 @@ -0,0 +1,290 @@
@@ -2903,7 +2903,7 @@ index 0000000000000..41845f9d90257
 +#endif /* IPTS_SPEC_DEVICE_H */
 diff --git a/drivers/hid/ipts/spec-hid.h b/drivers/hid/ipts/spec-hid.h
 new file mode 100644
-index 0000000000000..5a58d4a0a610f
+index 000000000000..5a58d4a0a610
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-hid.h
 @@ -0,0 +1,34 @@
@@ -2943,7 +2943,7 @@ index 0000000000000..5a58d4a0a610f
 +#endif /* IPTS_SPEC_HID_H */
 diff --git a/drivers/hid/ipts/thread.c b/drivers/hid/ipts/thread.c
 new file mode 100644
-index 0000000000000..355e92bea26f8
+index 000000000000..355e92bea26f
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.c
 @@ -0,0 +1,84 @@
@@ -3033,7 +3033,7 @@ index 0000000000000..355e92bea26f8
 +}
 diff --git a/drivers/hid/ipts/thread.h b/drivers/hid/ipts/thread.h
 new file mode 100644
-index 0000000000000..1f966b8b32c45
+index 000000000000..1f966b8b32c4
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.h
 @@ -0,0 +1,59 @@
@@ -3097,5 +3097,5 @@ index 0000000000000..1f966b8b32c45
 +
 +#endif /* IPTS_THREAD_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
@@ -1,7 +1,7 @@
 From 5ffa95f66c0b36b6928d7482f6d75eb115a9b9a8 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
-Subject: [PATCH 159/344] SURFACE: iommu: intel: Disable source id verification
+Subject: [PATCH 159/345] SURFACE: iommu: intel: Disable source id verification
  for ITHC
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 16 insertions(+)
 
 diff --git a/drivers/iommu/intel/irq_remapping.c b/drivers/iommu/intel/irq_remapping.c
-index 4f9b01dc91e86..e4d73e45473cc 100644
+index 4f9b01dc91e8..e4d73e45473c 100644
 --- a/drivers/iommu/intel/irq_remapping.c
 +++ b/drivers/iommu/intel/irq_remapping.c
 @@ -381,6 +381,22 @@ static int set_msi_sid(struct irte *irte, struct pci_dev *dev)
@@ -41,5 +41,5 @@ index 4f9b01dc91e86..e4d73e45473cc 100644
  	 * DMA alias provides us with a PCI device and alias.  The only case
  	 * where the it will return an alias on a different bus than the
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
@@ -1,7 +1,7 @@
 From 53b70d4e44e576baecd5e900eaa1301d5f2f6b00 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
-Subject: [PATCH 160/344] SURFACE: hid: Add support for Intel Touch Host
+Subject: [PATCH 160/345] SURFACE: hid: Add support for Intel Touch Host
  Controller
 
 Based on quo/ithc-linux@34539af4726d.
@@ -49,7 +49,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/hid/ithc/ithc.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index b2cc5db65f5b0..707983ce68547 100644
+index b2cc5db65f5b..707983ce6854 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -1430,6 +1430,8 @@ source "drivers/hid/intel-thc-hid/Kconfig"
@@ -62,7 +62,7 @@ index b2cc5db65f5b0..707983ce68547 100644
  
  # USB support may be used with HID disabled
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 7ba7d26391e91..d939da7ac2e86 100644
+index 7ba7d26391e9..d939da7ac2e8 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
 @@ -177,3 +177,4 @@ obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
@@ -72,7 +72,7 @@ index 7ba7d26391e91..d939da7ac2e86 100644
 +obj-$(CONFIG_HID_ITHC)          += ithc/
 diff --git a/drivers/hid/ithc/Kbuild b/drivers/hid/ithc/Kbuild
 new file mode 100644
-index 0000000000000..4937ba1312973
+index 000000000000..4937ba131297
 --- /dev/null
 +++ b/drivers/hid/ithc/Kbuild
 @@ -0,0 +1,6 @@
@@ -84,7 +84,7 @@ index 0000000000000..4937ba1312973
 +
 diff --git a/drivers/hid/ithc/Kconfig b/drivers/hid/ithc/Kconfig
 new file mode 100644
-index 0000000000000..ede7130236096
+index 000000000000..ede713023609
 --- /dev/null
 +++ b/drivers/hid/ithc/Kconfig
 @@ -0,0 +1,12 @@
@@ -102,7 +102,7 @@ index 0000000000000..ede7130236096
 +	  module will be called ithc.
 diff --git a/drivers/hid/ithc/ithc-debug.c b/drivers/hid/ithc/ithc-debug.c
 new file mode 100644
-index 0000000000000..2d8c6afe99663
+index 000000000000..2d8c6afe9966
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-debug.c
 @@ -0,0 +1,149 @@
@@ -257,7 +257,7 @@ index 0000000000000..2d8c6afe99663
 +
 diff --git a/drivers/hid/ithc/ithc-debug.h b/drivers/hid/ithc/ithc-debug.h
 new file mode 100644
-index 0000000000000..38c53d916bdb5
+index 000000000000..38c53d916bdb
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-debug.h
 @@ -0,0 +1,7 @@
@@ -270,7 +270,7 @@ index 0000000000000..38c53d916bdb5
 +
 diff --git a/drivers/hid/ithc/ithc-dma.c b/drivers/hid/ithc/ithc-dma.c
 new file mode 100644
-index 0000000000000..bf4eab33062b0
+index 000000000000..bf4eab33062b
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-dma.c
 @@ -0,0 +1,312 @@
@@ -588,7 +588,7 @@ index 0000000000000..bf4eab33062b0
 +
 diff --git a/drivers/hid/ithc/ithc-dma.h b/drivers/hid/ithc/ithc-dma.h
 new file mode 100644
-index 0000000000000..1749a5819b3e7
+index 000000000000..1749a5819b3e
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-dma.h
 @@ -0,0 +1,47 @@
@@ -641,7 +641,7 @@ index 0000000000000..1749a5819b3e7
 +
 diff --git a/drivers/hid/ithc/ithc-hid.c b/drivers/hid/ithc/ithc-hid.c
 new file mode 100644
-index 0000000000000..065646ab499ef
+index 000000000000..065646ab499e
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-hid.c
 @@ -0,0 +1,207 @@
@@ -854,7 +854,7 @@ index 0000000000000..065646ab499ef
 +
 diff --git a/drivers/hid/ithc/ithc-hid.h b/drivers/hid/ithc/ithc-hid.h
 new file mode 100644
-index 0000000000000..599eb912c8c84
+index 000000000000..599eb912c8c8
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-hid.h
 @@ -0,0 +1,32 @@
@@ -892,7 +892,7 @@ index 0000000000000..599eb912c8c84
 +
 diff --git a/drivers/hid/ithc/ithc-legacy.c b/drivers/hid/ithc/ithc-legacy.c
 new file mode 100644
-index 0000000000000..8883987fb3521
+index 000000000000..8883987fb352
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-legacy.c
 @@ -0,0 +1,254 @@
@@ -1152,7 +1152,7 @@ index 0000000000000..8883987fb3521
 +
 diff --git a/drivers/hid/ithc/ithc-legacy.h b/drivers/hid/ithc/ithc-legacy.h
 new file mode 100644
-index 0000000000000..28d6924620722
+index 000000000000..28d692462072
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-legacy.h
 @@ -0,0 +1,8 @@
@@ -1166,7 +1166,7 @@ index 0000000000000..28d6924620722
 +
 diff --git a/drivers/hid/ithc/ithc-main.c b/drivers/hid/ithc/ithc-main.c
 new file mode 100644
-index 0000000000000..094d878d671b3
+index 000000000000..094d878d671b
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-main.c
 @@ -0,0 +1,438 @@
@@ -1610,7 +1610,7 @@ index 0000000000000..094d878d671b3
 +
 diff --git a/drivers/hid/ithc/ithc-quickspi.c b/drivers/hid/ithc/ithc-quickspi.c
 new file mode 100644
-index 0000000000000..e2d1690b8cf8c
+index 000000000000..e2d1690b8cf8
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-quickspi.c
 @@ -0,0 +1,607 @@
@@ -2223,7 +2223,7 @@ index 0000000000000..e2d1690b8cf8c
 +
 diff --git a/drivers/hid/ithc/ithc-quickspi.h b/drivers/hid/ithc/ithc-quickspi.h
 new file mode 100644
-index 0000000000000..74d882f6b2f0a
+index 000000000000..74d882f6b2f0
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-quickspi.h
 @@ -0,0 +1,39 @@
@@ -2268,7 +2268,7 @@ index 0000000000000..74d882f6b2f0a
 +
 diff --git a/drivers/hid/ithc/ithc-regs.c b/drivers/hid/ithc/ithc-regs.c
 new file mode 100644
-index 0000000000000..c0f13506af205
+index 000000000000..c0f13506af20
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-regs.c
 @@ -0,0 +1,154 @@
@@ -2428,7 +2428,7 @@ index 0000000000000..c0f13506af205
 +
 diff --git a/drivers/hid/ithc/ithc-regs.h b/drivers/hid/ithc/ithc-regs.h
 new file mode 100644
-index 0000000000000..4f541fe533fac
+index 000000000000..4f541fe533fa
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-regs.h
 @@ -0,0 +1,211 @@
@@ -2645,7 +2645,7 @@ index 0000000000000..4f541fe533fac
 +
 diff --git a/drivers/hid/ithc/ithc.h b/drivers/hid/ithc/ithc.h
 new file mode 100644
-index 0000000000000..aec320d4e945c
+index 000000000000..aec320d4e945
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc.h
 @@ -0,0 +1,89 @@
@@ -2739,5 +2739,5 @@ index 0000000000000..aec320d4e945c
 +int ithc_reset(struct ithc *ithc);
 +
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
@@ -1,7 +1,7 @@
 From 2fd8d43a013e68f574da1c3960404cf0cec16025 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
-Subject: [PATCH 161/344] SURFACE: rtc: Add basic support for RTC via Surface
+Subject: [PATCH 161/345] SURFACE: rtc: Add basic support for RTC via Surface
  System Aggregator Module
 
 Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/rtc/rtc-surface.c
 
 diff --git a/drivers/rtc/Kconfig b/drivers/rtc/Kconfig
-index 64f6e9756aff4..bf05361f7f133 100644
+index 64f6e9756aff..bf05361f7f13 100644
 --- a/drivers/rtc/Kconfig
 +++ b/drivers/rtc/Kconfig
 @@ -1379,6 +1379,13 @@ config RTC_DRV_NTXEC
@@ -35,7 +35,7 @@ index 64f6e9756aff4..bf05361f7f133 100644
  
  config RTC_DRV_ASM9260
 diff --git a/drivers/rtc/Makefile b/drivers/rtc/Makefile
-index 789bddfea99d8..a6df073320800 100644
+index 789bddfea99d..a6df07332080 100644
 --- a/drivers/rtc/Makefile
 +++ b/drivers/rtc/Makefile
 @@ -181,6 +181,7 @@ obj-$(CONFIG_RTC_DRV_SUN4V)	+= rtc-sun4v.o
@@ -48,7 +48,7 @@ index 789bddfea99d8..a6df073320800 100644
  obj-$(CONFIG_RTC_DRV_TI_K3)	+= rtc-ti-k3.o
 diff --git a/drivers/rtc/rtc-surface.c b/drivers/rtc/rtc-surface.c
 new file mode 100644
-index 0000000000000..f6c17c4e98d5f
+index 000000000000..f6c17c4e98d5
 --- /dev/null
 +++ b/drivers/rtc/rtc-surface.c
 @@ -0,0 +1,129 @@
@@ -182,5 +182,5 @@ index 0000000000000..f6c17c4e98d5f
 +MODULE_DESCRIPTION("RTC driver for Surface System Aggregator Module");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
@@ -1,7 +1,7 @@
 From 1670a74b7776c5754aac899a6bbd618e4429399e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
-Subject: [PATCH 162/344] SURFACE: platform/surface: aggregator_registry: Add
+Subject: [PATCH 162/345] SURFACE: platform/surface: aggregator_registry: Add
  Surface Laptop 7 (ACPI)
 
 Patchset: surface-sam
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/platform/surface/surface_aggregator_registry.c b/drivers/platform/surface/surface_aggregator_registry.c
-index a594d5fcfcfd1..07b03aa4fa7f9 100644
+index a594d5fcfcfd..07b03aa4fa7f 100644
 --- a/drivers/platform/surface/surface_aggregator_registry.c
 +++ b/drivers/platform/surface/surface_aggregator_registry.c
 @@ -460,6 +460,9 @@ static const struct acpi_device_id ssam_platform_hub_acpi_match[] = {
@@ -27,5 +27,5 @@ index a594d5fcfcfd1..07b03aa4fa7f9 100644
  	{ "MSHW0118", (unsigned long)ssam_node_group_slg1 },
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
@@ -1,7 +1,7 @@
 From db99b0cbf2d70193d72b72553b65680d1863b5f9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
-Subject: [PATCH 163/344] SURFACE: i2c: acpi: Implement RawBytes read access
+Subject: [PATCH 163/345] SURFACE: i2c: acpi: Implement RawBytes read access
 
 Microsoft Surface Pro 4 and Book 1 devices access the MSHW0030 I2C
 device via a generic serial bus operation region and RawBytes read
@@ -58,7 +58,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 34 insertions(+)
 
 diff --git a/drivers/i2c/i2c-core-acpi.c b/drivers/i2c/i2c-core-acpi.c
-index ed90858a27b7b..070c366378115 100644
+index ed90858a27b7..070c36637811 100644
 --- a/drivers/i2c/i2c-core-acpi.c
 +++ b/drivers/i2c/i2c-core-acpi.c
 @@ -662,6 +662,27 @@ static int acpi_gsb_i2c_write_bytes(struct i2c_client *client,
@@ -110,5 +110,5 @@ index ed90858a27b7b..070c366378115 100644
  		dev_warn(&adapter->dev, "protocol 0x%02x not supported for client 0x%02x\n",
  			 accessor_type, client->addr);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
@@ -1,7 +1,7 @@
 From abd3a22365736ffb8734a767bd77ec7404cfea76 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
-Subject: [PATCH 164/344] SURFACE: platform/surface: Add driver for Surface
+Subject: [PATCH 164/345] SURFACE: platform/surface: Add driver for Surface
  Book 1 dGPU switch
 
 Add driver exposing the discrete GPU power-switch of the  Microsoft
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/surface/surfacebook1_dgpu_switch.c
 
 diff --git a/drivers/platform/surface/Kconfig b/drivers/platform/surface/Kconfig
-index f775c6ca1ec1d..2075e3852053a 100644
+index f775c6ca1ec1..2075e3852053 100644
 --- a/drivers/platform/surface/Kconfig
 +++ b/drivers/platform/surface/Kconfig
 @@ -149,6 +149,13 @@ config SURFACE_AGGREGATOR_TABLET_SWITCH
@@ -43,7 +43,7 @@ index f775c6ca1ec1d..2075e3852053a 100644
  	tristate "Surface DTX (Detachment System) Driver"
  	depends on SURFACE_AGGREGATOR
 diff --git a/drivers/platform/surface/Makefile b/drivers/platform/surface/Makefile
-index 53344330939bf..7efcd0cdb5329 100644
+index 53344330939b..7efcd0cdb532 100644
 --- a/drivers/platform/surface/Makefile
 +++ b/drivers/platform/surface/Makefile
 @@ -12,6 +12,7 @@ obj-$(CONFIG_SURFACE_AGGREGATOR_CDEV)	+= surface_aggregator_cdev.o
@@ -56,7 +56,7 @@ index 53344330939bf..7efcd0cdb5329 100644
  obj-$(CONFIG_SURFACE_HOTPLUG)		+= surface_hotplug.o
 diff --git a/drivers/platform/surface/surfacebook1_dgpu_switch.c b/drivers/platform/surface/surfacebook1_dgpu_switch.c
 new file mode 100644
-index 0000000000000..68db237734a13
+index 000000000000..68db237734a1
 --- /dev/null
 +++ b/drivers/platform/surface/surfacebook1_dgpu_switch.c
 @@ -0,0 +1,136 @@
@@ -197,5 +197,5 @@ index 0000000000000..68db237734a13
 +MODULE_DESCRIPTION("Discrete GPU Power-Switch for Surface Book 1");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
@@ -1,7 +1,7 @@
 From 64e10036848414d2ae63a694e22601e6475198cf Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
-Subject: [PATCH 165/344] SURFACE: Input: soc_button_array - support AMD
+Subject: [PATCH 165/345] SURFACE: Input: soc_button_array - support AMD
  variant Surface devices
 
 The power button on the AMD variant of the Surface Laptop uses the
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 25 deletions(-)
 
 diff --git a/drivers/input/misc/soc_button_array.c b/drivers/input/misc/soc_button_array.c
-index b8cad415c62ca..43b5d56383e36 100644
+index b8cad415c62c..43b5d56383e3 100644
 --- a/drivers/input/misc/soc_button_array.c
 +++ b/drivers/input/misc/soc_button_array.c
 @@ -540,8 +540,8 @@ static const struct soc_device_data soc_device_MSHW0028 = {
@@ -77,5 +77,5 @@ index b8cad415c62ca..43b5d56383e36 100644
  
  /*
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
@@ -1,7 +1,7 @@
 From 6c89a78acdf37d2c1e4a4d000a5e92eda54bb3ab Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
-Subject: [PATCH 166/344] SURFACE: platform/surface: surfacepro3_button: don't
+Subject: [PATCH 166/345] SURFACE: platform/surface: surfacepro3_button: don't
  load on amd variant
 
 The AMD variant of the Surface Laptop report 0 for their OEM platform
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/platform/surface/surfacepro3_button.c b/drivers/platform/surface/surfacepro3_button.c
-index 2755601f979cd..4240c98ca2265 100644
+index 2755601f979c..4240c98ca226 100644
 --- a/drivers/platform/surface/surfacepro3_button.c
 +++ b/drivers/platform/surface/surfacepro3_button.c
 @@ -149,7 +149,8 @@ static int surface_button_resume(struct device *dev)
@@ -71,5 +71,5 @@ index 2755601f979cd..4240c98ca2265 100644
  
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
@@ -1,7 +1,7 @@
 From 6e004e76c801d58322fbfe555a68bda0f9b24a3a Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
-Subject: [PATCH 167/344] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
+Subject: [PATCH 167/345] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
  Surface Go 3 Type-Cover
 
 The touchpad on the Type-Cover of the Surface Go 3 is sometimes not
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index 47f589c4104a3..6b00aec67ee28 100644
+index 47f589c4104a..6b00aec67ee2 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
 @@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
@@ -40,5 +40,5 @@ index 47f589c4104a3..6b00aec67ee28 100644
  	{ USB_DEVICE(0x046a, 0x0023), .driver_info = USB_QUIRK_RESET_RESUME },
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From 9db40623145f2bd0d326bc0ee754911ff54f8061 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 168/344] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 168/345] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 
 The Type Cover for Microsoft Surface devices supports a special usb
@@ -37,7 +37,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index a9ff84f0bd9bb..1b2fc88ce1cfd 100644
+index a9ff84f0bd9b..1b2fc88ce1cf 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@
@@ -234,5 +234,5 @@ index a9ff84f0bd9bb..1b2fc88ce1cfd 100644
  	{ .driver_data = MT_CLS_GOOGLE,
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
 From 46ae64036690f38afbc00927aa23edee96bef720 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 169/344] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 169/345] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 1b2fc88ce1cfd..dd200064e3093 100644
+index 1b2fc88ce1cf..dd200064e309 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -79,6 +79,7 @@ MODULE_LICENSE("GPL");
@@ -298,5 +298,5 @@ index 1b2fc88ce1cfd..dd200064e3093 100644
  	unregister_pm_notifier(&td->pm_notifier);
  	timer_delete_sync(&td->release_timer);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
@@ -1,7 +1,7 @@
 From 980e1df42af986a96513a0fcb8dcf66ede2183c4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH 170/344] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
+Subject: [PATCH 170/345] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
  shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 40 insertions(+)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 2c60f5c490216..1972e7cdd2869 100644
+index 2c60f5c49021..1972e7cdd286 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -505,6 +505,9 @@ static void pci_device_shutdown(struct device *dev)
@@ -43,7 +43,7 @@ index 2c60f5c490216..1972e7cdd2869 100644
  
  	if (drv && drv->shutdown)
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 76afe49aeddcd..822dbee372ce4 100644
+index 76afe49aeddc..822dbee372ce 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -6415,3 +6415,39 @@ static void pci_release_bar0(struct pci_dev *pdev)
@@ -87,7 +87,7 @@ index 76afe49aeddcd..822dbee372ce4 100644
 +DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x466d, quirk_no_shutdown);  // Thunderbolt 4 NHI
 +DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x46a8, quirk_no_shutdown);  // GPU
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index 41b9f92d64632..3b4071d4c5585 100644
+index 41b9f92d6463..3b4071d4c558 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -485,6 +485,7 @@ struct pci_dev {
@@ -99,5 +99,5 @@ index 41b9f92d64632..3b4071d4c5585 100644
  	atomic_t	enable_cnt;	/* pci_enable_device has been called */
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
@@ -1,7 +1,7 @@
 From 7d30708290307a5b2bfb63decb5e0e1faa9b38dd Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
-Subject: [PATCH 171/344] SURFACE: platform/surface: gpe: Add support for
+Subject: [PATCH 171/345] SURFACE: platform/surface: gpe: Add support for
  Surface Pro 9
 
 Add the lid GPE used by the Surface Pro 9.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 17 insertions(+)
 
 diff --git a/drivers/platform/surface/surface_gpe.c b/drivers/platform/surface/surface_gpe.c
-index b359413903b13..b4496db79f392 100644
+index b359413903b1..b4496db79f39 100644
 --- a/drivers/platform/surface/surface_gpe.c
 +++ b/drivers/platform/surface/surface_gpe.c
 @@ -41,6 +41,11 @@ static const struct property_entry lid_device_props_l4F[] = {
@@ -51,5 +51,5 @@ index b359413903b13..b4496db79f392 100644
  		.ident = "Surface Book 1",
  		.matches = {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 007d8c614c27330c4c1d45ec3ee394895642b822 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 172/344] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 172/345] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices
@@ -61,7 +61,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
-index fb1fe9f3b1a36..5be8893b39127 100644
+index fb1fe9f3b1a3..5be8893b3912 100644
 --- a/drivers/acpi/scan.c
 +++ b/drivers/acpi/scan.c
 @@ -2197,6 +2197,9 @@ static acpi_status acpi_bus_check_add_2(acpi_handle handle, u32 lvl_not_used,
@@ -75,5 +75,5 @@ index fb1fe9f3b1a36..5be8893b39127 100644
  	 * Do not enumerate devices with enumeration_by_parent flag set as
  	 * they will be enumerated by their respective parents.
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
@@ -1,7 +1,7 @@
 From dfebef5434529ec2fd9c7ad71d7d4f82221885b9 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 173/344] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
+Subject: [PATCH 173/345] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
  passthrough mode for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index d94f84bb68602..6222b066ef06a 100644
+index d94f84bb6860..6222b066ef06 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -44,6 +44,13 @@
@@ -113,5 +113,5 @@ index d94f84bb68602..6222b066ef06a 100644
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9D3E, quirk_iommu_ipts);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x34E4, quirk_iommu_ipts);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From 200d47a32a2e61952989972a6a52f582310396cf Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 174/344] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 174/345] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index 0133405697dc3..9e0763bdc7587 100644
+index 0133405697dc..9e0763bdc758 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -46,6 +46,13 @@ static int tps68470_chip_init(struct device *dev, struct regmap *regmap)
@@ -37,5 +37,5 @@ index 0133405697dc3..9e0763bdc7587 100644
  
  	return 0;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From 2df49f22d70ebd0b537cd2a619359533b29ae0e5 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 175/344] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 175/345] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/i2c/ov7251.c b/drivers/media/i2c/ov7251.c
-index 31a42d81e9701..0d5a8fd86e677 100644
+index 31a42d81e970..0d5a8fd86e67 100644
 --- a/drivers/media/i2c/ov7251.c
 +++ b/drivers/media/i2c/ov7251.c
 @@ -1053,7 +1053,7 @@ static int ov7251_s_ctrl(struct v4l2_ctrl *ctrl)
@@ -39,5 +39,5 @@ index 31a42d81e9701..0d5a8fd86e677 100644
  				     V4L2_CID_TEST_PATTERN,
  				     ARRAY_SIZE(ov7251_test_pattern_menu) - 1,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From 464363b03fdffbbfe3c378fb501e5dc8f02a367b Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 176/344] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 176/345] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/v4l2-core/v4l2-async.c b/drivers/media/v4l2-core/v4l2-async.c
-index ee884a8221fbd..4f6bafd900eee 100644
+index ee884a8221fb..4f6bafd900ee 100644
 --- a/drivers/media/v4l2-core/v4l2-async.c
 +++ b/drivers/media/v4l2-core/v4l2-async.c
 @@ -799,6 +799,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
@@ -35,7 +35,7 @@ index ee884a8221fbd..4f6bafd900eee 100644
  	 * No reference taken. The reference is held by the device (struct
  	 * v4l2_subdev.dev), and async sub-device does not exist independently
 diff --git a/drivers/media/v4l2-core/v4l2-fwnode.c b/drivers/media/v4l2-core/v4l2-fwnode.c
-index cb153ce42c45d..f11b499e14bba 100644
+index cb153ce42c45..f11b499e14bb 100644
 --- a/drivers/media/v4l2-core/v4l2-fwnode.c
 +++ b/drivers/media/v4l2-core/v4l2-fwnode.c
 @@ -1260,10 +1260,6 @@ int v4l2_async_register_subdev_sensor(struct v4l2_subdev *sd)
@@ -50,5 +50,5 @@ index cb153ce42c45d..f11b499e14bba 100644
  	if (ret < 0)
  		goto out_cleanup;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From f3a53dc7c8c375d161c107f13ce8340d494c1b90 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 177/344] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 177/345] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index 9e0763bdc7587..0976b267972b9 100644
+index 9e0763bdc758..0976b267972b 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -17,7 +17,7 @@
@@ -41,5 +41,5 @@ index 9e0763bdc7587..0976b267972b9 100644
  		for (i = 0; i < board_data->n_gpiod_lookups; i++)
  			gpiod_add_lookup_table(board_data->tps68470_gpio_lookup_tables[i]);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From e13afbd531c55589e82a740335d477c5b7bc8ad4 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 178/344] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 178/345] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/include/linux/mfd/tps68470.h b/include/linux/mfd/tps68470.h
-index 7807fa329db00..2d2abb25b944f 100644
+index 7807fa329db0..2d2abb25b944 100644
 --- a/include/linux/mfd/tps68470.h
 +++ b/include/linux/mfd/tps68470.h
 @@ -34,6 +34,7 @@
@@ -41,5 +41,5 @@ index 7807fa329db00..2d2abb25b944f 100644
 +
  #endif /* __LINUX_MFD_TPS68470_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From b5d73beeab04423153393ec770cfd7d1833379bf Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 179/344] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 179/345] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/leds/leds-tps68470.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 84d66b7d7a17d..673627baac012 100644
+index 84d66b7d7a17..673627baac01 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -1014,6 +1014,18 @@ config LEDS_TPS6105X
@@ -47,7 +47,7 @@ index 84d66b7d7a17d..673627baac012 100644
  	tristate "LED support for SGI Octane machines"
  	depends on LEDS_CLASS
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index cbb759e92d55a..2baec45017a54 100644
+index cbb759e92d55..2baec45017a5 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -94,6 +94,7 @@ obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
@@ -60,7 +60,7 @@ index cbb759e92d55a..2baec45017a54 100644
  obj-$(CONFIG_LEDS_WM831X_STATUS)	+= leds-wm831x-status.o
 diff --git a/drivers/leds/leds-tps68470.c b/drivers/leds/leds-tps68470.c
 new file mode 100644
-index 0000000000000..35aeb5db89c8f
+index 000000000000..35aeb5db89c8
 --- /dev/null
 +++ b/drivers/leds/leds-tps68470.c
 @@ -0,0 +1,185 @@
@@ -250,5 +250,5 @@ index 0000000000000..35aeb5db89c8f
 +MODULE_DESCRIPTION("LED driver for TPS68470 PMIC");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From 1e489728e808befde27dcaa9b3442ab36ead1954 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 180/344] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 180/345] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
-index 032fbcb981f20..e03a1d8cdcb4e 100644
+index 032fbcb981f2..e03a1d8cdcb4 100644
 --- a/drivers/media/i2c/dw9719.c
 +++ b/drivers/media/i2c/dw9719.c
 @@ -87,6 +87,9 @@ static int dw9719_power_up(struct dw9719_device *dw9719, bool detect)
@@ -32,5 +32,5 @@ index 032fbcb981f20..e03a1d8cdcb4e 100644
  	cci_write(dw9719->regmap, DW9719_CONTROL, DW9719_SHUTDOWN, &ret);
  	fsleep(100);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
@@ -1,7 +1,7 @@
 From f1be9adef2841f07066b6149686978b1651f519d Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
-Subject: [PATCH 181/344] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
+Subject: [PATCH 181/345] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
  missing irq 7 override
 
 This patch is the work of Thomas Gleixner <tglx@linutronix.de> and is
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 17 insertions(+)
 
 diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
-index 9fa321a95eb33..8914a922be2bc 100644
+index 9fa321a95eb3..8914a922be2b 100644
 --- a/arch/x86/kernel/acpi/boot.c
 +++ b/arch/x86/kernel/acpi/boot.c
 @@ -22,6 +22,7 @@
@@ -66,5 +66,5 @@ index 9fa321a95eb33..8914a922be2bc 100644
  	mp_config_acpi_legacy_irqs();
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
@@ -1,7 +1,7 @@
 From e41089c36d06b04f2d3b6649101aafa43aee1139 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
-Subject: [PATCH 182/344] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
+Subject: [PATCH 182/345] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
  irq 7 override quirk
 
 The 13" version of the Surface Laptop 4 has the same problem as the 15"
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
-index 8914a922be2bc..c43d0a553867c 100644
+index 8914a922be2b..c43d0a553867 100644
 --- a/arch/x86/kernel/acpi/boot.c
 +++ b/arch/x86/kernel/acpi/boot.c
 @@ -1174,12 +1174,19 @@ static void __init mp_config_acpi_legacy_irqs(void)
@@ -41,5 +41,5 @@ index 8914a922be2bc..c43d0a553867c 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
@@ -1,7 +1,7 @@
 From 1e760af13d8d915225f3f607b764d1c001acc40d Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
-Subject: [PATCH 183/344] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
+Subject: [PATCH 183/345] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
  HW-reduced platforms
 
 The specification [1] allows so-called HW-reduced platforms,
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/acpi/acpi_tad.c b/drivers/acpi/acpi_tad.c
-index 33418dd6768a1..f94bbdc1de061 100644
+index 33418dd6768a..f94bbdc1de06 100644
 --- a/drivers/acpi/acpi_tad.c
 +++ b/drivers/acpi/acpi_tad.c
 @@ -433,6 +433,14 @@ static ssize_t caps_show(struct device *dev, struct device_attribute *attr,
@@ -113,5 +113,5 @@ index 33418dd6768a1..f94bbdc1de061 100644
  		ret = sysfs_create_group(&dev->kobj, &acpi_tad_dc_attr_group);
  		if (ret)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-FROMEXT-cjktty-6.16.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-FROMEXT-cjktty-6.16.patch.patch
@@ -1,7 +1,7 @@
 From 57c5b9fd01ac454f6b26f7a76194f6f27d9104c9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 7 Aug 2025 17:45:03 +0800
-Subject: [PATCH 184/344] FROMEXT: cjktty-6.16.patch
+Subject: [PATCH 184/345] FROMEXT: cjktty-6.16.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>
@@ -36,7 +36,7 @@ Signed-off-by: Xinhui Yang <cyan@cyano.uk>
  create mode 100644 lib/fonts/font_cjk_32x32.h
 
 diff --git a/drivers/tty/vt/selection.c b/drivers/tty/vt/selection.c
-index 24b0a53e5a796..8b36dd90990bd 100644
+index 24b0a53e5a79..8b36dd90990b 100644
 --- a/drivers/tty/vt/selection.c
 +++ b/drivers/tty/vt/selection.c
 @@ -243,6 +243,8 @@ static int vc_selection_store_chars(struct vc_data *vc, bool unicode)
@@ -49,7 +49,7 @@ index 24b0a53e5a796..8b36dd90990bd 100644
  	vc_sel.buf_len = bp - vc_sel.buffer;
  
 diff --git a/drivers/tty/vt/vt.c b/drivers/tty/vt/vt.c
-index 62049ceb34de6..57e9c7124704d 100644
+index 62049ceb34de..57e9c7124704 100644
 --- a/drivers/tty/vt/vt.c
 +++ b/drivers/tty/vt/vt.c
 @@ -301,6 +301,14 @@ static void con_putc(struct vc_data *vc, u16 ca, unsigned int y, unsigned int x)
@@ -242,7 +242,7 @@ index 62049ceb34de6..57e9c7124704d 100644
  		c |= 0x100;
  	return c;
 diff --git a/drivers/video/fbdev/core/bitblit.c b/drivers/video/fbdev/core/bitblit.c
-index f9475c14f7339..50c0475d40029 100644
+index f9475c14f733..50c0475d4002 100644
 --- a/drivers/video/fbdev/core/bitblit.c
 +++ b/drivers/video/fbdev/core/bitblit.c
 @@ -16,6 +16,7 @@
@@ -335,7 +335,7 @@ index f9475c14f7339..50c0475d40029 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
-index 5940e2eb92316..f7abe8fdadcce 100644
+index 5940e2eb9231..f7abe8fdadcc 100644
 --- a/drivers/video/fbdev/core/fbcon.c
 +++ b/drivers/video/fbdev/core/fbcon.c
 @@ -1087,7 +1087,7 @@ static void fbcon_init(struct vc_data *vc, bool init)
@@ -417,7 +417,7 @@ index 5940e2eb92316..f7abe8fdadcce 100644
  
  	updatescrollmode(p, info, vc);
 diff --git a/drivers/video/fbdev/core/fbcon.h b/drivers/video/fbdev/core/fbcon.h
-index 4d97e6d8a16a2..8e5c4c7406f18 100644
+index 4d97e6d8a16a..8e5c4c7406f1 100644
 --- a/drivers/video/fbdev/core/fbcon.h
 +++ b/drivers/video/fbdev/core/fbcon.h
 @@ -82,10 +82,12 @@ struct fbcon_ops {
@@ -444,7 +444,7 @@ index 4d97e6d8a16a2..8e5c4c7406f18 100644
 +
  #endif /* _VIDEO_FBCON_H */
 diff --git a/drivers/video/fbdev/core/fbcon_ccw.c b/drivers/video/fbdev/core/fbcon_ccw.c
-index 89ef4ba7e8672..ba76f80617e12 100644
+index 89ef4ba7e867..ba76f80617e1 100644
 --- a/drivers/video/fbdev/core/fbcon_ccw.c
 +++ b/drivers/video/fbdev/core/fbcon_ccw.c
 @@ -18,6 +18,8 @@
@@ -475,7 +475,7 @@ index 89ef4ba7e8672..ba76f80617e12 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_cw.c b/drivers/video/fbdev/core/fbcon_cw.c
-index b9dac7940fb77..f2711c7faf059 100644
+index b9dac7940fb7..f2711c7faf05 100644
 --- a/drivers/video/fbdev/core/fbcon_cw.c
 +++ b/drivers/video/fbdev/core/fbcon_cw.c
 @@ -18,6 +18,8 @@
@@ -506,7 +506,7 @@ index b9dac7940fb77..f2711c7faf059 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_rotate.c b/drivers/video/fbdev/core/fbcon_rotate.c
-index ec3c883400f7b..d549b0880862e 100644
+index ec3c883400f7..d549b0880862 100644
 --- a/drivers/video/fbdev/core/fbcon_rotate.c
 +++ b/drivers/video/fbdev/core/fbcon_rotate.c
 @@ -14,10 +14,74 @@
@@ -613,7 +613,7 @@ index ec3c883400f7b..d549b0880862e 100644
  	return err;
  }
 diff --git a/drivers/video/fbdev/core/fbcon_ud.c b/drivers/video/fbdev/core/fbcon_ud.c
-index 0af7913a2abdc..e2da1f6340809 100644
+index 0af7913a2abd..e2da1f634080 100644
 --- a/drivers/video/fbdev/core/fbcon_ud.c
 +++ b/drivers/video/fbdev/core/fbcon_ud.c
 @@ -18,6 +18,8 @@
@@ -653,7 +653,7 @@ index 0af7913a2abdc..e2da1f6340809 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/include/linux/font.h b/include/linux/font.h
-index 81caffd51bb49..c073140557d74 100644
+index 81caffd51bb4..c073140557d7 100644
 --- a/include/linux/font.h
 +++ b/include/linux/font.h
 @@ -35,6 +35,8 @@ struct font_desc {
@@ -677,7 +677,7 @@ index 81caffd51bb49..c073140557d74 100644
  /* Find a font with a specific name */
  
 diff --git a/lib/fonts/Kconfig b/lib/fonts/Kconfig
-index ae59b5b4e225e..dd7ab91926b74 100644
+index ae59b5b4e225..dd7ab91926b7 100644
 --- a/lib/fonts/Kconfig
 +++ b/lib/fonts/Kconfig
 @@ -128,6 +128,26 @@ config FONT_6x8
@@ -717,7 +717,7 @@ index ae59b5b4e225e..dd7ab91926b74 100644
  
  endif # FONT_SUPPORT
 diff --git a/lib/fonts/Makefile b/lib/fonts/Makefile
-index e16f68492174a..3e1091d15bbb7 100644
+index e16f68492174..3e1091d15bbb 100644
 --- a/lib/fonts/Makefile
 +++ b/lib/fonts/Makefile
 @@ -16,6 +16,8 @@ font-objs-$(CONFIG_FONT_MINI_4x6)  += font_mini_4x6.o
@@ -731,7 +731,7 @@ index e16f68492174a..3e1091d15bbb7 100644
  
 diff --git a/lib/fonts/font_cjk_16x16.c b/lib/fonts/font_cjk_16x16.c
 new file mode 100644
-index 0000000000000..a0c56bd9f65b2
+index 000000000000..a0c56bd9f65b
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.c
 @@ -0,0 +1,27 @@
@@ -764,7 +764,7 @@ index 0000000000000..a0c56bd9f65b2
 +};
 diff --git a/lib/fonts/font_cjk_16x16.h b/lib/fonts/font_cjk_16x16.h
 new file mode 100644
-index 0000000000000..54e7e0db4a5e7
+index 000000000000..54e7e0db4a5e
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.h
 @@ -0,0 +1,196609 @@
@@ -197379,7 +197379,7 @@ index 0000000000000..54e7e0db4a5e7
 +0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 diff --git a/lib/fonts/font_cjk_32x32.c b/lib/fonts/font_cjk_32x32.c
 new file mode 100644
-index 0000000000000..88ba3f2783f54
+index 000000000000..88ba3f2783f5
 --- /dev/null
 +++ b/lib/fonts/font_cjk_32x32.c
 @@ -0,0 +1,27 @@
@@ -197412,9 +197412,9 @@ index 0000000000000..88ba3f2783f54
 +};
 diff --git a/lib/fonts/font_cjk_32x32.h b/lib/fonts/font_cjk_32x32.h
 new file mode 100644
-index 0000000000000..e69de29bb2d1d
+index 000000000000..e69de29bb2d1
 diff --git a/lib/fonts/fonts.c b/lib/fonts/fonts.c
-index 47e34950b665c..9e3ac0d00f49c 100644
+index 47e34950b665..9e3ac0d00f49 100644
 --- a/lib/fonts/fonts.c
 +++ b/lib/fonts/fonts.c
 @@ -60,6 +60,12 @@ static const struct font_desc *fonts[] = {
@@ -197431,5 +197431,5 @@ index 47e34950b665c..9e3ac0d00f49c 100644
  
  #define num_fonts ARRAY_SIZE(fonts)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From d9a90755a5b4192eaa2b8d7be47aeccb537c2171 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 186/344] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 186/345] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 65f4a76490eac..50afeed2ac8f3 100644
+index 65f4a76490ea..50afeed2ac8f 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -629,13 +629,8 @@ module_param_named(timeout_period, amdgpu_watchdog_timer.period, uint, 0644);
@@ -53,7 +53,7 @@ index 65f4a76490eac..50afeed2ac8f3 100644
  module_param_named(cik_support, amdgpu_cik_support, int, 0444);
  #endif
 diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
-index 88e821d67af77..cb6ba9631d3c4 100644
+index 88e821d67af7..cb6ba9631d3c 100644
 --- a/drivers/gpu/drm/radeon/radeon_drv.c
 +++ b/drivers/gpu/drm/radeon/radeon_drv.c
 @@ -241,12 +241,12 @@ module_param_named(uvd, radeon_uvd, int, 0444);
@@ -74,5 +74,5 @@ index 88e821d67af77..cb6ba9631d3c4 100644
  
  static const struct pci_device_id pciidlist[] = {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 96e3f514f27dcef71684ac3b5ffea920ff3de7d0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 187/344] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 187/345] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 24 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
-index 2aa323dab34e3..6cb275adbfd63 100644
+index 2aa323dab34e..6cb275adbfd6 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 @@ -2125,6 +2125,13 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -47,7 +47,7 @@ index 2aa323dab34e3..6cb275adbfd63 100644
  	/* Then send the real EOP event down the pipe. */
  	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
-index 367449d8061b0..7727a570ff5c4 100644
+index 367449d8061b..7727a570ff5c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 @@ -6109,6 +6109,13 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -73,7 +73,7 @@ index 367449d8061b0..7727a570ff5c4 100644
  	/* Then send the real EOP event down the pipe:
  	 * EVENT_WRITE_EOP - flush caches, send int */
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 0b804e951b7b6..7e7f6248b63a6 100644
+index 0b804e951b7b..7e7f6248b63a 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -3543,6 +3543,13 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
@@ -99,5 +99,5 @@ index 0b804e951b7b6..7e7f6248b63a6 100644
  	/* Then send the real EOP event down the pipe. */
  	radeon_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From f78e4a9766a58ccc87bb6e708edd7918bd2c46d8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 188/344] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 188/345] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index eea8421955134..ea37d120113d1 100644
+index eea842195513..ea37d120113d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)
@@ -34,5 +34,5 @@ index eea8421955134..ea37d120113d1 100644
  
  #ifdef CONFIG_OF
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From ee3c95adb3042e28c9fc40426ee2ca9deb6523d3 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 189/344] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 189/345] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 26478b090ced0..5e8b670d1a205 100644
+index 26478b090ced..5e8b670d1a20 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -176,7 +176,7 @@ static int phytmac_set_ringparam(struct net_device *ndev,
@@ -25,5 +25,5 @@ index 26478b090ced0..5e8b670d1a205 100644
  	struct phytmac *pdata = netdev_priv(ndev);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From a31adcf9e30d0330c2f60262791bd075eee48f6b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 190/344] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 190/345] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index d958ca1f168bb..3724936cc826e 100644
+index d958ca1f168b..3724936cc826 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -313,14 +313,12 @@ static int phytmac_plat_probe(struct platform_device *pdev)
@@ -32,5 +32,5 @@ index d958ca1f168bb..3724936cc826e 100644
  
  static void phytmac_plat_shutdown(struct platform_device *pdev)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 0f6bc28ba6ac9faac36ff6a0dbad1ec079998b4e Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 191/344] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 191/345] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
-index a9021c524afbf..429ac5492ab4d 100644
+index a9021c524afb..429ac5492ab4 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 @@ -795,6 +795,10 @@ &usb_host0_xhci {
@@ -39,5 +39,5 @@ index a9021c524afbf..429ac5492ab4d 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From cdf730b9be1da64f26f9964bceae2081b5775f1c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 192/344] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 192/345] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/perf/hisilicon/Makefile b/drivers/perf/hisilicon/Makefile
-index 48dcc8381ea75..a62ab2f0766f0 100644
+index 48dcc8381ea7..a62ab2f0766f 100644
 --- a/drivers/perf/hisilicon/Makefile
 +++ b/drivers/perf/hisilicon/Makefile
 @@ -1,6 +1,6 @@
@@ -25,5 +25,5 @@ index 48dcc8381ea75..a62ab2f0766f0 100644
  
  obj-$(CONFIG_HISI_PCIE_PMU) += hisi_pcie_pmu.o
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From 1ba56ca4e5715fd44c568b9a61f4fe82ca92b582 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 193/344] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 193/345] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 860a3bc030e06..b4db71690c70e 100644
+index 860a3bc030e0..b4db71690c70 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -98,6 +98,23 @@ static void __init init_screen_info(void)
@@ -67,7 +67,7 @@ index 860a3bc030e06..b4db71690c70e 100644
  	early_memunmap(config_tables, efi_nr_tables * size);
  
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index aed901c57fb43..86d37a447eec1 100644
+index aed901c57fb4..86d37a447eec 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -19,6 +19,7 @@ void __init memblock_init(void)
@@ -79,7 +79,7 @@ index aed901c57fb43..86d37a447eec1 100644
  		mem_size = md->num_pages << EFI_PAGE_SHIFT;
  		mem_end = mem_start + mem_size;
 diff --git a/drivers/firmware/efi/libstub/loongarch.c b/drivers/firmware/efi/libstub/loongarch.c
-index 3782d0a187d1f..8bea96492ef21 100644
+index 3782d0a187d1..8bea96492ef2 100644
 --- a/drivers/firmware/efi/libstub/loongarch.c
 +++ b/drivers/firmware/efi/libstub/loongarch.c
 @@ -23,6 +23,8 @@ struct exit_boot_struct {
@@ -134,5 +134,5 @@ index 3782d0a187d1f..8bea96492ef21 100644
  	csr_write64(CSR_DMW0_INIT, LOONGARCH_CSR_DMWIN0);
  	csr_write64(CSR_DMW1_INIT, LOONGARCH_CSR_DMWIN1);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From 3d811208f318e4fb6b038b330add2245094aa3ef Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 194/344] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 194/345] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/kernel/legacy_boot.h
 
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index 001924877772f..53ad38c9c98f5 100644
+index 001924877772..53ad38c9c98f 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -80,3 +80,5 @@ obj-$(CONFIG_UPROBES)		+= uprobes.o
@@ -45,7 +45,7 @@ index 001924877772f..53ad38c9c98f5 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index b4db71690c70e..999a7a75e0ace 100644
+index b4db71690c70..999a7a75e0ac 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@
@@ -67,7 +67,7 @@ index b4db71690c70e..999a7a75e0ace 100644
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
 new file mode 100644
-index 0000000000000..30c01c8b22a0a
+index 000000000000..30c01c8b22a0
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -0,0 +1,297 @@
@@ -370,7 +370,7 @@ index 0000000000000..30c01c8b22a0a
 +}
 diff --git a/arch/loongarch/kernel/legacy_boot.h b/arch/loongarch/kernel/legacy_boot.h
 new file mode 100644
-index 0000000000000..6d3a36ebaab71
+index 000000000000..6d3a36ebaab7
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.h
 @@ -0,0 +1,18 @@
@@ -393,7 +393,7 @@ index 0000000000000..6d3a36ebaab71
 +
 +#endif /* __LEGACY_BOOT_H_ */
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index 86d37a447eec1..b24b3db96018d 100644
+index 86d37a447eec..b24b3db96018 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -10,6 +10,8 @@
@@ -415,7 +415,7 @@ index 86d37a447eec1..b24b3db96018d 100644
  
  	/* Reserve the first 2MB */
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index d6e73e8f9c0b6..87ef4677b688d 100644
+index d6e73e8f9c0b..87ef4677b688 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -27,6 +27,8 @@
@@ -436,7 +436,7 @@ index d6e73e8f9c0b6..87ef4677b688d 100644
  		return -EINVAL;
  
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 69c17d162fff3..1d295b1ad0880 100644
+index 69c17d162fff..1d295b1ad088 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -49,6 +49,8 @@
@@ -457,7 +457,7 @@ index 69c17d162fff3..1d295b1ad0880 100644
  	pagetable_init();
  	bootcmdline_init(cmdline_p);
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 46036d98da75b..bf0c2a7bd0999 100644
+index 46036d98da75..bf0c2a7bd099 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -36,6 +36,8 @@
@@ -479,5 +479,5 @@ index 46036d98da75b..bf0c2a7bd0999 100644
  	cpuboot_data.thread_info = (unsigned long)task_thread_info(idle);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From a1a885a76abf753578aa2ed328b3756ee04e1cc9 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 195/344] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 195/345] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 321 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 7376840fa9f78..1f5905e0acffa 100644
+index 7376840fa9f7..1f5905e0acff 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -45,6 +45,11 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -38,7 +38,7 @@ index 7376840fa9f78..1f5905e0acffa 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0a..841d8db85a3cb 100644
+index 30c01c8b22a0..841d8db85a3c 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -382,7 +382,7 @@ index 30c01c8b22a0a..841d8db85a3cb 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/tables.c b/drivers/acpi/tables.c
-index fa9bb8c8ce953..be129bc075e4e 100644
+index fa9bb8c8ce95..be129bc075e4 100644
 --- a/drivers/acpi/tables.c
 +++ b/drivers/acpi/tables.c
 @@ -693,6 +693,7 @@ acpi_status acpi_os_table_override(struct acpi_table_header *existing_table,
@@ -402,7 +402,7 @@ index fa9bb8c8ce953..be129bc075e4e 100644
  
  int __init acpi_table_init(void)
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 1c5bb1e887cd1..7df7350a5f14a 100644
+index 1c5bb1e887cd..7df7350a5f14 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -779,6 +779,16 @@ const char *acpi_get_subsystem_id(acpi_handle handle);
@@ -423,5 +423,5 @@ index 1c5bb1e887cd1..7df7350a5f14a 100644
  
  #define acpi_disabled 1
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From b4b60e798d8dfcfbd74cfbbe0ec4da940a70918a Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 196/344] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 196/345] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 1f5905e0acffa..fcf2cc1b37da1 100644
+index 1f5905e0acff..fcf2cc1b37da 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -49,6 +49,8 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -44,7 +44,7 @@ index 1f5905e0acffa..fcf2cc1b37da1 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 841d8db85a3cb..7043bfd0399d6 100644
+index 841d8db85a3c..7043bfd0399d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -85,7 +85,7 @@ index 841d8db85a3cb..7043bfd0399d6 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index 74ade41603145..e51c8d3a752c1 100644
+index 74ade4160314..e51c8d3a752c 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -909,6 +909,7 @@ int acpi_pci_probe_root_resources(struct acpi_pci_root_info *info)
@@ -97,7 +97,7 @@ index 74ade41603145..e51c8d3a752c1 100644
  				acpi_pci_root_remap_iospace(&device->fwnode,
  						entry);
 diff --git a/include/linux/pci-acpi.h b/include/linux/pci-acpi.h
-index 078225b514d48..1c22ca4ec794c 100644
+index 078225b514d4..1c22ca4ec794 100644
 --- a/include/linux/pci-acpi.h
 +++ b/include/linux/pci-acpi.h
 @@ -133,6 +133,10 @@ static inline void pci_acpi_remove_edr_notifier(struct pci_dev *pdev) { }
@@ -112,5 +112,5 @@ index 078225b514d48..1c22ca4ec794c 100644
  static inline void acpi_pci_add_bus(struct pci_bus *bus) { }
  static inline void acpi_pci_remove_bus(struct pci_bus *bus) { }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From 5742ebe9cf5d1fedb363b6f06d6aae3e78b6a3fc Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 197/344] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 197/345] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 49 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index fcf2cc1b37da1..fa0202d02f97b 100644
+index fcf2cc1b37da..fa0202d02f97 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -51,6 +51,8 @@ extern void acpi_arch_os_table_override (struct acpi_table_header *existing_tabl
@@ -42,7 +42,7 @@ index fcf2cc1b37da1..fa0202d02f97b 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 7043bfd0399d6..3ec69ffd8b942 100644
+index 7043bfd0399d..3ec69ffd8b94 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -617,6 +617,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)
@@ -100,5 +100,5 @@ index 7043bfd0399d6..3ec69ffd8b942 100644
  	return have_bpi;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From 0e2d6d6ff8a46c5f5fa780187b216cfb05700246 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 198/344] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 198/345] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory
@@ -44,7 +44,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 27 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 3ec69ffd8b942..2888e2b9fb456 100644
+index 3ec69ffd8b94..2888e2b9fb45 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -46,6 +46,19 @@ enum bpi_mem_type {
@@ -89,5 +89,5 @@ index 3ec69ffd8b942..2888e2b9fb456 100644
  
  void acpi_arch_os_table_override (struct acpi_table_header *existing_table, struct acpi_table_header **new_table){
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From 139db75ef8c79478626715826ea64300438c3a4a Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 199/344] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 199/345] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 2888e2b9fb456..204b33109f37d 100644
+index 2888e2b9fb45..204b33109f37 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -59,6 +59,16 @@ enum bpi_mem_type {
@@ -61,5 +61,5 @@ index 2888e2b9fb456..204b33109f37d 100644
  
  void acpi_arch_os_table_override (struct acpi_table_header *existing_table, struct acpi_table_header **new_table){
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From 2d341a623819f2d929e48496b9c29f7285f1bf6c Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 200/344] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 200/345] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
@@ -40,7 +40,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/systable.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
-index beb8499dd8ed8..42a6b4c6adbe3 100644
+index beb8499dd8ed..42a6b4c6adbe 100644
 --- a/arch/loongarch/Kbuild
 +++ b/arch/loongarch/Kbuild
 @@ -7,3 +7,5 @@ obj-$(CONFIG_KVM) += kvm/
@@ -51,7 +51,7 @@ index beb8499dd8ed8..42a6b4c6adbe3 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..65cd78995176f
+index 000000000000..65cd78995176
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,38 @@
@@ -95,7 +95,7 @@ index 0000000000000..65cd78995176f
 +clean-files += kernel_feature.h feat_test.syms module_version.h
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
-index 0000000000000..d159169d10508
+index 000000000000..d159169d1050
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/LICENSE
 @@ -0,0 +1,339 @@
@@ -440,7 +440,7 @@ index 0000000000000..d159169d10508
 +Public License instead of this License.
 diff --git a/arch/loongarch/ow_syscall/Makefile b/arch/loongarch/ow_syscall/Makefile
 new file mode 100644
-index 0000000000000..e975aa1cdb7af
+index 000000000000..e975aa1cdb7a
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Makefile
 @@ -0,0 +1,37 @@
@@ -483,7 +483,7 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..25c6757983896
+index 000000000000..25c675798389
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
 @@ -0,0 +1,77 @@
@@ -566,14 +566,14 @@ index 0000000000000..25c6757983896
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 0000000000000..17e51c385ea38
+index 000000000000..17e51c385ea3
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
 +0.1.1
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..ad9aec128e6f8
+index 000000000000..ad9aec128e6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
 @@ -0,0 +1,11 @@
@@ -590,7 +590,7 @@ index 0000000000000..ad9aec128e6f8
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/feat_test.c b/arch/loongarch/ow_syscall/feat_test.c
 new file mode 100644
-index 0000000000000..5fc3b8709364d
+index 000000000000..5fc3b8709364
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/feat_test.c
 @@ -0,0 +1,16 @@
@@ -612,7 +612,7 @@ index 0000000000000..5fc3b8709364d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 0000000000000..1f5c336f52ec1
+index 000000000000..1f5c336f52ec
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
 @@ -0,0 +1,87 @@
@@ -705,7 +705,7 @@ index 0000000000000..1f5c336f52ec1
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 0000000000000..fa40914afa414
+index 000000000000..fa40914afa41
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
 @@ -0,0 +1,4 @@
@@ -715,7 +715,7 @@ index 0000000000000..fa40914afa414
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..4ae3fc6d70785
+index 000000000000..4ae3fc6d7078
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 @@ -0,0 +1,274 @@
@@ -995,7 +995,7 @@ index 0000000000000..4ae3fc6d70785
 +MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name, provide this when unable to find using kprobe");
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..90eb34727680d
+index 000000000000..90eb34727680
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
 @@ -0,0 +1,239 @@
@@ -1240,7 +1240,7 @@ index 0000000000000..90eb34727680d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..adcd53bedc662
+index 000000000000..adcd53bedc66
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
 @@ -0,0 +1,44 @@
@@ -1290,7 +1290,7 @@ index 0000000000000..adcd53bedc662
 +#endif
 diff --git a/arch/loongarch/ow_syscall/systable.c b/arch/loongarch/ow_syscall/systable.c
 new file mode 100644
-index 0000000000000..8b311954d62ef
+index 000000000000..8b311954d62e
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.c
 @@ -0,0 +1,65 @@
@@ -1361,7 +1361,7 @@ index 0000000000000..8b311954d62ef
 +};
 diff --git a/arch/loongarch/ow_syscall/systable.h b/arch/loongarch/ow_syscall/systable.h
 new file mode 100644
-index 0000000000000..f2b6602cc7ef4
+index 000000000000..f2b6602cc7ef
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.h
 @@ -0,0 +1,8 @@
@@ -1374,5 +1374,5 @@ index 0000000000000..f2b6602cc7ef4
 +extern const char *sys_call_table_name[];
 +extern struct syscall_replace_table syscall_to_replace[];
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 917f014817021f5f3715cf05bb820e1f61b1261d Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 201/344] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 201/345] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 [Xi Ruoyao: Select KALLSYMS and KPROBE]
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/Kconfig
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index 0f1f53b3c58bf..b88df88996a93 100644
+index 0f1f53b3c58b..b88df88996a9 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -768,3 +768,5 @@ source "drivers/cpufreq/Kconfig"
@@ -25,7 +25,7 @@ index 0f1f53b3c58bf..b88df88996a93 100644
 +source "arch/loongarch/ow_syscall/Kconfig"
 diff --git a/arch/loongarch/ow_syscall/Kconfig b/arch/loongarch/ow_syscall/Kconfig
 new file mode 100644
-index 0000000000000..8ef159cf10557
+index 000000000000..8ef159cf1055
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kconfig
 @@ -0,0 +1,17 @@
@@ -47,5 +47,5 @@ index 0000000000000..8ef159cf10557
 +	  If unsure, say N.
 +
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From 702b78576d22cae40ddc5ef44e8fd04e11d54be0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 202/344] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 202/345] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom
@@ -100,7 +100,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/kernel/rcu/tree.c b/kernel/rcu/tree.c
-index 8eff357b0436b..82bc370c305b3 100644
+index 8eff357b0436..82bc370c305b 100644
 --- a/kernel/rcu/tree.c
 +++ b/kernel/rcu/tree.c
 @@ -4439,15 +4439,11 @@ void rcutree_migrate_callbacks(int cpu)
@@ -123,5 +123,5 @@ index 8eff357b0436b..82bc370c305b3 100644
  	rcu_barrier_entrain(rdp);
  	my_rdp = this_cpu_ptr(&rcu_data);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From 5d6f8ca76f75ad5de423523ac04147938c357f32 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 203/344] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 203/345] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Makefile.postlink b/arch/mips/Makefile.postlink
-index ea0add7d56b23..2543679da1492 100644
+index ea0add7d56b2..2543679da149 100644
 --- a/arch/mips/Makefile.postlink
 +++ b/arch/mips/Makefile.postlink
 @@ -24,9 +24,6 @@ quiet_cmd_relocs = RELOCS  $@
@@ -34,5 +34,5 @@ index ea0add7d56b23..2543679da1492 100644
  	$(call if_changed,relocs)
  endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 4fea7ff00984a4294ca03d89522e0a6669a2e296 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 204/344] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 204/345] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 13 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index d2a51bd395f6c..89915a33ec718 100644
+index d2a51bd395f6..89915a33ec71 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -17,6 +17,10 @@ int loongson_vblank = 1;
@@ -38,7 +38,7 @@ index d2a51bd395f6c..89915a33ec718 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 931c17521bf01..0dcc9646d2ff1 100644
+index 931c17521bf0..0dcc9646d2ff 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -7,6 +7,7 @@
@@ -50,7 +50,7 @@ index 931c17521bf01..0dcc9646d2ff1 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index 12193d2a301ac..ada66e809f364 100644
+index 12193d2a301a..ada66e809f36 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -265,6 +265,14 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
@@ -69,5 +69,5 @@ index 12193d2a301ac..ada66e809f364 100644
  		return -ENODEV;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From a3d2e40f4cadb2ba4de06cc04f2edf6135b6ec48 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 205/344] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 205/345] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/hp/hp-wmi.c b/drivers/platform/x86/hp/hp-wmi.c
-index 8b3533d6ba091..1e59c0d63cb5a 100644
+index 8b3533d6ba09..1e59c0d63cb5 100644
 --- a/drivers/platform/x86/hp/hp-wmi.c
 +++ b/drivers/platform/x86/hp/hp-wmi.c
 @@ -68,7 +68,7 @@ static const char * const omen_thermal_profile_boards[] = {
@@ -40,5 +40,5 @@ index 8b3533d6ba091..1e59c0d63cb5a 100644
  
  /* DMI Board names of Victus 16-d1xxx laptops */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From fe66bb62f2cc80c450d173c0f7caf06eb789a900 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 206/344] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 206/345] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 50afeed2ac8f3..dc93da749d12a 100644
+index 50afeed2ac8f..dc93da749d12 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -896,9 +896,9 @@ module_param_named(visualconfirm, amdgpu_dc_visual_confirm, uint, 0444);
@@ -36,5 +36,5 @@ index 50afeed2ac8f3..dc93da749d12a 100644
  
  int amdgpu_backlight = -1;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From 6087e24926ffbbcae29b9f3330605c934d6d0a88 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 207/344] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 207/345] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 28 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/unaligned.c b/arch/mips/kernel/unaligned.c
-index db652c99b72e3..4f2055afbd7e8 100644
+index db652c99b72e..4f2055afbd7e 100644
 --- a/arch/mips/kernel/unaligned.c
 +++ b/arch/mips/kernel/unaligned.c
 @@ -1514,14 +1514,37 @@ static void emulate_load_store_MIPS16e(struct pt_regs *regs, void __user * addr)
@@ -67,5 +67,5 @@ index db652c99b72e3..4f2055afbd7e8 100644
  		goto sigbus;
  	if (unaligned_action == UNALIGNED_ACTION_SIGNAL)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From 575184289d8d8198e2487d2d2abbebe5e4d6334d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 208/344] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 208/345] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 4 deletions(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 3636fa0bfe6b4..c12d69c487474 100644
+index 3636fa0bfe6b..c12d69c48747 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1719,7 +1719,6 @@ menu "PCI GPIO expanders"
@@ -28,7 +28,7 @@ index 3636fa0bfe6b4..c12d69c487474 100644
  	help
  	  Say yes here to support GPIO pins on Single Board Computers produced
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 597538bfe2f83..cfe74f1d5904b 100644
+index 597538bfe2f8..cfe74f1d5904 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -41,7 +41,6 @@ comment "Native drivers"
@@ -40,7 +40,7 @@ index 597538bfe2f83..cfe74f1d5904b 100644
  	help
  	  This hwmon driver adds support for reporting temperature or fan
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 673627baac012..9513b245b2982 100644
+index 673627baac01..9513b245b298 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -75,7 +75,6 @@ config LEDS_88PM860X
@@ -52,7 +52,7 @@ index 673627baac012..9513b245b2982 100644
  	help
  	  This led driver adds support for LED brightness control on Single
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 0b3691ec4949c..c5ee21ad32192 100644
+index 0b3691ec4949..c5ee21ad3219 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2344,7 +2344,6 @@ config MFD_QCOM_PM8008
@@ -64,5 +64,5 @@ index 0b3691ec4949c..c5ee21ad32192 100644
  	  Say yes here to support mltiple IO devices on Single Board Computers
  	  produced by AAEON.
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From b7a13f6099bf035166bc86c2827aa9944e3b01b9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 209/344] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 209/345] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling
@@ -35,7 +35,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index 6c07dd423458c..89a65f7ff15d8 100644
+index 6c07dd423458..89a65f7ff15d 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -5555,7 +5555,7 @@ static struct miscdevice kvm_dev = {
@@ -48,5 +48,5 @@ index 6c07dd423458c..89a65f7ff15d8 100644
  EXPORT_SYMBOL_GPL(enable_virt_at_load);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From e82348168d2c011232fb4a90024ac0d91fc18d3c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 210/344] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 210/345] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 12 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index 89915a33ec718..99e5fef3f2d9d 100644
+index 89915a33ec71..99e5fef3f2d9 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -21,6 +21,10 @@ int loongson_ls7a1000_support = 0;
@@ -41,7 +41,7 @@ index 89915a33ec718..99e5fef3f2d9d 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 0dcc9646d2ff1..183a8a0586605 100644
+index 0dcc9646d2ff..183a8a058660 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -8,6 +8,7 @@
@@ -53,7 +53,7 @@ index 0dcc9646d2ff1..183a8a0586605 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index ada66e809f364..31d187fe3d24f 100644
+index ada66e809f36..31d187fe3d24 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -273,6 +273,13 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
@@ -71,5 +71,5 @@ index ada66e809f364..31d187fe3d24f 100644
  		return -ENODEV;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 22e8f78dbadc91ec44493aea486d56f9734c9e07 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 211/344] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 211/345] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index a36bb567d66e1..3775d2b066519 100644
+index a36bb567d66e..3775d2b06651 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -25,7 +25,7 @@ config MIPS
@@ -28,5 +28,5 @@ index a36bb567d66e1..3775d2b066519 100644
  	select ARCH_WANT_IPC_PARSE_VERSION
  	select ARCH_WANT_LD_ORPHAN_WARN
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From ec830f0e35cd2d57f52dde4102fbcc3f732d8bb9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 212/344] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 212/345] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/cpu_hwmon.c b/drivers/platform/mips/cpu_hwmon.c
-index 2ac2f31090f96..93619227f0396 100644
+index 2ac2f31090f9..93619227f039 100644
 --- a/drivers/platform/mips/cpu_hwmon.c
 +++ b/drivers/platform/mips/cpu_hwmon.c
 @@ -135,9 +135,22 @@ static int __init loongson_hwmon_init(void)
@@ -58,5 +58,5 @@ index 2ac2f31090f96..93619227f0396 100644
  	if (!csr_temp_enable && !loongson_chiptemp[0])
  		return -ENODEV;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From 33e3505af1a28631cb44ac5396ae1476bab61df1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 213/344] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 213/345] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:
@@ -39,7 +39,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 346f0e49bb2ea..92aa8e1364c31 100644
+index 346f0e49bb2e..92aa8e1364c3 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,7 +185,9 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,
@@ -53,5 +53,5 @@ index 346f0e49bb2ea..92aa8e1364c31 100644
  
  /**
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 078c62b52ebadaaa7f885d8e78d949c60405b99d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 214/344] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 214/345] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 390f82b4845df..5bf1bd87afff7 100644
+index 390f82b4845d..5bf1bd87afff 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3522,7 +3522,9 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)
@@ -51,5 +51,5 @@ index 390f82b4845df..5bf1bd87afff7 100644
   err_wakeup:
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From ab28c468b68c17f392a9bb5bd4fbff7752af79b4 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 215/344] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 215/345] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 2a0caf15671d5..e7ce09d66adcd 100644
+index 2a0caf15671d..e7ce09d66adc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -42,6 +42,7 @@
@@ -23,5 +23,5 @@ index 2a0caf15671d5..e7ce09d66adcd 100644
  #include "phytmac_ptp.h"
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From 23651699859d904a5b5a775a600b084d86cafee2 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 216/344] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 216/345] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/tools/bpf/bpftool/Makefile b/tools/bpf/bpftool/Makefile
-index 9e9a5f006cd2a..1b7c3fe54fe6c 100644
+index 9e9a5f006cd2..1b7c3fe54fe6 100644
 --- a/tools/bpf/bpftool/Makefile
 +++ b/tools/bpf/bpftool/Makefile
 @@ -273,8 +273,8 @@ clean: $(LIBBPF)-clean $(LIBBPF_BOOTSTRAP)-clean feature-detect-clean
@@ -33,5 +33,5 @@ index 9e9a5f006cd2a..1b7c3fe54fe6c 100644
  
  doc:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
@@ -1,7 +1,7 @@
 From 42c88fc94f027b5fda32c6d2b990c9693b167a88 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 16:01:27 +0800
-Subject: [PATCH 217/344] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
+Subject: [PATCH 217/345] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
  support
 
 On IPASON NL38-N11 laptops, the touchpad device (a HID multitouch device
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/gpio/gpio-loongson-64bit.c b/drivers/gpio/gpio-loongson-64bit.c
-index 818c606fbc514..2cd240d7db679 100644
+index 818c606fbc51..2cd240d7db67 100644
 --- a/drivers/gpio/gpio-loongson-64bit.c
 +++ b/drivers/gpio/gpio-loongson-64bit.c
 @@ -27,6 +27,7 @@ struct loongson_gpio_chip_data {
@@ -56,5 +56,5 @@ index 818c606fbc514..2cd240d7db679 100644
  
  /* LS7A2000 chipset GPIO */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
@@ -1,7 +1,7 @@
 From 3a2019208b5e495919b59ee034ed8390a8c2c898 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:36:15 +0800
-Subject: [PATCH 218/344] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
+Subject: [PATCH 218/345] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
  xdp_do_flush()
 
 Per 7f04bd109d4c ("net: Tree wide: Replace xdp_do_flush_map() with
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index e7ce09d66adcd..03392c537666d 100644
+index e7ce09d66adc..03392c537666 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1247,7 +1247,7 @@ static int phytmac_rx(struct phytmac_queue *queue, struct napi_struct *napi,
@@ -33,5 +33,5 @@ index e7ce09d66adcd..03392c537666d 100644
  	phytmac_rx_clean(queue);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
@@ -1,7 +1,7 @@
 From 7f547a62b885ab240b3fb614db700e334ee1d267 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:38:09 +0800
-Subject: [PATCH 219/344] AOSCOS: net/phytmac: Remove unnecessary
+Subject: [PATCH 219/345] AOSCOS: net/phytmac: Remove unnecessary
  pcim_iounmap_regions() call
 
 pcim_iounmap_regions() is removed in commit 855c634930f0 ("PCI: Remove
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index fac5d717ad766..69f34c2faaf5b 100644
+index fac5d717ad76..69f34c2faaf5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -177,7 +177,6 @@ static void phytmac_pci_remove(struct pci_dev *pdev)
@@ -29,5 +29,5 @@ index fac5d717ad766..69f34c2faaf5b 100644
  	pci_disable_device(pdev);
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
@@ -1,7 +1,7 @@
 From 53f80978ad8aaab852ab6774c140ccf02ef8c37b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 21:59:21 +0800
-Subject: [PATCH 220/344] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
+Subject: [PATCH 220/345] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
 
 The driver seems relying on ACPI to power up the device.  And the device
 is only available as a part of Phytium SoC.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
-index 14a77adbfdc12..34cbb2a0ce82c 100644
+index 14a77adbfdc1..34cbb2a0ce82 100644
 --- a/drivers/net/ethernet/phytium/Kconfig
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -19,6 +19,8 @@ if NET_VENDOR_PHYTIUM
@@ -27,5 +27,5 @@ index 14a77adbfdc12..34cbb2a0ce82c 100644
  	select PHYLINK
  	select CRC32
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-arm64-Disable-MPAM-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-AOSCOS-arm64-Disable-MPAM-by-default.patch
@@ -1,7 +1,7 @@
 From 843ad3bd4cb9b5284c5a09de7b0385ecadf24800 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 14 Jul 2025 18:06:42 +0800
-Subject: [PATCH 221/344] AOSCOS: arm64: Disable MPAM by default
+Subject: [PATCH 221/345] AOSCOS: arm64: Disable MPAM by default
 
 We have to work OotB on W510, and ARM64 does not support extending the
 built-in command line with the one from the bootloader.  So only try
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 20 insertions(+)
 
 diff --git a/arch/arm64/kernel/pi/idreg-override.c b/arch/arm64/kernel/pi/idreg-override.c
-index bc57b290e5e7b..2d45dbb689476 100644
+index bc57b290e5e7..2d45dbb68947 100644
 --- a/arch/arm64/kernel/pi/idreg-override.c
 +++ b/arch/arm64/kernel/pi/idreg-override.c
 @@ -215,6 +215,17 @@ static const struct ftr_set_desc sw_features __prel64_initconst = {
@@ -60,5 +60,5 @@ index bc57b290e5e7b..2d45dbb689476 100644
  
  void __init init_feature_override(u64 boot_status, const void *fdt,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From e28bf1eaa5d75638984fbf1d42132382d59dc66e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 222/344] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 222/345] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 3775d2b066519..dae56c1544345 100644
+index 3775d2b06651..dae56c154434 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -532,6 +532,7 @@ config MACH_LOONGSON64
@@ -21,5 +21,5 @@ index 3775d2b066519..dae56c1544345 100644
  	  This enables the support of Loongson-2/3 family of machines.
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From 256ce155e805a488a5cdf0c03a43043e9d23b329 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 223/344] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 223/345] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00.h b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
-index 09b9d1f9f793f..18bc1632a175b 100644
+index 09b9d1f9f793..18bc1632a175 100644
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 @@ -1167,23 +1167,27 @@ static inline bool rt2x00_intf(struct rt2x00_dev *rt2x00dev,
@@ -58,5 +58,5 @@ index 09b9d1f9f793f..18bc1632a175b 100644
  
  /* Helpers for capability flags */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From 95015171e41b34bcd38eaa5adecfffdd1608f232 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 224/344] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 224/345] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open
@@ -29,7 +29,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
-index 86d404d649a35..bac26b08be326 100644
+index 86d404d649a3..bac26b08be32 100644
 --- a/drivers/tty/serial/serial_core.c
 +++ b/drivers/tty/serial/serial_core.c
 @@ -1971,6 +1971,8 @@ static int uart_open(struct tty_struct *tty, struct file *filp)
@@ -42,5 +42,5 @@ index 86d404d649a35..bac26b08be326 100644
  		retval = 0;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From 45c6996b41c1a0d86544e97f4167058aabfb3472 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 225/344] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 225/345] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").
@@ -40,7 +40,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/constant_timer.c
 
 diff --git a/arch/mips/include/asm/cpu-features.h b/arch/mips/include/asm/cpu-features.h
-index 404390bb87eaf..e522efa1b53d0 100644
+index 404390bb87ea..e522efa1b53d 100644
 --- a/arch/mips/include/asm/cpu-features.h
 +++ b/arch/mips/include/asm/cpu-features.h
 @@ -659,6 +659,10 @@
@@ -55,7 +55,7 @@ index 404390bb87eaf..e522efa1b53d0 100644
   * Guest capabilities
   */
 diff --git a/arch/mips/include/asm/cpu.h b/arch/mips/include/asm/cpu.h
-index ecb9854cb4324..3c1299b718e10 100644
+index ecb9854cb432..3c1299b718e1 100644
 --- a/arch/mips/include/asm/cpu.h
 +++ b/arch/mips/include/asm/cpu.h
 @@ -421,6 +421,7 @@ enum cpu_type_enum {
@@ -67,7 +67,7 @@ index ecb9854cb4324..3c1299b718e10 100644
  /*
   * CPU ASE encodings
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_regs.h b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
-index fec7675076049..47294ab78a2cd 100644
+index fec767507604..47294ab78a2c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 @@ -131,6 +131,9 @@ static inline u32 read_cpucfg(u32 reg)
@@ -120,7 +120,7 @@ index fec7675076049..47294ab78a2cd 100644
 +
  #endif
 diff --git a/arch/mips/include/asm/mipsregs.h b/arch/mips/include/asm/mipsregs.h
-index c025558754d57..b47833b7e5269 100644
+index c025558754d5..b47833b7e526 100644
 --- a/arch/mips/include/asm/mipsregs.h
 +++ b/arch/mips/include/asm/mipsregs.h
 @@ -838,6 +838,7 @@
@@ -132,7 +132,7 @@ index c025558754d57..b47833b7e5269 100644
  #define MTI_CONF6_FTLBEN	(_ULCAST_(1) << 15)
  /* Disable load/store bonding */
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index 93f8cd52e3d47..72fec943a9e44 100644
+index 93f8cd52e3d4..72fec943a9e4 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -42,11 +42,19 @@ extern int __weak get_c0_perfcount_int(void);
@@ -178,7 +178,7 @@ index 93f8cd52e3d47..72fec943a9e44 100644
  	return 0;
  #endif
 diff --git a/arch/mips/include/asm/vdso/clocksource.h b/arch/mips/include/asm/vdso/clocksource.h
-index 510e1671d8985..7fd43ca06eb11 100644
+index 510e1671d898..7fd43ca06eb1 100644
 --- a/arch/mips/include/asm/vdso/clocksource.h
 +++ b/arch/mips/include/asm/vdso/clocksource.h
 @@ -4,6 +4,7 @@
@@ -191,7 +191,7 @@ index 510e1671d8985..7fd43ca06eb11 100644
  
  #endif /* __ASM_VDSOCLOCKSOURCE_H */
 diff --git a/arch/mips/include/asm/vdso/gettimeofday.h b/arch/mips/include/asm/vdso/gettimeofday.h
-index fd32baa30e172..a3e7bec7ff631 100644
+index fd32baa30e17..a3e7bec7ff63 100644
 --- a/arch/mips/include/asm/vdso/gettimeofday.h
 +++ b/arch/mips/include/asm/vdso/gettimeofday.h
 @@ -183,6 +183,22 @@ static __always_inline u64 read_gic_count(const struct vdso_time_data *data)
@@ -229,7 +229,7 @@ index fd32baa30e172..a3e7bec7ff631 100644
  	/*
  	 * Core checks mode already. So this raced against a concurrent
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index ae0a4849e80e6..1c3734ffc8eb4 100644
+index ae0a4849e80e..1c3734ffc8eb 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -34,6 +34,10 @@
@@ -270,7 +270,7 @@ index ae0a4849e80e6..1c3734ffc8eb4 100644
  				  LOONGSON_CONF6_INTIMER);
  		break;
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index cbba30dfddf5d..ba083beb6ca81 100644
+index cbba30dfddf5..ba083beb6ca8 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,6 +4,7 @@
@@ -283,7 +283,7 @@ index cbba30dfddf5d..ba083beb6ca81 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
 new file mode 100644
-index 0000000000000..b8bdbb2c47b51
+index 000000000000..b8bdbb2c47b5
 --- /dev/null
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -0,0 +1,256 @@
@@ -544,7 +544,7 @@ index 0000000000000..b8bdbb2c47b51
 +	return res;
 +}
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 69c1e77e6bfc7..f8e2fb4c7cd8c 100644
+index 69c1e77e6bfc..f8e2fb4c7cd8 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -425,7 +425,9 @@ static void loongson3_smp_finish(void)
@@ -559,5 +559,5 @@ index 69c1e77e6bfc7..f8e2fb4c7cd8c 100644
  	ipi_clear_buf(cpu);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From a35e1f017db4d3afe6cb339c793aeb6f2775c120 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 226/344] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 226/345] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index b8bdbb2c47b51..975fb93c4efa2 100644
+index b8bdbb2c47b5..975fb93c4efa 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -42,12 +42,6 @@ static irqreturn_t constant_timer_interrupt(int irq, void *data)
@@ -61,5 +61,5 @@ index b8bdbb2c47b51..975fb93c4efa2 100644
  	return 0;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From bf9a77a488aafc6d212ee86b346760ebc34867c1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 227/344] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 227/345] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index 975fb93c4efa2..c1fda4a3ae165 100644
+index 975fb93c4efa..c1fda4a3ae16 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -252,7 +252,7 @@ int __init init_constant_clocksource(void)
@@ -29,5 +29,5 @@ index 975fb93c4efa2..c1fda4a3ae165 100644
  	return res;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 98eb8a32181e79847ce7fdc5f0bf72e9ed2c30cd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 228/344] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 228/345] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 new file mode 100644
-index 0000000000000..3d2ca3245a3e2
+index 000000000000..3d2ca3245a3e
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -0,0 +1,381 @@
@@ -417,7 +417,7 @@ index 0000000000000..3d2ca3245a3e2
 +
 +#endif /* __EC_WPCE775L_H__ */
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index ba083beb6ca81..0cb1654f346ab 100644
+index ba083beb6ca8..0cb1654f346a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -431,7 +431,7 @@ index ba083beb6ca81..0cb1654f346ab 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/ec_wpce775l.c b/arch/mips/loongson64/ec_wpce775l.c
 new file mode 100644
-index 0000000000000..f407ddbe933a1
+index 000000000000..f407ddbe933a
 --- /dev/null
 +++ b/arch/mips/loongson64/ec_wpce775l.c
 @@ -0,0 +1,249 @@
@@ -685,7 +685,7 @@ index 0000000000000..f407ddbe933a1
 +}
 +EXPORT_SYMBOL(ec_query_get_event_num);
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index cab5a4c5baf52..23fda821d6b38 100644
+index cab5a4c5baf5..23fda821d6b3 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -142,7 +142,7 @@ static struct fwnode_handle *i8042_kbd_fwnode;
@@ -698,5 +698,5 @@ index cab5a4c5baf52..23fda821d6b38 100644
  /*
   * Writers to AUX and KBD ports as well as users issuing i8042_command
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From 7b276fc59c12557a0723e8bdbe267c50799836c4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 229/344] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 229/345] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index 3d2ca3245a3e2..fc60026bc6741 100644
+index 3d2ca3245a3e..fc60026bc674 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -374,6 +374,7 @@ extern int ec_write_noindex(unsigned char command, unsigned char data);
@@ -28,5 +28,5 @@ index 3d2ca3245a3e2..fc60026bc6741 100644
  
  extern void clean_ec_event_status(void);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 089f163a306ca8c39a63dc3891747b5cfc52412e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 230/344] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 230/345] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and
@@ -44,7 +44,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/wpce_fan.c
 
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
-index 721eafc4644e5..071e8f445f5c9 100644
+index 721eafc4644e..071e8f445f5c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 @@ -36,7 +36,7 @@ struct temp_range {
@@ -66,7 +66,7 @@ index 721eafc4644e5..071e8f445f5c9 100644
 +
  #endif /* __LOONGSON_HWMON_H_*/
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 0cb1654f346ab..16b0c555b52ae 100644
+index 0cb1654f346a..16b0c555b52a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -80,7 +80,7 @@ index 0cb1654f346ab..16b0c555b52ae 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/platform.c b/arch/mips/loongson64/platform.c
 new file mode 100644
-index 0000000000000..a447eab0218d2
+index 000000000000..a447eab0218d
 --- /dev/null
 +++ b/arch/mips/loongson64/platform.c
 @@ -0,0 +1,67 @@
@@ -152,7 +152,7 @@ index 0000000000000..a447eab0218d2
 +	.type = CONSTANT_SPEED_POLICY,
 +};
 diff --git a/drivers/hwmon/lm93.c b/drivers/hwmon/lm93.c
-index be4853fad80fd..649c5e1cf8200 100644
+index be4853fad80f..649c5e1cf820 100644
 --- a/drivers/hwmon/lm93.c
 +++ b/drivers/hwmon/lm93.c
 @@ -2497,8 +2497,9 @@ ATTRIBUTE_GROUPS(lm93);
@@ -194,7 +194,7 @@ index be4853fad80fd..649c5e1cf8200 100644
  	for (i = 0; i < 20; i++) {
  		msleep(10);
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index fb4ac4b08e891..59b6027eeadf5 100644
+index fb4ac4b08e89..59b6027eeadf 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -37,4 +37,20 @@ config LS2K_RESET
@@ -219,7 +219,7 @@ index fb4ac4b08e891..59b6027eeadf5 100644
 +
  endif # MIPS_PLATFORM_DEVICES
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4c71444e453a6..4dcbbcfcf7a1e 100644
+index 4c71444e453a..4dcbbcfcf7a1 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -2,3 +2,6 @@
@@ -231,7 +231,7 @@ index 4c71444e453a6..4dcbbcfcf7a1e 100644
 +obj-$(CONFIG_LEMOTE3A_LAPTOP) += lemote3a-laptop.o
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
 new file mode 100644
-index 0000000000000..02f2284743ed3
+index 000000000000..02f2284743ed
 --- /dev/null
 +++ b/drivers/platform/mips/emc1412.c
 @@ -0,0 +1,454 @@
@@ -691,7 +691,7 @@ index 0000000000000..02f2284743ed3
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
 new file mode 100644
-index 0000000000000..b06e7b6ae97c7
+index 000000000000..b06e7b6ae97c
 --- /dev/null
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -0,0 +1,1179 @@
@@ -1876,7 +1876,7 @@ index 0000000000000..b06e7b6ae97c7
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
 new file mode 100644
-index 0000000000000..6331e09722a1f
+index 000000000000..6331e09722a1
 --- /dev/null
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -0,0 +1,767 @@
@@ -2649,7 +2649,7 @@ index 0000000000000..6331e09722a1f
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
 new file mode 100644
-index 0000000000000..be42c58822901
+index 000000000000..be42c5882290
 --- /dev/null
 +++ b/drivers/platform/mips/sd5075.c
 @@ -0,0 +1,211 @@
@@ -2866,7 +2866,7 @@ index 0000000000000..be42c58822901
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/tmp75.c b/drivers/platform/mips/tmp75.c
 new file mode 100644
-index 0000000000000..0582c8fa2e2b2
+index 000000000000..0582c8fa2e2b
 --- /dev/null
 +++ b/drivers/platform/mips/tmp75.c
 @@ -0,0 +1,24 @@
@@ -2896,7 +2896,7 @@ index 0000000000000..0582c8fa2e2b2
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/wpce_fan.c b/drivers/platform/mips/wpce_fan.c
 new file mode 100644
-index 0000000000000..ecef3158c59bc
+index 000000000000..ecef3158c59b
 --- /dev/null
 +++ b/drivers/platform/mips/wpce_fan.c
 @@ -0,0 +1,311 @@
@@ -3212,5 +3212,5 @@ index 0000000000000..ecef3158c59bc
 +MODULE_DESCRIPTION("WPCE775L fan control driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From e6524d90b31d8e1f7e6f94a1d4fe6730855eae2e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 231/344] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 231/345] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 59b6027eeadf5..7ef9a47556d59 100644
+index 59b6027eeadf..7ef9a47556d5 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -39,7 +39,7 @@ config LS2K_RESET
@@ -28,5 +28,5 @@ index 59b6027eeadf5..7ef9a47556d59 100644
  	select LCD_CLASS_DEVICE
  	select BACKLIGHT_CLASS_DEVICE
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 1b6cd9188334336d4902d1bb281503f8a5fa5407 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 232/344] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 232/345] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index be42c58822901..02bb998210191 100644
+index be42c5882290..02bb99821019 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -93,7 +93,7 @@ static int sd5075_probe(struct platform_device *dev)
@@ -30,5 +30,5 @@ index be42c58822901..02bb998210191 100644
  		pr_err("failed to attach sd5075 sensor\n");
  		goto fail;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From ec178135bd33d311557aa1d7a7a36fc543155d94 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 233/344] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 233/345] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 02f2284743ed3..3fb2dcd600106 100644
+index 02f2284743ed..3fb2dcd60010 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -143,7 +143,7 @@ static int emc1412_probe(struct platform_device *dev)
@@ -30,5 +30,5 @@ index 02f2284743ed3..3fb2dcd600106 100644
  		printk(KERN_ERR "failed to attach EMC1412 sensor\n");
  		goto fail;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From 70fa06707d11d298fc67952dbb06daf4a10faf14 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 234/344] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 234/345] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index 02bb998210191..27e9fb359b9f6 100644
+index 02bb99821019..27e9fb359b9f 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -128,7 +128,7 @@ static ssize_t get_sd5075_label(struct device *dev,
@@ -28,5 +28,5 @@ index 02bb998210191..27e9fb359b9f6 100644
  	int reg_value = 0, temp;
  	
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From 280448f4053885946d4fee1ed15dced0ca1cc0bc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 235/344] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 235/345] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 3fb2dcd600106..bf2fa4b815c8f 100644
+index 3fb2dcd60010..bf2fa4b815c8 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -182,7 +182,7 @@ static void emc1412_shutdown(struct platform_device *dev)
@@ -46,5 +46,5 @@ index 3fb2dcd600106..bf2fa4b815c8f 100644
  	static int printed[MAX_PACKAGES] = {0, 0, 0, 0};
  	int i, value, temp_min = 50000, temp_max = -20000;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From 203ae81e75f745aced34987eb83bee8f2882cca6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 236/344] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 236/345] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 60 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index bf2fa4b815c8f..6524baddd6ca2 100644
+index bf2fa4b815c8..6524baddd6ca 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -336,66 +336,6 @@ static void do_thermal_timer(struct work_struct *work)
@@ -86,5 +86,5 @@ index bf2fa4b815c8f..6524baddd6ca2 100644
  	.probe		= emc1412_probe,
  	.shutdown	= emc1412_shutdown,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From 470c1d5c89ac3c41f3ac7045a4d8efce19e5dfbc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 237/344] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 237/345] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 24 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 6524baddd6ca2..fc1a26cd34fe0 100644
+index 6524baddd6ca..fc1a26cd34fe 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -174,30 +174,6 @@ static void emc1412_shutdown(struct platform_device *dev)
@@ -50,5 +50,5 @@ index 6524baddd6ca2..fc1a26cd34fe0 100644
  {
  	u8 reg;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From 36ecbdd5d9d1eb753b4f4c193e3c296bfdc59c81 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 238/344] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 238/345] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b06e7b6ae97c7..6e6b0c46aca4c 100644
+index b06e7b6ae97c..6e6b0c46aca4 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -625,9 +625,8 @@ static int lemote3a_set_brightness(struct backlight_device * pdev)
@@ -33,5 +33,5 @@ index b06e7b6ae97c7..6e6b0c46aca4c 100644
  	if (MAX_BRIGHTNESS < level) {
  		level = MAX_BRIGHTNESS;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From d1d67267e644d87963a056d6d3fee37a15babdfd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 239/344] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 239/345] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index 6e6b0c46aca4c..a8d339a3e30b7 100644
+index 6e6b0c46aca4..a8d339a3e30b 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -542,10 +542,16 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s
@@ -40,5 +40,5 @@ index 6e6b0c46aca4c..a8d339a3e30b7 100644
  	/* Process LID event */
  	lemote3a_sci_event_handler(SCI_EVENT_NUM_LID);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 5797567f6910e19d0d1ecdd147983eccc9a7d182 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 240/344] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 240/345] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 38 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
-index 6331e09722a1f..51c2017ebe1d6 100644
+index 6331e09722a1..51c2017ebe1d 100644
 --- a/drivers/platform/mips/sbx00_fan.c
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -97,10 +97,44 @@ static struct loongson_fan_policy fan_policy[MAX_SBX00_FANS];
@@ -69,5 +69,5 @@ index 6331e09722a1f..51c2017ebe1d6 100644
  /* up_temp & down_temp used in fan auto adjust */
  static u8 fan_up_temp[MAX_SBX00_FANS];
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From 33bf73bfa1c7651881ccd5bc3342d98098c405fa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 241/344] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 241/345] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 73 insertions(+)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 5b8f9cc325893..35d2be41a54c4 100644
+index 5b8f9cc32589..35d2be41a54c 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -1,10 +1,13 @@
@@ -127,5 +127,5 @@ index 5b8f9cc325893..35d2be41a54c4 100644
  
  static int rs780e_acpi_probe(struct platform_device *pdev)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From 1d6c71691ec750f41ba5fcb5628c870d448970fb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 242/344] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 242/345] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 35d2be41a54c4..6e53355be9d9f 100644
+index 35d2be41a54c..6e53355be9d9 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -95,7 +95,7 @@ static int __init power_button_init(void)
@@ -33,5 +33,5 @@ index 35d2be41a54c4..6e53355be9d9f 100644
  	case PCI_VENDOR_ID_AMD:
  	case PCI_VENDOR_ID_ATI:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From cb2f96f63e9280da123dd45a7d53fee294bbd1ff Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 243/344] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 243/345] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/input/keyboard/lmps2atkbd.h
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 7c4f309a4cb63..1cbc420807da0 100644
+index 7c4f309a4cb6..1cbc420807da 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -157,6 +157,17 @@ config KEYBOARD_ATKBD_RDI_KEYCODES
@@ -44,7 +44,7 @@ index 7c4f309a4cb63..1cbc420807da0 100644
  	tristate "Microchip AT42QT1050 Touch Sensor Chip"
  	depends on I2C
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 422e28ad1e8e2..477e6134b8585 100644
+index 422e28ad1e8e..477e6134b858 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -77,7 +77,13 @@ MODULE_PARM_DESC(terminal, "Enable break codes on an IBM Terminal keyboard conne
@@ -98,7 +98,7 @@ index 422e28ad1e8e2..477e6134b8585 100644
  
 diff --git a/drivers/input/keyboard/lmps2atkbd.h b/drivers/input/keyboard/lmps2atkbd.h
 new file mode 100644
-index 0000000000000..95d4ac5365c0d
+index 000000000000..95d4ac5365c0
 --- /dev/null
 +++ b/drivers/input/keyboard/lmps2atkbd.h
 @@ -0,0 +1,32 @@
@@ -135,5 +135,5 @@ index 0000000000000..95d4ac5365c0d
 +
 +	  0,  0,  0, 65, 99,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From 7eab1d3e84f9b77e59f91a299231028b6800b3dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 244/344] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 244/345] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 1cbc420807da0..730ba70a2461c 100644
+index 1cbc420807da..730ba70a2461 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -159,7 +159,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES
@@ -30,5 +30,5 @@ index 1cbc420807da0..730ba70a2461c 100644
  	help
  	  Say Y here if you want to use an AT or PS/2 keyboard, and your
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From 8a758f8b5ddab2b73f0e1a8c4538dcbe36bbc7ab Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 245/344] AOSCOS: input: atkbd: disable
+Subject: [PATCH 245/345] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 730ba70a2461c..d78baaf67a40d 100644
+index 730ba70a2461..d78baaf67a40 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -160,7 +160,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES
@@ -33,5 +33,5 @@ index 730ba70a2461c..d78baaf67a40d 100644
  	  Say Y here if you want to use an AT or PS/2 keyboard, and your
  	  keyboard uses keycodes that are specific to Lemote laptop (A1201)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 10a48e912d786263ddbb4d749f1dac9cb5e9121a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 246/344] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 246/345] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/ec_rom.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
+index 4dcbbcfcf7a1..5929b5ad7b6c 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,3 +5,4 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -27,7 +27,7 @@ index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
 +obj-m += ec_rom.o
 diff --git a/drivers/platform/mips/ec_rom.c b/drivers/platform/mips/ec_rom.c
 new file mode 100644
-index 0000000000000..b7b1624191f7a
+index 000000000000..b7b1624191f7
 --- /dev/null
 +++ b/drivers/platform/mips/ec_rom.c
 @@ -0,0 +1,179 @@
@@ -211,5 +211,5 @@ index 0000000000000..b7b1624191f7a
 +MODULE_DESCRIPTION("WPCE775L resources misc Management");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From 28271bff61081bdaaf489e37d614357f8460c612 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 247/344] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 247/345] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/pmon_flash.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 5929b5ad7b6cd..98eef2e092264 100644
+index 5929b5ad7b6c..98eef2e09226 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -6,3 +6,7 @@ obj-$(CONFIG_I2C_PIIX4) += emc1412.o sd5075.o tmp75.o
@@ -38,7 +38,7 @@ index 5929b5ad7b6cd..98eef2e092264 100644
 +endif
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
 new file mode 100644
-index 0000000000000..8fd5f4bf8b1bb
+index 000000000000..8fd5f4bf8b1b
 --- /dev/null
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -0,0 +1,100 @@
@@ -143,5 +143,5 @@ index 0000000000000..8fd5f4bf8b1bb
 +MODULE_AUTHOR("Yanhua");
 +MODULE_DESCRIPTION("MTD map driver for pmon programming module");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 3fd102e8fe6b6d80a271c5ac6d03f60bd2d0a8ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 248/344] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 248/345] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
-index 8fd5f4bf8b1bb..6c5a3c4342b29 100644
+index 8fd5f4bf8b1b..6c5a3c4342b2 100644
 --- a/drivers/platform/mips/pmon_flash.c
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -53,7 +53,7 @@ struct mtd_partition flash_parts[] = {
@@ -28,5 +28,5 @@ index 8fd5f4bf8b1bb..6c5a3c4342b29 100644
  	printk(KERN_NOTICE "Flash flash device: %x at %x\n",
  			FLASH_SIZE, FLASH_PHYS_ADDR);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From a7f0360502c91124a89c91108a33ff37833cbe52 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 249/344] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 249/345] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/at24c04.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 98eef2e092264..4dde0988fdadb 100644
+index 98eef2e09226..4dde0988fdad 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,7 +5,7 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -30,7 +30,7 @@ index 98eef2e092264..4dde0988fdadb 100644
  obj-m += pmon_flash.o
 diff --git a/drivers/platform/mips/at24c04.c b/drivers/platform/mips/at24c04.c
 new file mode 100644
-index 0000000000000..7ba3d1c8692e1
+index 000000000000..7ba3d1c8692e
 --- /dev/null
 +++ b/drivers/platform/mips/at24c04.c
 @@ -0,0 +1,26 @@
@@ -61,5 +61,5 @@ index 0000000000000..7ba3d1c8692e1
 +MODULE_DESCRIPTION("AT24c04 driver, based on the at24 driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From d485196593a95c734275322b2be67b049b3992f0 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 250/344] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 250/345] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ioremap.h b/arch/mips/include/asm/mach-loongson64/ioremap.h
 new file mode 100644
-index 0000000000000..155dafe2ef346
+index 000000000000..155dafe2ef34
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ioremap.h
 @@ -0,0 +1,44 @@
@@ -68,5 +68,5 @@ index 0000000000000..155dafe2ef346
 +
 +#endif /* __ASM_MACH_LOONGSON_IOREMAP_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 339638aebf3ccca1c7e25c7fa6730e9ad9e9d326 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 251/344] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 251/345] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/input/mouse/sentelic.c b/drivers/input/mouse/sentelic.c
-index 44b136fc29aaf..6ccdec46e1f44 100644
+index 44b136fc29aa..6ccdec46e1f4 100644
 --- a/drivers/input/mouse/sentelic.c
 +++ b/drivers/input/mouse/sentelic.c
 @@ -899,8 +899,8 @@ static int fsp_activate_protocol(struct psmouse *psmouse)
@@ -28,5 +28,5 @@ index 44b136fc29aaf..6ccdec46e1f44 100644
  		/* Enable absolute coordinates output for Cx/Dx hardware */
  		if (fsp_reg_write(psmouse, FSP_REG_SWC1,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 1b4a13a9243cbed3359e0d14ad07d810d8a6b851 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 252/344] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 252/345] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3
@@ -47,7 +47,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 42 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_64xx.c b/drivers/scsi/mvsas/mv_64xx.c
-index 1f2b61de8c632..855d8465b30f2 100644
+index 1f2b61de8c63..855d8465b30f 100644
 --- a/drivers/scsi/mvsas/mv_64xx.c
 +++ b/drivers/scsi/mvsas/mv_64xx.c
 @@ -376,10 +376,14 @@ static int mvs_64xx_init(struct mvs_info *mvi)
@@ -81,7 +81,7 @@ index 1f2b61de8c632..855d8465b30f2 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_94xx.c b/drivers/scsi/mvsas/mv_94xx.c
-index fc0b8eb682045..1d1042ab82c8c 100644
+index fc0b8eb68204..1d1042ab82c8 100644
 --- a/drivers/scsi/mvsas/mv_94xx.c
 +++ b/drivers/scsi/mvsas/mv_94xx.c
 @@ -515,10 +515,14 @@ static int mvs_94xx_init(struct mvs_info *mvi)
@@ -115,7 +115,7 @@ index fc0b8eb682045..1d1042ab82c8c 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 7f1ad305eee63..03a0ac5fab63f 100644
+index 7f1ad305eee6..03a0ac5fab63 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -10,7 +10,11 @@
@@ -139,7 +139,7 @@ index 7f1ad305eee63..03a0ac5fab63f 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index 15b3d9d55a4b6..b6b1bc6ff2c7c 100644
+index 15b3d9d55a4b..b6b1bc6ff2c7 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -255,6 +255,20 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -205,7 +205,7 @@ index 15b3d9d55a4b6..b6b1bc6ff2c7c 100644
  
  	case SAS_PROTOCOL_SATA:
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index 09ce3f2241f24..b6f5b739d67c9 100644
+index 09ce3f2241f2..b6f5b739d67c 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -429,6 +429,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,
@@ -217,5 +217,5 @@ index 09ce3f2241f24..b6f5b739d67c9 100644
  int mvs_scan_finished(struct Scsi_Host *shost, unsigned long time);
  int mvs_queue_command(struct sas_task *task, gfp_t gfp_flags);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From eebffae34033c7ab820750eb29756f08b4a25cb4 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 253/344] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 253/345] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/gpio/gpio-nct6102.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index c12d69c487474..109ce8d6d5fe6 100644
+index c12d69c48747..109ce8d6d5fe 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -546,6 +546,13 @@ config GPIO_NPCM_SGPIO
@@ -37,7 +37,7 @@ index c12d69c487474..109ce8d6d5fe6 100644
  	tristate "Cavium OCTEON GPIO"
  	depends on CAVIUM_OCTEON_SOC
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index 3d8b2a1606d57..d1ddf2acd5623 100644
+index 3d8b2a1606d5..d1ddf2acd562 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -131,6 +131,7 @@ obj-$(CONFIG_GPIO_MXC)			+= gpio-mxc.o
@@ -50,7 +50,7 @@ index 3d8b2a1606d57..d1ddf2acd5623 100644
  obj-$(CONFIG_GPIO_PALMAS)		+= gpio-palmas.o
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
 new file mode 100644
-index 0000000000000..25efc588c7612
+index 000000000000..25efc588c761
 --- /dev/null
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -0,0 +1,191 @@
@@ -246,5 +246,5 @@ index 0000000000000..25efc588c7612
 +}
 +subsys_initcall(nct6102_gpio_setup);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From 338d58e87f994fba3fec0bc99d73a1a972d140b9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 254/344] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 254/345] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 109ce8d6d5fe6..f1609c6fb2617 100644
+index 109ce8d6d5fe..f1609c6fb261 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -549,7 +549,7 @@ config GPIO_NPCM_SGPIO
@@ -27,5 +27,5 @@ index 109ce8d6d5fe6..f1609c6fb2617 100644
  	  Say yes here to support the NCT6102 GPIO device
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From cde6b336c8513fd584a1ddb5a1d602ca46e2eb9a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 255/344] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 255/345] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 25efc588c7612..547b61008390d 100644
+index 25efc588c761..547b61008390 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -6,6 +6,7 @@
@@ -28,5 +28,5 @@ index 25efc588c7612..547b61008390d 100644
  #define NCT6102_GPIO_BASE 	80
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From 73f40437e9e10f44bf51a36759c83f78ef364c72 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 256/344] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 256/345] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 9 deletions(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 547b61008390d..c376f9fd6d076 100644
+index 547b61008390..c376f9fd6d07 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -47,15 +47,6 @@ static unsigned char read_gbl(u8 gbl_reg)
@@ -34,5 +34,5 @@ index 547b61008390d..c376f9fd6d076 100644
   read/write_dev() is used to read/write Logical Device register.
   */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From ef37199aa8c15aa3a3606682e281638a9980f1d6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 257/344] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 257/345] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index c376f9fd6d076..1bb29ea5f5f2d 100644
+index c376f9fd6d07..1bb29ea5f5f2 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -170,7 +170,6 @@ static struct gpio_chip nct6102_chip = {
@@ -29,5 +29,5 @@ index c376f9fd6d076..1bb29ea5f5f2d 100644
  
  	/* Detect device */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 11506e9cbcafeee1ab7cf98f9106688a8e392d37 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 258/344] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 258/345] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 1bb29ea5f5f2d..143f0a139e212 100644
+index 1bb29ea5f5f2..143f0a139e21 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -177,6 +177,6 @@ static int __init nct6102_gpio_setup(void)
@@ -32,5 +32,5 @@ index 1bb29ea5f5f2d..143f0a139e212 100644
  }
  subsys_initcall(nct6102_gpio_setup);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From a6fd48e3de92becf8250f7b217683cc8ab0cf3f1 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 259/344] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 259/345] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/hwmon/nct7511.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index cfe74f1d5904b..a203dbb1a4255 100644
+index cfe74f1d5904..a203dbb1a425 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -1765,6 +1765,17 @@ config SENSORS_NCT7363
@@ -44,7 +44,7 @@ index cfe74f1d5904b..a203dbb1a4255 100644
  	tristate "Nuvoton NCT7802Y"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index 5ef7c156cc76c..bcb57b86becbe 100644
+index 5ef7c156cc76..bcb57b86becb 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -180,6 +180,7 @@ nct6775-objs			:= nct6775-platform.o
@@ -57,7 +57,7 @@ index 5ef7c156cc76c..bcb57b86becbe 100644
  obj-$(CONFIG_SENSORS_NPCM7XX)	+= npcm750-pwm-fan.o
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
 new file mode 100644
-index 0000000000000..a945ffc2ab3d5
+index 000000000000..a945ffc2ab3d
 --- /dev/null
 +++ b/drivers/hwmon/nct7511.c
 @@ -0,0 +1,801 @@
@@ -863,5 +863,5 @@ index 0000000000000..a945ffc2ab3d5
 +MODULE_DESCRIPTION("NCT7511Y Hardware Monitoring Driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From 2a5c91e606ae408a9a415899aea542c19b36468d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 260/344] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 260/345] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index a945ffc2ab3d5..e5006ecd83465 100644
+index a945ffc2ab3d..e5006ecd8346 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -709,7 +709,7 @@ static int nct7511_detect(struct i2c_client *client,
@@ -38,5 +38,5 @@ index a945ffc2ab3d5..e5006ecd83465 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From 6deaa0e6d42b9af3ff09c95f14be67cf09e17e48 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 261/344] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 261/345] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index e5006ecd83465..808755e2c37d5 100644
+index e5006ecd8346..808755e2c37d 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -744,8 +744,7 @@ static int nct7511_init_chip(struct nct7511_data *data)
@@ -30,5 +30,5 @@ index e5006ecd83465..808755e2c37d5 100644
  	struct device *dev = &client->dev;
  	struct nct7511_data *data;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From aabaa83ee3d48cbc94fe58a9c25fbe0737955c1b Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 262/344] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 262/345] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 74 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index c881bf213ebe6..fa2ba7be97496 100644
+index c881bf213ebe..fa2ba7be9749 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -1168,6 +1168,78 @@ static void add_cx5051_fake_mutes(struct hda_codec *codec)
@@ -117,5 +117,5 @@ index c881bf213ebe6..fa2ba7be97496 100644
  	spec->gen.own_eapd_ctl = 1;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 03c74dc5601b69175f7b4449bf1bbf6721321023 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 263/344] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 263/345] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 20 insertions(+)
 
 diff --git a/include/sound/hda_codec.h b/include/sound/hda_codec.h
-index ddc9c392f93f6..71501e6ef3ec2 100644
+index ddc9c392f93f..71501e6ef3ec 100644
 --- a/include/sound/hda_codec.h
 +++ b/include/sound/hda_codec.h
 @@ -371,6 +371,8 @@ struct hda_verb {
@@ -31,7 +31,7 @@ index ddc9c392f93f6..71501e6ef3ec2 100644
  			    const struct hda_verb *seq);
  
 diff --git a/sound/hda/common/codec.c b/sound/hda/common/codec.c
-index eb268d442201a..5a68ba6f82c76 100644
+index eb268d442201..5a68ba6f82c7 100644
 --- a/sound/hda/common/codec.c
 +++ b/sound/hda/common/codec.c
 @@ -68,6 +68,24 @@ static int codec_exec_verb(struct hdac_device *dev, unsigned int cmd,
@@ -60,5 +60,5 @@ index eb268d442201a..5a68ba6f82c76 100644
   * snd_hda_sequence_write - sequence writes
   * @codec: the HDA codec
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From 87272fb6bcca1d46ecb4e321034e98dcde5e76fb Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 264/344] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 264/345] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index fa2ba7be97496..1445e42caa5bb 100644
+index fa2ba7be9749..1445e42caa5b 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -43,6 +43,9 @@ struct conexant_spec {
@@ -51,5 +51,5 @@ index fa2ba7be97496..1445e42caa5bb 100644
  	if (!spec->dynamic_eapd)
  		cx_auto_turn_eapd(codec, spec->num_eapds, spec->eapds, true);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From cdaa4d573445a49e03b4c23b624d201aabd218e7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 265/344] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 265/345] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index 1445e42caa5bb..914d6e4c27fe0 100644
+index 1445e42caa5b..914d6e4c27fe 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -285,6 +285,7 @@ enum {
@@ -82,5 +82,5 @@ index 1445e42caa5bb..914d6e4c27fe0 100644
  		.type = HDA_FIXUP_PINS,
  		.chained = true,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From 94ecc3bff6a292704f8872f90b8c49621f1c856f Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 266/344] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 266/345] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
-index 5de856f65f0d5..49d550f90a23a 100644
+index 5de856f65f0d..49d550f90a23 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
 @@ -2120,6 +2120,7 @@ static const struct usb_device_id option_ids[] = {
@@ -26,5 +26,5 @@ index 5de856f65f0d5..49d550f90a23a 100644
  	{ USB_DEVICE_INTERFACE_CLASS(0x1e0e, 0x9011, 0xff),	/* Simcom SIM7500/SIM7600 RNDIS mode */
  	  .driver_info = RSVD(7) },
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From 05c8cb0c7629ef48016a23d9ee7ce793c31a36c5 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 267/344] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 267/345] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index 914d6e4c27fe0..08d856c0d885d 100644
+index 914d6e4c27fe..08d856c0d885 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -1323,6 +1323,13 @@ static int cx_probe(struct hda_codec *codec, const struct hda_device_id *id)
@@ -34,5 +34,5 @@ index 914d6e4c27fe0..08d856c0d885d 100644
  		codec->pin_amp_workaround = 1;
  		spec->gen.mixer_nid = 0x22;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From 76aa330d064108b2d29b3c1039569e8b5d559c97 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 268/344] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 268/345] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index 08d856c0d885d..12db34441e219 100644
+index 08d856c0d885..12db34441e21 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -1323,8 +1323,9 @@ static int cx_probe(struct hda_codec *codec, const struct hda_device_id *id)
@@ -30,5 +30,5 @@ index 08d856c0d885d..12db34441e219 100644
  		codec->pin_amp_workaround = 1;
  		snd_hda_pick_fixup(codec, cxt5066_fixup_models,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From eb6f6fa061140c0cbab67c85f643e52086210d7f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 269/344] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 269/345] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 82 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/e1000e/e1000.h b/drivers/net/ethernet/intel/e1000e/e1000.h
-index 952898151565f..083f3d88d1cca 100644
+index 952898151565..083f3d88d1cc 100644
 --- a/drivers/net/ethernet/intel/e1000e/e1000.h
 +++ b/drivers/net/ethernet/intel/e1000e/e1000.h
 @@ -228,6 +228,7 @@ struct e1000_adapter {
@@ -43,7 +43,7 @@ index 952898151565f..083f3d88d1cca 100644
  	u16 tx_ring_count;
  	u16 rx_ring_count;
 diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
-index b27a61fab3717..0806c263062ab 100644
+index b27a61fab371..0806c263062a 100644
 --- a/drivers/net/ethernet/intel/e1000e/netdev.c
 +++ b/drivers/net/ethernet/intel/e1000e/netdev.c
 @@ -637,6 +637,69 @@ static void e1000e_update_tdt_wa(struct e1000_ring *tx_ring, unsigned int i)
@@ -165,5 +165,5 @@ index b27a61fab3717..0806c263062ab 100644
  
  err_register:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From 7ce97f7750dddd2981e3cd7443f258732b4e9fd8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 270/344] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 270/345] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/message.c b/drivers/usb/core/message.c
-index d2b2787be4092..8128bd0fc00b7 100644
+index d2b2787be409..8128bd0fc00b 100644
 --- a/drivers/usb/core/message.c
 +++ b/drivers/usb/core/message.c
 @@ -1999,7 +1999,7 @@ int usb_set_configuration(struct usb_device *dev, int configuration)
@@ -48,5 +48,5 @@ index d2b2787be4092..8128bd0fc00b7 100644
  		for (i = 0; i < nintf; ++i) {
  			usb_disable_interface(dev, cp->interface[i], true);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From f0567a13fd44aeb6e0eb21a5b0475fa34b3ad8d0 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 271/344] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 271/345] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 52 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index fc60026bc6741..f1c686ef7a54b 100644
+index fc60026bc674..f1c686ef7a54 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -127,6 +127,13 @@ enum
@@ -36,7 +36,7 @@ index fc60026bc6741..f1c686ef7a54b 100644
  /*
   * The reported battery die temperature.
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 7ef9a47556d59..a5a80e0a399ff 100644
+index 7ef9a47556d5..a5a80e0a399f 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -49,6 +49,7 @@ config LEMOTE3A_LAPTOP
@@ -48,7 +48,7 @@ index 7ef9a47556d59..a5a80e0a399ff 100644
  	help
  	  Lemote Loongson-3A/2Gq family laptops driver.
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index a8d339a3e30b7..b6f585b0f7d35 100644
+index a8d339a3e30b..b6f585b0f7d3 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -19,12 +19,14 @@
@@ -151,5 +151,5 @@ index a8d339a3e30b7..b6f585b0f7d35 100644
  static int lemote3a_hotkey_init(void)
  {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From ad9040ea476f9c00439073b74e3026d5d6831303 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 272/344] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 272/345] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 61 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index f1c686ef7a54b..e1f8577a6ed61 100644
+index f1c686ef7a54..e1f8577a6ed6 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -320,6 +320,17 @@ enum
@@ -36,7 +36,7 @@ index f1c686ef7a54b..e1f8577a6ed61 100644
  /* EC Status query, by direct read 66h port. */
  #define EC_SMI_EVT		(1 << 6)	/* 1 = SMI event padding */
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b6f585b0f7d35..dbb37e376ee80 100644
+index b6f585b0f7d3..dbb37e376ee8 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -160,6 +160,7 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s
@@ -160,5 +160,5 @@ index b6f585b0f7d35..dbb37e376ee80 100644
  static int lemote3a_hotkey_init(void)
  {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 0e5aca64ceb9666e056ecc83dbc9bbd42decea0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 273/344] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 273/345] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.h
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2248badc3acb6..2e9ac29588c81 100644
+index 2248badc3acb..2e9ac29588c8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -4,6 +4,7 @@
@@ -39,7 +39,7 @@ index 2248badc3acb6..2e9ac29588c81 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-n32.h b/arch/mips/kernel/audit-n32.h
 new file mode 100644
-index 0000000000000..781de2e9ad66b
+index 000000000000..781de2e9ad66
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.h
 @@ -0,0 +1,5 @@
@@ -49,7 +49,7 @@ index 0000000000000..781de2e9ad66b
 +int audit_classify_syscall_n32(int abi, unsigned syscall);
 +#endif /* CONFIG_AUDITSYSCALL_N32 */
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 09ae3dbcfecbc..88e283f8df385 100644
+index 09ae3dbcfecb..88e283f8df38 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -2,6 +2,8 @@
@@ -72,7 +72,7 @@ index 09ae3dbcfecbc..88e283f8df385 100644
  {
  	int res;
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index e8b9b50f7d267..6bf302c04e5d3 100644
+index e8b9b50f7d26..6bf302c04e5d 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -4,6 +4,7 @@
@@ -85,7 +85,7 @@ index e8b9b50f7d267..6bf302c04e5d3 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-o32.h b/arch/mips/kernel/audit-o32.h
 new file mode 100644
-index 0000000000000..8a782fdd1c6e7
+index 000000000000..8a782fdd1c6e
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.h
 @@ -0,0 +1,5 @@
@@ -95,5 +95,5 @@ index 0000000000000..8a782fdd1c6e7
 +int audit_classify_syscall_o32(int abi, unsigned syscall);
 +#endif /* CONFIG_AUDITSYSCALL_O32 */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From 00a8e16664bc7c25af4789d974cc87fad5518aa8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 274/344] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 274/345] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 16 insertions(+), 13 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2e9ac29588c81..8d114bf854254 100644
+index 2e9ac29588c8..8d114bf85425 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -35,11 +35,11 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -38,7 +38,7 @@ index 2e9ac29588c81..8d114bf854254 100644
  		return 0;
  	}
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 88e283f8df385..4a0fecd0e4867 100644
+index 88e283f8df38..4a0fecd0e486 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -45,20 +45,20 @@ int audit_classify_syscall(int abi, unsigned syscall)
@@ -67,7 +67,7 @@ index 88e283f8df385..4a0fecd0e4867 100644
  	default:
  #ifdef CONFIG_AUDITSYSCALL_O32
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index 6bf302c04e5d3..818f91ce14acf 100644
+index 6bf302c04e5d..818f91ce14ac 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -35,15 +35,15 @@ int audit_classify_syscall_o32(int abi, unsigned syscall)
@@ -92,7 +92,7 @@ index 6bf302c04e5d3..818f91ce14acf 100644
  }
  
 diff --git a/include/linux/audit_arch.h b/include/linux/audit_arch.h
-index 0e34d673ef171..0436757bfc33e 100644
+index 0e34d673ef17..0436757bfc33 100644
 --- a/include/linux/audit_arch.h
 +++ b/include/linux/audit_arch.h
 @@ -17,6 +17,9 @@ enum auditsc_class_t {
@@ -106,7 +106,7 @@ index 0e34d673ef171..0436757bfc33e 100644
  	AUDITSC_NVALS /* count */
  };
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index e3a6a37e5e40a..a3016db68c27b 100644
+index e3a6a37e5e40..a3016db68c27 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -190,7 +190,7 @@ static int audit_match_perm(struct audit_context *ctx, int mask)
@@ -119,5 +119,5 @@ index e3a6a37e5e40a..a3016db68c27b 100644
  		     audit_match_class(AUDIT_CLASS_WRITE_N32, n))
  			return 1;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From 321cc2f14b935db0a028d1b261133523290b0937 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 275/344] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 275/345] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 27 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 8d114bf854254..76c95ff924f83 100644
+index 8d114bf85425..76c95ff924f8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -41,7 +41,7 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -29,7 +29,7 @@ index 8d114bf854254..76c95ff924f83 100644
  }
  
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 4a0fecd0e4867..763f0e6b3636a 100644
+index 4a0fecd0e486..763f0e6b3636 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -41,45 +41,26 @@ int audit_classify_arch(int arch)
@@ -86,5 +86,5 @@ index 4a0fecd0e4867..763f0e6b3636a 100644
  
  static int __init audit_classes_init(void)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From 4fe71de974b995ab018c93a2b1ba3620b74e61bd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 276/344] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 276/345] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 37 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index 63c47585afbcf..371e6cd211453 100644
+index 63c47585afbc..371e6cd21145 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -2403,6 +2403,8 @@ struct radeon_device {
@@ -31,7 +31,7 @@ index 63c47585afbcf..371e6cd211453 100644
  	struct mutex dc_hw_i2c_mutex; /* display controller hw i2c mutex */
  	bool has_uvd;
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 7a3e510327b79..f717c1ecf2b53 100644
+index 7a3e510327b7..f717c1ecf2b5 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1640,7 +1640,28 @@ int radeon_suspend_kms(struct drm_device *dev, bool suspend,
@@ -89,7 +89,7 @@ index 7a3e510327b79..f717c1ecf2b53 100644
  }
  
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index 9961251b44ba0..e5d5ea218579f 100644
+index 9961251b44ba..e5d5ea218579 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -307,6 +307,8 @@ static bool radeon_msi_ok(struct radeon_device *rdev)
@@ -112,5 +112,5 @@ index 9961251b44ba0..e5d5ea218579f 100644
  	r = radeon_irq_install(rdev, rdev->pdev->irq);
  	if (r) {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 52efa8a3901269ff5da97043a64cb0eaed74b3ab Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 277/344] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 277/345] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.h b/drivers/gpu/drm/radeon/radeon_device.h
-index 31a0ae295cc8f..e7f6d468b5674 100644
+index 31a0ae295cc8..e7f6d468b567 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.h
 +++ b/drivers/gpu/drm/radeon/radeon_device.h
 @@ -29,4 +29,6 @@
@@ -28,7 +28,7 @@ index 31a0ae295cc8f..e7f6d468b5674 100644
 +
  #endif                         /* __RADEON_DEVICE_H__ */
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index e5d5ea218579f..d4ad1fa826454 100644
+index e5d5ea218579..d4ad1fa82645 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -40,6 +40,7 @@
@@ -49,5 +49,5 @@ index e5d5ea218579f..d4ad1fa826454 100644
   * radeon_irq_kms_init - init driver interrupt info
   *
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From de996b2da7ed005191436ced8a1131f1b2540ffc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 278/344] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 278/345] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.
@@ -25,7 +25,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  4 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index f717c1ecf2b53..bb1f38a25a8b0 100644
+index f717c1ecf2b5..bb1f38a25a8b 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1788,6 +1788,7 @@ int radeon_gpu_reset(struct radeon_device *rdev)
@@ -55,7 +55,7 @@ index f717c1ecf2b53..bb1f38a25a8b0 100644
  	rdev->needs_reset = false;
  
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index b4fb7e70320b8..54b4b9b161f71 100644
+index b4fb7e70320b..54b4b9b161f7 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1854,10 +1854,11 @@ static bool radeon_pm_debug_check_in_vbl(struct radeon_device *rdev, bool finish
@@ -80,7 +80,7 @@ index b4fb7e70320b8..54b4b9b161f71 100644
  
  /*
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index f4d9e68b21e70..69bca4efee30c 100644
+index f4d9e68b21e7..69bca4efee30 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -331,6 +331,20 @@ void ttm_bo_put(struct ttm_buffer_object *bo)
@@ -105,7 +105,7 @@ index f4d9e68b21e70..69bca4efee30c 100644
  				     struct ttm_operation_ctx *ctx,
  				     struct ttm_place *hop)
 diff --git a/include/drm/ttm/ttm_bo.h b/include/drm/ttm/ttm_bo.h
-index 479b7ed075c0f..19880b94f18a2 100644
+index 479b7ed075c0..19880b94f18a 100644
 --- a/include/drm/ttm/ttm_bo.h
 +++ b/include/drm/ttm/ttm_bo.h
 @@ -355,6 +355,22 @@ static inline void ttm_bo_move_null(struct ttm_buffer_object *bo,
@@ -132,5 +132,5 @@ index 479b7ed075c0f..19880b94f18a2 100644
   * ttm_bo_unreserve
   *
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 1b836fd351a0c5b98faf90644d740e326132442f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 279/344] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 279/345] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index bb1f38a25a8b0..53183a6f42746 100644
+index bb1f38a25a8b..53183a6f4274 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1656,7 +1656,7 @@ void radeon_recover_callback(struct work_struct *work)
@@ -32,5 +32,5 @@ index bb1f38a25a8b0..53183a6f42746 100644
  	up_write(&rdev->exclusive_lock);
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From afd6c4a5d552de06c80df6eef4879ff7a8b3dfa5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 280/344] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 280/345] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index 69bca4efee30c..094beeba0bd30 100644
+index 69bca4efee30..094beeba0bd3 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -333,14 +333,14 @@ EXPORT_SYMBOL(ttm_bo_put);
@@ -47,7 +47,7 @@ index 69bca4efee30c..094beeba0bd30 100644
  }
  EXPORT_SYMBOL(ttm_bo_unlock_delayed_workqueue);
 diff --git a/include/drm/ttm/ttm_device.h b/include/drm/ttm/ttm_device.h
-index c2e61312a43a2..de7195ef9b131 100644
+index c2e61312a43a..de7195ef9b13 100644
 --- a/include/drm/ttm/ttm_device.h
 +++ b/include/drm/ttm/ttm_device.h
 @@ -276,6 +276,11 @@ struct ttm_device {
@@ -63,5 +63,5 @@ index c2e61312a43a2..de7195ef9b131 100644
  
  int ttm_global_swapout(struct ttm_operation_ctx *ctx, gfp_t gfp_flags);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 8186c798e1fd020ce3f96960e5e6d1e07a9dff7b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 281/344] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 281/345] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1ce165c627a6c..493022119c1a7 100644
+index 1ce165c627a6..493022119c1a 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,6 +1010,9 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -27,7 +27,7 @@ index 1ce165c627a6c..493022119c1a7 100644
  						 evergreen_golden_registers,
  						 (const u32)ARRAY_SIZE(evergreen_golden_registers));
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 54b4b9b161f71..c6c60f1b64cbf 100644
+index 54b4b9b161f7..c6c60f1b64cb 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1520,6 +1520,7 @@ int radeon_pm_init(struct radeon_device *rdev)
@@ -47,5 +47,5 @@ index 54b4b9b161f71..c6c60f1b64cbf 100644
  	case CHIP_HEMLOCK:
  	case CHIP_PALM:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From 92ca21b009d32805c3cc99f6229988877d224b7e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 282/344] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 282/345] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 493022119c1a7..1a15f9264ead0 100644
+index 493022119c1a..1a15f9264ead 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,8 +1010,10 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -31,7 +31,7 @@ index 493022119c1a7..1a15f9264ead0 100644
  		radeon_program_register_sequence(rdev,
  						 evergreen_golden_registers,
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index c6c60f1b64cbf..539065746db08 100644
+index c6c60f1b64cb..539065746db0 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1520,7 +1520,9 @@ int radeon_pm_init(struct radeon_device *rdev)
@@ -55,5 +55,5 @@ index c6c60f1b64cbf..539065746db08 100644
  	case CHIP_HEMLOCK:
  	case CHIP_PALM:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From c4f72536f4a0e6a4f265369aa184bf8428dd440a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 283/344] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 283/345] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 539065746db08..f5ee0cc05c2d0 100644
+index 539065746db0..f5ee0cc05c2d 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1354,7 +1354,7 @@ static int radeon_pm_init_old(struct radeon_device *rdev)
@@ -25,5 +25,5 @@ index 539065746db08..f5ee0cc05c2d0 100644
  	rdev->pm.dynpm_planned_action = DYNPM_ACTION_NONE;
  	rdev->pm.dynpm_can_upclock = true;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From b86626f5213ee496d0b3ba71be11e0668a993747 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 284/344] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 284/345] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do
@@ -27,7 +27,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  12 files changed, 35 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 7e7f6248b63a6..170d54c4b5eb5 100644
+index 7e7f6248b63a..170d54c4b5eb 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -5435,6 +5435,7 @@ static int cik_pcie_gart_enable(struct radeon_device *rdev)
@@ -39,7 +39,7 @@ index 7e7f6248b63a6..170d54c4b5eb5 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1a15f9264ead0..4a7774c35e850 100644
+index 1a15f9264ead..4a7774c35e85 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -2414,6 +2414,7 @@ static int evergreen_pcie_gart_enable(struct radeon_device *rdev)
@@ -51,7 +51,7 @@ index 1a15f9264ead0..4a7774c35e850 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/ni.c b/drivers/gpu/drm/radeon/ni.c
-index 3890911fe693c..03335fa3367bb 100644
+index 3890911fe693..03335fa3367b 100644
 --- a/drivers/gpu/drm/radeon/ni.c
 +++ b/drivers/gpu/drm/radeon/ni.c
 @@ -1256,6 +1256,7 @@ static int cayman_pcie_gart_enable(struct radeon_device *rdev)
@@ -63,7 +63,7 @@ index 3890911fe693c..03335fa3367bb 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/r100.c b/drivers/gpu/drm/radeon/r100.c
-index 80703417d8a18..c926e3b27df89 100644
+index 80703417d8a1..c926e3b27df8 100644
 --- a/drivers/gpu/drm/radeon/r100.c
 +++ b/drivers/gpu/drm/radeon/r100.c
 @@ -672,6 +672,7 @@ int r100_pci_gart_enable(struct radeon_device *rdev)
@@ -75,7 +75,7 @@ index 80703417d8a18..c926e3b27df89 100644
  	tmp = RREG32(RADEON_AIC_CNTL) | RADEON_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32(RADEON_AIC_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r300.c b/drivers/gpu/drm/radeon/r300.c
-index d22889fbfa9c8..59404a4605727 100644
+index d22889fbfa9c..59404a460572 100644
 --- a/drivers/gpu/drm/radeon/r300.c
 +++ b/drivers/gpu/drm/radeon/r300.c
 @@ -161,6 +161,7 @@ int rv370_pcie_gart_enable(struct radeon_device *rdev)
@@ -87,7 +87,7 @@ index d22889fbfa9c8..59404a4605727 100644
  	tmp = RADEON_PCIE_TX_GART_UNMAPPED_ACCESS_DISCARD;
  	WREG32_PCIE(RADEON_PCIE_TX_GART_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 88e38fb3f3476..4c57b429af216 100644
+index 88e38fb3f347..4c57b429af21 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -1137,6 +1137,7 @@ static int r600_pcie_gart_enable(struct radeon_device *rdev)
@@ -99,7 +99,7 @@ index 88e38fb3f3476..4c57b429af216 100644
  	/* Setup L2 cache */
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index 371e6cd211453..cc0bc138f56b0 100644
+index 371e6cd21145..cc0bc138f56b 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -625,6 +625,7 @@ void radeon_gart_unbind(struct radeon_device *rdev, unsigned offset,
@@ -111,7 +111,7 @@ index 371e6cd211453..cc0bc138f56b0 100644
  
  /*
 diff --git a/drivers/gpu/drm/radeon/radeon_gart.c b/drivers/gpu/drm/radeon/radeon_gart.c
-index 4bb242437ff60..b34b8b9066947 100644
+index 4bb242437ff6..b34b8b906694 100644
 --- a/drivers/gpu/drm/radeon/radeon_gart.c
 +++ b/drivers/gpu/drm/radeon/radeon_gart.c
 @@ -317,6 +317,30 @@ int radeon_gart_bind(struct radeon_device *rdev, unsigned int offset,
@@ -146,7 +146,7 @@ index 4bb242437ff60..b34b8b9066947 100644
   * radeon_gart_init - init the driver info for managing the gart
   *
 diff --git a/drivers/gpu/drm/radeon/rs400.c b/drivers/gpu/drm/radeon/rs400.c
-index 13cd0a688a65c..6dad165e90fcc 100644
+index 13cd0a688a65..6dad165e90fc 100644
 --- a/drivers/gpu/drm/radeon/rs400.c
 +++ b/drivers/gpu/drm/radeon/rs400.c
 @@ -113,6 +113,7 @@ int rs400_gart_enable(struct radeon_device *rdev)
@@ -158,7 +158,7 @@ index 13cd0a688a65c..6dad165e90fcc 100644
  	tmp |= RS690_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32_MC(RS690_AIC_CTRL_SCRATCH, tmp);
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 88c8e91ea6512..7cfe137d7dcdd 100644
+index 88c8e91ea651..7cfe137d7dcd 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -571,6 +571,7 @@ static int rs600_gart_enable(struct radeon_device *rdev)
@@ -170,7 +170,7 @@ index 88c8e91ea6512..7cfe137d7dcdd 100644
  	tmp = RREG32(RADEON_BUS_CNTL) & ~RS600_BUS_MASTER_DIS;
  	WREG32(RADEON_BUS_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/rv770.c b/drivers/gpu/drm/radeon/rv770.c
-index 7d4b0bf591090..c7317aff4cd64 100644
+index 7d4b0bf59109..c7317aff4cd6 100644
 --- a/drivers/gpu/drm/radeon/rv770.c
 +++ b/drivers/gpu/drm/radeon/rv770.c
 @@ -903,6 +903,7 @@ static int rv770_pcie_gart_enable(struct radeon_device *rdev)
@@ -182,7 +182,7 @@ index 7d4b0bf591090..c7317aff4cd64 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 2d7eeb781969d..8c66b602009e3 100644
+index 2d7eeb781969..8c66b602009e 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -4273,6 +4273,7 @@ static int si_pcie_gart_enable(struct radeon_device *rdev)
@@ -194,5 +194,5 @@ index 2d7eeb781969d..8c66b602009e3 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From f9fb78a8a08e8bf45de33bbd982d8d0aef385c97 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 285/344] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 285/345] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 7cfe137d7dcdd..8fb559af1a37f 100644
+index 7cfe137d7dcd..8fb559af1a37 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -654,6 +654,9 @@ uint64_t rs600_gart_get_page_entry(uint64_t addr, uint32_t flags)
@@ -31,5 +31,5 @@ index 7cfe137d7dcdd..8fb559af1a37f 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From 704a7e29c79e5a985420caf754e7c78c9fd0e4f4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 286/344] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 286/345] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index 3659af7e519db..ff7f6f278f8fa 100644
+index 3659af7e519d..ff7f6f278f8f 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -34,7 +34,7 @@ static int g_hwcursor = 1;
@@ -24,5 +24,5 @@ index 3659af7e519db..ff7f6f278f8fa 100644
  static int g_dualview;
  static char *g_option;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From eca0aa1a8f6f5015aa399ac70dd85daedc29228f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 287/344] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 287/345] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index ff7f6f278f8fa..7add1b65932df 100644
+index ff7f6f278f8f..7add1b65932d 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -30,7 +30,7 @@
@@ -34,5 +34,5 @@ index ff7f6f278f8fa..7add1b65932df 100644
  	if (!src || !*src) {
  		dev_warn(&sm750_dev->pdev->dev, "no specific g_option.\n");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 053a8981a757ce9e4bf0e3d68509ad28b02d5c71 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 288/344] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 288/345] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index 23fda821d6b38..f4ac256d91dd3 100644
+index 23fda821d6b3..f4ac256d91dd 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -131,7 +131,9 @@ MODULE_PARM_DESC(unmask_kbd_data, "Unconditional enable (may reveal sensitive da
@@ -32,5 +32,5 @@ index 23fda821d6b38..f4ac256d91dd3 100644
  static char i8042_aux_firmware_id[128];
  static struct fwnode_handle *i8042_kbd_fwnode;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From e6ecfa7bf8011631cfc8190493e4cad15121248f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 289/344] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 289/345] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 76 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/igb/igb.h b/drivers/net/ethernet/intel/igb/igb.h
-index c3f4f7cd264e9..b6038182800e4 100644
+index c3f4f7cd264e..b6038182800e 100644
 --- a/drivers/net/ethernet/intel/igb/igb.h
 +++ b/drivers/net/ethernet/intel/igb/igb.h
 @@ -380,6 +380,13 @@ struct igb_q_vector {
@@ -30,7 +30,7 @@ index c3f4f7cd264e9..b6038182800e4 100644
  	struct igb_ring ring[] ____cacheline_internodealigned_in_smp;
  };
 diff --git a/drivers/net/ethernet/intel/igb/igb_main.c b/drivers/net/ethernet/intel/igb/igb_main.c
-index 453deb6d14b31..b2791796a427c 100644
+index 453deb6d14b3..b2791796a427 100644
 --- a/drivers/net/ethernet/intel/igb/igb_main.c
 +++ b/drivers/net/ethernet/intel/igb/igb_main.c
 @@ -4223,6 +4223,15 @@ static int __igb_open(struct net_device *netdev, bool resuming)
@@ -124,5 +124,5 @@ index 453deb6d14b31..b2791796a427c 100644
  		union e1000_adv_rx_desc *rx_desc;
  		struct igb_rx_buffer *rx_buffer;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0290-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From b7a617711c37838bd94a3ad18ea51f4d262e885e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 290/344] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 290/345] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!
@@ -31,7 +31,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/staging/sb105x/sb_ser_core.h
 
 diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
-index 075e775d3868b..bd2999a91b31f 100644
+index 075e775d3868..bd2999a91b31 100644
 --- a/drivers/staging/Kconfig
 +++ b/drivers/staging/Kconfig
 @@ -36,6 +36,8 @@ source "drivers/staging/nvec/Kconfig"
@@ -44,7 +44,7 @@ index 075e775d3868b..bd2999a91b31f 100644
  
  source "drivers/staging/most/Kconfig"
 diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
-index e681e403509ce..7d80e07d27583 100644
+index e681e403509c..7d80e07d2758 100644
 --- a/drivers/staging/Makefile
 +++ b/drivers/staging/Makefile
 @@ -8,6 +8,7 @@ obj-$(CONFIG_VME_BUS)		+= vme_user/
@@ -57,7 +57,7 @@ index e681e403509ce..7d80e07d27583 100644
  obj-$(CONFIG_GREYBUS)		+= greybus/
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
 new file mode 100644
-index 0000000000000..245e7847a3542
+index 000000000000..245e7847a354
 --- /dev/null
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -0,0 +1,9 @@
@@ -72,7 +72,7 @@ index 0000000000000..245e7847a3542
 +	  will be called "sb105x".
 diff --git a/drivers/staging/sb105x/Makefile b/drivers/staging/sb105x/Makefile
 new file mode 100644
-index 0000000000000..b1bf3779acaed
+index 000000000000..b1bf3779acae
 --- /dev/null
 +++ b/drivers/staging/sb105x/Makefile
 @@ -0,0 +1,3 @@
@@ -81,7 +81,7 @@ index 0000000000000..b1bf3779acaed
 +sb105x-y :=  sb_pci_mp.o
 diff --git a/drivers/staging/sb105x/sb_mp_register.h b/drivers/staging/sb105x/sb_mp_register.h
 new file mode 100644
-index 0000000000000..276c1bbcc18dd
+index 000000000000..276c1bbcc18d
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_mp_register.h
 @@ -0,0 +1,295 @@
@@ -382,7 +382,7 @@ index 0000000000000..276c1bbcc18dd
 +#endif 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
 new file mode 100644
-index 0000000000000..c9d6ee3903adc
+index 000000000000..c9d6ee3903ad
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -0,0 +1,3189 @@
@@ -3577,7 +3577,7 @@ index 0000000000000..c9d6ee3903adc
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
 new file mode 100644
-index 0000000000000..80ae4ab046031
+index 000000000000..80ae4ab04603
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -0,0 +1,291 @@
@@ -3874,7 +3874,7 @@ index 0000000000000..80ae4ab046031
 +
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
 new file mode 100644
-index 0000000000000..c8fb991732997
+index 000000000000..c8fb99173299
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -0,0 +1,368 @@
@@ -4247,5 +4247,5 @@ index 0000000000000..c8fb991732997
 +
 +
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From 1b11bc291bfb0773edd1faec9decec0704cd6741 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 291/344] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 291/345] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
 new file mode 100644
-index 0000000000000..a780ee51a7188
+index 000000000000..a780ee51a718
 --- /dev/null
 +++ b/arch/mips/include/asm/serial.h
 @@ -0,0 +1,19 @@
@@ -45,7 +45,7 @@ index 0000000000000..a780ee51a7188
 +
 +#endif /* __ASM__SERIAL_H */
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
-index 245e7847a3542..c5f741e71c14b 100644
+index 245e7847a354..c5f741e71c14 100644
 --- a/drivers/staging/sb105x/Kconfig
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -1,7 +1,7 @@
@@ -58,7 +58,7 @@ index 245e7847a3542..c5f741e71c14b 100644
  	  A driver for the SystemBase Multi-2/PCI serial card
  
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c9d6ee3903adc..18e91bc61ba16 100644
+index c9d6ee3903ad..18e91bc61ba1 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1,6 +1,7 @@
@@ -314,7 +314,7 @@ index c9d6ee3903adc..18e91bc61ba16 100644
              
  	   		     	if (status != 0)
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
-index 80ae4ab046031..0920beb31c15e 100644
+index 80ae4ab04603..0920beb31c15 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.h
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -287,5 +287,4 @@ static const struct sb105x_uart_config uart_config[] = {
@@ -325,5 +325,5 @@ index 80ae4ab046031..0920beb31c15e 100644
 -
 +static struct tty_port tt_port[MAX_MP_PORT];
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From 79f3fd2369b9efd91c542b3c2d018d31c16aceaf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 292/344] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 292/345] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index c8fb991732997..8835415e1d3df 100644
+index c8fb99173299..8835415e1d3d 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -196,13 +196,13 @@ struct uart_driver {
@@ -55,5 +55,5 @@ index c8fb991732997..8835415e1d3df 100644
          unsigned int quot;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From 4b3ea80497f964582d5e2b7d55d8e17c69100e85 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 293/344] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 293/345] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 18e91bc61ba16..e333245ec9c5d 100644
+index 18e91bc61ba1..e333245ec9c5 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -480,7 +480,7 @@ static void __mp_start(struct tty_struct *tty)
@@ -41,7 +41,7 @@ index 18e91bc61ba16..e333245ec9c5d 100644
  
  	return put_user(result, value);
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index 8835415e1d3df..d8664e723b4a3 100644
+index 8835415e1d3d..d8664e723b4a 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -52,7 +52,7 @@
@@ -54,5 +54,5 @@ index 8835415e1d3df..d8664e723b4a3 100644
  #define UART_ENABLE_MS(port,cflag)	((port)->flags & UPF_HARDPPS_CD || \
  					 (cflag) & CRTSCTS || \
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From f6209bc8bf2c21a89c27c25bda1fd9ba0f0a79b9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 294/344] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 294/345] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index e333245ec9c5d..963f3091a5c95 100644
+index e333245ec9c5..963f3091a5c9 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1051,7 +1051,7 @@ static int mp_wait_modem_status(struct sb_uart_state *state, unsigned long arg)
@@ -31,5 +31,5 @@ index e333245ec9c5d..963f3091a5c95 100644
  
  	return ret;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 813b70133735b14e233b903616c06c01fe020110 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 295/344] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 295/345] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 963f3091a5c95..cd98d3b0183da 100644
+index 963f3091a5c9..cd98d3b0183d 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1624,7 +1624,7 @@ static inline void mp_report_port(struct uart_driver *drv, struct sb_uart_port *
@@ -39,5 +39,5 @@ index 963f3091a5c95..cd98d3b0183da 100644
  	}
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From 309dd516004192ddff86942ba16673166ff3501f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 296/344] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 296/345] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all
@@ -21,7 +21,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index cd98d3b0183da..ccf02cfeb2fcc 100644
+index cd98d3b0183d..ccf02cfeb2fc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1728,12 +1728,10 @@ static int mp_register_driver(struct uart_driver *drv)
@@ -50,5 +50,5 @@ index cd98d3b0183da..ccf02cfeb2fcc 100644
  
  	tty_set_operations(normal, &sb_mp_ops);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From d9410c30aba38594cf0bf838080952d69e39eb9b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 297/344] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 297/345] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index ccf02cfeb2fcc..c5e1c39e7a7a2 100644
+index ccf02cfeb2fc..c5e1c39e7a7a 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1765,7 +1765,7 @@ for (i = 0; i < drv->nr; i++) {
@@ -40,5 +40,5 @@ index ccf02cfeb2fcc..c5e1c39e7a7a2 100644
  
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From ff096cb595c4e7497ed86d66ba3fd7126145f690 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 298/344] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 298/345] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
-index a780ee51a7188..2777148dbfc5a 100644
+index a780ee51a718..2777148dbfc5 100644
 --- a/arch/mips/include/asm/serial.h
 +++ b/arch/mips/include/asm/serial.h
 @@ -12,7 +12,6 @@
@@ -30,5 +30,5 @@ index a780ee51a7188..2777148dbfc5a 100644
  #endif
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From fa91bbfa94685174b397c904f2d4662933c4d928 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 299/344] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 299/345] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c5e1c39e7a7a2..32f60de269ccb 100644
+index c5e1c39e7a7a..32f60de269cc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -2808,7 +2808,7 @@ static void __init multi_init_ports(void)
@@ -31,5 +31,5 @@ index c5e1c39e7a7a2..32f60de269ccb 100644
  			mtpt->port.ops      = &multi_pops;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 1fc36e6e8a591c4797add5d4c3df5d272758ff88 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 300/344] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 300/345] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 32f60de269ccb..841e9b15486b0 100644
+index 32f60de269cc..841e9b15486b 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1736,7 +1736,6 @@ static int mp_register_driver(struct uart_driver *drv)
@@ -28,5 +28,5 @@ index 32f60de269ccb..841e9b15486b0 100644
  	normal->name		= drv->dev_name;
  	normal->major		= drv->major;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From 1812810cc1d79d296553cbbe7e25fa803e3b9eb9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 301/344] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 301/345] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 841e9b15486b0..0d7e216fad94a 100644
+index 841e9b15486b..0d7e216fad94 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -33,7 +33,7 @@ static void mp_tasklet_action(unsigned long data);
@@ -78,7 +78,7 @@ index 841e9b15486b0..0d7e216fad94a 100644
  	struct mp_port *mtpt = (struct mp_port *)port;
  	unsigned char cval, fcr = 0;
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index d8664e723b4a3..978b4b26ddbb1 100644
+index d8664e723b4a..978b4b26ddbb 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -77,7 +77,7 @@ struct sb_uart_ops {
@@ -100,5 +100,5 @@ index d8664e723b4a3..978b4b26ddbb1 100644
  {
          unsigned int try, baud, altbaud = 38400;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From 6401a77119d2594877faa2747f48788c3981aa29 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 302/344] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 302/345] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 0d7e216fad94a..f61451fabdcd0 100644
+index 0d7e216fad94..f61451fabdcd 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -39,7 +39,7 @@ static inline int __mp_put_char(struct sb_uart_port *port, struct circ_buf *circ
@@ -41,5 +41,5 @@ index 0d7e216fad94a..f61451fabdcd0 100644
  	struct sb_uart_state *state = tty->driver_data;
  	struct sb_uart_port *port;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From 22777d72f108b7a6a89bbd06880bc2b7a1fb331f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 303/344] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 303/345] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index f61451fabdcd0..593835f0ad11c 100644
+index f61451fabdcd..593835f0ad11 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -40,7 +40,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);
@@ -41,5 +41,5 @@ index f61451fabdcd0..593835f0ad11c 100644
  	struct sb_uart_state *state = tty->driver_data;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 9ab368d3aaa6b6fe64a47b4bf251160970e379da Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 304/344] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 304/345] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 593835f0ad11c..8712e74230648 100644
+index 593835f0ad11..8712e7423064 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -41,7 +41,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);
@@ -41,5 +41,5 @@ index 593835f0ad11c..8712e74230648 100644
  	struct sb_uart_state *state = tty->driver_data;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 379ba84e343b18392e78e7e094c279f6ed7558d7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 305/344] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 305/345] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 8712e74230648..19098bbfa113e 100644
+index 8712e7423064..19098bbfa113 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -43,7 +43,7 @@ static ssize_t mp_write(struct tty_struct *tty, const unsigned char *buf, long u
@@ -42,5 +42,5 @@ index 8712e74230648..19098bbfa113e 100644
  	struct sb_uart_state *state = tty->driver_data;
  	struct sb_uart_port *port = state->port;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From 09fbc0fc94733258b967bb790b1a0175ea97f46e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 306/344] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 306/345] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 22 insertions(+)
 
 diff --git a/drivers/parport/parport_serial.c b/drivers/parport/parport_serial.c
-index 24d4f3a3ec3d0..9e1af7103d603 100644
+index 24d4f3a3ec3d..9e1af7103d60 100644
 --- a/drivers/parport/parport_serial.c
 +++ b/drivers/parport/parport_serial.c
 @@ -60,6 +60,7 @@ enum parport_pc_pci_cards {
@@ -63,7 +63,7 @@ index 24d4f3a3ec3d0..9e1af7103d603 100644
  		.flags		= FL_BASE2,
  		.num_ports	= 5,
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 152f914c599dc..fd2c9fa64bedb 100644
+index 152f914c599d..fd2c9fa64bed 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,6 +74,7 @@
@@ -99,5 +99,5 @@ index 152f914c599dc..fd2c9fa64bedb 100644
  	/* Intel platforms with MID UART */
  	{ PCI_VDEVICE(INTEL, 0x081b), REPORT_8250_CONFIG(MID), },
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 74931dd758a5a6a6bdbabada5d041f57f65da38c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 307/344] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 307/345] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in
@@ -19,7 +19,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index fd2c9fa64bedb..5091a94b559f3 100644
+index fd2c9fa64bed..5091a94b559f 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -332,6 +332,12 @@ static int pci_plx9050_init(struct pci_dev *dev)
@@ -63,7 +63,7 @@ index fd2c9fa64bedb..5091a94b559f3 100644
  		PCI_VENDOR_ID_PLX,
  		PCI_SUBDEVICE_ID_UNKNOWN_0x1588, 0, 0,
 diff --git a/drivers/tty/serial/8250/8250_pcilib.c b/drivers/tty/serial/8250/8250_pcilib.c
-index d8d0ae0d72387..cd70b62dbbb94 100644
+index d8d0ae0d7238..cd70b62dbbb9 100644
 --- a/drivers/tty/serial/8250/8250_pcilib.c
 +++ b/drivers/tty/serial/8250/8250_pcilib.c
 @@ -27,6 +27,12 @@ int serial8250_pci_setup_port(struct pci_dev *dev, struct uart_8250_port *port,
@@ -80,5 +80,5 @@ index d8d0ae0d72387..cd70b62dbbb94 100644
  		if (!pcim_iomap(dev, bar, 0) && !pcim_iomap_table(dev))
  			return -ENOMEM;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From 2725fc0813d7db4b6bc350a195217584486d5286 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 308/344] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 308/345] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 52 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index ded5348d190c5..2a41357e571f8 100644
+index ded5348d190c..2a41357e571f 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -671,7 +671,17 @@
@@ -36,7 +36,7 @@ index ded5348d190c5..2a41357e571f8 100644
  #define USB_VENDOR_ID_INTEL_0		0x8086
  #define USB_VENDOR_ID_INTEL_1		0x8087
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index dd200064e3093..05fcba979607e 100644
+index dd200064e309..05fcba979607 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -2366,7 +2366,47 @@ static const struct hid_device_id mt_devices[] = {
@@ -89,5 +89,5 @@ index dd200064e3093..05fcba979607e 100644
  	/* LG Melfas panel */
  	{ .driver_data = MT_CLS_LG,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From f5157babcb3a5f4adefc6504bd55f4408a51f290 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 309/344] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 309/345] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt
@@ -23,7 +23,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/host/ohci-hcd.c b/drivers/usb/host/ohci-hcd.c
-index 9c7f3008646ed..0d263f99f9154 100644
+index 9c7f3008646e..0d263f99f915 100644
 --- a/drivers/usb/host/ohci-hcd.c
 +++ b/drivers/usb/host/ohci-hcd.c
 @@ -1139,8 +1139,10 @@ int ohci_resume(struct usb_hcd *hcd, bool hibernated)
@@ -39,5 +39,5 @@ index 9c7f3008646ed..0d263f99f9154 100644
  	/* See if the controller is already running or has been reset */
  	ohci->hc_control = ohci_readl(ohci, &ohci->regs->control);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From 1e88c4f886af0c8d187ce056cc23a7bf367d68d0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 310/344] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 310/345] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 drivers/platform/mips/ls7a_fan.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dde0988fdadb..a3e9e6b2f38fb 100644
+index 4dde0988fdad..a3e9e6b2f38f 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -3,7 +3,7 @@ obj-$(CONFIG_CPU_HWMON) += cpu_hwmon.o
@@ -28,7 +28,7 @@ index 4dde0988fdadb..a3e9e6b2f38fb 100644
  
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
 new file mode 100644
-index 0000000000000..cc188d4d05762
+index 000000000000..cc188d4d0576
 --- /dev/null
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -0,0 +1,598 @@
@@ -631,5 +631,5 @@ index 0000000000000..cc188d4d05762
 +MODULE_DESCRIPTION("LS7A fan control driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From 5f28d9d500a12c50b7d7d101a08af6ff812e74a6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 311/344] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 311/345] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where
@@ -28,7 +28,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
-index cc188d4d05762..e9cf2dded39e4 100644
+index cc188d4d0576..e9cf2dded39e 100644
 --- a/drivers/platform/mips/ls7a_fan.c
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -9,10 +9,16 @@
@@ -51,5 +51,5 @@ index cc188d4d05762..e9cf2dded39e4 100644
  #define LS7A_PWM0_LOW                   0x004
  #define LS7A_PWM0_FULL                  0x008
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From d6fdb8bf0ced2b9b419bffb403a5969ff99a41d7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 312/344] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 312/345] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index cc0360e8dd62c..fc1d0c83b554a 100644
+index cc0360e8dd62..fc1d0c83b554 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,7 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)
@@ -47,5 +47,5 @@ index cc0360e8dd62c..fc1d0c83b554a 100644
  			handler = ieee754dp_madd;
  			goto dcoptop;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From e5518fcbdbbdce9bad34b7e08e0f8059b16ff57f Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 313/344] AOSCOS: Optimize clear_page
+Subject: [PATCH 313/345] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -14,7 +14,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  5 files changed, 56 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/uasm.h b/arch/mips/include/asm/uasm.h
-index b43bfd4452521..2573d559320e6 100644
+index b43bfd445252..2573d559320e 100644
 --- a/arch/mips/include/asm/uasm.h
 +++ b/arch/mips/include/asm/uasm.h
 @@ -42,6 +42,10 @@ void uasm_i##op(u32 **buf, unsigned int a, signed int b, unsigned int c)
@@ -37,7 +37,7 @@ index b43bfd4452521..2573d559320e6 100644
  Ip_u3u2u1(_sllv);
  Ip_s3s1s2(_slt);
 diff --git a/arch/mips/include/uapi/asm/inst.h b/arch/mips/include/uapi/asm/inst.h
-index c29dbc8c1d491..6d41c8bbbdec2 100644
+index c29dbc8c1d49..6d41c8bbbdec 100644
 --- a/arch/mips/include/uapi/asm/inst.h
 +++ b/arch/mips/include/uapi/asm/inst.h
 @@ -137,6 +137,13 @@ enum ddivu_op {
@@ -55,7 +55,7 @@ index c29dbc8c1d491..6d41c8bbbdec2 100644
   * rt field of bcond opcodes.
   */
 diff --git a/arch/mips/mm/page.c b/arch/mips/mm/page.c
-index 1df237bd4a72b..21c9d35ec25e8 100644
+index 1df237bd4a72..21c9d35ec25e 100644
 --- a/arch/mips/mm/page.c
 +++ b/arch/mips/mm/page.c
 @@ -206,6 +206,11 @@ static void set_prefetch_parameters(void)
@@ -87,7 +87,7 @@ index 1df237bd4a72b..21c9d35ec25e8 100644
  
  static inline void build_clear_pref(u32 **buf, int off)
 diff --git a/arch/mips/mm/uasm-mips.c b/arch/mips/mm/uasm-mips.c
-index e15c6700cd088..7e44ea365795b 100644
+index e15c6700cd08..7e44ea365795 100644
 --- a/arch/mips/mm/uasm-mips.c
 +++ b/arch/mips/mm/uasm-mips.c
 @@ -27,6 +27,10 @@
@@ -143,7 +143,7 @@ index e15c6700cd088..7e44ea365795b 100644
  		op |= build_simm(va_arg(ap, s32));
  	if (ip->fields & UIMM)
 diff --git a/arch/mips/mm/uasm.c b/arch/mips/mm/uasm.c
-index 125140979d62c..2a9ca7de43760 100644
+index 125140979d62..2a9ca7de4376 100644
 --- a/arch/mips/mm/uasm.c
 +++ b/arch/mips/mm/uasm.c
 @@ -26,6 +26,8 @@ enum fields {
@@ -187,5 +187,5 @@ index 125140979d62c..2a9ca7de43760 100644
  I_u3u2u1(_sllv)
  I_s3s1s2(_slt)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From abc698ef1457ec4b4c7c6e7f1dc4eee61db07428 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 314/344] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 314/345] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memset.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 16b0c555b52ae..f6a1fd6cb736e 100644
+index 16b0c555b52a..f6a1fd6cb736 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,6 +5,7 @@
@@ -30,7 +30,7 @@ index 16b0c555b52ae..f6a1fd6cb736e 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
 new file mode 100644
-index 0000000000000..227b2d67082e3
+index 000000000000..227b2d67082e
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -0,0 +1,206 @@
@@ -241,5 +241,5 @@ index 0000000000000..227b2d67082e3
 +	jr		ra
 +	 PTR_SUBU	a2, a0, t1
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From b5e8feda011403e2ecd2e758fed8b78d9ff34d8a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 315/344] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 315/345] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 227b2d67082e3..0a35c013f6df4 100644
+index 227b2d67082e..0a35c013f6df 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -8,9 +8,9 @@
@@ -33,5 +33,5 @@ index 227b2d67082e3..0a35c013f6df4 100644
  
  #define LONG_S_L sdl
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From caf92045e171578e9d27f6fd1eb1f250f7a25745 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 316/344] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 316/345] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 0a35c013f6df4..55c3b8d7bc458 100644
+index 0a35c013f6df..55c3b8d7bc45 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -22,7 +22,7 @@
@@ -40,5 +40,5 @@ index 0a35c013f6df4..55c3b8d7bc458 100644
  
  	.macro	f_fill128 dst, offset, val, fixup
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From a8432bcf5f2f3fccc660b9f90ca5f86812f05f49 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 317/344] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 317/345] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/lib/Makefile b/arch/mips/lib/Makefile
-index 5d5b993cbc2bf..b5532bab9337b 100644
+index 5d5b993cbc2b..b5532bab9337 100644
 --- a/arch/mips/lib/Makefile
 +++ b/arch/mips/lib/Makefile
 @@ -10,6 +10,7 @@ lib-y	+= bitops.o csum_partial.o delay.o memcpy.o memset.o \
@@ -32,5 +32,5 @@ index 5d5b993cbc2bf..b5532bab9337b 100644
  obj-$(CONFIG_CPU_GENERIC_DUMP_TLB) += dump_tlb.o
  obj-$(CONFIG_CPU_R3000)		+= r3k_dump_tlb.o
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 6d0544e3a80e6a1e6737b336c68641a592109104 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 318/344] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 318/345] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memcpy.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index f6a1fd6cb736e..9783e54388902 100644
+index f6a1fd6cb736..9783e5438890 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,7 +5,7 @@
@@ -31,7 +31,7 @@ index f6a1fd6cb736e..9783e54388902 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
 new file mode 100644
-index 0000000000000..28b785363351c
+index 000000000000..28b785363351
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -0,0 +1,506 @@
@@ -542,5 +542,5 @@ index 0000000000000..28b785363351c
 +	END(__rmemcpy)
 +#endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From b5565458238d6de11a99f83feb372a057e3dd3c5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 319/344] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 319/345] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 28b785363351c..4c0b6b8474f04 100644
+index 28b785363351..4c0b6b8474f0 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -37,13 +37,13 @@
@@ -38,5 +38,5 @@ index 28b785363351c..4c0b6b8474f04 100644
  
  #endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From c6d6d31db321b784013f7955c37b67d5e4f367fe Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 320/344] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 320/345] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -18,7 +18,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 4c0b6b8474f04..2021e75d5dd2e 100644
+index 4c0b6b8474f0..2021e75d5dd2 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -29,9 +29,9 @@
@@ -33,5 +33,5 @@ index 4c0b6b8474f04..2021e75d5dd2e 100644
  
  #define EXC(inst_reg,addr,handler)		\
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From e7d994e02073cc94e83fedcbcf5d866c289b5a96 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 321/344] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 321/345] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index dae56c1544345..5c41c5950bc25 100644
+index dae56c154434..5c41c5950bc2 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -1369,6 +1369,7 @@ config CPU_LOONGSON64
@@ -27,5 +27,5 @@ index dae56c1544345..5c41c5950bc25 100644
  	  The Loongson GSx64(GS264/GS464/GS464E/GS464V) series of processor
  	  cores implements the MIPS64R2 instruction set with many extensions,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 452e85ce57b1a3e5c82ca81abee0292d695da11a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 322/344] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 322/345] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 2021e75d5dd2e..c5dd2e2866c3c 100644
+index 2021e75d5dd2..c5dd2e2866c3 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -119,8 +119,10 @@ LEAF(memcpy)				/* a0=dst a1=src a2=len */
@@ -37,5 +37,5 @@ index 2021e75d5dd2e..c5dd2e2866c3c 100644
  	sltu	t2, a2, 0x28
  	andi	t0, dst, 0xf
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From 7bafda5a7990e28230b8d78a691bd05433f67227 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 323/344] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 323/345] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index 891729c9c5642..0334a85d2594b 100644
+index 891729c9c564..0334a85d2594 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -578,12 +578,12 @@ config SPI_LM70_LLP
@@ -43,5 +43,5 @@ index 891729c9c5642..0334a85d2594b 100644
  	  This bus driver supports the Loongson SPI hardware controller in
  	  the Loongson platforms and supports to use DTS framework to
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From ad6bbc0f33f09a2ed375a6a06b4649d39d14ec5d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 324/344] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 324/345] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 5c41c5950bc25..4f25bee70fd5f 100644
+index 5c41c5950bc2..4f25bee70fd5 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2141,9 +2141,9 @@ config ZBOOT_LOAD_ADDRESS
@@ -33,5 +33,5 @@ index 5c41c5950bc25..4f25bee70fd5f 100644
  	help
  	  The kernel memory allocator divides physically contiguous memory
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From 69c4b9f75a1c91a0bce54dd9a8862f97eaeb968b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 325/344] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 325/345] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further
@@ -16,7 +16,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/init/Kconfig b/init/Kconfig
-index 87c868f86a060..5f4365dedaeb7 100644
+index 87c868f86a06..5f4365dedaeb 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -966,6 +966,7 @@ config NUMA_BALANCING
@@ -28,5 +28,5 @@ index 87c868f86a060..5f4365dedaeb7 100644
  	  This option adds support for automatic NUMA aware memory/task placement.
  	  The mechanism is quite primitive and is based on migrating memory when
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From 71de5ea9172867929dda900d0c5d107854913460 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 326/344] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 326/345] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/lib/audit.c b/lib/audit.c
-index 738bda22dd39b..5f68998fdaf60 100644
+index 738bda22dd39..5f68998fdaf6 100644
 --- a/lib/audit.c
 +++ b/lib/audit.c
 @@ -29,6 +29,7 @@ static unsigned signal_class[] = {
@@ -33,5 +33,5 @@ index 738bda22dd39b..5f68998fdaf60 100644
  static int __init audit_classes_init(void)
  {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From 4401817b018b9c9a36209d7636ed3c9b6e2e288f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 327/344] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 327/345] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 10 deletions(-)
 
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index 1c054e3096db8..ba83d3fb0a848 100644
+index 1c054e3096db..ba83d3fb0a84 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,14 +64,4 @@
@@ -36,5 +36,5 @@ index 1c054e3096db8..ba83d3fb0a848 100644
 -
  #endif /* _ASM_UNISTD_H */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From 6d3163c55a9a8941321e2ea748cb57835cea796f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 328/344] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 328/345] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper
@@ -13,7 +13,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index b501ea16ccd40..63bfa241b3aa5 100644
+index b501ea16ccd4..63bfa241b3aa 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,6 +6,9 @@
@@ -27,5 +27,5 @@ index b501ea16ccd40..63bfa241b3aa5 100644
  #ifndef _UAPI_ASM_UNISTD_H
  #define _UAPI_ASM_UNISTD_H
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From 6f11b71870b8cf513f43b1cb76bf09f4f80e1f68 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 329/344] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 329/345] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In
@@ -26,7 +26,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 22f4f9158413d..0f25914991f44 100644
+index 22f4f9158413..0f25914991f4 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -622,7 +622,9 @@ static void __init bootcmdline_init(void)
@@ -49,5 +49,5 @@ index 22f4f9158413d..0f25914991f44 100644
  
  static void reserve_oldmem_region(int node, unsigned long s0, unsigned long e0)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 9faca831cc848110636a2417d9b2cd686a304827 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 330/344] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 330/345] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>
@@ -11,7 +11,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 9783e54388902..04eba1ce8ff54 100644
+index 9783e5438890..04eba1ce8ff5 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -29,5 +29,5 @@ index 9783e54388902..04eba1ce8ff54 100644
  obj-$(CONFIG_SYSFS) += boardinfo.o
 +obj-$(CONFIG_CPU_HWMON) += platform.o
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From 5111c094091f82fe52dbb1c772982421008432e5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 331/344] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 331/345] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes; Also move the struct domain_device
@@ -18,7 +18,7 @@ Signed-off-by: Xinhui Yang <cyan@cyano.uk>
  3 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 03a0ac5fab63f..888e48cf71477 100644
+index 03a0ac5fab63..888e48cf7147 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -36,7 +36,7 @@ static const struct attribute_group *mvst_sdev_groups[];
@@ -31,7 +31,7 @@ index 03a0ac5fab63f..888e48cf71477 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index b6b1bc6ff2c7c..8b0546a57f638 100644
+index b6b1bc6ff2c7..8b0546a57f63 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -255,13 +255,13 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -53,7 +53,7 @@ index b6b1bc6ff2c7c..8b0546a57f638 100644
  		scsi_change_queue_depth(sdev, MVS_QUEUE_SIZE);
  #endif
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index b6f5b739d67c9..6d7831bd9c014 100644
+index b6f5b739d67c..6d7831bd9c01 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -429,7 +429,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,
@@ -66,5 +66,5 @@ index b6f5b739d67c9..6d7831bd9c014 100644
  int mvs_scan_finished(struct Scsi_Host *shost, unsigned long time);
  int mvs_queue_command(struct sas_task *task, gfp_t gfp_flags);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From 3ba362873d1b324260aa4369342372f01176a27a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 332/344] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 332/345] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.
@@ -15,7 +15,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 5091a94b559f3..8e4c74c060f7c 100644
+index 5091a94b559f..8e4c74c060f7 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,7 +74,6 @@
@@ -27,7 +27,7 @@ index 5091a94b559f3..8e4c74c060f7c 100644
  
  #define PCI_DEVICE_ID_MOXA_CP102E	0x1024
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 91385152ea450..0fb1a1b8954cc 100644
+index 91385152ea45..0fb1a1b8954c 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -2599,6 +2599,7 @@
@@ -39,5 +39,5 @@ index 91385152ea450..0fb1a1b8954cc 100644
  #define PCI_VENDOR_ID_SILICOM_DENMARK	0x1c2c
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
@@ -1,7 +1,7 @@
 From 16eb631ba63c188db83e5e8abeeada53bc2c6266 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 22:05:56 +0800
-Subject: [PATCH 333/344] AOSCOS: sb105x: Adapt for timer related function
+Subject: [PATCH 333/345] AOSCOS: sb105x: Adapt for timer related function
  renames
 
 The upstream has renamed the timer related functions to have a strict
@@ -17,7 +17,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 19098bbfa113e..416a0d30a40f6 100644
+index 19098bbfa113..416a0d30a40f 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -2306,7 +2306,7 @@ static void serial_unlink_irq_chain(struct mp_port *mtpt)
@@ -39,5 +39,5 @@ index 19098bbfa113e..416a0d30a40f6 100644
  	else
  	{
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0334-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0334-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 870a06bc3fa880d2badbc39b4deacf7133e3c91d Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 334/344] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 334/345] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 4f25bee70fd5f..fc0d950c12e74 100644
+index 4f25bee70fd5..fc0d950c12e7 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -532,7 +532,6 @@ config MACH_LOONGSON64
@@ -21,5 +21,5 @@ index 4f25bee70fd5f..fc0d950c12e74 100644
  	  This enables the support of Loongson-2/3 family of machines.
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
@@ -1,7 +1,7 @@
 From 65559d526586b08b2d2574b9adffa5b325f9207d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 09:50:44 +0800
-Subject: [PATCH 335/344] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
+Subject: [PATCH 335/345] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
  LS7A
 
 On LoongArch laptops using LG110 GPU for display, LS7A PWM3 is used for
@@ -20,7 +20,7 @@ Signed-off-by: Xi Ruoyao <xry111@xry111.site>
  create mode 100644 drivers/acpi/loongarch/acpi-ls7a-backlight.c
 
 diff --git a/drivers/acpi/Makefile b/drivers/acpi/Makefile
-index d1b0affb844f0..2148e6a5ebcca 100644
+index d1b0affb844f..2148e6a5ebcc 100644
 --- a/drivers/acpi/Makefile
 +++ b/drivers/acpi/Makefile
 @@ -134,3 +134,4 @@ obj-$(CONFIG_ACPI_VIOT)		+= viot.o
@@ -29,7 +29,7 @@ index d1b0affb844f0..2148e6a5ebcca 100644
  obj-$(CONFIG_X86)		+= x86/
 +obj-$(CONFIG_LOONGARCH)		+= loongarch/
 diff --git a/drivers/acpi/internal.h b/drivers/acpi/internal.h
-index e2781864fdceb..d89674af40616 100644
+index e2781864fdce..d89674af4061 100644
 --- a/drivers/acpi/internal.h
 +++ b/drivers/acpi/internal.h
 @@ -76,6 +76,12 @@ void acpi_lpss_init(void);
@@ -47,7 +47,7 @@ index e2781864fdceb..d89674af40616 100644
  acpi_status acpi_hotplug_schedule(struct acpi_device *adev, u32 src);
 diff --git a/drivers/acpi/loongarch/Makefile b/drivers/acpi/loongarch/Makefile
 new file mode 100644
-index 0000000000000..25f207f841222
+index 000000000000..25f207f84122
 --- /dev/null
 +++ b/drivers/acpi/loongarch/Makefile
 @@ -0,0 +1,3 @@
@@ -56,7 +56,7 @@ index 0000000000000..25f207f841222
 +endif
 diff --git a/drivers/acpi/loongarch/acpi-ls7a-backlight.c b/drivers/acpi/loongarch/acpi-ls7a-backlight.c
 new file mode 100644
-index 0000000000000..5363747cd3a7f
+index 000000000000..5363747cd3a7
 --- /dev/null
 +++ b/drivers/acpi/loongarch/acpi-ls7a-backlight.c
 @@ -0,0 +1,42 @@
@@ -103,7 +103,7 @@ index 0000000000000..5363747cd3a7f
 +	acpi_scan_add_handler(&ls7a_pwm_handler);
 +}
 diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
-index 5be8893b39127..44b7aeeaf6020 100644
+index 5be8893b3912..44b7aeeaf602 100644
 --- a/drivers/acpi/scan.c
 +++ b/drivers/acpi/scan.c
 @@ -2707,6 +2707,7 @@ void __init acpi_scan_init(void)
@@ -115,5 +115,5 @@ index 5be8893b39127..44b7aeeaf6020 100644
  	acpi_scan_add_handler(&generic_device_handler);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
@@ -1,7 +1,7 @@
 From cd44853b4d72b59d635edd61e4148e1190ff9bc4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:32:58 +0800
-Subject: [PATCH 336/344] AOSCOS: gpio: aaeon: use new GPIO line value setter
+Subject: [PATCH 336/345] AOSCOS: gpio: aaeon: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 10 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/gpio/gpio-aaeon.c b/drivers/gpio/gpio-aaeon.c
-index 3183c45dd1946..c723c59b5ea8b 100644
+index 3183c45dd194..c723c59b5ea8 100644
 --- a/drivers/gpio/gpio-aaeon.c
 +++ b/drivers/gpio/gpio-aaeon.c
 @@ -50,7 +50,7 @@ static int aaeon_gpio_input_set_direction(struct gpio_chip *chip,
@@ -54,5 +54,5 @@ index 3183c45dd1946..c723c59b5ea8b 100644
  
  static int aaeon_gpio_get_number(void)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
@@ -1,7 +1,7 @@
 From e030ca18794b0ef1109a69703d6a0ff2ec52c6e4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:36:16 +0800
-Subject: [PATCH 337/344] AOSCOS: gpio: nct6102: use new GPIO line value setter
+Subject: [PATCH 337/345] AOSCOS: gpio: nct6102: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 143f0a139e212..b79bd13e2c51e 100644
+index 143f0a139e21..b79bd13e2c51 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -104,7 +104,7 @@ static int nct6102_gpio_get_value(struct gpio_chip *chip, unsigned offset)
@@ -37,5 +37,5 @@ index 143f0a139e212..b79bd13e2c51e 100644
  
  static int nct6102_gpio_direction_input(struct gpio_chip *chip, unsigned offset)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-PCI-fix-name-for-3C6000-PCIe-bridge-speeds-qu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-PCI-fix-name-for-3C6000-PCIe-bridge-speeds-qu.patch
@@ -1,7 +1,7 @@
 From 81508bdf1b97f2aeb05869658d7012a8572c1e5a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:54:33 +0800
-Subject: [PATCH 338/344] AOSCOS: PCI: fix name for 3C6000 PCIe bridge speeds
+Subject: [PATCH 338/345] AOSCOS: PCI: fix name for 3C6000 PCIe bridge speeds
  quirk
 
 The original patch declares the quirk under an incorrect name.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 822dbee372ce4..8fc2635f14866 100644
+index 822dbee372ce..8fc2635f1486 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -2007,8 +2007,8 @@ static void quirk_loongson_pci_bridge_supported_speeds(struct pci_dev *pdev)
@@ -30,5 +30,5 @@ index 822dbee372ce4..8fc2635f14866 100644
  /*
   * HiSilicon KunPeng920 and KunPeng930 have devices appear as PCI but are
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-PCI-add-break-to-cases-for-3C6000-PCIe-bridge.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-PCI-add-break-to-cases-for-3C6000-PCIe-bridge.patch
@@ -1,7 +1,7 @@
 From 57a152a4b907c1c0335434b173dc43de4d98eb0a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 4 Sep 2025 16:25:58 +0800
-Subject: [PATCH 339/344] AOSCOS: PCI: add break to cases for 3C6000 PCIe
+Subject: [PATCH 339/345] AOSCOS: PCI: add break to cases for 3C6000 PCIe
  bridge speeds quirk
 
 The original patch did not write `break;' for each case, triggering
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 8fc2635f14866..0dc7e27f6b785 100644
+index 8fc2635f1486..0dc7e27f6b78 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -1997,12 +1997,16 @@ static void quirk_loongson_pci_bridge_supported_speeds(struct pci_dev *pdev)
@@ -37,5 +37,5 @@ index 8fc2635f14866..0dc7e27f6b785 100644
  		break;
  	}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
@@ -1,7 +1,7 @@
 From da7afd4eb3d5a52c9b378da660b780893e345367 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 10 Sep 2025 23:21:26 +0800
-Subject: [PATCH 340/344] AOSCOS: scsi: dc395x: correctly discard the return
+Subject: [PATCH 340/345] AOSCOS: scsi: dc395x: correctly discard the return
  value in certain reads
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -37,7 +37,7 @@ Signed-off-by: Xinhui Yang <cyan@cyano.uk>
  1 file changed, 12 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/dc395x.c b/drivers/scsi/dc395x.c
-index 386c8359e1cc8..137b7b3d1335b 100644
+index 386c8359e1cc..137b7b3d1335 100644
 --- a/drivers/scsi/dc395x.c
 +++ b/drivers/scsi/dc395x.c
 @@ -94,6 +94,12 @@
@@ -101,5 +101,5 @@ index 386c8359e1cc8..137b7b3d1335b 100644
  
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0341-REVERT-Revert-LoongArch-KVM-Fix-VM-migration-failure.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0341-REVERT-Revert-LoongArch-KVM-Fix-VM-migration-failure.patch
@@ -1,7 +1,7 @@
 From fbad5f54287edc4f454bebe8cf907cd5a76d6bc7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 14 Oct 2025 16:16:02 +0800
-Subject: [PATCH 341/344] REVERT: Revert "LoongArch: KVM: Fix VM migration
+Subject: [PATCH 341/345] REVERT: Revert "LoongArch: KVM: Fix VM migration
  failure with PTW enabled"
 
 This reverts commit 1c731284374a5335ee8323c92ab66d7cab5e9f0b.
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 8 insertions(+), 20 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_mmu.h b/arch/loongarch/include/asm/kvm_mmu.h
-index e36cc7e8ed200..099bafc6f797c 100644
+index e36cc7e8ed20..099bafc6f797 100644
 --- a/arch/loongarch/include/asm/kvm_mmu.h
 +++ b/arch/loongarch/include/asm/kvm_mmu.h
 @@ -16,13 +16,6 @@
@@ -71,7 +71,7 @@ index e36cc7e8ed200..099bafc6f797c 100644
  {
  	return ctx->flag & _KVM_FLUSH_PGTABLE;
 diff --git a/arch/loongarch/kvm/mmu.c b/arch/loongarch/kvm/mmu.c
-index 7c8143e79c127..ed956c5cf2cc0 100644
+index 7c8143e79c12..ed956c5cf2cc 100644
 --- a/arch/loongarch/kvm/mmu.c
 +++ b/arch/loongarch/kvm/mmu.c
 @@ -569,7 +569,7 @@ static int kvm_map_page_fast(struct kvm_vcpu *vcpu, unsigned long gpa, bool writ
@@ -105,5 +105,5 @@ index 7c8143e79c127..ed956c5cf2cc0 100644
  
  out:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-LoongArch-KVM-enable-ptw-for-kvm.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-LoongArch-KVM-enable-ptw-for-kvm.patch
@@ -1,7 +1,7 @@
 From 2e84e7d011e164e9abb0da172cf421b8cb6c0ac6 Mon Sep 17 00:00:00 2001
 From: Xianglai Li <lixianglai@loongson.cn>
 Date: Thu, 9 Jan 2025 16:58:04 +0800
-Subject: [PATCH 342/344] AOSCOS: LoongArch: KVM: enable ptw for kvm
+Subject: [PATCH 342/345] AOSCOS: LoongArch: KVM: enable ptw for kvm
 
 Upstream: no
 
@@ -20,7 +20,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  3 files changed, 27 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_mmu.h b/arch/loongarch/include/asm/kvm_mmu.h
-index 099bafc6f797c..24862a32d66af 100644
+index 099bafc6f797..24862a32d66a 100644
 --- a/arch/loongarch/include/asm/kvm_mmu.h
 +++ b/arch/loongarch/include/asm/kvm_mmu.h
 @@ -18,6 +18,15 @@
@@ -57,7 +57,7 @@ index 099bafc6f797c..24862a32d66af 100644
  
  static inline kvm_pte_t kvm_pte_mkhuge(kvm_pte_t pte)
 diff --git a/arch/loongarch/kvm/exit.c b/arch/loongarch/kvm/exit.c
-index 6c9c7de7226b6..0becfe61d954a 100644
+index 6c9c7de7226b..0becfe61d954 100644
 --- a/arch/loongarch/kvm/exit.c
 +++ b/arch/loongarch/kvm/exit.c
 @@ -44,6 +44,8 @@ static int kvm_emu_cpucfg(struct kvm_vcpu *vcpu, larch_inst inst)
@@ -70,7 +70,7 @@ index 6c9c7de7226b6..0becfe61d954a 100644
  	case CPUCFG_KVM_SIG:
  		/* CPUCFG emulation between 0x40000000 -- 0x400000ff */
 diff --git a/arch/loongarch/kvm/mmu.c b/arch/loongarch/kvm/mmu.c
-index ed956c5cf2cc0..50d2198f12551 100644
+index ed956c5cf2cc..50d2198f1255 100644
 --- a/arch/loongarch/kvm/mmu.c
 +++ b/arch/loongarch/kvm/mmu.c
 @@ -568,6 +568,14 @@ static int kvm_map_page_fast(struct kvm_vcpu *vcpu, unsigned long gpa, bool writ
@@ -103,5 +103,5 @@ index ed956c5cf2cc0..50d2198f12551 100644
  			prot_bits |= __WRITEABLE;
  	}
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-LoongArch-fix-migrate-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-LoongArch-fix-migrate-issue.patch
@@ -1,7 +1,7 @@
 From a9fe36669474e7090202b6d2a71f806e5dd5edd0 Mon Sep 17 00:00:00 2001
 From: Song Gao <gaosong@loongson.cn>
 Date: Fri, 23 May 2025 11:41:37 +0800
-Subject: [PATCH 343/344] AOSCOS: LoongArch: fix migrate issue
+Subject: [PATCH 343/345] AOSCOS: LoongArch: fix migrate issue
 
 Upstream: no
 
@@ -22,7 +22,7 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  2 files changed, 9 insertions(+), 13 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_mmu.h b/arch/loongarch/include/asm/kvm_mmu.h
-index 24862a32d66af..76d92b9014d55 100644
+index 24862a32d66a..76d92b9014d5 100644
 --- a/arch/loongarch/include/asm/kvm_mmu.h
 +++ b/arch/loongarch/include/asm/kvm_mmu.h
 @@ -61,8 +61,7 @@ static inline void kvm_set_pte(kvm_pte_t *ptep, kvm_pte_t val)
@@ -50,7 +50,7 @@ index 24862a32d66af..76d92b9014d55 100644
  
  static inline kvm_pte_t kvm_pte_mkclean(kvm_pte_t pte)
 diff --git a/arch/loongarch/kvm/mmu.c b/arch/loongarch/kvm/mmu.c
-index 50d2198f12551..695a6779badf4 100644
+index 50d2198f1255..695a6779badf 100644
 --- a/arch/loongarch/kvm/mmu.c
 +++ b/arch/loongarch/kvm/mmu.c
 @@ -568,14 +568,6 @@ static int kvm_map_page_fast(struct kvm_vcpu *vcpu, unsigned long gpa, bool writ
@@ -81,5 +81,5 @@ index 50d2198f12551..695a6779badf4 100644
  
  	/* Disable dirty logging on HugePages */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
@@ -1,7 +1,7 @@
 From fc49457391686740d44fe1d86507e6596d584508 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 12 Nov 2025 11:41:05 +0800
-Subject: [PATCH 344/344] AOSCOS: crypto: padlock-sha: return -ENODEV on
+Subject: [PATCH 344/345] AOSCOS: crypto: padlock-sha: return -ENODEV on
  Zhaoxin KaiXian KX-6000/6000G
 
 On Zhaoxin KaiXian KX-6000/6000G series of processors, this crypto module
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/crypto/padlock-sha.c b/drivers/crypto/padlock-sha.c
-index 329f60ad422e6..10297ca54b760 100644
+index 329f60ad422e..10297ca54b76 100644
 --- a/drivers/crypto/padlock-sha.c
 +++ b/drivers/crypto/padlock-sha.c
 @@ -329,7 +329,17 @@ static int __init padlock_init(void)
@@ -43,5 +43,5 @@ index 329f60ad422e6..10297ca54b760 100644
  
  	/* Register the newly added algorithm module if on *
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-nvme-pci-add-Wodposit-NVMe-SSD-to-nvme_id_tab.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-nvme-pci-add-Wodposit-NVMe-SSD-to-nvme_id_tab.patch
@@ -1,0 +1,27 @@
+From 4444b7c5ca7a8cd3e018f4c421b0737159be9ab8 Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Sun, 7 Dec 2025 21:09:34 +0800
+Subject: [PATCH 345/345] AOSCOS: nvme-pci: add Wodposit NVMe SSD to
+ nvme_id_table and apply NVME_QUIRK_NO_SECONDARY_TEMP_THRESH
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ drivers/nvme/host/pci.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/nvme/host/pci.c b/drivers/nvme/host/pci.c
+index 8ed5f1941f05..000004a24a92 100644
+--- a/drivers/nvme/host/pci.c
++++ b/drivers/nvme/host/pci.c
+@@ -3906,6 +3906,8 @@ static const struct pci_device_id nvme_id_table[] = {
+ 		.driver_data = NVME_QUIRK_NO_DEEPEST_PS, },
+ 	{ PCI_DEVICE(0x1e49, 0x0041),   /* ZHITAI TiPro7000 NVMe SSD */
+ 		.driver_data = NVME_QUIRK_NO_DEEPEST_PS, },
++	{ PCI_DEVICE(0x1fa0, 0x2283),   /* Wodposit NVMe SSD */
++		.driver_data = NVME_QUIRK_NO_SECONDARY_TEMP_THRESH, },
+ 	{ PCI_DEVICE(0x025e, 0xf1ac),   /* SOLIDIGM  P44 pro SSDPFKKW020X7  */
+ 		.driver_data = NVME_QUIRK_NO_DEEPEST_PS, },
+ 	{ PCI_DEVICE(0xc0a9, 0x540a),   /* Crucial P2 */
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.17.7
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=3
+REL=4
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: add Wodposit NVMe SSD to nvme_id_table and apply NVME_QUIRK_NO_SECONDARY_TEMP_THRESH
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.17.7-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
