### PR TITLE
krita: update to 5.2.14

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,4 +1,4 @@
-VER=5.2.13
+VER=5.2.14
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
-CHKSUMS="sha256::ddd3955d77a9d760499466c9e7e11a51e080020ee52e929e2579a0aab600b45a"
+CHKSUMS="sha256::41770910517a8d4546f7028c4725b3bd44c69d10d328c978a2788dbcc707d3df"
 CHKUPDATE="anitya::id=10918"


### PR DESCRIPTION
Topic Description
-----------------

- krita: update to 5.2.14
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- krita: 5.2.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit krita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
