### PR TITLE
xdotool-3: drop unversioned shared object to fix conflict

### DIFF
--- a/app-utils/xdotool-3/autobuild/build
+++ b/app-utils/xdotool-3/autobuild/build
@@ -5,3 +5,6 @@ abinfo "Installing xdotool-3 (runtime only) ..."
 make installlib \
     DESTDIR="$PKGDIR" \
     PREFIX="/usr"
+
+abinfo "Dropping unversioned library ..."
+rm -v "$PKGDIR"/usr/lib/libxdo.so

--- a/app-utils/xdotool-3/spec
+++ b/app-utils/xdotool-3/spec
@@ -1,4 +1,5 @@
 VER=3.20211022.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/jordansissel/xdotool"
 CHKSUMS="SKIP"
 # Note: No date necessary, old runtime.


### PR DESCRIPTION
Topic Description
-----------------

- xdotool-3: drop unversioned shared object to fix conflict

Package(s) Affected
-------------------

- xdotool-3: 3.20211022.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdotool-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
