### PR TITLE
loonggpu-kernel-dkms: update to 1.0.1~alpha~lnd25.5-11

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-chore-initialise-a-gitignore-file.patch
@@ -1,7 +1,7 @@
 From 2e20048c55fa5ec168f5a44f4f5733c7e2703346 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:15 +0800
-Subject: [PATCH 01/52] chore: initialise a gitignore file
+Subject: [PATCH 01/61] chore: initialise a gitignore file
 
 Just to make my life easier.
 ---
@@ -24,5 +24,5 @@ index 0000000..223542a
 +*.order
 +conftest
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-include-use-video-aperture-helpers-for-Linu.patch
@@ -1,7 +1,7 @@
 From f50458a8b381bb6b5858ad27b8ab51982d7655db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:29:59 +0800
-Subject: [PATCH 02/52] loonggpu: include: use video aperture helpers for Linux
+Subject: [PATCH 02/61] loonggpu: include: use video aperture helpers for Linux
  >= 6.13.
 
 Per commit 689274a56c0c ("drm: Remove DRM aperture helpers"), the DRM
@@ -54,5 +54,5 @@ index c4f9727..fa26309 100644
  #endif
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-pass-string-literal-parameter-to-MODULE_IMP.patch
@@ -1,7 +1,7 @@
 From c8c543febf29491562e32a6c21805ca2af963c2f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 20 Jan 2025 18:34:47 +0800
-Subject: [PATCH 03/52] loonggpu: pass string literal parameter to
+Subject: [PATCH 03/61] loonggpu: pass string literal parameter to
  MODULE_IMPORT_NS for Linux >= 6.13
 
 With commit cdd30ebb1b9f ("module: Convert symbol namespace to string
@@ -35,5 +35,5 @@ index 90bc2c4..8bcc5a2 100644
  static void gsgpu_display_flip_callback(struct dma_fence *f,
  					 struct dma_fence_cb *cb)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-dkms-drop-deprecated-REMAKE_INITRD-yes-opti.patch
@@ -1,7 +1,7 @@
 From d78344d1e4534a20fbe9a9691fb20c86fa605701 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 11:51:25 +0800
-Subject: [PATCH 04/52] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
+Subject: [PATCH 04/61] loonggpu: dkms: drop deprecated REMAKE_INITRD=yes
  option
 
 This option is marked deprecated and causes a warning during DKMS builds.
@@ -24,5 +24,5 @@ index d31fb96..044472a 100644
  MAKE[0]="unset ARCH; env LG_VERBOSE=1 \
      make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-gsgpu_dc_connector-gsgpu-bridge-drop-an-unu.patch
@@ -1,7 +1,7 @@
 From 37c11b5b83ccc184e10bdea24dc4c8ed02474d1d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 17:49:35 +0800
-Subject: [PATCH 05/52] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
+Subject: [PATCH 05/61] loonggpu: gsgpu_dc_connector: gsgpu-bridge: drop an
  unused variable i
 
 A variable `i' was defined under multiple functions, triggering
@@ -40,5 +40,5 @@ index 86daef6..b0a9185 100644
  
  	/* pick the first one */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-gsgpu_vm-move-struct-definition-to-include-.patch
@@ -1,7 +1,7 @@
 From fb033217bfa7ca1b3b900ba448bd96688910b164 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:30:31 +0800
-Subject: [PATCH 06/52] loonggpu: gsgpu_vm: move struct definition to
+Subject: [PATCH 06/61] loonggpu: gsgpu_vm: move struct definition to
  include/gsgpu_vm.h
 
 Move struct definition to header so that non-static functions may access
@@ -172,5 +172,5 @@ index 4e7da19..e71570a 100644
   * DIR0->DIR1->DIR2
   */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-gsgpu-gsgpu-bridge-lint-prototypes.patch
@@ -1,7 +1,7 @@
 From 960d2e37e3a0b833b7f5ce34fb4d80a22e6b0c7b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 21 Jan 2025 18:33:02 +0800
-Subject: [PATCH 07/52] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
+Subject: [PATCH 07/61] loonggpu: gsgpu: gsgpu-bridge: lint prototypes
 
 Lots of functions in this driver were missing prototype definitions,
 triggering a large number of `-Wmissing-prototypes' warnings.
@@ -245,5 +245,5 @@ index e71570a..36e533f 100644
  			 struct gsgpu_task_info *task_info);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-AOSCOS-loonggpu-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From 6a96edffd9f5bbc1b2cf3a488032623b0b2a361c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 6 Feb 2025 18:12:15 +0800
-Subject: [PATCH 08/52] AOSCOS: loonggpu: remove driver date
+Subject: [PATCH 08/61] AOSCOS: loonggpu: remove driver date
 
 Following upstream changes.
 
@@ -42,5 +42,5 @@ index 8a34e3f..891c43b 100644
  long gsgpu_drm_ioctl(struct file *filp,
  		      unsigned int cmd, unsigned long arg);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
@@ -1,7 +1,7 @@
 From 535a3a5be05a569abe24eaa21ee6236a44744f3e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:03:46 +0800
-Subject: [PATCH 09/52] loonggpu: Remove unused fbdev_list field in
+Subject: [PATCH 09/61] loonggpu: Remove unused fbdev_list field in
  gsgpu_framebuffer
 
 This field is referred nowhere.
@@ -24,5 +24,5 @@ index e5d2cfd..4e21dbc 100644
  };
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Remove-the-unused-gsgpu_fbdev_total_size-fu.patch
@@ -1,7 +1,7 @@
 From 67052920d0d65c559f3d91cc1087dd7794eb9018 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:21:48 +0800
-Subject: [PATCH 10/52] loonggpu: Remove the unused gsgpu_fbdev_total_size
+Subject: [PATCH 10/61] loonggpu: Remove the unused gsgpu_fbdev_total_size
  function
 
 It's referred nowhere.
@@ -49,5 +49,5 @@ index 4e21dbc..0845aa2 100644
  int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
  int gsgpu_display_modeset_create_props(struct gsgpu_device *adev);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Improve-fbdev-object-test-helper.patch
@@ -1,7 +1,7 @@
 From 6505d6bb76b24f59444420c3105d20052cf02c23 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:27:04 +0800
-Subject: [PATCH 11/52] loonggpu: Improve fbdev object-test helper
+Subject: [PATCH 11/61] loonggpu: Improve fbdev object-test helper
 
 Follow the change of our reference implementation, allowing us to
 remove struct gsgpu_fbdev later.
@@ -48,5 +48,5 @@ index a1447af..81294a9 100644
 +	return true;
  }
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
@@ -1,7 +1,7 @@
 From 84c8becebd2d7d1429b514a9b887b785fc98dcaf Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:34:42 +0800
-Subject: [PATCH 12/52] loonggpu: Remove struct gsgpu_fbdev and add some clean
+Subject: [PATCH 12/61] loonggpu: Remove struct gsgpu_fbdev and add some clean
  up code
 
 Both data fields in struct gsgpu_fbdev, the framebuffer and the
@@ -237,5 +237,5 @@ index 0845aa2..860a68d 100644
  	int			num_hpd; /* number of hpd pins */
  	int			num_i2c;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
