### PR TITLE
fcitx5-configtool: update to 5.1.11

### DIFF
--- a/app-i18n/fcitx5-configtool/01-configtool/patches/0001-Revert-Drop-Qt5-code.patch
+++ b/app-i18n/fcitx5-configtool/01-configtool/patches/0001-Revert-Drop-Qt5-code.patch
@@ -1,6 +1,6 @@
-From ce57960447fe171e8d94a60f349805782e4217a2 Mon Sep 17 00:00:00 2001
-From: Kaiyang Wu <self@origincode.me>
-Date: Fri, 20 Jun 2025 04:02:26 -0700
+From 3c2de9cfe83949674b83dda9791cfef6305d9e22 Mon Sep 17 00:00:00 2001
+From: pugaizai <i@pugai.life>
+Date: Sat, 20 Dec 2025 22:19:17 +0800
 Subject: [PATCH] Revert "Drop Qt5 code"
 
 This reverts commit 8b4600faaaf817f22f48f279591b1cb126127bd2.
@@ -35,13 +35,13 @@ This reverts commit 8b4600faaaf817f22f48f279591b1cb126127bd2.
  src/kcm/package/contents/ui/utils.js          |  29 ++
  src/kcm/package/metadata.json                 |  46 +++
  src/lib/configlib/addonmodel.cpp              |   4 +
- src/lib/configlib/model.cpp                   |  14 +
+ src/lib/configlib/model.cpp                   |  62 +++
  src/lib/configwidgetslib/addonselector.cpp    |  12 +
  src/lib/configwidgetslib/listoptionwidget.cpp |   8 +
  src/lib/configwidgetslib/varianthelper.cpp    |   4 +
  src/plasmathemegenerator/CMakeLists.txt       |   5 +
  src/plasmathemegenerator/main.cpp             |  24 +-
- 36 files changed, 2084 insertions(+), 22 deletions(-)
+ 36 files changed, 2132 insertions(+), 22 deletions(-)
  create mode 100644 src/kcm/kcm_fcitx5.desktop.in
  create mode 100644 src/kcm/kcm_fcitx5_kservice.desktop.in
  create mode 100644 src/kcm/package/contents/ui/AddIMPage.qml
@@ -66,12 +66,12 @@ This reverts commit 8b4600faaaf817f22f48f279591b1cb126127bd2.
  create mode 100644 src/kcm/package/metadata.json
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 26c722f..3e03e01 100644
+index 7ebb7d4..72272f0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -13,13 +13,24 @@ endif()
  
- project(fcitx5-configtool VERSION 5.1.10)
+ project(fcitx5-configtool VERSION 5.1.11)
  
 +option(USE_QT6 "Build with Qt6" On)
 +
@@ -2376,15 +2376,18 @@ index 0000000..027adb6
 +    "X-Plasma-MainScript": "ui/main.qml"
 +}
 diff --git a/src/lib/configlib/addonmodel.cpp b/src/lib/configlib/addonmodel.cpp
-index 9147c04..16845ba 100644
+index 8f472d6..62036a0 100644
 --- a/src/lib/configlib/addonmodel.cpp
 +++ b/src/lib/configlib/addonmodel.cpp
