### PR TITLE
xh: new, 0.25.3

### DIFF
--- a/app-web/xh/autobuild/beyond
+++ b/app-web/xh/autobuild/beyond
@@ -1,0 +1,6 @@
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/doc/xh.1 \
+    "$PKGDIR"/usr/share/man/man1/xh.1
+abinfo "Create symlinks for xhs ..."
+ln -sfv ./xh "$PKGDIR"/usr/bin/xhs
+ln -sfv ./xh.1.xz "$PKGDIR"/usr/share/man/man1/xhs.1.xz

--- a/app-web/xh/autobuild/defines
+++ b/app-web/xh/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME="xh"
+PKGDES="Command-line HTTP request sender"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="rustc llvm"
+PKGSEC="net"
+ABTYPE="rust"
+USECLANG=1

--- a/app-web/xh/spec
+++ b/app-web/xh/spec
@@ -1,0 +1,4 @@
+VER=0.25.3
+SRCS="git::commit=tags/v${VER}::https://github.com/ducaale/xh"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=180023"


### PR DESCRIPTION
Topic Description
-----------------

- xh: new, 0.25.3

Package(s) Affected
-------------------

- xh: 0.25.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit xh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