@@ -1,7 +1,7 @@
 From a169f227222a60a30f99c4640de9823f6dbacfff Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:50:01 +0800
-Subject: [PATCH 13/52] loonggpu: Move fbdev cleanup code into fb_destroy
+Subject: [PATCH 13/61] loonggpu: Move fbdev cleanup code into fb_destroy
  callback
 
 Fbdev calls struct fb_ops.fb_destroy after cleaning up the final
@@ -124,5 +124,5 @@ index aa213b4..5bee711 100644
  	kfree(adev->ddev->fb_helper);
  	adev->ddev->fb_helper = NULL;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-redundant-info-par-assignment.patch
@@ -1,7 +1,7 @@
 From 9b5968d63571d2beff31fe0fbadd6b98540c7473 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:59:39 +0800
-Subject: [PATCH 14/52] loonggpu: Remove redundant info->par assignment
+Subject: [PATCH 14/61] loonggpu: Remove redundant info->par assignment
 
 It's already assigned by lg_drm_fb_helper_fill_info (no matter what the
 kernel version is).
@@ -24,5 +24,5 @@ index 5bee711..7b3f38b 100644
  
  	fb = kzalloc(sizeof(struct gsgpu_framebuffer), GFP_KERNEL);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
@@ -1,7 +1,7 @@
 From 3d6e1f3088cddf98c0bc419812908fdc14534ee1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:19:37 +0800
-Subject: [PATCH 15/52] loonggpu: Remove test for !screen_base in fbdev probing
+Subject: [PATCH 15/61] loonggpu: Remove test for !screen_base in fbdev probing
 
 The screen_base field comes from the fbdev BO and contains the fbdev
 framebuffer base address. We get the BO memory via gsgpu_bo_kmap(),
@@ -34,5 +34,5 @@ index 7b3f38b..fb0253c 100644
  	DRM_INFO("vram apper at 0x%lX\n",  (unsigned long)adev->gmc.aper_base);
  	DRM_INFO("size %lu\n", (unsigned long)gsgpu_bo_size(abo));
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Correctly-clean-up-failed-display-probing.patch
@@ -1,7 +1,7 @@
 From fd00f34c73088c7a838276c85a188a441549bbb1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:21:28 +0800
-Subject: [PATCH 16/52] loonggpu: Correctly clean up failed display probing
+Subject: [PATCH 16/61] loonggpu: Correctly clean up failed display probing
 
 Improve the fbdev probing function to fully clean up if it failed.
 Allows to remove special cases from fb_destroy as well.
@@ -147,5 +147,5 @@ index fb0253c..ad1990e 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-load-callback-from-kms_driver.patch
@@ -1,7 +1,7 @@
 From 83ef7728a8f023468e5c0aa4ec907b442ddd7d54 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:10:14 +0800
-Subject: [PATCH 17/52] loonggpu: Remove load callback from kms_driver
+Subject: [PATCH 17/61] loonggpu: Remove load callback from kms_driver
 
 The ".load" callback in "struct drm_driver" is deprecated. In order to
 remove the callback, we have to manually call "gsgpu_driver_load_kms"
@@ -37,5 +37,5 @@ index 94d9f88..d0d51cf 100644
  	.postclose = gsgpu_driver_postclose_kms,
  	lg_drm_driver_set_lastclose
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,7 +1,7 @@
 From 6a2e84785264b6dfc36a910b86fa7acd1b54d114 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:21:11 +0800
-Subject: [PATCH 18/52] loonggpu: Implement client-based fbdev emulation
+Subject: [PATCH 18/61] loonggpu: Implement client-based fbdev emulation
 
 Implement fbdev emulation on top of struct drm_client and its helpers.
 Replaces ad-hoc interfaces for restoring and closing fbdev emulation with
@@ -267,5 +267,5 @@ index 860a68d..a66bfaf 100644
  bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
  int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,7 +1,7 @@
 From 09c4bae40f4d1191a3d8a8caab81a70f8c5d35c3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:31:20 +0800
-Subject: [PATCH 19/52] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
+Subject: [PATCH 19/61] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
  call
 
 It's not needed anymore as now the generic drm_client_register() calls
@@ -29,5 +29,5 @@ index 5057665..f1d9546 100644
  
  	return;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,7 +1,7 @@
 From 443a5275c42e8833079eb621775b7faf144e7b7c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:35:32 +0800
-Subject: [PATCH 20/52] loonggpu: Disable outputs when releasing fbdev client
+Subject: [PATCH 20/61] loonggpu: Disable outputs when releasing fbdev client
 
 Following up the reference implementation change to avoid potential
 errors.