-@@ -417,9 +417,13 @@ void launchExternalConfig(const QString &uri, WId wid) {
+@@ -420,12 +420,16 @@ void launchExternalConfig(const QString &uri, WId wid) {
          QProcess::startDetached(wrapperToUse, args);
      } else {
          // Assume this is a program path.
 +#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
          QStringList args = QProcess::splitCommand(uri);
+         if (args.isEmpty()) {
+             return;
+         }
          QString program = args.takeFirst();
          QProcess::startDetached(program, args);
 +#else
@@ -2394,34 +2397,56 @@ index 9147c04..16845ba 100644
  }
  
 diff --git a/src/lib/configlib/model.cpp b/src/lib/configlib/model.cpp
-index 5eec96a..1c19e7f 100644
+index a07689c..c183190 100644
 --- a/src/lib/configlib/model.cpp
 +++ b/src/lib/configlib/model.cpp
-@@ -103,8 +103,13 @@ static QString languageName(const QString &langCode) {
-             return langCode;
-         }
+@@ -145,6 +145,68 @@ QVariant CategorizedItemModel::data(const QModelIndex &index, int role) const {
+     return dataForItem(index, role);
+ }
  
++static QString languageName(const QString &langCode) {
++    if (langCode.isEmpty()) {
++        return _("Unknown");
++    } else if (langCode == "*")
++        return _("Multilingual");
++    else {
++        QLocale locale(langCode);
++        if (locale.language() == QLocale::C) {
++            // return lang code seems to be a better solution other than
++            // indistinguishable "unknown"
++            return langCode;
++        }
++
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-         const bool hasTerritory = (langCode.indexOf("_") != -1 &&
-                                    locale.territory() != QLocale::AnyTerritory);
++        const bool hasTerritory = (langCode.indexOf("_") != -1 &&
++                                   locale.territory() != QLocale::AnyTerritory);
 +#else
 +        const bool hasTerritory = langCode.indexOf("_") != -1 &&
 +                                  locale.country() != QLocale::AnyCountry;
 +#endif
-         QString languageName;
-         if (hasTerritory) {
-             languageName = locale.nativeLanguageName();
-@@ -121,12 +126,21 @@ static QString languageName(const QString &langCode) {
-         // QLocale will always assign a default country for us, check if our
-         // lang code
- 
++        QString languageName;
++        if (hasTerritory) {
++            languageName = locale.nativeLanguageName();
++        }
++        if (languageName.isEmpty()) {
++            languageName =
++                D_("iso_639",
++                   QLocale::languageToString(locale.language()).toUtf8());
++        }
++        if (languageName.isEmpty()) {
++            languageName = _("Other");
++        }
++        QString territoryName;
++        // QLocale will always assign a default country for us, check if our
++        // lang code
++
 +#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-         if (hasTerritory) {
-             territoryName = locale.nativeTerritoryName();
-             if (territoryName.isEmpty()) {
-                 territoryName = QLocale::territoryToString(locale.territory());
-             }
-         }
++        if (hasTerritory) {
++            territoryName = locale.nativeTerritoryName();
++            if (territoryName.isEmpty()) {
++                territoryName = QLocale::territoryToString(locale.territory());
++            }
++        }
 +#else
 +        if (hasTerritory) {
 +            territoryName = locale.nativeCountryName();
@@ -2430,9 +2455,20 @@ index 5eec96a..1c19e7f 100644
 +            }
 +        }
 +#endif
++
++        if (territoryName.isEmpty()) {
++            return languageName;
++        } else {
++            return QString(
++                       C_("%1 is language name, %2 is country name", "%1 (%2)"))
++                .arg(languageName, territoryName);
++        }
++    }
++}
++
+ AvailIMModel::AvailIMModel(QObject *parent) : CategorizedItemModel(parent) {}
  
-         if (territoryName.isEmpty()) {
-             return languageName;
+ QVariant AvailIMModel::dataForCategory(const QModelIndex &index,
 diff --git a/src/lib/configwidgetslib/addonselector.cpp b/src/lib/configwidgetslib/addonselector.cpp
 index dc75492..0fbc73d 100644
 --- a/src/lib/configwidgetslib/addonselector.cpp
@@ -2532,7 +2568,7 @@ index 3d9b280..d6ab597 100644
  
  install(TARGETS fcitx5-plasma-theme-generator DESTINATION ${CMAKE_INSTALL_BINDIR})
 diff --git a/src/plasmathemegenerator/main.cpp b/src/plasmathemegenerator/main.cpp
-index c94fae2..0060d16 100644
+index 105cd7e..b3ffa90 100644
 --- a/src/plasmathemegenerator/main.cpp
 +++ b/src/plasmathemegenerator/main.cpp
 @@ -7,9 +7,6 @@
@@ -2617,5 +2653,4 @@ index c94fae2..0060d16 100644
  };
  
 -- 
-2.49.0
-
+2.52.0

--- a/app-i18n/fcitx5-configtool/spec
+++ b/app-i18n/fcitx5-configtool/spec
@@ -1,4 +1,4 @@
-VER=5.1.10
+VER=5.1.11
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-configtool"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138233"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-configtool: update to 5.1.11
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- fcitx5-configtool: 1:5.1.11
- fcitx5-migrator: 1:5.1.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-configtool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
