### PR TITLE
goreleaser: update to 2.13.1

### DIFF
--- a/lang-golang/goreleaser/spec
+++ b/lang-golang/goreleaser/spec
@@ -1,4 +1,4 @@
-VER=2.12.7
+VER=2.13.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/goreleaser/goreleaser.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374129"


### PR DESCRIPTION
Topic Description
-----------------

- goreleaser: update to 2.13.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- goreleaser: 2.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit goreleaser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
