### PR TITLE
COSMIC 1.0.1 Survey

### DIFF
--- a/desktop-cosmic/cosmic-app-library/spec
+++ b/desktop-cosmic/cosmic-app-library/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-applibrary.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377102"

--- a/desktop-cosmic/cosmic-applets/spec
+++ b/desktop-cosmic/cosmic-applets/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-applets.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377113"

--- a/desktop-cosmic/cosmic-bg/spec
+++ b/desktop-cosmic/cosmic-bg/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-bg.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377115"

--- a/desktop-cosmic/cosmic-comp/spec
+++ b/desktop-cosmic/cosmic-comp/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-comp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377116"

--- a/desktop-cosmic/cosmic-edit/spec
+++ b/desktop-cosmic/cosmic-edit/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-edit.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377117"

--- a/desktop-cosmic/cosmic-files/spec
+++ b/desktop-cosmic/cosmic-files/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-files.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377118"

--- a/desktop-cosmic/cosmic-greeter/spec
+++ b/desktop-cosmic/cosmic-greeter/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-greeter.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377119"

--- a/desktop-cosmic/cosmic-icons/spec
+++ b/desktop-cosmic/cosmic-icons/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER::https://github.com/pop-os/cosmic-icons.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377120"

--- a/desktop-cosmic/cosmic-idle/spec
+++ b/desktop-cosmic/cosmic-idle/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-idle.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377121"

--- a/desktop-cosmic/cosmic-initial-setup/spec
+++ b/desktop-cosmic/cosmic-initial-setup/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-initial-setup.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383659"

--- a/desktop-cosmic/cosmic-launcher/spec
+++ b/desktop-cosmic/cosmic-launcher/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-launcher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377122"

--- a/desktop-cosmic/cosmic-notifications/spec
+++ b/desktop-cosmic/cosmic-notifications/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-notifications.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377123"

--- a/desktop-cosmic/cosmic-osd/spec
+++ b/desktop-cosmic/cosmic-osd/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-osd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377124"

--- a/desktop-cosmic/cosmic-panel/spec
+++ b/desktop-cosmic/cosmic-panel/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-panel.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377125"

--- a/desktop-cosmic/cosmic-player/spec
+++ b/desktop-cosmic/cosmic-player/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-player.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377126"

--- a/desktop-cosmic/cosmic-randr/autobuild/defines
+++ b/desktop-cosmic/cosmic-randr/autobuild/defines
@@ -2,8 +2,6 @@ PKGNAME=cosmic-randr
 PKGSEC=COSMIC
 PKGDEP="gcc-runtime glibc"
 BUILDDEP="rustc llvm just"
-# FIXME: rust nightly toolchain need llvm-21
-BUILDDEP__PPC64EL="llvm-21 just"
 PKGDES="Display configuration command line tool for the COSMIC Desktop Environment"
 
 ABTYPE=rust

--- a/desktop-cosmic/cosmic-randr/autobuild/prepare
+++ b/desktop-cosmic/cosmic-randr/autobuild/prepare
@@ -1,6 +1,0 @@
-# FIXME: error[E0658]: inline assembly is not stable yet on this architecture`
-if ab_match_arch ppc64el; then
-    abinfo "Installing Rust nightly version ..."
-    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
-    export PATH="$HOME"/.cargo/bin:"$PATH"
-fi

--- a/desktop-cosmic/cosmic-randr/spec
+++ b/desktop-cosmic/cosmic-randr/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-randr.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377127"

--- a/desktop-cosmic/cosmic-screenshot/spec
+++ b/desktop-cosmic/cosmic-screenshot/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-screenshot.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377128"

--- a/desktop-cosmic/cosmic-session/spec
+++ b/desktop-cosmic/cosmic-session/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-session.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377129"

--- a/desktop-cosmic/cosmic-settings-daemon/spec
+++ b/desktop-cosmic/cosmic-settings-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-settings-daemon.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377131"

