### PR TITLE
libsixel: update to 1.10.5

### DIFF
--- a/runtime-imaging/libsixel/spec
+++ b/runtime-imaging/libsixel/spec
@@ -1,4 +1,4 @@
-VER=1.8.7
+VER=1.10.5
 SRCS="git::commit=tags/v$VER::https://github.com/saitoha/libsixel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243242"


### PR DESCRIPTION
Topic Description
-----------------

- libsixel: update to 1.10.5
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- libsixel: 1.10.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsixel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
