### PR TITLE
glew: update to 2.3.0

### DIFF
--- a/runtime-display/glew/spec
+++ b/runtime-display/glew/spec
@@ -1,5 +1,4 @@
-VER=2.2.0
-REL=5
+VER=2.3.0
 SRCS="tbl::https://sourceforge.net/projects/glew/files/glew/$VER/glew-$VER.tgz"
-CHKSUMS="sha256::d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1"
+CHKSUMS="sha256::b261a06dfc8b970e0a1974488530e58dd2390acf68acb05b45235cd6fb17a086"
 CHKUPDATE="anitya::id=7878"


### PR DESCRIPTION
Topic Description
-----------------

- glew: update to 2.3.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- glew: 2.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit glew
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
