### PR TITLE
imagemagick: update to 6.9.13-37

### DIFF
--- a/app-utils/imagemagick/autobuild/beyond
+++ b/app-utils/imagemagick/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Remove unused empty directory …"
-rm -rv "$PKGDIR"/usr/man

--- a/app-utils/imagemagick/autobuild/defines
+++ b/app-utils/imagemagick/autobuild/defines
@@ -23,55 +23,44 @@ BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
 BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
-PKGDES="An image viewing and manipulation program"
+PKGDES="Image viewing and manipulation program"
 
-AUTOTOOLS_AFTER="--with-modules \
-                 --enable-hdri \
-                 --with-wmf \
-                 --with-openexr \
-                 --with-xml \
-                 --with-heic \
-                 --with-webp \
-                 --with-gslib \
-                 --with-gs-font-dir=/usr/share/fonts/Type1 \
-                 --with-perl \
-                 --with-perl-options=INSTALLDIRS=site \
-                 --with-lqr \
-                 --with-rsvg \
-                 --with-openjp2 \
-                 --without-gvc \
-                 --with-djvu \
-                 --without-autotrace \
-                 --without-jbig \
-                 --without-fpx \
-                 --without-dps \
-                 --with-fftw \
-	         --enable-opencl \
-                 LIBS=-ldl"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-openexr \
-                 --without-gslib \
-                 --without-lqr \
-                 --without-djvu \
-                 --without-fftw \
-                 --disable-opencl \
-                 LIBS=-ldl"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+    '--with-modules'
+    '--enable-hdri'
+    '--with-wmf'
+    '--with-openexr'
+    '--with-xml'
+    '--with-heic'
+    '--with-webp'
+    '--with-gslib'
+    '--with-gs-font-dir=/usr/share/fonts/Type1'
+    '--with-perl'
+    '--with-perl-options=INSTALLDIRS=site'
+    '--with-lqr'
+    '--with-rsvg'
+    '--with-openjp2'
+    '--without-gvc'
+    '--with-djvu'
+    '--without-autotrace'
+    '--without-jbig'
+    '--without-fpx'
+    '--without-dps'
+    '--with-fftw'
+    '--enable-opencl'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--without-openexr'
+    '--without-gslib'
+    '--without-lqr'
+    '--without-djvu'
+    '--without-fftw'
+    '--disable-opencl'
+)
 
-ABSHADOW=0
+# Note: Needed for plugin detection.
 NOLIBTOOL=0
-RECONF=0
-
-# FIXME: FTBFS with LTO.
-NOLTO=1
 
 AB_FLAGS_O3=1
 

--- a/app-utils/imagemagick/spec
+++ b/app-utils/imagemagick/spec
@@ -1,4 +1,5 @@
-VER=6.9.13+16
-SRCS="git::commit=tags/${VER/+/-}::https://github.com/ImageMagick/ImageMagick6.git"
+UPSTREAM_VER=6.9.13-37
+VER=${UPSTREAM_VER/\-/+}
+SRCS="git::commit=tags/${UPSTREAM_VER}::https://github.com/ImageMagick/ImageMagick6.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16253"

--- a/topics/imagemagick-6.9.13-37.toml
+++ b/topics/imagemagick-6.9.13-37.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "ImageMagick 6.9.13-37"
+
+[caution]
+default = "Fixes 10 security vulnerabilities since ImageMagick 6.9.13-16 (4 of high severity)"
+zh_CN = "修复自 ImageMagick 6.9.13-16 以来的 10 个安全漏洞（含 4 个高危漏洞）"
+
+[packages-v2]
+"imagemagick" = "< 6.9.13+37"


### PR DESCRIPTION
Topic Description
-----------------

- imagemagick: update to 6.9.13-37
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- imagemagick: 6.9.13-37

Security Update?
----------------

No

Build Order
-----------

```
#buildit imagemagick
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
