### PR TITLE
shadowsocks-rust: update to 1.24.0

### DIFF
--- a/app-proxy/shadowsocks-rust/spec
+++ b/app-proxy/shadowsocks-rust/spec
@@ -1,5 +1,4 @@
-VER=1.23.5
-REL=1
+VER=1.24.0
 SRCS="git::commit=tags/v$VER::https://github.com/shadowsocks/shadowsocks-rust.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230992"


### PR DESCRIPTION
Topic Description
-----------------

- shadowsocks-rust: update to 1.24.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- shadowsocks-rust: 1.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadowsocks-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
