### PR TITLE
dart-sdk: update to 3.10.5

### DIFF
--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -1,5 +1,5 @@
-VER=3.10.4
+VER=3.10.5
 SRCS="tbl::https://repo.aosc.io/aosc-repacks/dart-sdk-${VER}.tar.zst"
-CHKSUMS="sha256::c68f0b661357e52d508512f8a546ac475c80ca44c3b1aaeff84f85a541fde1ee"
+CHKSUMS="sha256::b98a907caa6ade84e8a911d88fda8d50854846e4fa36e05b44e87d180e330fc3"
 CHKUPDATE="anitya::id=14718"
 SUBDIR="dart-sdk-${VER}"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sdk: update to 3.10.5
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- dart-sdk: 3.10.5
- dartaotruntime: 3.10.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
