### PR TITLE
glib: update to 2.86.3

### DIFF
--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,4 +1,4 @@
-VER=2.86.0
+VER=2.86.3
 SRCS="https://download.gnome.org/sources/glib/${VER:0:4}/glib-$VER.tar.xz"
-CHKSUMS="sha256::b5739972d737cfb0d6fd1e7f163dfe650e2e03740bb3b8d408e4d1faea580d6d"
+CHKSUMS="sha256::b3211d8d34b9df5dca05787ef0ad5d7ca75dec998b970e1aab0001d229977c65"
 CHKUPDATE="anitya::id=10024"

--- a/topics/glib-2.86.3.toml
+++ b/topics/glib-2.86.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "GLib 2.86.3"
+
+[caution]
+default = "Fixes a heap-based buffer overflow in the URI string escaping, which may cause remote code execution or a denial of service (Severity: High)"
+zh_CN = "修复 URI 字符串转义时的一处堆缓冲区溢出漏洞，该漏洞可能导致远程代码执行或拒绝服务（严重性：高）"
+
+[packages-v2]
+"glib" = "< 2.86.3"


### PR DESCRIPTION
Topic Description
-----------------

Update glib to fix a security issue.

Package(s) Affected
-------------------

glib: `2.86.3`

Security Update?
----------------

Yes, #13980 

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit glib
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
