### PR TITLE
gamescope: update to 3.16.18

### DIFF
--- a/desktop-wm/gamescope/spec
+++ b/desktop-wm/gamescope/spec
@@ -1,5 +1,4 @@
-VER=3.16.17
-REL=1
+VER=3.16.18
 # Note: Stb commit hash is defined at https://github.com/ValveSoftware/gamescope/$VER/subprojects/stb.wrap
 SRCS="git::commit=tags/$VER::https://github.com/ValveSoftware/gamescope.git \
       git::commit=5736b15f7ea0ffb08dd38af21067c314d6a3aae9;rename=gamescope/subprojects/stb::https://github.com/nothings/stb.git"


### PR DESCRIPTION
Topic Description
-----------------

- gamescope: update to 3.16.18
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gamescope: 3.16.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit gamescope
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
