### PR TITLE
networkmanager: update to 1.54.3

### DIFF
--- a/app-network/networkmanager/spec
+++ b/app-network/networkmanager/spec
@@ -1,5 +1,4 @@
-VER=1.54.2
-REL=1
+VER=1.54.3
 SRCS="tbl::https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/releases/$VER/downloads/NetworkManager-$VER.tar.xz"
-CHKSUMS="sha256::abcd4949509aeebe394f45761e6a6789657d4dc8979fe52d2d466145928fc7a2"
+CHKSUMS="sha256::cf4fefc3be96802c5a4dab3e690bdc4ce4c78251954ef0a1b65026d886709989"
 CHKUPDATE="anitya::id=21197"


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager: update to 1.54.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- networkmanager: 1.54.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit networkmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
