### PR TITLE
rustc: update to 1.92.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 241676438261b7de6cc7258c40a50a63f615f0c3 Mon Sep 17 00:00:00 2001
+From 424d63d2175a12fe42d7e3f36d7b909c54b8df5c Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/3] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/3] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 07fb1ce63f..ae990e8287 100644
+index 1638c87c9ca..73c3be2e026 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1443,6 +1443,7 @@ supported_targets! {
+@@ -1433,6 +1433,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
@@ -23,7 +23,7 @@ index 07fb1ce63f..ae990e8287 100644
      ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
 diff --git a/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 new file mode 100644
-index 0000000000..a57ef97626
+index 00000000000..a57ef976265
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 @@ -0,0 +1,8 @@
@@ -36,5 +36,5 @@ index 0000000000..a57ef97626
 +    base
 +}
 -- 
-2.51.1
+2.52.0
 

--- a/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,4 +1,4 @@
-From e102669ba06d73e6ecafd9b9abf8c911509f4985 Mon Sep 17 00:00:00 2001
+From 2169980e0afd8b3f66bef56a57675b69e2a91bd7 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 20:12:53 +0200
 Subject: [PATCH 2/3] ARCHLINUX: compiler: Swap primary and secondary lib dirs
@@ -9,7 +9,7 @@ Arch Linux (editor's note: also AOSC OS) prefers "lib" over "lib64".
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/compiler/rustc_target/src/lib.rs b/compiler/rustc_target/src/lib.rs
-index b3fe1fffcc..913bb3fde6 100644
+index 8c6a77cba8b..2158f3d313c 100644
 --- a/compiler/rustc_target/src/lib.rs
 +++ b/compiler/rustc_target/src/lib.rs
 @@ -53,20 +53,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
@@ -41,5 +41,5 @@ index b3fe1fffcc..913bb3fde6 100644
          }
          Some(libdir) => libdir.into(),
 -- 
-2.51.1
+2.52.0
 

--- a/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,4 +1,4 @@
-From 361f32674a871526b81ea55415cdfbd0459df86c Mon Sep 17 00:00:00 2001
+From 8eb141519c8ad449c2509e05ac6731d2063e078b Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 19:01:26 +0200
 Subject: [PATCH 3/3] ARCHLINUX: bootstrap: Workaround for system stage0
@@ -9,10 +9,10 @@ See: http://github.com/rust-lang/rust/issues/143735
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
-index 82fd1119c7..0e1e2a2d39 100644
+index 6857a40ada8..ad419c494ce 100644
 --- a/src/bootstrap/src/core/build_steps/compile.rs
 +++ b/src/bootstrap/src/core/build_steps/compile.rs
-@@ -794,7 +794,10 @@ impl Step for StdLink {
+@@ -818,7 +818,10 @@ impl Step for StdLink {
                  let _ = fs::remove_dir_all(sysroot.join("lib/rustlib/src/rust"));
              }
  
@@ -25,5 +25,5 @@ index 82fd1119c7..0e1e2a2d39 100644
              if builder.download_rustc() {
                  // Ensure there are no CI-rustc std artifacts.
 -- 
-2.51.1
+2.52.0
 

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,7 +1,7 @@
-VER=1.91.1
+VER=1.92.0
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::66401bb815e236cc6b2aacbbe23b61b286c1fe27a67902e7c0222cfe77b3dbab"
+CHKSUMS="sha256::ebee170bfe4c4dfc59521a101de651e5534f4dae889756a5c97ca9ea40d0c307"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.92.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.92.0
    \(HEAD: 8eb141519c8ad449c2509e05ac6731d2063e078b\).

Package(s) Affected
-------------------

- rustc: 1:1.92.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
