### PR TITLE
v4l2loopback: update to 0.15.3

### DIFF
--- a/app-utils/v4l2loopback/spec
+++ b/app-utils/v4l2loopback/spec
@@ -1,4 +1,4 @@
-VER=0.15.2
+VER=0.15.3
 SRCS="git::commit=tags/v${VER}::https://github.com/v4l2loopback/v4l2loopback.git"
 CHKSUMS="SKIP"
 


### PR DESCRIPTION
Topic Description
-----------------

- v4l2loopback: update to 0.15.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- v4l2loopback: 0.15.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit v4l2loopback
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
