### PR TITLE
binutils: fix host-prefixed symlinks

### DIFF
--- a/app-devel/binutils/02-amd64/build
+++ b/app-devel/binutils/02-amd64/build
@@ -52,5 +52,5 @@ mkdir -pv "$PKGDIR"/usr/bin
 cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
 for i in *; do
     ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-        "$PKGDIR"/usr/bin/${ARCH_TARGET[${__CROSS}]}-$i
+        "$PKGDIR"/usr/bin/$i
 done

--- a/app-devel/binutils/03-arm64/build
+++ b/app-devel/binutils/03-arm64/build
@@ -52,5 +52,5 @@ mkdir -pv "$PKGDIR"/usr/bin
 cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
 for i in *; do
     ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-        "$PKGDIR"/usr/bin/${ARCH_TARGET[${__CROSS}]}-$i
+        "$PKGDIR"/usr/bin/$i
 done

--- a/app-devel/binutils/04-loongarch64/build
+++ b/app-devel/binutils/04-loongarch64/build
@@ -52,5 +52,5 @@ mkdir -pv "$PKGDIR"/usr/bin
 cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
 for i in *; do
     ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-        "$PKGDIR"/usr/bin/${ARCH_TARGET[${__CROSS}]}-$i
+        "$PKGDIR"/usr/bin/$i
 done

--- a/app-devel/binutils/05-loongson3/build
+++ b/app-devel/binutils/05-loongson3/build
@@ -52,5 +52,5 @@ mkdir -pv "$PKGDIR"/usr/bin
 cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
 for i in *; do
     ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-        "$PKGDIR"/usr/bin/${ARCH_TARGET[${__CROSS}]}-$i
+        "$PKGDIR"/usr/bin/$i
 done

--- a/app-devel/binutils/06-ppc64el/build
+++ b/app-devel/binutils/06-ppc64el/build
@@ -52,5 +52,5 @@ mkdir -pv "$PKGDIR"/usr/bin
 cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
 for i in *; do
     ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-        "$PKGDIR"/usr/bin/${ARCH_TARGET[${__CROSS}]}-$i
+        "$PKGDIR"/usr/bin/$i
 done

--- a/app-devel/binutils/07-riscv64/build
+++ b/app-devel/binutils/07-riscv64/build
@@ -51,5 +51,5 @@ mkdir -pv "$PKGDIR"/usr/bin
 cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
 for i in *; do
     ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-        "$PKGDIR"/usr/bin/${ARCH_TARGET[${__CROSS}]}-$i
+        "$PKGDIR"/usr/bin/$i
 done

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,4 +1,5 @@
 VER=2.45
+REL=1
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::c50c0e7f9cb188980e2cc97e4537626b1672441815587f1eab69d2a1bfbef5d2"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: fix host-prefixed symlinks

Package(s) Affected
-------------------

- binutils: 2.45-1
- binutils+cross-amd64: 2.45-1
- binutils+cross-arm-none-eabi: 2.45-1
- binutils+cross-arm64: 2.45-1
- binutils+cross-loongarch64: 2.45-1
- binutils+cross-loongson3: 2.45-1
- binutils+cross-ppc64el: 2.45-1
- binutils+cross-riscv64: 2.45-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
