### PR TITLE
wolfssl: update to 5.8.4

### DIFF
--- a/runtime-cryptography/wolfssl/autobuild/defines
+++ b/runtime-cryptography/wolfssl/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=wolfssl
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="A TLS/SSL library for embedded and cloud environments"
+PKGDES="TLS/SSL library for embedded and cloud environments"
 
-AUTOTOOLS_AFTER="--enable-all \
-                 --enable-dtls13 \
-                 --enable-dtls-mtu \
-                 --disable-examples \
-                 --disable-static"
+AUTOTOOLS_AFTER=(
+    "--enable-all"
+    "--enable-dtls13"
+    "--enable-dtls-mtu"
+    "--disable-examples"
+    "--disable-static"
+    "--disable-armasm" # Error: selected processor does not support `sha256h2 q1,q25,v24.4s' 
+)

--- a/runtime-cryptography/wolfssl/spec
+++ b/runtime-cryptography/wolfssl/spec
@@ -1,4 +1,4 @@
-VER=5.7.0
+VER=5.8.4
 SRCS="git::commit=tags/v${VER}-stable::https://github.com/wolfSSL/wolfssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21631"

--- a/topics/wolfssl-5.8.4.toml
+++ b/topics/wolfssl-5.8.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "wolfSSL 5.8.4"
+
+[caution]
+default = "Fixes 5 security vulnerabilities (1 of critical severity, 1 high, 3 medium)"
+zh_CN = "修复 5 个安全漏洞（含 1 个严重漏洞，1 个高危漏洞，3 个中危漏洞）"
+
+[packages-v2]
+"wolfssl" = "< 5.8.4"


### PR DESCRIPTION
Topic Description
-----------------

- wolfssl: update to 5.8.4-stable
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- wolfssl: 5.8.4-stable

Security Update?
----------------

No

Build Order
-----------

```
#buildit wolfssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
