### PR TITLE
ecl: build with `-std=gnu17`

### DIFF
--- a/lang-lisp/ecl/autobuild/prepare
+++ b/lang-lisp/ecl/autobuild/prepare
@@ -3,8 +3,10 @@ abinfo "Removing spurious executable bits ..."
 find c -type f -perm /0111 | xargs chmod a-x
 find h -type f -perm /0111 | xargs chmod a-x
 
+# NOTE: ecl will pass compilation parameters when compiling other packages,
+# and '-std=gnu17' is important for some packages, such as `maxima`.
 abinfo "Tweaking compiler flags ..."
-export CPPFLAGS="$(pkg-config --cflags libffi)"
-export CFLAGS="$(pkg-config --cflags libffi) -Wno-unused -Wno-return-type -Wno-unknown-pragmas"
+export CPPFLAGS="$(pkg-config --cflags libffi) -std=gnu17"
+export CFLAGS="$(pkg-config --cflags libffi) -Wno-unused -Wno-return-type -Wno-unknown-pragmas -std=gnu17"
 unset LDFLAGS
 

--- a/lang-lisp/ecl/spec
+++ b/lang-lisp/ecl/spec
@@ -1,5 +1,5 @@
 VER=24.5.10
-REL=1
+REL=2
 SRCS="tbl::https://common-lisp.net/project/ecl/static/files/release/ecl-$VER.tgz"
 SUBDIR="ecl-$VER/src"
 CHKSUMS="sha256::e4ea65bb1861e0e495386bfa8bc673bd014e96d3cf9d91e9038f91435cbe622b"


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- ecl will pass compilation parameters when compiling packages, and `-std=gnu17` is important for some packages, such as `maxima`.
- Fix `sagemath` rebuild faild at `maxima`.
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- ecl: 24.5.10-2
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit ecl
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
