### PR TITLE
radare2: update to 6.0.7

### DIFF
--- a/app-devel/radare2/autobuild/defines
+++ b/app-devel/radare2/autobuild/defines
@@ -1,10 +1,19 @@
 PKGNAME=radare2
-PKGDES="A reverse-engineering statical analyze tool"
-PKGDEP="capstone libzip openssl"
+PKGDES="Reverse-engineering statical analyze tool"
+PKGDEP="capstone gcc-runtime glibc libuv libzip lz4 openssl xxhash zlib"
 PKGSEC=devel
 
 ABTYPE=meson
-
-MESON_AFTER="-D use_sys_capstone=true \
-	-D use_sys_zip=true \
-	-D use_sys_openssl=true"
+MESON_AFTER=(
+    "-D" "use_sys_capstone=true"
+    "-D" "use_capstone_version=v5"
+    "-D" "use_sys_magic=true"
+    "-D" "use_sys_zip=true"
+    "-D" "use_sys_zlib=true"
+    "-D" "use_sys_lz4=true"
+    "-D" "use_sys_xxhash=true"
+    "-D" "use_sys_openssl=true"
+    "-D" "use_libuv=true"
+    "-D" "use_webui=true"
+    "-D" "wrap_mode=default"
+)

--- a/app-devel/radare2/spec
+++ b/app-devel/radare2/spec
@@ -1,4 +1,4 @@
-VER=5.9.4
+VER=6.0.7
 SRCS="git::commit=tags/$VER::https://github.com/radare/radare2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11009"

--- a/topics/radare2-6.0.7.toml
+++ b/topics/radare2-6.0.7.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "radare2 6.0.7"
+
+[caution]
+default = "Fixes 10 security vulnerabilities (2 of critical severity, 1 of high severity)"
+zh_CN = "修复 10 个安全漏洞（含 2 个严重漏洞和 1 个高危漏洞）"
+
+[packages-v2]
+"radare2" = "<6.0.7"


### PR DESCRIPTION
Topic Description
-----------------

- radare2: update to 6.0.7
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- radare2: 6.0.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit radare2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
