### PR TITLE
qemu: update to 10.2.0

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,5 +1,4 @@
-VER=10.1.2
-REL=1
+VER=10.2.0
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::9d75f331c1a5cb9b6eb8fd9f64f563ec2eab346c822cb97f8b35cd82d3f11479"
+CHKSUMS="sha256::9e30ad1b8b9f7b4463001582d1ab297f39cfccea5d08540c0ca6d6672785883a"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 10.2.0
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- qemu: 10.2.0
- qemu-aarch64-static: 10.2.0
- qemu-alpha-static: 10.2.0
- qemu-arm-static: 10.2.0
- qemu-armeb-static: 10.2.0
- qemu-guest-agent: 10.2.0
- qemu-i386-static: 10.2.0
- qemu-loongarch64-static: 10.2.0
- qemu-m68k-static: 10.2.0
- qemu-microblaze-static: 10.2.0
- qemu-microblazeel-static: 10.2.0
- qemu-mips-static: 10.2.0
- qemu-mips64-static: 10.2.0
- qemu-mips64el-static: 10.2.0
- qemu-mipsel-static: 10.2.0
- qemu-mipsn32-static: 10.2.0
- qemu-mipsn32el-static: 10.2.0
- qemu-or32-static: 10.2.0
- qemu-ppc-static: 10.2.0
- qemu-ppc64-static: 10.2.0
- qemu-ppc64le-static: 10.2.0
- qemu-riscv32-static: 10.2.0
- qemu-riscv64-static: 10.2.0
- qemu-s390x-static: 10.2.0
- qemu-sh4-static: 10.2.0
- qemu-sh4eb-static: 10.2.0
- qemu-sparc-static: 10.2.0
- qemu-sparc32plus-static: 10.2.0
- qemu-sparc64-static: 10.2.0
- qemu-user-static: 10.2.0
- qemu-x86-64-static: 10.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
