### PR TITLE
imapsync: drop, orphaned

### DIFF
--- a/app-network/imapsync/autobuild/build
+++ b/app-network/imapsync/autobuild/build
@@ -1,1 +1,0 @@
-make install DESTDIR="$PKGDIR"

--- a/app-network/imapsync/autobuild/defines
+++ b/app-network/imapsync/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=imapsync
-PKGSEC=mail
-PKGDEP="libwww-perl perl-crypt-openssl-rsa perl-file-copy-recursive perl-file-tail perl-html-parser perl-io-socket-inet6 perl-io-socket-ssl perl-regexp-common perl-term-readkey perl-encode-imaputf7 perl-mail-imapclient perl-module-runtime perl-ntlm perl-json-webtoken perl-io-tee perl-data-uniqid perl-readonly perl-sys-meminfo perl-test-mockobject perl-unicode-string"
-BUILDDEP="perl-try-tiny perl-test-pod perl-module-scandeps perl-test-deep perl-test-fatal perl-test-requires perl-package-stash perl-package-stash-xs perl-par-packer perl-test-mock-guard perl-cgi perl-app-cpanminus perl-test-requires"
-PKGDES="IMAP synchronisation, sync, copy or migration tool"
-
-ABHOST=noarch

--- a/app-network/imapsync/spec
+++ b/app-network/imapsync/spec
@@ -1,4 +1,0 @@
-VER=1.977
-SRCS="git::commit=b3ff66078b0e7a95873f8661682abc5a7ad5d580::https://github.com/imapsync/imapsync"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=6533"


### PR DESCRIPTION
Topic Description
-----------------

- imapsync: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
