### PR TITLE
libindi: update to 2.1.7

### DIFF
--- a/runtime-scientific/libindi/autobuild/defines
+++ b/runtime-scientific/libindi/autobuild/defines
@@ -3,9 +3,13 @@ PKGSEC=libs
 PKGDEP="libnova libjpeg-turbo cfitsio gsl boost libusb-compat qt-5 libev"
 PKGDES="A distributed control protocol designed to operate astronomical instrumentation"
 
-CMAKE_AFTER="-DUDEVRULES_INSTALL_DIR=/usr/lib/udev/rules.d \
-             -DINDI_BUILD_QT5_CLIENT=ON \
-             -DLIBEV_INCLUDE_DIR=/usr/include/libev"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DUDEVRULES_INSTALL_DIR=/usr/lib/udev/rules.d'
+    '-DINDI_BUILD_QT5_CLIENT=ON'
+    '-DLIBEV_INCLUDE_DIR=/usr/include/libev'
+)
+
 PKGBREAK="kstars<=1:2.9.8"
 
 NOLTO=1

--- a/runtime-scientific/libindi/spec
+++ b/runtime-scientific/libindi/spec
@@ -1,5 +1,4 @@
-VER=2.1.1
-SRCS="https://github.com/indilib/indi/archive/v$VER.tar.gz"
-CHKSUMS="sha256::919862d5ccb4ea91ecb0e94f8f89a88c76bd1716e0098be07870c4408b233a20"
+VER=2.1.7
+SRCS="git::commit=tags/v$VER::https://github.com/indilib/indi.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6838"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- libindi: update to 2.1.7

Package(s) Affected
-------------------

- libindi: 2.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libindi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
