### PR TITLE
libeconf: rebuild to fix executable stack on loongson3

### DIFF
--- a/runtime-common/libeconf/spec
+++ b/runtime-common/libeconf/spec
@@ -1,5 +1,5 @@
 VER=0.5.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/openSUSE/libeconf/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::d6f794418a8f3ea2932bfaa33576ee604328edf7aff0c5ada1ffc74ef0362e3a"
 CHKUPDATE="anitya::id=21922"


### PR DESCRIPTION
Topic Description
-----------------

- libeconf: rebuild to fix RWE GNU_STACK on loongson3
    GNU_STACK should be RW.

Package(s) Affected
-------------------

- libeconf: 0.5.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libeconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
