### PR TITLE
rocm: Libraries without MachineLearning update to 7.1.1[1/3]

### DIFF
--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas-common"

--- a/runtime-rocm/rocm-origami/spec
+++ b/runtime-rocm/rocm-origami/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/shared/origami"

--- a/runtime-rocm/rocm-rocblas/autobuild/prepare
+++ b/runtime-rocm/rocm-rocblas/autobuild/prepare
@@ -1,12 +1,3 @@
-BUILD_FINAL(){
-    # FIXME: Missing build dependencies steps
-    # CMake Error at clients/cmake_install.cmake:51 (file):
-    #   file INSTALL cannot find
-    #   "clients/staging/rocblas_common.yaml":
-    #   No such file or directory.
-    ninja rocblas-common
-}
-
 abinfo "Setting ROCM_PATH ..."
 export ROCM_PATH=/usr/lib/rocm
 

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocblas"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocfft"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocrand"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocrand: upgrade to 7.1.1
- rocm-rocfft: upgrade to 7.1.1
- rocm-rocblas: upgrade to 7.1.1
- rocm-origami: upgrade to 7.1.1
- rocm-hipblas-common: upgrade to 7.1.1

Package(s) Affected
-------------------

- rocm-hipblas-common: 7.1.1
- rocm-origami: 7.1.1
- rocm-rocblas: 7.1.1
- rocm-rocfft: 7.1.1
- rocm-rocrand: 7.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipblas-common rocm-origami rocm-rocblas rocm-rocfft rocm-rocrand
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
