### PR TITLE
nodeenv: update to 1.10.0

### DIFF
--- a/lang-python/nodeenv/spec
+++ b/lang-python/nodeenv/spec
@@ -1,4 +1,4 @@
-VER=1.9.1
+VER=1.10.0
 SRCS="pypi::version=$VER::nodeenv"
-CHKSUMS="sha256::6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"
+CHKSUMS="sha256::996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"
 CHKUPDATE="anitya::id=61153"


### PR DESCRIPTION
Topic Description
-----------------

- nodeenv: update to 1.10.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- nodeenv: 1.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodeenv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
