### PR TITLE
py-setproctitle: update to 1.3.7

### DIFF
--- a/lang-python/py-setproctitle/autobuild/defines
+++ b/lang-python/py-setproctitle/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=py-setproctitle
 PKGSEC=python
-PKGDEP="python-3"
+PKGDEP="glibc python-3"
 BUILDDEP="setuptools-python3"
 PKGDES="Allows a python process to change its process title"
 
-ABTYPE=python
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/py-setproctitle/spec
+++ b/lang-python/py-setproctitle/spec
@@ -1,5 +1,4 @@
-VER=1.1.10
-REL=4
-SRCS="tbl::https://github.com/dvarrazzo/py-setproctitle/archive/version-$VER.tar.gz"
-CHKSUMS="sha256::1c3a8f60b90bbe1d7987597c1ef637ecfbc8f4bb2a5500c36fb232ea7bedf925"
+VER=1.3.7
+SRCS="pypi::version=$VER::setproctitle"
+CHKSUMS="sha256::bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e"
 CHKUPDATE="anitya::id=11699"


### PR DESCRIPTION
Topic Description
-----------------

- py-setproctitle: update to 1.3.7

Package(s) Affected
-------------------

- py-setproctitle: 1.3.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit py-setproctitle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
