### PR TITLE
wcslib: update to 8.5

### DIFF
--- a/runtime-scientific/wcslib/autobuild/beyond
+++ b/runtime-scientific/wcslib/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing docs ..."
+rm -rv "$PKGDIR"/usr/share/doc/

--- a/runtime-scientific/wcslib/autobuild/defines
+++ b/runtime-scientific/wcslib/autobuild/defines
@@ -3,9 +3,13 @@ PKGSEC=libs
 PKGDEP="cfitsio"
 PKGDES="A C library that implements the 'World Coordinate System' (WCS) standard in FITS"
 
-AUTOTOOLS_AFTER="--without-pgplot --disable-fortran"
+ABTPYE=autotools
+AUTOTOOLS_AFTER=(
+    '--without-pgplot'
+    '--disable-fortran'
+)
+
 ABSHADOW=0
 NOPARALLEL=1
-ABTPYE=autotools
 
 PKGBREAK="kstars<=1:2.9.8-1"

--- a/runtime-scientific/wcslib/spec
+++ b/runtime-scientific/wcslib/spec
@@ -1,5 +1,4 @@
-VER=8.3
-REL=1
-SRCS="tbl::http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-$VER.tar.bz2"
-CHKSUMS="sha256::431ea3417927bbc02b89bfa3415dc0b4668b0f21a3b46fb8a3525e2fcf614508"
+VER=8.5
+SRCS="tbl::https://www.atnf.csiro.au/computing/software/wcs/wcslib-releases/wcslib-$VER.tar.bz2"
+CHKSUMS="sha256::f1fd1b78fbfdbabda363f8045e0c59e32735eca45482a5302191e56fe062eace"
 CHKUPDATE="anitya::id=7693"


### PR DESCRIPTION
Topic Description
-----------------

- wcslib: update to 8.5

Package(s) Affected
-------------------

- wcslib: 8.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit wcslib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
