### PR TITLE
nvidia-settings: break and rep nvidia-utils

### DIFF
--- a/app-admin/nvidia-settings/autobuild/defines
+++ b/app-admin/nvidia-settings/autobuild/defines
@@ -6,5 +6,5 @@ PKGDES="NVIDIA driver control panel"
 
 FAIL_ARCH="!(amd64|arm64)"
 
-PKGBREAK="nvidia<=580.95.05"
-PKGREP="nvidia<=580.95.05"
+PKGBREAK="nvidia<=580.95.05 nvidia-utils<=580.95.05"
+PKGREP="nvidia<=580.95.05 nvidia-utils<=580.95.05"

--- a/app-admin/nvidia-settings/spec
+++ b/app-admin/nvidia-settings/spec
@@ -1,4 +1,5 @@
 VER=580.95.05
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-settings: break and rep nvidia-utils
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- nvidia-settings: 580.95.05-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
