### PR TITLE
multipath-tools: fix etc prefix

### DIFF
--- a/app-admin/multipath-tools/autobuild/defines
+++ b/app-admin/multipath-tools/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="json-c libaio liburcu lvm2"
 PKGDES="Tools to maintain multipath block device access"
 
 MAKE_AFTER="prefix=/usr \
+            etc_prefix= \
             LIB=lib \
             SYSTEMDPATH=lib"
 

--- a/app-admin/multipath-tools/spec
+++ b/app-admin/multipath-tools/spec
@@ -1,4 +1,5 @@
 VER=0.13.0
-SRCS="https://github.com/opensvc/multipath-tools/archive/$VER.tar.gz"
-CHKSUMS="sha256::ed0bf455d5886d642875c302f7cf0362ca29cd2ab8dbc42e50cca9bd5855640b"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/opensvc/multipath-tools.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=424"


### PR DESCRIPTION
Topic Description
-----------------

- multipath-tools: fix etc prefix
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- multipath-tools: 0.13.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit multipath-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
