### PR TITLE
opentofu: update to 1.11.2

### DIFF
--- a/app-admin/opentofu/spec
+++ b/app-admin/opentofu/spec
@@ -1,5 +1,4 @@
-VER=1.10.6
-REL=1
+VER=1.11.2
 SRCS="git::commit=tags/v${VER}::https://github.com/opentofu/opentofu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371292"


### PR DESCRIPTION
Topic Description
-----------------

- opentofu: update to 1.11.2
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- opentofu: 1.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentofu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
