### PR TITLE
loongson3 executable stack survey 20251218

### DIFF
--- a/app-admin/f2fs-tools/autobuild/patches/0001-AOSCOS-include-f2fs_fs.h-avoid-defining-bool-for-c23.patch
+++ b/app-admin/f2fs-tools/autobuild/patches/0001-AOSCOS-include-f2fs_fs.h-avoid-defining-bool-for-c23.patch
@@ -1,0 +1,25 @@
+From 95a443e0ae7da69e9165856f9405fd9db471f50b Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Thu, 18 Dec 2025 15:38:40 +0800
+Subject: [PATCH] AOSCOS: include/f2fs_fs.h: avoid defining bool for c23
+
+---
+ include/f2fs_fs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/f2fs_fs.h b/include/f2fs_fs.h
+index f890634..1365de4 100644
+--- a/include/f2fs_fs.h
++++ b/include/f2fs_fs.h
+@@ -103,7 +103,7 @@ typedef uint16_t	u16;
+ typedef uint8_t		u8;
+ typedef u32		block_t;
+ typedef u32		nid_t;
+-#ifndef bool
++#if !defined(bool) && (__STDC_VERSION__ < 202311)
+ typedef u8		bool;
+ #endif
+ typedef unsigned long	pgoff_t;
+-- 
+2.52.0
+

--- a/app-admin/f2fs-tools/spec
+++ b/app-admin/f2fs-tools/spec
@@ -2,3 +2,4 @@ VER=1.16.0
 SRCS="tbl::https://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/f2fs-tools-$VER.tar.gz"
 CHKSUMS="sha256::208c7a07e95383fbd7b466b5681590789dcb41f41bf197369c41a95383b57c5e"
 CHKUPDATE="anitya::id=14689"
+REL=1

--- a/app-admin/fuse-3/spec
+++ b/app-admin/fuse-3/spec
@@ -2,3 +2,4 @@ VER=3.16.2
 SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.gz"
 CHKSUMS="sha256::f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87"
 CHKUPDATE="anitya::id=861"
+REL=1

--- a/app-admin/hwloc/spec
+++ b/app-admin/hwloc/spec
@@ -2,3 +2,4 @@ VER=2.10.0
 SRCS="tbl::https://www.open-mpi.org/software/hwloc/v${VER:0:4}/downloads/hwloc-$VER.tar.bz2"
 CHKSUMS="sha256::0305dd60c9de2fbe6519fe2a4e8fdc6d3db8de574a0ca7812b92e80c05ae1392"
 CHKUPDATE="anitya::id=13501"
+REL=1

--- a/app-admin/parted/autobuild/defines
+++ b/app-admin/parted/autobuild/defines
@@ -1,20 +1,21 @@
 PKGNAME=parted
 PKGSEC=admin
 PKGDEP="lvm2 e2fsprogs"
-PKGDES="A program for creating, destroying, resizing, checking and copying partitions"
+PKGDES="Utility to manipulate disk partitions"
 
-AUTOTOOLS_AFTER="--disable-mtrace \
-                 --enable-device-mapper \
-                 --disable-discover-only \
-                 --enable-debug \
-                 --disable-read-only \
-                 --enable-pc98 \
-                 --enable-hfs-extract-fs \
-                 --enable-largefile \
-                 --enable-year2038 \
-                 --enable-threads=isoc+posix \
-                 --enable-assert \
-                 --with-readline \
-                 --with-packager=AOSC \
-                 --with-packager-bug-reports=https://github.com/AOSC-Dev/aosc-os-abbs/issues \
-                 LIBS=-luuid"
+AUTOTOOLS_AFTER=(
+    '--disable-mtrace'
+    '--enable-device-mapper'
+    '--disable-discover-only'
+    '--enable-debug'
+    '--disable-read-only'
+    '--enable-pc98'
+    '--enable-hfs-extract-fs'
+    '--enable-largefile'
+    '--enable-year2038'
+    '--enable-threads=isoc+posix'
+    '--enable-assert'
+    '--with-readline'
+    '--with-packager=AOSC'
+    '--with-packager-bug-reports=https://github.com/AOSC-Dev/aosc-os-abbs/issues'
+)

--- a/app-admin/parted/autobuild/patches/0001-UPSTREAM-parted-link-to-libuuid.patch
+++ b/app-admin/parted/autobuild/patches/0001-UPSTREAM-parted-link-to-libuuid.patch
@@ -1,0 +1,32 @@
+From a6782b5d0f8649b07c62195829fe3763feb85431 Mon Sep 17 00:00:00 2001
+From: Yegor Yefremov <yegorslists@googlemail.com>
+Date: Thu, 11 May 2023 10:03:59 +0200
+Subject: [PATCH 01/11] UPSTREAM: parted: link to libuuid
+
+parted.c uses libuuid since 61b3a9733c0e0a79ccc43096642d378c8706add6.
+Hence, add UUID_LIBS to PARTED_LIBS to avoid
+"DSO missing from command line" error.
+
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index cf9fb8a..03081af 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -298,6 +298,8 @@ Note: originally, libuuid was part of the e2fsprogs package.  Later, it
+ moved to util-linux-ng-2.16, and that package is now the preferred source.])])
+ AC_SUBST([UUID_LIBS])
+ 
++PARTED_LIBS="$PARTED_LIBS $UUID_LIBS"
++
+ dnl Check for libdevmapper
+ DM_LIBS=
+ if test $ENABLE_DEVICE_MAPPER = yes; then
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0002-UPSTREAM-bug-64034-PATCH-libparted-link-libparted-fs.patch
+++ b/app-admin/parted/autobuild/patches/0002-UPSTREAM-bug-64034-PATCH-libparted-link-libparted-fs.patch
@@ -1,0 +1,37 @@
+From 495431f926eb72d58ababd678c20f2ad45f24bbe Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 12 Jun 2023 10:55:19 -0700
+Subject: [PATCH 02/11] UPSTREAM: bug#64034: [PATCH] libparted: link
+ libparted-fs-resize.so to libuuid
+
+uuid_generate() is used in this library
+Hence, add UUID_LIBS to libparted_fs_resize_la_LIBADD to avoid
+
+"ld.lld: error: undefined reference due to --no-allow-shlib-undefined: uuid_generate"
+
+This is uncovered by lld linker linking fatresize package
+due to this linker defaulting to --no-allow-shlib-undefined.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libparted/fs/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libparted/fs/Makefile.am b/libparted/fs/Makefile.am
+index 41a60d9..7fa8d14 100644
+--- a/libparted/fs/Makefile.am
++++ b/libparted/fs/Makefile.am
+@@ -75,6 +75,7 @@ libparted_fs_resize_la_LDFLAGS =		\
+ EXTRA_DIST += fsresize.sym
+ libparted_fs_resize_la_DEPENDENCIES = $(sym_file)
+ 
++libparted_fs_resize_la_LIBADD  = $(UUID_LIBS)
+ libparted_fs_resize_la_SOURCES = \
+   r/filesys.c			\
+   r/fat/bootsector.c		\
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0003-UPSTREAM-parted-Print-the-Fixing.-message-to-stderr.patch
+++ b/app-admin/parted/autobuild/patches/0003-UPSTREAM-parted-Print-the-Fixing.-message-to-stderr.patch
@@ -1,0 +1,30 @@
+From 21fe50b45aadd880423afd7342cb22e92a121b10 Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 10 Jul 2024 15:41:16 -0700
+Subject: [PATCH 03/11] UPSTREAM: parted: Print the Fixing... message to stderr
+
+Otherwise it messes up stdout of things like --json
+
+Thanks to Mikael Q for reporting this.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ parted/ui.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/parted/ui.c b/parted/ui.c
+index 33a1808..d6d1da4 100644
+--- a/parted/ui.c
++++ b/parted/ui.c
+@@ -645,7 +645,7 @@ exception_handler (PedException* ex)
+         /* script-mode and fix? */
+         int fix_is_an_option = (ex->options & PED_EXCEPTION_FIX);
+         if (opt_script_mode && opt_fix_mode && fix_is_an_option) {
+-                printf ("Fixing, due to --fix\n");
++                fprintf (stderr, "Fixing, due to --fix\n");
+                 return PED_EXCEPTION_FIX;
+         }
+ 
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0004-UPSTREAM-doc-Document-IEC-unit-behavior-in-the-manpa.patch
+++ b/app-admin/parted/autobuild/patches/0004-UPSTREAM-doc-Document-IEC-unit-behavior-in-the-manpa.patch
@@ -1,0 +1,40 @@
+From f8440d77f1a2e928dd9d752fc1146ac61563df9e Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Fri, 12 Jul 2024 16:24:58 -0700
+Subject: [PATCH 04/11] UPSTREAM: doc: Document IEC unit behavior in the
+ manpage
+
+Previously this has only been documented in the info page.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ doc/C/parted.8 | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/doc/C/parted.8 b/doc/C/parted.8
+index 3069c33..171269c 100644
+--- a/doc/C/parted.8
++++ b/doc/C/parted.8
+@@ -151,6 +151,19 @@ Toggle the state of the disk \fIflag\fP.
+ .B version
+ Display version information and a copyright message.
+ .RE
++.SH UNITS
++\fBparted\fP will compute sensible ranges for the locations you specify when using
++units like "GB", "MB", etc. Use the sector unit "s" or IEC binary units like
++"GiB", "MiB", to specify exact locations.
++
++When you specify start or end values using IEC binary units like "MiB",
++"GiB", "TiB", etc., \fBparted\fP treats those values as exact, and equivalent to
++the same number specified in bytes (i.e., with the "B" suffix), in that it
++provides no helpful range of sloppiness.  Contrast that with a partition
++start request of "4GB", which may actually resolve to some sector up to 500MB
++before or after that point.  Thus, when creating a partition in an exact location
++you should use units of bytes ("B"), sectors ("s"), or IEC binary units like
++"MiB", "GiB", but not "MB", "GB", etc.
+ .SH REPORTING BUGS
+ Report bugs to <bug-parted@gnu.org>
+ .SH SEE ALSO
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0005-UPSTREAM-libparted-Fail-early-when-detecting-nilfs2.patch
+++ b/app-admin/parted/autobuild/patches/0005-UPSTREAM-libparted-Fail-early-when-detecting-nilfs2.patch
@@ -1,0 +1,57 @@
+From 95a81bd322b4791267c761d9f4cf2affb558784b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Old=C5=99ich=20Jedli=C4=8Dka?= <oldium.pro@gmail.com>
+Date: Sat, 6 Apr 2024 19:21:11 +0200
+Subject: [PATCH 05/11] UPSTREAM: libparted: Fail early when detecting nilfs2
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When the disk is encrypted with TCG Opal HW encryption (supported by
+cryptsetup 2.7.0+), the partition initially contains locked area, which
+shows reading errors in kernel logs and may lead to configuring the disk
+to work with lower reading speed. When the disk area is unlocked with
+password, the reading succeeds. The beginning of the protected partition is
+not locked and contains LUKS header, this is always readable.
+
+To work around the errors when reading from the locked area, try first
+detecting nilfs2 at the beginning (may be an unprotected LUKS header area)
+and only check the second superblock that is at the end of the area (and
+possibly locked) if the first one is valid (meaning the partition is not
+LUKS-protected).
+
+This is a change in behavior, but is consistent with the nilfs2 code, which
+considers both superblocks mandatory, see [1].
+
+[1] https://github.com/nilfs-dev/nilfs-utils/blob/master/lib/sb.c#L135-L158
+
+Signed-off-by: Oldřich Jedlička <oldium.pro@gmail.com>
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libparted/fs/nilfs2/nilfs2.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/libparted/fs/nilfs2/nilfs2.c b/libparted/fs/nilfs2/nilfs2.c
+index 6204542..40f8567 100644
+--- a/libparted/fs/nilfs2/nilfs2.c
++++ b/libparted/fs/nilfs2/nilfs2.c
+@@ -118,11 +118,12 @@ nilfs2_probe (PedGeometry* geom)
+ 
+ 	if (ped_geometry_read(geom, buf, 0, sectors))
+ 		sb = (struct nilfs2_super_block*)(buf + 1024);
++	if (!sb || !is_valid_nilfs_sb(sb))
++		return NULL;
++
+ 	if (ped_geometry_read(geom, buff2, sb2off, sectors2))
+ 		sb2 = (struct nilfs2_super_block*)buff2;
+-
+-	if ((!sb || !is_valid_nilfs_sb(sb)) &&
+-	    (!sb2 || !is_valid_nilfs_sb(sb2)))
++	if (!sb2 || !is_valid_nilfs_sb(sb2))
+ 		return NULL;
+ 
+ 	/* reserve 4k bytes for secondary superblock */
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0006-UPSTREAM-bug-74444-PATCH-parted-fix-do_version-decla.patch
+++ b/app-admin/parted/autobuild/patches/0006-UPSTREAM-bug-74444-PATCH-parted-fix-do_version-decla.patch
@@ -1,0 +1,44 @@
+From 27afd51e833c6daab2e0158cdcb0383dce4e4439 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 20 Nov 2024 12:22:22 +0000
+Subject: [PATCH 06/11] UPSTREAM: bug#74444: [PATCH] parted: fix do_version
+ declaration
+
+With gcc 15-20241117 compile fails with the below error, update the
+do_version declaration to match the header in command.h
+
+../../parted/parted.c: In function '_init_commands':
+../../parted/parted.c:2469:9: error: passing argument 2 of 'command_create' from incompatible pointer type [-Wincompatible-pointer-types]
+ 2469 |         do_version,
+      |         ^~~~~~~~~~
+      |         |
+      |         int (*)(void)
+In file included from ../../parted/parted.c:28:
+../../parted/command.h:35:39: note: expected 'int (*)(PedDevice **, PedDisk **)' {aka 'int (*)(struct _PedDevice **, struct _PedDisk **)'} but argument is of type 'int (*)(void)'
+   35 |                                 int (*method) (PedDevice** dev, PedDisk** diskp),
+      |                                 ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ parted/parted.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/parted/parted.c b/parted/parted.c
+index 3abb52f..fc2aeba 100644
+--- a/parted/parted.c
++++ b/parted/parted.c
+@@ -2172,7 +2172,7 @@ do_unit (PedDevice** dev, PedDisk** diskp)
+ }
+ 
+ static int
+-do_version ()
++do_version (PedDevice** dev, PedDisk** diskp)
+ {
+     printf ("\n%s\n%s",
+             prog_name,
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0007-UPSTREAM-libparted-Fix-sun-disklabel-unhandled-excep.patch
+++ b/app-admin/parted/autobuild/patches/0007-UPSTREAM-libparted-Fix-sun-disklabel-unhandled-excep.patch
@@ -1,0 +1,34 @@
+From 685265c1fb385caa182cf465c63c0ee1528aa9cc Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Tue, 7 Jan 2025 16:50:21 -0800
+Subject: [PATCH 07/11] UPSTREAM: libparted: Fix sun disklabel unhandled
+ exception
+
+The CHS warning should only continue if ignored, not if unhandled.
+
+Script mode, or exception handlers can return PED_EXCEPTION_UNHANDLED
+which should act the same as a cancel. Previously it would only exit if
+cancel was selected, allowing it to continue to use the bad CHS and
+crash later.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libparted/labels/sun.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libparted/labels/sun.c b/libparted/labels/sun.c
+index 5ed2886..853576b 100644
+--- a/libparted/labels/sun.c
++++ b/libparted/labels/sun.c
+@@ -284,7 +284,7 @@ _check_geometry_sanity (PedDisk* disk, SunRawLabel* label)
+ 				PED_BE16_TO_CPU(label->pcylcount),
+ 				PED_BE16_TO_CPU(label->ntrks),
+ 				PED_BE16_TO_CPU(label->nsect))
+-			== PED_EXCEPTION_CANCEL)
++			!= PED_EXCEPTION_IGNORE)
+ 			return 0;
+ #endif
+ 		dev->bios_geom.sectors = PED_BE16_TO_CPU(label->nsect);
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0008-UPSTREAM-libparted-Fix-dvh-disklabel-unhandled-excep.patch
+++ b/app-admin/parted/autobuild/patches/0008-UPSTREAM-libparted-Fix-dvh-disklabel-unhandled-excep.patch
@@ -1,0 +1,32 @@
+From 39aa0300ccd361f0752178bcd3d94f218fc1cb06 Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 8 Jan 2025 13:35:04 -0800
+Subject: [PATCH 08/11] UPSTREAM: libparted: Fix dvh disklabel unhandled
+ exception
+
+When an exception is using PED_EXCEPTION_IGNORE_CANCEL it should check
+for !PED_EXCEPTION_IGNORE so that an unhandled exception is treated the
+same as cancel. Otherwise it could lead to using the disklabel with
+incorrect values.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libparted/labels/dvh.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libparted/labels/dvh.c b/libparted/labels/dvh.c
+index 0f9124d..7d7dae3 100644
+--- a/libparted/labels/dvh.c
++++ b/libparted/labels/dvh.c
+@@ -308,7 +308,7 @@ dvh_read (PedDisk* disk)
+ 			PED_EXCEPTION_IGNORE_CANCEL,
+ 			_("Checksum is wrong, indicating the partition "
+ 			  "table is corrupt."))
+-				== PED_EXCEPTION_CANCEL)
++				!= PED_EXCEPTION_IGNORE)
+ 			return 0;
+ 	}
+ 
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0009-UPSTREAM-libparted-Do-not-detect-ext4-without-journa.patch
+++ b/app-admin/parted/autobuild/patches/0009-UPSTREAM-libparted-Do-not-detect-ext4-without-journa.patch
@@ -1,0 +1,64 @@
+From 2e2c51c6ee1826725e96d14aacf40299bce22c3e Mon Sep 17 00:00:00 2001
+From: Pascal Hambourg <pascal@plouf.fr.eu.org>
+Date: Thu, 17 Apr 2025 18:42:33 +0200
+Subject: [PATCH 09/11] UPSTREAM: libparted: Do not detect ext4 without journal
+ as ext2
+
+ext4 may have other incompatible features than journal and cannot be
+mounted as ext2 by linux, so detect it as ext4 even without journal
+if it has other incompatible features.
+
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libparted/fs/ext2/interface.c | 33 +++++++++++++++------------------
+ 1 file changed, 15 insertions(+), 18 deletions(-)
+
+diff --git a/libparted/fs/ext2/interface.c b/libparted/fs/ext2/interface.c
+index 7e0b197..5f64ab3 100644
+--- a/libparted/fs/ext2/interface.c
++++ b/libparted/fs/ext2/interface.c
+@@ -52,24 +52,21 @@ _ext2_generic_probe (PedGeometry* geom, int expect_ext_ver)
+ 		int is_ext3 = 0;
+ 		int is_ext4 = 0;
+ 
+-		is_ext3 = (EXT2_SUPER_FEATURE_COMPAT (*sb)
+-			   & EXT3_FEATURE_COMPAT_HAS_JOURNAL) != 0;
+-		if (is_ext3) {
+-			is_ext4 = ((EXT2_SUPER_FEATURE_RO_COMPAT (*sb)
+-				    & EXT4_FEATURE_RO_COMPAT_HUGE_FILE)
+-				   || (EXT2_SUPER_FEATURE_RO_COMPAT (*sb)
+-				       & EXT4_FEATURE_RO_COMPAT_GDT_CSUM)
+-				   || (EXT2_SUPER_FEATURE_RO_COMPAT (*sb)
+-				       & EXT4_FEATURE_RO_COMPAT_DIR_NLINK)
+-				   || (EXT2_SUPER_FEATURE_INCOMPAT (*sb)
+-				       & EXT4_FEATURE_INCOMPAT_EXTENTS)
+-				   || (EXT2_SUPER_FEATURE_INCOMPAT (*sb)
+-				       & EXT4_FEATURE_INCOMPAT_64BIT)
+-				   || (EXT2_SUPER_FEATURE_INCOMPAT (*sb)
+-				       & EXT4_FEATURE_INCOMPAT_FLEX_BG));
+-			if (is_ext4)
+-				is_ext3 = 0;
+-		}
++		is_ext4 = ((EXT2_SUPER_FEATURE_RO_COMPAT (*sb)
++			    & EXT4_FEATURE_RO_COMPAT_HUGE_FILE)
++			   || (EXT2_SUPER_FEATURE_RO_COMPAT (*sb)
++			       & EXT4_FEATURE_RO_COMPAT_GDT_CSUM)
++			   || (EXT2_SUPER_FEATURE_RO_COMPAT (*sb)
++			       & EXT4_FEATURE_RO_COMPAT_DIR_NLINK)
++			   || (EXT2_SUPER_FEATURE_INCOMPAT (*sb)
++			       & EXT4_FEATURE_INCOMPAT_EXTENTS)
++			   || (EXT2_SUPER_FEATURE_INCOMPAT (*sb)
++			       & EXT4_FEATURE_INCOMPAT_64BIT)
++			   || (EXT2_SUPER_FEATURE_INCOMPAT (*sb)
++			       & EXT4_FEATURE_INCOMPAT_FLEX_BG));
++		if (!is_ext4)
++			is_ext3 = (EXT2_SUPER_FEATURE_COMPAT (*sb)
++				   & EXT3_FEATURE_COMPAT_HAS_JOURNAL) != 0;
+ 		if (expect_ext_ver == 2 && (is_ext3 || is_ext4))
+ 			return NULL;
+ 		if (expect_ext_ver == 3 && !is_ext3)
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0010-UPSTREAM-nilfs2-Fixed-possible-sigsegv-in-case-of-co.patch
+++ b/app-admin/parted/autobuild/patches/0010-UPSTREAM-nilfs2-Fixed-possible-sigsegv-in-case-of-co.patch
@@ -1,0 +1,63 @@
+From 9df5a90ddb2db604cc9189788d5d0b1646570865 Mon Sep 17 00:00:00 2001
+From: Anton Butenko <abutenko@akamai.com>
+Date: Fri, 28 Feb 2025 16:09:18 +0100
+Subject: [PATCH 10/11] UPSTREAM: nilfs2: Fixed possible sigsegv in case of
+ corrupted superblock
+
+bytes value comes from the superblock and it must be at least as long as
+s_sum which is a 32 bit value. So sumoff + 4 is the correct lower limit
+for it, not sumoff - 4.
+
+Signed-off-by: Brian C. Lane <bcl@redhat.com>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libparted/fs/nilfs2/nilfs2.c |  2 +-
+ tests/t4301-nilfs2-badsb2.sh | 10 ++++++++--
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/libparted/fs/nilfs2/nilfs2.c b/libparted/fs/nilfs2/nilfs2.c
+index 40f8567..74186f1 100644
+--- a/libparted/fs/nilfs2/nilfs2.c
++++ b/libparted/fs/nilfs2/nilfs2.c
+@@ -88,7 +88,7 @@ is_valid_nilfs_sb(struct nilfs2_super_block *sb)
+ 		return 0;
+ 
+ 	bytes = PED_LE16_TO_CPU(sb->s_bytes);
+-	if (bytes > 1024 || bytes < sumoff - 4)
++	if (bytes > 1024 || bytes < sumoff + 4)
+ 		return 0;
+ 
+ 	crc = __efi_crc32(sb, sumoff, PED_LE32_TO_CPU(sb->s_crc_seed));
+diff --git a/tests/t4301-nilfs2-badsb2.sh b/tests/t4301-nilfs2-badsb2.sh
+index 2a1205b..45b6644 100755
+--- a/tests/t4301-nilfs2-badsb2.sh
++++ b/tests/t4301-nilfs2-badsb2.sh
+@@ -27,16 +27,22 @@ end=$(($len * 512 / $ss))
+ parted -s $dev mklabel msdos mkpart primary 1s ${end}s || framework_failure_
+ 
+ # Write a secondary superblock with the nilfs magic number and a nilfs
+-# superblock length (s_bytes) field of only 10 bytes.
++# superblock length (s_bytes) field of only 13 bytes.
+ # struct nilfs2_super_block starts with these four fields...
+ #	uint32_t	s_rev_level;
+ #	uint16_t	s_minor_rev_level;
+ #	uint16_t	s_magic;
+ #	uint16_t	s_bytes;
+ sb2_offset=$(( 24 / ($ss / 512) + 1))
+-perl -e "print pack 'LSSS.', 0, 0, 0x3434, 10, $ss" |
++perl -e "print pack 'LSSS.', 0, 0, 0x3434, 13, $ss" |
+     dd of=$dev bs=$ss seek=$sb2_offset count=1 conv=notrunc
+ 
++# Write primary nilfs magic number and a nilfs
++# superblock length (s_bytes) field of only 13 bytes.
++sb_offset=3
++perl -e "print pack 'LSSS.', 0, 0, 0x3434, 13, $ss" |
++    dd of=$dev bs=$ss seek=$sb_offset count=1 conv=notrunc
++
+ # This used to give parted a sigsegv.
+ parted -s $dev print || fail=1
+ 
+-- 
+2.52.0
+

