### PR TITLE
flatpak: update to 1.17.2

### DIFF
--- a/app-admin/flatpak/autobuild/defines
+++ b/app-admin/flatpak/autobuild/defines
@@ -1,27 +1,27 @@
 PKGNAME=flatpak
 PKGSEC=admin
-PKGDEP="appstream bubblewrap curl dbus dconf fuse-3 gdk-pixbuf glib gpgme \
-        json-glib libarchive libcap libseccomp libsodium libxml2 malcontent \
-        ostree polkit systemd wayland x11-app xdg-dbus-proxy zstd"
-BUILDDEP="gobject-introspection gtk-doc intltool libxslt wayland-protocols \
-          xmlto"
+PKGDEP="appstream bubblewrap curl dbus dconf fuse-3 gcc-runtime gdk-pixbuf \
+        glib glibc gpgme json-glib libarchive libcap libseccomp libsodium \
+        libxau libxml2 malcontent ostree polkit systemd wayland x11-app \
+        xdg-dbus-proxy zstd"
+BUILDDEP="docbook-xsl gobject-introspection wayland-protocols xmlto"
 PKGDES="Application deployment framework for desktop applications"
 
+ABTYPE=meson
 MESON_AFTER=(
     '-Dselinux_module=disabled'
     '-Dsystem_helper=enabled'
     '-Dauto_sideloading=true'
     '-Ddconf=enabled'
     '-Dgir=enabled'
-    '-Dhttp_backend=curl'
     '-Dlibzstd=enabled'
     '-Dmalcontent=enabled'
     '-Dman=enabled'
     '-Dgdm_env_file=true'
     '-Dsandboxed_triggers=true'
     '-Dseccomp=enabled'
-    '-Dgtkdoc=enabled'
-    '-Ddocbook_docs=enabled'
+    '-Dgtkdoc=disabled'
+    '-Ddocbook_docs=disabled'
     '-Dinternal_checks=false'
     '-Dinstalled_tests=false'
     '-Dprivileged_group=wheel'

--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,5 +1,5 @@
-VER=1.17.0
-SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak \
+VER=1.17.2
+SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak.git \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \
          sha256::3371dd250e61d9e1633630073fefda153cd4426f72f4afa0c3373ae2e8fea03a"


### PR DESCRIPTION
Topic Description
-----------------

- flatpak: update to 1.17.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- flatpak: 1.17.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
