### PR TITLE
oma: update to 1.23.1

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.23.0
+VER=1.23.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.23.1.toml
+++ b/topics/oma-1.23.1.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.23.1"
+zh_CN = "小熊猫包管理 (oma) 1.23.1"
+
+[caution]
+default = "Improves compatibility with APT's `Optional' configuration for repository metadata, fixing metadta refreshing with CrowdSec's repository (and maybe others), also fixes path completion for `oma provides'"
+zh_CN = "增强对 APT `Optional' 配置字段的兼容性，修复无法从 CrowdSec 等软件源刷新元数据的问题，并为 `oma provides' 命令添加了路径补全功能"
+
+[packages-v2]
+"oma" = "< 1.23.1"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.23.1

Package(s) Affected
-------------------

- oma: 1.23.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



