### PR TITLE
linux pam loongson3 dependency fix survey

### DIFF
--- a/runtime-common/libtirpc/spec
+++ b/runtime-common/libtirpc/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
-REL=2
+VER=1.3.7
 SRCS="tbl::https://downloads.sourceforge.net/project/libtirpc/libtirpc/$VER/libtirpc-$VER.tar.bz2"
-CHKSUMS="sha256::245895caf066bec5e3d4375942c8cb4366adad184c29c618d97f724ea309ee17"
+CHKSUMS="sha256::b47d3ac19d3549e54a05d0019a6c400674da716123858cfdb6d3bdd70a66c702"
 CHKUPDATE="anitya::id=1740"

--- a/runtime-network/libnsl2/spec
+++ b/runtime-network/libnsl2/spec
@@ -1,5 +1,5 @@
 VER=1.3.0
-REL=2
+REL=3
 SRCS="tbl::https://github.com/thkukuk/libnsl/releases/download/v$VER/libnsl-$VER.tar.xz"
 CHKSUMS="sha256::eac3062957fa302c62eff4aed718a07bacbf9ceb0a058289f12a19bfdda3c8e2"
 CHKUPDATE="anitya::id=17345"


### PR DESCRIPTION
Topic Description
-----------------

- libnsl2: rebuild for loongson3 RWE GNU_STACK
- libtirpc: update to 1.3.7

Package(s) Affected
-------------------

- libnsl2: 1.3.0-3
- libtirpc: 1.3.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtirpc libnsl2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
