### PR TITLE
grub: fix FTBFS with Core 13

### DIFF
--- a/app-admin/grub/autobuild/amd64/build
+++ b/app-admin/grub/autobuild/amd64/build
@@ -30,7 +30,8 @@ abinfo "Configuring GRUB for EFI (32-bit) ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI (32-bit) ..."
 make
@@ -84,7 +85,8 @@ abinfo "Configuring GRUB for PC BIOS ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for PC BIOS ..."
 make
@@ -120,7 +122,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make
@@ -174,7 +177,8 @@ abinfo "Configuring GRUB for userspace emulation ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for userspace emulation ..."
 make

--- a/app-admin/grub/autobuild/amd64/build.stage2
+++ b/app-admin/grub/autobuild/amd64/build.stage2
@@ -30,7 +30,8 @@ abinfo "Configuring GRUB for EFI (32-bit) ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI (32-bit) ..."
 make
@@ -67,7 +68,8 @@ abinfo "Configuring GRUB for PC BIOS ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for PC BIOS ..."
 make
@@ -103,7 +105,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make
@@ -140,7 +143,8 @@ abinfo "Configuring GRUB for userspace emulation ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for userspace emulation ..."
 make

--- a/app-admin/grub/autobuild/arm32/build
+++ b/app-admin/grub/autobuild/arm32/build
@@ -25,7 +25,8 @@ abinfo "Configuring GRUB for EFI (32-bit) ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI (32-bit) ..."
 make

--- a/app-admin/grub/autobuild/arm32/build.stage2
+++ b/app-admin/grub/autobuild/arm32/build.stage2
@@ -25,7 +25,8 @@ abinfo "Configuring GRUB for EFI (32-bit) ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI (32-bit) ..."
 make

--- a/app-admin/grub/autobuild/arm64/build
+++ b/app-admin/grub/autobuild/arm64/build
@@ -25,7 +25,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/arm64/build.stage2
+++ b/app-admin/grub/autobuild/arm64/build.stage2
@@ -25,7 +25,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/i486/build
+++ b/app-admin/grub/autobuild/i486/build
@@ -29,7 +29,8 @@ abinfo "Configuring GRUB for PC BIOS ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for PC BIOS ..."
 make
@@ -68,7 +69,8 @@ abinfo "Configuring GRUB for EFI32 ..."
     --program-prefix= \
     --with-bootdir=/boot \
     --with-grubdir=grub \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI32 ..."
 make

--- a/app-admin/grub/autobuild/loongarch64/build
+++ b/app-admin/grub/autobuild/loongarch64/build
@@ -22,7 +22,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/loongarch64/build.stage2
+++ b/app-admin/grub/autobuild/loongarch64/build.stage2
@@ -22,7 +22,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/loongson2f/build
+++ b/app-admin/grub/autobuild/loongson2f/build
@@ -25,7 +25,8 @@ abinfo "Configuring GRUB for PMON2000 ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for PMON2000 ..."
 make

--- a/app-admin/grub/autobuild/loongson3/build
+++ b/app-admin/grub/autobuild/loongson3/build
@@ -25,7 +25,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/loongson3/build.stage2
+++ b/app-admin/grub/autobuild/loongson3/build.stage2
@@ -22,7 +22,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/powerpc/build
+++ b/app-admin/grub/autobuild/powerpc/build
@@ -26,7 +26,8 @@ abinfo "Configuring GRUB for IEEE1275 PowerPC bootloaders ..."
     --with-grubdir=grub \
     --enable-silent-rules \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for IEEE1275 PowerPC bootloaders ..."
 make

--- a/app-admin/grub/autobuild/ppc64el/build
+++ b/app-admin/grub/autobuild/ppc64el/build
@@ -23,7 +23,8 @@ abinfo "Configuring GRUB for IEEE1275 PowerPC bootloaders ..."
     --with-bootdir="/boot" \
     --with-grubdir="grub" \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for IEEE1275 PowerPC bootloaders ..."
 make

--- a/app-admin/grub/autobuild/riscv64/build
+++ b/app-admin/grub/autobuild/riscv64/build
@@ -22,7 +22,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/autobuild/riscv64/build.stage2
+++ b/app-admin/grub/autobuild/riscv64/build.stage2
@@ -22,7 +22,8 @@ abinfo "Configuring GRUB for EFI ..."
     --with-bootdir=/boot \
     --with-grubdir=grub \
     --enable-build-id \
-    --disable-rpm-sort
+    --disable-rpm-sort \
+    --disable-werror
 
 abinfo "Building GRUB for EFI ..."
 make

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -8,7 +8,7 @@ RETROFONTVER=20200402
 GNULIB_REV=9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 VER=${__GRUBVER}+unifont${__UNIFONTVER}
-REL=1
+REL=2
 SRCS="git::commit=tags/grub-${UPSTREAM_VER};rename=grub-${UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       git::commit=${GNULIB_REV};rename=gnulib::https://https.git.savannah.gnu.org/git/gnulib.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

With GCC-15 in Core 13, some code patterns in grub triggers a warning that -Werror will turn into an error:

    lib/gnulib/base64.c:65:3: error: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (65 chars into 64 available) [-Werror=unterminated-string-initialization]
       65 |   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
	  |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Add --disable-werror to get rid of -Werror and allow grub to build.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- grub: `2.12-2`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
