### PR TITLE
mise: update to 2025.12.7

### DIFF
--- a/app-devel/mise/autobuild/defines
+++ b/app-devel/mise/autobuild/defines
@@ -6,5 +6,7 @@ BUILDDEP="rustc llvm"
 
 USECLANG=1
 
-# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; recompile with -fPIC
-NOLTO__LOONGSON3=1
+# FIXME: lto fail with gcc>=14
+# mold: error: undefined symbol: aws_lc_0_29_0_AES_set_decrypt_key
+# = note: ld.lld: error: undefined symbol: aws_lc_0_29_0_EVP_parse_private_key
+NOLTO=1

--- a/app-devel/mise/autobuild/prepare
+++ b/app-devel/mise/autobuild/prepare
@@ -1,0 +1,4 @@
+# FIXME: Use lld to workaround aws-lc-rs discovery issue.
+if ab_match_arch loongson3; then
+        export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"
+fi

--- a/app-devel/mise/spec
+++ b/app-devel/mise/spec
@@ -1,4 +1,4 @@
-VER=2025.8.9
+VER=2025.12.7
 SRCS="git::commit=tags/v$VER::https://github.com/jdx/mise.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376460"


### PR DESCRIPTION
Topic Description
-----------------

- mise: update to 2025.12.7
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- mise: 2025.12.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit mise
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
