### PR TITLE
clash-verge-service-ipc: update to 2.0.26

### DIFF
--- a/app-proxy/clash-verge-service-ipc/spec
+++ b/app-proxy/clash-verge-service-ipc/spec
@@ -1,3 +1,3 @@
-VER=2.0.25
-SRCS="git::commit=v"$VER"::https://github.com/clash-verge-rev/clash-verge-service-ipc"
+VER=2.0.26
+SRCS="git::commit=tags/v"$VER"::https://github.com/clash-verge-rev/clash-verge-service-ipc"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-service-ipc: update to 2.0.26
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- clash-verge-service-ipc: 2.0.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-service-ipc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
