### PR TITLE
easytier: update to 2.5.0

### DIFF
--- a/app-network/easytier/spec
+++ b/app-network/easytier/spec
@@ -1,4 +1,4 @@
-VER=2.4.5
+VER=2.5.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/EasyTier/EasyTier"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377832"


### PR DESCRIPTION
Topic Description
-----------------

- easytier: update to 2.5.0
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- easytier: 2.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit easytier
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