--- a/desktop-cosmic/cosmic-settings/autobuild/patches/0001-use-latest-cosmic-randr-to-fix-ppc64le-build-failed.patch
+++ b/desktop-cosmic/cosmic-settings/autobuild/patches/0001-use-latest-cosmic-randr-to-fix-ppc64le-build-failed.patch
@@ -1,0 +1,183 @@
+From 7a05783f9e0a022188ad2d1db398ec92ed63ba6d Mon Sep 17 00:00:00 2001
+From: pugaizai <i@pugai.life>
+Date: Sat, 3 Jan 2026 04:36:06 +0800
+Subject: [PATCH] use latest cosmic-randr to fix ppc64le build failed
+
+---
+ Cargo.lock | 63 ++++++++----------------------------------------------
+ 1 file changed, 9 insertions(+), 54 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 46cee13..eee3c71 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -899,15 +899,6 @@ dependencies = [
+  "zbus 5.12.0",
+ ]
+ 
+-[[package]]
+-name = "branches"
+-version = "0.3.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f11502672c5570f77f6bdf573332483f8475bab6a7fda00f1fae8ddb5a6245c0"
+-dependencies = [
+- "rustc_version",
+-]
+-
+ [[package]]
+ name = "brotli-decompressor"
+ version = "5.0.0"
+@@ -1601,23 +1592,21 @@ dependencies = [
+ [[package]]
+ name = "cosmic-randr"
+ version = "0.1.0"
+-source = "git+https://github.com/pop-os/cosmic-randr#f5923d1ef58b87ef103abe1a0e44460236d8fa36"
++source = "git+https://github.com/pop-os/cosmic-randr#741089cf5e3aa7d5e48042101c1d4cc813b13637"
+ dependencies = [
+  "cosmic-protocols",
+- "futures-lite 2.6.1",
+  "indexmap 2.12.1",
+  "thiserror 2.0.17",
+  "tokio",
+  "tracing",
+  "wayland-client",
+  "wayland-protocols-wlr",
+- "xutex",
+ ]
+ 
+ [[package]]
+ name = "cosmic-randr-shell"
+ version = "0.1.0"
+-source = "git+https://github.com/pop-os/cosmic-randr#f5923d1ef58b87ef103abe1a0e44460236d8fa36"
++source = "git+https://github.com/pop-os/cosmic-randr#741089cf5e3aa7d5e48042101c1d4cc813b13637"
+ dependencies = [
+  "kdl",
+  "slotmap",
+@@ -1954,15 +1943,6 @@ dependencies = [
+  "crossbeam-utils",
+ ]
+ 
+-[[package]]
+-name = "crossbeam-queue"
+-version = "0.3.12"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+-dependencies = [
+- "crossbeam-utils",
+-]
+-
+ [[package]]
+ name = "crossbeam-utils"
+ version = "0.8.21"
+@@ -2222,7 +2202,7 @@ dependencies = [
+  "libc",
+  "option-ext",
+  "redox_users",
+- "windows-sys 0.61.2",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+@@ -2412,7 +2392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+ dependencies = [
+  "libc",
+- "windows-sys 0.61.2",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -4484,7 +4464,7 @@ version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d463f34ca3c400fde3a054da0e0b8c6ffa21e4590922f3e18281bb5eeef4cbdc"
+ dependencies = [
+- "windows-sys 0.61.2",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+@@ -5175,7 +5155,7 @@ version = "0.50.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+ dependencies = [
+- "windows-sys 0.61.2",
++ "windows-sys 0.59.0",
+ ]
+ 
+ [[package]]
+@@ -6595,15 +6575,6 @@ version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+ 
+-[[package]]
+-name = "rustc_version"
+-version = "0.4.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+-dependencies = [
+- "semver",
+-]
+-
+ [[package]]
+ name = "rustix"
+ version = "0.37.28"
+@@ -6641,7 +6612,7 @@ dependencies = [
+  "errno",
+  "libc",
+  "linux-raw-sys 0.11.0",
+- "windows-sys 0.61.2",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -6746,12 +6717,6 @@ version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
+ 
+-[[package]]
+-name = "semver"
+-version = "1.0.27"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+-
+ [[package]]
+ name = "serde"
+ version = "1.0.228"
+@@ -7336,7 +7301,7 @@ dependencies = [
+  "getrandom 0.3.4",
+  "once_cell",
+  "rustix 1.1.2",
+- "windows-sys 0.61.2",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -8380,7 +8345,7 @@ version = "0.1.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+ dependencies = [
+- "windows-sys 0.61.2",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+@@ -9161,16 +9126,6 @@ version = "0.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+ 
+-[[package]]
+-name = "xutex"
+-version = "0.1.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8f7b2794adabee656fae931dc27d457c4e8a83cfe96ad1e1c73de770b8401b57"
+-dependencies = [
+- "branches",
+- "crossbeam-queue",
+-]
+-
+ [[package]]
+ name = "y4m"
+ version = "0.8.0"
+-- 
+2.52.0
+

--- a/desktop-cosmic/cosmic-settings/spec
+++ b/desktop-cosmic/cosmic-settings/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-settings.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377130"

--- a/desktop-cosmic/cosmic-store/spec
+++ b/desktop-cosmic/cosmic-store/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-store.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377132"

--- a/desktop-cosmic/cosmic-term/spec
+++ b/desktop-cosmic/cosmic-term/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-term.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377133"

--- a/desktop-cosmic/cosmic-wallpapers/spec
+++ b/desktop-cosmic/cosmic-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-wallpapers.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=382459"

--- a/desktop-cosmic/cosmic-workspaces/spec
+++ b/desktop-cosmic/cosmic-workspaces/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-workspaces-epoch.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383658"

--- a/desktop-cosmic/pop-launcher/spec
+++ b/desktop-cosmic/pop-launcher/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/launcher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377135"

--- a/desktop-cosmic/xdg-desktop-portal-cosmic/spec
+++ b/desktop-cosmic/xdg-desktop-portal-cosmic/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/xdg-desktop-portal-cosmic.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377137"


### PR DESCRIPTION
Topic Description
-----------------

- cosmic-wallpapers: update to 1.0.1
- cosmic-term: update to 1.0.1
- cosmic-store: update to 1.0.1
- cosmic-player: update to 1.0.1
- cosmic-edit: update to 1.0.1
- cosmic-session: update to 1.0.1
- xdg-desktop-portal-cosmic: update to 1.0.1
- cosmic-settings-daemon: update to 1.0.1
- cosmic-settings: update to 1.0.1
- cosmic-workspaces: update to 1.0.1

... and 16 more commits

Package(s) Affected
-------------------

- cosmic-app-library: 1.0.1
- cosmic-applets: 1.0.1
- cosmic-bg: 1.0.1
- cosmic-comp: 1.0.1
- cosmic-edit: 1.0.1
- cosmic-files: 1.0.1
- cosmic-greeter: 1.0.1
- cosmic-icons: 1.0.1
- cosmic-idle: 1.0.1
- cosmic-initial-setup: 1.0.1
- cosmic-launcher: 1.0.1
- cosmic-notifications: 1.0.1
- cosmic-osd: 1.0.1
- cosmic-panel: 1.0.1
- cosmic-player: 1.0.1
- cosmic-randr: 1.0.1
- cosmic-screenshot: 1.0.1
- cosmic-session: 1.0.1
- cosmic-settings: 1.0.1
- cosmic-settings-daemon: 1.0.1
- cosmic-store: 1.0.1
- cosmic-term: 1.0.1
- cosmic-wallpapers: 1.0.1
- cosmic-workspaces: 1.0.1
- pop-launcher: 1.0.1
- xdg-desktop-portal-cosmic: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit groups/cosmic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
