### PR TITLE
.NET SDK 10

### DIFF
--- a/lang-dotnet/dotnet10/01-source-built-artifacts/build
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/build
@@ -1,0 +1,61 @@
+arch=""
+mono=""
+
+if ab_match_arch amd64; then
+    arch=x64
+elif ab_match_arch arm64; then
+    arch=arm64
+elif ab_match_arch riscv64; then
+    arch=riscv64
+elif ab_match_arch ppc64el; then
+    arch=ppc64le
+    # Note: CoreCLR have no ppc64le support
+    mono="--use-mono-runtime"
+elif ab_match_arch loongarch64; then
+    # FIXME: compilation will fail when not using specific -march -mtune combination on LA464 CPU
+    # possible compiler bug, when happened will result in NPE in either ilc or crossgen2:
+    #   ilc throws System.NullReferenceException
+    #   corssgen2 exited with code 139 (SIGSEGV)
+    arch=loongarch64
+    CFLAGS=${CFLAGS/-mtune=la664/-mtune=loongarch64}
+    CXXFLAGS=${CXXFLAGS/-mtune=la664/-mtune=loongarch64}
+elif ab_match_arch loongarch64_nosimd; then
+    arch=loongarch64
+    CFLAGS=${CFLAGS/-mtune=loongarch64/-mtune=la464}
+    CXXFLAGS=${CXXFLAGS/-mtune=loongarch64/-mtune=la464}
+elif ab_match_arch loongarch64_nosimd; then
+    arch=loongarch64
+else
+    aberr "Unsupported architecture."
+fi
+
+abinfo "Installing build artifacts ..."
+temp=`mktemp -d`
+mkdir -pv "$temp"/artifacts
+tar -xzvf /opt/Private.SourceBuilt.Artifacts.* -C "$temp"/artifacts
+mkdir -pv "$temp"/prereqs/packages/archive/
+cp -v /opt/Private.SourceBuilt.Artifacts.* "$SRCDIR"/prereqs/packages/archive/
+
+abinfo "Preparing .NET SDK source build ..."
+"$SRCDIR"/prep-source-build.sh --no-sdk --no-artifacts --no-bootstrap \
+    --with-sdk /usr/lib/dotnet/ \
+    --with-packages "$temp"/artifacts/
+
+abinfo "Building .NET SDK for $arch ..."
+"$SRCDIR"/build.sh -sb --os linux --rid linux-$arch --arch $arch \
+    --branding release -v n \
+    --with-sdk /usr/lib/dotnet/ $mono
+
+abinfo "Collecting generated tarballs ..."
+mkdir -pv "$SRCDIR"/output
+tar -xzvf "$SRCDIR"/artifacts/assets/Release/dotnet-sdk-* -C "$SRCDIR"/output
+
+mkdir -pv "$PKGDIR"/opt/
+mv -v "$SRCDIR"/artifacts/assets/Release/Private.SourceBuilt.Artifacts.* \
+    "$PKGDIR"/opt/
+
+# Note: dotnet use different version number in SDK and runtime
+abinfo "Saving version info for later use ..."
+ls "$SRCDIR"/output/shared/Microsoft.NETCore.App > "$SRCDIR"/runtime-version.txt
+ls "$SRCDIR"/output/sdk > "$SRCDIR"/sdk-version.txt
+ls "$SRCDIR"/output/shared/Microsoft.AspNetCore.App > "$SRCDIR"/aspnet-version.txt

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/build
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/build
@@ -9,7 +9,7 @@ elif ab_match_arch riscv64; then
     arch=riscv64
 elif ab_match_arch ppc64el; then
     arch=ppc64le
