### PR TITLE
php: update to 8.5.1

### DIFF
--- a/app-devel/php/autobuild/patches/0001-fix-fpm-define-perferences-for-AOSC-OS.patch
+++ b/app-devel/php/autobuild/patches/0001-fix-fpm-define-perferences-for-AOSC-OS.patch
@@ -1,7 +1,7 @@
-From e6d6e23baea0e4e3fb969ac054fc197d21a663ba Mon Sep 17 00:00:00 2001
+From f73f6d6169c066a566a23760abf496d21c3d4a0f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 27 Nov 2024 16:41:48 +0800
-Subject: [PATCH 1/3] fix(fpm): define perferences for AOSC OS
+Subject: [PATCH 1/2] fix(fpm): define perferences for AOSC OS
 
 - Use syslog (-> journald) infrastructure to output server logs.
 - Listen /run/php-fpm/php-fpm.sock to integrate with systemd.
@@ -18,7 +18,7 @@ Subject: [PATCH 1/3] fix(fpm): define perferences for AOSC OS
  4 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/sapi/fpm/Makefile.frag b/sapi/fpm/Makefile.frag
-index c6a290f9d59b..b96d7f11079e 100644
+index c6a290f9d59..b96d7f11079 100644
 --- a/sapi/fpm/Makefile.frag
 +++ b/sapi/fpm/Makefile.frag
 @@ -15,8 +15,8 @@ install-fpm: $(SAPI_FPM_PATH)
@@ -33,7 +33,7 @@ index c6a290f9d59b..b96d7f11079e 100644
  
  	@echo "Installing PHP FPM man page:      $(INSTALL_ROOT)$(mandir)/man8/"
 diff --git a/sapi/fpm/php-fpm.conf.in b/sapi/fpm/php-fpm.conf.in
-index f1b48adca08f..c212d728a7e2 100644
+index f1b48adca08..c212d728a7e 100644
 --- a/sapi/fpm/php-fpm.conf.in
 +++ b/sapi/fpm/php-fpm.conf.in
 @@ -14,14 +14,14 @@
@@ -54,7 +54,7 @@ index f1b48adca08f..c212d728a7e2 100644
  ; syslog_facility is used to specify what type of program is logging the
  ; message. This lets syslogd specify that messages from different facilities
 diff --git a/sapi/fpm/php-fpm.service.in b/sapi/fpm/php-fpm.service.in
-index 50a87dc555f4..64c03bc48765 100644
+index 50a87dc555f..64c03bc4876 100644
 --- a/sapi/fpm/php-fpm.service.in
 +++ b/sapi/fpm/php-fpm.service.in
 @@ -8,7 +8,7 @@ After=network.target
@@ -67,7 +67,7 @@ index 50a87dc555f4..64c03bc48765 100644
  ExecReload=/bin/kill -USR2 $MAINPID
  
 diff --git a/sapi/fpm/www.conf.in b/sapi/fpm/www.conf.in
-index 9689e4defab0..d2d23213cdc6 100644
+index 69df3e66300..34ce3fbfe8b 100644
 --- a/sapi/fpm/www.conf.in
 +++ b/sapi/fpm/www.conf.in
 @@ -38,7 +38,7 @@ group = @php_fpm_group@
@@ -99,8 +99,6 @@ index 9689e4defab0..d2d23213cdc6 100644
  
  ; Redirect worker stdout and stderr into main error log. If not set, stdout and
  ; stderr will be redirected to /dev/null according to FastCGI specs.
-
-base-commit: 9327bec388094ecf44f2bd6db9fe8e6518849b15
 -- 
-2.48.0.rc1
+2.52.0
 

--- a/app-devel/php/autobuild/patches/0002-fix-php.ini-production-set-default-extensions-direct.patch
+++ b/app-devel/php/autobuild/patches/0002-fix-php.ini-production-set-default-extensions-direct.patch
@@ -1,7 +1,7 @@
-From 85d908747454cb41680ec30f4a514295f3835932 Mon Sep 17 00:00:00 2001
+From a99bb028f820de441a5a4ead02ed3510607edc04 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 27 Nov 2024 16:45:03 +0800
-Subject: [PATCH 2/3] fix(php.ini-production): set default extensions directory
+Subject: [PATCH 2/2] fix(php.ini-production): set default extensions directory
 
 Use /usr/lib/php/modules/ as the directory for PHP modules.
 ---
@@ -9,10 +9,10 @@ Use /usr/lib/php/modules/ as the directory for PHP modules.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/php.ini-production b/php.ini-production
-index c62faf52b673..715536fdce2a 100644
+index 9aafad21e9c..af08864e9fd 100644
 --- a/php.ini-production
 +++ b/php.ini-production
-@@ -761,7 +761,7 @@ user_dir =
+@@ -755,7 +755,7 @@ user_dir =
  
  ; Directory in which the loadable extensions (modules) reside.
  ; https://php.net/extension-dir
@@ -22,5 +22,5 @@ index c62faf52b673..715536fdce2a 100644
  ;extension_dir = "ext"
  
 -- 
-2.48.0.rc1
+2.52.0
 

--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,5 +1,4 @@
-VER=8.4.7
-REL=4
+VER=8.5.1
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::e29f4c23be2816ed005aa3f06bbb8eae0f22cc133863862e893515fc841e65e3"
+CHKSUMS="sha256::3f5bf99ce81201f526d25e288eddb2cfa111d068950d1e9a869530054ff98815"
 CHKUPDATE="anitya::id=3627"

--- a/topics/php-8.5.1.toml
+++ b/topics/php-8.5.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PHP 8.5.1"
+
+[caution]
+default = "Fixes 10 security vulnerabilities since PHP 8.4.7 (8 of moderate severity, 2 of low severity)"
+zh_CN = "修复自 PHP 8.4.7 起的 10 个安全漏洞（8 个中危漏洞，2 个低危漏洞）"
+
+[packages-v2]
+"krita" = "< 1:8.5.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add php-8.5.1.toml
- php: update to 8.5.1
    Track patches at AOSC-Tracking/php-src @ aosc/php-8.5.1
    \(HEAD: a99bb028f820de441a5a4ead02ed3510607edc04\).

Package(s) Affected
-------------------

- php: 1:8.5.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
