### PR TITLE
daed: update to 1.21.1

### DIFF
--- a/app-proxy/daed/spec
+++ b/app-proxy/daed/spec
@@ -1,7 +1,7 @@
-VER=1.5.1
+VER=1.21.1
 SRCS="tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/daed-full-src.zip \
       tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/web.zip"
-CHKSUMS="sha256::557157d5e95142aad4ec7f5127f75ad797cd94755678fa24990ccfdf38a9ed81 \
-         sha256::92c77aa820e3434606ef0912aa30311b052b4319672f9394ad0aa9f2b8d8a2b8"
+CHKSUMS="sha256::92cbdeadf30045e6a2e280d742f23125d686115093af1cde4f9def84c076dc24 \
+         sha256::ffba0f8b5e9411ad0da10349dfaab2336922d47cd5effd81163ce4415b4d84d7"
 CHKUPDATE="anitya::id=375373"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- daed: update to 1.21.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- daed: 1.21.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit daed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
