### PR TITLE
id3: fix ANSI C behavior

### DIFF
--- a/app-utils/id3/autobuild/patches/0001-AOSCOS-remove-ANSI-C-code-to-fix-compliation.patch
+++ b/app-utils/id3/autobuild/patches/0001-AOSCOS-remove-ANSI-C-code-to-fix-compliation.patch
@@ -1,0 +1,25 @@
+From 09b784961fb7719ef6069c88378604c8118f8bc9 Mon Sep 17 00:00:00 2001
+From: RawDiamondMC <RawDiamondMC@outlook.com>
+Date: Wed, 31 Dec 2025 18:24:54 +0800
+Subject: [PATCH] AOSCOS: remove ANSI C code to fix compliation
+
+Signed-off-by: RawDiamondMC <RawDiamondMC@outlook.com>
+---
+ fileops.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/fileops.c b/fileops.c
+index 1e70af1..9017bd0 100644
+--- a/fileops.c
++++ b/fileops.c
+@@ -68,7 +68,6 @@ FILE *ftemp(char *templ, const char *mode)
+ #else
+     int fd = mkstemp(templ);
+     if(fd >= 0) {
+-        FILE* fdopen();                         /* in case -ansi is used */
+         if(f = fdopen(fd, mode)) return f;
+         close(fd);
+ #endif
+-- 
+2.52.0
+

--- a/app-utils/id3/spec
+++ b/app-utils/id3/spec
@@ -1,5 +1,5 @@
 VER=0.81
-REL=1
+REL=2
 SRCS="tbl::https://github.com/squell/id3/releases/download/$VER/id3-$VER.tar.gz"
 CHKSUMS="sha256::5eda41e277e67492bfe0116d24962c24c47ead56a925a00f05f724bcc7687b0c"
 CHKUPDATE="anitya::id=231597"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- id3: fix ANSI C behavior

Package(s) Affected
-------------------

- id3: 0.81-2

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit id3
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
