### PR TITLE
x11-lib: bump xtrans to 1.6.0

### DIFF
--- a/runtime-display/x11-lib/spec
+++ b/runtime-display/x11-lib/spec
@@ -1,6 +1,6 @@
 VER=7.7.20240731
 REL=2
-__XTRANS_VER=1.5.0
+__XTRANS_VER=1.6.0
 __LIBX11_VER=1.8.10
 __LIBXEXT_VER=1.3.5
 __LIBFS_VER=1.0.9
@@ -72,7 +72,7 @@ SRCS="tbl::${__BASE_URL}/xtrans-${__XTRANS_VER}.tar.gz \
       tbl::${__BASE_URL}/libXfont-${__LIBXFONT_VER}.tar.gz \
       tbl::${__BASE_URL}/libXp-${__LIBXP_VER}.tar.gz \
       tbl::${__BASE_URL}/libXpresent-${__LIBXPRESENT_VER}.tar.gz"
-CHKSUMS="sha256::a806f8a92f879dcd0146f3f1153fdffe845f2fc0df9b1a26c19312b7b0a29c86 \
+CHKSUMS="sha256::936b74c60b19c317c3f3cb1b114575032528dbdaf428740483200ea874c2ca0a \
          sha256::b7a1a90d881bb7b94df5cf31509e6b03f15c0972d3ac25ab0441f5fbc789650f \
          sha256::1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd \
          sha256::8bc2762f63178905228a28670539badcfa2c8793f7b6ce3f597b7741b932054a \


### PR DESCRIPTION
Topic Description
-----------------

- x11-lib: bump xtrans to 1.6.0
    Otherwise X server couldn't be built because of a Werror.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- x11-lib: 7.7.20240731-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit x11-lib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
