### PR TITLE
opencv: remove wrong PKGBREAK

### DIFF
--- a/runtime-scientific/opencv/autobuild/defines
+++ b/runtime-scientific/opencv/autobuild/defines
@@ -9,7 +9,7 @@ BUILDDEP="apache-ant beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
           swig v4l-utils vulkan-headers"
 PKGDES="Open Source Computer Vision Library"
 
-PKGBREAK="digikam<=8.6.0 emukit<=20240730 frei0r-plugins<=2.3.3 gmic<=3.2.6-1 \
+PKGBREAK="digikam<=8.6.0 frei0r-plugins<=2.3.3 gmic<=3.2.6-1 \
           gstreamer<=1.26.8 mlt<=7.32.0 openimageio<=2.5.19.1 \
           spectacle<=22.12.3-1"
 

--- a/runtime-scientific/opencv/autobuild/defines.stage2
+++ b/runtime-scientific/opencv/autobuild/defines.stage2
@@ -3,13 +3,13 @@ PKGSEC=libs
 PKGDEP="clp coinutils freetype gdal gst-plugins-base-1-0 harfbuzz hdf5 \
         libdc1394 libjpeg-turbo libpng libtiff libva libwebp numpy openblas \
         openexr openjpeg protobuf python-3 qt-5 tbb tesseract vtk zlib json-c"
-BUILDDEP="beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
+PKGSUG="openjdk"
+BUILDDEP="apache-ant beautifulsoup4 eigen-3 gflags glog glu jasper lapack \
           libcl libglvnd libgphoto2 libraw1394 libtheora libtool libvorbis \
           swig v4l-utils vulkan-headers"
-BUILDDEP__RISCV64="${BUILDDEP/apache-ant/}"
 PKGDES="Open Source Computer Vision Library"
 
-PKGBREAK="digikam<=8.6.0 emukit<=20240730 frei0r-plugins<=2.3.3 gmic<=3.2.6-1 \
+PKGBREAK="digikam<=8.6.0 frei0r-plugins<=2.3.3 gmic<=3.2.6-1 \
           gstreamer<=1.26.8 mlt<=7.32.0 openimageio<=2.5.19.1 \
           spectacle<=22.12.3-1"
 
@@ -70,4 +70,3 @@ CMAKE_AFTER__RISCV64=(
 )
 
 NOSTATIC=0
-NOLTO__PPC64EL=1

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,4 +1,5 @@
 VER=4.12.0
+REL=1
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/opencv/opencv \
       git::commit=tags/$VER;copy-repo=true;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- opencv: remove wrong PKGBREAK
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- opencv: 4.12.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opencv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
