### PR TITLE
qemu: update to 10.1.3

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,4 @@
-VER=10.1.2
-REL=1
+VER=10.1.3
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::9d75f331c1a5cb9b6eb8fd9f64f563ec2eab346c822cb97f8b35cd82d3f11479"
+CHKSUMS="sha256::fbaa7a0d7a9a1deb5695b125916746ec28fe0de6275d4454f3e3bbaf8b339b53"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 10.1.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qemu: 10.1.3
- qemu-aarch64-static: 10.1.3
- qemu-alpha-static: 10.1.3
- qemu-arm-static: 10.1.3
- qemu-armeb-static: 10.1.3
- qemu-guest-agent: 10.1.3
- qemu-i386-static: 10.1.3
- qemu-loongarch64-static: 10.1.3
- qemu-m68k-static: 10.1.3
- qemu-microblaze-static: 10.1.3
- qemu-microblazeel-static: 10.1.3
- qemu-mips-static: 10.1.3
- qemu-mips64-static: 10.1.3
- qemu-mips64el-static: 10.1.3
- qemu-mipsel-static: 10.1.3
- qemu-mipsn32-static: 10.1.3
- qemu-mipsn32el-static: 10.1.3
- qemu-or32-static: 10.1.3
- qemu-ppc-static: 10.1.3
- qemu-ppc64-static: 10.1.3
- qemu-ppc64le-static: 10.1.3
- qemu-riscv32-static: 10.1.3
- qemu-riscv64-static: 10.1.3
- qemu-s390x-static: 10.1.3
- qemu-sh4-static: 10.1.3
- qemu-sh4eb-static: 10.1.3
- qemu-sparc-static: 10.1.3
- qemu-sparc32plus-static: 10.1.3
- qemu-sparc64-static: 10.1.3
- qemu-user-static: 10.1.3
- qemu-x86-64-static: 10.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
