### PR TITLE
[PREVIEW] Box64 (hourly updates)

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=0.4.5-1
-VER=${UPSTREAM_VER//\-/+}
+VER=${UPSTREAM_VER//\-/+}+git20260814
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=tags/v${UPSTREAM_VER};copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=b38a33c00da42c567b4c58c620b3023063ecbe51;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

Hourly automatic updates for Box64.

Package(s) Affected
-------------------

- box64

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
