### PR TITLE
mangohud: enable all optional features

### DIFF
--- a/app-utils/mangohud/autobuild/defines
+++ b/app-utils/mangohud/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=mangohud
 PKGSEC=utils
-PKGDEP="libglvnd glslang mesa dbus x11-lib wayland libxkbcommon"
+PKGDEP="libglvnd glslang mesa dbus x11-lib wayland libxkbcommon glfw"
 PKGDEP__AMD64="${PKGDEP} libxnvctrl"
 PKGDEP__ARM64="${PKGDEP__AMD64}"
 BUILDDEP="mako nlohmann-json spdlog vulkan-headers"
@@ -11,6 +11,10 @@ MESON_AFTER=(
     '-Dappend_libdir_mangohud=false'
     '-Ddynamic_string_tokens=false'
     '-Dwith_xnvctrl=disabled'
+    '-Dmangoapp=true'
+    '-Dmangohudctl=true'
+    '-Dmangoplot=enabled'
+    '-Dtests=disabled'
 )
 MESON_AFTER__AMD64=(
     "${MESON_AFTER[@]}"

--- a/app-utils/mangohud/spec
+++ b/app-utils/mangohud/spec
@@ -1,4 +1,5 @@
 VER=0.8.2
+REL=1
 SRCS="tbl::https://github.com/flightlessmango/MangoHud/releases/download/v${VER/\+/-}/MangoHud-v${VER/\+/-}-Source.tar.xz"
 CHKSUMS="sha256::9fe98da24f790f4489efc1e0c8e3ad0291c80efd882a406797d54dab82f8765b"
 CHKUPDATE="anitya::id=138139"

--- a/desktop-wm/gamescope/autobuild/defines
+++ b/desktop-wm/gamescope/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=gamescope
 PKGSEC=x11
 PKGDEP="gcc-runtime glibc libavif libcap libdecor libdrm libei libinput \
         libxkbcommon luajit pipewire pixman sdl2 seatd systemd wayland x11-lib \
-        xwayland"
+        xwayland mangohud"
 BUILDDEP="benchmark cmake glm glslang meson xcb-util-errors"
 PKGDES="Micro-compositor for video games on Wayland"
 

--- a/desktop-wm/gamescope/spec
+++ b/desktop-wm/gamescope/spec
@@ -1,4 +1,5 @@
 VER=3.16.18
+REL=1
 # Note: Stb commit hash is defined at https://github.com/ValveSoftware/gamescope/$VER/subprojects/stb.wrap
 SRCS="git::commit=tags/$VER::https://github.com/ValveSoftware/gamescope.git \
       git::commit=5736b15f7ea0ffb08dd38af21067c314d6a3aae9;rename=gamescope/subprojects/stb::https://github.com/nothings/stb.git"


### PR DESCRIPTION
Topic Description
-----------------

- gamescope: depend on mangohud \(mangoapp\)
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- mangohud: enable all optional features
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- gamescope: 3.16.18-1
- mangohud: 0.8.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mangohud gamescope
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
