### PR TITLE
i3: update to 4.25

### DIFF
--- a/desktop-wm/i3/spec
+++ b/desktop-wm/i3/spec
@@ -1,4 +1,4 @@
-VER=4.24
+VER=4.25
 SRCS="tbl::https://i3wm.org/downloads/i3-$VER.tar.xz"
-CHKSUMS="sha256::5baefd0e5e78f1bafb7ac85deea42bcd3cbfe65f1279aa96f7e49661637ac981"
+CHKSUMS="sha256::7eebdef9b14a4f56242764d102c5a30507a97967f1507457e44ec4b775762e42"
 CHKUPDATE="anitya::id=1348"


### PR DESCRIPTION
Topic Description
-----------------

- i3: update to 4.25
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- i3: 4.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit i3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
