### PR TITLE
wcwidth: update to 0.2.14

### DIFF
--- a/lang-python/wcwidth/spec
+++ b/lang-python/wcwidth/spec
@@ -1,5 +1,4 @@
-VER=0.1.8
+VER=0.2.14
 SRCS="tbl::https://pypi.io/packages/source/w/wcwidth/wcwidth-$VER.tar.gz"
-CHKSUMS="sha256::f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
-REL=4
+CHKSUMS="sha256::4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"
 CHKUPDATE="anitya::id=8743"


### PR DESCRIPTION
Topic Description
-----------------

- wcwidth: update to 0.2.14
    Co-authored-by: Xinmudotmoe \(@Xinmudotmoe\) <zhang1813023404@outlook.com>

Package(s) Affected
-------------------

- wcwidth: 0.2.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit wcwidth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
