### PR TITLE
fvm: update to 4.0.5

### DIFF
--- a/lang-dart/fvm/spec
+++ b/lang-dart/fvm/spec
@@ -1,4 +1,4 @@
-VER=4.0.4
+VER=4.0.5
 SRCS="git::commit=tags/$VER::https://github.com/leoafarias/fvm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379051"


### PR DESCRIPTION
Topic Description
-----------------

- fvm: update to 4.0.5
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- fvm: 4.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit fvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
