### PR TITLE
dart-sass: update to 1.97.0

### DIFF
--- a/app-devel/dart-sass/autobuild/build
+++ b/app-devel/dart-sass/autobuild/build
@@ -11,7 +11,7 @@ UPDATE_SASS_PROTOCOL=false dart run grinder protobuf
 dart compile aot-snapshot \
     --verbose \
     -Dversion="$PKGVER" \
-    -Dprotocol-version="$SASS_VER" \
+    -Dprotocol-version="$(cat $SRCDIR/build/language/spec/EMBEDDED_PROTOCOL_VERSION)" \
     -o "$SRCDIR"/dart-sass.aot \
     "$SRCDIR"/bin/sass.dart
 

--- a/app-devel/dart-sass/spec
+++ b/app-devel/dart-sass/spec
@@ -1,4 +1,4 @@
-VER=1.96.0
+VER=1.97.0
 SASS_VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/sass/dart-sass.git \
       git::commit=tags/embedded-protocol-$SASS_VER;rename=dart-sass/embedded-protocol::https://github.com/sass/sass.git"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sass: update to 1.97.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- dart-sass: 1.97.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
