### PR TITLE
vtk: fix build with GCC15

### DIFF
--- a/app-scientific/vtk/autobuild/patches/0001-fix-gcc15-build.patch
+++ b/app-scientific/vtk/autobuild/patches/0001-fix-gcc15-build.patch
@@ -1,0 +1,17 @@
+# credits: https://bugs.gentoo.org/937734#c1
+@@ -, +, @@ 
+---
+ Utilities/octree/octree/octree_node.txx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+--- a/Utilities/octree/octree/octree_node.txx	
++++ a/Utilities/octree/octree/octree_node.txx	
+@@ -210,7 +210,7 @@ const octree_node<T_, d_, A_>& octree_node<T_, d_, A_>::operator[](int child) co
+   {
+     throw std::domain_error("Attempt to access children of an octree leaf node.");
+   }
+-  return this->_M_chilren[child];
++  return this->m_children[child];
+ }
+ 
+ /**\brief Return a reference to a child node.
+-- 

--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.3.0
-REL=13
+REL=14
 SRCS="tbl::https://www.vtk.org/files/release/${VER%.*}/VTK-$VER.tar.gz"
 CHKSUMS="sha256::fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9"
 CHKUPDATE="anitya::id=15084"


### PR DESCRIPTION
Topic Description
-----------------

- vtk: fix build with GCC15
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- vtk: 9.3.0-13

Security Update?
----------------

No

Build Order
-----------

```
#buildit vtk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
