### PR TITLE
exim: update to 4.99

### DIFF
--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,4 +1,4 @@
-VER=4.98.2
+VER=4.99
 SRCS="git::commit=tags/exim-$VER;copy-repo=true::https://github.com/Exim/exim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=768"


### PR DESCRIPTION
Topic Description
-----------------

- exim: update to 4.99
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- exim: 4.99

Security Update?
----------------

No

Build Order
-----------

```
#buildit exim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
