### PR TITLE
vlc: update to 3.0.23+2

### DIFF
--- a/app-multimedia/vlc/autobuild/patches/0001-configure-fix-linking-on-RISC-V-ISA.patch
+++ b/app-multimedia/vlc/autobuild/patches/0001-configure-fix-linking-on-RISC-V-ISA.patch
@@ -1,4 +1,4 @@
-From 4e67adb0839d95c09178eadc1cebc3b3bc07851a Mon Sep 17 00:00:00 2001
+From 897a0832ad72cfb9fd30dc3b07221fac6f2fb16b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
 Date: Sat, 16 Jun 2018 21:31:45 +0300
 Subject: [PATCH 1/2] configure: fix linking on RISC-V ISA
@@ -8,7 +8,7 @@ Subject: [PATCH 1/2] configure: fix linking on RISC-V ISA
  1 file changed, 1 insertion(+)
 
 diff --git a/configure.ac b/configure.ac
-index 0a898d1c76..db003b6462 100644
+index f4a0a02a21..69487883ee 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -113,6 +113,7 @@ case "${host_os}" in

--- a/app-multimedia/vlc/autobuild/patches/0002-Do-not-generate-cache-during-build.patch
+++ b/app-multimedia/vlc/autobuild/patches/0002-Do-not-generate-cache-during-build.patch
@@ -1,4 +1,4 @@
-From 9e0d1e0bf462c4a90f3a5a0c67c61b6da9980d87 Mon Sep 17 00:00:00 2001
+From 0db073f96e6cd1c8e5a187948a2bed2b38861a8d Mon Sep 17 00:00:00 2001
 From: Sebastian Ramacher <sramacher@debian.org>
 Date: Tue, 7 Jul 2020 00:18:39 +0200
 Subject: [PATCH 2/2] Do not generate cache during build

--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,4 +1,5 @@
-VER=3.0.22
-SRCS="tbl::https://get.videolan.org/vlc/$VER/vlc-$VER.tar.xz"
-CHKSUMS="sha256::e2cc1cf0ae0902a09da5a37c249a8a4e4b5ec4dc095443b8e1493c6a7cc138ea"
+UPSTREAM_VER=3.0.23-2
+VER=${UPSTREAM_VER/-/+}
+SRCS="git::copy-repo=true;commit=tags/${UPSTREAM_VER}::https://github.com/videolan/vlc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6504"


### PR DESCRIPTION
Topic Description
-----------------

- vlc: update to 3.0.23+2
    Track patches at AOSC-Tracking/vlc @ aosc/3.0.23-2
    \(HEAD: 0db073f96e6cd1c8e5a187948a2bed2b38861a8d\).

Package(s) Affected
-------------------

- vlc: 3.0.23+2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vlc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
