### PR TITLE
lbrowser: new, 3.4.2039.0

### DIFF
--- a/app-web/lbrowser/autobuild/build
+++ b/app-web/lbrowser/autobuild/build
@@ -1,0 +1,22 @@
+abinfo "Unpacking .deb package ..."
+dpkg -x "$SRCDIR"/lbrowser.deb \
+    "$PKGDIR"/
+
+abinfo "Patching up hard-coded paths in data files ..."
+cd "$PKGDIR"/
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.build
+
+abinfo "Moving lbrowser directory to a more compliant location ..."
+mkdir -pv "$PKGDIR"/usr/lib
+mv -v "$PKGDIR"/opt/apps/lbrowser \
+    "$PKGDIR"/usr/lib/
+rm -rv "$PKGDIR"/opt
+
+abinfo "Re-creating a symlink for /usr/bin/lbrowser ..."
+rm -v "$PKGDIR"/usr/bin/lbrowser
+ln -sv ../lib/lbrowser/lbrowser.sh \
+    "$PKGDIR"/usr/bin/lbrowser
+chmod -v +x "$PKGDIR"/usr/bin/lbrowser
+
+abinfo "Setting executable bit for bundled libraries ..."
+chmod -v +x "$PKGDIR"/usr/lib/lbrowser/*.so*

--- a/app-web/lbrowser/autobuild/defines
+++ b/app-web/lbrowser/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=lbrowser
+PKGSEC=web
+PKGDEP="alsa-lib at-spi2-core ca-certs cairo cups curl dbus expat \
+        gdk-pixbuf gtk-2 gtk-4 libxcb mesa nspr nss pango pulseaudio \
+        systemd wget x11-lib xdg-utils"
+PKGRECOM="vulkan"
+PKGDES="Web browser from Loongson Technology"
+
+# Note: Binary packaging.
+FAIL_ARCH="!(amd64|arm64|loongarch64)"
+ABSTRIP=0

--- a/app-web/lbrowser/autobuild/patches/0001-AOSCOS-fix-up-hard-coded-paths.patch.build
+++ b/app-web/lbrowser/autobuild/patches/0001-AOSCOS-fix-up-hard-coded-paths.patch.build
@@ -1,0 +1,50 @@
+diff -Naur a/opt/apps/lbrowser/default-app-block b/opt/apps/lbrowser/default-app-block
+--- a/opt/apps/lbrowser/default-app-block	2025-12-11 02:42:29.000000000 +0800
++++ b/opt/apps/lbrowser/default-app-block	2025-12-29 01:09:52.117182270 +0800
+@@ -1,10 +1,10 @@
+     <web-browser>
+       <name>龙芯浏览器</name>
+-      <executable>/opt/apps/lbrowser/lbrowser.sh</executable>
+-      <command>/opt/apps/lbrowser/lbrowser.sh %s</command>
++      <executable>/usr/bin/lbrowser</executable>
++      <command>/usr/bin/lbrowser %s</command>
+       <icon-name>lbrowser</icon-name>
+       <run-in-terminal>false</run-in-terminal>
+       <netscape-remote>true</netscape-remote>
+-      <tab-command>/opt/apps/lbrowser/lbrowser.sh %s</tab-command>
+-      <win-command>/opt/apps/lbrowser/lbrowser.sh --new-window %s</win-command>
++      <tab-command>/usr/bin/lbrowser %s</tab-command>
++      <win-command>/usr/bin/lbrowser --new-window %s</win-command>
+     </web-browser>
+diff -Naur a/usr/share/gnome-control-center/default-apps/lbrowser.xml b/usr/share/gnome-control-center/default-apps/lbrowser.xml
+--- a/usr/share/gnome-control-center/default-apps/lbrowser.xml	2025-12-11 02:42:29.000000000 +0800
++++ b/usr/share/gnome-control-center/default-apps/lbrowser.xml	2025-12-29 01:10:33.530031193 +0800
+@@ -8,13 +8,13 @@
+   <web-browsers>
+     <web-browser>
+       <name>龙芯浏览器</name>
+-      <executable>/opt/apps/lbrowser/lbrowser.sh</executable>
+-      <command>/opt/apps/lbrowser/lbrowser.sh %s</command>
++      <executable>/usr/bin/lbrowser</executable>
++      <command>/usr/bin/lbrowser %s</command>
+       <icon-name>lbrowser</icon-name>
+       <run-in-terminal>false</run-in-terminal>
+       <netscape-remote>true</netscape-remote>
+-      <tab-command>/opt/apps/lbrowser/lbrowser.sh %s</tab-command>
+-      <win-command>/opt/apps/lbrowser/lbrowser.sh --new-window %s</win-command>
++      <tab-command>/usr/bin/lbrowser %s</tab-command>
++      <win-command>/usr/bin/lbrowser --new-window %s</win-command>
+     </web-browser>
+   </web-browsers>
+ </default-apps>
+diff -Naur a/usr/share/menu/lbrowser.menu b/usr/share/menu/lbrowser.menu
+--- a/usr/share/menu/lbrowser.menu	2025-12-11 02:42:31.000000000 +0800
++++ b/usr/share/menu/lbrowser.menu	2025-12-29 01:10:18.915309037 +0800
+@@ -2,5 +2,5 @@
+   section="Applications/Network/Web Browsing" \
+   hints="Web browsers" \
+   title="龙芯浏览器" \
+-  icon="/opt/apps/lbrowser/product_logo_32.xpm" \
+-  command="/opt/apps/lbrowser/lbrowser.sh"
++  icon="/usr/lib/lbrowser/product_logo_32.xpm" \
++  command="/usr/bin/lbrowser"

--- a/app-web/lbrowser/spec
+++ b/app-web/lbrowser/spec
@@ -1,0 +1,10 @@
+UPSTREAM_VER=3.4.2039.0
+DEBREL=1
+VER=${UPSTREAM_VER}+${DEBREL}
+SRCS__AMD64="file::rename=lbrowser.deb::https://ftp.loongnix.cn/browser/lbrowser/${UPSTREAM_VER}/amd64/lbrowser_${UPSTREAM_VER}-${DEBREL}.stable.amd64.deb"
+SRCS__ARM64="file::rename=lbrowser.deb::https://ftp.loongnix.cn/browser/lbrowser/${UPSTREAM_VER}/arm64/lbrowser_${UPSTREAM_VER}-${DEBREL}.stable.arm64.deb"
+SRCS__LOONGARCH64="file::rename=lbrowser.deb::https://ftp.loongnix.cn/browser/lbrowser/${UPSTREAM_VER}/la64/abi2.0/lbrowser_${UPSTREAM_VER}-${DEBREL}.stable.loong64.deb"
+CHKSUMS__AMD64="sha256::48e8268f937b3f4cdefaabbdae7d85a8bbf45983d0ad9d908cbe3d9b85ce0620"
+CHKSUMS__ARM64="sha256::ab828b006ee5431935e310012fa6dcb1792eaaa4a84d1d80cf525b3eaf0386d7"
+CHKSUMS__LOONGARCH64="sha256::853377baa8be3445e139c109bca61546386ef0f0b5488d7562279b522cfd81bb"
+CHKUPDATE="anitya::id=387847"


### PR DESCRIPTION
Topic Description
-----------------

- lbrowser: new, 3.4.2039.0

Package(s) Affected
-------------------

- lbrowser: 3.4.2039.0+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lbrowser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
