### PR TITLE
webkit2gtk: update to 2.50.3

### DIFF
--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,6 +1,6 @@
-VER=2.50.2
+VER=2.50.3
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::19ab61f2d44e62cd443673943d2d5341b84d08405f67a7c37b7a77ad3550f880"
+CHKSUMS="sha256::70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f"
 CHKUPDATE="anitya::id=324014"
 
 # Let's be a little conservative than sorry.  Combined with the parallel job

--- a/topics/webkit2gtk-2.50.3.toml
+++ b/topics/webkit2gtk-2.50.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "WebKitGTK 2.50.3"
+
+[caution]
+default = "Fixes 5 security vulnerabilities disclosed in WebKitGTK and WPE WebKit Security Advisories WSA-2025-0009 (Severity: High)"
+zh_CN = "修复 WebKitGTK 及 WPE WebKit 第 WSA-2025-0009 号安全公告中披露的 5 个安全漏洞（严重性：高）"
+
+[packages-v2]
+"webkit2gtk" = "< 1:2.50.3"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: update to 2.50.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- webkit2gtk: 1:2.50.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
