### PR TITLE
pixi: update to 0.62.2

### DIFF
--- a/app-devel/pixi/autobuild/defines
+++ b/app-devel/pixi/autobuild/defines
@@ -4,5 +4,5 @@ BUILDDEP="llvm-20 rustc"
 PKGDEP="glibc gcc-runtime zlib bzip2"
 PKGDES="Package manager tool for multiple programming languages."
 ABTYPE="rust"
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64)"
 USECLANG=1

--- a/app-devel/pixi/autobuild/patches/0001-feat-add-support-for-LoongArch64-platform.patch
+++ b/app-devel/pixi/autobuild/patches/0001-feat-add-support-for-LoongArch64-platform.patch
@@ -1,0 +1,2811 @@
+From f22c7d08b4fef21d857b08aa7cd99abe2a0dd020 Mon Sep 17 00:00:00 2001
+From: xffish <xffish@126.com>
+Date: Mon, 12 Jan 2026 00:56:52 +0800
+Subject: [PATCH 1/1] feat: add support for LoongArch64 platform
+
+This enables pixi to work on LoongArch 64-bit Linux systems
+---
+ Cargo.lock                                    | 967 ++++++++----------
+ Cargo.toml                                    |  20 +
+ ...space__tests__invalid_target_specific.snap |   2 +-
+ crates/pixi_manifest/src/toml/platform.rs     |   4 +
+ ...st__toml__platform__test__deserialize.snap |   2 +
+ crates/pypi_modifiers/src/pypi_marker_env.rs  |   1 +
+ crates/pypi_modifiers/src/pypi_tags.rs        |   2 +-
+ schema/model.py                               |   1 +
+ schema/schema.json                            |   1 +
+ 9 files changed, 453 insertions(+), 547 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 51ca2bff8..2d1d7ceba 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -292,16 +292,16 @@ dependencies = [
+  "futures-lite",
+  "parking",
+  "polling",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "slab",
+  "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "async-lock"
+-version = "3.4.1"
++version = "3.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
++checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+ dependencies = [
+  "event-listener",
+  "event-listener-strategy",
+@@ -329,7 +329,7 @@ dependencies = [
+  "cfg-if",
+  "event-listener",
+  "futures-lite",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+ ]
+ 
+ [[package]]
+@@ -355,7 +355,7 @@ dependencies = [
+  "cfg-if",
+  "futures-core",
+  "futures-io",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "signal-hook-registry",
+  "slab",
+  "windows-sys 0.61.2",
+@@ -426,9 +426,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+ 
+ [[package]]
+ name = "aws-config"
+-version = "1.8.11"
++version = "1.8.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a0149602eeaf915158e14029ba0c78dedb8c08d554b024d54c8f239aab46511d"
++checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
+ dependencies = [
+  "aws-credential-types",
+  "aws-runtime",
+@@ -462,9 +462,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-credential-types"
+-version = "1.2.10"
++version = "1.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b01c9521fa01558f750d183c8c68c81b0155b9d193a4ba7f84c36bd1b6d04a06"
++checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+ dependencies = [
+  "aws-smithy-async",
+  "aws-smithy-runtime-api",
+@@ -474,9 +474,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-runtime"
+-version = "1.5.16"
++version = "1.5.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ce527fb7e53ba9626fc47824f25e256250556c40d8f81d27dd92aa38239d632"
++checksum = "d81b5b2898f6798ad58f484856768bca817e3cd9de0974c24ae0f1113fe88f1b"
+ dependencies = [
+  "aws-credential-types",
+  "aws-sigv4",
+@@ -499,9 +499,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-sdk-s3"
+-version = "1.116.0"
++version = "1.119.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cd4c10050aa905b50dc2a1165a9848d598a80c3a724d6f93b5881aa62235e4a5"
++checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+ dependencies = [
+  "aws-credential-types",
+  "aws-runtime",
+@@ -533,9 +533,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-sdk-signin"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "539a464c46384f614b887611bf958ec5a9fb3bf6e3ee966f18fd0b040ced9996"
++checksum = "c084bd63941916e1348cb8d9e05ac2e49bdd40a380e9167702683184c6c6be53"
+ dependencies = [
+  "aws-credential-types",
+  "aws-runtime",
+@@ -555,9 +555,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-sdk-sso"
+-version = "1.90.0"
++version = "1.91.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4f18e53542c522459e757f81e274783a78f8c81acdfc8d1522ee8a18b5fb1c66"
++checksum = "8ee6402a36f27b52fe67661c6732d684b2635152b676aa2babbfb5204f99115d"
+ dependencies = [
+  "aws-credential-types",
+  "aws-runtime",
+@@ -577,9 +577,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-sdk-ssooidc"
+-version = "1.92.0"
++version = "1.93.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "532f4d866012ffa724a4385c82e8dd0e59f0ca0e600f3f22d4c03b6824b34e4a"
++checksum = "a45a7f750bbd170ee3677671ad782d90b894548f4e4ae168302c57ec9de5cb3e"
+ dependencies = [
+  "aws-credential-types",
+  "aws-runtime",
+@@ -599,9 +599,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-sdk-sts"
+-version = "1.94.0"
++version = "1.95.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1be6fbbfa1a57724788853a623378223fe828fc4c09b146c992f0c95b6256174"
++checksum = "55542378e419558e6b1f398ca70adb0b2088077e79ad9f14eb09441f2f7b2164"
+ dependencies = [
+  "aws-credential-types",
+  "aws-runtime",
+@@ -622,9 +622,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-sigv4"
+-version = "1.3.6"
++version = "1.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c35452ec3f001e1f2f6db107b6373f1f48f05ec63ba2c5c9fa91f07dad32af11"
++checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+ dependencies = [
+  "aws-credential-types",
+  "aws-smithy-eventstream",
+@@ -738,9 +738,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-smithy-json"
+-version = "0.61.8"
++version = "0.61.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a6864c190cbb8e30cf4b77b2c8f3b6dfffa697a09b7218d2f7cd3d4c4065a9f7"
++checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+ dependencies = [
+  "aws-smithy-types",
+ ]
+@@ -841,9 +841,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-types"
+-version = "1.3.10"
++version = "1.3.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d79fb68e3d7fe5d4833ea34dc87d2e97d26d3086cb3da660bb6b1f76d98680b6"
++checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+ dependencies = [
+  "aws-credential-types",
+  "aws-smithy-async",
+@@ -855,9 +855,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "axum"
+-version = "0.8.7"
++version = "0.8.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
++checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+ dependencies = [
+  "axum-core",
+  "bytes",
+@@ -888,9 +888,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "axum-core"
+-version = "0.5.5"
++version = "0.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
++checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+ dependencies = [
+  "bytes",
+  "futures-core",
+@@ -985,9 +985,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "base64ct"
+-version = "1.8.1"
++version = "1.8.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
++checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+ 
+ [[package]]
+ name = "bincode"
+@@ -1088,9 +1088,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "bon"
+-version = "3.8.1"
++version = "3.8.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
++checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
+ dependencies = [
+  "bon-macros",
+  "rustversion",
+@@ -1098,11 +1098,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "bon-macros"
+-version = "3.8.1"
++version = "3.8.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
++checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
+ dependencies = [
+- "darling",
++ "darling 0.23.0",
+  "ident_case",
+  "prettyplease",
+  "proc-macro2",
+@@ -1130,9 +1130,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "bumpalo"
+-version = "3.19.0"
++version = "3.19.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
++checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+ 
+ [[package]]
+ name = "bytecheck"
+@@ -1245,9 +1245,9 @@ checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
+ 
+ [[package]]
+ name = "cargo-util"
+-version = "0.2.23"
++version = "0.2.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5fbac95faac578313b0ba60f9a5594a97cae42692f23b133ecd17615dedca50e"
++checksum = "03ae3fc62640c9e0235c95b07e68a59a31919d7331bd95961cc811bc0607c87b"
+ dependencies = [
+  "anyhow",
+  "core-foundation 0.10.1",
+@@ -1263,7 +1263,7 @@ dependencies = [
+  "tempfile",
+  "tracing",
+  "walkdir",
+- "windows-sys 0.60.2",
++ "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+@@ -1277,9 +1277,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cc"
+-version = "1.2.49"
++version = "1.2.52"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
++checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+ dependencies = [
+  "find-msvc-tools",
+  "jobserver",
+@@ -1341,9 +1341,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap"
+-version = "4.5.53"
++version = "4.5.54"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
++checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+ dependencies = [
+  "clap_builder",
+  "clap_derive",
+@@ -1351,9 +1351,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_builder"
+-version = "4.5.53"
++version = "4.5.54"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
++checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+ dependencies = [
+  "anstream",
+  "anstyle",
+@@ -1364,9 +1364,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "clap_complete"
+-version = "4.5.61"
++version = "4.5.65"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
++checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+ dependencies = [
+  "clap",
+ ]
+@@ -1402,8 +1402,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+ [[package]]
+ name = "coalesced_map"
+ version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "dashmap",
+  "tokio",
+@@ -1669,7 +1668,7 @@ dependencies = [
+  "crossterm_winapi",
+  "document-features",
+  "parking_lot",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "winapi",
+ ]
+ 
+@@ -1755,49 +1754,45 @@ dependencies = [
+ ]
+ 
+ [[package]]
+-name = "curve25519-dalek"
+-version = "4.1.3"
++name = "darling"
++version = "0.21.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
++checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+ dependencies = [
+- "cfg-if",
+- "cpufeatures",
+- "curve25519-dalek-derive",
+- "digest",
+- "fiat-crypto",
+- "rustc_version",
+- "subtle",
+- "zeroize",
++ "darling_core 0.21.3",
++ "darling_macro 0.21.3",
+ ]
+ 
+ [[package]]
+-name = "curve25519-dalek-derive"
+-version = "0.1.1"
++name = "darling"
++version = "0.23.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
++checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+ dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
++ "darling_core 0.23.0",
++ "darling_macro 0.23.0",
+ ]
+ 
+ [[package]]
+-name = "darling"
++name = "darling_core"
+ version = "0.21.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
++checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+ dependencies = [
+- "darling_core",
+- "darling_macro",
++ "fnv",
++ "ident_case",
++ "proc-macro2",
++ "quote",
++ "strsim",
++ "syn",
+ ]
+ 
+ [[package]]
+ name = "darling_core"
+-version = "0.21.3"
++version = "0.23.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
++checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+ dependencies = [
+- "fnv",
+  "ident_case",
+  "proc-macro2",
+  "quote",
+@@ -1811,7 +1806,18 @@ version = "0.21.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+ dependencies = [
+- "darling_core",
++ "darling_core 0.21.3",
++ "quote",
++ "syn",
++]
++
++[[package]]
++name = "darling_macro"
++version = "0.23.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
++dependencies = [
++ "darling_core 0.23.0",
+  "quote",
+  "syn",
+ ]
+@@ -1832,15 +1838,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "data-encoding"
+-version = "2.9.0"
++version = "2.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
++checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+ 
+ [[package]]
+ name = "dbus"
+-version = "0.9.9"
++version = "0.9.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "190b6255e8ab55a7b568df5a883e9497edc3e4821c06396612048b430e5ad1e9"
++checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+ dependencies = [
+  "libc",
+  "libdbus-sys",
+@@ -1902,9 +1908,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "deno_task_shell"
+-version = "0.26.1"
++version = "0.26.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dcb3527b0dc64fb6c1cb19023ef92a949b54c735c37af9bfb9fe4095922278da"
++checksum = "d6c8906a44dee412f17bf3ec79da41548612c5da3741fd0023c718408d6fe685"
+ dependencies = [
+  "anyhow",
+  "deno_path_util",
+@@ -1912,7 +1918,6 @@ dependencies = [
+  "glob",
+  "monch",
+  "nix 0.29.0",
+- "os_pipe",
+  "path-dedot",
+  "sys_traits",
+  "thiserror 2.0.17",
+@@ -1965,18 +1970,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "derive_more"
+-version = "2.1.0"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
++checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+ dependencies = [
+  "derive_more-impl",
+ ]
+ 
+ [[package]]
+ name = "derive_more-impl"
+-version = "2.1.0"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
++checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -2114,30 +2119,6 @@ dependencies = [
+  "spki 0.7.3",
+ ]
+ 
+-[[package]]
+-name = "ed25519"
+-version = "2.2.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+-dependencies = [
+- "pkcs8 0.10.2",
+- "signature 2.2.0",
+-]
+-
+-[[package]]
+-name = "ed25519-dalek"
+-version = "2.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+-dependencies = [
+- "curve25519-dalek",
+- "ed25519",
+- "serde",
+- "sha2",
+- "subtle",
+- "zeroize",
+-]
+-
+ [[package]]
+ name = "either"
+ version = "1.15.0"
+@@ -2176,7 +2157,6 @@ dependencies = [
+  "ff 0.13.1",
+  "generic-array",
+  "group 0.13.0",
+- "hkdf",
+  "pem-rfc7468",
+  "pkcs8 0.10.2",
+  "rand_core 0.6.4",
+@@ -2389,17 +2369,10 @@ dependencies = [
+  "subtle",
+ ]
+ 
+-[[package]]
+-name = "fiat-crypto"
+-version = "0.2.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+-
+ [[package]]
+ name = "file_url"
+ version = "0.2.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "81d37aab514a05a249a5b15408dc74d716f5745a2c5daf22e40a245ffd38fa84"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "itertools 0.14.0",
+  "percent-encoding",
+@@ -2422,9 +2395,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "find-msvc-tools"
+-version = "0.1.5"
++version = "0.1.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
++checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+ 
+ [[package]]
+ name = "fixedbitset"
+@@ -2496,9 +2469,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "fs-err"
+-version = "3.2.1"
++version = "3.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "824f08d01d0f496b3eca4f001a13cf17690a6ee930043d20817f547455fd98f8"
++checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+ dependencies = [
+  "autocfg",
+  "tokio",
+@@ -2521,7 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+ dependencies = [
+  "fs-err",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "tokio",
+  "windows-sys 0.59.0",
+ ]
+@@ -2806,16 +2779,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "google-cloud-auth"
+-version = "1.2.0"
++version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1cc977b20996b87e207b0a004ea34aa5f0f8692c44a1ca8c8802a08f553bf79c"
++checksum = "590a1c28795779d5da6fda35b149d5271bcddcf2ce1709eae9e9460faf2f2aa9"
+ dependencies = [
+  "async-trait",
+  "base64 0.22.1",
+  "bon",
++ "bytes",
+  "google-cloud-gax",
+  "http 1.4.0",
+- "jsonwebtoken",
+  "reqwest",
+  "rustc_version",
+  "rustls",
+@@ -2829,9 +2802,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "google-cloud-gax"
+-version = "1.3.1"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "48c26e6f1be47e93e5360a77e67e4e996a2d838b1924ffe0763bcb21d47be68b"
++checksum = "324fb97d35103787e80a33ed41ccc43d947c376d2ece68ca53e860f5844dbe24"
+ dependencies = [
+  "base64 0.22.1",
+  "bytes",
+@@ -2849,9 +2822,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "google-cloud-rpc"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e5b655e3540a78e18fd753ebd8f11e068210a3fa392892370f932ffcc8774346"
++checksum = "bd10e97751ca894f9dad6be69fcef1cb72f5bc187329e0254817778fc8235030"
+ dependencies = [
+  "bytes",
+  "google-cloud-wkt",
+@@ -2862,9 +2835,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "google-cloud-wkt"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02931df6af9beda1c852bbbbe5f7b6ba6ae5e4cd49c029fa0ca2cecc787cd9b1"
++checksum = "c6f270e404be7ce76a3260abe0c3c71492ab2599ccd877f3253f3dd552f48cc9"
+ dependencies = [
+  "base64 0.22.1",
+  "bytes",
+@@ -2900,9 +2873,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "h2"
+-version = "0.4.12"
++version = "0.4.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
++checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+ dependencies = [
+  "atomic-waker",
+  "bytes",
+@@ -2910,7 +2883,7 @@ dependencies = [
+  "futures-core",
+  "futures-sink",
+  "http 1.4.0",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "slab",
+  "tokio",
+  "tokio-util",
+@@ -3275,7 +3248,7 @@ dependencies = [
+  "tokio",
+  "tower-service",
+  "tracing",
+- "windows-registry",
++ "windows-registry 0.6.1",
+ ]
+ 
+ [[package]]
+@@ -3350,9 +3323,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+ 
+ [[package]]
+ name = "icu_properties"
+-version = "2.1.1"
++version = "2.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
++checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+ dependencies = [
+  "icu_collections",
+  "icu_locale_core",
+@@ -3364,9 +3337,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "icu_properties_data"
+-version = "2.1.1"
++version = "2.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
++checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+ 
+ [[package]]
+ name = "icu_provider"
+@@ -3439,9 +3412,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "indexmap"
+-version = "2.12.1"
++version = "2.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
++checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+ dependencies = [
+  "equivalent",
+  "hashbrown 0.16.1",
+@@ -3506,9 +3479,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+ 
+ [[package]]
+ name = "iri-string"
+-version = "0.7.9"
++version = "0.7.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
++checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+ dependencies = [
+  "memchr",
+  "serde",
+@@ -3564,15 +3537,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "itoa"
+-version = "1.0.15"
++version = "1.0.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
++checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+ 
+ [[package]]
+ name = "jiff"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
++checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+ dependencies = [
+  "jiff-static",
+  "jiff-tzdb-platform",
+@@ -3585,9 +3558,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "jiff-static"
+-version = "0.2.16"
++version = "0.2.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
++checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -3596,9 +3569,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "jiff-tzdb"
+-version = "0.1.4"
++version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
++checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+ 
+ [[package]]
+ name = "jiff-tzdb-platform"
+@@ -3799,27 +3772,6 @@ dependencies = [
+  "url",
+ ]
+ 
+-[[package]]
+-name = "jsonwebtoken"
+-version = "10.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
+-dependencies = [
+- "base64 0.22.1",
+- "ed25519-dalek",
+- "getrandom 0.2.16",
+- "hmac",
+- "js-sys",
+- "p256 0.13.2",
+- "p384",
+- "rand 0.8.5",
+- "rsa",
+- "serde",
+- "serde_json",
+- "sha2",
+- "signature 2.2.0",
+-]
+-
+ [[package]]
+ name = "junction"
+ version = "1.3.0"
+@@ -3858,9 +3810,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "lazy-regex"
+-version = "3.4.2"
++version = "3.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "191898e17ddee19e60bccb3945aa02339e81edd4a8c50e21fd4d48cdecda7b29"
++checksum = "c5c13b6857ade4c8ee05c3c3dc97d2ab5415d691213825b90d3211c425c1f907"
+ dependencies = [
+  "lazy-regex-proc_macros",
+  "once_cell",
+@@ -3869,9 +3821,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "lazy-regex-proc_macros"
+-version = "3.4.2"
++version = "3.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c35dc8b0da83d1a9507e12122c80dea71a9c7c613014347392483a83ea593e04"
++checksum = "32a95c68db5d41694cea563c86a4ba4dc02141c16ef64814108cb23def4d5438"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -3884,9 +3836,6 @@ name = "lazy_static"
+ version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+-dependencies = [
+- "spin",
+-]
+ 
+ [[package]]
+ name = "libbz2-rs-sys"
+@@ -3896,15 +3845,15 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.178"
++version = "0.2.180"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
++checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+ 
+ [[package]]
+ name = "libdbus-sys"
+-version = "0.2.6"
++version = "0.2.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5cbe856efeb50e4681f010e9aaa2bf0a644e10139e54cde10fc83a307c23bd9f"
++checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+ dependencies = [
+  "pkg-config",
+ ]
+@@ -3937,20 +3886,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "libredox"
+-version = "0.1.10"
++version = "0.1.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
++checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+ dependencies = [
+  "bitflags",
+  "libc",
+- "redox_syscall",
++ "redox_syscall 0.7.0",
+ ]
+ 
+ [[package]]
+ name = "libz-rs-sys"
+-version = "0.5.3"
++version = "0.5.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b484ba8d4f775eeca644c452a56650e544bf7e617f1d170fe7298122ead5222"
++checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+ dependencies = [
+  "zlib-rs",
+ ]
+@@ -4021,9 +3970,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "lzma-rust2"
+-version = "0.15.4"
++version = "0.15.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "48172246aa7c3ea28e423295dd1ca2589a24617cc4e588bb8cfe177cb2c54d95"
++checksum = "17f7337d278fec032975dc884152491580dd23750ee957047856735fe0e61ede"
+ 
+ [[package]]
+ name = "lzma-sys"
+@@ -4273,7 +4222,7 @@ dependencies = [
+  "libc",
+  "log",
+  "openssl",
+- "openssl-probe",
++ "openssl-probe 0.1.6",
+  "openssl-sys",
+  "schannel",
+  "security-framework 2.11.1",
+@@ -4310,7 +4259,6 @@ dependencies = [
+  "cfg-if",
+  "cfg_aliases",
+  "libc",
+- "memoffset",
+ ]
+ 
+ [[package]]
+@@ -4343,9 +4291,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ntapi"
+-version = "0.4.1"
++version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
++checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+ dependencies = [
+  "winapi",
+ ]
+@@ -4384,22 +4332,6 @@ dependencies = [
+  "num-traits",
+ ]
+ 
+-[[package]]
+-name = "num-bigint-dig"
+-version = "0.8.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+-dependencies = [
+- "lazy_static",
+- "libm",
+- "num-integer",
+- "num-iter",
+- "num-traits",
+- "rand 0.8.5",
+- "smallvec",
+- "zeroize",
+-]
+-
+ [[package]]
+ name = "num-complex"
+ version = "0.4.6"
+@@ -4453,7 +4385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+ dependencies = [
+  "autocfg",
+- "libm",
+ ]
+ 
+ [[package]]
+@@ -4581,6 +4512,12 @@ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+ 
++[[package]]
++name = "openssl-probe"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
++
+ [[package]]
+ name = "openssl-sys"
+ version = "0.9.111"
+@@ -4630,25 +4567,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "ordermap"
+-version = "1.0.0"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ed637741ced8fb240855d22a2b4f208dab7a06bcce73380162e5253000c16758"
++checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde",
+  "serde_core",
+ ]
+ 
+-[[package]]
+-name = "os_pipe"
+-version = "1.2.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+-dependencies = [
+- "libc",
+- "windows-sys 0.61.2",
+-]
+-
+ [[package]]
+ name = "os_str_bytes"
+ version = "6.6.1"
+@@ -4699,18 +4626,6 @@ dependencies = [
+  "sha2",
+ ]
+ 
+-[[package]]
+-name = "p384"
+-version = "0.13.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+-dependencies = [
+- "ecdsa 0.16.9",
+- "elliptic-curve 0.13.8",
+- "primeorder",
+- "sha2",
+-]
+-
+ [[package]]
+ name = "parking"
+ version = "2.2.1"
+@@ -4735,17 +4650,11 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+ dependencies = [
+  "cfg-if",
+  "libc",
+- "redox_syscall",
++ "redox_syscall 0.5.18",
+  "smallvec",
+  "windows-link 0.2.1",
+ ]
+ 
+-[[package]]
+-name = "paste"
+-version = "1.0.15"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+-
+ [[package]]
+ name = "path-dedot"
+ version = "3.1.1"
+@@ -4763,13 +4672,12 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+ 
+ [[package]]
+ name = "path_resolver"
+-version = "0.2.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "01693f3eaa8c61226a6def42ca70616c1c06736f1233a6c5d26cb13523e2aad3"
++version = "0.2.4"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "ahash",
+  "fs-err",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "proptest",
+  "tempfile",
+@@ -4811,7 +4719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
+ dependencies = [
+  "boxcar",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.13.0",
+  "once_cell",
+  "pep440_rs",
+@@ -4834,9 +4742,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+ 
+ [[package]]
+ name = "pest"
+-version = "2.8.4"
++version = "2.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
++checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+ dependencies = [
+  "memchr",
+  "ucd-trie",
+@@ -4844,9 +4752,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_derive"
+-version = "2.8.4"
++version = "2.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
++checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+ dependencies = [
+  "pest",
+  "pest_generator",
+@@ -4854,9 +4762,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_generator"
+-version = "2.8.4"
++version = "2.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
++checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+ dependencies = [
+  "pest",
+  "pest_meta",
+@@ -4867,9 +4775,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "pest_meta"
+-version = "2.8.4"
++version = "2.8.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
++checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+ dependencies = [
+  "pest",
+  "sha2",
+@@ -4883,7 +4791,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+ dependencies = [
+  "fixedbitset",
+  "hashbrown 0.15.5",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde",
+ ]
+ 
+@@ -4941,7 +4849,7 @@ dependencies = [
+  "fs_extra",
+  "futures",
+  "http 1.4.0",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "indicatif",
+  "insta",
+  "miette 7.6.0",
+@@ -5000,7 +4908,7 @@ dependencies = [
+  "dunce",
+  "fancy_display",
+  "fs-err",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "miette 7.6.0",
+  "minijinja",
+@@ -5145,7 +5053,7 @@ dependencies = [
+  "flate2",
+  "fs-err",
+  "futures",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "indicatif",
+  "insta",
+  "is_executable",
+@@ -5231,7 +5139,7 @@ dependencies = [
+  "dunce",
+  "fs-err",
+  "futures",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "insta",
+  "itertools 0.14.0",
+  "miette 7.6.0",
+@@ -5337,7 +5245,7 @@ dependencies = [
+  "futures",
+  "human_bytes",
+  "humantime",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "indicatif",
+  "insta",
+  "itertools 0.14.0",
+@@ -5432,7 +5340,7 @@ version = "0.1.0"
+ dependencies = [
+  "ahash",
+  "console 0.16.2",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "pixi_consts",
+  "pixi_manifest",
+@@ -5506,7 +5414,7 @@ dependencies = [
+  "fancy_display",
+  "fs-err",
+  "futures",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "indicatif",
+  "insta",
+  "is_executable",
+@@ -5621,7 +5529,7 @@ dependencies = [
+  "dunce",
+  "fancy_display",
+  "fs-err",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "insta",
+  "itertools 0.14.0",
+  "miette 7.6.0",
+@@ -5745,7 +5653,7 @@ dependencies = [
+  "console 0.16.2",
+  "futures",
+  "human_bytes",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "indicatif",
+  "itertools 0.14.0",
+  "parking_lot",
+@@ -5798,7 +5706,7 @@ dependencies = [
+ name = "pixi_spec_containers"
+ version = "0.1.0"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "pixi_spec",
+  "rattler_conda_types",
+@@ -5871,7 +5779,7 @@ version = "0.1.0"
+ dependencies = [
+  "digest",
+  "hex",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "insta",
+  "itertools 0.14.0",
+  "miette 7.6.0",
+@@ -6013,17 +5921,6 @@ dependencies = [
+  "serde",
+ ]
+ 
+-[[package]]
+-name = "pkcs1"
+-version = "0.7.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+-dependencies = [
+- "der 0.7.10",
+- "pkcs8 0.10.2",
+- "spki 0.7.3",
+-]
+-
+ [[package]]
+ name = "pkcs8"
+ version = "0.9.0"
+@@ -6063,7 +5960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+ dependencies = [
+  "base64 0.22.1",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "quick-xml 0.38.4",
+  "serde",
+  "time",
+@@ -6079,15 +5976,15 @@ dependencies = [
+  "concurrent-queue",
+  "hermit-abi",
+  "pin-project-lite",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "windows-sys 0.61.2",
+ ]
+ 
+ [[package]]
+ name = "portable-atomic"
+-version = "1.11.1"
++version = "1.13.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
++checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+ 
+ [[package]]
+ name = "portable-atomic-util"
+@@ -6154,7 +6051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+ dependencies = [
+  "equivalent",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde",
+ ]
+ 
+@@ -6169,9 +6066,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.103"
++version = "1.0.105"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
++checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -6220,9 +6117,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "prost"
+-version = "0.14.1"
++version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
++checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+ dependencies = [
+  "bytes",
+  "prost-derive",
+@@ -6230,9 +6127,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "prost-derive"
+-version = "0.14.1"
++version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
++checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+ dependencies = [
+  "anyhow",
+  "itertools 0.14.0",
+@@ -6243,9 +6140,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "prost-types"
+-version = "0.14.1"
++version = "0.14.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
++checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+ dependencies = [
+  "prost",
+ ]
+@@ -6275,7 +6172,7 @@ name = "pubgrub"
+ version = "0.3.0"
+ source = "git+https://github.com/astral-sh/pubgrub?rev=d8efd77673c9a90792da9da31b6c0da7ea8a324b#d8efd77673c9a90792da9da31b6c0da7ea8a324b"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "log",
+  "priority-queue",
+  "rustc-hash",
+@@ -6346,7 +6243,7 @@ version = "0.13.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f6d755483ad14b49e76713b52285235461a5b4f73f17612353e11a5de36a5fd2"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "pep440_rs",
+  "pep508_rs",
+  "serde",
+@@ -6437,9 +6334,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.42"
++version = "1.0.43"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
++checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -6541,9 +6438,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler"
+-version = "0.39.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2f38d4388230d7d3654a461425dd438a0fb51258e93f53cd8d44b678922ccb0"
++version = "0.39.7"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "anyhow",
+  "clap",
+@@ -6553,7 +6449,7 @@ dependencies = [
+  "fs-err",
+  "futures",
+  "humantime",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "indicatif",
+  "itertools 0.14.0",
+  "memchr",
+@@ -6586,9 +6482,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_cache"
+-version = "0.6.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a29965498c078084a82930bc868065a4ac2441ce79b5995ab09ea9503a539048"
++version = "0.6.6"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "ahash",
+  "anyhow",
+@@ -6619,9 +6514,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_conda_types"
+-version = "0.42.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3850be1f8879c4580f5c3d3a649afc5f46efa14be3c64957fa790c97d6c7c34a"
++version = "0.42.4"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "ahash",
+  "chrono",
+@@ -6632,7 +6526,7 @@ dependencies = [
+  "fs-err",
+  "glob",
+  "hex",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "lazy-regex",
+  "memmap2 0.9.9",
+@@ -6662,13 +6556,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_config"
+-version = "0.2.22"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b12cabcb8dd512fea07a95d71e2a91db09090cefda992253d87e1f72bdb31226"
++version = "0.2.23"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "console 0.16.2",
+  "fs-err",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "rattler_conda_types",
+  "serde",
+  "serde_json",
+@@ -6680,9 +6573,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_digest"
+-version = "1.2.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ff2a29fc465890f5bca54ed506df1ffb19b282fd591598d8f10d05abda964996"
++version = "1.2.2"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "blake2",
+  "digest",
+@@ -6699,14 +6591,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_lock"
+-version = "0.26.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "74210faf20624f2043a76ead894777325b51c97ad11eedcf764dcbdba2e584b1"
++version = "0.26.9"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "ahash",
+  "chrono",
+  "file_url",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "pep440_rs",
+  "pep508_rs",
+@@ -6725,9 +6616,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_macros"
+-version = "1.0.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "988d5d7ace4fb1d7549008236cf08de95e8ea2f1f80754109324a08c31e6dc6a"
++version = "1.0.12"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "quote",
+  "syn",
+@@ -6735,15 +6625,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_menuinst"
+-version = "0.2.41"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a16c104335ff2948837d216799b7a05a1771f3b85cbe9c0d6c8e6be79bca0d5a"
++version = "0.2.42"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "chrono",
+  "configparser",
+  "dirs",
+  "fs-err",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "known-folders",
+  "once_cell",
+  "plist",
+@@ -6761,14 +6650,13 @@ dependencies = [
+  "unicode-normalization",
+  "which",
+  "windows 0.61.3",
+- "windows-registry",
++ "windows-registry 0.5.3",
+ ]
+ 
+ [[package]]
+ name = "rattler_networking"
+-version = "0.25.28"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "50fbf0e3a98ecd105df3ff76c9ccb50f8f00497269e38101d8626edc7fc4030d"
++version = "0.25.29"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "anyhow",
+  "async-once-cell",
+@@ -6799,9 +6687,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_package_streaming"
+-version = "0.23.20"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e009ea293947e9fc0d986ae819bd5990ed610eeebbfa17482fc04c24405995f1"
++version = "0.23.21"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "astral-tokio-tar",
+  "async-compression",
+@@ -6833,9 +6720,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_pty"
+-version = "0.2.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "86a84e6b351c46c7588bb8f5c90994be23d5c3c31cf87f9ec903cd91d9fc4246"
++version = "0.2.8"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "libc",
+  "nix 0.30.1",
+@@ -6845,9 +6731,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_redaction"
+-version = "0.1.12"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3aa5057629aeb20861919e9ae56875985d58028f3c6f433a20b5ded086e1cec5"
++version = "0.1.13"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "reqwest",
+  "reqwest-middleware",
+@@ -6856,9 +6741,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_repodata_gateway"
+-version = "0.25.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b9e4fbd2f0eb24a7081a0df9df4b945bb6a8fad34ad1168bd800b25147bd68c9"
++version = "0.25.7"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "anyhow",
+  "async-compression",
+@@ -6917,9 +6801,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_s3"
+-version = "0.1.17"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "db2b85238aa5a8bf17093aa6f8f4d25c29a6a51f039591152e386703f2448678"
++version = "0.1.18"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "aws-config",
+  "aws-credential-types",
+@@ -6934,14 +6817,13 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_shell"
+-version = "0.25.14"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "740fdcb7e9b510969b27d6312b305cf2ffa0babbfe3285b51d900527bbddfb54"
++version = "0.25.15"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "anyhow",
+  "enum_dispatch",
+  "fs-err",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "rattler_conda_types",
+  "rattler_pty",
+@@ -6955,9 +6837,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_solve"
+-version = "4.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a1eb6e2f7fdb3513fe6733ac363814615dbcc90b1ace75e98b8c7ef45a27eeb8"
++version = "4.1.2"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "chrono",
+  "futures",
+@@ -6974,9 +6855,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_upload"
+-version = "0.4.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "921e9151bfc7048d4edf872719028d4d4fbb57e06239b520dddc24f7e3740134"
++version = "0.4.7"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "base64 0.22.1",
+  "clap",
+@@ -7010,9 +6890,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "rattler_virtual_packages"
+-version = "2.3.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a5453f17909e31bff3c9a6ece45b34ab9b392107ee6bff96ccc9999f1a59294f"
++version = "2.3.4"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "archspec",
+  "libloading",
+@@ -7056,6 +6935,15 @@ dependencies = [
+  "bitflags",
+ ]
+ 
++[[package]]
++name = "redox_syscall"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
++dependencies = [
++ "bitflags",
++]
++
+ [[package]]
+ name = "redox_users"
+ version = "0.5.2"
+@@ -7095,7 +6983,7 @@ checksum = "23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92"
+ dependencies = [
+  "cfg-if",
+  "libc",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "windows 0.62.2",
+ ]
+ 
+@@ -7292,9 +7180,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "reqwest"
+-version = "0.12.26"
++version = "0.12.28"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
++checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+ dependencies = [
+  "base64 0.22.1",
+  "bytes",
+@@ -7395,16 +7283,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "resolvo"
+-version = "0.10.1"
++version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "670175f9a825ad2419bea0e14bfe74e5dcc0227ec7a652a655b1c11e2b911754"
++checksum = "57a085c6cecab01bf88df532b7a03f066d5ab92e461bf4614a9de13f562eb163"
+ dependencies = [
+  "ahash",
+  "bitvec",
+  "elsa",
+  "event-listener",
+  "futures",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "petgraph",
+  "tracing",
+@@ -7465,14 +7353,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "rkyv"
+-version = "0.8.12"
++version = "0.8.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "35a640b26f007713818e9a9b65d34da1cf58538207b052916a83d80e43f3ffa4"
++checksum = "8b2e88acca7157d83d789836a3987dafc12bc3d88a050e54b8fe9ea4aaa29d20"
+ dependencies = [
+  "bytecheck",
+  "bytes",
+- "hashbrown 0.15.5",
+- "indexmap 2.12.1",
++ "hashbrown 0.16.1",
++ "indexmap 2.13.0",
+  "munge",
+  "ptr_meta",
+  "rancor",
+@@ -7485,9 +7373,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rkyv_derive"
+-version = "0.8.12"
++version = "0.8.13"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
++checksum = "7f6dffea3c91fa91a3c0fc8a061b0e27fef25c6304728038a6d6bcb1c58ba9bd"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -7505,46 +7393,23 @@ dependencies = [
+ 
+ [[package]]
+ name = "rmp"
+-version = "0.8.14"
++version = "0.8.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
++checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+ dependencies = [
+- "byteorder",
+  "num-traits",
+- "paste",
+ ]
+ 
+ [[package]]
+ name = "rmp-serde"
+-version = "1.3.0"
++version = "1.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
++checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+ dependencies = [
+- "byteorder",
+  "rmp",
+  "serde",
+ ]
+ 
+-[[package]]
+-name = "rsa"
+-version = "0.9.9"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+-dependencies = [
+- "const-oid",
+- "digest",
+- "num-bigint-dig",
+- "num-integer",
+- "num-traits",
+- "pkcs1",
+- "pkcs8 0.10.2",
+- "rand_core 0.6.4",
+- "signature 2.2.0",
+- "spki 0.7.3",
+- "subtle",
+- "zeroize",
+-]
+-
+ [[package]]
+ name = "rstest"
+ version = "0.26.1"
+@@ -7630,9 +7495,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustix"
+-version = "1.1.2"
++version = "1.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
++checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+ dependencies = [
+  "bitflags",
+  "errno",
+@@ -7643,9 +7508,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls"
+-version = "0.23.35"
++version = "0.23.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
++checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+ dependencies = [
+  "log",
+  "once_cell",
+@@ -7658,11 +7523,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-native-certs"
+-version = "0.8.2"
++version = "0.8.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
++checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+ dependencies = [
+- "openssl-probe",
++ "openssl-probe 0.2.0",
+  "rustls-pki-types",
+  "schannel",
+  "security-framework 3.5.1",
+@@ -7679,9 +7544,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-pki-types"
+-version = "1.13.1"
++version = "1.13.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
++checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+ dependencies = [
+  "web-time",
+  "zeroize",
+@@ -7745,9 +7610,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ryu"
+-version = "1.0.20"
++version = "1.0.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
++checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+ 
+ [[package]]
+ name = "same-file"
+@@ -7781,9 +7646,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "schemars"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
++checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+ dependencies = [
+  "dyn-clone",
+  "ref-cast",
+@@ -7795,9 +7660,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "schemars_derive"
+-version = "1.1.0"
++version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
++checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -7900,7 +7765,7 @@ dependencies = [
+  "once_cell",
+  "serde",
+  "sha2",
+- "zbus 5.12.0",
++ "zbus 5.13.1",
+ ]
+ 
+ [[package]]
+@@ -7952,9 +7817,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "self_cell"
+-version = "1.2.1"
++version = "1.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
++checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+ 
+ [[package]]
+ name = "semver"
+@@ -8053,16 +7918,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.145"
++version = "1.0.149"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
++checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itoa",
+  "memchr",
+- "ryu",
+  "serde",
+  "serde_core",
++ "zmij",
+ ]
+ 
+ [[package]]
+@@ -8089,9 +7954,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_spanned"
+-version = "1.0.3"
++version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
++checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+ dependencies = [
+  "serde_core",
+ ]
+@@ -8118,9 +7983,9 @@ dependencies = [
+  "chrono",
+  "hex",
+  "indexmap 1.9.3",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "schemars 0.9.0",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde_core",
+  "serde_json",
+  "serde_with_macros",
+@@ -8133,7 +7998,7 @@ version = "3.16.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+ dependencies = [
+- "darling",
++ "darling 0.21.3",
+  "proc-macro2",
+  "quote",
+  "syn",
+@@ -8145,7 +8010,7 @@ version = "0.9.34+deprecated"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itoa",
+  "ryu",
+  "serde",
+@@ -8154,9 +8019,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sevenz-rust2"
+-version = "0.20.0"
++version = "0.20.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "611081ec4fc67633b979fc0c24385de90fa60acd18126d796c8758a24294a950"
++checksum = "65126b94d6f5a6d727b1e35b0a796685a79062ceaf5fa45321315e62b65251a2"
+ dependencies = [
+  "aes",
+  "bzip2 0.6.1",
+@@ -8230,9 +8095,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+ 
+ [[package]]
+ name = "shell-words"
+-version = "1.1.0"
++version = "1.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
++checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+ 
+ [[package]]
+ name = "shellexpand"
+@@ -8263,10 +8128,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "signal-hook-registry"
+-version = "1.4.7"
++version = "1.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
++checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+ dependencies = [
++ "errno",
+  "libc",
+ ]
+ 
+@@ -8325,8 +8191,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+ [[package]]
+ name = "simple_spawn_blocking"
+ version = "1.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
++source = "git+https://github.com/conda/rattler?rev=ab42cbeb63dbe08d28218007168236f32e088092#ab42cbeb63dbe08d28218007168236f32e088092"
+ dependencies = [
+  "tokio",
+ ]
+@@ -8395,12 +8260,6 @@ dependencies = [
+  "smallvec",
+ ]
+ 
+-[[package]]
+-name = "spin"
+-version = "0.9.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+-
+ [[package]]
+ name = "spki"
+ version = "0.6.0"
+@@ -8500,9 +8359,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "supports-hyperlinks"
+-version = "3.1.0"
++version = "3.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
++checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+ 
+ [[package]]
+ name = "supports-unicode"
+@@ -8512,9 +8371,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+ 
+ [[package]]
+ name = "syn"
+-version = "2.0.111"
++version = "2.0.114"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
++checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -8651,9 +8510,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "target-lexicon"
+-version = "0.13.3"
++version = "0.13.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
++checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+ 
+ [[package]]
+ name = "temp-env"
+@@ -8667,14 +8526,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "tempfile"
+-version = "3.23.0"
++version = "3.24.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
++checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+ dependencies = [
+  "fastrand",
+  "getrandom 0.3.4",
+  "once_cell",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "windows-sys 0.61.2",
+ ]
+ 
+@@ -8684,7 +8543,7 @@ version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+ dependencies = [
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "windows-sys 0.60.2",
+ ]
+ 
+@@ -8846,9 +8705,9 @@ source = "git+https://github.com/astral-sh/tl.git?rev=6e25b2ee2513d75385101a8ff9
+ 
+ [[package]]
+ name = "tokio"
+-version = "1.48.0"
++version = "1.49.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
++checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+ dependencies = [
+  "bytes",
+  "libc",
+@@ -8894,9 +8753,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-stream"
+-version = "0.1.17"
++version = "0.1.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
++checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+ dependencies = [
+  "futures-core",
+  "pin-project-lite",
+@@ -8906,9 +8765,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokio-util"
+-version = "0.7.17"
++version = "0.7.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
++checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+ dependencies = [
+  "bytes",
+  "futures-core",
+@@ -8920,12 +8779,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml"
+-version = "0.9.8"
++version = "0.9.11+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
++checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+ dependencies = [
+  "foldhash 0.2.0",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde_core",
+  "serde_spanned",
+  "toml_datetime",
+@@ -8946,20 +8805,20 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml_datetime"
+-version = "0.7.3"
++version = "0.7.5+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
++checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+ dependencies = [
+  "serde_core",
+ ]
+ 
+ [[package]]
+ name = "toml_edit"
+-version = "0.23.9"
++version = "0.23.10+spec-1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
++checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+ dependencies = [
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "serde_core",
+  "serde_spanned",
+  "toml_datetime",
+@@ -8970,18 +8829,18 @@ dependencies = [
+ 
+ [[package]]
+ name = "toml_parser"
+-version = "1.0.4"
++version = "1.0.6+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
++checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+ dependencies = [
+  "winnow",
+ ]
+ 
+ [[package]]
+ name = "toml_writer"
+-version = "1.0.4"
++version = "1.0.6+spec-1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
++checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+ 
+ [[package]]
+ name = "tonic"
+@@ -9031,7 +8890,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+ dependencies = [
+  "futures-core",
+  "futures-util",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "pin-project-lite",
+  "slab",
+  "sync_wrapper",
+@@ -9079,9 +8938,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+ 
+ [[package]]
+ name = "tracing"
+-version = "0.1.43"
++version = "0.1.44"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
++checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+ dependencies = [
+  "log",
+  "pin-project-lite",
+@@ -9102,9 +8961,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "tracing-core"
+-version = "0.1.35"
++version = "0.1.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
++checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+ dependencies = [
+  "once_cell",
+  "valuable",
+@@ -9209,9 +9068,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+ 
+ [[package]]
+ name = "unicase"
+-version = "2.8.1"
++version = "2.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
++checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+ 
+ [[package]]
+ name = "unicode-ident"
+@@ -9278,14 +9137,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+ 
+ [[package]]
+ name = "url"
+-version = "2.5.7"
++version = "2.5.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
++checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+ dependencies = [
+  "form_urlencoded",
+  "idna",
+  "percent-encoding",
+  "serde",
++ "serde_derive",
+ ]
+ 
+ [[package]]
+@@ -9345,7 +9205,7 @@ dependencies = [
+  "reqwest-middleware",
+  "rust-netrc",
+  "rustc-hash",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "serde_json",
+  "thiserror 2.0.17",
+@@ -9377,7 +9237,7 @@ dependencies = [
+  "globset",
+  "itertools 0.14.0",
+  "rustc-hash",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "sha2",
+  "spdx",
+@@ -9471,7 +9331,7 @@ source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770
+ dependencies = [
+  "fs-err",
+  "globwalk",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "thiserror 2.0.17",
+  "toml",
+@@ -9558,7 +9418,7 @@ dependencies = [
+  "rayon",
+  "rustc-hash",
+  "same-file",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "serde-untagged",
+  "thiserror 2.0.17",
+@@ -9708,7 +9568,7 @@ dependencies = [
+  "petgraph",
+  "rkyv",
+  "rustc-hash",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "serde_json",
+  "thiserror 2.0.17",
+@@ -9784,9 +9644,9 @@ dependencies = [
+  "junction",
+  "path-slash",
+  "percent-encoding",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "same-file",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "tempfile",
+  "tokio",
+@@ -9862,7 +9722,7 @@ dependencies = [
+  "regex",
+  "rustc-hash",
+  "same-file",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "self-replace",
+  "serde",
+  "serde_json",
+@@ -9975,7 +9835,7 @@ version = "0.0.1"
+ source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+ dependencies = [
+  "rkyv",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "uv-small-str",
+ ]
+@@ -10019,12 +9879,12 @@ source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770
+ dependencies = [
+  "arcstr",
+  "boxcar",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "regex",
+  "rkyv",
+  "rustc-hash",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "smallvec",
+  "thiserror 2.0.17",
+@@ -10084,7 +9944,7 @@ version = "0.0.1"
+ source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+ dependencies = [
+  "hashbrown 0.16.1",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "jiff",
+  "mailparse",
+@@ -10092,7 +9952,7 @@ dependencies = [
+  "regex",
+  "rkyv",
+  "rustc-hash",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "serde-untagged",
+  "thiserror 2.0.17",
+@@ -10120,7 +9980,7 @@ dependencies = [
+  "dunce",
+  "fs-err",
+  "futures",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "once_cell",
+  "owo-colors",
+@@ -10132,7 +9992,7 @@ dependencies = [
+  "rmp-serde",
+  "rustc-hash",
+  "same-file",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "serde_json",
+  "sys-info",
+@@ -10165,7 +10025,7 @@ dependencies = [
+  "uv-warnings",
+  "which",
+  "windows 0.59.0",
+- "windows-registry",
++ "windows-registry 0.5.3",
+ ]
+ 
+ [[package]]
+@@ -10174,7 +10034,7 @@ version = "0.0.1"
+ source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+ dependencies = [
+  "ref-cast",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "url",
+ ]
+@@ -10252,7 +10112,7 @@ dependencies = [
+  "fs-err",
+  "futures",
+  "hashbrown 0.16.1",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "itertools 0.14.0",
+  "jiff",
+  "owo-colors",
+@@ -10261,7 +10121,7 @@ dependencies = [
+  "rkyv",
+  "rustc-hash",
+  "same-file",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "smallvec",
+  "textwrap",
+@@ -10375,7 +10235,7 @@ dependencies = [
+  "uv-fs",
+  "uv-static",
+  "windows 0.59.0",
+- "windows-registry",
++ "windows-registry 0.5.3",
+ ]
+ 
+ [[package]]
+@@ -10385,7 +10245,7 @@ source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770
+ dependencies = [
+  "arcstr",
+  "rkyv",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+ ]
+ 
+@@ -10415,7 +10275,7 @@ dependencies = [
+  "clap",
+  "either",
+  "fs-err",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "thiserror 2.0.17",
+  "tracing",
+@@ -10511,7 +10371,7 @@ dependencies = [
+  "itertools 0.14.0",
+  "owo-colors",
+  "rustc-hash",
+- "schemars 1.1.0",
++ "schemars 1.2.0",
+  "serde",
+  "thiserror 2.0.17",
+  "tokio",
+@@ -10743,23 +10603,23 @@ version = "0.26.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+ dependencies = [
+- "webpki-root-certs 1.0.4",
++ "webpki-root-certs 1.0.5",
+ ]
+ 
+ [[package]]
+ name = "webpki-root-certs"
+-version = "1.0.4"
++version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
++checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+ dependencies = [
+  "rustls-pki-types",
+ ]
+ 
+ [[package]]
+ name = "webpki-roots"
+-version = "1.0.4"
++version = "1.0.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
++checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+ dependencies = [
+  "rustls-pki-types",
+ ]
+@@ -10772,7 +10632,7 @@ checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+ dependencies = [
+  "env_home",
+  "regex",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+  "winsafe",
+ ]
+ 
+@@ -11006,6 +10866,17 @@ dependencies = [
+  "windows-strings 0.4.2",
+ ]
+ 
++[[package]]
++name = "windows-registry"
++version = "0.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
++dependencies = [
++ "windows-link 0.2.1",
++ "windows-result 0.4.1",
++ "windows-strings 0.5.1",
++]
++
+ [[package]]
+ name = "windows-result"
+ version = "0.3.4"
+@@ -11423,7 +11294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+ dependencies = [
+  "libc",
+- "rustix 1.1.2",
++ "rustix 1.1.3",
+ ]
+ 
+ [[package]]
+@@ -11520,9 +11391,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus"
+-version = "5.12.0"
++version = "5.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
++checksum = "17f79257df967b6779afa536788657777a0001f5b42524fcaf5038d4344df40b"
+ dependencies = [
+  "async-broadcast",
+  "async-recursion",
+@@ -11532,8 +11403,9 @@ dependencies = [
+  "futures-core",
+  "futures-lite",
+  "hex",
+- "nix 0.30.1",
++ "libc",
+  "ordered-stream",
++ "rustix 1.1.3",
+  "serde",
+  "serde_repr",
+  "tokio",
+@@ -11542,9 +11414,9 @@ dependencies = [
+  "uuid",
+  "windows-sys 0.61.2",
+  "winnow",
+- "zbus_macros 5.12.0",
+- "zbus_names 4.2.0",
+- "zvariant 5.8.0",
++ "zbus_macros 5.13.1",
++ "zbus_names 4.3.1",
++ "zvariant 5.9.1",
+ ]
+ 
+ [[package]]
+@@ -11562,17 +11434,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_macros"
+-version = "5.12.0"
++version = "5.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1cdb94821ca8a87ca9c298b5d1cbd80e2a8b67115d99f6e4551ac49e42b6a314"
++checksum = "aad23e2d2f91cae771c7af7a630a49e755f1eb74f8a46e9f6d5f7a146edf5a37"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+  "quote",
+  "syn",
+- "zbus_names 4.2.0",
+- "zvariant 5.8.0",
+- "zvariant_utils 3.2.1",
++ "zbus_names 4.3.1",
++ "zvariant 5.9.1",
++ "zvariant_utils 3.3.0",
+ ]
+ 
+ [[package]]
+@@ -11588,30 +11460,29 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus_names"
+-version = "4.2.0"
++version = "4.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
++checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+ dependencies = [
+  "serde",
+- "static_assertions",
+  "winnow",
+- "zvariant 5.8.0",
++ "zvariant 5.9.1",
+ ]
+ 
+ [[package]]
+ name = "zerocopy"
+-version = "0.8.31"
++version = "0.8.33"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
++checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+ dependencies = [
+  "zerocopy-derive",
+ ]
+ 
+ [[package]]
+ name = "zerocopy-derive"
+-version = "0.8.31"
++version = "0.8.33"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
++checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -11650,9 +11521,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zeroize_derive"
+-version = "1.4.2"
++version = "1.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
++checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -11704,7 +11575,7 @@ dependencies = [
+  "crossbeam-utils",
+  "displaydoc",
+  "flate2",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "lzma-rs",
+  "memchr",
+  "thiserror 2.0.17",
+@@ -11723,7 +11594,7 @@ dependencies = [
+  "arbitrary",
+  "crc32fast",
+  "flate2",
+- "indexmap 2.12.1",
++ "indexmap 2.13.0",
+  "memchr",
+  "time",
+  "zopfli",
+@@ -11731,9 +11602,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "zlib-rs"
+-version = "0.5.3"
++version = "0.5.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
++
++[[package]]
++name = "zmij"
++version = "1.0.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "36134c44663532e6519d7a6dfdbbe06f6f8192bde8ae9ed076e9b213f0e31df7"
++checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+ 
+ [[package]]
+ name = "zopfli"
+@@ -11790,16 +11667,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant"
+-version = "5.8.0"
++version = "5.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
++checksum = "326aaed414f04fe839777b4c443d4e94c74e7b3621093bd9c5e649ac8aa96543"
+ dependencies = [
+  "endi",
+  "enumflags2",
+  "serde",
+  "winnow",
+- "zvariant_derive 5.8.0",
+- "zvariant_utils 3.2.1",
++ "zvariant_derive 5.9.1",
++ "zvariant_utils 3.3.0",
+ ]
+ 
+ [[package]]
+@@ -11817,15 +11694,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant_derive"
+-version = "5.8.0"
++version = "5.9.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
++checksum = "ba44e1f8f4da9e6e2d25d2a60b116ef8b9d0be174a7685e55bb12a99866279a7"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+  "quote",
+  "syn",
+- "zvariant_utils 3.2.1",
++ "zvariant_utils 3.3.0",
+ ]
+ 
+ [[package]]
+@@ -11841,9 +11718,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zvariant_utils"
+-version = "3.2.1"
++version = "3.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
++checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+diff --git a/Cargo.toml b/Cargo.toml
+index 5a06f8c1f..5d0626c95 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -222,6 +222,26 @@ zstd = { version = "0.13.3", default-features = false }
+ reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "7650ed76215a962a96d94a79be71c27bffde7ab2" }
+ reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "7650ed76215a962a96d94a79be71c27bffde7ab2" }
+ version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "d8efd77673c9a90792da9da31b6c0da7ea8a324b" }
++# Patch rattler for LoongArch64 support until official release
++# Need to patch all rattler crates for version consistency
++coalesced_map = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++file_url = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++path_resolver = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++simple_spawn_blocking = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_cache = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_conda_types = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_digest = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_lock = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_menuinst = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_networking = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_package_streaming = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_redaction = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_repodata_gateway = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_shell = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_solve = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_upload = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
++rattler_virtual_packages = { git = "https://github.com/conda/rattler", rev = "ab42cbeb63dbe08d28218007168236f32e088092" }
+ 
+ [profile.ci]
+ codegen-units = 16
+diff --git a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
+index ebb7c9ae4..c6a4e913c 100644
+--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
++++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
+@@ -2,7 +2,7 @@
+ source: crates/pixi_manifest/src/manifests/workspace.rs
+ expression: "expect_parse_failure(&format!(\"{PROJECT_BOILERPLATE}\\n{}\", examples[0]))"
+ ---
+-  × 'foobar' is not a known platform. Valid platforms are 'noarch', 'unknown', 'linux-32', 'linux-64', 'linux-aarch64', 'linux-armv6l', 'linux-armv7l', 'linux-loong64', 'linux-ppc64le', 'linux-
++  × 'foobar' is not a known platform. Valid platforms are 'noarch', 'unknown', 'linux-32', 'linux-64', 'linux-aarch64', 'linux-armv6l', 'linux-armv7l', 'linux-loongarch64', 'linux-ppc64le', 'linux-
+   │ ppc64', 'linux-ppc', 'linux-s390x', 'linux-riscv32', 'linux-riscv64', 'freebsd-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64', 'win-arm64', 'emscripten-wasm32', 'wasi-wasm32', 'zos-z'
+    ╭─[pixi.toml:8:9]
+  7 │
+diff --git a/crates/pixi_manifest/src/toml/platform.rs b/crates/pixi_manifest/src/toml/platform.rs
+index 2a7684b4e..f2d647dc1 100644
+--- a/crates/pixi_manifest/src/toml/platform.rs
++++ b/crates/pixi_manifest/src/toml/platform.rs
+@@ -28,6 +28,9 @@ pub enum TomlPlatform {
+     LinuxRiscv32,
+     LinuxRiscv64,
+ 
++    #[strum(serialize = "linux-loongarch64")]
++    LinuxLoongArch64,
++
+     #[strum(serialize = "osx-64")]
+     Osx64,
+     OsxArm64,
+@@ -57,6 +60,7 @@ impl From<TomlPlatform> for Platform {
+             TomlPlatform::LinuxS390X => Platform::LinuxS390X,
+             TomlPlatform::LinuxRiscv32 => Platform::LinuxRiscv32,
+             TomlPlatform::LinuxRiscv64 => Platform::LinuxRiscv64,
++            TomlPlatform::LinuxLoongArch64 => Platform::LinuxLoongArch64,
+             TomlPlatform::Osx64 => Platform::Osx64,
+             TomlPlatform::OsxArm64 => Platform::OsxArm64,
+             TomlPlatform::Win32 => Platform::Win32,
+diff --git a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__platform__test__deserialize.snap b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__platform__test__deserialize.snap
+index f3d0ffec5..fb8a69d49 100644
+--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__platform__test__deserialize.snap
++++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__platform__test__deserialize.snap
+@@ -1,5 +1,6 @@
+ ---
+ source: crates/pixi_manifest/src/toml/platform.rs
++assertion_line: 97
+ expression: "TomlPlatform::VARIANTS"
+ ---
+ [
+@@ -13,6 +14,7 @@ expression: "TomlPlatform::VARIANTS"
+     "linux-s390x",
+     "linux-riscv32",
+     "linux-riscv64",
++    "linux-loongarch64",
+     "osx-64",
+     "osx-arm64",
+     "win-32",
+diff --git a/crates/pypi_modifiers/src/pypi_marker_env.rs b/crates/pypi_modifiers/src/pypi_marker_env.rs
+index 8713e9343..f7795ccf3 100644
+--- a/crates/pypi_modifiers/src/pypi_marker_env.rs
++++ b/crates/pypi_modifiers/src/pypi_marker_env.rs
+@@ -40,6 +40,7 @@ pub fn determine_marker_environment(
+         Platform::LinuxS390X => "s390x",
+         Platform::LinuxRiscv32 => "riscv32",
+         Platform::LinuxRiscv64 => "riscv64",
++        Platform::LinuxLoongArch64 => "loongarch64",
+         Platform::Osx64 => "x86_64",
+         Platform::OsxArm64 => "arm64",
+         Platform::Win32 => "x86",
+diff --git a/crates/pypi_modifiers/src/pypi_tags.rs b/crates/pypi_modifiers/src/pypi_tags.rs
+index 2ce8ba5a7..c47e0959f 100644
+--- a/crates/pypi_modifiers/src/pypi_tags.rs
++++ b/crates/pypi_modifiers/src/pypi_tags.rs
+@@ -190,7 +190,7 @@ fn get_arch_tags(platform: Platform) -> Result<uv_platform_tags::Arch, PyPITagEr
+         Some(Arch::Ppc64) => Ok(uv_platform_tags::Arch::Powerpc64),
+         Some(Arch::Riscv64) => Ok(uv_platform_tags::Arch::Riscv64),
+         Some(Arch::S390X) => Ok(uv_platform_tags::Arch::S390X),
+-        Some(Arch::Loong64) => Ok(uv_platform_tags::Arch::LoongArch64),
++        Some(Arch::LoongArch64) => Ok(uv_platform_tags::Arch::LoongArch64),
+         Some(unsupported_arch) => Err(PyPITagError::FailedToDetermineArchTags(unsupported_arch)),
+     }
+ }
+diff --git a/schema/model.py b/schema/model.py
+index eed0f80c8..e48e190fd 100644
+--- a/schema/model.py
++++ b/schema/model.py
+@@ -58,6 +58,7 @@ class Platform(str, Enum):
+     linux_riscv32 = "linux-riscv32"
+     linux_riscv64 = "linux-riscv64"
+     linux_s390x = "linux-s390x"
++    linux_loongarch64 = "linux-loongarch64"
+     noarch = "noarch"
+     osx_64 = "osx-64"
+     osx_arm64 = "osx-arm64"
+diff --git a/schema/schema.json b/schema/schema.json
+index f1f1655fd..51065dc78 100644
+--- a/schema/schema.json
++++ b/schema/schema.json
+@@ -1330,6 +1330,7 @@
+         "linux-riscv32",
+         "linux-riscv64",
+         "linux-s390x",
++        "linux-loongarch64",
+         "noarch",
+         "osx-64",
+         "osx-arm64",
+-- 
+2.52.0
+

--- a/app-devel/pixi/spec
+++ b/app-devel/pixi/spec
@@ -1,4 +1,4 @@
-VER=0.59.0
+VER=0.62.2
 SRCS="git::commit=tags/v$VER::https://github.com/prefix-dev/pixi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379204"


### PR DESCRIPTION
Topic Description
-----------------

- pixi: update to 0.62.2

Package(s) Affected
-------------------

- pixi: 0.62.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pixi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