--- a/app-admin/parted/autobuild/patches/0011-UPSTREAM-doc-Fix-some-groff-mandoc-linting-complaint.patch
+++ b/app-admin/parted/autobuild/patches/0011-UPSTREAM-doc-Fix-some-groff-mandoc-linting-complaint.patch
@@ -1,0 +1,91 @@
+From 438be63b494c300bae384a0dcbc1c74c36284cce Mon Sep 17 00:00:00 2001
+From: "Brian C. Lane" <bcl@redhat.com>
+Date: Wed, 28 May 2025 13:09:32 -0700
+Subject: [PATCH 11/11] UPSTREAM: doc: Fix some groff/mandoc linting complaints
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ doc/C/parted.8 | 27 ++++++++++++---------------
+ 1 file changed, 12 insertions(+), 15 deletions(-)
+
+diff --git a/doc/C/parted.8 b/doc/C/parted.8
+index 171269c..c852112 100644
+--- a/doc/C/parted.8
++++ b/doc/C/parted.8
+@@ -54,7 +54,6 @@ Use optimum alignment as given by the disk topology information. This
+ aligns to a multiple of the physical block size in a way that guarantees
+ optimal performance.
+ .RE
+-
+ .SH COMMANDS
+ .TP
+ .B [device]
+@@ -62,8 +61,7 @@ The block device to be used.  When none is given, \fBparted\fP will use the
+ first block device it finds.
+ .TP
+ .B [command [options]]
+-Specifies the command to be executed.  If no command is given,
+-.BR parted
++Specifies the command to be executed.  If no command is given, \fBparted\fP
+ will present a command prompt.  Possible commands are:
+ .RS
+ .TP
+@@ -119,8 +117,8 @@ or an LVM logical volume if necessary.
+ .B set \fIpartition\fP \fIflag\fP \fIstate\fP
+ Change the state of the \fIflag\fP on \fIpartition\fP to \fIstate\fP.
+ Supported flags are: "boot", "root", "swap", "hidden", "raid", "lvm", "lba",
+-"legacy_boot", "irst", "msftres", "esp", "chromeos_kernel", "bls_boot", "linux-home",
+-"no_automount", "bios_grub", and "palo".
++"legacy_boot", "irst", "msftres", "esp", "chromeos_kernel", "bls_boot",
++"linux-home", "no_automount", "bios_grub", and "palo".
+ \fIstate\fP should be either "on" or "off".
+ .TP
+ .B unit \fIunit\fP
+@@ -140,10 +138,10 @@ On MS-DOS set the type aka. partition id of \fIpartition\fP to
+ the type-uuid of \fIpartition\fP to \fIuuid\fP.
+ .TP
+ .B disk_set \fIflag\fP \fIstate\fP
+-Change a \fIflag\fP on the disk to \fIstate\fP. A flag can be either "on" or "off".
+-Some or all of these flags will be available, depending on what disk label you
+-are using.  Supported flags are: "pmbr_boot" on GPT to enable the boot flag on the
+-GPT's protective MBR partition.
++Change a \fIflag\fP on the disk to \fIstate\fP. A flag can be either "on" or
++"off".  Some or all of these flags will be available, depending on what disk
++abel you are using.  Supported flags are: "pmbr_boot" on GPT to enable the
++boot flag on the GPT's protective MBR partition.
+ .TP
+ .B disk_toggle \fIflag\fP
+ Toggle the state of the disk \fIflag\fP.
+@@ -155,24 +153,23 @@ Display version information and a copyright message.
+ \fBparted\fP will compute sensible ranges for the locations you specify when using
+ units like "GB", "MB", etc. Use the sector unit "s" or IEC binary units like
+ "GiB", "MiB", to specify exact locations.
+-
+ When you specify start or end values using IEC binary units like "MiB",
+ "GiB", "TiB", etc., \fBparted\fP treats those values as exact, and equivalent to
+ the same number specified in bytes (i.e., with the "B" suffix), in that it
+ provides no helpful range of sloppiness.  Contrast that with a partition
+ start request of "4GB", which may actually resolve to some sector up to 500MB
+-before or after that point.  Thus, when creating a partition in an exact location
+-you should use units of bytes ("B"), sectors ("s"), or IEC binary units like
+-"MiB", "GiB", but not "MB", "GB", etc.
++before or after that point.  Thus, when creating a partition in an exact
++location you should use units of bytes ("B"), sectors ("s"), or IEC binary units
++like "MiB", "GiB", but not "MB", "GB", etc.
+ .SH REPORTING BUGS
+ Report bugs to <bug-parted@gnu.org>
+ .SH SEE ALSO
+ .BR fdisk (8),
+ .BR mkfs (8),
+ The \fIparted\fP program is fully documented in the
+-.BR info(1)
++.BR info (1)
+ format
+-.IR "GNU partitioning software"
++.I "GNU partitioning software"
+ manual.
+ .SH AUTHOR
+ This manual page was written by Timshel Knoll <timshel@debian.org>,
+-- 
+2.52.0
+

