### PR TITLE
rocm: Runtimes,Compilers,Tools update to 7.1.1

### DIFF
--- a/runtime-rocm/rocm-aqlprofile/autobuild/defines
+++ b/runtime-rocm/rocm-aqlprofile/autobuild/defines
@@ -1,0 +1,22 @@
+PKGNAME=rocm-aqlprofile
+PKGDES="Architected Queuing Language Profiling Library"
+PKGSEC=devel
+PKGDEP="gcc-runtime rocm-core rocm-llvm rocr-runtime"
+BUILDDEP="cmake"
+
+USECLANG=1
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DCMAKE_SKIP_RPATH=OFF'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib;/usr/lib/rocm/lib/llvm/lib'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/runtime-rocm/rocm-aqlprofile/spec
+++ b/runtime-rocm/rocm-aqlprofile/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
+CHKSUMS="SKIP"
+SUBDIR="rocm-systems/projects/aqlprofile"
+CHKUPDATE="anitya::id=386527"

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems \
       git::commit=tags/rocm-${VER};rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP \

--- a/runtime-rocm/rocm-cmake/spec
+++ b/runtime-rocm/rocm-cmake/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocm-cmake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231446"

--- a/runtime-rocm/rocm-comgr/spec
+++ b/runtime-rocm/rocm-comgr/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/comgr"

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocm-core"

--- a/runtime-rocm/rocm-device-libs/spec
+++ b/runtime-rocm/rocm-device-libs/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/device-libs/"

--- a/runtime-rocm/rocm-half/spec
+++ b/runtime-rocm/rocm-half/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/half"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378431"

--- a/runtime-rocm/rocm-hipfort/spec
+++ b/runtime-rocm/rocm-hipfort/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipfort.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378520"

--- a/runtime-rocm/rocm-hipify/spec
+++ b/runtime-rocm/rocm-hipify/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/HIPIFY.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378519"

--- a/runtime-rocm/rocm-llvm/autobuild/patches/0006-llvm-fix-compile-fail.patch
+++ b/runtime-rocm/rocm-llvm/autobuild/patches/0006-llvm-fix-compile-fail.patch
@@ -1,0 +1,8 @@
+--- a/llvm/lib/Transforms/Scalar/CMakeLists.txt    2025-11-27 02:34:27.033183750 +0000
++++ b/llvm/lib/Transforms/Scalar/CMakeLists.txt    2025-11-27 02:34:32.887916250 +0000
+@@ -97,4 +97,5 @@
+   InstCombine
+   Support
+   TransformUtils
++  TargetParser
+   )

--- a/runtime-rocm/rocm-llvm/spec
+++ b/runtime-rocm/rocm-llvm/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/llvm"

--- a/runtime-rocm/rocm-rocprofiler-register/spec
+++ b/runtime-rocm/rocm-rocprofiler-register/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocprofiler-register"

--- a/runtime-rocm/rocm-roctracer/spec
+++ b/runtime-rocm/rocm-roctracer/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/roctracer"

--- a/runtime-rocm/rocm-smi-lib/spec
+++ b/runtime-rocm/rocm-smi-lib/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocm-smi-lib"

--- a/runtime-rocm/rocminfo/spec
+++ b/runtime-rocm/rocminfo/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocminfo"

--- a/runtime-rocm/rocr-runtime/autobuild/defines
+++ b/runtime-rocm/rocr-runtime/autobuild/defines
@@ -7,6 +7,8 @@ BUILDDEP="cmake vim"
 PKGBREAK="roct-thunk-interface<=6.0.2"
 PKGREP="roct-thunk-interface<=6.0.2"
 USECLANG=1
+# Note: Keep libhsakmt.a, rocprofiler-sdk dependency ...
+NOSTATIC=0
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocr-runtime"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-hipify: upgrade to 7.1.1
- rocm-aqlprofile: add, 7.1.1
- rocm-roctracer: upgrade to 7.1.1
- rocm-hipfort: upgrade to 7.1.1
- rocm-smi-lib: upgrade to 7.1.1
- rocm-half: upgrade to 7.1.1
- rocm-clr: upgrade to 7.1.1
- rocminfo: upgrade to 7.1.1
- rocr-runtime: upgrade to 7.1.1
- rocm-rocprofiler-register: upgrade to 7.1.1

... and 5 more commits

Package(s) Affected
-------------------

- rocm-aqlprofile: 7.1.1
- rocm-clr: 7.1.1
- rocm-cmake: 7.1.1
- rocm-comgr: 7.1.1
- rocm-core: 7.1.1
- rocm-device-libs: 7.1.1
- rocm-half: 7.1.1
- rocm-hipfort: 7.1.1
- rocm-hipify: 7.1.1
- rocm-llvm: 7.1.1
- rocm-rocprofiler-register: 7.1.1
- rocm-roctracer: 7.1.1
- rocm-smi-lib: 7.1.1
- rocminfo: 7.1.1
- rocr-runtime: 7.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocm-llvm rocm-device-libs rocm-comgr rocm-cmake rocm-rocprofiler-register rocr-runtime rocminfo rocm-clr rocm-half rocm-smi-lib rocm-hipify rocm-hipfort rocm-roctracer rocm-aqlprofile
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
