### PR TITLE
gvfs: update to 1.58.0

### DIFF
--- a/desktop-gnome/gvfs/spec
+++ b/desktop-gnome/gvfs/spec
@@ -1,5 +1,4 @@
-VER=1.50.2
-REL=2
+VER=1.58.0
 SRCS="https://download.gnome.org/sources/gvfs/${VER:0:4}/gvfs-$VER.tar.xz"
-CHKSUMS="sha256::03d72b8c15ef438110f0cf457b5655266c8b515d0412b30f4d55cfa0da06ac5e"
+CHKSUMS="sha256::dd9be36873d0fcb309eb89a8d274770ce576287628a2cf111bd387e1c34f182f"
 CHKUPDATE="anitya::id=5496"


### PR DESCRIPTION
Topic Description
-----------------

- gvfs: update to 1.58.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gvfs: 1.58.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gvfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