--- a/app-admin/parted/spec
+++ b/app-admin/parted/spec
@@ -1,5 +1,5 @@
 VER=3.6
-REL=1
+REL=2
 SRCS="tbl::https://ftp.gnu.org/gnu/parted/parted-$VER.tar.xz"
 CHKSUMS="sha256::3b43dbe33cca0f9a18601ebab56b7852b128ec1a3df3a9b30ccde5e73359e612"
 CHKUPDATE="anitya::id=2596"

--- a/app-admin/reiserfsprogs/spec
+++ b/app-admin/reiserfsprogs/spec
@@ -1,5 +1,5 @@
 VER=3.6.27
-REL=2
+REL=3
 SRCS="tbl::https://www.kernel.org/pub/linux/kernel/people/jeffm/reiserfsprogs/v$VER/reiserfsprogs-$VER.tar.xz"
 CHKSUMS="sha256::0e95b67fa7746a3c2d59145e9b9c2feb4a6be52853e83b497b182eae508e62e3"
 CHKUPDATE="anitya::id=226801"

--- a/app-admin/sg3-utils/spec
+++ b/app-admin/sg3-utils/spec
@@ -2,3 +2,4 @@ VER=1.47r915
 SRCS="tbl::http://sg.danny.cz/sg/p/sg3_utils-$VER.tar.xz"
 CHKSUMS="sha256::45c9d754ebfdd85524b7465af3be10f8d74c3b02de3c36747ad9dd631c368e4a"
 CHKUPDATE="anitya::id=4801"
+REL=1

--- a/app-database/lmdb/spec
+++ b/app-database/lmdb/spec
@@ -1,5 +1,5 @@
 VER=0.9.33
-REL=1
+REL=2
 SRCS="git::commit=tags/LMDB_$VER::https://git.openldap.org/openldap/openldap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6974"

--- a/app-devel/babeltrace/spec
+++ b/app-devel/babeltrace/spec
@@ -2,3 +2,4 @@ VER=1.5.11
 SRCS="tbl::https://github.com/efficios/babeltrace/archive/v$VER.tar.gz"
 CHKSUMS="sha256::54ab865d009e673ee62c71badef51d9933c8d83a84c19763fa263ba4cadebb53"
 CHKUPDATE="anitya::id=155"
+REL=1

--- a/app-devel/cmocka/spec
+++ b/app-devel/cmocka/spec
@@ -2,3 +2,4 @@ VER=1.1.7
 SRCS="tbl::https://cmocka.org/files/${VER:0:3}/cmocka-$VER.tar.xz"
 CHKSUMS="sha256::810570eb0b8d64804331f82b29ff47c790ce9cd6b163e98d47a4807047ecad82"
 CHKUPDATE="anitya::id=11779"
+REL=1

--- a/app-i18n/ibus/01-libibus/patches/0001-AOSCOS-use-python3-as-the-interpreter-for-gensimple..patch
+++ b/app-i18n/ibus/01-libibus/patches/0001-AOSCOS-use-python3-as-the-interpreter-for-gensimple..patch
@@ -1,0 +1,22 @@
+From 355980856e384254982bbe75421eeb39ed6c3c78 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.xyz>
+Date: Tue, 28 Sep 2021 10:16:07 -0700
+Subject: [PATCH 1/3] AOSCOS: use python3 as the interpreter for gensimple.py
+
+---
+ engine/gensimple.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/engine/gensimple.py b/engine/gensimple.py
+index de6d7ff5..bad3e3e5 100755
+--- a/engine/gensimple.py
++++ b/engine/gensimple.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ # vim:set fileencoding=utf-8 et sts=4 sw=4:
+ #
+ # ibus - Intelligent Input Bus for Linux / Unix OS
+-- 
+2.52.0
+

--- a/app-i18n/ibus/01-libibus/patches/0001-Use-python3-as-interpreter-for-gensimple.py.patch
+++ b/app-i18n/ibus/01-libibus/patches/0001-Use-python3-as-interpreter-for-gensimple.py.patch
@@ -1,8 +1,0 @@
---- ibus-1.5.25/engine/gensimple.py	2021-08-19 17:44:49.000000000 -0700
-+++ ibus-1.5.25.python3/engine/gensimple.py	2021-09-21 00:39:03.560099096 -0700
-@@ -1,4 +1,4 @@
--#!/usr/bin/python
-+#!/usr/bin/python3
- # vim:set fileencoding=utf-8 et sts=4 sw=4:
- #
- # ibus - Intelligent Input Bus for Linux / Unix OS

