### PR TITLE
renderdoc: update to 1.42

### DIFF
--- a/app-devel/renderdoc/autobuild/defines
+++ b/app-devel/renderdoc/autobuild/defines
@@ -6,6 +6,6 @@ PKGDES="Stand-alone graphics API debugging tool for Vulkan and OpenGL"
 
 CMAKE_AFTER="-DBUILD_VERSION_STABLE=ON \
              -DPYSIDE2_PACKAGE_INIT_PY=/usr/lib/python${ABPY3VER}/site-packages/PySide2/__init__.py"
-FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|riscv64)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|loongarch64_nosimd|riscv64)"
 # FIXME: LTO breaks binary
 NOLTO=1

--- a/app-devel/renderdoc/spec
+++ b/app-devel/renderdoc/spec
@@ -1,4 +1,4 @@
-VER=1.41
+VER=1.42
 SRCS="git::commit=tags/v$VER::https://github.com/baldurk/renderdoc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14973"


### PR DESCRIPTION
Topic Description
-----------------

- renderdoc: update to 1.42
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- renderdoc: 1.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit renderdoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
