### PR TITLE
samba: update to 4.23.4

### DIFF
--- a/app-network/samba/spec
+++ b/app-network/samba/spec
@@ -1,4 +1,4 @@
-VER=4.23.0
+VER=4.23.4
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
-CHKSUMS="sha256::b0cb963a63eb1515227f3779a46d3a7f790c1bbfeeb4b31fd43e405eefe7a3af"
+CHKSUMS="sha256::af429d078a86f1ce16d0d1ecee35c42a3610790b47b84468f31284a8c4060140"
 CHKUPDATE="anitya::id=4758"


### PR DESCRIPTION
Topic Description
-----------------

- samba: update to 4.23.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ldb: 2:4.23.4
- samba: 4.23.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit samba
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
