### PR TITLE
iosevka-fonts: update to 33.3.6

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.3.5
+VER=33.3.6
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::88b6d7e2442b39ef98ce4c352018a90906aa1eea8d54497743ffc1c0e1697981 \
-         sha256::fcc5aac4a6857801c206a2822b30ec30677e84dab40c24de64a3a308efb64d43 \
-         sha256::f2168ca681e8a973635db5a5aac41659f36dc2ef32c361296c56369f58ce82a1 \
-         sha256::1828cbf43016cdfc4b7c132c6ac022de07cd6206c023b3f707f2642e04ab71e8 \
-         sha256::8ed780b5fabbf4aef445981bf7d497b5eae68e022e52e75e0559b3909feb00c5 \
-         sha256::88f20e60aab36ccac82eb6214f630bac6f9deca3d8bb7aee0093a5157908c66d \
-         sha256::fcf55c9ab82442d21e56c432102b8e6602b99a54b491ed8c67d50afebbac4130 \
-         sha256::44e01d5a233e7146891be49709c3c3846734d8183ce70e06eeb71eed99723665 \
-         sha256::90bbb8b5f4724c1324787849f0c3590c25797f3cad2360c86fe9dc6695af94b4 \
-         sha256::b5f99d94919276a0e5290d6e23b1435ea23e2cb08222aa519266524702eb5e77 \
-         sha256::74b54d6f69178bdb4b6e39551fd09d9e21ea312f4910297871a39570e87158f0 \
-         sha256::785cb90f6ff2abe4aba377591d5e8cffc293c6a77ea22a8420ef5d4cd3a86f24 \
-         sha256::783e6094a4cbe80a23422a8a8322c77df02029c34060a823e5b68cb51756cb42 \
-         sha256::789f26a2a62f161dc0b818623159a864df862785cf944c6279b5d308913e7074 \
-         sha256::01c26abb4df7f36bdb577455b78672e8bbae72ef6f35fac65abc52cf96c9905d \
-         sha256::a38fb571b81f49cce72e609c93f13245f89e6f1396982b0662216d69ff8c66ad \
-         sha256::81043733d66b9b1a5bd00dc8848eca2d3ae7b0d6ee1f73f0ef1744649ed66284 \
-         sha256::a9c691d6054ca9f8aef85c89d6856166532448ca5a6971939c165512064a9f57 \
-         sha256::e386eb76426b9b332ae0d4505a055e25de02160e9e79ae8a3d91acec2bd04aa6 \
-         sha256::eb5eb4ba00a94389f5fe3170f3051f3d9a44f04c4bd747565716793f241d9cc2 \
-         sha256::712afa8986e5c275c374bcf3758c5d681c6357b4f260470583a88709dc85654d \
-         sha256::39860a205b0c0733157847f3734bfbc313f7857686ee18d6c2df1fc7d2bf9987 \
-         sha256::2088c746610fa0c901dfc840e24fa7d00ede13efd3d6ed91d95130e10b081925 \
-         sha256::d0bc8cfbf87a5776c663e9e59fa9e0570db3c0306c918f352db9b510458a898e \
+CHKSUMS="sha256::6f4e2e562463bf416dfd99f7490c61da6d40ac2c21d757300c8a4b6f2484c919 \
+         sha256::fd998e85c4c289de52919d2a71eccd465b1e4583ac08744436e0a7c6a1dd66a3 \
+         sha256::f4e88e9b85d63a39ff61a96fdfb4703523cffeecf9e4bd62856dbc7449cd3321 \
+         sha256::4f76e2b2955364ded0b302baf4081fc63cc08fe4c82c4abf4c7c1e6f8611e239 \
+         sha256::6ebde0105a707f3e7612028afc9b693f9972006f1abfb85976524f28dd35bf88 \
+         sha256::2f0590f097d2b15e17500241e06e0adcf43301a50b1ea81840b2f3b3db08d1b9 \
+         sha256::d0545c063f133a2c56628a4e3e5e196bfcaab9eb3ca7bb73403dba642a4a08f8 \
+         sha256::f08c2488b6f288c6f2a3cb8668ca6906d0e4ea7f4d6e5c4ad2c79c73156cc717 \
+         sha256::e945a6e5eb396da80d72d03d11fe6995505d4b7ce1c1a9bb266e96f7980d1591 \
+         sha256::9196bb8e4e433087c191580a32e73b4c9abf4781711a2035af8195aa67f29065 \
+         sha256::60ebaeb43ac0c1459cef6be88a251252742077ee5db22757b4287a5c62027a18 \
+         sha256::b41a37dbe27883e44cd1fcbd1664c12f03e6fc2d6aa5119aa74f76f7569e76a5 \
+         sha256::711d0ec94bea61efbdac656674d73de0fdabbc8053aa102a58607a48f7a3b04c \
+         sha256::3003ffe201d804e9214b864ab8a42c24c0cea5a77d5323b00ae2457b371530f1 \
+         sha256::c07aee8c07ccc1f604d6cbf9ab2e766f4f11bbd7b84b8acabd0fc677d9d7f183 \
+         sha256::8781f0d6323d3d066667852bdd24c9beb70811e23cac2db530ae97693507565a \
+         sha256::48d13f102fd8b183ec63818c338a5688fa2be015c57024a06fbedb9203276dfb \
+         sha256::def49b4095dd80772d6605359f294a8b041f5021d47a6d4018d37092900e3963 \
+         sha256::b2c146eaaff8dd511409f3491083dc7c57f46ed26ead3781ee633e9e60ab93ce \
+         sha256::89f1c423ae8f155aed3a3b2883bd703bae12f860cf1cb937d9930424d288aab0 \
+         sha256::35541783e8c041e367a3c3a024f577b51b4c7fcf019b49b2c3bcf54208fe9548 \
+         sha256::d861052de4bafa02ff7a9d69f7216e5c16dc7978658659c698d061a5206ff036 \
+         sha256::97f6d996d219e0385be04a329f64a02930089e637c28eeec2d78b3dd4ab45b47 \
+         sha256::9faacb9215d879259fe4ddfc1a5a79bcb6b5b069ced7d1282926e2e3f2d3fbca \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 33.3.6
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 33.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
