### PR TITLE
stellarium: update to 25.3

### DIFF
--- a/app-scientific/stellarium/autobuild/defines
+++ b/app-scientific/stellarium/autobuild/defines
@@ -1,5 +1,10 @@
 PKGNAME=stellarium
 PKGSEC=science
-PKGDEP="qt-5 zlib desktop-file-utils freetype glu xdg-utils gpsd"
-BUILDDEP="cmake graphviz doxygen appstream-glib boost"
-PKGDES="A stellarium with great graphics and a nice database of sky-objects"
+PKGDEP="qt-6 desktop-file-utils freetype glu xdg-utils gpsd zlib"
+BUILDDEP="graphviz appstream-glib boost"
+PKGDES="3D stellarium software"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DENABLE_QT6=ON"
+)

--- a/app-scientific/stellarium/autobuild/patches/0001-fix-build-with-qt-6.10.patch
+++ b/app-scientific/stellarium/autobuild/patches/0001-fix-build-with-qt-6.10.patch
@@ -1,0 +1,16 @@
+# https://gitlab.archlinux.org/archlinux/packaging/packages/stellarium/-/blob/main/qt-6.10.patch?ref_type=heads
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3d8d1e906f..a735474f34 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -822,6 +822,9 @@ IF(ENABLE_XLSX)
+      # version exports "QXlsxQt5" (or ...Qt6) instead. Try both, but
+      # download newer one, because 1.4.4 doesn't link on windows when
+      # added via add_subdirectory().
++     if(Qt${QT_VERSION_MAJOR}_VERSION VERSION_GREATER_EQUAL 6.10)
++         find_package(Qt${QT_VERSION_MAJOR} COMPONENTS GuiPrivate)
++     endif()
+      FIND_PACKAGE(QXlsx NAMES QXlsxQt${QT_VERSION_MAJOR} QXlsx QUIET)
+      IF(QXlsx_FOUND)
+           MESSAGE(STATUS "Using system-provided QXlsx ${QXlsx_VERSION}")

--- a/app-scientific/stellarium/spec
+++ b/app-scientific/stellarium/spec
@@ -1,4 +1,5 @@
-VER=24.3
-SRCS="tbl::https://github.com/Stellarium/stellarium/releases/download/v$VER/stellarium-$VER.tar.gz"
-CHKSUMS="sha256::c3ffb56a049061c7754bafab176146a2c4474ecede108d650f3c7551e1eae50a"
+VER=25.3
+SRCS="git::commit=tags/v$VER::https://github.com/Stellarium/stellarium.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4891"
+ENVREQ="total_mem_per_core=1"


### PR DESCRIPTION
Topic Description
-----------------

- stellarium: update to 25.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- stellarium: 25.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit stellarium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
