### PR TITLE
broadcom-wl: update to 6.30.223.271-10

### DIFF
--- a/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
+++ b/runtime-kernel/broadcom-wl/autobuild/dkms.conf.in
@@ -23,12 +23,13 @@ PATCH[15]="017-linux612.patch"
 PATCH[16]="018-linux613.patch"
 PATCH[17]="019-linux614.patch"
 PATCH[18]="020-linux615.patch"
+PATCH[19]="021-linux617.patch"
 # Debian patches
 # https://packages.debian.org/sid/broadcom-sta-dkms
-PATCH[19]="05-remove-time-and-date-macros.patch"
-PATCH[20]="33-wl-Add-explanation-for-IBT-warnings-in-newer-kernels.patch"
-PATCH[21]="37-wl-Fix-memcpy-field-spanning-write-warning.patch"
+PATCH[20]="05-remove-time-and-date-macros.patch"
+PATCH[21]="33-wl-Add-explanation-for-IBT-warnings-in-newer-kernels.patch"
+PATCH[22]="37-wl-Fix-memcpy-field-spanning-write-warning.patch"
 # AOSC OS patches
-PATCH[22]="aosc-1-wlan-ifname.patch"
-PATCH[23]="aosc-2-blob-path.patch"
+PATCH[23]="aosc-1-wlan-ifname.patch"
+PATCH[24]="aosc-2-blob-path.patch"
 AUTOINSTALL="yes"

--- a/runtime-kernel/broadcom-wl/autobuild/patches/021-linux617.patch
+++ b/runtime-kernel/broadcom-wl/autobuild/patches/021-linux617.patch
@@ -1,0 +1,75 @@
+diff -Nurp a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+--- a/src/wl/sys/wl_cfg80211_hybrid.c	2025-10-03 03:51:20.992964139 +0200
++++ b/src/wl/sys/wl_cfg80211_hybrid.c	2025-10-03 04:03:06.124451834 +0200
+@@ -68,7 +68,11 @@ wl_cfg80211_scan(struct wiphy *wiphy,
+ static s32 wl_cfg80211_scan(struct wiphy *wiphy, struct net_device *ndev,
+            struct cfg80211_scan_request *request);
+ #endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, s32 radio_idx, u32 changed);
++#else
+ static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed);
++#endif
+ static s32 wl_cfg80211_join_ibss(struct wiphy *wiphy, struct net_device *dev,
+            struct cfg80211_ibss_params *params);
+ static s32 wl_cfg80211_leave_ibss(struct wiphy *wiphy, struct net_device *dev);
+@@ -87,7 +91,10 @@ static int wl_cfg80211_connect(struct wi
+            struct cfg80211_connect_params *sme);
+ static s32 wl_cfg80211_disconnect(struct wiphy *wiphy, struct net_device *dev, u16 reason_code);
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++           s32 radio_idx, enum nl80211_tx_power_setting type, s32 dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32
+ wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                          enum nl80211_tx_power_setting type, s32 dbm);
+@@ -99,7 +106,10 @@ static s32 wl_cfg80211_set_tx_power(stru
+            enum tx_power_setting type, s32 dbm);
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 radio_idx,
++           u32 /*link_id*/, s32 *dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, u32 /*link_id*/, s32 *dbm);
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm);
+@@ -659,7 +669,11 @@ static s32 wl_set_retry(struct net_devic
+ 	return err;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, s32 radio_idx, u32 changed)
++#else
+ static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
++#endif
+ {
+ 	struct wl_cfg80211_priv *wl = wiphy_to_wl(wiphy);
+ 	struct net_device *ndev = wl_to_ndev(wl);
+@@ -1093,7 +1107,10 @@ wl_cfg80211_disconnect(struct wiphy *wip
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++           s32 radio_idx, enum nl80211_tx_power_setting type, s32 dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32
+ wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                          enum nl80211_tx_power_setting type, s32 dbm)
+@@ -1154,7 +1171,10 @@ wl_cfg80211_set_tx_power(struct wiphy *w
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 radio_idx,
++           u32 /*link_id*/, s32 *dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, u32 /*link_id*/, s32 *dbm)
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm)

--- a/runtime-kernel/broadcom-wl/spec
+++ b/runtime-kernel/broadcom-wl/spec
@@ -1,5 +1,5 @@
 VER=6.30.223.271
-REL=9
+REL=10
 SRCS="tbl::https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/hybrid-v35_64-nodebug-pcoem-${VER//./_}.tar.gz"
 CHKSUMS="sha256::5f79774d5beec8f7636b59c0fb07a03108eef1e3fd3245638b20858c714144be"
 SUBDIR=.


### PR DESCRIPTION
Bring in latest patch from Arch Linux for Linux 6.17

Topic Description
-----------------

broadcom-wl-6.30.223.271-10
Proprietary Broadcom WiFi driver updated for Linux v6.17

Package(s) Affected
-------------------

runtime-kernel/broadcom-wl

Security Update?
----------------

No

Build Order
-----------

```
#buildit broadcom-wl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
