### PR TITLE
box64: update to 0.3.9+git20251227

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,5 +1,5 @@
-VER=0.3.9+git20251218
+VER=0.3.9+git20251227
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=7f20c20031fb1f910d9b90c3a6f3fad4526ac774;copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=cc117019ff2c6db60d695fa82bf003ddec554dff;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.3.9+git20251227

Package(s) Affected
-------------------

- box64: 0.3.9+git20251227

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
