### PR TITLE
dart-sdk: update to 3.10.4

### DIFF
--- a/app-devel/dart-sass/spec
+++ b/app-devel/dart-sass/spec
@@ -1,7 +1,7 @@
-VER=1.95.0
+VER=1.95.1
 SASS_VER=3.2.0
-SRCS="git::commit=tags/$VER::https://github.com/sass/dart-sass \
-      git::commit=tags/embedded-protocol-$SASS_VER;rename=dart-sass/embedded-protocol::https://github.com/sass/sass"
+SRCS="git::commit=tags/$VER::https://github.com/sass/dart-sass.git \
+      git::commit=tags/embedded-protocol-$SASS_VER;rename=dart-sass/embedded-protocol::https://github.com/sass/sass.git"
 CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=326670"

--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -1,5 +1,5 @@
-VER=3.10.3
+VER=3.10.4
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/dart-sdk-${VER}.tar.zst"
-CHKSUMS="sha256::833f34f56bf199251953cf11af5cfa5dddaab308531685833619477e1c27188e"
+CHKSUMS="sha256::c68f0b661357e52d508512f8a546ac475c80ca44c3b1aaeff84f85a541fde1ee"
 CHKUPDATE="anitya::id=14718"
 SUBDIR="dart-sdk-${VER}"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sdk: update to 3.10.4
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>
- dart-sass: update to 1.95.1

Package(s) Affected
-------------------

- dart-sdk: 3.10.4
- dartaotruntime: 3.10.4
- dart-sass: 1.95.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk dart-sass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
