### PR TITLE
llama.cpp: update to 7571

### DIFF
--- a/runtime-creativity/llama.cpp/spec
+++ b/runtime-creativity/llama.cpp/spec
@@ -1,4 +1,4 @@
-VER=7091
+VER=7571
 # The build system uses git tags to determine version number
 SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggerganov/llama.cpp.git"
 CHKSUMS="SKIP"

--- a/runtime-scientific/ggml/spec
+++ b/runtime-scientific/ggml/spec
@@ -1,4 +1,4 @@
-VER=0.9.4+git20251117
-SRCS="git::commit=c23776f22d616d8cb635145381cad365bac675e7;copy-repo=true::https://github.com/ggml-org/ggml"
+VER=0.9.4+git20251217
+SRCS="git::commit=ac0c8be49c7458bcc6eae164244d7335ce9cc184;copy-repo=true::https://github.com/ggml-org/ggml"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383765"


### PR DESCRIPTION
Topic Description
-----------------

- llama.cpp: update to 7571
- ggml: update to 0.9.4+git20251217

Package(s) Affected
-------------------

- ggml: 0.9.4+git20251217
- llama.cpp: 7571

Security Update?
----------------

No

Build Order
-----------

```
#buildit ggml llama.cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
