### PR TITLE
rclone: update to 1.72.1

### DIFF
--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -1,4 +1,4 @@
-VER=1.72.0
+VER=1.72.1
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"


### PR DESCRIPTION
Topic Description
-----------------

- rclone: update to 1.72.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- rclone: 1.72.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rclone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
