### PR TITLE
xdg-user-dirs-gtk: update to 0.16

### DIFF
--- a/desktop-gnome/xdg-user-dirs-gtk/autobuild/defines
+++ b/desktop-gnome/xdg-user-dirs-gtk/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=xdg-user-dirs-gtk
 PKGSEC=gnome
-PKGDEP="gtk-3 xdg-user-dirs"
-BUILDDEP="intltool"
+PKGDEP="glib glibc gtk-3 xdg-user-dirs"
+BUILDDEP="meson"
 PKGDES="Creates user directories and asks to relocalize them"

--- a/desktop-gnome/xdg-user-dirs-gtk/autobuild/patches/0001-Also-start-in-MATE-and-Cinnamon.patch
+++ b/desktop-gnome/xdg-user-dirs-gtk/autobuild/patches/0001-Also-start-in-MATE-and-Cinnamon.patch
@@ -1,12 +1,13 @@
-diff -Naur xdg-user-dirs-gtk-0.10/user-dirs-update-gtk.desktop.in xdg-user-dirs-gtk-0.10.morede/user-dirs-update-gtk.desktop.in
---- xdg-user-dirs-gtk-0.10/user-dirs-update-gtk.desktop.in	2013-01-21 13:18:32.000000000 +0000
-+++ xdg-user-dirs-gtk-0.10.morede/user-dirs-update-gtk.desktop.in	2018-11-30 06:34:42.252428539 +0000
-@@ -4,7 +4,7 @@
- _Name=User folders update
- _Comment=Update common folders names to match current locale
+diff --git a/user-dirs-update-gtk.desktop.in b/user-dirs-update-gtk.desktop.in
+index 52b2600..d67fb3c 100644
+--- a/user-dirs-update-gtk.desktop.in
++++ b/user-dirs-update-gtk.desktop.in
+@@ -4,7 +4,7 @@ Exec=xdg-user-dirs-gtk-update
+ Name=User folders update
+ Comment=Update common folders names to match current locale
  Terminal=false
 -OnlyShowIn=GNOME;LXDE;Unity;
 +OnlyShowIn=GNOME;LXDE;Unity;MATE;Cinnamon;
+ NoDisplay=true
  Type=Application
  StartupNotify=false
- X-KDE-autostart-after=panel

--- a/desktop-gnome/xdg-user-dirs-gtk/spec
+++ b/desktop-gnome/xdg-user-dirs-gtk/spec
@@ -1,4 +1,4 @@
-VER=0.11
+VER=0.16
 SRCS="tbl::https://download.gnome.org/sources/xdg-user-dirs-gtk/$VER/xdg-user-dirs-gtk-$VER.tar.xz"
-CHKSUMS="sha256::534bd563d3c0e3f8dcbf3578cb8ab0e49d3ba41c966d477c8af9438364121e7d"
+CHKSUMS="sha256::be825de7f89175db5ead0cd3744d2761109c70943251a87092259163025520a9"
 CHKUPDATE="anitya::id=14875"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-user-dirs-gtk: update to 0.16
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- xdg-user-dirs-gtk: 0.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-user-dirs-gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
