### PR TITLE
tauri-cli: update to 2.9.6

### DIFF
--- a/lang-rust/tauri-cli/spec
+++ b/lang-rust/tauri-cli/spec
@@ -1,4 +1,4 @@
-VER=2.9.4
+VER=2.9.6
 SRCS="git::commit=tags/tauri-cli-v$VER::https://github.com/tauri-apps/tauri"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371844"


### PR DESCRIPTION
Topic Description
-----------------

- tauri-cli: update to 2.9.6
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- tauri-cli: 2.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit tauri-cli
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
