### PR TITLE
bat: add missing dependency

### DIFF
--- a/app-utils/bat/autobuild/defines
+++ b/app-utils/bat/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=bat
-PKGDES="cat(1) clone with syntax highlighting and git integration"
+PKGDES="File display tool with syntax highlighting and Git integration"
+PKGDEP="gcc-runtime glibc libgit2"
 BUILDDEP="rustc llvm"
 PKGSEC="utils"
 
 USECLANG=1
+ABTYPE=rust

--- a/app-utils/bat/spec
+++ b/app-utils/bat/spec
@@ -1,4 +1,5 @@
 VER=0.26.0
+REL=1
 SRCS="git::commit=tags/v$VER;submodule=false;copy-repo=true::https://github.com/sharkdp/bat/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17642"


### PR DESCRIPTION
Topic Description
-----------------

- bat: add missing dependency

Package(s) Affected
-------------------

- bat: 0.26.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
