### PR TITLE
aosc-community-wallpapers: update to 2025.12.1

### DIFF
--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2025.12.0
+VER=2025.12.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-community-wallpapers: update to 2025.12.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- aosc-community-wallpapers: 1:2025.12.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-community-wallpapers
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
