### PR TITLE
libtpms: update to 0.10.1

### DIFF
--- a/runtime-devices/libtpms/autobuild/defines
+++ b/runtime-devices/libtpms/autobuild/defines
@@ -3,8 +3,11 @@ PKGSEC=libs
 PKGDEP="openssl"
 PKGDES="Library to provide software emulation of a Trusted Platform Module (1.2 and 2.0)"
 
-AUTOTOOLS_AFTER="--enable-use-openssl-functions \
-                 --enable-hardening \
-                 --with-tpm1 \
-                 --with-tpm2 \
-                 --with-openssl"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--enable-use-openssl-functions"
+    "--enable-hardening"
+    "--with-tpm1"
+    "--with-tpm2"
+    "--with-openssl"
+)

--- a/runtime-devices/libtpms/spec
+++ b/runtime-devices/libtpms/spec
@@ -1,5 +1,4 @@
-VER=0.9.6
-REL=1
+VER=0.10.1
 SRCS="git::commit=tags/v$VER::https://github.com/stefanberger/libtpms"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=116460"

--- a/topics/libtpms-0.10.1.toml
+++ b/topics/libtpms-0.10.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libtpms 0.10.1"
+
+[caution]
+default = "Fixes a Out-of-Bounds Read vulnerability - CVE-2025-49133 (Severity: Medium)"
+zh_CN = "修复一处越界读取 (Out-of-Bounds Read) 漏洞，漏洞编号 CVE-2025-49133（严重性：中）"
+
+[packages-v2]
+"libtpms" = "< 0.10.1"


### PR DESCRIPTION
Topic Description
-----------------

- libtpms: update to 0.10.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libtpms: 0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtpms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
