### PR TITLE
vscode: update to 1.107.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.107.0
+VER=1.107.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::88a9198b18c6df0b807c716861af7cbb403bc9bc4dd5617803b01dc03efd785b"
-CHKSUMS__ARM64="sha256::18759cd554dbd4311e6c60e3a85085eb9a8e4b8a58612be5b1556e033bc7ea7a"
+CHKSUMS__AMD64="sha256::d5c4694a49d373d78657172c29c3bf3a6693cc905f3a4d4efb783428aba3f9c3"
+CHKSUMS__ARM64="sha256::6c93a9eb81af2238f4650e4721b01a0db9afef256c61fcf6e84808a6389d8f15"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.107.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.107.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
