### PR TITLE
box64: update to 0.3.9+git20251213

### DIFF
--- a/app-emulation/box64/autobuild/defines
+++ b/app-emulation/box64/autobuild/defines
@@ -1,14 +1,12 @@
 PKGNAME=box64
 PKGSEC=utils
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="mold"
 PKGDES="Userspace emulator for running x86-64 applications on non-x86 systems"
 ABTYPE="cmakeninja"
 
 # Note: -DCI=ON, regenerates function wrappers, which is unnecessary for packaging?
 CMAKE_AFTER=(
     "-DCI=ON"
-    "-DWITH_MOLD=ON"
     "-DBOX32=ON"
     "-DBOX32_BINFMT=ON"
 )

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,5 +1,5 @@
-VER=0.3.9+git20251130
+VER=0.3.9+git20251213
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=c4e09fddb9e15de5d7b096af17dabc5fe0d2663c;copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=e6961d845e6acb1d790d5da9377aab073df7a2dc;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251213
    - Remove unused BUILDDEP

Package(s) Affected
-------------------

- box64: 0.3.9+git20251213

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
