### PR TITLE
rnote: introduce a workaround for gtk wacom issue

### DIFF
--- a/app-doc/rnote/autobuild/patches/0001-workaround-for-gtk-issue-7793.patch
+++ b/app-doc/rnote/autobuild/patches/0001-workaround-for-gtk-issue-7793.patch
@@ -1,0 +1,32 @@
+From be741dea2e024a23f4dd9c2bf246a242b3981f40 Mon Sep 17 00:00:00 2001
+From: Doublonmousse <115779707+Doublonmousse@users.noreply.github.com>
+Date: Tue, 30 Sep 2025 17:50:48 +0000
+Subject: [PATCH] workaround for gtk issue 7793
+
+---
+ crates/rnote-ui/src/canvas/input.rs | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/crates/rnote-ui/src/canvas/input.rs b/crates/rnote-ui/src/canvas/input.rs
+index 221ece62..bfdb0400 100644
+--- a/crates/rnote-ui/src/canvas/input.rs
++++ b/crates/rnote-ui/src/canvas/input.rs
+@@ -178,6 +178,15 @@ pub(crate) fn handle_pointer_controller_event(
+                 }
+             }
+ 
++            // workaround for issue https://gitlab.gnome.org/GNOME/gtk/-/issues/7793
++            #[cfg(target_os = "linux")]
++            {
++                if element.pressure > 0.0 && is_stylus {
++                    pen_state = PenState::Down;
++                }
++            }
++
++
+             match pen_state {
+                 PenState::Up => {
+                     canvas.enable_drawing_cursor(false);
+-- 
+2.51.1
+

--- a/app-doc/rnote/spec
+++ b/app-doc/rnote/spec
@@ -1,5 +1,5 @@
 VER=0.13.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/flxzt/rnote.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375549"


### PR DESCRIPTION
Topic Description
-----------------

- rnote: introduce a workaround for gtk wacom issue
    - Tracking patches at AOSC-Tracking/rnote @ aosc/0.13.1 \(HEAD: be741de\)

Package(s) Affected
-------------------

- rnote: 0.13.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rnote
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
