### PR TITLE
vscode: update to 1.107.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.106.3
+VER=1.107.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::f26c3a808fb2d34107b353b2ce73fd0acee012f90ffe598deff50789739152cc"
-CHKSUMS__ARM64="sha256::cfc6584816e321360e544f11d0295e93916519a5b91dff60454203215af4a7ab"
+CHKSUMS__AMD64="sha256::88a9198b18c6df0b807c716861af7cbb403bc9bc4dd5617803b01dc03efd785b"
+CHKSUMS__ARM64="sha256::18759cd554dbd4311e6c60e3a85085eb9a8e4b8a58612be5b1556e033bc7ea7a"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.107.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.107.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
