### PR TITLE
psutils: update to 3.3.14

### DIFF
--- a/lang-python/psutils/autobuild/prepare
+++ b/lang-python/psutils/autobuild/prepare
@@ -2,5 +2,4 @@
 mkdir -v "${SRCDIR}"/.tempsrc
 mv -v "${SRCDIR}"/* "${SRCDIR}"/.tempsrc
 mv -v "${SRCDIR}"/.tempsrc "${SRCDIR}"/psutils_src
-mv -v "${SRCDIR}"/psutils_src/abqa*log "${SRCDIR}"
 mv -v "${SRCDIR}"/psutils_src/autobuild "${SRCDIR}"

--- a/lang-python/psutils/spec
+++ b/lang-python/psutils/spec
@@ -1,5 +1,4 @@
-VER=3.3.2
-REL=1
+VER=3.3.14
 SRCS="git::commit=v$VER::https://github.com/rrthomas/psutils.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12921"

--- a/lang-python/puremagic/spec
+++ b/lang-python/puremagic/spec
@@ -1,4 +1,4 @@
-VER=1.15
+VER=1.30
 SRCS="git::commit=$VER::https://github.com/cdgriffith/puremagic.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=86511"

--- a/lang-python/pypdf/spec
+++ b/lang-python/pypdf/spec
@@ -1,4 +1,4 @@
-VER=4.0.1
+VER=6.5.0
 SRCS="git::commit=$VER::https://github.com/py-pdf/pypdf.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=315408"


### PR DESCRIPTION
Topic Description
-----------------

- psutils: update to 3.3.14
    Signed-off-by: stydxm <stydxm@outlook.com>
- puremagic: update to 1.30
    Signed-off-by: stydxm <stydxm@outlook.com>
- pypdf: update to 6.4.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit pypdf puremagic psutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
