### PR TITLE
extra-cmake-modules: Disable --fatal-warnings in linker flags

### DIFF
--- a/app-devel/extra-cmake-modules/autobuild/patches/0001-KDECompilerSettings-disable-fatal-warnings-in-linker.patch
+++ b/app-devel/extra-cmake-modules/autobuild/patches/0001-KDECompilerSettings-disable-fatal-warnings-in-linker.patch
@@ -1,0 +1,33 @@
+From 5853363e436c9ed8c1c9b2f81c2755edd343ea2e Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Sun, 21 Dec 2025 09:53:24 +0800
+Subject: [PATCH] KDECompilerSettings: disable --fatal-warnings in linker flags
+
+We now have GCS warnings spamming the terminal when linking to shared
+objects that don't come with GCS enabled. GCC 15 now default to enable
+GCS when branch protection is either set to 'standard' or 'gcs'.
+---
+ kde-modules/KDECompilerSettings.cmake | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/kde-modules/KDECompilerSettings.cmake b/kde-modules/KDECompilerSettings.cmake
+index cf551ca2..a21c309c 100644
+--- a/kde-modules/KDECompilerSettings.cmake
++++ b/kde-modules/KDECompilerSettings.cmake
+@@ -536,10 +536,9 @@ endfunction()
+ if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE) OR
+         (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT APPLE) OR
+         (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND NOT WIN32))
+-    # Linker warnings should be treated as errors
+-    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--fatal-warnings ${CMAKE_SHARED_LINKER_FLAGS}")
+-    set(CMAKE_MODULE_LINKER_FLAGS "-Wl,--fatal-warnings ${CMAKE_MODULE_LINKER_FLAGS}")
+-
++    # We now have GCS warnings scattering everywhere when linking with shared
++    # libraries that doesn't come with GCS enabled.
++    # Removing --fatal-warnings for the linker.
+     # Do not allow undefined symbols, even in non-symbolic shared libraries
+     # On OpenBSD we must disable this to allow the stuff to properly compile without explicit libc specification
+     if (NOT CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+-- 
+2.52.0
+

--- a/app-devel/extra-cmake-modules/spec
+++ b/app-devel/extra-cmake-modules/spec
@@ -1,4 +1,5 @@
 VER=5.115.0
+REL=1
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/extra-cmake-modules-$VER.tar.xz"
 CHKSUMS="sha256::ee3e35f6a257526b8995a086dd190528a8ef4b3854b1e457b8122701b0ce45ee"
 CHKUPDATE="anitya::id=8762"


### PR DESCRIPTION
Topic Description
-----------------

- extra-cmake-modules: disable --fatal-warnings for linker
    We now have GCS warnings when linking to shared objects that aren't
    built with GCS \(this is only being default since GCC 15\).

Package(s) Affected
-------------------

- extra-cmake-modules: 5.115.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit extra-cmake-modules
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
