### PR TITLE
Multimedia Survey 20251223 +32 Rework

### DIFF
--- a/runtime-optenv32/libcdio+32/autobuild/defines
+++ b/runtime-optenv32/libcdio+32/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="aosc-aaa+32 libcddb+32 ncurses+32"
 BUILDDEP="devel-base+32"
 PKGDES="GNU compact disk input and control library (32-bit x86 runtime)"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-cpp-progs'
 )

--- a/runtime-optenv32/libcdio+32/autobuild/patches/0001-GENTOO-Do-not-use-LFS-shims-rely-on-_FILE_OFFSET_BIT.patch
+++ b/runtime-optenv32/libcdio+32/autobuild/patches/0001-GENTOO-Do-not-use-LFS-shims-rely-on-_FILE_OFFSET_BIT.patch
@@ -1,4 +1,4 @@
-From 12975e67d701daba390c1635439c9d2d31bdeab2 Mon Sep 17 00:00:00 2001
+From 4d94ddb2ea1bb6e3ea754ea54a4580c672201134 Mon Sep 17 00:00:00 2001
 From: Alfred Wingate <parona@protonmail.com>
 Date: Mon, 20 May 2024 22:02:08 +0300
 Subject: [PATCH] GENTOO: Do not use LFS shims, rely on _FILE_OFFSET_BITS=64
@@ -21,12 +21,12 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 6 insertions(+), 20 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 5f9f9e78..37e5928e 100644
+index 596316c0..41ac8c2f 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -561,10 +561,10 @@ AC_DEFINE_UNQUOTED(LIBCDIO_SOURCE_PATH, "$LIBCDIO_SOURCE_PATH",
- 	[Full path to libcdio top_sourcedir.])
- AC_SUBST(LIBCDIO_SOURCE_PATH)
+@@ -550,10 +550,10 @@ AC_SUBST(HAVE_SOLARIS_CDROM)
+ AC_SUBST(HAVE_WIN32_CDROM)
+ AC_SUBST(HAVE_OS2_CDROM)
  
 -AC_CHECK_FUNCS( [chdir drand48 fseeko fseeko64 ftruncate geteuid getgid \
 -		 getuid getpwuid gettimeofday lseek64 lstat memcpy memset mkstemp rand \
@@ -40,7 +40,7 @@ index 5f9f9e78..37e5928e 100644
  # check for timegm() support
  AC_CHECK_FUNC(timegm, AC_DEFINE(HAVE_TIMEGM,1,
 diff --git a/lib/driver/_cdio_generic.c b/lib/driver/_cdio_generic.c
-index 4a7fcadf..f5c8c402 100644
+index c9719489..e5e40d96 100644
 --- a/lib/driver/_cdio_generic.c
 +++ b/lib/driver/_cdio_generic.c
 @@ -55,16 +55,6 @@
@@ -70,7 +70,7 @@ index 4a7fcadf..f5c8c402 100644
  
  /*!
 diff --git a/lib/driver/_cdio_stdio.c b/lib/driver/_cdio_stdio.c
-index 1d46b156..c26a35d0 100644
+index 0c00ec47..5719f6ee 100644
 --- a/lib/driver/_cdio_stdio.c
 +++ b/lib/driver/_cdio_stdio.c
 @@ -47,11 +47,7 @@
@@ -86,6 +86,3 @@ index 1d46b156..c26a35d0 100644
  #define CDIO_FSEEK fseeko
  #else
  #define CDIO_FSEEK fseek
--- 
-2.48.1
-

--- a/runtime-optenv32/libxkbcommon+32/autobuild/beyond
+++ b/runtime-optenv32/libxkbcommon+32/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Dropping unneeded shared data ..."
-rm -rv "$PKGDIR"/usr/share

--- a/runtime-optenv32/libxkbcommon+32/autobuild/defines
+++ b/runtime-optenv32/libxkbcommon+32/autobuild/defines
@@ -1,7 +1,17 @@
 PKGNAME=libxkbcommon+32
 PKGSEC=x11
-PKGDEP="aosc-aaa+32 libxcb+32 wayland+32 x11-lib+32"
+PKGDEP="aosc-aaa+32 libxcb+32 libxml2+32 wayland+32 x11-lib+32"
 BUILDDEP="devel-base+32"
 PKGDES="Keyboard handling library using XKB data for X11 XCB clients (32-bit x86 runtime)"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Denable-x11=true'
+    '-Denable-docs=false'
+    '-Denable-cool-uris=true'
+    '-Denable-wayland=true'
+    '-Denable-xkbregistry=true'
+    '-Denable-bash-completion=false'
+)
 
 ABHOST=optenv32

--- a/runtime-optenv32/libxkbcommon+32/spec
+++ b/runtime-optenv32/libxkbcommon+32/spec
@@ -1,4 +1,4 @@
-VER=1.13
-SRCS="tbl::https://xkbcommon.org/download/libxkbcommon-$VER.tar.xz"
-CHKSUMS="sha256::65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247"
+VER=1.13.1
+SRCS="git::commit=tags/xkbcommon-$VER::https://github.com/xkbcommon/libxkbcommon.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1780"


### PR DESCRIPTION
Topic Description
-----------------

- libxkbcommon: update to 1.13.1, fix broken SRCS url
- libcdio+32: regenerate patch to fix build

Package(s) Affected
-------------------

- lcms2+32: 2.17
- libcdio+32: 2.3.0
- libdrm+32: 2.4.131
- libdvdcss+32: 1.5.0
- libdvdnav+32: 7.0.0
- libdvdread+32: 7.0.1
- libjpeg-turbo+32: 3.1.3
- libunwind+32: 1.8.3
- libva+32: 2.23.0
- libxkbcommon+32: 1.13.1
- openal-soft+32: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libunwind+32 openal-soft+32 lcms2+32 libcdio+32 libdrm+32 libva+32 libjpeg-turbo+32 libxkbcommon+32 libdvdcss+32 libdvdread+32 libdvdnav+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
