### PR TITLE
matugen: Fix build on loongson3

### DIFF
--- a/app-utils/matugen/autobuild/defines
+++ b/app-utils/matugen/autobuild/defines
@@ -5,3 +5,6 @@ BUILDDEP="rustc llvm"
 PKGDES="Tool to manage Material You color palettes"
 
 ABTYPE=rust
+
+# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol
+NOLTO__LOONGSON3=1

--- a/app-utils/matugen/spec
+++ b/app-utils/matugen/spec
@@ -1,4 +1,5 @@
 VER=3.1.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/InioX/matugen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=340788"


### PR DESCRIPTION
Topic Description
-----------------

- matugen: Disable lto on loongson3 fix ld.lld error

Package(s) Affected
-------------------

- matugen: 3.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit matugen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
