### PR TITLE
xournalpp: update to 1.3.1

### DIFF
--- a/app-doc/qpdf/autobuild/defines
+++ b/app-doc/qpdf/autobuild/defines
@@ -3,4 +3,9 @@ PKGDES="Command-line programs and library for handling PDF files"
 PKGSEC=libs
 PKGDEP="zlib libjpeg-turbo gnutls openssl"
 
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_STATIC_LIBS=0'
+)
+
 PKGBREAK="libcupsfilters<=2.0.0 pikepdf<=8.15.1"

--- a/app-doc/qpdf/spec
+++ b/app-doc/qpdf/spec
@@ -1,4 +1,5 @@
 VER=12.2.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/qpdf/qpdf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5542"

--- a/runtime-productivity/xournalpp/autobuild/defines
+++ b/runtime-productivity/xournalpp/autobuild/defines
@@ -1,10 +1,11 @@
 PKGNAME=xournalpp
-PKGDES="Handwriting notetaking software"
-PKGDEP="gtk-3 gtksourceview-4 poppler libxml2 libzip portaudio libsndfile librsvg lua-5.4"
+PKGDES="Handwriting note-taking software"
+PKGDEP="gtk-3 gtksourceview-4 poppler libxml2 libzip portaudio \
+        libsndfile librsvg lua-5.4 qpdf"
 PKGSEC=utils
 
 ABTYPE=cmakeninja
-CMAKE_AFTER=" \
-          -DLUA_INCLUDE_DIR=/usr/include/lua5.4 \
-          -DLUA_LIBRARY=/usr/lib/liblua-5.4.so \
-"
+CMAKE_AFTER=(
+    '-DLUA_INCLUDE_DIR=/usr/include/lua5.4'
+    '-DLUA_LIBRARY=/usr/lib/liblua-5.4.so'
+)

--- a/runtime-productivity/xournalpp/spec
+++ b/runtime-productivity/xournalpp/spec
@@ -1,5 +1,4 @@
-VER=1.2.5
-REL=1
+VER=1.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/xournalpp/xournalpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57279"


### PR DESCRIPTION
Topic Description
-----------------

- qpdf: do not build static libraries
    This avoids CMake configuration errors as we purge static libraries by
    default. They were not useful anyway.
- xournalpp: update to 1.3.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qpdf: 12.2.0-1
- xournalpp: 1.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qpdf xournalpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
