### PR TITLE
buildstream: new, 2.6.0

### DIFF
--- a/app-admin/buildbox/autobuild/defines
+++ b/app-admin/buildbox/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=buildbox
+PKGSEC=admin
+PKGDEP="abseil-cpp benchmark bubblewrap cmake curl fuse-3 gcc gcc-runtime \
+        gflags glibc glog grpc gtest libtomlplusplus make ninja nlohmann-json \
+        openssl protobuf pkgconf util-linux-runtime zlib"
+PKGDES="A set of tools for remote worker build execution"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DBUILDBOX_VERSION=$PKGVER"
+)

--- a/app-admin/buildbox/spec
+++ b/app-admin/buildbox/spec
@@ -1,0 +1,4 @@
+VER=1.3.44
+SRCS="git::commit=tags/$VER::https://gitlab.com/BuildGrid/buildbox/buildbox"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=373765"

--- a/app-admin/buildstream-plugins-community/autobuild/defines
+++ b/app-admin/buildstream-plugins-community/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=buildstream-plugins-community
+PKGSEC=admin
+PKGDEP="buildstream setuptools setuptools-scm"
+PKGDES="A collection of community-maintained plugins for the BuildStream project"
+PKGRECOM="android-platform-tools dpkg flatpak-builder git git-lfs llvm make \
+          ostree patch qt-5 qt-6 rustc snapd tar unzip zip"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/app-admin/buildstream-plugins-community/spec
+++ b/app-admin/buildstream-plugins-community/spec
@@ -1,0 +1,4 @@
+VER=2.1.1
+SRCS="pypi::version=$VER::buildstream-plugins-community"
+CHKSUMS="sha256::6cd10dc85ecb92dda926f60e67893571014fd7d739486d0d66233a03f8a5ca99"
+CHKUPDATE="anitya::id=66371"

--- a/app-admin/buildstream-plugins/autobuild/defines
+++ b/app-admin/buildstream-plugins/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=buildstream-plugins
+PKGSEC=admin
+PKGDEP="buildstream"
+BUILDDEP="cython"
+PKGDES="A collection of plugins for the BuildStream project"
+PKGRECOM="breezy cmake git git-lfs llvm make meson ninja rustc setuptools \
+          unzip zip"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/app-admin/buildstream-plugins/spec
+++ b/app-admin/buildstream-plugins/spec
@@ -1,0 +1,4 @@
+VER=2.5.0
+SRCS="pypi::version=$VER::buildstream-plugins"
+CHKSUMS="sha256::49c57dec88c0b4558f474520c2e29c69ecd42a1e5c07423baae5b29b153e54a6"
+CHKUPDATE="anitya::id=254248"

--- a/app-admin/buildstream/autobuild/defines
+++ b/app-admin/buildstream/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=buildstream
+PKGSEC=admin
+PKGDEP="buildbox click fuse-3 grpc importlib-metadata jinja2 lzip packaging \
+        patch pluginbase python-protobuf pypsutil pyroaring python-3 \
+        ruamel-yaml ruamel-yaml-clib tar ujson"
+BUILDDEP="cython setuptools"
+PKGRECOM="buildstream-plugins buildstream-plugins-community"
+PKGDES="A framework for modelling build pipelines in YAML"
+
+ABTYPE=pep517

--- a/app-admin/buildstream/autobuild/prepare
+++ b/app-admin/buildstream/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Building gRPC modules ..."
+"$SRCDIR"/setup.py build_grpc

--- a/app-admin/buildstream/spec
+++ b/app-admin/buildstream/spec
@@ -1,0 +1,4 @@
+VER=2.6.0
+SRCS="pypi::version=$VER::BuildStream"
+CHKSUMS="sha256::d6f835bab11dda88a3f213441768b1566e21a6c658913f0f0488fcf01a5c23bf"
+CHKUPDATE="anitya::id=65026"

--- a/lang-python/pyroaring/autobuild/defines
+++ b/lang-python/pyroaring/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pyroaring
+PKGSEC=python
+PKGDEP="gcc-runtime glibc python-3"
+BUILDDEP="setuptools cython"
+PKGDES="Python library for handling efficiently sorted integer sets"
+
+ABTYPE=pep517

--- a/lang-python/pyroaring/spec
+++ b/lang-python/pyroaring/spec
@@ -1,0 +1,4 @@
+VER=1.0.3
+SRCS="pypi::version=$VER::pyroaring"
+CHKSUMS="sha256::cd7392d1c010c9e41c11c62cd0610c8852e7e9698b1f7f6c2fcdefe50e7ef6da"
+CHKUPDATE="anitya::id=46692"


### PR DESCRIPTION
Topic Description
-----------------

- buildstream-plugins-community: new, 2.1.1
- buildstream-plugins: new, 2.5.0
- buildstream: new, 2.6.0
- buildbox: new, 1.3.44
- pyroaring: new, 1.0.3

Package(s) Affected
-------------------

- buildbox: 1.3.44
- buildstream: 2.6.0
- buildstream-plugins: 2.5.0
- buildstream-plugins-community: 2.1.1
- pyroaring: 1.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyroaring buildbox buildstream buildstream-plugins buildstream-plugins-community
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
