### PR TITLE
pyiso8601 Survey 10151215

### DIFF
--- a/app-multimedia/ykdl/spec
+++ b/app-multimedia/ykdl/spec
@@ -1,5 +1,4 @@
-VER=1.8.0~a2
-SRCS="tbl::https://github.com/SeaHOH/ykdl/archive/refs/tags/v${VER/\~}.tar.gz"
-CHKSUMS="sha256::b5ad62f83ceb191784a369d28bce4f11bd724c227fa584abfed4d01323824574"
+VER=1.8.2
+SRCS="git::commit=tags/v${VER}::https://github.com/SeaHOH/ykdl"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=202874"
-REL=1

--- a/lang-python/keystoneauth1/spec
+++ b/lang-python/keystoneauth1/spec
@@ -1,4 +1,4 @@
-VER=5.7.0
-SRCS="tbl::https://pypi.io/packages/source/k/keystoneauth1/keystoneauth1-$VER.tar.gz"
-CHKSUMS="sha256::b2cc2d68d1a48e9c2c6d9b1b1fd00d7c7bdfe086e8040b51e70938a8ba3adfd1"
+VER=5.12.0
+SRCS="pypi::version=$VER::keystoneauth1"
+CHKSUMS="sha256::dd113c2f3dcb418d9f761c73b8cd43a96ddfa8a612b51c576822381f39ca4ae8"
 CHKUPDATE="anitya::id=7508"

--- a/lang-python/keystoneclient/spec
+++ b/lang-python/keystoneclient/spec
@@ -1,4 +1,4 @@
-VER=5.4.0
-SRCS="tbl::https://pypi.io/packages/source/p/python-keystoneclient/python-keystoneclient-$VER.tar.gz"
-CHKSUMS="sha256::b2b4bdbe9daf7b0b353b8807672eeed01f87dd03b4f8b42d0d061b09b8931f41"
+VER=5.7.0
+SRCS="pypi::version=$VER::python-keystoneclient"
+CHKSUMS="sha256::8ce7bf1c8cddca6d7140fc76918b44eddf1d64040a60cb8ff7059136104d4ceb"
 CHKUPDATE="anitya::id=29732"

--- a/lang-python/m3u8/autobuild/defines
+++ b/lang-python/m3u8/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=m3u8
 PKGSEC=python
-PKGDES="A Python written m3u8 parser"
+PKGDES="Python m3u8 Parser for HTTP Live Streaming (HLS) Transmissions"
 PKGDEP="python-3 pyiso8601"
 
 ABTYPE=python

--- a/lang-python/m3u8/spec
+++ b/lang-python/m3u8/spec
@@ -1,5 +1,4 @@
-VER=0.7.1
-SRCS="tbl::https://github.com/globocom/m3u8/archive/${VER}.tar.gz"
-CHKSUMS="sha256::cc643ec55d2fa9cf6ee43bfa6a71d76693584709036df63356509c2bc2a2ed24"
+VER=6.0.0
+SRCS="git::commit=tags/${VER}::https://github.com/globocom/m3u8"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=37610"
-REL=1

--- a/lang-python/novaclient/spec
+++ b/lang-python/novaclient/spec
@@ -1,4 +1,4 @@
-VER=18.6.0
-SRCS="tbl::https://pypi.io/packages/source/p/python-novaclient/python-novaclient-$VER.tar.gz"
-CHKSUMS="sha256::573c10aa420b0898d35fb146edd8bb005806bfff0131ae2b5a30ca22ac89477b"
+VER=18.11.0
+SRCS="pypi::version=$VER::python-novaclient"
+CHKSUMS="sha256::0a31ae20779d4cd171bb29c1fe4e6b22b9c7d97c79670db5149bbdfac03f57dc"
 CHKUPDATE="anitya::id=5460"

