### PR TITLE
tuwunel: update to 1.7.1

### DIFF
--- a/app-web/tuwunel/autobuild/defines
+++ b/app-web/tuwunel/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="tuwunel"
 PKGSEC=web
 PKGDES="Matrix homeserver implementation"
-PKGDEP="glibc liburing gcc-runtime"
+PKGDEP="glibc liburing gcc-runtime jemalloc"
 BUILDDEP="rustc llvm"
 PKGSUG="nginx caddy"
 
@@ -10,6 +10,3 @@ CARGO_AFTER="--all-features"
 
 # FIXME: disable LTO, for rocksdb symbol not found
 NOLTO=1
-
-# FIXME: force use clang for aws-lc-rs not found on loongson3
-USECLANG__LOONGSON3=1

--- a/app-web/tuwunel/autobuild/defines
+++ b/app-web/tuwunel/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="tuwunel"
 PKGSEC=web
 PKGDES="Matrix homeserver implementation"
-PKGDEP="glibc liburing gcc-runtime"
+PKGDEP="glibc liburing gcc-runtime jemalloc"
 BUILDDEP="rustc llvm"
 PKGSUG="nginx caddy"
 
@@ -11,5 +11,5 @@ CARGO_AFTER="--all-features"
 # FIXME: disable LTO, for rocksdb symbol not found
 NOLTO=1
 
-# FIXME: force use clang for aws-lc-rs not found on loongson3
-USECLANG__LOONGSON3=1
+# FIXME: force use clang for someone 
+#USECLANG=1

