### PR TITLE
webkit2gtk: update to 2.50.4

### DIFF
--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,6 +1,6 @@
-VER=2.50.3
+VER=2.50.4
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f"
+CHKSUMS="sha256::d3bfa473845acfab72635bada5e0d134fda6792c5b95c5c5cd141b46125bd8e4"
 CHKUPDATE="anitya::id=324014"
 
 # Let's be a little conservative than sorry.  Combined with the parallel job


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: update to 2.50.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- webkit2gtk: 1:2.50.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
