### PR TITLE
zhaoxin-linux-graphics-driver: update to 21.00.83

### DIFF
--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,4 +1,4 @@
-From a5963cfc6208bed7e5c6f7ebd808739bf8c13fa6 Mon Sep 17 00:00:00 2001
+From b7838e45375657565d927c74b32c78204f73b113 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
 Subject: [PATCH 1/9] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
@@ -63,5 +63,5 @@ index a2b2900..277d1cf 100644
               -I${ZXGPU_FULL_PATH}/src/cbios/Device \
               -I${ZXGPU_FULL_PATH}/src/cbios/Device/Port \
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,4 +1,4 @@
-From 8e4d5357faabde017294faffeb43721416edf196 Mon Sep 17 00:00:00 2001
+From f7319cdfe52aafde9a2574153d63e78397a2ff9b Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
 Subject: [PATCH 2/9] chore: dkms: remove useless variables
@@ -11,12 +11,12 @@ Link: https://github.com/dkms-project/dkms/commit/961f9ceac4cf6772cb4c52bf4836a0
  1 file changed, 5 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index ebd645e..0c366b0 100644
+index 6dc8d99..f708c69 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,16 +1,12 @@
  PACKAGE_NAME="zx"
- PACKAGE_VERSION=21.00.79
+ PACKAGE_VERSION=21.00.83
  AUTOINSTALL="yes"
 -REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1
@@ -37,5 +37,5 @@ index ebd645e..0c366b0 100644
  MAKE[0]="make -j$(num_cpu_cores) LINUXDIR=$kernel_source_dir -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
 -#POST_REMOVE="post-remove.sh $kernelver"
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,4 +1,4 @@
-From 3a384c2fafe324402aa95fa9c704c9077ca4ee30 Mon Sep 17 00:00:00 2001
+From a7ad39ecceb1bdcfdbac088e93d882f316a8e519 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
 Subject: [PATCH 3/9] fix: kernel: 6.15
@@ -13,10 +13,10 @@ Link: https://patchwork.freedesktop.org/patch/msgid/20241214-drm-connector-mode-
  2 files changed, 6 insertions(+)
 
 diff --git a/src/zx_connector.c b/src/zx_connector.c
-index 92fe498..16a7dc3 100644
+index eb6c48f..3127cbd 100644
 --- a/src/zx_connector.c
 +++ b/src/zx_connector.c
-@@ -294,7 +294,11 @@ END:
+@@ -303,7 +303,11 @@ END:
  }
  
  enum drm_mode_status 
@@ -43,5 +43,5 @@ index 89a7819..48706c2 100644
      .fb_dirty           = zxfb_dirty,
  #endif
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,4 +1,4 @@
-From f1e1314b6ce3f541b7da43c839978c7acce44ce4 Mon Sep 17 00:00:00 2001
+From e7d02059b59d52dee6aea48f15e7faebc9bb8b3c Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
 Subject: [PATCH 4/9] fix: kernel: 6.16
@@ -39,5 +39,5 @@ index 84ff1da..4e91f71 100644
      struct pci_dev*    pdev    = to_pci_dev(kobj_to_dev(kobj));
      struct drm_device* drm_dev = pci_get_drvdata(pdev);
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,4 +1,4 @@
-From e170a0eb554203120c8356bdc1f27db33d55b379 Mon Sep 17 00:00:00 2001
+From fcf1a06cbd68649dd4459c7cb0dde03880ac07fc Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
 Subject: [PATCH 5/9] fix: kernel: 6.17
@@ -134,5 +134,5 @@ index 6acc810..1f49859 100644
  #else
  typedef struct {
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,4 +1,4 @@
-From 4a49d7b148cf57ae0044875796e1e6594b728e3f Mon Sep 17 00:00:00 2001
+From cb9512cdc016c397e39ed999dad64a160f9124d5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
 Subject: [PATCH 6/9] fix: kernel: 6.18
@@ -42,5 +42,5 @@ index 6eecac4..b55023e 100644
  }
  
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,4 +1,4 @@
-From d4a86def62bc8f02dcb384d4667d716edff41989 Mon Sep 17 00:00:00 2001
+From 61d66b0c857fb489b8bb0a0a9e5ecbba911e9188 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:34 +0800
 Subject: [PATCH 7/9] chore: import .gitignore from loonggpu-kernel-dkms
@@ -24,5 +24,5 @@ index 0000000..223542a
 +*.order
 +conftest
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,4 +1,4 @@
-From fb992beebfeca0d47a2c0d4d7ee3eba84d00ac84 Mon Sep 17 00:00:00 2001
+From 77b3bbfed62a6485c8afedc227724c52b0f6c2d9 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:48 +0800
 Subject: [PATCH 8/9] refactor (NFC): rename zxfb_create to zx_fbdev_probe
@@ -33,5 +33,5 @@ index b55023e..96a1456 100644
  #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
      .fb_dirty           = zxfb_dirty,
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,4 +1,4 @@
-From 64e92f64e09b35bb9d1025c0f0cb65696b0403e2 Mon Sep 17 00:00:00 2001
+From bf29a0ab8afd1f5c8d503f32a47f95b8c0fb4c81 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 19:07:04 +0800
 Subject: [PATCH 9/9] fix: run DRM default client setup on Linux >= 6.15
@@ -93,5 +93,5 @@ index a989f9a..8fe5d35 100644
  
  err_pci:
 -- 
-2.51.1
+2.52.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,7 +1,6 @@
-UPSTREAM_VER=21.00.79
+UPSTREAM_VER=21.00.83
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
-REL=2
-SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3418&tag=0&ref=qdxz&pre=0&t=83e1707a341d4e51"
-CHKSUMS="sha256::5d2f466b20e47c1814bdea3b07fe73ed81ff42b58d7e9805660a85ed1d27ca23"
+SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=2509&tag=0&ref=qdxz&pre=0&t=eecb7eac5d344b6d"
+CHKSUMS="sha256::38049d03dcb5d16f393d49a919f4e41b2a81bb910e16f556305d626ce127de22"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- zhaoxin-linux-graphics-driver: update to 21.00.83
    Track DKMS patches at AOSC-Tracking/zx-kernel-dkms @ aosc/v21.00.83
    \(HEAD: bf29a0ab8afd1f5c8d503f32a47f95b8c0fb4c81\)

Package(s) Affected
-------------------

- zhaoxin-linux-graphics-driver-dri: 21.00.83

Security Update?
----------------

No

Build Order
-----------

```
#buildit zhaoxin-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