@@ -25,5 +25,5 @@ index f1d9546..4c16273 100644
  	} else {
  		drm_client_release(&fb_helper->client);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,7 +1,7 @@
 From 5d470d0074d8db599d7aaf3334b56c9a51d266f6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:58:47 +0800
-Subject: [PATCH 21/52] loonggpu: Run DRM default client setup
+Subject: [PATCH 21/61] loonggpu: Run DRM default client setup
 
 Rework fbdev probing to support fbdev_probe in struct drm_driver
 and remove the old fb_probe callback. Provide an initializer macro
@@ -218,5 +218,5 @@ index a66bfaf..be2e123 100644
  bool gsgpu_fbdev_robj_is_fb(struct gsgpu_device *adev, struct gsgpu_bo *robj);
  int gsgpu_align_pitch(struct gsgpu_device *adev, int width, int bpp, bool tiled);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
@@ -1,7 +1,7 @@
 From 0871ad4bb96b29174dd0cb86b4758bd77592b376 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:36:09 +0800
-Subject: [PATCH 22/52] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
+Subject: [PATCH 22/61] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
 
 A comment in Kbuild says "using EXTRA_CFLAGS for compatibility with
 kernel older than 2.6.24" which does not make any sense for loonggpu: we
@@ -127,5 +127,5 @@ index 9a5a508..84e0566 100644
  LG_CONFTEST_COMPILE_TEST_HEADERS := $(obj)/conftest/macros.h
  LG_CONFTEST_COMPILE_TEST_HEADERS += $(obj)/conftest/functions.h
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
@@ -1,7 +1,7 @@
 From 8a7019df11c908bddbcc0ded58a6a38ce557318d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:59:23 +0800
-Subject: [PATCH 23/52] AOSCOS: loonggpu: Adapt for drm_sched_init struct
+Subject: [PATCH 23/61] AOSCOS: loonggpu: Adapt for drm_sched_init struct
  params
 
 Since kernel commit 796a9f55a8d1 ("drm/sched: Use struct for
@@ -115,5 +115,5 @@ index fa26309..ebe56f0 100644
  #else
  	kthread_unpark(ring->sched.thread);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
@@ -1,7 +1,7 @@
 From 7b7a3db4e073f207cff231791a11d6a11a80c2cb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:07:26 +0800
-Subject: [PATCH 24/52] AOSCOS: loonggpu: Adapt for renaming of from_timer to
+Subject: [PATCH 24/61] AOSCOS: loonggpu: Adapt for renaming of from_timer to
  timer_container_of
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -79,5 +79,5 @@ index ebe56f0..4d56c91 100644
 +
  #endif /* __GSGPU_HELPER_H__ */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
@@ -1,7 +1,7 @@
 From 51778b8977329840486c9c0c3d7b65a9917461dd Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:15:51 +0800
-Subject: [PATCH 25/52] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
+Subject: [PATCH 25/61] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
  to timer_delete_sync
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -76,5 +76,5 @@ index 4d56c91..8cb4fa3 100644
 +
  #endif /* __GSGPU_HELPER_H__ */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
@@ -1,7 +1,7 @@
 From 5a01159f90249c17dd9acafe01b42ddd27f06e15 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 22 Jun 2025 16:05:51 +0800
-Subject: [PATCH 26/52] loonggpu: bridge: Adapt for recent kernel API changes
+Subject: [PATCH 26/61] loonggpu: bridge: Adapt for recent kernel API changes
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
@@ -48,5 +48,5 @@ index 921583e..353a481 100644
  	struct gsgpu_bridge_phy *phy = to_bridge_phy(bridge);
  	struct gsgpu_connector *lconnector;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,7 +1,7 @@
 From cbfbdeabb1ae75c3979ddb0f8c35d1d7c01685f2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 10:49:40 +0800
-Subject: [PATCH 27/52] loonggpu: Remove the check against moving pinned BOs
+Subject: [PATCH 27/61] loonggpu: Remove the check against moving pinned BOs
 
 The check is already in the generic code.
 
@@ -29,5 +29,5 @@ index 6d06d42..e048982 100644
  
  	if (!old_mem || (old_mem->mem_type == TTM_PL_SYSTEM && bo->ttm == NULL)) {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Remove-dead-code.patch
@@ -1,7 +1,7 @@
 From f24dbfb4d81ab70a5919f9281d349accdebcf2e2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 11:18:49 +0800
-Subject: [PATCH 28/52] loonggpu: Remove dead code
+Subject: [PATCH 28/61] loonggpu: Remove dead code
 
 The body of this if statement is obviously unreachable.
 
@@ -27,5 +27,5 @@ index e048982..4c85ac3 100644
  	     new_mem->mem_type == TTM_PL_SYSTEM) ||
  	    (old_mem->mem_type == TTM_PL_SYSTEM &&
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,7 +1,7 @@
 From 3f819995623623251838683cd761144fcd961d0d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 12:11:28 +0800
-Subject: [PATCH 29/52] loonggpu: NFC: Clean up gsgpu_bo_move
+Subject: [PATCH 29/61] loonggpu: NFC: Clean up gsgpu_bo_move
 
 Just use goto to deduplicate some identical code, and wrap a long line
 to make the flow more similar to the reference implementation.
@@ -50,5 +50,5 @@ index 4c85ac3..8f4d6a3 100644
  	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
  	gsgpu_bo_move_notify(bo, evict, new_mem);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Handle-tt-moves-properly.patch
@@ -1,7 +1,7 @@
 From c9a04e21d03f0385b57a074d8018e4011e3ec9df Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:08:07 +0800
-Subject: [PATCH 30/52] loonggpu: Handle tt moves properly
+Subject: [PATCH 30/61] loonggpu: Handle tt moves properly
 
 It seems required since a TTM move refactoring in 2020.  Following up the
 reference implementation change (and several changes after that).
@@ -58,5 +58,5 @@ index 8f4d6a3..a12f0c0 100644
  		goto memcpy;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Use-multihop.patch
@@ -1,7 +1,7 @@
 From 95174f237cc75370e7c99a69ab8779e2b263324a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:35:15 +0800
-Subject: [PATCH 31/52] loonggpu: Use multihop
+Subject: [PATCH 31/61] loonggpu: Use multihop
 
 Remove the code to move resources directly between
 SYSTEM and VRAM in favour of using the core ttm mulithop code.
@@ -231,5 +231,5 @@ index a12f0c0..dd76658 100644
  	/* update statistics */
  	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,7 +1,7 @@
 From 859801da3ffd26fdc27a5a6f77484c9137a100f5 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:42:37 +0800
-Subject: [PATCH 32/52] loonggpu: Drop the unused no_wait_gpu parameter of
+Subject: [PATCH 32/61] loonggpu: Drop the unused no_wait_gpu parameter of
  gsgpu_move_blit
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -33,5 +33,5 @@ index dd76658..95ccd5e 100644
  		r = -ENODEV;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,7 +1,7 @@
 From fef5eeb09edd5421ab852efc8e1bff0db0030e80 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:49:20 +0800
-Subject: [PATCH 33/52] loonggpu: Drop lg_ttm_tt_bind
+Subject: [PATCH 33/61] loonggpu: Drop lg_ttm_tt_bind
 
 Get rid of the ttm_tt_populate usage: this symbol is only exported if
 DRM_TTM_KUNIT_TEST which requires COMPILE_TEST on LoongArch.
@@ -83,5 +83,5 @@ index 5eeebf3..f352344 100644
  {
  #if defined(LG_TTM_BO_MEM_PUT) && defined(LG_DRM_TTM_TTM_BO_DRIVER_H_PRESENT)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Make-the-mode-parameter-of-the-mode_valid-c.patch
@@ -1,7 +1,7 @@
 From 17d2c2dec632865fbb4bde88ac66e838153ace10 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:09:20 +0800
-Subject: [PATCH 34/52] loonggpu: Make the mode parameter of the mode_valid
+Subject: [PATCH 34/61] loonggpu: Make the mode parameter of the mode_valid
  callback of bridge_phy_cfg_funcs a pointer to const
 
 Fix a -Wdiscarded-qualifiers warning.
@@ -53,5 +53,5 @@ index 1e494ec..7abb77c 100644
          if (mode->hdisplay == 1680 && mode->vdisplay == 1050)
              return MODE_BAD;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,7 +1,7 @@
 From f2f40bb47d116791d979df9fd1e6f09b5210bc0f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:24:23 +0800
-Subject: [PATCH 35/52] loonggpu: Remove an invalid "const" qualifier
+Subject: [PATCH 35/61] loonggpu: Remove an invalid "const" qualifier
 
 You obviously cannot sprintf things into a const char array!
 
@@ -24,5 +24,5 @@ index 8a2fa3b..8b97512 100644
  	sprintf(pwm_name, "pwm%d", ls_bl->pwm_id);
  	ls_bl->pwm = lg_pwm_request(adev->ddev->dev, pwm_name, ls_bl->pwm_id, "Loongson_bl");
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,7 +1,7 @@
 From 45ca1bad62a6824155b08fdbe627bb0a74d49763 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:26:21 +0800
-Subject: [PATCH 36/52] loonggpu: Fix the parameter order of a kmalloc_array
+Subject: [PATCH 36/61] loonggpu: Fix the parameter order of a kmalloc_array
  call
 
 The element size should be the second parameter.
@@ -25,5 +25,5 @@ index ed06003..cc3d157 100644
  		return -ENOMEM;
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,7 +1,7 @@
 From 5d88458aaf0edfb43d7674b8afa674e80406ea8e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 16:10:04 +0800
-Subject: [PATCH 37/52] loonggpu: Handle the different drm_client_setup.h
+Subject: [PATCH 37/61] loonggpu: Handle the different drm_client_setup.h
  location in 6.12
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -28,5 +28,5 @@ index 4e31e33..924d3bb 100644
  #include <drm/drm_drv.h>
  #include <drm/drm_device.h>
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
@@ -1,7 +1,7 @@
 From aedb6d4c922ba8a8d3019cbf29bc5b9a79b76022 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 13 Aug 2025 12:38:30 +0800
-Subject: [PATCH 38/52] loonggpu: Handle the error from gsgpu_driver_load_kms
+Subject: [PATCH 38/61] loonggpu: Handle the error from gsgpu_driver_load_kms
  correctly
 
 With a 4KiB-page kernel, gsgpu_gart_init will fail because it requires
@@ -34,5 +34,5 @@ index 924d3bb..ede1066 100644
  retry_init:
  	ret = drm_dev_register(dev, pci_gpu_flags);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
@@ -1,7 +1,7 @@
 From b5446a8767e99c4d35fb5e9057a8eda188d791c2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:06:53 +0800
-Subject: [PATCH 39/52] loonggpu: Adapt for drm_get_format_info() API change
+Subject: [PATCH 39/61] loonggpu: Adapt for drm_get_format_info() API change
 
 Link: https://git.kernel.org/torvalds/c/0e7d5874fb6b
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -27,5 +27,5 @@ index 936c36b..eedbe38 100644
  
  	/* need to align pitch with crtc limits */
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-Adapt-for-.fb_create-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-Adapt-for-.fb_create-API-change.patch
@@ -1,7 +1,7 @@
 From 2d8b77ff31988dec54db98bff35d6315b9815b57 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:12:24 +0800
-Subject: [PATCH 40/52] loonggpu: Adapt for .fb_create API change
+Subject: [PATCH 40/61] loonggpu: Adapt for .fb_create API change
 
 Link: https://git.kernel.org/torvalds/c/81112eaac559
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -47,5 +47,5 @@ index 46523aa..eb3f0ca 100644
  int gsgpu_display_crtc_page_flip_target(struct drm_crtc *crtc,
                                  struct drm_framebuffer *fb,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
@@ -1,7 +1,7 @@
 From 0a1e7a25605f1df7048e5f4dd105a9e38fd201f8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:15:46 +0800
-Subject: [PATCH 41/52] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
+Subject: [PATCH 41/61] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
  change
 
 Link: https://git.kernel.org/torvalds/c/a34cc7bf1034
@@ -29,5 +29,5 @@ index 69980f5..05e760f 100644
  	if (ret) {
  		rfb->base.obj[0] = NULL;
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
@@ -1,7 +1,7 @@
 From 1b821f27321c039151ff82fe9f8bd0e06210c9b8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:24:55 +0800
-Subject: [PATCH 42/52] loonggpu: Pass along the format info from .fb_create()
+Subject: [PATCH 42/61] loonggpu: Pass along the format info from .fb_create()
  to drm_helper_mode_fill_fb_struct()
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -128,5 +128,5 @@ index be2e123..b08b967 100644
  				   struct drm_gem_object *obj);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
@@ -1,7 +1,7 @@
 From 97ce999696fd7372e983b480a333666f23633723 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:18:18 +0800
-Subject: [PATCH 43/52] loonggpu: Pass DRM client ID to drm_sched_job_init
+Subject: [PATCH 43/61] loonggpu: Pass DRM client ID to drm_sched_job_init
 
 Adapt for upstream API change.
 
@@ -172,5 +172,5 @@ index eed859c..5b4d3ab 100644
  			     struct dma_fence **fence);
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
@@ -1,7 +1,7 @@
 From eaf52006639d5e39fa24879d86f00629b3db0f0f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:20:01 +0800
-Subject: [PATCH 44/52] loonggpu: Adapt for the rename of
+Subject: [PATCH 44/61] loonggpu: Adapt for the rename of
  DRM_GPU_SCHED_STAT_NOMINAL to DRM_GPU_SCHED_STAT_RESET
 
 Link: https://git.kernel.org/torvalds/c/0a5dc1b67ef5
@@ -27,5 +27,5 @@ index 8fa0bf7..e21d402 100644
  #define lg_gsgpu_job_timedout_ret void
  #define LG_DRM_GPU_SCHED_STAT_NOMINAL
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Don-t-directly-use-ttm_bo_get.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Don-t-directly-use-ttm_bo_get.patch
@@ -1,7 +1,7 @@
 From dfba9f4e909cf8d30265a3aa38850eea4d98cd74 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:23:20 +0800
-Subject: [PATCH 45/52] loonggpu: Don't directly use ttm_bo_get
+Subject: [PATCH 45/61] loonggpu: Don't directly use ttm_bo_get
 
 Adapt for upstream API change which made this function internal.
 
@@ -100,5 +100,5 @@ index 06b8ef9..20e6760 100644
  int gsgpu_gem_object_open(struct drm_gem_object *obj,
  				struct drm_file *file_priv);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-backlight-Get-PWM-correctly-and-skip-GPIO-f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-backlight-Get-PWM-correctly-and-skip-GPIO-f.patch
@@ -1,7 +1,7 @@
 From aaee8cb5d7f879ba4cd2cb268a8591f99735b729 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 19:15:10 +0800
-Subject: [PATCH 46/52] loonggpu: backlight: Get PWM correctly and skip GPIO
+Subject: [PATCH 46/61] loonggpu: backlight: Get PWM correctly and skip GPIO
  for now
 
 This should make backlight control at least usable with AOSC 6.16.1-rc1
@@ -115,5 +115,5 @@ index 8ecc610..178c225 100644
  int gsgpu_backlight_register(struct drm_connector *connector);
  int gsgpu_late_register(struct drm_connector *connector);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-Get-rid-of-drm_sched_job.id.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-Get-rid-of-drm_sched_job.id.patch
@@ -1,7 +1,7 @@
 From e1f22e5a2793ff149cf71b7d5cff8aaefbe9e45c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 27 Aug 2025 10:31:29 +0800
-Subject: [PATCH 47/52] loonggpu: Get rid of drm_sched_job.id
+Subject: [PATCH 47/61] loonggpu: Get rid of drm_sched_job.id
 
 It's removed in the upstream kernel.  I don't bother to add a #ifdef for
 kernel version check here because our users don't care about tracing
@@ -70,5 +70,5 @@ index 2b43c9e..42ca767 100644
  );
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
@@ -1,7 +1,7 @@
 From 781daf42e56e1907fff7a6bf33c1ee0a0598e64c Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:28:47 +0800
-Subject: [PATCH 48/52] loonggpu: fix typo mistake in
+Subject: [PATCH 48/61] loonggpu: fix typo mistake in
  include/gsgpu_ttm_resource_helper.h
 
 ---
@@ -19,5 +19,5 @@ index 361517c..c12b3f5 100644
  
  #if !defined (LG_DRM_TTM_TTM_BO_H_PRESENT)
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,7 +1,7 @@
 From 743e20b11c639d09b66fac43704238f5265e0b07 Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:33:29 +0800
-Subject: [PATCH 49/52] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
+Subject: [PATCH 49/61] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
  switched to c23
 
 ---
@@ -25,5 +25,5 @@ index 497c1f4..e7df1a1
      if [ "$OUTPUT" != "$SOURCES" ]; then
          OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
@@ -1,7 +1,7 @@
 From e3b7e8daaf2462138213cd845bddb862f1d41349 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 13 Oct 2025 11:37:06 +0800
-Subject: [PATCH 50/52] loonggpu: Get rid of ida_simple_get and
+Subject: [PATCH 50/61] loonggpu: Get rid of ida_simple_get and
  ida_simple_remove
 
 They'd been a deprecated wrapper of ida_alloc_range and ida_free since
@@ -43,5 +43,5 @@ index cc3d157..edf4678 100644
  
  static void gsgpu_pasid_free_cb(struct dma_fence *fence,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
@@ -1,7 +1,7 @@
 From d6aab208624b345e19debc1424910c1984cd3d19 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 30 Oct 2025 10:12:33 +0800
-Subject: [PATCH 51/52] loonggpu: Only build a dummy if page size is 4 KiB
+Subject: [PATCH 51/61] loonggpu: Only build a dummy if page size is 4 KiB
 
 The hack [1] is not enough as when we install a kernel package (like
 linux-kernel-6.17.1), the postinstall script of the kernel package still
@@ -63,5 +63,5 @@ index 0000000..4c38f23
 +MODULE_LICENSE("GPL");
 +#endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Drop-CLEAN-from-dkms.conf.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Drop-CLEAN-from-dkms.conf.patch
@@ -1,7 +1,7 @@
 From 8673745cf5ef57269f03496c00b98e196a66c82b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 4 Nov 2025 11:26:37 +0800
-Subject: [PATCH 52/52] loonggpu: Drop CLEAN= from dkms.conf
+Subject: [PATCH 52/61] loonggpu: Drop CLEAN= from dkms.conf
 
 It's unneeded and deprecated in the recent dkms release.
 
@@ -20,5 +20,5 @@ index 044472a..ee69c4e 100644
      make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
 -CLEAN="make KERNEL_UNAME=${kernelver} clean"
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0053-loonggpu-adapt-for-ttm_device_init-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0053-loonggpu-adapt-for-ttm_device_init-API-change.patch
@@ -1,0 +1,36 @@
+From e58dec077d50868b7dec65f9806b18684e203743 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 14:58:46 +0800
+Subject: [PATCH 53/61] loonggpu: adapt for ttm_device_init API change
+
+Link: https://git.kernel.org/torvalds/c/77e19f8d3297
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/gsgpu_helper.h | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index e21d402..dd55fb0 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -102,7 +102,16 @@ static inline int lg_gsgpu_ttm_bo_device_init(struct gsgpu_device *adev,
+ 					#endif
+ 					     )
+ {
+-#if defined(LG_DRM_TTM_TTM_DEVICE_H_PRESENT)
++#ifdef TTM_ALLOCATION_POOL_USE_DMA_ALLOC
++	return ttm_device_init(&adev->mman.bdev,
++				driver, adev->dev,
++				adev->ddev->anon_inode->i_mapping,
++				adev->ddev->vma_offset_manager,
++				(adev->need_swiotlb ?
++				 TTM_ALLOCATION_POOL_USE_DMA_ALLOC : 0) |
++				(dma_addressing_limited(adev->dev) ?
++				 TTM_ALLOCATION_POOL_USE_DMA32 : 0));
++#elif defined(LG_DRM_TTM_TTM_DEVICE_H_PRESENT)
+ 	return ttm_device_init(&adev->mman.bdev,
+ 				driver, adev->dev,
+ 				adev->ddev->anon_inode->i_mapping,
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0054-loonggpu-drop-LG_DRM_CRTC_STATE_HAS_ASYNC_FLIP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0054-loonggpu-drop-LG_DRM_CRTC_STATE_HAS_ASYNC_FLIP.patch
@@ -1,0 +1,73 @@
+From 74365a9e0d3a9f62fd67ea465d2901060e329205 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 15:19:45 +0800
+Subject: [PATCH 54/61] loonggpu: drop LG_DRM_CRTC_STATE_HAS_ASYNC_FLIP
+
+The "conftest" for this seems buggy on Linux 6.19.  We don't care about
+compatibility with Linux < 5.4 so drop it.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh            | 16 ----------------
+ gsgpu/gsgpu.Kbuild     |  1 -
+ include/gsgpu_helper.h |  4 ----
+ 3 files changed, 21 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index e7df1a1..e4471eb 100755
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -1112,22 +1112,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_DRM_SCHED_JOB_INIT_HAS_CREDITS" "" "types"
+         ;;
+ 
+-        drm_crtc_state_has_async_flip)
+-            #
+-            # Determine if the drm_crtc_state has an async_flip member.
+-            #
+-            # Added by commit 4d85f45c73a2 ("drm/atomic: Rename
+-            # crtc_state->pageflip_flags to async_flip") in v5.4-rc1.
+-            #
+-            CODE="
+-            #include <drm/drm_crtc.h>
+-            int conftest_drm_crtc_state_has_async_flip(void) {
+-                return offsetof(struct drm_crtc_state, async_flip);
+-            }"
+-
+-            compile_check_conftest "$CODE" "LG_DRM_CRTC_STATE_HAS_ASYNC_FLIP" "" "types"
+-        ;;
+-
+         drm_mode_config_funcs_has_output_pull_changed)
+             #
+             # Determine if the drm_mode_config_funcs has output_pull_changed member.
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index 1c90385..a59249e 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -109,7 +109,6 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_hdmi_avi_infoframe_from_display_mode_const
+ LG_CONFTEST_TYPE_COMPILE_TESTS += ttm_buffer_object_has_base
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_gem_prime_res_obj
+ LG_CONFTEST_TYPE_COMPILE_TESTS += ttm_validate_buffer_has_num_shared
+-LG_CONFTEST_TYPE_COMPILE_TESTS += drm_crtc_state_has_async_flip
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_gem_prime_export_has_dev_arg
+ LG_CONFTEST_TYPE_COMPILE_TESTS += loongson_screen_state
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_connector_for_each_possible_encoder
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index dd55fb0..fb8f2d2 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -242,11 +242,7 @@ static inline void lg_ttm_validate_buffer_set_shared(struct ttm_validate_buffer
+  */
+ static inline bool lg_drm_crtc_state_async_flip(struct drm_crtc_state *state)
+ {
+-#if defined(LG_DRM_CRTC_STATE_HAS_ASYNC_FLIP)
+ 	return state->async_flip;
+-#else
+-	return (state->pageflip_flags & DRM_MODE_PAGE_FLIP_ASYNC);
+-#endif
+ }
+ 
+ /*
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0055-loonggpu-drop-LG_DRM_BRIDGE_ATTACH_HAS_FLAGS_ARG.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0055-loonggpu-drop-LG_DRM_BRIDGE_ATTACH_HAS_FLAGS_ARG.patch
@@ -1,0 +1,110 @@
+From 5ec2a96d8525b3df6a83eb9605697a1f693169ac Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 16:19:01 +0800
+Subject: [PATCH 55/61] loonggpu: drop LG_DRM_BRIDGE_ATTACH_HAS_FLAGS_ARG
+
+The "conftest" for this seems buggy on Linux 6.19.  We don't care about
+compatibility with Linux < 5.7 so drop it.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh               | 18 ------------------
+ gsgpu-bridge/bridge_phy.c |  8 +++++---
+ gsgpu/gsgpu.Kbuild        |  1 -
+ include/gsgpu_helper.h    | 11 -----------
+ 4 files changed, 5 insertions(+), 33 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index e4471eb..971faec 100755
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -1221,24 +1221,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_DRM_CONNECTOR_FOR_EACH_POSSIBLE_ENCODER_HAS_I" "" "types"
+         ;;
+ 
+-        drm_bridge_attach)
+-            #
+-            # Determine if the drm_bridge_attach() function has the flags argument.
+-            #
+-            # Changed by commit a25b988ff83f3ca0d8f5acf855fb1717c1c61a69 ("drm/bridge:
+-            # Extend bridge API to disable connector creation") in v5.6-rc3.
+-            #
+-            CODE="
+-            #include <drm/drm_bridge.h>
+-            #include <drm/drm_encoder.h>
+-            int conftest_drm_bridge_attach(struct drm_encoder *encoder, struct drm_bridge *bridge,
+-                                           struct drm_bridge *previous,
+-                                           enum drm_bridge_attach_flags flags) {
+-                return drm_bridge_attach(encoder, bridge, previous, flags);
+-            }"
+-            compile_check_conftest "$CODE" "LG_DRM_BRIDGE_ATTACH_HAS_FLAGS_ARG" "" "types"
+-        ;;
+-
+         drm_sched_priority)
+             #
+             # Determine if drm_sched_priority structure contains the DRM_SCHED_PRIORITY_COUNT.
+diff --git a/gsgpu-bridge/bridge_phy.c b/gsgpu-bridge/bridge_phy.c
+index 353a481..b3bf1b6 100644
+--- a/gsgpu-bridge/bridge_phy.c
++++ b/gsgpu-bridge/bridge_phy.c
+@@ -176,15 +176,17 @@ void bridge_phy_mode_set(struct gsgpu_bridge_phy *phy,
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+-#define lg_bridge_phy_attach_args_1 \
++#define lg_bridge_phy_attach_args \
+ 	struct drm_bridge *bridge, \
+ 	struct drm_encoder *encoder, \
+ 	enum drm_bridge_attach_flags flags
+ #else
+-#define lg_bridge_phy_attach_args_1 lg_bridge_phy_attach_args
++#define lg_bridge_phy_attach_args \
++	struct drm_bridge *bridge, \
++	enum drm_bridge_attach_flags flags
+ #endif
+ 
+-static int bridge_phy_attach (lg_bridge_phy_attach_args_1)
++static int bridge_phy_attach (lg_bridge_phy_attach_args)
+ {
+ 	struct gsgpu_bridge_phy *phy = to_bridge_phy(bridge);
+ 	struct gsgpu_connector *lconnector;
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index a59249e..6f0357d 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -112,7 +112,6 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += ttm_validate_buffer_has_num_shared
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_gem_prime_export_has_dev_arg
+ LG_CONFTEST_TYPE_COMPILE_TESTS += loongson_screen_state
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_connector_for_each_possible_encoder
+-LG_CONFTEST_TYPE_COMPILE_TESTS += drm_bridge_attach
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_priority
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_priority_has_min
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_entity_init
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index fb8f2d2..dfeea60 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -316,20 +316,9 @@ static inline int lg_drm_bridge_attach(struct drm_encoder *encoder,
+ 					struct drm_bridge *previous,
+ 					int flags)
+ {
+-#if defined(LG_DRM_BRIDGE_ATTACH_HAS_FLAGS_ARG)
+ 	return drm_bridge_attach(encoder, bridge, previous, (enum drm_bridge_attach_flags)flags);
+-#else
+-	return drm_bridge_attach(encoder, bridge, previous);
+-#endif
+ }
+ 
+-
+-#if defined(LG_DRM_BRIDGE_ATTACH_HAS_FLAGS_ARG)
+-#define lg_bridge_phy_attach_args struct drm_bridge *bridge, enum drm_bridge_attach_flags flags
+-#else
+-#define lg_bridge_phy_attach_args struct drm_bridge *bridge
+-#endif
+-
+ #if defined(LG_DRM_CRTC_HELPER_FUNCS_HAS_GET_SCANOUT_POSITION)
+ #define lg_get_scanout_position_setting(func) .get_scanout_position = func
+ #else
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0056-loonggpu-drop-LG_DRM_FB_HELPER_PREPARE_HAS_BPP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0056-loonggpu-drop-LG_DRM_FB_HELPER_PREPARE_HAS_BPP.patch
@@ -1,0 +1,83 @@
+From 040497a08c0af0bd5da18407d2137e29d2b26b22 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 16:26:56 +0800
+Subject: [PATCH 56/61] loonggpu: drop LG_DRM_FB_HELPER_PREPARE_HAS_BPP
+
+The "conftest" for this seems buggy on Linux 6.19.  We don't care about
+compatibility with Linux < 6.3 so drop it.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh            | 14 --------------
+ gsgpu/gsgpu.Kbuild     |  1 -
+ include/gsgpu_helper.h |  8 --------
+ 3 files changed, 23 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index 971faec..54ab5d3 100755
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -2031,20 +2031,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_FB_INFO_HAS_APERTURES" "" "types"
+         ;;
+ 
+-        drm_fb_helper_prepare)
+-            #
+-            # Determine if the drm_fb_helper_prepare has preferred_bpp argument.
+-            #
+-            # Added by commit 6c80a93be62d398e1854d95069340b2e60f96166 ("drm/fb-helper:
+-            # Initialize fb-helper's preferred BPP in prepare function") in v6.2-rc6
+-            CODE="
+-            #include <drm/drm_fb_helper.h>
+-            void conftest_drm_fb_helper_prepare(void) {
+-                drm_fb_helper_prepare(NULL, NULL, 0, NULL);
+-            }"
+-            compile_check_conftest "$CODE" "LG_DRM_FB_HELPER_PREPARE_HAS_BPP" "" "types"
+-        ;;
+-
+         pwm_free)
+             #
+             # Determine if pwm_free exist.
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index 6f0357d..27df55c 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -140,7 +140,6 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += dma_resv_usage_bookkeep
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_plane_atomic_check_has_atomic_state_arg
+ LG_CONFTEST_TYPE_COMPILE_TESTS += vga_client_register
+ LG_CONFTEST_TYPE_COMPILE_TESTS += fb_info_has_apertures
+-LG_CONFTEST_TYPE_COMPILE_TESTS += drm_fb_helper_prepare
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_mode_config_has_fb_base
+ LG_CONFTEST_TYPE_COMPILE_TESTS += pci_set_dma_mask
+ LG_CONFTEST_TYPE_COMPILE_TESTS += ttm_device_has_lru_lock
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index dfeea60..fad6670 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -531,11 +531,7 @@ static inline void lg_drm_fb_helper_prepare(struct drm_device *dev, struct drm_f
+ 						unsigned int bpp,
+ 						const struct drm_fb_helper_funcs *funcs)
+ {
+-#if defined(LG_DRM_FB_HELPER_PREPARE_HAS_BPP)
+ 	drm_fb_helper_prepare(dev, helper, bpp, funcs);
+-#else
+-	drm_fb_helper_prepare(dev, helper, funcs);
+-#endif
+ }
+ 
+ static inline void lg_drm_fb_helper_single_add_all_connectors(struct drm_fb_helper *helper)
+@@ -548,11 +544,7 @@ static inline void lg_drm_fb_helper_single_add_all_connectors(struct drm_fb_help
+ 
+ static inline void lg_drm_fb_helper_initial_config(struct drm_fb_helper *helper, unsigned int bpp)
+ {
+-#if defined(LG_DRM_FB_HELPER_PREPARE_HAS_BPP)
+ 	drm_fb_helper_initial_config(helper);
+-#else
+-	drm_fb_helper_initial_config(helper, bpp);
+-#endif
+ }
+ 
+ static inline void lg_pwm_free(struct pwm_device *pwm)
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0057-loonggpu-drop-LG_ATOMIC_CHECK_HAS_DRM_ATOMIC_STATE.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0057-loonggpu-drop-LG_ATOMIC_CHECK_HAS_DRM_ATOMIC_STATE.patch
@@ -1,0 +1,95 @@
+From 9ddab858054f356e46d5d0e4de3bc131c334d4b4 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Dec 2025 15:01:33 +0800
+Subject: [PATCH 57/61] loonggpu: drop LG_ATOMIC_CHECK_HAS_DRM_ATOMIC_STATE
+
+The "conftest" for this seems buggy on Linux 6.19.  We don't care about
+compatibility with Linux < 5.13 so drop it.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh            | 22 ----------------------
+ gsgpu/gsgpu.Kbuild     |  1 -
+ gsgpu/gsgpu_dc_plane.c |  3 ++-
+ include/gsgpu_helper.h |  6 ------
+ 4 files changed, 2 insertions(+), 30 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index 54ab5d3..fa08845 100755
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -1949,28 +1949,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "LG_DMA_RESV_USAGE_BOOKKEEP_PRESENT" "" "types"
+         ;;
+ 
+-        drm_plane_atomic_check_has_atomic_state_arg)
+-            #
+-            # Determine if the drm_plane_helper_funcs->atomic_check()
+-            # has 'atomic_state' parameter.
+-            #
+-            # Changed by commit 7c11b99a8e58c0875c4d433c6aea10e9fb93beb1 ("drm/atomic:
+-            # Pass the full state to planes atomic_check") in v5.12-rc1
+-            #
+-            CODE="
+-            #include <drm/drm_modeset_helper_vtables.h>
+-            #include <drm/drm_plane.h>
+-            #include <drm/drm_atomic.h>
+-            static const struct drm_plane_helper_funcs *funcs;
+-            typeof(*funcs->atomic_check) conftest_drm_plane_atomic_check_has_atomic_state_arg;
+-            int conftest_drm_plane_atomic_check_has_atomic_state_arg(
+-                    struct drm_plane *plane,
+-                    struct drm_atomic_state *state) {
+-                return 0;
+-            }"
+-            compile_check_conftest "$CODE" "LG_ATOMIC_CHECK_HAS_DRM_ATOMIC_STATE" "" "types"
+-        ;;
+-
+         vga_client_register)
+             #
+             # Determine if the function vga_client_register() has
+diff --git a/gsgpu/gsgpu.Kbuild b/gsgpu/gsgpu.Kbuild
+index 27df55c..dac495a 100644
+--- a/gsgpu/gsgpu.Kbuild
++++ b/gsgpu/gsgpu.Kbuild
+@@ -137,7 +137,6 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_backend_ops_timedout_job_ret_sched_s
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_entity_push_job
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_sched_backend_ops_has_prepare
+ LG_CONFTEST_TYPE_COMPILE_TESTS += dma_resv_usage_bookkeep
+-LG_CONFTEST_TYPE_COMPILE_TESTS += drm_plane_atomic_check_has_atomic_state_arg
+ LG_CONFTEST_TYPE_COMPILE_TESTS += vga_client_register
+ LG_CONFTEST_TYPE_COMPILE_TESTS += fb_info_has_apertures
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_mode_config_has_fb_base
+diff --git a/gsgpu/gsgpu_dc_plane.c b/gsgpu/gsgpu_dc_plane.c
+index 2005e44..78f64df 100644
+--- a/gsgpu/gsgpu_dc_plane.c
++++ b/gsgpu/gsgpu_dc_plane.c
+@@ -105,7 +105,8 @@ static void dc_plane_helper_cleanup_fb(struct drm_plane *plane,
+ 	gsgpu_bo_unref(&rbo);
+ }
+ 
+-static int dc_plane_atomic_check(lg_dc_plane_atomic_check_args)
++static int dc_plane_atomic_check(struct drm_plane *plane,
++				 struct drm_atomic_state *state)
+ {
+ 	return 0;
+ }
+diff --git a/include/gsgpu_helper.h b/include/gsgpu_helper.h
+index fad6670..8c0eee5 100644
+--- a/include/gsgpu_helper.h
++++ b/include/gsgpu_helper.h
+@@ -461,12 +461,6 @@ static inline void lg_drm_sched_job_arm(struct drm_sched_job *job)
+ #define LG_DMA_RESV_USAGE_READ		0
+ #endif
+ 
+-#if defined(LG_ATOMIC_CHECK_HAS_DRM_ATOMIC_STATE)
+-#define lg_dc_plane_atomic_check_args	struct drm_plane *plane, struct drm_atomic_state *state
+-#else
+-#define lg_dc_plane_atomic_check_args	struct drm_plane *plane, struct drm_plane_state *state
+-#endif
+-
+ #if defined(LG_VGA_CLIENT_REGISTER_HAS_COOKIE)
+ #define lg_vga_set_decode_args void *cookie, bool state
+ #define lg_vga_set_decode_get_adev cookie
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0058-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0058-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
@@ -1,0 +1,44 @@
+From 2e90c56b687f6e20f2c6deb6821f63c2bb595133 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 17:12:38 +0800
+Subject: [PATCH 58/61] loonggpu: remove gsgpu_driver_lastclose_kms on Linux >=
+ 6.12
+
+This is not used on Linux >= 6.12, and it fails to build on Linux 6.19.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_kms.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gsgpu/gsgpu_kms.c b/gsgpu/gsgpu_kms.c
+index fb37143..adf674d 100644
+--- a/gsgpu/gsgpu_kms.c
++++ b/gsgpu/gsgpu_kms.c
+@@ -6,6 +6,7 @@
+ #include <linux/slab.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/pci.h>
++#include <linux/version.h>
+ #include <drm/drm_debugfs.h>
+ #include "gsgpu_gtt_mgr_helper.h"
+ 
+@@ -534,6 +535,7 @@ static int gsgpu_info_ioctl(struct drm_device *dev, void *data, struct drm_file
+ }
+ 
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ /*
+  * Outdated mess for old drm with Xorg being in charge (void function now).
+  */
+@@ -549,6 +551,7 @@ void gsgpu_driver_lastclose_kms(struct drm_device *dev)
+ 	drm_fb_helper_lastclose(dev);
+ 	vga_switcheroo_process_delayed_switch();
+ }
++#endif
+ 
+ /**
+  * gsgpu_driver_open_kms - drm callback for open
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0059-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0059-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
@@ -1,0 +1,31 @@
+From 4abb9827e9309342285a40f737856f3a17067bf7 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Dec 2025 09:49:49 +0800
+Subject: [PATCH 59/61] loonggpu: use ttm_resource_manager_cleanup instead of
+ manually inlining it
+
+It should work since Linux 5.9.  And inlining an outdated copy causes a
+build failure on Linux 6.19.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_ttm.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/gsgpu/gsgpu_ttm.c b/gsgpu/gsgpu_ttm.c
+index 2cd63c0..0c583af 100644
+--- a/gsgpu/gsgpu_ttm.c
++++ b/gsgpu/gsgpu_ttm.c
+@@ -1718,8 +1718,7 @@ void gsgpu_ttm_set_buffer_funcs_status(struct gsgpu_device *adev, bool enable)
+ 		}
+ 	} else {
+ 		drm_sched_entity_destroy(&adev->mman.entity);
+-		dma_fence_put(man->move);
+-		man->move = NULL;
++		ttm_resource_manager_cleanup(man);
+ 	}
+ 
+ 	/* this just adjusts TTM size idea, which sets lpfn to the correct value */
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0060-loonggpu-restore-PWM-enable-disable.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0060-loonggpu-restore-PWM-enable-disable.patch
@@ -1,0 +1,77 @@
+From daa80307427e8e2fcb2f7c34cdd483928a6baccc Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Dec 2025 10:49:49 +0800
+Subject: [PATCH 60/61] loonggpu: restore PWM enable/disable
+
+When I removed the GPIO support, for convenience I removed the entire
+backlight enable/disable routines.  But it turns out doing so will leave
+PWM enabled on suspend and then PWM subsystem will reject the suspend
+request.
+
+Restore PWM enable/disable routine to fix it.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/gsgpu_backlight.h | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/include/gsgpu_backlight.h b/include/gsgpu_backlight.h
+index 178c225..759447a 100644
+--- a/include/gsgpu_backlight.h
++++ b/include/gsgpu_backlight.h
+@@ -34,11 +34,17 @@ struct gsgpu_backlight {
+ 	void (*power)(struct gsgpu_backlight *ls_bl, bool enable);
+ };
+ 
++static inline void lg_gpio_set_value(int gpio, int val)
++{
+ #ifdef LG_GPIO_WORKS
++	gpio_set_value(gpio, val);
++#endif
++}
++
+ #define BACKLIGHT_DEFAULT_METHOD_CLOSE(ls_bl)\
+ 	do { \
+ 		ls_bl->hw_enabled = false;\
+-		gpio_set_value(GPIO_LCD_EN, 0);\
++		lg_gpio_set_value(GPIO_LCD_EN, 0);\
+ 		msleep(10);\
+ 		pwm_disable(ls_bl->pwm); \
+ 	} while (0)
+@@ -48,30 +54,24 @@ struct gsgpu_backlight {
+ 		ls_bl->hw_enabled = false;\
+ 		BACKLIGHT_DEFAULT_METHOD_CLOSE(ls_bl);\
+ 		msleep(160);\
+-		gpio_set_value(GPIO_LCD_VDD, 0); \
++		lg_gpio_set_value(GPIO_LCD_VDD, 0); \
+ 	} while (0)
+ 
+ #define BACKLIGHT_DEFAULT_METHOD_OPEN(ls_bl)\
+ 	do { \
+ 		pwm_enable(ls_bl->pwm);\
+ 		msleep(10);\
+-		gpio_set_value(GPIO_LCD_EN, 1);\
++		lg_gpio_set_value(GPIO_LCD_EN, 1);\
+ 		ls_bl->hw_enabled = true; \
+ 	} while (0)
+ 
+ #define BACKLIGHT_DEFAULT_METHOD_FORCE_OPEN(ls_bl)\
+ 	do {\
+-		gpio_set_value(GPIO_LCD_VDD, 1);\
++		lg_gpio_set_value(GPIO_LCD_VDD, 1);\
+ 		msleep(160);\
+ 		BACKLIGHT_DEFAULT_METHOD_OPEN(ls_bl);\
+ 		ls_bl->hw_enabled = true; \
+ 	} while (0)
+-#else /* LG_GPIO_WORKS */
+-#define BACKLIGHT_DEFAULT_METHOD_CLOSE(ls_bl)
+-#define BACKLIGHT_DEFAULT_METHOD_FORCE_CLOSE(ls_bl)
+-#define BACKLIGHT_DEFAULT_METHOD_OPEN(ls_bl)
+-#define BACKLIGHT_DEFAULT_METHOD_FORCE_OPEN(ls_bl)
+-#endif
+ 
+ int gsgpu_backlight_register(struct drm_connector *connector);
+ int gsgpu_late_register(struct drm_connector *connector);
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0061-loonggpu-limit-the-7A2000-DC-resolution-to-WUXGA.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0061-loonggpu-limit-the-7A2000-DC-resolution-to-WUXGA.patch
@@ -1,0 +1,36 @@
+From e0fd7386c160f9e67e287bd180e9f00dbd506ef8 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Dec 2025 10:57:33 +0800
+Subject: [PATCH 61/61] loonggpu: limit the 7A2000 DC resolution to WUXGA
+
+The manual states 1080p is the maximum supported resolution but
+unfortunately some laptops using 7A2000 DC to display on WUXGA
+(1920x1200) screen, and they seem working fine.
+
+Anyway 4K does not work correctly, so limit the resolution to WUXGA,
+the maximum resolution we've "verified."
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gsgpu/gsgpu_dc_crtc.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gsgpu/gsgpu_dc_crtc.c b/gsgpu/gsgpu_dc_crtc.c
+index 0de388e..dc8f9e5 100644
+--- a/gsgpu/gsgpu_dc_crtc.c
++++ b/gsgpu/gsgpu_dc_crtc.c
+@@ -559,9 +559,9 @@ static enum drm_mode_status gsgpu_dc_mode_valid(struct drm_crtc *crtc,
+ 
+ 	switch (adev->chip) {
+ 	case dev_7a2000:
+-		if (mode->hdisplay > 4096)
++		if (mode->hdisplay > 1920)
+ 			return MODE_BAD;
+-		if (mode->vdisplay > 2160)
++		if (mode->vdisplay > 1200)
+ 			return MODE_BAD;
+ 		if (mode->hdisplay == 1680)
+ 			return MODE_BAD;
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.1-alpha-lnd25.5
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/\~}
-REL=10
+REL=11
 SRCS="file::use-url-name=true::https://pkg.loongnix.cn/loongnix/25/pool/main/l/loonggpu-kernel-dkms/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::54457137f702b4d5f1f36ee27d4d8de964181cec8898253291343cccefa2f0bd"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- Prepare for Linux 6.19: add adaptions which do not need check LINUX_VERSION_CODE that the upstream won't bump until 6.19-rc1 release.
- Limit the resolution to 1920x1200 per the manual and field test result.
- Fix suspend failure.
- Track AOSC patches at https://github.com/AOSC-Tracking/loonggpu-kernel-dkms (HEAD: e0fd7386c160f9e67e287bd180e9f00dbd506ef8)

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

loonggpu-kernel-dkms: `1.0.1~alpha~lnd25.5-11`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`