### PR TITLE
libva: update to 2.23.0

### DIFF
--- a/runtime-multimedia/libva/spec
+++ b/runtime-multimedia/libva/spec
@@ -1,4 +1,4 @@
-VER=2.22.0
+VER=2.23.0
 SRCS="git::commit=tags/$VER::https://github.com/intel/libva"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1752"


### PR DESCRIPTION
Topic Description
-----------------

- libva: update to 2.23.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- libva: 2.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libva
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
