### PR TITLE
fcitx5-pinyin-moegirl: update to 20251210

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20251109
+VER=20251210
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::06a8a81402dad598cc5425a04fd3dd4c72b4fd8aa2a4e1623619fe3e7f9341ce
-         sha256::1817afb23a3a29177a522732d8ba4cc20649925b8de67d880ff0c089a28957be
+CHKSUMS="sha256::9ce545715ee42105ebcf9bcacdb31a24f448936d31f3ea4ec423a06028a239a9
+         sha256::3f8000c00a649c4695e0f167ebfe6ba5ac29d223867431fe9ae622f91fe212b9
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20251210

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20251210
- rime-pinyin-moegirl: 20251210

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
