### PR TITLE
gcc-15: fix defines.stage2 again

### DIFF
--- a/app-devel/gcc-15/01-runtime/defines.stage2
+++ b/app-devel/gcc-15/01-runtime/defines.stage2
@@ -44,10 +44,9 @@ AUTOTOOLS_AFTER=(
 )
 
 # Note: Languages to enable.
-
-LANGS__NOGO="--enable-languages=c,c++,fortran,lto,objc,obj-c++"
-LANGS__GO="--enable-languages=c,c++,fortran,lto,go,objc,obj-c++"
-LANGS__RETRO="--enable-languages=c,c++,fortran,lto,objc,obj-c++"
+LANGS__NOGO="c,c++,fortran,lto,objc,obj-c++"
+LANGS__GO="c,c++,fortran,lto,go,objc,obj-c++"
+LANGS__RETRO="c,c++,fortran,lto,objc,obj-c++"
 
 AUTOTOOLS_AFTER__AMD64=(
     "${AUTOTOOLS_AFTER[@]}"


### PR DESCRIPTION
Topic Description
-----------------

- gcc-15: fix defines.stage2 again

Package(s) Affected
-------------------

- gcc-15: 15.2.0-3
- gcc-runtime-15: 15.2.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gcc-15:+stage2 gcc-15
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