--- a/app-i18n/ibus/01-libibus/patches/0002-UPSTREAM-src-Fix-declaration-errors-with-GCC-15.patch
+++ b/app-i18n/ibus/01-libibus/patches/0002-UPSTREAM-src-Fix-declaration-errors-with-GCC-15.patch
@@ -1,0 +1,35 @@
+From 9b80e795069a2531891ffd13cc6cd1746103a68a Mon Sep 17 00:00:00 2001
+From: fujiwarat <takao.fujiwara1@gmail.com>
+Date: Fri, 24 Jan 2025 09:40:31 +0900
+Subject: [PATCH 2/3] UPSTREAM: src: Fix declaration errors with GCC 15
+
+BUG=rhbz#2340629
+---
+ src/ibusenginesimple.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ibusenginesimple.c b/src/ibusenginesimple.c
+index 83b04ebc..ebaa3150 100644
+--- a/src/ibusenginesimple.c
++++ b/src/ibusenginesimple.c
+@@ -477,7 +477,7 @@ check_hex (IBusEngineSimple *simple,
+ }
+ 
+ static IBusEngineDict *
+-load_emoji_dict ()
++load_emoji_dict (void)
+ {
+     IBusEngineDict *emoji_dict;
+     GList *keys;
+@@ -520,7 +520,7 @@ check_emoji_table (IBusEngineSimple       *simple,
+         g_object_ref_sink (priv->lookup_table);
+     }
+     if (emoji_dict == NULL)
+-        emoji_dict = priv->emoji_dict = load_emoji_dict (simple);
++        emoji_dict = priv->emoji_dict = load_emoji_dict ();
+ 
+     if (emoji_dict == NULL || emoji_dict->dict == NULL)
+         return FALSE;
+-- 
+2.52.0
+

--- a/app-i18n/ibus/01-libibus/patches/0003-UPSTREAM-util-IMdkit-Fix-incompatible-pointer-types-.patch
+++ b/app-i18n/ibus/01-libibus/patches/0003-UPSTREAM-util-IMdkit-Fix-incompatible-pointer-types-.patch
@@ -1,0 +1,108 @@
+From d90d80b9c0a863ff20092bc5f3fa0b80df17fcab Mon Sep 17 00:00:00 2001
+From: fujiwarat <takao.fujiwara1@gmail.com>
+Date: Fri, 24 Jan 2025 10:01:11 +0900
+Subject: [PATCH 3/3] UPSTREAM: util/IMdkit: Fix incompatible-pointer-types in
+ TransportSW.checkAddr
+
+BUG=rhbz#2340629
+---
+ util/IMdkit/Xi18n.h           | 18 ++++++++++--------
+ util/IMdkit/i18nMethod.c      |  3 ++-
+ util/IMdkit/i18nOffsetCache.c | 10 ++++++----
+ 3 files changed, 18 insertions(+), 13 deletions(-)
+
+diff --git a/util/IMdkit/Xi18n.h b/util/IMdkit/Xi18n.h
+index 79dd9619..09097bb6 100644
+--- a/util/IMdkit/Xi18n.h
++++ b/util/IMdkit/Xi18n.h
+@@ -3,7 +3,7 @@
+          Copyright (C) 1994-1995 Sun Microsystems, Inc.
+          Copyright (C) 1993-1994 Hewlett-Packard Company
+          Copyright (C) 2014 Peng Huang <shawn.p.huang@gmail.com>
+-         Copyright (C) 2014 Red Hat, Inc.
++         Copyright (C) 2014-2025 Red Hat, Inc.
+  
+ Permission to use, copy, modify, distribute, and sell this software
+ and its documentation for any purpose is hereby granted without fee,
+@@ -71,13 +71,6 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ #define I18N_SET	1
+ #define I18N_GET	2
+ 
+-typedef struct
+-{
+-    char        *transportname;
+-    int         namelen;
+-    Bool        (*checkAddr) ();
+-} TransportSW;
+-
+ typedef struct _XIMPending
+ {
+     unsigned    char *p;
+@@ -172,6 +165,15 @@ typedef struct _Xi18nClient
+ 
+ typedef struct _Xi18nCore *Xi18n;
+ 
++typedef struct _TransportSW TransportSW;
++
++struct _TransportSW
++{
++    char        *transportname;
++    int         namelen;
++    Bool        (*checkAddr) (Xi18n, TransportSW *, char *);
++};
++
+ /*
+  * Callback Struct for XIM Protocol
+  */
+diff --git a/util/IMdkit/i18nMethod.c b/util/IMdkit/i18nMethod.c
+index 9c44e7fe..7f343d87 100644
+--- a/util/IMdkit/i18nMethod.c
++++ b/util/IMdkit/i18nMethod.c
+@@ -2,6 +2,7 @@
+  
+          Copyright 1994, 1995 by Sun Microsystems, Inc.
+          Copyright 1993, 1994 by Hewlett-Packard Company
++         Copyright (C) 2014-2025 Red Hat, Inc.
+  
+ Permission to use, copy, modify, distribute, and sell this software
+ and its documentation for any purpose is hereby granted without fee,
+@@ -89,7 +90,7 @@ TransportSW _TransR[] =
+ #ifdef DNETCONN
+     {"decnet",          6, _Xi18nCheckTransAddress},
+ #endif
+-    {(char *) NULL,     0, (Bool (*) ()) NULL}
++    {(char *) NULL,     0, (Bool (*) (Xi18n, TransportSW *, char *))NULL}
+ };
+ 
+ static Bool GetInputStyles (Xi18n i18n_core, XIMStyles **p_style)
+diff --git a/util/IMdkit/i18nOffsetCache.c b/util/IMdkit/i18nOffsetCache.c
+index e2fe8c6b..cab974c7 100644
+--- a/util/IMdkit/i18nOffsetCache.c
++++ b/util/IMdkit/i18nOffsetCache.c
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (C) 2014 Peng Huang <shawn.p.huang@gmail.com>
+- * Copyright (C) 2014 Red Hat, Inc.
++ * Copyright (C) 2014-2025 Red Hat, Inc.
+  *
+  * Permission to use, copy, modify, distribute, and sell this
+  * software and its documentation for any purpose is hereby granted
+@@ -83,10 +83,12 @@ void _Xi18nSetPropertyOffset (Xi18nOffsetCache *offset_cache, Atom key,
+     }
+ 
+     if (++offset_cache->size > offset_cache->capacity) {
+-        offset_cache->capacity *= OFFSET_CACHE_GROWTH_FACTOR;
+-        offset_cache->data = (Xi18nAtomOffsetPair *) realloc (data,
++        Xi18nAtomOffsetPair *pair = (Xi18nAtomOffsetPair *) realloc (data,
+                 offset_cache->capacity * sizeof (Xi18nAtomOffsetPair));
+-        if (offset_cache->data == NULL) {
++        offset_cache->capacity *= OFFSET_CACHE_GROWTH_FACTOR;
++        if (pair) {
++            offset_cache->data = pair;
++        } else {
+             offset_cache->data = data;
+             --offset_cache->size;
+         }
+-- 
+2.52.0
+

--- a/app-i18n/ibus/spec
+++ b/app-i18n/ibus/spec
@@ -1,5 +1,5 @@
 VER=1.5.25
-REL=1
+REL=2
 SRCS="tbl::https://github.com/ibus/ibus/archive/$VER.tar.gz"
 CHKSUMS="sha256::cb6fbb166e19ccd5a179ec3c0bda4fcfe8676980271993e0c3fce2e0a9d64c16"
 CHKUPDATE="anitya::id=1352"

--- a/app-network/lksctp-tools/spec
+++ b/app-network/lksctp-tools/spec
@@ -1,5 +1,5 @@
 VER=1.0.17
-REL=1
+REL=2
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/lksctp/lksctp-tools-$VER.tar.gz"
 CHKSUMS="sha256::1aeb204cdb2befc94d9eb3037d1609c9d1d2cd5379d6dd2c0a8ca9b10533aa15"
 CHKUPDATE="anitya::id=21497"

--- a/app-network/rtmpdump/spec
+++ b/app-network/rtmpdump/spec
@@ -1,5 +1,5 @@
 VER=20151223
-REL=5
+REL=6
 SRCS="git::commit=fa8646daeb19dfd12c181f7d19de708d623704c0::https://git.ffmpeg.org/rtmpdump.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141551"

--- a/app-network/wireless-tools/spec
+++ b/app-network/wireless-tools/spec
@@ -1,5 +1,5 @@
 VER=30.pre9
-REL=3
+REL=4
 SRCS="tbl::https://deb.debian.org/debian/pool/main/w/wireless-tools/wireless-tools_30~pre9.orig.tar.gz"
 CHKSUMS="sha256::abd9c5c98abf1fdd11892ac2f8a56737544fe101e1be27c6241a564948f34c63"
 CHKUPDATE="anitya::id=5136"

--- a/app-scientific/fribidi/spec
+++ b/app-scientific/fribidi/spec
@@ -2,3 +2,4 @@ VER=1.0.14
 SRCS="tbl::https://github.com/fribidi/fribidi/releases/download/v$VER/fribidi-$VER.tar.xz"
 CHKSUMS="sha256::76ae204a7027652ac3981b9fa5817c083ba23114340284c58e756b259cd2259a"
 CHKUPDATE="anitya::id=857"
+REL=1

--- a/app-scientific/lapack/spec
+++ b/app-scientific/lapack/spec
@@ -2,3 +2,4 @@ VER=3.12.0
 SRCS="git::commit=tags/v$VER::https://github.com/Reference-LAPACK/lapack"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1534"
+REL=1

--- a/app-utils/gpm/autobuild/patches/0001-FROMLIST-LFS-Fix-several-build-failures.patch
+++ b/app-utils/gpm/autobuild/patches/0001-FROMLIST-LFS-Fix-several-build-failures.patch
@@ -1,16 +1,25 @@
-Submitted by: Pierre Labastie <pierre dot labastie at neuf dot fr>
-Date: 2020-05-10
-Initial Package Version: 1.20.7
-Origin: Upstream + PR's
-Upstream Status: some fixes committed, others pending
-Description: Fix several build failures
-             - some introduced by glibc-2.26
-             - some introduced by gcc-10
-             - also fix an ignored error when gpm.h is not already in
-               /usr/include
-diff -Naur gpm-1.20.7.old/src/daemon/open_console.c gpm-1.20.7.new/src/daemon/open_console.c
---- gpm-1.20.7.old/src/daemon/open_console.c	2012-10-26 23:21:38.000000000 +0200
-+++ gpm-1.20.7.new/src/daemon/open_console.c	2020-05-10 15:48:59.752067421 +0200
+From b3b01081a7c6fda663d3fc4d8dbc4665df37dccc Mon Sep 17 00:00:00 2001
+From: Pierre Labastie <pierre.labastie@neuf.fr>
+Date: Sun, 10 May 2020 15:48:59 +0200
+Subject: [PATCH 1/2] FROMLIST LFS: Fix several build failures
+
+- some introduced by glibc-2.26
+- some introduced by gcc-10
+- also fix an ignored error when gpm.h is not already in
+  /usr/include
+---
+ src/daemon/open_console.c  |  4 ++++
+ src/headers/daemon.h       |  2 +-
+ src/prog/display-buttons.c |  2 +-
+ src/prog/display-coords.c  |  2 +-
+ src/prog/get-versions.c    |  2 +-
+ src/prog/gpm-root.y        | 12 ++++--------
+ 6 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/src/daemon/open_console.c b/src/daemon/open_console.c
+index 98297c9..0948501 100644
+--- a/src/daemon/open_console.c
++++ b/src/daemon/open_console.c
 @@ -23,6 +23,10 @@
  #include <sys/stat.h>               /* stat()            */
  #include <sys/ioctl.h>              /* ioctl             */
@@ -22,10 +31,11 @@ diff -Naur gpm-1.20.7.old/src/daemon/open_console.c gpm-1.20.7.new/src/daemon/op
  /* Linux specific (to be outsourced in gpm2 */
  #include <linux/serial.h>           /* for serial console check */
  #include <asm/ioctls.h>            /* for serial console check */
-diff -Naur gpm-1.20.7.old/src/headers/daemon.h gpm-1.20.7.new/src/headers/daemon.h
---- gpm-1.20.7.old/src/headers/daemon.h	2012-10-26 23:21:38.000000000 +0200
-+++ gpm-1.20.7.new/src/headers/daemon.h	2020-05-10 15:48:52.719159555 +0200
-@@ -180,7 +180,7 @@
+diff --git a/src/headers/daemon.h b/src/headers/daemon.h
+index a8936ad..949eb84 100644
+--- a/src/headers/daemon.h
++++ b/src/headers/daemon.h
+@@ -180,7 +180,7 @@ extern struct mouse_features  mouse_table[3],
  extern Gpm_Type         mice[];
  extern Gpm_Type         *repeated_type;
  
@@ -34,9 +44,10 @@ diff -Naur gpm-1.20.7.old/src/headers/daemon.h gpm-1.20.7.new/src/headers/daemon
  
  
  
-diff -Naur gpm-1.20.7.old/src/prog/display-buttons.c gpm-1.20.7.new/src/prog/display-buttons.c
---- gpm-1.20.7.old/src/prog/display-buttons.c	2012-10-26 23:21:38.000000000 +0200
-+++ gpm-1.20.7.new/src/prog/display-buttons.c	2020-05-10 15:48:59.751067434 +0200
+diff --git a/src/prog/display-buttons.c b/src/prog/display-buttons.c
+index de8e5b2..155c6c2 100644
+--- a/src/prog/display-buttons.c
++++ b/src/prog/display-buttons.c
 @@ -36,7 +36,7 @@
  #include <stdio.h>            /* printf()             */
  #include <time.h>             /* time()               */
@@ -46,9 +57,10 @@ diff -Naur gpm-1.20.7.old/src/prog/display-buttons.c gpm-1.20.7.new/src/prog/dis
  
  /* display resulting data */
  int display_data(Gpm_Event *event, void *data)
-diff -Naur gpm-1.20.7.old/src/prog/display-coords.c gpm-1.20.7.new/src/prog/display-coords.c
---- gpm-1.20.7.old/src/prog/display-coords.c	2012-10-26 23:21:38.000000000 +0200
-+++ gpm-1.20.7.new/src/prog/display-coords.c	2020-05-10 15:48:59.751067434 +0200
+diff --git a/src/prog/display-coords.c b/src/prog/display-coords.c
+index ed15c8a..8d552ba 100644
+--- a/src/prog/display-coords.c
++++ b/src/prog/display-coords.c
 @@ -37,7 +37,7 @@
  #include <stdio.h>            /* printf()             */
  #include <time.h>             /* time()               */
@@ -58,9 +70,10 @@ diff -Naur gpm-1.20.7.old/src/prog/display-coords.c gpm-1.20.7.new/src/prog/disp
  
  /* display resulting data */
  int display_data(Gpm_Event *event, void *data)
-diff -Naur gpm-1.20.7.old/src/prog/get-versions.c gpm-1.20.7.new/src/prog/get-versions.c
---- gpm-1.20.7.old/src/prog/get-versions.c	2012-10-26 23:21:38.000000000 +0200
-+++ gpm-1.20.7.new/src/prog/get-versions.c	2020-05-10 15:48:59.751067434 +0200
+diff --git a/src/prog/get-versions.c b/src/prog/get-versions.c
+index 00f1753..8abd38d 100644
+--- a/src/prog/get-versions.c
++++ b/src/prog/get-versions.c
 @@ -22,7 +22,7 @@
   ********/
  
@@ -70,10 +83,11 @@ diff -Naur gpm-1.20.7.old/src/prog/get-versions.c gpm-1.20.7.new/src/prog/get-ve
  
  int main()
  {
-diff -Naur gpm-1.20.7.old/src/prog/gpm-root.y gpm-1.20.7.new/src/prog/gpm-root.y
---- gpm-1.20.7.old/src/prog/gpm-root.y	2012-10-26 23:21:38.000000000 +0200
-+++ gpm-1.20.7.new/src/prog/gpm-root.y	2020-05-10 15:48:59.752067421 +0200
-@@ -443,6 +443,7 @@
+diff --git a/src/prog/gpm-root.y b/src/prog/gpm-root.y
+index 069d801..6b3a5a6 100644
+--- a/src/prog/gpm-root.y
++++ b/src/prog/gpm-root.y
+@@ -443,6 +443,7 @@ void f__fix(struct passwd *pass)
  }
  
  /*---------------------------------------------------------------------*/
@@ -81,7 +95,7 @@ diff -Naur gpm-1.20.7.old/src/prog/gpm-root.y gpm-1.20.7.new/src/prog/gpm-root.y
  static int f_debug_one(FILE *f, Draw *draw)
  {
     DrawItem *ip;
-@@ -465,6 +466,7 @@
+@@ -465,6 +466,7 @@ static int f_debug_one(FILE *f, Draw *draw)
  #undef LINE
     return 0;
  }
@@ -89,7 +103,7 @@ diff -Naur gpm-1.20.7.old/src/prog/gpm-root.y gpm-1.20.7.new/src/prog/gpm-root.y
  
  int f_debug(int mode, DrawItem *self, int uid)
  {
-@@ -960,10 +962,8 @@
+@@ -960,10 +962,8 @@ static inline void scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
  /*------------*/
  static inline void scr_restore(int fd, FILE *f, unsigned char *buffer, int vc)
  {
@@ -101,7 +115,7 @@ diff -Naur gpm-1.20.7.old/src/prog/gpm-root.y gpm-1.20.7.new/src/prog/gpm-root.y
     
     /* WILL NOT WORK WITH DEVFS! FIXME! */
     sprintf(dumpname,"/dev/vcsa%i",vc);
-@@ -1196,11 +1196,7 @@
+@@ -1196,11 +1196,7 @@ int main(int argc, char **argv)
                                                          LOG_DAEMON : LOG_USER);
     /* reap your zombies */
     childaction.sa_handler=reap_children;
@@ -114,3 +128,6 @@ diff -Naur gpm-1.20.7.old/src/prog/gpm-root.y gpm-1.20.7.new/src/prog/gpm-root.y
     childaction.sa_flags=SA_INTERRUPT; /* need to break the select() call */
     sigaction(SIGCHLD,&childaction,NULL);
  
+-- 
+2.52.0
+

--- a/app-utils/gpm/autobuild/patches/0002-FROMLIST-fix-build-on-gcc-15.patch
+++ b/app-utils/gpm/autobuild/patches/0002-FROMLIST-fix-build-on-gcc-15.patch
@@ -1,0 +1,325 @@
+From 1802997c3c831a83c0cf65939487b7552525e1ee Mon Sep 17 00:00:00 2001
+From: NHOrus <jy6x2b32pie9@yahoo.com>
+Date: Tue, 11 Feb 2025 18:42:47 +0400
+Subject: [PATCH 2/2] FROMLIST: fix build on gcc-15
+
+Avoid shadowing ncurses functions. This fails with GCC-15 and other compilers implementing C23 Added prefix gpm_ to raw() and noraw() used in two files because they are implemented in same two files, and are static. Same with scr_dump() and src_restore() in yacc source file
+
+Fix function definition in yacc source file until valid C23. Fill empty argument lists with values. Add 0 as third argument for two-argument function, it will be ignored at call site.
+
+Add incomplete type definition for WINDOW in Gpm_Wgetch()
+
+Window handle is an opaque pointer that Gpm_Wgetch() passes
+through straight to ncurses if it's not null and calls getch
+if it's null. Code doesn't care what's inside the handle
+as long as it agrees with curses definition.
+---
+ src/headers/gpm.h     |  9 ++++++++-
+ src/prog/gpm-root.y   | 24 ++++++++++++------------
+ src/prog/hltest.c     | 11 +++++------
+ src/prog/mouse-test.c | 24 ++++++++++++------------
+ 4 files changed, 37 insertions(+), 31 deletions(-)
+
+diff --git a/src/headers/gpm.h b/src/headers/gpm.h
+index 57dc618..6c53fbf 100644
+--- a/src/headers/gpm.h
++++ b/src/headers/gpm.h
+@@ -268,7 +268,14 @@ Gpm_Roi * Gpm_LowerRoi(Gpm_Roi *which, Gpm_Roi *after);
+ /* libcurses.c */
+ /* #include <curses.h>  Hmm... seems risky */
+ 
+-extern int Gpm_Wgetch();
++/* Window handle is an opaque pointer that Gpm_Wgetch()
++ * passes through to ncurses if it's not null and calls getch
++ * if it's null. Code doesn't care what's inside the handle
++ * as long as it agrees with curses definition.
++*/
++typedef struct _win_st WINDOW;
++
++extern int Gpm_Wgetch(WINDOW *);
+ #define Gpm_Getch() (Gpm_Wgetch(NULL))
+ 
+ /* libxtra.c */
+diff --git a/src/prog/gpm-root.y b/src/prog/gpm-root.y
+index 6b3a5a6..0380184 100644
+--- a/src/prog/gpm-root.y
++++ b/src/prog/gpm-root.y
+@@ -128,7 +128,7 @@ typedef struct DrawItem {
+    char *name;
+    char *arg;   /* a cmd string */
+    void *clientdata;  /* a (Draw *) for menus or whatever   */
+-   int (*fun)();
++   int (*fun)(int, struct DrawItem *, int);
+    struct DrawItem *next;
+ } DrawItem;
+ 
+@@ -159,7 +159,7 @@ int yyerror(char *s);
+ int yylex(void);
+ 
+ DrawItem *cfg_cat(DrawItem *, DrawItem *);
+-DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(), void *detail);
++DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(int,  DrawItem *, int), void *detail);
+ 
+ 
+ /*===================================================================*
+@@ -195,7 +195,7 @@ int f_pipe(int mode, DrawItem *self, int uid);
+       char *string;
+       Draw *draw;
+       DrawItem *item;
+-      int (*fun)();
++      int (*fun)(int,  DrawItem *, int);
+       }
+ 
+ %token <string> T_STRING
+@@ -284,7 +284,7 @@ struct tokenName tokenList[] = {
+ struct funcName {
+    char *name;
+    int token;
+-   int (*fun)();
++   int (*fun)(int,  DrawItem *, int);
+    };
+ struct funcName funcList[] = {
+    {"f.debug",T_FUNC,f_debug},
+@@ -390,7 +390,7 @@ Draw *cfg_alloc(void)
+ 
+ /*---------------------------------------------------------------------*/
+ /* malloc an empty DrawItem and fill it */
+-DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(), void *detail)
++DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(int,  DrawItem *, int), void *detail)
+ {
+    DrawItem *new=calloc(1,sizeof(DrawItem));
+ 
+@@ -405,7 +405,7 @@ DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(), void *detail)
+ 
+       case 'F': /* a function without args */
+          new->fun=fun;
+-         if (fun) fun(F_CREATE,new);
++         if (fun) fun(F_CREATE,new,0);
+          break;
+ 
+       case 'M':
+@@ -941,7 +941,7 @@ static unsigned short clear_sel_args[6]={0, 0,0, 0,0, 4};
+ static unsigned char *clear_sel_arg= (unsigned char *)clear_sel_args+1;
+ 
+ /*------------*/
+-static inline void scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
++static inline void gpm_scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
+ {
+    int dumpfd;
+    char dumpname[20];
+@@ -960,7 +960,7 @@ static inline void scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
+ }
+ 
+ /*------------*/
+-static inline void scr_restore(int fd, FILE *f, unsigned char *buffer, int vc)
++static inline void gpm_scr_restore(int fd, FILE *f, unsigned char *buffer, int vc)
+ {
+    int dumpfd;
+    char dumpname[20];
+@@ -1002,7 +1002,7 @@ Posted *postmenu(int fd, FILE *f, Draw *draw, int x, int y, int console)
+    if (!new) return NULL;
+    new->draw=draw;
+    new->dump=dump=malloc(opt_buf);
+-   scr_dump(fd,f,dump,console);
++   gpm_scr_dump(fd,f,dump,console);
+    lines=dump[0]; columns=dump[1];
+    i=(columns*dump[3]+dump[2])*2+1; /* where to get it */
+    if (i<0) i=1;
+@@ -1047,7 +1047,7 @@ Posted *postmenu(int fd, FILE *f, Draw *draw, int x, int y, int console)
+    }
+    /* sides and items */
+    for (item=draw->menu; y++, item; item=item->next) {
+-         if (item->fun) (*(item->fun))(F_POST,item);
++         if (item->fun) (*(item->fun))(F_POST,item,0);
+          GOTO(x,y); PUTC(VERLINE,draw->bord,draw->back);
+          for (i=0;i<item->pad;i++) PUTC(' ',draw->fore,draw->back);
+          PUTS(item->name,draw->fore,draw->back); i+=strlen(item->name);
+@@ -1060,7 +1060,7 @@ Posted *postmenu(int fd, FILE *f, Draw *draw, int x, int y, int console)
+    for (i=0; i<draw->width; i++) PUTC(HORLINE,draw->bord,draw->back);
+    PUTC(LRCORNER,draw->bord,draw->back);
+ 
+-   scr_restore(fd,f,dump,console);
++   gpm_scr_restore(fd,f,dump,console);
+    free(dump);
+ 
+ #undef PUTC
+@@ -1077,7 +1077,7 @@ Posted *unpostmenu(int fd, FILE *f, Posted *which, int vc)
+ {
+    Posted *prev=which->prev;
+ 
+-   scr_restore(fd,f,which->dump, vc);
++   gpm_scr_restore(fd,f,which->dump, vc);
+    ioctl(fd,TCXONC,TCOON); /* activate the console */  
+    free(which->dump);
+    free(which);
+diff --git a/src/prog/hltest.c b/src/prog/hltest.c
+index cce0abc..a916873 100644
+--- a/src/prog/hltest.c
++++ b/src/prog/hltest.c
+@@ -80,7 +80,6 @@ int wid,hei,vcsize;
+ unsigned short clear_sel_args[6]={0, 0,0, 0,0, 4};
+ unsigned char *clear_sel_arg= (unsigned char *)clear_sel_args+1;
+ 
+-
+ static inline int scrdump(char *buf)
+ {
+    clear_sel_arg[0]=2;  /* clear_selection */
+@@ -99,7 +98,7 @@ static inline int scrrestore(char *buf)
+ 
+ 
+ /* I don't like curses, so I'm doing low level stuff here */
+-static void raw(void)
++static void gpm_raw(void)
+ {
+ struct termios it;
+ 
+@@ -115,7 +114,7 @@ tcsetattr(fileno(stdin),TCSANOW,&it);
+ 
+ }
+ 
+-static void noraw(void)
++static void gpm_noraw(void)
+ {
+ struct termios it;
+ 
+@@ -136,7 +135,7 @@ void killed(int signo)
+ {
+    CLEAR;
+    fprintf(stderr,"hltest: killed by signal %i\r\n",signo);
+-   noraw();
++   gpm_noraw();
+    exit(0);
+ }
+ 
+@@ -525,7 +524,7 @@ int main(int argc, char **argv)
+    gpm_roi_handler=xhandler;
+    gpm_roi_data=NULL;
+ 
+-   raw();
++   gpm_raw();
+    newmsg(0,NULL); /* init data structures */
+    while((c=Gpm_Getchar())!=EOF) {
+       char s[32];
+@@ -538,6 +537,6 @@ int main(int argc, char **argv)
+    newmsg(roi ? ((WinInfo *)roi->clientdata)->number : 0,s);
+    }
+ 
+-   noraw();
++   gpm_noraw();
+    exit(0);
+ }
+diff --git a/src/prog/mouse-test.c b/src/prog/mouse-test.c
+index 0bb1982..7235bba 100644
+--- a/src/prog/mouse-test.c
++++ b/src/prog/mouse-test.c
+@@ -106,7 +106,7 @@ return 0;
+ /*----------------------------------------------------------------------------- 
+    Place the description here.
+  -----------------------------------------------------------------------------*/
+-static void raw(void)
++static void gpm_raw(void)
+ {
+    struct termios it;
+ 
+@@ -125,7 +125,7 @@ static void raw(void)
+ /*----------------------------------------------------------------------------- 
+    Place the description here.
+  -----------------------------------------------------------------------------*/
+-static void noraw(void)
++static void gpm_noraw(void)
+ {
+    struct termios it;
+ 
+@@ -144,7 +144,7 @@ static void noraw(void)
+ void killed(int signo)
+ {
+    fprintf(stderr,"mouse-test: killed by signal %i\r\n",signo);
+-   noraw();
++   gpm_noraw();
+    exit(0);
+ }
+ 
+@@ -196,7 +196,7 @@ int mousereopen(int oldfd, char *name, Gpm_Type *type)
+ 
+ int noneofthem(void)
+ {
+-   noraw();
++   gpm_noraw();
+    printf("\n\nSomething went wrong, I didn't manage to detect your"
+ 	 "protocol\n\nFeel free to report your problems to the author\n");
+    exit(1);
+@@ -336,7 +336,7 @@ int main(int argc, char **argv)
+    I_serial=mice->init; /* the first one has I_serial */
+ 
+    signal(SIGINT,killed);   /* control-C kills us */
+-   raw();
++   gpm_raw();
+ 
+ /*====================================== First of all, detect the device */
+ 
+@@ -568,7 +568,7 @@ int main(int argc, char **argv)
+    /* why checking and not using return value ??? */
+    CHECKFAIL(typecount);
+    if (typecount==1) {
+-      noraw();
++      gpm_noraw();
+       printf("\n\n\nWell, it seems like your mouse is already detected:\n"
+       "it is on the device \"%s\", and speaks the protocol \"%s\"\n",
+       mousename,list->this->name);
+@@ -587,7 +587,7 @@ int main(int argc, char **argv)
+    } while(i!='y' && i!='n');
+ 
+    if (i=='n') {
+-      noraw();
++      gpm_noraw();
+       printf("\nThen, you should use the \"bare\" protocol on \"%s\"\n",
+ 	   mousename);
+       exit(0);
+@@ -634,7 +634,7 @@ int main(int argc, char **argv)
+    for (pending=0,i=0;i<got-16;i++)
+       if(!memcmp(buf+i,buf+i+8,8)) pending++;
+    if (pending > 3) {
+-      noraw();
++      gpm_noraw();
+       printf("\nYour mouse seems to be a 'mman' one  on \"%s\" (%i matches)\n",
+ 	   mousename,pending);
+       exit(0);
+@@ -660,7 +660,7 @@ int main(int argc, char **argv)
+          continue;
+       }
+ 	   if (pending>3) {
+-	      noraw();
++	      gpm_noraw();
+ 	      printf("\nYour mouse seems to be a '%s' one on \"%s\" (%i matches)\n",
+ 		   cur->this->name,mousename,pending);
+ 	      exit(0);
+@@ -695,7 +695,7 @@ int main(int argc, char **argv)
+          for (pending=0,i=0;i<got-20;i++)
+             if(!memcmp(buf+i,buf+i+10,10)) pending++;
+          if (pending>3) {
+-            noraw();
++            gpm_noraw();
+             printf("\nYour mouse becomes a 3-buttons ('-t msc') one when\n"
+ 	         "gpm gets '-o %s' on it command line, and X gets\n"
+ 	         "%s in XF86Config\nThe device is \"%s\"",
+@@ -726,7 +726,7 @@ int main(int argc, char **argv)
+    for (pending=0,i=0;i<got-20;i++)
+       if(!memcmp(buf+i,buf+i+10,10)) pending++;
+    if (pending>3) {
+-      noraw();
++      gpm_noraw();
+       printf("\nWorked. You should keep the button pressed every time the\n"
+ 	   "computer boots, and run gpm in '-R' mode in order to ignore\n"
+ 	   "such hassle when starting X\n\nStill better, but a better mouse\n"
+@@ -734,7 +734,7 @@ int main(int argc, char **argv)
+ 
+       exit(0);
+    }
+-   noraw();
++   gpm_noraw();
+    printf("\nI'm lost. Can't tell you how to use your middle button\n");
+    return 0;
+ }
+-- 
+2.52.0
+

--- a/app-utils/gpm/spec
+++ b/app-utils/gpm/spec
@@ -1,5 +1,5 @@
 VER=1.20.7
-REL=9
+REL=10
 SRCS="tbl::https://www.nico.schottelius.org/software/gpm/archives/gpm-$VER.tar.bz2"
 CHKSUMS="sha256::f011b7dc7afb824e0a017b89b7300514e772853ece7fc4ee640310889411a48d"
 CHKUPDATE="anitya::id=1242"

--- a/app-utils/lsof/autobuild/defines
+++ b/app-utils/lsof/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=lsof
 PKGSEC=utils
 PKGDEP="libtirpc"
-PKGDES="A utility that lists files opened by processes"
+PKGDES="Utility that lists files opened by processes"
 
 ABTYPE=autotools

--- a/app-utils/lsof/spec
+++ b/app-utils/lsof/spec
@@ -2,3 +2,4 @@ VER=4.99.3
 SRCS="git::commit=tags/$VER::https://github.com/lsof-org/lsof"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1844"
+REL=1

--- a/app-utils/lsof/spec
+++ b/app-utils/lsof/spec
@@ -1,5 +1,4 @@
-VER=4.99.3
+VER=4.99.5
 SRCS="git::commit=tags/$VER::https://github.com/lsof-org/lsof"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1844"
-REL=1

--- a/app-utils/lz4/spec
+++ b/app-utils/lz4/spec
@@ -3,3 +3,4 @@ SRCS="git::commit=tags/v$VER::https://github.com/lz4/lz4"
 CHKSUMS="SKIP"
 SUBDIR="lz4/build/meson"
 CHKUPDATE="anitya::id=1865"
+REL=1

--- a/app-utils/lzo/spec
+++ b/app-utils/lzo/spec
@@ -1,5 +1,5 @@
 VER=2.10
-REL=3
+REL=4
 SRCS="tbl::https://www.oberhumer.com/opensource/lzo/download/lzo-$VER.tar.gz"
 CHKSUMS="sha256::c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"
 CHKUPDATE="anitya::id=1868"

--- a/app-utils/nfs-utils/autobuild/defines
+++ b/app-utils/nfs-utils/autobuild/defines
@@ -14,52 +14,46 @@ BUILDDEP="rpcsvc-proto"
 PKGDES="Support programs for Network File Systems"
 BUILDDEP="rpcsvc-proto"
 
-# Note:
-# --enable-gums, Enable support for the GUMS mapping library [default=false].
-AUTOTOOLS_AFTER="--enable-nfsv4 \
-                 --enable-nfsv41 \
-                 --enable-gss \
-                 --enable-svcgss \
-                 --disable-kprefix \
-                 --enable-uuid \
-                 --enable-mount \
-                 --enable-libmount-mount \
-                 --disable-sbin-override \
-                 --enable-junction \
-                 --enable-ipv6 \
-                 --enable-mountconfig \
-                 --enable-nfsdcld \
-                 --enable-nfsdcltrack \
-                 --enable-caps \
-                 --enable-largefile \
-                 --enable-ldap \
-                 --disable-gums \
-                 --with-statedir=/var/lib/nfs \
-                 --with-nfsconfig=/etc/nfs.conf \
-                 --with-statdpath=/var/lib/nfs \
-                 --with-statduser=nobody \
-                 --with-start-statd=/usr/bin/start-statd \
-                 --with-systemd=/usr/lib/systemd/system \
-                 --with-modprobedir=/usr/lib/modprobe.d \
-                 --with-mountfile=/etc/nfsmounts.conf \
-                 --with-tcp-wrappers=no \
-                 --with-krb5=/usr \
-                 --without-gssglue \
-                 --with-pluginpath=/usr/lib/libnfsidmap"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-gss \
-                 --disable-ldap \
-                 --disable-svcgss"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+# FIXME: mount_xdr.c:6:10: fatal error: [...]/support/export/mount.h: No such file or directory
 ABSHADOW=0
+# Note: --enable-gums, Enable support for the GUMS mapping library [default=false].
+AUTOTOOLS_AFTER=(
+    '--enable-nfsv4'
+    '--enable-nfsv41'
+    '--enable-gss'
+    '--enable-svcgss'
+    '--disable-kprefix'
+    '--enable-uuid'
+    '--enable-mount'
+    '--enable-libmount-mount'
+    '--disable-sbin-override'
+    '--enable-junction'
+    '--enable-ipv6'
+    '--enable-mountconfig'
+    '--enable-nfsdcld'
+    '--enable-nfsdcltrack'
+    '--enable-caps'
+    '--enable-largefile'
+    '--enable-ldap'
+    '--disable-gums'
+    '--with-statedir=/var/lib/nfs'
+    '--with-nfsconfig=/etc/nfs.conf'
+    '--with-statdpath=/var/lib/nfs'
+    '--with-statduser=nobody'
+    '--with-start-statd=/usr/bin/start-statd'
+    '--with-systemd=/usr/lib/systemd/system'
+    '--with-mountfile=/etc/nfsmounts.conf'
+    '--with-tcp-wrappers=no'
+    '--with-krb5=/usr'
+    '--without-gssglue'
+    '--with-pluginpath=/usr/lib/libnfsidmap'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-gss'
+    '--disable-ldap'
+    '--disable-svcgss'
+)
 
 PKGREP="libnfsidmap<=0.27-1"
 PKGBREAK="libnfsidmap<=0.27-1"

--- a/app-utils/nfs-utils/spec
+++ b/app-utils/nfs-utils/spec
@@ -1,5 +1,5 @@
 VER=2.6.2
-REL=2
+REL=3
 SRCS="tbl::https://sourceforge.net/projects/nfs/files/nfs-utils/$VER/nfs-utils-$VER.tar.gz"
 CHKSUMS="sha256::2d8820583dd6a806cd8034d32d890c049a552c58c671a9021cb5d0271bb59eee"
 CHKUPDATE="anitya::id=2081"

--- a/app-utils/nfs-utils/spec
+++ b/app-utils/nfs-utils/spec
@@ -1,5 +1,4 @@
-VER=2.6.2
-REL=3
+VER=2.8.4
 SRCS="tbl::https://sourceforge.net/projects/nfs/files/nfs-utils/$VER/nfs-utils-$VER.tar.gz"
-CHKSUMS="sha256::2d8820583dd6a806cd8034d32d890c049a552c58c671a9021cb5d0271bb59eee"
+CHKSUMS="sha256::403c6aed9b8a7cc365df13cbc1358c0b8ed3a14326d1f84a117c42da6dabcd1c"
 CHKUPDATE="anitya::id=2081"

--- a/app-utils/rhash/spec
+++ b/app-utils/rhash/spec
@@ -2,3 +2,4 @@ VER=1.4.4
 SRCS="git::commit=tags/v$VER::https://github.com/rhash/RHash"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13843"
+REL=1

--- a/app-utils/sysfsutils/spec
+++ b/app-utils/sysfsutils/spec
@@ -2,3 +2,4 @@ VER=2.1.1
 SRCS="tbl::https://github.com/linux-ras/sysfsutils/archive/refs/tags/v$VER.tar.gz"
 CHKSUMS="sha256::f7f669d27c997d3eb3f3e014b4c0aa1aa4d07ce4d6f9e41fa835240f2bf38810"
 CHKUPDATE="anitya::id=4928"
+REL=1

--- a/app-utils/tre/spec
+++ b/app-utils/tre/spec
@@ -1,5 +1,5 @@
 VER=20161208
-REL=1
+REL=2
 SRCS="git::commit=6fb7206b935b35814c5078c20046dbe065435363::https://github.com/laurikari/tre.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5007"

--- a/lang-js/mujs/spec
+++ b/lang-js/mujs/spec
@@ -2,3 +2,4 @@ VER=1.3.8
 SRCS="tbl::https://mujs.com/downloads/mujs-$VER.tar.gz"
 CHKSUMS="sha256::506d34882f2620a2fdeb6db63dbb7a8ffd98f417689d8f3c84f2feac275e39a9"
 CHKUPDATE="anitya::id=269367"
+REL=1

--- a/runtime-admin/dbus-glib/spec
+++ b/runtime-admin/dbus-glib/spec
@@ -1,5 +1,4 @@
-VER=0.110
-REL=3
+VER=0.114
 SRCS="tbl::https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-$VER.tar.gz"
-CHKSUMS="sha256::7ce4760cf66c69148f6bd6c92feaabb8812dee30846b24cd0f7395c436d7e825"
+CHKSUMS="sha256::c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c"
 CHKUPDATE="anitya::id=1979"

--- a/runtime-admin/ding-libs/spec
+++ b/runtime-admin/ding-libs/spec
@@ -2,3 +2,4 @@ VER=0.6.1
 SRCS="tbl::https://fedorahosted.org/released/ding-libs/ding-libs-$VER.tar.gz"
 CHKSUMS="sha256::a319a327deb81f2dfab9ce4a4926e80e1dac5dcfc89f4c7e548cec2645af27c1"
 CHKUPDATE="anitya::id=13710"
+REL=1

--- a/runtime-admin/libgudev/spec
+++ b/runtime-admin/libgudev/spec
@@ -2,3 +2,4 @@ VER=238
 SRCS="tbl::https://download.gnome.org/sources/libgudev/$VER/libgudev-$VER.tar.xz"
 CHKSUMS="sha256::61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1"
 CHKUPDATE="anitya::id=7735"
+REL=1

--- a/runtime-admin/libtracefs/spec
+++ b/runtime-admin/libtracefs/spec
@@ -2,3 +2,4 @@ VER=1.8.1
 SRCS="git::commit=tags/libtracefs-$VER::https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=288157"
+REL=1

--- a/runtime-common/attr/spec
+++ b/runtime-common/attr/spec
@@ -1,5 +1,5 @@
 VER=2.4.48
-REL=2
+REL=3
 SRCS="tbl::https://download.savannah.gnu.org/releases/attr/attr-$VER.tar.gz"
 CHKSUMS="sha256::5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7"
 CHKUPDATE="anitya::id=137"

--- a/runtime-common/iniparser/spec
+++ b/runtime-common/iniparser/spec
@@ -2,3 +2,4 @@ VER=4.2.4
 SRCS="git::commit=tags/v$VER::https://github.com/ndevilla/iniparser"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1380"
+REL=1

--- a/runtime-common/jansson/spec
+++ b/runtime-common/jansson/spec
@@ -2,3 +2,4 @@ VER=2.14
 SRCS="tbl::https://github.com/akheron/jansson/releases/download/v${VER}/jansson-${VER}.tar.gz"
 CHKSUMS="sha256::5798d010e41cf8d76b66236cfb2f2543c8d082181d16bc3085ab49538d4b9929"
 CHKUPDATE="anitya::id=1417"
+REL=1

--- a/runtime-common/libaio/spec
+++ b/runtime-common/libaio/spec
@@ -2,3 +2,4 @@ VER=0.3.113
 SRCS="git::commit=tags/libaio-${VER}::https://pagure.io/libaio.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1557"
+REL=1

--- a/runtime-common/libcroco/spec
+++ b/runtime-common/libcroco/spec
@@ -1,5 +1,5 @@
 VER=0.6.13
-REL=2
+REL=3
 SRCS="tbl::https://download.gnome.org/sources/libcroco/0.6/libcroco-$VER.tar.xz"
 CHKSUMS="sha256::767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4"
 CHKUPDATE="anitya::id=11787"

--- a/runtime-common/libdaemon/spec
+++ b/runtime-common/libdaemon/spec
@@ -1,5 +1,5 @@
 VER=0.14
-REL=4
+REL=5
 SRCS="tbl::http://0pointer.de/lennart/projects/libdaemon/libdaemon-$VER.tar.gz"
 CHKSUMS="sha256::fd23eb5f6f986dcc7e708307355ba3289abe03cc381fc47a80bca4a50aa6b834"
 CHKUPDATE="anitya::id=13299"

--- a/runtime-common/libev/spec
+++ b/runtime-common/libev/spec
@@ -2,3 +2,4 @@ VER=4.33
 SRCS="tbl::https://distfiles.macports.org/libev/libev-$VER.tar.gz"
 CHKSUMS="sha256::507eb7b8d1015fbec5b935f34ebed15bf346bed04a11ab82b8eee848c4205aea"
 CHKUPDATE="anitya::id=1605"
+REL=1

--- a/runtime-common/libpipeline/spec
+++ b/runtime-common/libpipeline/spec
@@ -1,5 +1,5 @@
 VER=1.5.3
-REL=1
+REL=2
 SRCS="tbl::https://download.savannah.gnu.org/releases/libpipeline/libpipeline-$VER.tar.gz"
 CHKSUMS="sha256::5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0"
 CHKUPDATE="anitya::id=1704"

--- a/runtime-common/libsigsegv/autobuild/defines
+++ b/runtime-common/libsigsegv/autobuild/defines
@@ -3,7 +3,11 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="Page fault detection library"
 
-ABSHADOW=0
-AUTOTOOLS_AFTER="--enable-shared"
+# FIXME: *** Subdirectory 'gnulib' does not yet exist. Use './gitsub.sh pull' to create it, or set the environment variable GNULIB_SRCDIR.
+RECONF=0
+
+AUTOTOOLS_AFTER=(
+    '--enable-shared'
+)
 
 PKGEPOCH=1

--- a/runtime-common/libsigsegv/spec
+++ b/runtime-common/libsigsegv/spec
@@ -1,5 +1,5 @@
 VER=2.12
-REL=2
+REL=3
 SRCS="tbl::https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-$VER.tar.gz"
 CHKSUMS="sha256::3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6"
 CHKUPDATE="anitya::id=1722"

--- a/runtime-common/libsigsegv/spec
+++ b/runtime-common/libsigsegv/spec
@@ -1,5 +1,4 @@
-VER=2.12
-REL=3
+VER=2.15
 SRCS="tbl::https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-$VER.tar.gz"
-CHKSUMS="sha256::3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6"
+CHKSUMS="sha256::036855660225cb3817a190fc00e6764ce7836051bacb48d35e26444b8c1729d9"
 CHKUPDATE="anitya::id=1722"

--- a/runtime-common/libunwind/spec
+++ b/runtime-common/libunwind/spec
@@ -2,3 +2,4 @@ VER=1.8.3
 SRCS="tbl::https://github.com/libunwind/libunwind/releases/download/v$VER/libunwind-$VER.tar.gz"
 CHKSUMS="sha256::be30d910e67f58d82e753231f1357f326a1a088acf126b21ff77e60aab19b90b"
 CHKUPDATE="anitya::id=1748"
+REL=1

--- a/runtime-common/libutempter/spec
+++ b/runtime-common/libutempter/spec
@@ -1,5 +1,5 @@
 VER=1.2.1
-REL=1
+REL=2
 SRCS="tbl::ftp://ftp.altlinux.org/pub/people/ldv/utempter/libutempter-$VER.tar.gz"
 CHKSUMS="sha256::967fef372f391de501843ad87570c6cf5dabd9651f00f1783090fbc12b2a34cb"
 CHKUPDATE="anitya::id=1751"

--- a/runtime-common/libuv/spec
+++ b/runtime-common/libuv/spec
@@ -1,5 +1,5 @@
 VER=1.48.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/libuv/libuv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10784"

--- a/runtime-common/mpdecimal/spec
+++ b/runtime-common/mpdecimal/spec
@@ -2,3 +2,4 @@ VER=4.0.0
 SRCS="tbl::https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-$VER.tar.gz"
 CHKSUMS="sha256::942445c3245b22730fd41a67a7c5c231d11cb1b9936b9c0f76334fb7d0b4468c"
 CHKUPDATE="anitya::id=11578"
+REL=1

--- a/runtime-common/ncurses/autobuild/build
+++ b/runtime-common/ncurses/autobuild/build
@@ -1,7 +1,7 @@
 # The following configuration:
 #
 # 1. Enables shared library build (feel free to disable if you won't need Bash or an
-#                                  UNIX shell because you are awesome);
+#    UNIX shell because you are awesome);
 # 2. Disables debug support (will be stripped anyways...);
 # 3. Disables Ada support (our GCC does not include such support);
 # 4. Enables support for wide characters (CJK, you know);
@@ -9,24 +9,41 @@
 # 6. Enables C++ bindings (disable --with-cxx-binding if you are sure);
 # 7. Enables C++ shared bindings (remove if #6 is not needed);
 abinfo "Configuring..."
-./configure --prefix=/usr --libdir=/usr/lib \
-            --with-pkg-config-libdir=/usr/lib/pkgconfig \
-            --mandir=/usr/share/man \
-            --with-shared --with-normal --without-debug --without-ada \
-            --enable-widec --enable-pc-files --with-cxx-binding --with-cxx-shared \
-            --without-gpm --enable-ext-colors --with-versioned-syms ${AUTOTOOLS_AFTER}
+"$SRCDIR"/configure \
+    --prefix=/usr \
+    --libdir=/usr/lib \
+    --with-pkg-config-libdir=/usr/lib/pkgconfig \
+    --mandir=/usr/share/man \
+    --with-shared \
+    --with-normal \
+    --without-debug \
+    --without-ada \
+    --enable-widec \
+    --enable-pc-files \
+    --with-cxx-binding \
+    --with-cxx-shared \
+    --without-gpm \
+    --enable-ext-colors \
+    --with-versioned-syms
+
 abinfo "Building runtime libraries..."
 make
+
+abinfo "Installing runtime libraries ..."
 make install DESTDIR="$PKGDIR"
 
 abinfo "Appending wide-character linkage to pkg-config files..."
 for lib in ncurses ncurses++ form panel menu; do
-    echo "INPUT(-l${lib}w)" > "$PKGDIR"/usr/lib/lib${lib}.so
-    ln -s ${lib}w.pc "$PKGDIR"/usr/lib/pkgconfig/${lib}.pc
+    echo "INPUT(-l${lib}w)" \
+        > "$PKGDIR"/usr/lib/lib${lib}.so
+    ln -sv ${lib}w.pc \
+        "$PKGDIR"/usr/lib/pkgconfig/${lib}.pc
 done
 
 abinfo "Tweaking library for wide-character linkage/reference..."
-echo "INPUT(-lncursesw)" > "$PKGDIR"/usr/lib/libcursesw.so
+echo "INPUT(-lncursesw)" \
+    > "$PKGDIR"/usr/lib/libcursesw.so
 
 abinfo "Creating libcurses symlink..."
-ln -sv libncurses.so "$PKGDIR"/usr/lib/libcurses.so
+ln -sv libncurses.so \
+    "$PKGDIR"/usr/lib/libcurses.so

--- a/runtime-common/ncurses/autobuild/defines
+++ b/runtime-common/ncurses/autobuild/defines
@@ -3,5 +3,4 @@ PKGDEP="glibc texinfo"
 PKGDES="System V Release 4.0 curses emulation library"
 PKGSEC=libs
 
-NOPARALLEL=1
 PKGEPOCH=1

--- a/runtime-common/ncurses/autobuild/defines.stage2
+++ b/runtime-common/ncurses/autobuild/defines.stage2
@@ -3,5 +3,4 @@ PKGDEP="glibc"
 PKGDES="System V Release 4.0 curses emulation library"
 PKGSEC=libs
 
-NOPARALLEL=1
 PKGEPOCH=1

--- a/runtime-common/ncurses/autobuild/prepare
+++ b/runtime-common/ncurses/autobuild/prepare
@@ -1,1 +1,2 @@
+abinfo "Setting NCURSES_SEMVER ..."
 NCURSES_SEMVER=$(echo ${PKGVER} | cut -d '+' -f 1)

--- a/runtime-common/ncurses/spec
+++ b/runtime-common/ncurses/spec
@@ -1,5 +1,5 @@
-VER=6.4
-REL=4
-SRCS="https://ftp.gnu.org/gnu/ncurses/ncurses-${VER}.tar.gz"
-CHKSUMS="sha256::6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
+UPSTREAM_VER=6.5-20251213
+VER=${UPSTREAM_VER/-/+}
+SRCS="tbl::https://invisible-mirror.net/archives/ncurses/current/ncurses-${UPSTREAM_VER}.tgz"
+CHKSUMS="sha256::293665e89f9f1fa1cd897146618762dcd1aeaedfab26bb8fe97ffc96962b0645"
 CHKUPDATE="anitya::id=2057"

--- a/runtime-common/ncurses/spec
+++ b/runtime-common/ncurses/spec
@@ -1,5 +1,5 @@
 VER=6.4
-REL=3
+REL=4
 SRCS="https://ftp.gnu.org/gnu/ncurses/ncurses-${VER}.tar.gz"
 CHKSUMS="sha256::6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
 CHKUPDATE="anitya::id=2057"

--- a/runtime-common/npth/spec
+++ b/runtime-common/npth/spec
@@ -2,3 +2,4 @@ VER=1.8
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/npth/npth-$VER.tar.bz2"
 CHKSUMS="sha256::8bd24b4f23a3065d6e5b26e98aba9ce783ea4fd781069c1b35d149694e90ca3e"
 CHKUPDATE="anitya::id=2505"
+REL=1

--- a/runtime-common/rrdtool/spec
+++ b/runtime-common/rrdtool/spec
@@ -2,3 +2,4 @@ VER=1.7.2
 SRCS="tbl::https://github.com/oetiker/rrdtool-1.x/releases/download/v$VER/rrdtool-$VER.tar.gz"
 CHKSUMS="sha256::a199faeb7eff7cafc46fac253e682d833d08932f3db93a550a4a5af180ca58db"
 CHKUPDATE="anitya::id=4214"
+REL=1

--- a/runtime-common/slang/spec
+++ b/runtime-common/slang/spec
@@ -2,3 +2,4 @@ VER=2.3.3
 SRCS="tbl::https://www.jedsoft.org/releases/slang/slang-$VER.tar.bz2"
 CHKSUMS="sha256::f9145054ae131973c61208ea82486d5dd10e3c5cdad23b7c4a0617743c8f5a18"
 CHKUPDATE="anitya::id=4829"
+REL=1

--- a/runtime-common/yaml/spec
+++ b/runtime-common/yaml/spec
@@ -2,3 +2,4 @@ VER=0.2.5
 SRCS="tbl::https://github.com/yaml/libyaml/archive/$VER.tar.gz"
 CHKSUMS="sha256::fa240dbf262be053f3898006d502d514936c818e422afdcf33921c63bed9bf2e"
 CHKUPDATE="anitya::id=1800"
+REL=1

--- a/runtime-cryptography/libb2/spec
+++ b/runtime-cryptography/libb2/spec
@@ -2,3 +2,4 @@ VER=0.98.1
 SRCS="tbl::https://github.com/BLAKE2/libb2/releases/download/v$VER/libb2-$VER.tar.gz"
 CHKSUMS="sha256::53626fddce753c454a3fea581cbbc7fe9bbcf0bc70416d48fdbbf5d87ef6c72e"
 CHKUPDATE="anitya::id=21574"
+REL=1

--- a/runtime-cryptography/libksba/spec
+++ b/runtime-cryptography/libksba/spec
@@ -2,3 +2,4 @@ VER=1.6.6
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libksba/libksba-$VER.tar.bz2"
 CHKSUMS="sha256::5dec033d211559338838c0c4957c73dfdc3ee86f73977d6279640c9cd08ce6a4"
 CHKUPDATE="anitya::id=1649"
+REL=1

--- a/runtime-cryptography/libmd/spec
+++ b/runtime-cryptography/libmd/spec
@@ -2,3 +2,4 @@ VER=1.1.0
 SRCS="tbl::https://archive.hadrons.org/software/libmd/libmd-$VER.tar.xz"
 CHKSUMS="sha256::1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332"
 CHKUPDATE="anitya::id=15525"
+REL=1

--- a/runtime-cryptography/wolfssl/spec
+++ b/runtime-cryptography/wolfssl/spec
@@ -2,3 +2,4 @@ VER=5.8.4
 SRCS="git::commit=tags/v${VER}-stable::https://github.com/wolfSSL/wolfssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21631"
+REL=1

--- a/runtime-desktop/freetype/spec
+++ b/runtime-desktop/freetype/spec
@@ -2,3 +2,4 @@ VER=2.13.3
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/freetype/freetype-$VER.tar.xz"
 CHKSUMS="sha256::0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
 CHKUPDATE="anitya::id=854"
+REL=1

--- a/runtime-devices/libcl/spec
+++ b/runtime-devices/libcl/spec
@@ -2,3 +2,4 @@ VER=2.3.2
 SRCS="git::commit=tags/v$VER::https://github.com/OCL-dev/ocl-icd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2525"
+REL=1

--- a/runtime-devices/tpm2-tss/spec
+++ b/runtime-devices/tpm2-tss/spec
@@ -1,5 +1,5 @@
 VER=4.1.3
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/tpm2-software/tpm2-tss"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12683"

--- a/runtime-devices/tslib/spec
+++ b/runtime-devices/tslib/spec
@@ -1,5 +1,5 @@
 VER=1.21
-REL=1
+REL=2
 SRCS="tbl::https://github.com/kergoth/tslib/releases/download/$VER/tslib-$VER.tar.xz"
 CHKSUMS="sha256::d2a57b823ea59e53a3b130eef05dfed1190b857854f886eec764e1ca1957cf56"
 CHKUPDATE="anitya::id=15156"

--- a/runtime-display/freeglut/spec
+++ b/runtime-display/freeglut/spec
@@ -1,4 +1,4 @@
-VER=3.4.0
+VER=3.8.0
 SRCS="tbl::https://github.com/freeglut/freeglut/releases/download/v$VER/freeglut-$VER.tar.gz"
-CHKSUMS="sha256::3c0bcb915d9b180a97edaebd011b7a1de54583a838644dcd42bb0ea0c6f3eaec"
+CHKSUMS="sha256::674dcaff25010e09e450aec458b8870d9e98c46f99538db457ab659b321d9989"
 CHKUPDATE="anitya::id=846"

--- a/runtime-display/libglvnd/spec
+++ b/runtime-display/libglvnd/spec
@@ -1,5 +1,5 @@
 VER=1.7.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/NVIDIA/libglvnd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12098"

--- a/runtime-display/s2tc/spec
+++ b/runtime-display/s2tc/spec
@@ -3,3 +3,4 @@ __COMMIT="e68f78f497cd96601248a4bca3bd009d7517d00d"
 SRCS="git::commit=${__COMMIT}::https://github.com/divVerent/s2tc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230529"
+REL=1

--- a/runtime-display/xcb-util/spec
+++ b/runtime-display/xcb-util/spec
@@ -2,3 +2,4 @@ VER=0.4.1
 SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-$VER.tar.xz"
 CHKSUMS="sha256::5abe3bbbd8e54f0fa3ec945291b7e8fa8cfd3cccc43718f8758430f94126e512"
 CHKUPDATE="anitya::id=5165"
+REL=1

--- a/runtime-editors/source-highlight/spec
+++ b/runtime-editors/source-highlight/spec
@@ -1,5 +1,5 @@
 VER=3.1.9
 SRCS="tbl::https://ftp.gnu.org/gnu/src-highlite/source-highlight-$VER.tar.gz"
 CHKSUMS="sha256::3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91"
-REL=2
+REL=3
 CHKUPDATE="anitya::id=230539"

--- a/runtime-i18n/icu/spec
+++ b/runtime-i18n/icu/spec
@@ -2,3 +2,4 @@ VER=74.2
 SRCS="tbl::https://github.com/unicode-org/icu/releases/download/release-${VER//./-}/icu4c-${VER//./_}-src.tgz"
 CHKSUMS="sha256::68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c"
 CHKUPDATE="anitya::id=16134"
+REL=1

--- a/runtime-i18n/libdatrie/spec
+++ b/runtime-i18n/libdatrie/spec
@@ -2,3 +2,4 @@ VER=0.2.13
 SRCS="tbl::https://linux.thai.net/pub/thailinux/software/libthai/libdatrie-$VER.tar.xz"
 CHKSUMS="sha256::12231bb2be2581a7f0fb9904092d24b0ed2a271a16835071ed97bed65267f4be"
 CHKUPDATE="anitya::id=7342"
+REL=1

--- a/runtime-i18n/libthai/spec
+++ b/runtime-i18n/libthai/spec
@@ -1,5 +1,5 @@
 VER=0.1.28
-REL=3
+REL=4
 SRCS="tbl::https://linux.thai.net/pub/thailinux/software/libthai/libthai-$VER.tar.xz"
 CHKSUMS="sha256::ffe0a17b4b5aa11b153c15986800eca19f6c93a4025ffa5cf2cab2dcdf1ae911"
 CHKUPDATE="anitya::id=1737"

--- a/runtime-imaging/cairo/spec
+++ b/runtime-imaging/cairo/spec
@@ -2,3 +2,4 @@ VER=1.18.2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/cairo/cairo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=247"
+REL=1

--- a/runtime-imaging/imlib2/spec
+++ b/runtime-imaging/imlib2/spec
@@ -1,5 +1,5 @@
 VER=1.5.1
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/enlightenment/files/imlib2-src/$VER/imlib2-$VER.tar.bz2"
 CHKSUMS="sha256::fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae"
 CHKUPDATE="anitya::id=21676"

--- a/runtime-imaging/lcms2/spec
+++ b/runtime-imaging/lcms2/spec
@@ -2,3 +2,4 @@ VER=2.17
 SRCS="tbl::https://downloads.sourceforge.net/lcms/lcms2-$VER.tar.gz"
 CHKSUMS="sha256::d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074"
 CHKUPDATE="anitya::id=9815"
+REL=1

--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -2,3 +2,4 @@ VER=3.1.3
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"
+REL=1

--- a/runtime-imaging/libopenraw/spec
+++ b/runtime-imaging/libopenraw/spec
@@ -1,5 +1,5 @@
 VER=0.1.3
-REL=1
+REL=2
 SRCS="tbl::https://libopenraw.freedesktop.org/download/libopenraw-$VER.tar.bz2"
 CHKSUMS="sha256::6405634f555849eb01cb028e2a63936e7b841151ea2a1571ac5b5b10431cfab9"
 CHKUPDATE="anitya::id=7980"

--- a/runtime-kernel/libtraceevent/spec
+++ b/runtime-kernel/libtraceevent/spec
@@ -1,3 +1,4 @@
 VER=1.8.1
 SRCS="tbl::https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/libtraceevent-$VER.tar.gz"
 CHKSUMS="sha256::1801f416b317e2ae0430ce964cf22b9ecb9fb5cd9c6c2d1073b29953c3309bca"
+REL=1

--- a/runtime-multimedia/libid3tag/spec
+++ b/runtime-multimedia/libid3tag/spec
@@ -1,5 +1,5 @@
 VER=0.15.1b
-REL=4
+REL=5
 SRCS="tbl::https://sourceforge.net/projects/mad/files/libid3tag/$VER/libid3tag-$VER.tar.gz"
 CHKSUMS="sha256::63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151"
 CHKUPDATE="anitya::id=21478"

--- a/runtime-multimedia/libva/spec
+++ b/runtime-multimedia/libva/spec
@@ -2,3 +2,4 @@ VER=2.23.0
 SRCS="git::commit=tags/$VER::https://github.com/intel/libva"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1752"
+REL=1

--- a/runtime-multimedia/libvdpau/spec
+++ b/runtime-multimedia/libvdpau/spec
@@ -1,5 +1,5 @@
 VER=1.5
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/vdpau/libvdpau"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1755"

--- a/runtime-multimedia/libvpx/spec
+++ b/runtime-multimedia/libvpx/spec
@@ -2,3 +2,4 @@ VER=1.15.0
 SRCS="tbl::https://github.com/webmproject/libvpx/archive/v$VER/libvpx-$VER.tar.gz"
 CHKSUMS="sha256::e935eded7d81631a538bfae703fd1e293aad1c7fd3407ba00440c95105d2011e"
 CHKUPDATE="anitya::id=11083"
+REL=1

--- a/runtime-multimedia/libyuv/spec
+++ b/runtime-multimedia/libyuv/spec
@@ -1,4 +1,4 @@
 VER=0+git20240215
-REL=1
+REL=2
 SRCS="git::commit=a6a2ec654b1be1166b376476a7555c89eca0c275::https://chromium.googlesource.com/libyuv/libyuv"
 CHKSUMS="SKIP"

--- a/runtime-multimedia/x265/autobuild/build
+++ b/runtime-multimedia/x265/autobuild/build
@@ -1,45 +1,52 @@
-mkdir build{-10,-12}
+abinfo "Creating build directories ..."
+mkdir -pv "$BLDDIR"{,-1{0,2}}
 
-# High bit-depth support adapted from Arch Linux,
-# limited to x86_64 (amd64).
-if ! ab_match_arch amd64; then
-	cd build
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DENABLE_SHARED=TRUE \
-                ${CMAKE_AFTER}
-	make
-	make install DESTDIR="$PKGDIR"
-else
-	cd build-12
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DHIGH_BIT_DEPTH=TRUE \
-		-DMAIN12=TRUE \
-		-DEXPORT_C_API=FALSE \
-		-DENABLE_CLI=FALSE \
-		-DENABLE_SHARED=FALSE ${CMAKE_AFTER}
-	make
-	cd ../build-10
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DHIGH_BIT_DEPTH=TRUE \
-		-DEXPORT_C_API=FALSE \
-		-DENABLE_CLI=FALSE \
-		-DENABLE_SHARED=FALSE ${CMAKE_AFTER}
-	make
-	cd ../build
-	ln -s ../build-10/libx265.a libx265_main10.a
-	ln -s ../build-12/libx265.a libx265_main12.a
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DENABLE_SHARED=TRUE \
-		-DEXTRA_LIB='x265_main10.a;x265_main12.a' \
-		-DEXTRA_LINK_FLAGS=-L. \
-		-DLINKED_10BIT=TRUE \
-		-DLINKED_12BIT=TRUE ${CMAKE_AFTER}
-	make
-	make install DESTDIR="$PKGDIR"
-fi
+abinfo "Configuring x265 (12-bit depth) ..."
+cd "$BLDDIR"-12
+cmake "$SRCDIR"/source \
+    ${CMAKE_DEF[@]} \
+    -DENABLE_HDR10_PLUS=ON \
+    -DHIGH_BIT_DEPTH=ON \
+    -DMAIN12=ON \
+    -DEXPORT_C_API=OFF \
+    -DENABLE_CLI=OFF \
+    -DENABLE_SHARED=OFF
 
-cd "$SRCDIR"
+abinfo "Builing x265 (12-bit depth) ..."
+make
+
+abinfo "Configuring x265 (10-bit depth) ..."
+cd "$BLDDIR"-10
+cmake "$SRCDIR"/source \
+    ${CMAKE_DEF[@]} \
+    -DENABLE_HDR10_PLUS=ON \
+    -DHIGH_BIT_DEPTH=ON \
+    -DEXPORT_C_API=OFF \
+    -DENABLE_CLI=OFF \
+    -DENABLE_SHARED=OFF
+
+abinfo "Building x265 (10-bit depth) ..."
+make
+
+abinfo "Configuring x265 (main, linked against 10/12-bit depth versions) ..."
+cd "$BLDDIR"
+ln -sv "$BLDDIR"-10/libx265.a \
+    libx265_main10.a
+ln -sv "$BLDDIR"-12/libx265.a \
+    libx265_main12.a
+cmake "$SRCDIR"/source \
+    ${CMAKE_DEF[@]} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DENABLE_HDR10_PLUS=ON \
+    -DEXTRA_LIB='x265_main10.a;x265_main12.a' \
+    -DEXTRA_LINK_FLAGS=-L. \
+    -DLINKED_10BIT=ON \
+    -DLINKED_12BIT=ON \
+    -DENABLE_SHARED=ON
+
+abinfo "Building x265 (main, linked against 10/12-bit depth versions) ..."
+make
+
+abinfo "Installing x265 (main, linked against 10/12-bit depth versions) ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/runtime-multimedia/x265/autobuild/defines
+++ b/runtime-multimedia/x265/autobuild/defines
@@ -2,13 +2,7 @@ PKGNAME=x265
 PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
-PKGDES="Open source H265/HEVC video encoder"
-
-# some applications might want this e.g. sunshine
-CMAKE_AFTER="-DENABLE_HDR10_PLUS=ON"
-CMAKE_AFTER__PPC64=" \
-             ${CMAKE_AFTER} \
-             -DENABLE_ALTIVEC=OFF"
+PKGDES="H265/HEVC video encoder"
 
 PKGBREAK="avidemux<=2.8.1 digikam<=7.9.0-2 vlc<=3.0.20-3 xpra<=5.0.8 \
           gstreamer<=1.22.0-5 ffmpeg<=4.4.4-3 libheif<=1.17.6-1"

--- a/runtime-multimedia/x265/autobuild/patches/0001-ARCHLINUX-Fix-build-with-GCC-15.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0001-ARCHLINUX-Fix-build-with-GCC-15.patch
@@ -1,0 +1,28 @@
+From 0d8214d6fc8fd0697ca67040c7279105fba01451 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 5 Jun 2025 21:45:58 +0200
+Subject: [PATCH] ARCHLINUX: Fix build with GCC 15
+
+Signed-off-by: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+
+Link: https://gitlab.archlinux.org/archlinux/packaging/packages/x265/-/blob/9d27978355453de977f7ac88144857525a2fb5cc/0001-Fix-build-with-GCC-15.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/dynamicHDR10/json11/json11.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/source/dynamicHDR10/json11/json11.cpp b/source/dynamicHDR10/json11/json11.cpp
+index 762577735..74f990a51 100644
+--- a/source/dynamicHDR10/json11/json11.cpp
++++ b/source/dynamicHDR10/json11/json11.cpp
+@@ -25,6 +25,7 @@
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>
++#include <cstdint>
+ 
+ #if _MSC_VER
+ #pragma warning(disable: 4510) //const member cannot be default initialized
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/prepare
+++ b/runtime-multimedia/x265/autobuild/prepare
@@ -1,7 +1,0 @@
-# On mipsel GCC will refuse to link without -fPIC. Weird.
-if [[ "${ARCH}" == "mipsel" ]]; then
-    CXXFLAGS+=" -fPIC"
-fi
-
-# x265 does not use any other variables.
-export CXXFLAGS="${CXXFLAGS} ${CPPFLAGS} ${LDFLAGS}"

--- a/runtime-multimedia/x265/spec
+++ b/runtime-multimedia/x265/spec
@@ -2,3 +2,4 @@ VER=3.6
 SRCS="git::commit=tags/$VER::https://bitbucket.org/multicoreware/x265_git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7275"
+REL=1

--- a/runtime-network/c-ares/spec
+++ b/runtime-network/c-ares/spec
@@ -2,3 +2,4 @@ VER=1.28.1
 SRCS="tbl::https://github.com/c-ares/c-ares/releases/download/cares-${VER//./_}/c-ares-$VER.tar.gz"
 CHKSUMS="sha256::675a69fc54ddbf42e6830bc671eeb6cd89eeca43828eb413243fd2c0a760809d"
 CHKUPDATE="anitya::id=5840"
+REL=1

--- a/runtime-network/fstrm/spec
+++ b/runtime-network/fstrm/spec
@@ -1,3 +1,4 @@
 VER=0.6.1
 SRCS="tbl::https://dl.farsightsecurity.com/dist/fstrm/fstrm-$VER.tar.gz"
 CHKSUMS="sha256::bca4ac1e982a2d923ccd24cce2c98f4ceeed5009694430f73fc0dcebca8f098f"
+REL=1

--- a/runtime-network/libmnl/spec
+++ b/runtime-network/libmnl/spec
@@ -2,3 +2,4 @@ VER=1.0.5
 SRCS="tbl::https://www.netfilter.org/projects/libmnl/files/libmnl-$VER.tar.bz2"
 CHKSUMS="sha256::274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525"
 CHKUPDATE="anitya::id=1663"
+REL=1

--- a/runtime-network/libndp/spec
+++ b/runtime-network/libndp/spec
@@ -1,5 +1,5 @@
 VER=1.7
-REL=1
+REL=2
 SRCS="tbl::http://libndp.org/files/libndp-$VER.tar.gz"
 CHKSUMS="sha256::2c480afbffb02792dbae3c13bbfb71d89f735562f2795cca0640ed3428b491b6"
 CHKUPDATE="anitya::id=14944"

--- a/runtime-network/libnftnl/spec
+++ b/runtime-network/libnftnl/spec
@@ -2,3 +2,4 @@ VER=1.2.6
 SRCS="https://netfilter.org/projects/libnftnl/files/libnftnl-$VER.tar.xz"
 CHKSUMS="sha256::ceeaea2cd92147da19f13a35a7f1a4bc2767ff897e838e4b479cf54b59c777f4"
 CHKUPDATE="anitya::id=1681"
+REL=1

--- a/runtime-network/libnl/spec
+++ b/runtime-network/libnl/spec
@@ -2,3 +2,4 @@ VER=3.9.0
 SRCS="tbl::https://github.com/thom311/libnl/releases/download/libnl${VER//./_}/libnl-$VER.tar.gz"
 CHKSUMS="sha256::aed507004d728a5cf11eab48ca4bf9e6e1874444e33939b9d3dfed25018ee9bb"
 CHKUPDATE="anitya::id=1684"
+REL=1

--- a/runtime-network/libpcap/spec
+++ b/runtime-network/libpcap/spec
@@ -2,3 +2,4 @@ VER=1.10.4
 SRCS="tbl::https://www.tcpdump.org/release/libpcap-$VER.tar.gz"
 CHKSUMS="sha256::ed19a0383fad72e3ad435fd239d7cd80d64916b87269550159d20e47160ebe5f"
 CHKUPDATE="anitya::id=1702"
+REL=1

--- a/runtime-network/libpsl/spec
+++ b/runtime-network/libpsl/spec
@@ -1,5 +1,5 @@
 VER=0.21.5
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/rockdaboot/libpsl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7305"

--- a/runtime-network/libqrtr-glib/spec
+++ b/runtime-network/libqrtr-glib/spec
@@ -1,5 +1,5 @@
 VER=1.2.2
-REL=0retro1
+REL=1
 SRCS="git::commit=tags/${VER}::https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=192056"

--- a/runtime-network/libssh/spec
+++ b/runtime-network/libssh/spec
@@ -1,5 +1,5 @@
 VER=0.8.9
-REL=2
+REL=3
 SRCS="tbl::https://git.libssh.org/projects/libssh.git/snapshot/libssh-$VER.tar.gz"
 CHKSUMS="sha256::46763c6fadd101cba11d5aaa505c1a20bc4afc9c28d3adcc4c42932eeeaab3f0"
 CHKUPDATE="anitya::id=1729"

--- a/runtime-productivity/libical/spec
+++ b/runtime-productivity/libical/spec
@@ -1,5 +1,5 @@
 VER=3.0.18
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/libical/libical.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1637"

--- a/runtime-productivity/libpaper/spec
+++ b/runtime-productivity/libpaper/spec
@@ -2,3 +2,4 @@ VER=2.2.5
 SRCS="tbl::https://github.com/rrthomas/libpaper/releases/download/v$VER/libpaper-$VER.tar.gz"
 CHKSUMS="sha256::7be50974ce0df0c74e7587f10b04272cd53fd675cb6a1273ae1cc5c9cc9cab09"
 CHKUPDATE="anitya::id=15136"
+REL=1

--- a/runtime-web/geoip-api-c/spec
+++ b/runtime-web/geoip-api-c/spec
@@ -1,5 +1,5 @@
 VER=1.6.12
-REL=1
+REL=2
 SRCS="tbl::https://github.com/maxmind/geoip-api-c/releases/download/v$VER/GeoIP-$VER.tar.gz"
 CHKSUMS="sha256::1dfb748003c5e4b7fd56ba8c4cd786633d5d6f409547584f6910398389636f80"
 CHKUPDATE="anitya::id=11781"

--- a/runtime-web/libcss/spec
+++ b/runtime-web/libcss/spec
@@ -2,3 +2,4 @@ VER=0.9.2
 SRCS="tbl::https://download.netsurf-browser.org/libs/releases/libcss-$VER-src.tar.gz"
 CHKSUMS="sha256::2df215bbec34d51d60c1a04b01b2df4d5d18f510f1f3a7af4b80cddb5671154e"
 CHKUPDATE="anitya::id=1582"
+REL=1

--- a/runtime-web/libdom/spec
+++ b/runtime-web/libdom/spec
@@ -1,5 +1,5 @@
 VER=0.4.2
-SRCS="tbl::http://git.netsurf-browser.org/libdom.git/snapshot/libdom-release/$VER.tar.gz"
-CHKSUMS="sha256::736d8247a3e83fef327563e60565af60263b61169ad1a69d79b83d93dde3c792"
+SRCS="git::commit=tags/release/$VER::git://git.netsurf-browser.org/libdom.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1595"
-SUBDIR="libdom-release/$VER"
+REL=1

--- a/runtime-web/libhubbub/spec
+++ b/runtime-web/libhubbub/spec
@@ -2,3 +2,4 @@ VER=0.3.8
 SRCS="tbl::https://download.netsurf-browser.org/libs/releases/libhubbub-$VER-src.tar.gz"
 CHKSUMS="sha256::8ac1e6f5f3d48c05141d59391719534290c59cd029efc249eb4fdbac102cd5a5"
 CHKUPDATE="anitya::id=1633"
+REL=1

--- a/runtime-web/libmaxminddb/spec
+++ b/runtime-web/libmaxminddb/spec
@@ -2,3 +2,4 @@ VER=1.4.3
 SRCS="tbl::https://github.com/maxmind/libmaxminddb/releases/download/$VER/libmaxminddb-$VER.tar.gz"
 CHKSUMS="sha256::a5fdf6c7b4880fdc7620f8ace5bd5cbe9f65650c9493034b5b9fc7d83551a439"
 CHKUPDATE="anitya::id=7470"
+REL=1

--- a/runtime-web/libparserutils/spec
+++ b/runtime-web/libparserutils/spec
@@ -2,3 +2,4 @@ VER=0.2.5
 SRCS="tbl::https://download.netsurf-browser.org/libs/releases/libparserutils-$VER-src.tar.gz"
 CHKSUMS="sha256::317ed5c718f17927b5721974bae5de32c3fd6d055db131ad31b4312a032ed139"
 CHKUPDATE="anitya::id=1701"
+REL=1

--- a/runtime-web/ngtcp2/spec
+++ b/runtime-web/ngtcp2/spec
@@ -2,3 +2,4 @@ VER=1.5.0
 SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/ngtcp2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370247"
+REL=1

--- a/runtime-web/serf/spec
+++ b/runtime-web/serf/spec
@@ -2,3 +2,4 @@ VER=1.3.10
 SRCS="tbl::https://archive.apache.org/dist/serf/serf-$VER.tar.bz2"
 CHKSUMS="sha256::be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6"
 CHKUPDATE="anitya::id=1720"
+REL=1

--- a/runtime-web/spdylay/spec
+++ b/runtime-web/spdylay/spec
@@ -1,5 +1,5 @@
 VER=1.4.0
-REL=5
+REL=6
 SRCS="tbl::https://github.com/tatsuhiro-t/spdylay/releases/download/v$VER/spdylay-$VER.tar.xz"
 CHKSUMS="sha256::1a133578dd330f5ff3b1c25798c0594e39858e6a050513e5d7ec31eda6e89341"
 CHKUPDATE="anitya::id=230540"


### PR DESCRIPTION
Topic Description
-----------------

- yaml: rebuild for loongson3 RWE GNU_STACK
- xcb-util: rebuild for loongson3 RWE GNU_STACK
- x265: rebuild for loongson3 RWE GNU_STACK
- wireless-tools: rebuild for loongson3 RWE GNU_STACK
- tslib: rebuild for loongson3 RWE GNU_STACK
- tre: rebuild for loongson3 RWE GNU_STACK
- tpm2-tss: rebuild for loongson3 RWE GNU_STACK
- sysfsutils: rebuild for loongson3 RWE GNU_STACK
- spdylay: rebuild for loongson3 RWE GNU_STACK

... and 89 more commits

Package(s) Affected
-------------------

- acl: 2.3.1-1
- attr: 2.4.48-3
- babeltrace: 1.5.11-1
- c-ares: 1.28.1-1
- cairo: 1.18.2-1
- cmocka: 1.1.7-1
- dbus-glib: 0.110-4
- ding-libs: 0.6.1-1
- f2fs-tools: 1.16.0-1
- freeglut: 3.4.0-1
- freetype: 2.13.3-1
- fribidi: 1.0.14-1
- fstrm: 0.6.1-1
- fuse-3: 3.16.2-1
- fuse-common: 3.16.2-1
- geoip-api-c: 1.6.12-2
- gpm: 1.20.7-10
- harfbuzz: 8.4.0-2
- hwloc: 2.10.0-1
- ibus: 1.5.25-2
- icu: 74.2-1
- imlib2: 1.5.1-2
- iniparser: 4.2.4-1
- jansson: 2.14-1
- lapack: 3.12.0-1
- lcms2: 2.14-1
- libaio: 0.3.113-1
- libb2: 0.98.1-1
- libcl: 2.3.2-1
- libcroco: 0.6.13-3
- libcss: 0.9.2-1
- libdaemon: 0.14-5
- libdatrie: 0.2.13-1
- libdom: 0.4.2-1
- libev: 4.33-1
- libglvnd: 1.7.0-2
- libgudev: 238-1
- libhubbub: 0.3.8-1
- libibus: 1.5.25-2
- libical: 3.0.18-2
- libid3tag: 0.15.1b-5
- libjpeg-turbo: 2:3.0.4-1
- libksba: 1.6.6-1
- libmaxminddb: 1.4.3-1
- libmd: 1.1.0-1
- libmnl: 1.0.5-1
- libndp: 1.7-2
- libnftnl: 1.2.6-1
- libnl: 3.9.0-1
- libopenraw: 0.1.3-2
- libpaper: 2.2.5-1
- libparserutils: 0.2.5-1
- libpcap: 1.10.4-1
- libpipeline: 1.5.3-2
- libpsl: 0.21.5-2
- libqrtr-glib: 1.2.2-1
- libsigsegv: 1:2.12-3
- libssh: 0.8.9-3
- libthai: 0.1.28-4
- libtraceevent: 1.8.1-1
- libtracefs: 1.8.1-1
- libunwind: 1.8.2-1
- libutempter: 1.2.1-2
- libuv: 1.48.0-2
- libva: 2.22.0-1
- libvdpau: 1.5-2
- libvpx: 1.15.0-1
- libyuv: 0+git20240215-2
- lksctp-tools: 1.0.17-2
- lmdb: 0.9.33-2
- lsof: 4.99.3-1
- lz4: 1:1.10.0-1
- lzo: 2.10-4
- mpdecimal: 4.0.0-1
- mujs: 1.3.5-1
- ncurses: 1:6.4-4
- nfs-utils: 2.6.2-3
- ngtcp2: 1.5.0-1
- npth: 1.8-1
- parted: 3.6-2
- reiserfsprogs: 3.6.27-3
- rhash: 1.4.4-1
- rrdtool: 1.7.2-1
- rtmpdump: 20151223-6
- ruby: 3.4.7-1
- s2tc: 1:1.0+git20210317-1
- serf: 1.3.10-1
- sg3-utils: 1.47r915-1
- slang: 1:2.3.3-1
- spdylay: 1.4.0-6
- sysfsutils: 2.1.1-1
- tpm2-tss: 4.1.3-2
- tre: 20161208-2
- tslib: 1.21-2
- wireless-tools: 30.pre9-4
- wolfssl: 5.7.0-1
- x265: 3.6-1
- xcb-util: 0.4.1-1
- yaml: 0.2.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit attr acl babeltrace c-ares lzo libglvnd icu harfbuzz freetype cairo cmocka dbus-glib ding-libs lz4 f2fs-tools freeglut fribidi fstrm fuse-3 geoip-api-c gpm hwloc libid3tag libjpeg-turbo imlib2 iniparser jansson lapack lcms2 libaio libb2 ruby libcl libcroco libparserutils libcss libdaemon libdatrie libhubbub libdom libev libgudev ibus libical libksba libmaxminddb libmd libmnl libndp libnftnl libnl libopenraw libpaper libpcap libpipeline libpsl libqrtr-glib libsigsegv libssh libthai libtraceevent libtracefs libunwind libutempter libuv libva libvdpau libvpx libyuv lksctp-tools lmdb lsof mpdecimal mujs ncurses nfs-utils wolfssl ngtcp2 npth parted reiserfsprogs rhash rrdtool rtmpdump s2tc serf sg3-utils slang spdylay sysfsutils tpm2-tss tre tslib wireless-tools x265 xcb-util yaml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