--- a/app-web/tuwunel/autobuild/patches/0001-NO-AWS-LC-RS-INVERSION.patch
+++ b/app-web/tuwunel/autobuild/patches/0001-NO-AWS-LC-RS-INVERSION.patch
@@ -1,0 +1,159 @@
+From 849b5bf03474801bf24ca96deb002dbc818153d6 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
+Date: Tue, 23 Dec 2025 18:36:42 +0800
+Subject: [PATCH] NO AWS-LC-RS INVERSION
+
+---
+ Cargo.lock                 | 29 +++++++++++++++--------------
+ Cargo.toml                 |  4 ++--
+ src/service/globals/mod.rs |  4 ++--
+ 3 files changed, 19 insertions(+), 18 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 36058ed0..7549ba29 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -147,9 +147,9 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+ 
+ [[package]]
+ name = "asn1-rs"
+-version = "0.7.1"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
++checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+ dependencies = [
+  "asn1-rs-derive",
+  "asn1-rs-impl",
+@@ -157,15 +157,15 @@ dependencies = [
+  "nom 7.1.3",
+  "num-traits",
+  "rusticata-macros",
+- "thiserror 2.0.17",
++ "thiserror 1.0.69",
+  "time",
+ ]
+ 
+ [[package]]
+ name = "asn1-rs-derive"
+-version = "0.6.0"
++version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
++checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -1146,9 +1146,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "der-parser"
+-version = "10.0.0"
++version = "9.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
++checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+ dependencies = [
+  "asn1-rs",
+  "displaydoc",
+@@ -2302,7 +2302,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+ [[package]]
+ name = "lber"
+ version = "0.4.3"
+-source = "git+https://github.com/matrix-construct/ldap3?rev=fdfbba2bf916b53e5f73cdb1a495ebb649978079#fdfbba2bf916b53e5f73cdb1a495ebb649978079"
++source = "git+https://github.com/matrix-construct/ldap3?rev=7d423314b9dbc66347284e38fc2b78c3d8f3d494#7d423314b9dbc66347284e38fc2b78c3d8f3d494"
+ dependencies = [
+  "bytes",
+  "nom 7.1.3",
+@@ -2311,7 +2311,7 @@ dependencies = [
+ [[package]]
+ name = "ldap3"
+ version = "0.11.3"
+-source = "git+https://github.com/matrix-construct/ldap3?rev=fdfbba2bf916b53e5f73cdb1a495ebb649978079#fdfbba2bf916b53e5f73cdb1a495ebb649978079"
++source = "git+https://github.com/matrix-construct/ldap3?rev=7d423314b9dbc66347284e38fc2b78c3d8f3d494#7d423314b9dbc66347284e38fc2b78c3d8f3d494"
+ dependencies = [
+  "async-trait",
+  "bytes",
+@@ -2322,6 +2322,7 @@ dependencies = [
+  "log",
+  "nom 7.1.3",
+  "percent-encoding",
++ "ring",
+  "rustls",
+  "rustls-native-certs",
+  "thiserror 1.0.69",
+@@ -2943,9 +2944,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "oid-registry"
+-version = "0.8.1"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
++checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+ dependencies = [
+  "asn1-rs",
+ ]
+@@ -5933,9 +5934,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+ 
+ [[package]]
+ name = "x509-parser"
+-version = "0.18.0"
++version = "0.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
++checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+ dependencies = [
+  "asn1-rs",
+  "data-encoding",
+@@ -5944,7 +5945,7 @@ dependencies = [
+  "nom 7.1.3",
+  "oid-registry",
+  "rusticata-macros",
+- "thiserror 2.0.17",
++ "thiserror 1.0.69",
+  "time",
+ ]
+ 
+diff --git a/Cargo.toml b/Cargo.toml
+index 9fe89268..f86907ce 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -242,7 +242,7 @@ features = ["use_pem"]
+ 
+ [workspace.dependencies.ldap3]
+ git = "https://github.com/matrix-construct/ldap3"
+-rev = "fdfbba2bf916b53e5f73cdb1a495ebb649978079"
++rev = "7d423314b9dbc66347284e38fc2b78c3d8f3d494"
+ default-features = false
+ features = ["sync", "tls-rustls"]
+ 
+@@ -364,7 +364,7 @@ features = [
+ [workspace.dependencies.rustls]
+ version = "0.23"
+ default-features = false
+-features = ["aws_lc_rs", "logging", "tls12", "prefer-post-quantum"]
++features = ["ring", "logging", "tls12"]
+ 
+ [workspace.dependencies.rustyline-async]
+ version = "0.4.6"
+diff --git a/src/service/globals/mod.rs b/src/service/globals/mod.rs
+index 927f9320..0f7e2356 100644
+--- a/src/service/globals/mod.rs
++++ b/src/service/globals/mod.rs
+@@ -133,10 +133,10 @@ pub async fn get_registration_tokens(&self) -> HashSet<String> {
+ 
+ 	pub fn init_rustls_provider(&self) -> Result {
+ 		if rustls::crypto::CryptoProvider::get_default().is_none() {
+-			rustls::crypto::aws_lc_rs::default_provider()
++			rustls::crypto::ring::default_provider()
+ 				.install_default()
+ 				.map_err(|_provider| {
+-					err!(error!("Error initialising aws_lc_rs rustls crypto backend"))
++					err!(error!("Error initialising ring rustls crypto backend"))
+ 				})
+ 		} else {
+ 			Ok(())
+-- 
+2.52.0
+

--- a/app-web/tuwunel/autobuild/patches/0001-use-ring-instead-of-aws-lc-rs.patch
+++ b/app-web/tuwunel/autobuild/patches/0001-use-ring-instead-of-aws-lc-rs.patch
@@ -1,0 +1,52 @@
+From 75360ec57de885e378350bea62c06fededc111bf Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <i@lain.vg>
+Date: Sun, 7 Jun 2026 20:00:33 +0800
+Subject: [PATCH 1/2] use ring instead of aws-lc-rs
+
+---
+ Cargo.toml                 | 4 ++--
+ src/service/globals/mod.rs | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 44cb3f8b..0572faea 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -250,7 +250,7 @@ features = [
+ 
+ [workspace.dependencies.ldap3]
+ git = "https://github.com/matrix-construct/ldap3"
+-rev = "fdfbba2bf916b53e5f73cdb1a495ebb649978079"
++rev = "7d423314b9dbc66347284e38fc2b78c3d8f3d494"
+ default-features = false
+ features = ["sync", "tls-rustls"]
+ 
+@@ -406,7 +406,7 @@ features = ["server"]
+ [workspace.dependencies.rustls]
+ version = "0.23"
+ default-features = false
+-features = ["aws_lc_rs", "logging", "tls12", "prefer-post-quantum"]
++features = ["ring", "logging", "tls12"]
+ 
+ [workspace.dependencies.rustyline-async]
+ version = "0.4.6"
+diff --git a/src/service/globals/mod.rs b/src/service/globals/mod.rs
+index fb48acf5..52e43c54 100644
+--- a/src/service/globals/mod.rs
++++ b/src/service/globals/mod.rs
+@@ -108,10 +108,10 @@ pub fn is_read_only(&self) -> bool { self.db.db.is_read_only() }
+ 
+ 	pub fn init_rustls_provider(&self) -> Result {
+ 		if rustls::crypto::CryptoProvider::get_default().is_none() {
+-			rustls::crypto::aws_lc_rs::default_provider()
++			rustls::crypto::ring::default_provider()
+ 				.install_default()
+ 				.map_err(|_provider| {
+-					err!(error!("Error initialising aws_lc_rs rustls crypto backend"))
++					err!(error!("Error initialising ring rustls crypto backend"))
+ 				})
+ 		} else {
+ 			Ok(())
+-- 
+2.52.0
+

--- a/app-web/tuwunel/autobuild/patches/0002-update-Cargo.lock-for-patching.patch
+++ b/app-web/tuwunel/autobuild/patches/0002-update-Cargo.lock-for-patching.patch
@@ -1,0 +1,185 @@
+From 9a52ee3d0b18cfae9893c992184722b98be04022 Mon Sep 17 00:00:00 2001
+From: "Lain \"Fearyncess\" Yang" <i@lain.vg>
+Date: Sun, 7 Jun 2026 20:01:08 +0800
+Subject: [PATCH 2/2] update Cargo.lock for patching
+
+---
+ Cargo.lock | 45 +++++++++++++++++++++++----------------------
+ 1 file changed, 23 insertions(+), 22 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 39b67c56..eb307edc 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -115,9 +115,9 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+ 
+ [[package]]
+ name = "asn1-rs"
+-version = "0.7.2"
++version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
++checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+ dependencies = [
+  "asn1-rs-derive",
+  "asn1-rs-impl",
+@@ -125,15 +125,15 @@ dependencies = [
+  "nom",
+  "num-traits",
+  "rusticata-macros",
+- "thiserror 2.0.18",
++ "thiserror 1.0.69",
+  "time",
+ ]
+ 
+ [[package]]
+ name = "asn1-rs-derive"
+-version = "0.6.0"
++version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
++checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -1148,9 +1148,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "der-parser"
+-version = "10.0.0"
++version = "9.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
++checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+ dependencies = [
+  "asn1-rs",
+  "displaydoc",
+@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+ dependencies = [
+  "libc",
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -2368,7 +2368,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+ [[package]]
+ name = "lber"
+ version = "0.4.3"
+-source = "git+https://github.com/matrix-construct/ldap3?rev=fdfbba2bf916b53e5f73cdb1a495ebb649978079#fdfbba2bf916b53e5f73cdb1a495ebb649978079"
++source = "git+https://github.com/matrix-construct/ldap3?rev=7d423314b9dbc66347284e38fc2b78c3d8f3d494#7d423314b9dbc66347284e38fc2b78c3d8f3d494"
+ dependencies = [
+  "bytes",
+  "nom",
+@@ -2377,7 +2377,7 @@ dependencies = [
+ [[package]]
+ name = "ldap3"
+ version = "0.11.3"
+-source = "git+https://github.com/matrix-construct/ldap3?rev=fdfbba2bf916b53e5f73cdb1a495ebb649978079#fdfbba2bf916b53e5f73cdb1a495ebb649978079"
++source = "git+https://github.com/matrix-construct/ldap3?rev=7d423314b9dbc66347284e38fc2b78c3d8f3d494#7d423314b9dbc66347284e38fc2b78c3d8f3d494"
+ dependencies = [
+  "async-trait",
+  "bytes",
+@@ -2388,6 +2388,7 @@ dependencies = [
+  "log",
+  "nom",
+  "percent-encoding",
++ "ring",
+  "rustls",
+  "rustls-native-certs",
+  "thiserror 1.0.69",
+@@ -2733,7 +2734,7 @@ version = "0.50.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+ dependencies = [
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -3033,9 +3034,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "oid-registry"
+-version = "0.8.1"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
++checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+ dependencies = [
+  "asn1-rs",
+ ]
+@@ -4050,7 +4051,7 @@ dependencies = [
+  "errno",
+  "libc",
+  "linux-raw-sys",
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -4109,7 +4110,7 @@ dependencies = [
+  "security-framework",
+  "security-framework-sys",
+  "webpki-root-certs",
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -4646,7 +4647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+ dependencies = [
+  "libc",
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -4776,10 +4777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+ dependencies = [
+  "fastrand",
+- "getrandom 0.3.4",
++ "getrandom 0.4.2",
+  "once_cell",
+  "rustix",
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -6010,7 +6011,7 @@ version = "0.1.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+ dependencies = [
+- "windows-sys 0.61.2",
++ "windows-sys 0.60.2",
+ ]
+ 
+ [[package]]
+@@ -6365,9 +6366,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+ 
+ [[package]]
+ name = "x509-parser"
+-version = "0.18.1"
++version = "0.16.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
++checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+ dependencies = [
+  "asn1-rs",
+  "data-encoding",
+@@ -6376,7 +6377,7 @@ dependencies = [
+  "nom",
+  "oid-registry",
+  "rusticata-macros",
+- "thiserror 2.0.18",
++ "thiserror 1.0.69",
+  "time",
+ ]
+ 
+-- 
+2.52.0
+

--- a/app-web/tuwunel/autobuild/prepare
+++ b/app-web/tuwunel/autobuild/prepare
@@ -1,4 +1,2 @@
-# FIXME: Use lld to workaround aws-lc-rs discovery issue.
-if ab_match_arch loongson3; then
-        export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"
-fi
+abinfo "Setting JEMALLOC_OVERRIDE for using system libjemalloc..."
+export JEMALLOC_OVERRIDE="/usr/lib/libjemalloc.so"

--- a/app-web/tuwunel/autobuild/prepare
+++ b/app-web/tuwunel/autobuild/prepare
@@ -1,4 +1,6 @@
 # FIXME: Use lld to workaround aws-lc-rs discovery issue.
-if ab_match_arch loongson3; then
-        export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"
-fi
+#if ab_match_arch loongson3; then
+#        export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"
+#fi
+
+export JEMALLOC_OVERRIDE="/usr/lib/libjemalloc.so"

--- a/app-web/tuwunel/spec
+++ b/app-web/tuwunel/spec
@@ -1,4 +1,4 @@
-VER=1.4.5
+VER=1.7.1
 SRCS="git::commit=tags/v${VER}::https://github.com/matrix-construct/tuwunel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=386525"

--- a/app-web/tuwunel/spec
+++ b/app-web/tuwunel/spec
@@ -1,4 +1,4 @@
-VER=1.4.5
+VER=1.4.8
 SRCS="git::commit=tags/v${VER}::https://github.com/matrix-construct/tuwunel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=386525"


### PR DESCRIPTION
Topic Description
-----------------

- tuwunel: update to 1.7.1

Package(s) Affected
-------------------

- tuwunel: 1.7.1
Security Update?
----------------

No

Build Order
-----------

```
#buildit tuwunel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
