### PR TITLE
pushpkg: update to  v20251208

### DIFF
--- a/app-devel/pushpkg/spec
+++ b/app-devel/pushpkg/spec
@@ -1,4 +1,4 @@
-VER=20250806
+VER=20251208
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/pushpkg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=380490"


### PR DESCRIPTION
Topic Description
-----------------

- pushpkg: update to v20251208

Package(s) Affected
-------------------

- pushpkg: 1:20251208

Security Update?
----------------

No

Build Order
-----------

```
#buildit pushpkg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
