### PR TITLE
i3status-rust: update to 0.35.0

### DIFF
--- a/app-web/notmuch/autobuild/beyond
+++ b/app-web/notmuch/autobuild/beyond
@@ -13,17 +13,6 @@ make install \
 
 cd "$SRCDIR"/bindings/python
 
-abinfo "Building Python 2 bindings ..."
-python2 setup.py build
-
-abinfo "Installing Python 2 bindings ..."
-python2 setup.py install \
-    --prefix=/usr \
-    --root="$PKGDIR"
-
-abinfo "Cleaning up and preparing to build Python 3 bindings ..."
-python2 setup.py clean
-
 abinfo "Building Python 3 bindings ..."
 python3 setup.py build
 

--- a/app-web/notmuch/spec
+++ b/app-web/notmuch/spec
@@ -1,4 +1,5 @@
 VER=0.38.3
+REL=1
 SRCS="tbl::https://notmuchmail.org/releases/notmuch-$VER.tar.xz"
 CHKSUMS="sha256::9af46cc80da58b4301ca2baefcc25a40d112d0315507e632c0f3f0f08328d054"
 CHKUPDATE="anitya::id=2498"

--- a/desktop-wm/i3status-rust/autobuild/beyond
+++ b/desktop-wm/i3status-rust/autobuild/beyond
@@ -11,3 +11,13 @@ done
 for theme in "$SRCDIR"/files/themes/*.toml; do 
     install -Dvm644 -t "$PKGDIR"/usr/share/"$PKGNAME"/themes/ "$theme"
 done
+
+if ab_match_arch amd64 || ab_match_arch arm64; then
+    abinfo "Installing manpage ..."
+    cargo xtask generate-manpage
+    install -Dvm644 "$SRCDIR"/man/i3status-rs.1 \
+        -t "$PKGDIR"/usr/share/man/man1/
+fi
+
+abinfo "Removing temporary tool ..."
+rm -v "$PKGDIR"/usr/bin/xtask

--- a/desktop-wm/i3status-rust/autobuild/defines
+++ b/desktop-wm/i3status-rust/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=i3status-rust
 PKGSEC=x11
-PKGDEP="pulseaudio"
+PKGDEP="pulseaudio pipewire notmuch"
 BUILDDEP="rustc llvm"
-PKGDES="A Rust re-implementation of i3status"
+BUILDDEP__PANDOC="${BUILDDEP} pandoc"
+BUILDDEP__AMD64="${BUILDDEP__PANDOC}"
+BUILDDEP__ARM64="${BUILDDEP__PANDOC}"
+PKGDES="Rust re-implementation of i3status"
 
 USECLANG=1
-NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1
-ABSPLITDBG=0
 ABTYPE=rust

--- a/desktop-wm/i3status-rust/spec
+++ b/desktop-wm/i3status-rust/spec
@@ -1,4 +1,4 @@
-VER=0.34.0
+VER=0.35.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/greshake/i3status-rust"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231979"


### PR DESCRIPTION
Topic Description
-----------------

- i3status-rust: update to 0.35.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- i3status-rust: 0.35.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit notmuch i3status-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