--- a/lang-python/oslo-serialization/spec
+++ b/lang-python/oslo-serialization/spec
@@ -1,4 +1,4 @@
-VER=5.4.0
-SRCS="tbl::https://pypi.io/packages/source/o/oslo.serialization/oslo.serialization-$VER.tar.gz"
-CHKSUMS="sha256::315cb3465e99c685cb091b90365cb701bee7140e204ba3e5fc2d8a20b4ec6e76"
+VER=5.8.0
+SRCS="pypi::version=$VER::oslo.serialization"
+CHKSUMS="sha256::5871a62b23f98cacd5518482941ae6d2a983e2936ed52d543ad08685dc6d2343"
 CHKUPDATE="anitya::id=13181"

--- a/lang-python/oslo-utils/spec
+++ b/lang-python/oslo-utils/spec
@@ -1,4 +1,4 @@
-VER=7.2.0
-SRCS="tbl::https://pypi.io/packages/source/o/oslo.utils/oslo.utils-$VER.tar.gz"
-CHKSUMS="sha256::94f8053391a33502dab4d84465403262ca19ffd8cfd29a1a5ea3c8aa620ef610"
+VER=9.2.0
+SRCS="pypi::version=$VER::oslo.utils"
+CHKSUMS="sha256::1f42006de6b9291a0305025f5ccdb8907120d88ed7ebc3784a1472a3328048ab"
 CHKUPDATE="anitya::id=3951"

--- a/lang-python/pbr/autobuild/defines
+++ b/lang-python/pbr/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=pbr
 PKGSEC=python
 PKGDEP="pip"
 BUILDDEP="setuptools"
-PKGDES="A library that injects some useful and sensible default behaviors into your setuptools run"
+PKGDES="Inject useful and sensible default behaviors into setuptools"
 
 ABHOST=noarch
 ABTYPE=pep517

--- a/lang-python/pbr/spec
+++ b/lang-python/pbr/spec
@@ -1,4 +1,4 @@
-VER=6.0.0
-SRCS="tbl::https://pypi.io/packages/source/p/pbr/pbr-$VER.tar.gz"
-CHKSUMS="sha256::d1377122a5a00e2f940ee482999518efe16d745d423a670c27773dfbc3c9a7d9"
+VER=7.0.3
+SRCS="pypi::version=$VER::pbr"
+CHKSUMS="sha256::b46004ec30a5324672683ec848aed9e8fc500b0d261d40a3229c2d2bbfcedc29"
 CHKUPDATE="anitya::id=3960"

--- a/lang-python/pyiso8601/autobuild/defines
+++ b/lang-python/pyiso8601/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=pyiso8601
 PKGSEC=python
-PKGDES="ISO8601 formatted datetime parser for python "
+PKGDES="ISO 8601-formatted datetime parser for Python"
 PKGDEP="python-3"
 BUILDDEP="setuptools"
 

--- a/lang-python/pyiso8601/autobuild/defines
+++ b/lang-python/pyiso8601/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=pyiso8601
 PKGSEC=python
-PKGDES="A simple Python module to parse ISO 8601 dates"
+PKGDES="ISO8601 formatted datetime parser for python "
 PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
+BUILDDEP="setuptools"
 
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch
-
 NOPYTHON2=1

--- a/lang-python/pyiso8601/spec
+++ b/lang-python/pyiso8601/spec
@@ -1,5 +1,4 @@
-VER=0.1.13
-SRCS="tbl::https://github.com/micktwomey/pyiso8601/archive/${VER}.tar.gz"
-CHKSUMS="sha256::1058be84b1784504ad47118e7897ad369d18f40d378449eece599ab2393568e4"
+VER=2.1.0
+SRCS="git::commit=tags/${VER}::https://github.com/micktwomey/pyiso8601"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17228"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- oslo-serialization: update to 5.8.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- oslo-utils: update to 9.2.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- ykdl: update to 1.8.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- m3u8: update to 6.0.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- novaclient: update to 18.11.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- keystoneclient: update to 5.7.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- keystoneauth1: update to 5.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- pbr: update to 7.0.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- pyiso8601: update to 2.1.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit pyiso8601 pbr keystoneauth1 keystoneclient m3u8 ykdl oslo-utils oslo-serialization
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
