### PR TITLE
libcamera: rework rebuild and PKGBREAK

### DIFF
--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -7,7 +7,7 @@ PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         webrtc-audio-processing libcamera wireplumber"
 PKGRECOM="pipewire-jack"
 
-BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
+BUILDDEP="avahi doxygen graphviz meson ninja pulseaudio sdl2"
 
 # FIXME: Autobuild is not yet capable of generating Spiral markers for gstreamer1.0-* modules.
 PKGPROV="gstreamer1.0-pipewire_spiral"

--- a/app-multimedia/pipewire/autobuild/defines.stage2
+++ b/app-multimedia/pipewire/autobuild/defines.stage2
@@ -6,7 +6,7 @@ PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
         webrtc-audio-processing libcamera"
 
-BUILDDEP="avahi doxygen docutils graphviz meson ninja pulseaudio sdl2 sphinx"
+BUILDDEP="avahi doxygen graphviz meson ninja pulseaudio sdl2"
 
 # Must specify ABTYPE here because PipeWire owns Makefiles in the source root
 # to make building fairly straightforward as they say

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,5 @@
 VER=1.4.9
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -5,7 +5,8 @@ PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
         elfutils libunwind gstreamer glib gnutls qt-6 openssl libevent gtest"
 PKGDEP__ARM64="${PKGDEP} libpisp"
 BUILDDEP="jinja2 ply pyyaml"
-PKGBREAK="pipewire<=1.4.1"
+
+PKGBREAK="pipewire<=1.4.9-2"
 
 # Note: `-Dpipelines=auto` to let the project decide which pipelines to compile
 # for the host CPU architecture.

--- a/runtime-devices/libcamera/autobuild/defines.stage2
+++ b/runtime-devices/libcamera/autobuild/defines.stage2
@@ -5,7 +5,7 @@ PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
         elfutils libunwind gstreamer glib gnutls openssl libevent gtest"
 BUILDDEP="jinja2 ply pyyaml"
 
-PKGBREAK="pipewire<=1.4.1"
+PKGBREAK="pipewire<=1.4.9-2"
 
 # Note: `-Dpipelines=auto` to let the project decide which pipelines to compile
 # for the host CPU architecture.

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,5 @@
 VER=0.6.0
+REL=1
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: rebuild for libcamera 0.6.0
- libcamera: update PKGBREAK

Package(s) Affected
-------------------

- libcamera: 0.6.0-1
- pipewire: 1.4.9-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera:-pkgbreak pipewire libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
