### PR TITLE
libdecor: update to 0.2.5

### DIFF
--- a/runtime-desktop/libdecor/spec
+++ b/runtime-desktop/libdecor/spec
@@ -1,4 +1,4 @@
-VER=0.2.4
+VER=0.2.5
 SRCS="tbl::https://gitlab.freedesktop.org/libdecor/libdecor/-/releases/$VER/downloads/libdecor-$VER.tar.xz"
-CHKSUMS="sha256::b17cf420e8dcb526bf82da5d36f8443a91fad0777083fa4ec5c1df8ee877416f"
+CHKSUMS="sha256::7fd50f780a4fee90a03f7b2c09055033e488654cbaff4a0c4bbae616bac9cd1c"
 CHKUPDATE="anitya::id=312806"


### PR DESCRIPTION
Topic Description
-----------------

- libdecor: update to 0.2.5
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libdecor: 0.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdecor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
