### PR TITLE
gcc-15: fix defines.stage2

### DIFF
--- a/app-devel/gcc-15/01-runtime/defines.stage2
+++ b/app-devel/gcc-15/01-runtime/defines.stage2
@@ -53,7 +53,7 @@ AUTOTOOLS_AFTER__AMD64=(
     "${AUTOTOOLS_AFTER[@]}"
     "--enable-languages=${LANGS__GO}"
     '--with-arch=x86-64'
-    '--with-tune='znver4'
+    '--with-tune=znver4'
 )
 AUTOTOOLS_AFTER__ARM64=(
     "${AUTOTOOLS_AFTER[@]}"
@@ -120,7 +120,8 @@ AUTOTOOLS_AFTER__LOONGSON3=(
     '--with-abi=64'
     '--with-arch=gs464'
     '--with-tune=gs464e'
-    '--with-mips-fix-loongson3-llsc"
+    '--with-mips-fix-loongson3-llsc'
+)
 AUTOTOOLS_AFTER__M68K=(
     "${AUTOTOOLS_AFTER[@]}"
     "--enable-languages=${LANGS__RETRO}"


### PR DESCRIPTION
Topic Description
-----------------

- gcc-15: fix defines.stage2

Package(s) Affected
-------------------

- gcc-15: 15.2.0-3
- gcc-runtime-15: 15.2.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcc-15:+stage2 gcc-15
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
