### PR TITLE
kitty: update to 0.45.0

### DIFF
--- a/app-utils/kitty/autobuild/build
+++ b/app-utils/kitty/autobuild/build
@@ -7,3 +7,5 @@ for i in bin share lib; do
     cp -av "$SRCDIR"/linux-package/$i \
         "$PKGDIR"/usr/
 done
+abinfo "Removing local documentation per the Styling Manual ..."
+rm -rv "$PKGDIR"/usr/share/doc/kitty/html

--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,5 @@
-VER=0.43.1
-REL=1
+VER=0.45.0
+REL=0
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::44a875e34e6a5f9b8f599b25b0796c07a1506fec2b2310573e03077ef1ae159f"
+CHKSUMS="sha256::93fcba4984a97ccb7d811f487a818d406e681912b6bbb8f0ca426103ddce7ca5"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.45.0

Package(s) Affected
-------------------

- kitty: 0.45.0-0

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
