### PR TITLE
nvidia-settings: add PKGBREAK and PKGREP

### DIFF
--- a/app-admin/nvidia-settings/autobuild/defines
+++ b/app-admin/nvidia-settings/autobuild/defines
@@ -8,3 +8,6 @@ FAIL_ARCH="!(amd64|arm64)"
 
 PKGBREAK="nvidia<=580.95.05"
 PKGREP="nvidia<=580.95.05"
+PKGBREAK="nvidia-utils<=580.95.05"
+PKGREP="nvidia-utils<=580.95.05"
+


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-settings: add PKGBREAK and PKGREP

Package(s) Affected
-------------------

- nvidia-settings: 580.95.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
