### PR TITLE
bat: update to 0.26.1

### DIFF
--- a/app-utils/bat/spec
+++ b/app-utils/bat/spec
@@ -1,5 +1,4 @@
-VER=0.26.0
-REL=1
+VER=0.26.1
 SRCS="git::commit=tags/v$VER;submodule=false;copy-repo=true::https://github.com/sharkdp/bat/"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17642"


### PR DESCRIPTION
Topic Description
-----------------

- bat: update to 0.26.1

Package(s) Affected
-------------------

- bat: 0.26.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