-    # Note: CoreCLR have no ppc64le support
+    # Note: CoreCLR has no ppc64le support
     mono="--use-mono-runtime"
 elif ab_match_arch loongarch64; then
     # FIXME: compilation will fail when not using specific -march -mtune combination on LA464 CPU

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/build.stage2
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/build.stage2
@@ -1,0 +1,67 @@
+arch=""
+mono=""
+
+if ab_match_arch amd64; then
+    arch=x64
+elif ab_match_arch arm64; then
+    arch=arm64
+elif ab_match_arch riscv64; then
+    arch=riscv64
+elif ab_match_arch ppc64el; then
+    arch=ppc64le
+    # Note: CoreCLR have no ppc64le support
+    mono="--use-mono-runtime"
+elif ab_match_arch loongarch64; then
+    # FIXME: compilation will fail when not using specific -march -mtune combination on LA464 CPU
+    # possible compiler bug, when happened will result in NPE in either ilc or crossgen2:
+    #   ilc throws System.NullReferenceException
+    #   corssgen2 exited with code 139 (SIGSEGV)
+    arch=loongarch64
+    CFLAGS=${CFLAGS/-mtune=la664/-mtune=loongarch64}
+    CXXFLAGS=${CXXFLAGS/-mtune=la664/-mtune=loongarch64}
+elif ab_match_arch loongarch64_nosimd; then
+    arch=loongarch64
+    CFLAGS=${CFLAGS/-mtune=loongarch64/-mtune=la464}
+    CXXFLAGS=${CXXFLAGS/-mtune=loongarch64/-mtune=la464}
+else
+    aberr "Unsupported architecture."
+fi
+
+abinfo "Downloading bootstrap files ..."
+sdk_file=dotnet-sdk-10.0.100-linux-"$arch".tar.gz
+artifact_file=Private.SourceBuilt.Artifacts.10.0.100-rtm.linux-"$arch".tar.gz
+wget https://repo.aosc.io/aosc-repacks/dotnet-10/"$sdk_file"
+wget https://repo.aosc.io/aosc-repacks/dotnet-10/"$artifact_file"
+
+abinfo "Installing bootstrap .NET SDK ..."
+temp=`mktemp -d`
+mkdir -pv "$temp"/dotnet-sdk
+tar -xzvf $sdk_file -C "$temp"/dotnet-sdk
+mkdir -pv "$temp"/artifacts
+tar -xzvf $artifact_file -C "$temp"/artifacts
+mkdir -pv "$SRCDIR"/prereqs/packages/archive/
+cp -v $artifact_file "$SRCDIR"/prereqs/packages/archive/
+
+abinfo "Preparing .NET SDK source build ..."
+"$SRCDIR"/prep-source-build.sh --no-sdk --no-artifacts --no-bootstrap \
+    --with-sdk "$temp"/dotnet-sdk/ \
+    --with-packages "$temp"/artifacts/
+
+abinfo "Building .NET SDK for $arch ..."
+"$SRCDIR"/build.sh -sb --os linux --rid linux-$arch --arch $arch \
+    --branding release -v n \
+    --with-sdk "$temp"/dotnet-sdk/ $mono
+
+abinfo "Collecting generated tarballs ..."
+mkdir -pv "$SRCDIR"/output
+tar -xzvf "$SRCDIR"/artifacts/assets/Release/dotnet-sdk-* -C "$SRCDIR"/output
+
+mkdir -pv "$PKGDIR"/opt/
+mv -v "$SRCDIR"/artifacts/assets/Release/Private.SourceBuilt.Artifacts.* \
+    "$PKGDIR"/opt/
+
+# Note: dotnet use different version number in SDK and runtime
+abinfo "Saving version info for later use ..."
+ls "$SRCDIR"/output/shared/Microsoft.NETCore.App > "$SRCDIR"/runtime-version.txt
+ls "$SRCDIR"/output/sdk > "$SRCDIR"/sdk-version.txt
+ls "$SRCDIR"/output/shared/Microsoft.AspNetCore.App > "$SRCDIR"/aspnet-version.txt

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/defines
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/defines
@@ -1,0 +1,15 @@
+PKGNAME=dotnet-sdk-10.0-source-built-artifacts
+PKGSEC=devel
+PKGDES="Microsoft .NET source-built artifacts (version 10)"
+PKGDEP=""
+BUILDDEP="dotnet-sdk-10.0-source-built-artifacts dotnet-sdk-10.0 llvm"
+
+# FIXME: could not scrape payload in src/runtime/artifacts/obj/coreclr/linux.x64.Release/
+# vm/datadescriptor/CMakeFiles/cdac_contract_descriptor_temp.dir/__/__/debug/datadescriptor-shared/datadescriptor.cpp.o
+NOLTO=1
+USECLANG=1
+# Note: source built artifact itself is a tarball
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/defines.stage2
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/defines.stage2
@@ -1,0 +1,15 @@
+PKGNAME=dotnet-sdk-10.0-source-built-artifacts
+PKGSEC=devel
+PKGDES="Microsoft .NET source-built artifacts (version 10)"
+PKGDEP=""
+BUILDDEP="llvm"
+
+# FIXME: could not scrape payload in src/runtime/artifacts/obj/coreclr/linux.x64.Release/
+# vm/datadescriptor/CMakeFiles/cdac_contract_descriptor_temp.dir/__/__/debug/datadescriptor-shared/datadescriptor.cpp.o
+NOLTO=1
+USECLANG=1
+# Note: source built artifact itself is a tarball
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/patches/0001-add-packaging-document-and-script.patch
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/patches/0001-add-packaging-document-and-script.patch
@@ -1,0 +1,177 @@
+From 8adb902ba6464ef63e98bdc2b372a13b9a568b39 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Tue, 6 Jan 2026 05:33:20 +0800
+Subject: [PATCH 1/2] add packaging document and script
+
+---
+ aosc/bootstrap.sh | 53 +++++++++++++++++++++++++++++++++++
+ aosc/compile.sh   | 71 +++++++++++++++++++++++++++++++++++++++++++++++
+ aosc/readme.txt   | 18 ++++++++++++
+ 3 files changed, 142 insertions(+)
+ create mode 100755 aosc/bootstrap.sh
+ create mode 100755 aosc/compile.sh
+ create mode 100644 aosc/readme.txt
+
+diff --git a/aosc/bootstrap.sh b/aosc/bootstrap.sh
+new file mode 100755
+index 00000000000..71c3af3f26f
+--- /dev/null
++++ b/aosc/bootstrap.sh
+@@ -0,0 +1,53 @@
++arch=""
++src=""
++
++# arg parse begin
++help() {
++    echo "Usage: bootstrap.sh --arch ARCH --src SRC"
++    exit 2
++}
++parsed=$(getopt -o a:s: --long arch:,src: -- "$@")
++if [ "$?" != "0" ]; then
++    help
++fi
++
++eval set -- "$parsed"
++while :
++do
++    case "$1" in
++        --arch) arch="$2" ; shift 2 ;;
++        --src)  src="$2"  ; shift 2 ;;
++        --) shift; break ;;
++        *) echo "Unexpected option: $1"
++        help ;;
++    esac
++done
++
++if [[ -z "$arch" ]]; then
++    help
++fi
++
++if [[ -z "$src" ]]; then
++    help
++fi
++# arg parse end
++
++mono=""
++if [ "$arch" = "ppc64le" ]; then
++    mono="--use-mono-runtime"
++fi
++
++pushd .
++cd $src
++if [ "$arch" = "x64" ]; then
++    # x64 needn't cross compile
++    ./build.sh --prep -sb --os linux --rid linux-$arch --arch $arch
++else
++    # cross compile using microsoft provided toolchain
++    docker run --platform linux/amd64 --rm \
++    -v .:/dotnet -w /dotnet -e ROOTFS_DIR=/crossrootfs/$arch \
++    mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-$arch \
++    ./build.sh --prep -sb --os linux --rid linux-$arch --arch $arch $mono
++fi
++popd
++
+diff --git a/aosc/compile.sh b/aosc/compile.sh
+new file mode 100755
+index 00000000000..2c0159ccbac
+--- /dev/null
++++ b/aosc/compile.sh
+@@ -0,0 +1,71 @@
++arch=""
++src=""
++sdk=""
++artifact=""
++
++# arg parse begin
++help() {
++    echo "Usage: compile.sh --arch ARCH --src SRC --sdk SDK_TAR_GZ --artifact ARTIFACT_TAR_GZ"
++    exit 2
++}
++
++parsed=$(getopt -o a:s:k:t: --long arch:,src:,sdk:,artifact: -- "$@")
++if [ "$?" != "0" ]; then
++    help
++fi
++
++eval set -- "$parsed"
++while :
++do
++    case "$1" in
++        --arch)      arch="$2"      ; shift 2 ;;
++        --src)       src="$2"       ; shift 2 ;;
++        --sdk)       sdk="$2"       ; shift 2 ;;
++        --artifact)  artifact="$2"  ; shift 2 ;;
++        --) shift; break ;;
++        *) echo "Unexpected option: $1"
++        help ;;
++    esac
++done
++
++if [[ -z "$arch" ]]; then
++    help
++fi
++
++if [[ -z "$src" ]]; then
++    help
++fi
++
++if [[ -z "$sdk" ]]; then
++    help
++fi
++
++if [[ -z "$artifact" ]]; then
++    help
++fi
++# arg parse end
++
++mono=""
++if [ "$arch" = "ppc64le" ]; then
++    mono="--use-mono-runtime"
++fi
++
++temp=$(mktemp -d)
++mkdir -pv $temp/sdk
++mkdir -pv $temp/artifact
++
++tar -xzvf $sdk -C $temp/sdk
++tar -xzvf $artifact -C $temp/artifact
++
++# both this and prep-source-build.sh --with-package are required
++cp -v $artifact $src/prereqs/packages/archive/
++pushd .
++cd $src
++./prep-source-build.sh --no-sdk --no-artifacts --no-bootstrap \
++    --with-sdk $temp/sdk --with-packages $temp/artifact 
++
++./build.sh -sb --os linux --rid linux-$arch --arch $arch \
++    --with-sdk $temp/sdk $mono
++
++rm -rv $temp
++popd
+diff --git a/aosc/readme.txt b/aosc/readme.txt
+new file mode 100644
+index 00000000000..c5a5af95eda
+--- /dev/null
++++ b/aosc/readme.txt
+@@ -0,0 +1,18 @@
++1.  src              ==(bootstrap.sh)==> tar.gz     (on amd64)
++1a. tar.gz     + src ==(compile.sh  )==> tar.gz     (on native)
++2.  tar.gz     + src ==(build.stage2)==> stage2 deb (autobuild)
++3.  stage2 deb + src ==(build       )==> deb        (autobuild)
++3a. deb        + src ==(build       )==> deb        (autobuild)
++
++you should also read bootstrap.sh and compile.sh
++
++step 1a is unnecessary when bootstrap for build aosc package
++documented here just for ease of maintainence
++
++when update aosc package, only step 3a is needed
++
++build & build.stage2 is in aosc-os-abbs repo
++tar.gz include both dotnet-sdk and Private.SourceBuilt.Artifact
++upload tar.gz to https://repo.aosc.io/aosc-repacks/dotnet-10/ if necessary
++
++remember exclude these documents from patch
+-- 
+2.52.0
+

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/patches/0002-Comment-out-if-defs-that-cause-build-failure.patch
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/patches/0002-Comment-out-if-defs-that-cause-build-failure.patch
@@ -1,0 +1,42 @@
+From eff8f0ec9c51a8d96575986e94aab35c688829b3 Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Wed, 7 Jan 2026 10:53:58 +0800
+Subject: [PATCH 2/2] Comment out if-defs that cause build failure.
+
+Suggested-by: Armas Spann <zappel@simple-co.de>
+
+From https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-dotnet/dotnet-sdk/files/dotnet-sdk-9.0.108-libunwind.patch
+---
+ .../src/native/external/llvm-libunwind/src/Registers.hpp        | 2 +-
+ .../src/native/external/llvm-libunwind/src/UnwindCursor.hpp     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/runtime/src/native/external/llvm-libunwind/src/Registers.hpp b/src/runtime/src/native/external/llvm-libunwind/src/Registers.hpp
+index 5daa35a3241..2a9e8af5766 100644
+--- a/src/runtime/src/native/external/llvm-libunwind/src/Registers.hpp
++++ b/src/runtime/src/native/external/llvm-libunwind/src/Registers.hpp
+@@ -1951,7 +1951,7 @@ inline const char *Registers_ppc64::getRegisterName(int regNum) {
+ class _LIBUNWIND_HIDDEN Registers_arm64;
+ extern "C" void __libunwind_Registers_arm64_jumpto(Registers_arm64 *);
+ 
+-#if defined(_LIBUNWIND_USE_GCS)
++#if 0
+ extern "C" void *__libunwind_cet_get_jump_target() {
+   return reinterpret_cast<void *>(&__libunwind_Registers_arm64_jumpto);
+ }
+diff --git a/src/runtime/src/native/external/llvm-libunwind/src/UnwindCursor.hpp b/src/runtime/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
+index 1b1f032baf2..aaf30235e34 100644
+--- a/src/runtime/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
++++ b/src/runtime/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
+@@ -3086,7 +3086,7 @@ bool UnwindCursor<A, R>::isReadableAddr(const pint_t addr) const {
+ }
+ #endif
+ 
+-#if defined(_LIBUNWIND_USE_CET) || defined(_LIBUNWIND_USE_GCS)
++#if 0
+ extern "C" void *__libunwind_cet_get_registers(unw_cursor_t *cursor) {
+   AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
+   return co->get_registers();
+-- 
+2.52.0
+

--- a/lang-dotnet/dotnet10/02-runtime-deps/defines
+++ b/lang-dotnet/dotnet10/02-runtime-deps/defines
@@ -1,0 +1,10 @@
+PKGNAME=dotnet-runtime-deps-10.0
+PKGSEC=libs
+PKGDES="Meta-package containing runtime dependencies for .NET applications (version 10)"
+PKGDEP="glibc gcc-runtime krb5 zlib openssl icu"
+
+ABSTRIP=0
+ABTYPE=dummy
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/02-runtime-deps/prepare
+++ b/lang-dotnet/dotnet10/02-runtime-deps/prepare
@@ -1,0 +1,4 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/runtime-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER=$ver

--- a/lang-dotnet/dotnet10/03-host/build
+++ b/lang-dotnet/dotnet10/03-host/build
@@ -1,0 +1,84 @@
+# https://learn.microsoft.com/en-us/dotnet/core/distribution-packaging
+
+# <pkg> (ver): <content>
+#   <deps>
+#
+# sdk (sdk): 3,4,18,21
+#   runtime,aspnetcore-runtime,
+#   targeting-pack,aspnetcore-targeting-pack,netstandard-targeting-pack,
+#   apphost-pack,templates
+# sdk-aot (sdk): 19,20
+#   sdk
+# aspnetcore-runtime (aspnet): 6
+#   runtime
+# runtime-dep (runtime): null
+#   <distro specify>
+# runtime (runtime): 5
+#   hostfxr,runtime-dep
+# hostfxr (runtime): 2
+#   host
+# host (runtime): 1,8,9,10,16,22,23
+# apphost-pack (runtime): 13
+# targeting-pack (runtime): 12
+# aspnetcore-targeting-pack (aspnet): 11
+# netstandard-targeting-pack (netstd): 15 # no longer provided in sdk >= 10
+# templates (sdk): 17
+
+# {dotnet_root}            (0)
+#   dotnet                 (1)
+#   dnx                    (22)
+#   LICENSE.txt            (8)
+#   ThirdPartyNotices.txt  (8)
+#   host/fxr/<fxr>         (2)
+#   sdk/<sdk>              (3)
+#   sdk-manifests/<sdk feature band version>       (4)
+#   library-packs                                  (21)
+#   metadata/workloads/<sdk feature band version>  (4)
+#   template-packs                                 (4)
+#   packs
+#     Microsoft.AspNetCore.App.Ref/<aspnetcore ref>            (11)
+#     Microsoft.NETCore.App.Ref/<netcore ref>                  (12)
+#     Microsoft.NETCore.App.Host.<rid>/<apphost>               (13)
+#     Microsoft.WindowsDesktop.App.Ref/<desktop ref>           (14)
+#     NETStandard.Library.Ref/<netstandard>                    (15)
+#     Microsoft.NETCore.App.Runtime.<rid>/<runtime>            (18)
+#     Microsoft.AspNetCore.App.Runtime.<rid>/<aspnetcore>      (18)
+#     runtime.<rid>.Microsoft.DotNet.ILCompiler/<runtime>      (19)
+#     Microsoft.NETCore.App.Runtime.NativeAOT.<rid>/<runtime>  (20)
+#   shared/
+#     Microsoft.NETCore.App/<runtime>            (5)
+#     Microsoft.AspNetCore.App/<aspnetcore>      (6)
+#     Microsoft.AspNetCore.All/<aspnetcore>      (6)
+#     Microsoft.WindowsDesktop.App/<desktop app> (7)
+#   templates/<templates>                        (17)
+# /
+#   etc/dotnet/install_location     (16)
+#   usr/share/man/man1/dotnet.1.gz  (9)
+#   usr/bin/
+#     dotnet               (10)
+#     dnx                  (23)
+
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/runtime-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/bin
+install -dv "$PKGDIR"/usr/lib/dotnet
+install -dv "$PKGDIR"/usr/share/doc/dotnet-host
+install -dv "$PKGDIR"/usr/bin
+
+install -Dv "$SRCDIR"/output/ThirdPartyNotices.txt "$PKGDIR"/usr/share/doc/dotnet-host # 8
+install -Dv "$SRCDIR"/output/LICENSE.txt "$PKGDIR"/usr/share/doc/dotnet-host # 8
+
+
+# 16 see overrides
+install -Dv "$SRCDIR"/output/dotnet "$PKGDIR"/usr/lib/dotnet # 1
+ln -sv ../lib/dotnet/dotnet "$PKGDIR"/usr/bin/dotnet # 10
+install -Dv "$SRCDIR"/output/dnx "$PKGDIR"/usr/lib/dnx # 22
+ln -sv ../lib/dotnet/dnx "$PKGDIR"/usr/bin/dnx # 23
+
+abinfo "Installing manpages ..."
+install -dv "$PKGDIR"/usr/share/man/man1
+cp -v "$SRCDIR"/src/sdk/documentation/manpages/sdk/*.1 "$PKGDIR"/usr/share/man/man1 # 9

--- a/lang-dotnet/dotnet10/03-host/defines
+++ b/lang-dotnet/dotnet10/03-host/defines
@@ -1,0 +1,10 @@
+# Note: different SDK and runtime version shares same dotnet host by design
+# dotnet-host should always build from latest SDK source code
+
+PKGNAME=dotnet-host
+PKGSEC=libs
+PKGDES="Microsoft .NET Host"
+PKGDEP="glibc gcc-runtime"
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/03-host/defines
+++ b/lang-dotnet/dotnet10/03-host/defines
@@ -1,5 +1,5 @@
 # Note: different SDK and runtime version shares same dotnet host by design
-# dotnet-host should always build from latest SDK source code
+# dotnet-host should always be built from latest SDK source code
 
 PKGNAME=dotnet-host
 PKGSEC=libs

--- a/lang-dotnet/dotnet10/03-host/overrides/etc/dotnet/install_location
+++ b/lang-dotnet/dotnet10/03-host/overrides/etc/dotnet/install_location
@@ -1,0 +1,1 @@
+/usr/lib/dotnet

--- a/lang-dotnet/dotnet10/03-host/overrides/etc/profile.d/dotnet.sh
+++ b/lang-dotnet/dotnet10/03-host/overrides/etc/profile.d/dotnet.sh
@@ -1,0 +1,15 @@
+# https://learn.microsoft.com/dotnet/core/tools/telemetry
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# Set location for AppHost lookup	
+[ -z "$DOTNET_ROOT" ] && export DOTNET_ROOT=/usr/lib/dotnet
+
+# Add dotnet tools directory to PATH
+DOTNET_TOOLS_PATH="$HOME/.dotnet/tools"
+case "$PATH" in
+    *"$DOTNET_TOOLS_PATH"* ) true ;;
+    * ) PATH="$PATH:$DOTNET_TOOLS_PATH" ;;	
+esac
+# Extract self-contained executables under HOME
+# to avoid multi-user issues from using the default '/var/tmp'.
+[ -z "$DOTNET_BUNDLE_EXTRACT_BASE_DIR" ] && export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${XDG_CACHE_HOME:-"$HOME"/.cache}/dotnet_bundle_extract"

--- a/lang-dotnet/dotnet10/03-host/overrides/usr/share/bash-completion/completions/dotnet
+++ b/lang-dotnet/dotnet10/03-host/overrides/usr/share/bash-completion/completions/dotnet
@@ -1,0 +1,14 @@
+# https://learn.microsoft.com/dotnet/core/tools/enable-tab-autocomplete
+# bash parameter completion for the dotnet CLI
+
+function _dotnet_bash_complete()
+{
+  local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n' # On Windows you may need to use use IFS=$'\r\n'
+  local candidates
+
+  read -d '' -ra candidates < <(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)
+
+  read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
+}
+
+complete -f -F _dotnet_bash_complete dotnet

--- a/lang-dotnet/dotnet10/03-host/overrides/usr/share/fish/completions/dotnet
+++ b/lang-dotnet/dotnet10/03-host/overrides/usr/share/fish/completions/dotnet
@@ -1,0 +1,2 @@
+# https://learn.microsoft.com/dotnet/core/tools/enable-tab-autocomplete
+complete -f -c dotnet -a "(dotnet complete (commandline -cp))"

--- a/lang-dotnet/dotnet10/03-host/overrides/usr/share/zsh/site-functions/_dotnet
+++ b/lang-dotnet/dotnet10/03-host/overrides/usr/share/zsh/site-functions/_dotnet
@@ -1,0 +1,19 @@
+# https://learn.microsoft.com/dotnet/core/tools/enable-tab-autocomplete
+# zsh parameter completion for the dotnet CLI
+
+_dotnet_zsh_complete()
+{
+  local completions=("$(dotnet complete "$words")")
+
+  # If the completion list is empty, just continue with filename selection
+  if [ -z "$completions" ]
+  then
+    _arguments '*::arguments: _normal'
+    return
+  fi
+
+  # This is not a variable assignment, don't remove spaces!
+  _values = "${(ps:\n:)completions}"
+}
+
+compdef _dotnet_zsh_complete dotnet

--- a/lang-dotnet/dotnet10/04-hostfxr/build
+++ b/lang-dotnet/dotnet10/04-hostfxr/build
@@ -1,0 +1,8 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/runtime-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet
+mv -v "$SRCDIR"/output/host "$PKGDIR"/usr/lib/dotnet # 2

--- a/lang-dotnet/dotnet10/04-hostfxr/defines
+++ b/lang-dotnet/dotnet10/04-hostfxr/defines
@@ -1,0 +1,7 @@
+PKGNAME=dotnet-hostfxr-10.0
+PKGSEC=libs
+PKGDES="Microsoft .NET Host FX Resolver (version 10)"
+PKGDEP="dotnet-host"
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/05-runtime/build
+++ b/lang-dotnet/dotnet10/05-runtime/build
@@ -1,0 +1,8 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/aspnet-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet/shared
+mv -v "$SRCDIR"/output/shared/Microsoft.NETCore.App "$PKGDIR"/usr/lib/dotnet/shared # 5

--- a/lang-dotnet/dotnet10/05-runtime/defines
+++ b/lang-dotnet/dotnet10/05-runtime/defines
@@ -1,0 +1,7 @@
+PKGNAME=dotnet-runtime-10.0
+PKGSEC=libs
+PKGDES=".NET runtime (version 10)"
+PKGDEP="dotnet-hostfxr-10.0 dotnet-runtime-deps-10.0"
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/05-runtime/defines
+++ b/lang-dotnet/dotnet10/05-runtime/defines
@@ -3,5 +3,5 @@ PKGSEC=libs
 PKGDES=".NET runtime (version 10)"
 PKGDEP="dotnet-hostfxr-10.0 dotnet-runtime-deps-10.0"
 
-# FIXME: no upstream support on loongson3
+# FIXME: no upstream support for loongson3
 FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/06-aspnet-runtime/build
+++ b/lang-dotnet/dotnet10/06-aspnet-runtime/build
@@ -1,0 +1,10 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/aspnet-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet/shared
+mv -v "$SRCDIR"/output/shared/Microsoft.AspNetCore.App "$PKGDIR"/usr/lib/dotnet/shared # 6
+# Note: following directory is mentioned in Microsoft document but not exist in build result
+# mv -v "$SRCDIR"/output/shared/Microsoft.AspNetCore.All "$PKGDIR"/usr/lib/dotnet/shared # 6

--- a/lang-dotnet/dotnet10/06-aspnet-runtime/build
+++ b/lang-dotnet/dotnet10/06-aspnet-runtime/build
@@ -6,5 +6,6 @@ PKGVER="$ver"
 abinfo "Deploying files ..."
 install -dv "$PKGDIR"/usr/lib/dotnet/shared
 mv -v "$SRCDIR"/output/shared/Microsoft.AspNetCore.App "$PKGDIR"/usr/lib/dotnet/shared # 6
-# Note: following directory is mentioned in Microsoft document but not exist in build result
+# Note: following directory is mentioned in Microsoft document but does
+# not exist in build artifact.
 # mv -v "$SRCDIR"/output/shared/Microsoft.AspNetCore.All "$PKGDIR"/usr/lib/dotnet/shared # 6

--- a/lang-dotnet/dotnet10/06-aspnet-runtime/defines
+++ b/lang-dotnet/dotnet10/06-aspnet-runtime/defines
@@ -1,0 +1,10 @@
+PKGNAME=aspnetcore-runtime-10.0
+PKGSEC=devel
+PKGDES="Microsoft ASP.NET Core runtime (version 10)"
+PKGDEP="dotnet-runtime-10.0"
+
+# Note: .NET dll only, nothing to strip
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/06-aspnet-runtime/defines
+++ b/lang-dotnet/dotnet10/06-aspnet-runtime/defines
@@ -6,5 +6,5 @@ PKGDEP="dotnet-runtime-10.0"
 # Note: .NET dll only, nothing to strip
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
+# FIXME: no upstream support for loongson3
 FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/07-apphost-pack/build
+++ b/lang-dotnet/dotnet10/07-apphost-pack/build
@@ -1,0 +1,8 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/runtime-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet/packs
+mv -v "$SRCDIR"/output/packs/Microsoft.NETCore.App.Host.* "$PKGDIR"/usr/lib/dotnet/packs # 13

--- a/lang-dotnet/dotnet10/07-apphost-pack/defines
+++ b/lang-dotnet/dotnet10/07-apphost-pack/defines
@@ -1,0 +1,10 @@
+PKGNAME=dotnet-apphost-pack-10.0
+PKGSEC=libs
+PKGDES=".NET native application template (version 10)"
+PKGDEP=""
+
+# FIXME: conflict debug symbol with dotnet-sdk-10.0
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/07-apphost-pack/defines
+++ b/lang-dotnet/dotnet10/07-apphost-pack/defines
@@ -6,5 +6,5 @@ PKGDEP=""
 # FIXME: conflict debug symbol with dotnet-sdk-10.0
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
+# FIXME: no upstream support for loongson3
 FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/08-targeting-pack/build
+++ b/lang-dotnet/dotnet10/08-targeting-pack/build
@@ -1,0 +1,8 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/runtime-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet/packs
+mv -v "$SRCDIR"/output/packs/Microsoft.NETCore.App.Ref "$PKGDIR"/usr/lib/dotnet/packs # 12

--- a/lang-dotnet/dotnet10/08-targeting-pack/defines
+++ b/lang-dotnet/dotnet10/08-targeting-pack/defines
@@ -1,0 +1,10 @@
+PKGNAME=dotnet-targeting-pack-10.0
+PKGSEC=libs
+PKGDES=".NET API definition (version 10)"
+PKGDEP=""
+
+# Note: .NET dll only, nothing to strip
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/08-targeting-pack/defines
+++ b/lang-dotnet/dotnet10/08-targeting-pack/defines
@@ -6,5 +6,5 @@ PKGDEP=""
 # Note: .NET dll only, nothing to strip
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
+# FIXME: no upstream support for loongson3
 FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/09-aspnet-targeting-pack/build
+++ b/lang-dotnet/dotnet10/09-aspnet-targeting-pack/build
@@ -1,0 +1,8 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/aspnet-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet/packs
+mv -v "$SRCDIR"/output/packs/Microsoft.AspNetCore.App.Ref "$PKGDIR"/usr/lib/dotnet/packs # 11

--- a/lang-dotnet/dotnet10/09-aspnet-targeting-pack/defines
+++ b/lang-dotnet/dotnet10/09-aspnet-targeting-pack/defines
@@ -1,0 +1,10 @@
+PKGNAME=aspnetcore-targeting-pack-10.0
+PKGSEC=devel
+PKGDES="ASP.NET Core API definition (version 10)"
+PKGDEP="dotnet-targeting-pack-10.0"
+
+# Note: .NET dll only, nothing to strip
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/10-templates/build
+++ b/lang-dotnet/dotnet10/10-templates/build
@@ -1,0 +1,8 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/sdk-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet
+mv -v "$SRCDIR"/output/templates "$PKGDIR"/usr/lib/dotnet # 17

--- a/lang-dotnet/dotnet10/10-templates/defines
+++ b/lang-dotnet/dotnet10/10-templates/defines
@@ -1,0 +1,10 @@
+PKGNAME=dotnet-templates-10.0
+PKGSEC=devel
+PKGDES=".NET project templates (version 10)"
+PKGDEP=""
+
+# Note: .NET dll only, nothing to strip
+ABSTRIP=0
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/11-sdk/build
+++ b/lang-dotnet/dotnet10/11-sdk/build
@@ -1,0 +1,17 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/sdk-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet
+install -dv "$PKGDIR"/usr/lib/dotnet/packs
+mv -v "$SRCDIR"/output/sdk "$PKGDIR"/usr/lib/dotnet # 3
+mv -v "$SRCDIR"/output/sdk-manifests "$PKGDIR"/usr/lib/dotnet # 4
+# Note: exclude sdk-aot content
+mv -v "$SRCDIR"/output/packs/Microsoft.NETCore.App.Runtime.!(NativeAOT*) "$PKGDIR"/usr/lib/dotnet/packs # 18
+mv -v "$SRCDIR"/output/packs/Microsoft.AspNetCore.App.Runtime.* "$PKGDIR"/usr/lib/dotnet/packs # 18
+if ! ab_match_arch ppc64el; then
+    # Note: ppc64el use mono runtime
+    mv -v "$SRCDIR"/output/library-packs "$PKGDIR"/usr/lib/dotnet # 4
+fi

--- a/lang-dotnet/dotnet10/11-sdk/defines
+++ b/lang-dotnet/dotnet10/11-sdk/defines
@@ -1,0 +1,11 @@
+PKGNAME=dotnet-sdk-10.0
+PKGSEC=devel
+PKGDES="Microsoft .NET SDK (version 10)"
+PKGDEP="dotnet-runtime-10.0 aspnetcore-runtime-10.0 \
+    dotnet-targeting-pack-10.0 aspnetcore-targeting-pack-10.0 \
+    dotnet-apphost-pack-10.0 dotnet-templates-10.0"
+
+PKGPROV="dotnet10"
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="(loongson3)"

--- a/lang-dotnet/dotnet10/12-sdk-aot/build
+++ b/lang-dotnet/dotnet10/12-sdk-aot/build
@@ -1,0 +1,13 @@
+# Note: dotnet use different version number in SDK and runtime
+ver=$(cat "$SRCDIR"/sdk-version.txt)
+abinfo "Set version to $ver ..."
+PKGVER="$ver"
+
+abinfo "Deploying files ..."
+install -dv "$PKGDIR"/usr/lib/dotnet/packs
+chmod -v +x "$SRCDIR"/output/packs/runtime.*.Microsoft.DotNet.ILCompiler/10.*/tools/ilc
+mv -v "$SRCDIR"/output/packs/runtime.*.Microsoft.DotNet.ILCompiler "$PKGDIR"/usr/lib/dotnet/packs # 19
+
+chmod -v -x "$SRCDIR"/output/packs/Microsoft.NETCore.App.Runtime.NativeAOT.*/10.*/runtimes/linux-*/native/*.a
+chmod -v -x "$SRCDIR"/output/packs/Microsoft.NETCore.App.Runtime.NativeAOT.*/10.*/runtimes/linux-*/native/*.o
+mv -v "$SRCDIR"/output/packs/Microsoft.NETCore.App.Runtime.NativeAOT.* "$PKGDIR"/usr/lib/dotnet/packs # 20

--- a/lang-dotnet/dotnet10/12-sdk-aot/defines
+++ b/lang-dotnet/dotnet10/12-sdk-aot/defines
@@ -1,0 +1,13 @@
+PKGNAME=dotnet-sdk-aot-10.0
+PKGSEC=devel
+PKGDES="Microsoft .NET SDK NativeAOT compiler (version 10)"
+PKGDEP="dotnet-sdk-10.0"
+
+# FIXME: conflict debug symbol with dotnet-runtime-10.0
+ABSTRIP=0
+
+# Note: NativeAOT compiler ships static library to be linked with user program
+NOSTATIC=0
+
+# FIXME: no native aot support on ppc64el due to mono runtime
+FAIL_ARCH="(loongson3|ppc64el)"

--- a/lang-dotnet/dotnet10/spec
+++ b/lang-dotnet/dotnet10/spec
@@ -1,0 +1,3 @@
+VER=10.0.103
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/dotnet/dotnet.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- dotnet-sdk-10.0: new, 10.0.100

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-sdk-10.0-source-built-artifacts:+stage2 dotnet-sdk-10.0-source-built-artifacts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
