### PR TITLE
gearlever: update to 4.2.0

### DIFF
--- a/app-utils/gearlever/autobuild/patches/0001-Direct-internally-used-script-to-its-new-location-in.patch
+++ b/app-utils/gearlever/autobuild/patches/0001-Direct-internally-used-script-to-its-new-location-in.patch
@@ -1,4 +1,4 @@
-From 9bf3b2d5a8876669241e2cd8aa9eae3667beb27f Mon Sep 17 00:00:00 2001
+From c0f35aa81be5d06dc9d13757a63c00f08c2f749b Mon Sep 17 00:00:00 2001
 From: pugaizai <i@pugai.life>
 Date: Thu, 27 Nov 2025 01:09:58 +0800
 Subject: [PATCH] Direct internally used script to its new location in lib
@@ -8,18 +8,17 @@ Subject: [PATCH] Direct internally used script to its new location in lib
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/providers/AppImageProvider.py b/src/providers/AppImageProvider.py
-index cd9821e..b9fcf9f 100644
+index 8cb65d4..95f3522 100644
 --- a/src/providers/AppImageProvider.py
 +++ b/src/providers/AppImageProvider.py
-@@ -701,7 +701,7 @@ class AppImageProvider():
+@@ -715,7 +715,7 @@ class AppImageProvider():
  
-             if use_unsquashfs:
-                 logging.debug('Testing with unsquashfs')
--                appimage_offset = terminal.sandbox_sh(['get_appimage_offset', file.get_path()])
-+                appimage_offset = terminal.sandbox_sh(['/usr/lib/gearlever/get_appimage_offset', file.get_path()])
+         if  use_unsquashfs:
+             logging.debug('Testing with unsquashfs')
+-            appimage_offset = terminal.sandbox_sh(['get_appimage_offset', file.get_path()])
++            appimage_offset = terminal.sandbox_sh(['/usr/lib/gearlever/get_appimage_offset', file.get_path()])
  
-                 try:
-                     terminal.sandbox_sh(['unsquashfs', '-o', appimage_offset, '-l', file.get_path()])
+             try:
+                 terminal.sandbox_sh(['unsquashfs', '-o', appimage_offset, '-l', file.get_path()])
 -- 
 2.52.0
-

--- a/app-utils/gearlever/spec
+++ b/app-utils/gearlever/spec
@@ -1,4 +1,4 @@
-VER=4.1.1
-SRCS="git::commit=tags/${VER}::https://github.com/mijorus/gearlever"
+VER=4.2.0
+SRCS="git::commit=tags/$VER::https://github.com/mijorus/gearlever.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378021"


### PR DESCRIPTION
Topic Description
-----------------

- gearlever: update to 4.2.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gearlever: 4.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gearlever
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
