### PR TITLE
qemu: import patches for linux-user termios2

### DIFF
--- a/app-virtualization/qemu/01-shared/patches/0004-FROMLIST-Add-termios2-support-to-linux-user.patch
+++ b/app-virtualization/qemu/01-shared/patches/0004-FROMLIST-Add-termios2-support-to-linux-user.patch
@@ -1,0 +1,242 @@
+From 06932cca5bec25eee0ef5d819f6b5c71dfa59198 Mon Sep 17 00:00:00 2001
+From: Luca Bonissi <qemu@bonslack.org>
+Date: Fri, 31 Oct 2025 13:29:19 +0100
+Subject: [PATCH 04/11] FROMLIST: Add termios2 support to linux-user
+
+Signed-off-by: Luca Bonissi <qemu@bonslack.org>
+Link: https://lore.kernel.org/qemu-devel/745f18b6-ee62-4903-9a56-dcb903b610cf@bonslack.org
+---
+ linux-user/ioctls.h         |  6 +++
+ linux-user/strace.c         | 69 ++++++++++++++++++++++++++++++
+ linux-user/syscall.c        | 84 +++++++++++++++++++++++++++++++++++++
+ linux-user/syscall_types.h  |  3 ++
+ linux-user/user-internals.h |  3 ++
+ 5 files changed, 165 insertions(+)
+
+diff --git a/linux-user/ioctls.h b/linux-user/ioctls.h
+index 3b41128fd7..0b2deb2824 100644
+--- a/linux-user/ioctls.h
++++ b/linux-user/ioctls.h
+@@ -1,5 +1,11 @@
+      /* emulated ioctl list */
+ 
++#ifdef TARGET_TCGETS2
++     IOCTL(TCGETS2, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios2)))
++     IOCTL(TCSETS2, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios2)))
++     IOCTL(TCSETSW2, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios2)))
++     IOCTL(TCSETSF2, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios2)))
++#endif
+      IOCTL(TCGETS, IOC_R, MK_PTR(MK_STRUCT(STRUCT_termios)))
+      IOCTL(TCSETS, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
+      IOCTL(TCSETSF, IOC_W, MK_PTR(MK_STRUCT(STRUCT_termios)))
+diff --git a/linux-user/strace.c b/linux-user/strace.c
+index 85b956fdfb..13c88dd0bb 100644
+--- a/linux-user/strace.c
++++ b/linux-user/strace.c
+@@ -1929,6 +1929,75 @@ print_termios(void *arg)
+     qemu_log("}");
+ }
+ 
++#ifdef TARGET_TCGETS2
++void
++print_termios2(void *arg)
++{
++    const struct target_termios2 *target = arg;
++
++    target_tcflag_t iflags = tswap32(target->c_iflag);
++    target_tcflag_t oflags = tswap32(target->c_oflag);
++    target_tcflag_t cflags = tswap32(target->c_cflag);
++    target_tcflag_t lflags = tswap32(target->c_lflag);
++
++    qemu_log("{");
++
++    qemu_log("c_iflag = ");
++    print_flags(termios_iflags, iflags, 0);
++
++    qemu_log("c_oflag = ");
++    target_tcflag_t oflags_clean =  oflags & ~(TARGET_NLDLY | TARGET_CRDLY |
++                                               TARGET_TABDLY | TARGET_BSDLY |
++                                               TARGET_VTDLY | TARGET_FFDLY);
++    print_flags(termios_oflags, oflags_clean, 0);
++    if (oflags & TARGET_NLDLY) {
++        print_enums(termios_oflags_NLDLY, oflags & TARGET_NLDLY, 0);
++    }
++    if (oflags & TARGET_CRDLY) {
++        print_enums(termios_oflags_CRDLY, oflags & TARGET_CRDLY, 0);
++    }
++    if (oflags & TARGET_TABDLY) {
++        print_enums(termios_oflags_TABDLY, oflags & TARGET_TABDLY, 0);
++    }
++    if (oflags & TARGET_BSDLY) {
++        print_enums(termios_oflags_BSDLY, oflags & TARGET_BSDLY, 0);
++    }
++    if (oflags & TARGET_VTDLY) {
++        print_enums(termios_oflags_VTDLY, oflags & TARGET_VTDLY, 0);
++    }
++    if (oflags & TARGET_FFDLY) {
++        print_enums(termios_oflags_FFDLY, oflags & TARGET_FFDLY, 0);
++    }
++
++    qemu_log("c_cflag = ");
++    if (cflags & TARGET_CBAUD) {
++        print_enums(termios_cflags_CBAUD, cflags & TARGET_CBAUD, 0);
++    }
++    if (cflags & TARGET_CSIZE) {
++        print_enums(termios_cflags_CSIZE, cflags & TARGET_CSIZE, 0);
++    }
++    target_tcflag_t cflags_clean = cflags & ~(TARGET_CBAUD | TARGET_CSIZE);
++    print_flags(termios_cflags, cflags_clean, 0);
++
++    qemu_log("c_lflag = ");
++    print_flags(termios_lflags, lflags, 0);
++
++    qemu_log("c_ispeed = ");
++    print_raw_param("%u", tswap32(target->c_ispeed), 0);
++
++    qemu_log("c_ospeed = ");
++    print_raw_param("%u", tswap32(target->c_ospeed), 0);
++
++    qemu_log("c_cc = ");
++    qemu_log("\"%s\",", target->c_cc);
++
++    qemu_log("c_line = ");
++    print_raw_param("\'%c\'", target->c_line, 1);
++
++    qemu_log("}");
++}
++#endif
++
+ #undef UNUSED
+ 
+ #ifdef TARGET_NR_accept
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 91360a072c..076a9c69b0 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -88,6 +88,7 @@
+ #endif
+ 
+ #define termios host_termios
++#define termios2 host_termios2
+ #define winsize host_winsize
+ #define termio host_termio
+ #define sgttyb host_sgttyb /* same as target */
+@@ -5887,6 +5888,89 @@ static const StructEntry struct_termios_def = {
+     .print = print_termios,
+ };
+ 
++#ifdef TARGET_TCGETS2
++static void target_to_host_termios2 (void *dst, const void *src)
++{
++    struct host_termios2 *host = dst;
++    const struct target_termios2 *target = src;
++
++    host->c_iflag =
++        target_to_host_bitmask(tswap32(target->c_iflag), iflag_tbl);
++    host->c_oflag =
++        target_to_host_bitmask(tswap32(target->c_oflag), oflag_tbl);
++    host->c_cflag =
++        target_to_host_bitmask(tswap32(target->c_cflag), cflag_tbl);
++    host->c_lflag =
++        target_to_host_bitmask(tswap32(target->c_lflag), lflag_tbl);
++    host->c_line = target->c_line;
++    host->c_ispeed = tswap32(target->c_ispeed);
++    host->c_ospeed = tswap32(target->c_ospeed);
++
++    memset(host->c_cc, 0, sizeof(host->c_cc));
++    host->c_cc[VINTR] = target->c_cc[TARGET_VINTR];
++    host->c_cc[VQUIT] = target->c_cc[TARGET_VQUIT];
++    host->c_cc[VERASE] = target->c_cc[TARGET_VERASE];
++    host->c_cc[VKILL] = target->c_cc[TARGET_VKILL];
++    host->c_cc[VEOF] = target->c_cc[TARGET_VEOF];
++    host->c_cc[VTIME] = target->c_cc[TARGET_VTIME];
++    host->c_cc[VMIN] = target->c_cc[TARGET_VMIN];
++    host->c_cc[VSWTC] = target->c_cc[TARGET_VSWTC];
++    host->c_cc[VSTART] = target->c_cc[TARGET_VSTART];
++    host->c_cc[VSTOP] = target->c_cc[TARGET_VSTOP];
++    host->c_cc[VSUSP] = target->c_cc[TARGET_VSUSP];
++    host->c_cc[VEOL] = target->c_cc[TARGET_VEOL];
++    host->c_cc[VREPRINT] = target->c_cc[TARGET_VREPRINT];
++    host->c_cc[VDISCARD] = target->c_cc[TARGET_VDISCARD];
++    host->c_cc[VWERASE] = target->c_cc[TARGET_VWERASE];
++    host->c_cc[VLNEXT] = target->c_cc[TARGET_VLNEXT];
++    host->c_cc[VEOL2] = target->c_cc[TARGET_VEOL2];
++}
++
++static void host_to_target_termios2 (void *dst, const void *src)
++{
++    struct target_termios2 *target = dst;
++    const struct host_termios2 *host = src;
++
++    target->c_iflag =
++        tswap32(host_to_target_bitmask(host->c_iflag, iflag_tbl));
++    target->c_oflag =
++        tswap32(host_to_target_bitmask(host->c_oflag, oflag_tbl));
++    target->c_cflag =
++        tswap32(host_to_target_bitmask(host->c_cflag, cflag_tbl));
++    target->c_lflag =
++        tswap32(host_to_target_bitmask(host->c_lflag, lflag_tbl));
++    target->c_line = host->c_line;
++    target->c_ispeed = tswap32(host->c_ispeed);
++    target->c_ospeed = tswap32(host->c_ospeed);
++
++    memset(target->c_cc, 0, sizeof(target->c_cc));
++    target->c_cc[TARGET_VINTR] = host->c_cc[VINTR];
++    target->c_cc[TARGET_VQUIT] = host->c_cc[VQUIT];
++    target->c_cc[TARGET_VERASE] = host->c_cc[VERASE];
++    target->c_cc[TARGET_VKILL] = host->c_cc[VKILL];
++    target->c_cc[TARGET_VEOF] = host->c_cc[VEOF];
++    target->c_cc[TARGET_VTIME] = host->c_cc[VTIME];
++    target->c_cc[TARGET_VMIN] = host->c_cc[VMIN];
++    target->c_cc[TARGET_VSWTC] = host->c_cc[VSWTC];
++    target->c_cc[TARGET_VSTART] = host->c_cc[VSTART];
++    target->c_cc[TARGET_VSTOP] = host->c_cc[VSTOP];
++    target->c_cc[TARGET_VSUSP] = host->c_cc[VSUSP];
++    target->c_cc[TARGET_VEOL] = host->c_cc[VEOL];
++    target->c_cc[TARGET_VREPRINT] = host->c_cc[VREPRINT];
++    target->c_cc[TARGET_VDISCARD] = host->c_cc[VDISCARD];
++    target->c_cc[TARGET_VWERASE] = host->c_cc[VWERASE];
++    target->c_cc[TARGET_VLNEXT] = host->c_cc[VLNEXT];
++    target->c_cc[TARGET_VEOL2] = host->c_cc[VEOL2];
++}
++
++static const StructEntry struct_termios2_def = {
++    .convert = { host_to_target_termios2, target_to_host_termios2 },
++    .size = { sizeof(struct target_termios2), sizeof(struct host_termios2) },
++    .align = { __alignof__(struct target_termios2), __alignof__(struct host_termios2) },
++    .print = print_termios2,
++};
++#endif
++
+ /* If the host does not provide these bits, they may be safely discarded. */
+ #ifndef MAP_SYNC
+ #define MAP_SYNC 0
+diff --git a/linux-user/syscall_types.h b/linux-user/syscall_types.h
+index 6dd7a80ce5..ac45705acf 100644
+--- a/linux-user/syscall_types.h
++++ b/linux-user/syscall_types.h
+@@ -1,4 +1,7 @@
+ STRUCT_SPECIAL(termios)
++#ifdef TARGET_TCGETS2
++STRUCT_SPECIAL(termios2)
++#endif
+ 
+ STRUCT(winsize,
+        TYPE_SHORT, TYPE_SHORT, TYPE_SHORT, TYPE_SHORT)
+diff --git a/linux-user/user-internals.h b/linux-user/user-internals.h
+index 691b9a1775..191e01c3a8 100644
+--- a/linux-user/user-internals.h
++++ b/linux-user/user-internals.h
+@@ -127,6 +127,9 @@ static inline uint64_t target_offset64(uint64_t word0, uint64_t word1)
+ #endif /* TARGET_ABI_BITS != 32 */
+ 
+ void print_termios(void *arg);
++#ifdef TARGET_TCGETS2
++void print_termios2(void *arg);
++#endif
+ 
+ /* ARM EABI and MIPS expect 64bit types aligned even on pairs or registers */
+ #ifdef TARGET_ARM
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0005-AOSCOS-linux-user-fixup-termios2-related-things-on-P.patch
+++ b/app-virtualization/qemu/01-shared/patches/0005-AOSCOS-linux-user-fixup-termios2-related-things-on-P.patch
@@ -1,0 +1,45 @@
+From f966ba48ddc0af813cc9eb5b1af589bf91d533b2 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Tue, 16 Dec 2025 01:08:33 +0800
+Subject: [PATCH 05/11] AOSCOS: linux-user: fixup termios2 related things on
+ PowerPC
+
+The termios things on PowerPC equal to termios2 things otherwhere.
+
+Use some simple #define's to allow both termios and termios2 to map to
+termios on PowerPC.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ linux-user/syscall.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 076a9c69b0..e6e3dc252d 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -150,6 +150,21 @@
+ #include "fd-trans.h"
+ #include "user/cpu_loop.h"
+ 
++#if defined(__powerpc__)
++/*
++ * On PowerPC termios2 is lacking and termios along with ioctls w/o 2
++ * behaves like termios2 and things with 2 on other architectures.
++ *
++ * Just define termios2-related things to be the same with termios-related
++ * ones to support PowerPC.
++ */
++#define host_termios2 host_termios
++#define TCGETS2 TCGETS
++#define TCSETS2 TCSETS
++#define TCSETSW2 TCSETSW
++#define TCSETSF2 TCSETSF
++#endif
++
+ #ifndef CLONE_IO
+ #define CLONE_IO                0x80000000      /* Clone io context */
+ #endif
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0006-FROMLIST-Add-termios2-support-to-alpha-target.patch
+++ b/app-virtualization/qemu/01-shared/patches/0006-FROMLIST-Add-termios2-support-to-alpha-target.patch
@@ -1,0 +1,61 @@
+From e06610a9d88433970d18e157b707aabc066f73bc Mon Sep 17 00:00:00 2001
+From: Luca Bonissi <qemu@bonslack.org>
+Date: Fri, 31 Oct 2025 13:30:15 +0100
+Subject: [PATCH 06/11] FROMLIST: Add termios2 support to alpha target
+
+Signed-off-by: Luca Bonissi <qemu@bonslack.org>
+Link: https://lore.kernel.org/qemu-devel/02dba951-1bcf-4c74-8a6a-f4f4aa5ce909@bonslack.org
+---
+ linux-user/alpha/termbits.h | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/linux-user/alpha/termbits.h b/linux-user/alpha/termbits.h
+index 4a4b1e96f2..b7be23ea13 100644
+--- a/linux-user/alpha/termbits.h
++++ b/linux-user/alpha/termbits.h
+@@ -17,6 +17,29 @@ struct target_termios {
+ 	target_speed_t c_ospeed;		/* output speed */
+ };
+ 
++struct target_termios2 {
++	target_tcflag_t c_iflag;		/* input mode flags */
++	target_tcflag_t c_oflag;		/* output mode flags */
++	target_tcflag_t c_cflag;		/* control mode flags */
++	target_tcflag_t c_lflag;		/* local mode flags */
++	target_cc_t c_cc[TARGET_NCCS];		/* control characters */
++	target_cc_t c_line;			/* line discipline (== c_cc[19]) */
++	target_speed_t c_ispeed;		/* input speed */
++	target_speed_t c_ospeed;		/* output speed */
++};
++
++struct target_ktermios {
++	target_tcflag_t c_iflag;		/* input mode flags */
++	target_tcflag_t c_oflag;		/* output mode flags */
++	target_tcflag_t c_cflag;		/* control mode flags */
++	target_tcflag_t c_lflag;		/* local mode flags */
++	target_cc_t c_cc[TARGET_NCCS];		/* control characters */
++	target_cc_t c_line;			/* line discipline (== c_cc[19]) */
++	target_speed_t c_ispeed;		/* input speed */
++	target_speed_t c_ospeed;		/* output speed */
++};
++
++
+ /* c_cc characters */
+ #define TARGET_VEOF 0
+ #define TARGET_VEOL 1
+@@ -247,6 +270,12 @@ struct target_termios {
+ #define TARGET_TIOCSBRK	0x5427  /* BSD compatibility */
+ #define TARGET_TIOCCBRK	0x5428  /* BSD compatibility */
+ #define TARGET_TIOCGSID	0x5429  /* Return the session ID of FD */
++#define TARGET_TCGETS2		TARGET_IOR('T', 0x2A, struct target_termios2)
++#define TARGET_TCSETS2		TARGET_IOW('T', 0x2B, struct target_termios2)
++#define TARGET_TCSETSW2	TARGET_IOW('T', 0x2C, struct target_termios2)
++#define TARGET_TCSETSF2	TARGET_IOW('T', 0x2D, struct target_termios2)
++#define TARGET_TIOCGRS485	TARGET_IOR('T', 0x2E, struct serial_rs485)
++#define TARGET_TIOCSRS485	TARGET_IOWR('T', 0x2F, struct serial_rs485)
+ #define TARGET_TIOCGPTN	TARGET_IOR('T',0x30, unsigned int) /* Get Pty Number (of pty-mux device) */
+ #define TARGET_TIOCSPTLCK	TARGET_IOW('T',0x31, int)  /* Lock/unlock Pty */
+ #define TARGET_TIOCGPTPEER      TARGET_IO('T', 0x41) /* Safely open the slave */
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0007-FROMLIST-Add-termios2-support-to-hppa-target.patch
+++ b/app-virtualization/qemu/01-shared/patches/0007-FROMLIST-Add-termios2-support-to-hppa-target.patch
@@ -1,0 +1,61 @@
+From 694da3a9f9db1c81c2b879b7022da57d00dadbff Mon Sep 17 00:00:00 2001
+From: Luca Bonissi <qemu@bonslack.org>
+Date: Fri, 31 Oct 2025 13:30:48 +0100
+Subject: [PATCH 07/11] FROMLIST: Add termios2 support to hppa target
+
+Signed-off-by: Luca Bonissi <qemu@bonslack.org>
+Link: https://lore.kernel.org/qemu-devel/ccf1be5c-9e2e-46f6-b303-d29888371fb0@bonslack.org
+---
+ linux-user/hppa/termbits.h | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/linux-user/hppa/termbits.h b/linux-user/hppa/termbits.h
+index 11fd4eed62..645f17bf63 100644
+--- a/linux-user/hppa/termbits.h
++++ b/linux-user/hppa/termbits.h
+@@ -18,6 +18,29 @@ struct target_termios {
+     target_cc_t c_cc[TARGET_NCCS];         /* control characters */
+ };
+ 
++struct target_termios2 {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
++struct target_ktermios {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
++
+ /* c_iflag bits */
+ #define TARGET_IGNBRK  0000001
+ #define TARGET_BRKINT  0000002
+@@ -190,6 +213,12 @@ struct target_termios {
+ #define TARGET_TIOCSBRK         0x5427 /* BSD compatibility */
+ #define TARGET_TIOCCBRK         0x5428 /* BSD compatibility */
+ #define TARGET_TIOCGSID         TARGET_IOR('T', 20, int)
++#define TARGET_TCGETS2          TARGET_IOR('T', 0x2A, struct target_termios2)
++#define TARGET_TCSETS2          TARGET_IOW('T', 0x2B, struct target_termios2)
++#define TARGET_TCSETSW2         TARGET_IOW('T', 0x2C, struct target_termios2)
++#define TARGET_TCSETSF2         TARGET_IOW('T', 0x2D, struct target_termios2)
++#define TARGET_TIOCGRS485       TARGET_IOR('T', 0x2E, struct serial_rs485)
++#define TARGET_TIOCSRS485       TARGET_IOWR('T', 0x2F, struct serial_rs485)
+ #define TARGET_TIOCGPTN         TARGET_IOR('T', 0x30, unsigned int)
+         /* Get Pty Number (of pty-mux device) */
+ #define TARGET_TIOCSPTLCK       TARGET_IOW('T', 0x31, int)
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0008-FROMLIST-Add-termios2-support-to-mips-target.patch
+++ b/app-virtualization/qemu/01-shared/patches/0008-FROMLIST-Add-termios2-support-to-mips-target.patch
@@ -1,0 +1,63 @@
+From 94f8e8230cf539755c7bdba8529ce7bbed009278 Mon Sep 17 00:00:00 2001
+From: Luca Bonissi <qemu@bonslack.org>
+Date: Fri, 31 Oct 2025 13:31:15 +0100
+Subject: [PATCH 08/11] FROMLIST: Add termios2 support to mips target
+
+Signed-off-by: Luca Bonissi <qemu@bonslack.org>
+Link: https://lore.kernel.org/qemu-devel/361aa9c5-4464-4d27-8a2c-9ab767324530@bonslack.org
+---
+ linux-user/mips/termbits.h | 31 +++++++++++++++++++++++++++----
+ 1 file changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/linux-user/mips/termbits.h b/linux-user/mips/termbits.h
+index e8b4b58d87..27610f7c4d 100644
+--- a/linux-user/mips/termbits.h
++++ b/linux-user/mips/termbits.h
+@@ -18,6 +18,29 @@ struct target_termios {
+     target_cc_t c_cc[TARGET_NCCS];         /* control characters */
+ };
+ 
++struct target_termios2 {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
++struct target_ktermios {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
++
+ /* c_iflag bits */
+ #define TARGET_IGNBRK  0000001
+ #define TARGET_BRKINT  0000002
+@@ -227,10 +250,10 @@ struct target_termios {
+ #define TARGET_TIOCSBRK	0x5427  /* BSD compatibility */
+ #define TARGET_TIOCCBRK	0x5428  /* BSD compatibility */
+ #define TARGET_TIOCGSID	0x7416  /* Return the session ID of FD */
+-#define TARGET_TCGETS2          TARGET_IOR('T', 0x2A, struct termios2)
+-#define TARGET_TCSETS2          TARGET_IOW('T', 0x2B, struct termios2)
+-#define TARGET_TCSETSW2         TARGET_IOW('T', 0x2C, struct termios2)
+-#define TARGET_TCSETSF2         TARGET_IOW('T', 0x2D, struct termios2)
++#define TARGET_TCGETS2          TARGET_IOR('T', 0x2A, struct target_termios2)
++#define TARGET_TCSETS2          TARGET_IOW('T', 0x2B, struct target_termios2)
++#define TARGET_TCSETSW2         TARGET_IOW('T', 0x2C, struct target_termios2)
++#define TARGET_TCSETSF2         TARGET_IOW('T', 0x2D, struct target_termios2)
+ #define TARGET_TIOCGRS485       TARGET_IOR('T', 0x2E, struct serial_rs485)
+ #define TARGET_TIOCSRS485       TARGET_IOWR('T', 0x2F, struct serial_rs485)
+ #define TARGET_TIOCGPTN	TARGET_IOR('T',0x30, unsigned int) /* Get Pty Number (of pty-mux device) */
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0009-FROMLIST-Add-termios2-support-to-sh4-target.patch
+++ b/app-virtualization/qemu/01-shared/patches/0009-FROMLIST-Add-termios2-support-to-sh4-target.patch
@@ -1,0 +1,93 @@
+From 98c984d936e9093e57e60f77062380fa455721a2 Mon Sep 17 00:00:00 2001
+From: Luca Bonissi <qemu@bonslack.org>
+Date: Fri, 31 Oct 2025 13:32:05 +0100
+Subject: [PATCH 09/11] FROMLIST: Add termios2 support to sh4 target
+
+Signed-off-by: Luca Bonissi <qemu@bonslack.org>
+Link: https://lore.kernel.org/qemu-devel/642b32de-2985-45d2-bbdf-c0b2e3ea0551@bonslack.org
+---
+ linux-user/sh4/termbits.h | 46 +++++++++++++++++++++++++++++----------
+ 1 file changed, 34 insertions(+), 12 deletions(-)
+
+diff --git a/linux-user/sh4/termbits.h b/linux-user/sh4/termbits.h
+index 28e79f2c9a..cab6b1299e 100644
+--- a/linux-user/sh4/termbits.h
++++ b/linux-user/sh4/termbits.h
+@@ -18,6 +18,28 @@ struct target_termios {
+     target_cc_t c_cc[TARGET_NCCS];         /* control characters */
+ };
+ 
++struct target_termios2 {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
++struct target_ktermios {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
+ 
+ /* c_cc characters */
+ #define TARGET_VINTR 0
+@@ -251,14 +273,17 @@ struct target_termios {
+ #define TARGET_TIOCNOTTY       TARGET_IO('T', 34) /* 0x5422 */
+ #define TARGET_TIOCSETD        TARGET_IOW('T', 35, int) /* 0x5423 */
+ #define TARGET_TIOCGETD        TARGET_IOR('T', 36, int) /* 0x5424 */
+-#define TARGET_TCSBRKP         TARGET_IOW('T', 37, int) /* 0x5425 */ /* Needed for POSIX tcse
+-ndbreak() */
++#define TARGET_TCSBRKP         TARGET_IOW('T', 37, int) /* 0x5425 */ /* Needed for POSIX tcsendbreak() */
+ #define TARGET_TIOCSBRK        TARGET_IO('T', 39) /* 0x5427 */ /* BSD compatibility */
+ #define TARGET_TIOCCBRK        TARGET_IO('T', 40) /* 0x5428 */ /* BSD compatibility */
+-#define TARGET_TIOCGSID        TARGET_IOR('T', 41, pid_t) /* 0x5429 */ /* Return the session
+-ID of FD */
+-#define TARGET_TIOCGPTN        TARGET_IOR('T',0x30, unsigned int) /* Get Pty Number (of pty-m
+-ux device) */
++#define TARGET_TIOCGSID        TARGET_IOR('T', 41, pid_t) /* 0x5429 */ /* Return the session ID of FD */
++#define TARGET_TCGETS2         TARGET_IOR('T', 0x2A, struct target_termios2)
++#define TARGET_TCSETS2         TARGET_IOW('T', 0x2B, struct target_termios2)
++#define TARGET_TCSETSW2        TARGET_IOW('T', 0x2C, struct target_termios2)
++#define TARGET_TCSETSF2        TARGET_IOW('T', 0x2D, struct target_termios2)
++#define TARGET_TIOCGRS485      TARGET_IOR('T', 0x2E, struct serial_rs485)
++#define TARGET_TIOCSRS485      TARGET_IOWR('T', 0x2F, struct serial_rs485)
++#define TARGET_TIOCGPTN        TARGET_IOR('T',0x30, unsigned int) /* Get Pty Number (of pty-mux device) */
+ #define TARGET_TIOCSPTLCK      TARGET_IOW('T',0x31, int)  /* Lock/unlock Pty */
+ #define TARGET_TIOCGPTPEER     TARGET_IO('T', 0x41) /* Safely open the slave */
+ 
+@@ -270,8 +295,7 @@ ux device) */
+ #define TARGET_TIOCSLCKTRMIOS  0x5457
+ #define TARGET_TIOCSERGSTRUCT  TARGET_IOR('T', 88, int) /* 0x5458 */ /* For d
+ ebugging only */
+-#define TARGET_TIOCSERGETLSR   TARGET_IOR('T', 89, unsigned int) /* 0x5459 */ /* Get line sta
+-tus register */
++#define TARGET_TIOCSERGETLSR   TARGET_IOR('T', 89, unsigned int) /* 0x5459 */ /* Get line status register */
+   /* ioctl (fd, TIOCSERGETLSR, &result) where result may be as below */
+ # define TARGET_TIOCSER_TEMT   0x01   /* Transmitter physically empty */
+ #define TARGET_TIOCSERGETMULTI TARGET_IOR('T', 90, int) /* 0x545A
+@@ -279,9 +303,7 @@ tus register */
+ #define TARGET_TIOCSERSETMULTI TARGET_IOW('T', 91, int) /* 0x545B
+ */ /* Set multiport config */
+ 
+-#define TARGET_TIOCMIWAIT      TARGET_IO('T', 92) /* 0x545C */       /* wait for a change on
+-serial input line(s) */
+-#define TARGET_TIOCGICOUNT     TARGET_IOR('T', 93, int) /* 0x545D */ /* read
+-serial port inline interrupt counts */
++#define TARGET_TIOCMIWAIT      TARGET_IO('T', 92) /* 0x545C */       /* wait for a change on serial input line(s) */
++#define TARGET_TIOCGICOUNT     TARGET_IOR('T', 93, int) /* 0x545D */ /* read serial port inline interrupt counts */
+ 
+ #endif
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0010-FROMLIST-Add-termios2-support-to-sparc-target.patch
+++ b/app-virtualization/qemu/01-shared/patches/0010-FROMLIST-Add-termios2-support-to-sparc-target.patch
@@ -1,0 +1,60 @@
+From 269e3c99e35a5b8081615c6b3b23bd489c8b9ef5 Mon Sep 17 00:00:00 2001
+From: Luca Bonissi <qemu@bonslack.org>
+Date: Fri, 31 Oct 2025 13:32:44 +0100
+Subject: [PATCH 10/11] FROMLIST: Add termios2 support to sparc target
+
+Signed-off-by: Luca Bonissi <qemu@bonslack.org>
+Link: https://lore.kernel.org/qemu-devel/909d9d68-c6fe-4368-825c-6aa8fdbd3bbc@bonslack.org
+---
+ linux-user/sparc/termbits.h | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/linux-user/sparc/termbits.h b/linux-user/sparc/termbits.h
+index 704bee1c42..588d7e8dcd 100644
+--- a/linux-user/sparc/termbits.h
++++ b/linux-user/sparc/termbits.h
+@@ -18,6 +18,28 @@ struct target_termios {
+     target_cc_t c_cc[TARGET_NCCS];         /* control characters */
+ };
+ 
++struct target_termios2 {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
++struct target_ktermios {
++    target_tcflag_t c_iflag;       /* input mode flags */
++    target_tcflag_t c_oflag;       /* output mode flags */
++    target_tcflag_t c_cflag;       /* control mode flags */
++    target_tcflag_t c_lflag;       /* local mode flags */
++    target_cc_t c_line;            /* line discipline */
++    target_cc_t c_cc[TARGET_NCCS]; /* control characters */
++    target_speed_t c_ispeed;       /* input speed */
++    target_speed_t c_ospeed;       /* output speed */
++};
++
+ 
+ /* c_cc characters */
+ #define TARGET_VINTR    0
+@@ -251,6 +273,12 @@ struct target_termios {
+ #define TARGET_TIOCGPGRP	TARGET_IOR('t', 131, int)
+ #define TARGET_TIOCSCTTY	TARGET_IO('t', 132)
+ #define TARGET_TIOCGSID	TARGET_IOR('t', 133, int)
++#define TARGET_TCGETS2		TARGET_IOR('T', 12, struct target_termios2)
++#define TARGET_TCSETS2		TARGET_IOW('T', 13, struct target_termios2)
++#define TARGET_TCSETSW2	TARGET_IOW('T', 14, struct target_termios2)
++#define TARGET_TCSETSF2	TARGET_IOW('T', 15, struct target_termios2)
++#define TARGET_TIOCGRS485	TARGET_IOR('T', 0x41, struct serial_rs485)
++#define TARGET_TIOCSRS485	TARGET_IOWR('T', 0x42, struct serial_rs485)
+ /* Get minor device of a pty master's FD -- Solaris equiv is ISPTM */
+ #define TARGET_TIOCGPTN	TARGET_IOR('t', 134, unsigned int) /* Get Pty Number */
+ #define TARGET_TIOCSPTLCK	TARGET_IOW('t', 135, int) /* Lock/unlock PTY */
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0011-FROMLIST-linux-user-Add-missing-termios-baud-rates.patch
+++ b/app-virtualization/qemu/01-shared/patches/0011-FROMLIST-linux-user-Add-missing-termios-baud-rates.patch
@@ -1,0 +1,267 @@
+From 52c9b85172b993b666596e81a9f8ff1a5c7c76dd Mon Sep 17 00:00:00 2001
+From: Vivian Wang <wangruikang@iscas.ac.cn>
+Date: Wed, 3 Dec 2025 17:38:47 +0800
+Subject: [PATCH 11/11] FROMLIST: linux-user: Add missing termios baud rates
+
+Add several missing baud rates and inputs baud rates in cflag_tbl.
+
+Add these missing definitions in termbits.h:
+
+- TARGET_BOTHER for alpha, hppa, ppc, sh4, sparc
+- TARGET_IBSHIFT for hppa, mips, ppc, sh4, sparc
+- Missing standard baud rates for hppa
+
+These are required for the glibc test tst-termios-linux.
+
+Link: https://lore.kernel.org/qemu-devel/20251203-linux-user-higher-baud-rates-v2-1-e45b35224437@iscas.ac.cn
+Signed-off-by: Vivian Wang <wangruikang@iscas.ac.cn>
+---
+ linux-user/alpha/termbits.h   |  1 +
+ linux-user/generic/termbits.h |  2 +-
+ linux-user/hppa/termbits.h    | 16 ++++++-
+ linux-user/mips/termbits.h    |  4 +-
+ linux-user/ppc/termbits.h     |  1 +
+ linux-user/sh4/termbits.h     |  5 ++-
+ linux-user/sparc/termbits.h   |  5 ++-
+ linux-user/syscall.c          | 83 ++++++++++++++++++++++++++---------
+ 8 files changed, 92 insertions(+), 25 deletions(-)
+
+diff --git a/linux-user/alpha/termbits.h b/linux-user/alpha/termbits.h
+index b7be23ea13..50cff34f3c 100644
+--- a/linux-user/alpha/termbits.h
++++ b/linux-user/alpha/termbits.h
+@@ -149,6 +149,7 @@ struct target_ktermios {
+ #define TARGET_B3000000  00034
+ #define TARGET_B3500000  00035
+ #define TARGET_B4000000  00036
++#define TARGET_BOTHER    00037
+ 
+ #define TARGET_CSIZE	00001400
+ #define   TARGET_CS5	00000000
+diff --git a/linux-user/generic/termbits.h b/linux-user/generic/termbits.h
+index 6675e0d1ab..6cc5995981 100644
+--- a/linux-user/generic/termbits.h
++++ b/linux-user/generic/termbits.h
+@@ -157,7 +157,7 @@ struct target_ktermios {
+ #define  TARGET_B3000000  0010015
+ #define  TARGET_B3500000  0010016
+ #define  TARGET_B4000000  0010017
+-#define TARGET_CIBAUD     002003600000  /* input baud rate (not used) */
++#define TARGET_CIBAUD     002003600000  /* input baud rate */
+ #define TARGET_CMSPAR     010000000000  /* mark or space (stick) parity */
+ #define TARGET_CRTSCTS    020000000000  /* flow control */
+ 
+diff --git a/linux-user/hppa/termbits.h b/linux-user/hppa/termbits.h
+index 645f17bf63..9d1d1a1d12 100644
+--- a/linux-user/hppa/termbits.h
++++ b/linux-user/hppa/termbits.h
+@@ -123,14 +123,28 @@ struct target_ktermios {
+ #define TARGET_HUPCL   0002000
+ #define TARGET_CLOCAL  0004000
+ #define TARGET_CBAUDEX 0010000
++#define  TARGET_BOTHER  0010000
+ #define  TARGET_B57600  0010001
+ #define  TARGET_B115200 0010002
+ #define  TARGET_B230400 0010003
+ #define  TARGET_B460800 0010004
+-#define TARGET_CIBAUD    002003600000  /* input baud rate (not used) */
++#define  TARGET_B500000 0010005
++#define  TARGET_B576000 0010006
++#define  TARGET_B921600 0010007
++#define  TARGET_B1000000 0010010
++#define  TARGET_B1152000 0010011
++#define  TARGET_B1500000 0010012
++#define  TARGET_B2000000 0010013
++#define  TARGET_B2500000 0010014
++#define  TARGET_B3000000 0010015
++#define  TARGET_B3500000 0010016
++#define  TARGET_B4000000 0010017
++#define TARGET_CIBAUD    002003600000  /* input baud rate */
+ #define TARGET_CMSPAR    010000000000  /* mark or space (stick) parity */
+ #define TARGET_CRTSCTS   020000000000  /* flow control */
+ 
++#define TARGET_IBSHIFT   16            /* Shift from CBAUD to CIBAUD */
++
+ /* c_lflag bits */
+ #define TARGET_ISIG    0000001
+ #define TARGET_ICANON  0000002
+diff --git a/linux-user/mips/termbits.h b/linux-user/mips/termbits.h
+index 27610f7c4d..56b17441ee 100644
+--- a/linux-user/mips/termbits.h
++++ b/linux-user/mips/termbits.h
+@@ -139,10 +139,12 @@ struct target_ktermios {
+ #define  TARGET_B3000000 0010015
+ #define  TARGET_B3500000 0010016
+ #define  TARGET_B4000000 0010017
+-#define TARGET_CIBAUD    002003600000  /* input baud rate (not used) */
++#define TARGET_CIBAUD    002003600000  /* input baud rate */
+ #define TARGET_CMSPAR    010000000000  /* mark or space (stick) parity */
+ #define TARGET_CRTSCTS   020000000000  /* flow control */
+ 
++#define TARGET_IBSHIFT   16            /* Shift from CBAUD to CIBAUD */
++
+ /* c_lflag bits */
+ #define TARGET_ISIG    0000001
+ #define TARGET_ICANON  0000002
+diff --git a/linux-user/ppc/termbits.h b/linux-user/ppc/termbits.h
+index eb226e0999..71b398c83a 100644
+--- a/linux-user/ppc/termbits.h
++++ b/linux-user/ppc/termbits.h
+@@ -129,6 +129,7 @@ struct target_termios {
+ #define TARGET_B3000000  00034
+ #define TARGET_B3500000  00035
+ #define TARGET_B4000000  00036
++#define TARGET_BOTHER    00037
+ 
+ #define TARGET_CSIZE	00001400
+ #define   TARGET_CS5	00000000
+diff --git a/linux-user/sh4/termbits.h b/linux-user/sh4/termbits.h
+index cab6b1299e..861f861f6d 100644
+--- a/linux-user/sh4/termbits.h
++++ b/linux-user/sh4/termbits.h
+@@ -142,6 +142,7 @@ struct target_ktermios {
+ #define TARGET_HUPCL   0002000
+ #define TARGET_CLOCAL  0004000
+ #define TARGET_CBAUDEX 0010000
++#define TARGET_BOTHER 0010000
+ #define TARGET_B57600 0010001
+ #define TARGET_B115200 0010002
+ #define TARGET_B230400 0010003
+@@ -157,10 +158,12 @@ struct target_ktermios {
+ #define TARGET_B3000000 0010015
+ #define TARGET_B3500000 0010016
+ #define TARGET_B4000000 0010017
+-#define TARGET_CIBAUD    002003600000 /* input baud rate (not used) */
++#define TARGET_CIBAUD    002003600000 /* input baud rate */
+ #define TARGET_CMSPAR    010000000000 /* mark or space (stick) parity */
+ #define TARGET_CRTSCTS   020000000000 /* flow control */
+ 
++#define TARGET_IBSHIFT   16           /* Shift from CBAUD to CIBAUD */
++
+ /* c_lflag bits */
+ #define TARGET_ISIG     0000001
+ #define TARGET_ICANON   0000002
+diff --git a/linux-user/sparc/termbits.h b/linux-user/sparc/termbits.h
+index 588d7e8dcd..f64ea87d97 100644
+--- a/linux-user/sparc/termbits.h
++++ b/linux-user/sparc/termbits.h
+@@ -150,6 +150,7 @@ struct target_ktermios {
+ #define TARGET_HUPCL	  0x00000400
+ #define TARGET_CLOCAL	  0x00000800
+ #define TARGET_CBAUDEX   0x00001000
++#define  TARGET_BOTHER   0x00001000
+ /* We'll never see these speeds with the Zilogs, but for completeness... */
+ #define  TARGET_B57600   0x00001001
+ #define  TARGET_B115200  0x00001002
+@@ -176,10 +177,12 @@ struct target_ktermios {
+ #define B3000000  0x00001011
+ #define B3500000  0x00001012
+ #define B4000000  0x00001013  */
+-#define TARGET_CIBAUD	  0x100f0000  /* input baud rate (not used) */
++#define TARGET_CIBAUD	  0x100f0000  /* input baud rate */
+ #define TARGET_CMSPAR	  0x40000000  /* mark or space (stick) parity */
+ #define TARGET_CRTSCTS	  0x80000000  /* flow control */
+ 
++#define TARGET_IBSHIFT	  16          /* Shift from CBAUD to CIBAUD */
++
+ /* c_lflag bits */
+ #define TARGET_ISIG	0x00000001
+ #define TARGET_ICANON	0x00000002
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index e6e3dc252d..0cbc96b70d 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -5773,27 +5773,70 @@ static const bitmask_transtbl oflag_tbl[] = {
+ 	{ TARGET_FFDLY, TARGET_FF1, FFDLY, FF1 },
+ };
+ 
++#if defined(TARGET_CIBAUD) && defined(CIBAUD)
++
++# define BAUD_TRANSTBL(baud) \
++    { TARGET_CBAUD, TARGET_##baud, CBAUD, baud }, \
++    { TARGET_CIBAUD, TARGET_##baud << TARGET_IBSHIFT, CIBAUD, baud << IBSHIFT },
++
++#else
++
++/* Alpha in particular does not have CIBAUD/IBSHIFT */
++
++# define BAUD_TRANSTBL(baud) \
++    { TARGET_CBAUD, TARGET_##baud, CBAUD, baud },
++
++#endif
++
+ static const bitmask_transtbl cflag_tbl[] = {
+-	{ TARGET_CBAUD, TARGET_B0, CBAUD, B0 },
+-	{ TARGET_CBAUD, TARGET_B50, CBAUD, B50 },
+-	{ TARGET_CBAUD, TARGET_B75, CBAUD, B75 },
+-	{ TARGET_CBAUD, TARGET_B110, CBAUD, B110 },
+-	{ TARGET_CBAUD, TARGET_B134, CBAUD, B134 },
+-	{ TARGET_CBAUD, TARGET_B150, CBAUD, B150 },
+-	{ TARGET_CBAUD, TARGET_B200, CBAUD, B200 },
+-	{ TARGET_CBAUD, TARGET_B300, CBAUD, B300 },
+-	{ TARGET_CBAUD, TARGET_B600, CBAUD, B600 },
+-	{ TARGET_CBAUD, TARGET_B1200, CBAUD, B1200 },
+-	{ TARGET_CBAUD, TARGET_B1800, CBAUD, B1800 },
+-	{ TARGET_CBAUD, TARGET_B2400, CBAUD, B2400 },
+-	{ TARGET_CBAUD, TARGET_B4800, CBAUD, B4800 },
+-	{ TARGET_CBAUD, TARGET_B9600, CBAUD, B9600 },
+-	{ TARGET_CBAUD, TARGET_B19200, CBAUD, B19200 },
+-	{ TARGET_CBAUD, TARGET_B38400, CBAUD, B38400 },
+-	{ TARGET_CBAUD, TARGET_B57600, CBAUD, B57600 },
+-	{ TARGET_CBAUD, TARGET_B115200, CBAUD, B115200 },
+-	{ TARGET_CBAUD, TARGET_B230400, CBAUD, B230400 },
+-	{ TARGET_CBAUD, TARGET_B460800, CBAUD, B460800 },
++	BAUD_TRANSTBL(B0)
++	BAUD_TRANSTBL(B50)
++	BAUD_TRANSTBL(B75)
++	BAUD_TRANSTBL(B110)
++	BAUD_TRANSTBL(B134)
++	BAUD_TRANSTBL(B150)
++	BAUD_TRANSTBL(B200)
++	BAUD_TRANSTBL(B300)
++	BAUD_TRANSTBL(B600)
++	BAUD_TRANSTBL(B1200)
++	BAUD_TRANSTBL(B1800)
++	BAUD_TRANSTBL(B2400)
++	BAUD_TRANSTBL(B4800)
++	BAUD_TRANSTBL(B9600)
++	BAUD_TRANSTBL(B19200)
++	BAUD_TRANSTBL(B38400)
++	BAUD_TRANSTBL(B57600)
++	BAUD_TRANSTBL(B115200)
++	BAUD_TRANSTBL(B230400)
++	BAUD_TRANSTBL(B460800)
++	BAUD_TRANSTBL(B500000)
++	BAUD_TRANSTBL(B576000)
++	BAUD_TRANSTBL(B921600)
++	BAUD_TRANSTBL(B1000000)
++	BAUD_TRANSTBL(B1152000)
++	BAUD_TRANSTBL(B1500000)
++	BAUD_TRANSTBL(B2000000)
++
++	BAUD_TRANSTBL(BOTHER)
++
++	/* SPARC in particular is missing these higher baud rates */
++
++#if defined(TARGET_B2500000) && defined(B2500000)
++	BAUD_TRANSTBL(B2500000)
++#endif
++
++#if defined(TARGET_B3000000) && defined(B3000000)
++	BAUD_TRANSTBL(B3000000)
++#endif
++
++#if defined(TARGET_B3500000) && defined(B3500000)
++	BAUD_TRANSTBL(B3500000)
++#endif
++
++#if defined(TARGET_B4000000) && defined(B4000000)
++	BAUD_TRANSTBL(B4000000)
++#endif
++
+ 	{ TARGET_CSIZE, TARGET_CS5, CSIZE, CS5 },
+ 	{ TARGET_CSIZE, TARGET_CS6, CSIZE, CS6 },
+ 	{ TARGET_CSIZE, TARGET_CS7, CSIZE, CS7 },
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=10.1.2
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
 CHKSUMS="sha256::9d75f331c1a5cb9b6eb8fd9f64f563ec2eab346c822cb97f8b35cd82d3f11479"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: import patches for linux-user termios2
    These patches are needed for proper operation of newest Glibc release on
    most modern architectures \(seems that only Alpha is immune\) because
    Glibc switched to termios2 on all these architectures.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- qemu: 10.1.2-1
- qemu-aarch64-static: 10.1.2-1
- qemu-alpha-static: 10.1.2-1
- qemu-arm-static: 10.1.2-1
- qemu-armeb-static: 10.1.2-1
- qemu-guest-agent: 10.1.2-1
- qemu-i386-static: 10.1.2-1
- qemu-loongarch64-static: 10.1.2-1
- qemu-m68k-static: 10.1.2-1
- qemu-microblaze-static: 10.1.2-1
- qemu-microblazeel-static: 10.1.2-1
- qemu-mips-static: 10.1.2-1
- qemu-mips64-static: 10.1.2-1
- qemu-mips64el-static: 10.1.2-1
- qemu-mipsel-static: 10.1.2-1
- qemu-mipsn32-static: 10.1.2-1
- qemu-mipsn32el-static: 10.1.2-1
- qemu-or32-static: 10.1.2-1
- qemu-ppc-static: 10.1.2-1
- qemu-ppc64-static: 10.1.2-1
- qemu-ppc64le-static: 10.1.2-1
- qemu-riscv32-static: 10.1.2-1
- qemu-riscv64-static: 10.1.2-1
- qemu-s390x-static: 10.1.2-1
- qemu-sh4-static: 10.1.2-1
- qemu-sh4eb-static: 10.1.2-1
- qemu-sparc-static: 10.1.2-1
- qemu-sparc32plus-static: 10.1.2-1
- qemu-sparc64-static: 10.1.2-1
- qemu-user-static: 10.1.2-1
- qemu-x86-64-static: 10.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
