### PR TITLE
nmap: update to 7.98

### DIFF
--- a/app-network/nmap/autobuild/beyond
+++ b/app-network/nmap/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing uninstall_ndiff ..."
-rm -v "$PKGDIR"/usr/bin/uninstall_ndiff

--- a/app-network/nmap/spec
+++ b/app-network/nmap/spec
@@ -1,4 +1,4 @@
-VER=7.95
+VER=7.98
 SRCS="tbl::https://nmap.org/dist/nmap-$VER.tar.bz2"
-CHKSUMS="sha256::e14ab530e47b5afd88f1c8a2bac7f89cd8fe6b478e22d255c5b9bddb7a1c5778"
+CHKSUMS="sha256::ce847313eaae9e5c9f21708e42d2ab7b56c7e0eb8803729a3092f58886d897e6"
 CHKUPDATE="anitya::id=2096"


### PR DESCRIPTION
Topic Description
-----------------

- nmap: update to 7.98
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nmap: 7.98

Security Update?
----------------

No

Build Order
-----------

```
#buildit nmap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
