### PR TITLE
async-timeout: update to 5.0.1

### DIFF
--- a/lang-python/async-timeout/autobuild/defines
+++ b/lang-python/async-timeout/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="python-3"
 BUILDDEP="setuptools"
 PKGDES="An asyncio-compatible timeout context manager"
 
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1
 
 ABHOST=noarch

--- a/lang-python/async-timeout/spec
+++ b/lang-python/async-timeout/spec
@@ -1,4 +1,4 @@
-VER=4.0.2
-SRCS="tbl::https://github.com/aio-libs/async-timeout/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::1eb41fc35a0a24461b00f3479553972c99300e194eb212ff8b816c90c084d1d4"
+VER=5.0.1
+SRCS="pypi::version=${VER}::async-timeout"
+CHKSUMS="sha256::d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
 CHKUPDATE="anitya::id=37104"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

async-timeout: update to 5.0.1

Package(s) Affected
-------------------

async-timeout: 5.0.1

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit async-timeout
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [x] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
