### PR TITLE
gstreamer: update to 1.26.10

### DIFF
--- a/runtime-multimedia/gstreamer/autobuild/defines.stage2
+++ b/runtime-multimedia/gstreamer/autobuild/defines.stage2
@@ -2,7 +2,7 @@ PKGNAME=gstreamer
 PKGSEC=libs
 PKGDEP="a52dec aalib bluez bzip2 cairo cdparanoia chromaprint elfutils faac \
         faad2 ffmpeg flac fluidsynth game-music-emu glib glib-networking \
-        graphene gsm jack json-glib kate-runtime ladspa-sdk lame libavc1394 \
+        graphene gsm jack json-glib ladspa-sdk lame libavc1394 \
         libavtp libbs2b libcaca libcap libcdio libdca libde265 libdrm libdv \
         libdvdnav libdvdread libfdk-aac libfreeaptx libglvnd libgudev \
         libiec61883 libldac liblrdf libltc libmicrodns libmpcdec libmpeg2 \

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,4 @@
-VER=1.26.8
-REL=2
+VER=1.26.10
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- gstreamer: update to 1.26.10
    Drop non-sensical kate-runtime dependency in defines.stage2.

Package(s) Affected
-------------------

- gstreamer: 1.26.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit gstreamer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
