### PR TITLE
at-spi2-core: update to 2.58.2

### DIFF
--- a/desktop-gnome/at-spi2-core/autobuild/defines
+++ b/desktop-gnome/at-spi2-core/autobuild/defines
@@ -1,28 +1,19 @@
 PKGNAME=at-spi2-core
 PKGSEC=gnome
-PKGDEP="dbus glib x11-lib"
-BUILDDEP="gobject-introspection intltool meson ninja gi-docgen sphinx"
-BUILDDEP__RETRO="intltool"
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGDEP="dbus gcc-runtime glib glibc x11-lib"
+BUILDDEP="gobject-introspection"
 PKGDES="Protocol definitions and daemon for D-Bus at-spi"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Ddocs=false'
+    '-Dintrospection=enabled'
+    '-Dx11=enabled'
+)
 
 # atk and at-spi2-atk got merged into at-spi2-core
 PKGBREAK="gdm<=3.17.92 atk<=2.38.0-1 at-spi2-atk<=2.38.0-2"
 PKGREP="atk<=2.38.0-1 at-spi2-atk<=2.38.0-2"
-MESON_AFTER="-Ddocs=true \
-             -Dintrospection=enabled \
-             -Dx11=enabled"
-MESON_AFTER__RETRO=" \
-             ${MESON_AFTER} \
-             -Ddocs=false \
-             -Dintrospection=no"
 
 # Note: Extra Provides for Spiral (Debian compatibility)
 PKGPROV="libatspi2.0-0_spiral libatspi2.0-0-dev_spiral \

--- a/desktop-gnome/at-spi2-core/spec
+++ b/desktop-gnome/at-spi2-core/spec
@@ -1,4 +1,4 @@
-VER=2.52.0
+VER=2.58.2
 SRCS="https://download.gnome.org/sources/at-spi2-core/${VER:0:4}/at-spi2-core-$VER.tar.xz"
-CHKSUMS="sha256::0ac3fc8320c8d01fa147c272ba7fa03806389c6b03d3c406d0823e30e35ff5ab"
+CHKSUMS="sha256::a2823b962ed16cdd5cb1fc5365029fd218394d852acd4098b321854bd6692f6e"
 CHKUPDATE="anitya::id=7841"

--- a/runtime-optenv32/at-spi2-core+32/autobuild/defines
+++ b/runtime-optenv32/at-spi2-core+32/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=at-spi2-core+32
 PKGSEC=gnome
-PKGDEP="aosc-aaa+32 dbus+32 glib+32 x11-lib+32"
+PKGDEP="aosc-aaa+32 dbus+32 gcc+32 glib+32 glibc+32 x11-lib+32"
 BUILDDEP="devel-base+32"
 PKGDES="Protocol definitions and daemon for D-Bus at-spi (32-bit x86 runtime)"
 

--- a/runtime-optenv32/at-spi2-core+32/spec
+++ b/runtime-optenv32/at-spi2-core+32/spec
@@ -1,4 +1,4 @@
-VER=2.52.0
+VER=2.58.2
 SRCS="https://download.gnome.org/sources/at-spi2-core/${VER:0:4}/at-spi2-core-$VER.tar.xz"
-CHKSUMS="sha256::0ac3fc8320c8d01fa147c272ba7fa03806389c6b03d3c406d0823e30e35ff5ab"
+CHKSUMS="sha256::a2823b962ed16cdd5cb1fc5365029fd218394d852acd4098b321854bd6692f6e"
 CHKUPDATE="anitya::id=7841"


### PR DESCRIPTION
Topic Description
-----------------

- at-spi2-core: update to 2.58.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- at-spi2-core: 2.58.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit at-spi2-core
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
