### PR TITLE
rocm: Libraries without MachineLearning update to 7.1.1[2/3]

### DIFF
--- a/runtime-rocm/rocm-hipblaslt/autobuild/defines
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipblas-common rocm-roctracer rocm-or
 
 # FIXME: Undefined symbol: cblas_dgemm. Build-time dependency to lapack
 # was removed.
-BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib gtest pyyaml"
+BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib gtest pyyaml blis"
 
 USECLANG=1
 
@@ -42,8 +42,9 @@ CMAKE_AFTER=(
     '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
     '-DCMAKE_LINKER_TYPE=LLD'
-    # FIXME: Need flame/blis
-    '-DHIPBLASLT_ENABLE_BLIS=OFF'
+    '-DHIPBLASLT_ENABLE_BLIS=ON'
+    '-DBLIS_ROOT=/usr'
+    '-DBLIS_LIB=/usr/lib/libblis.so'
     # FIXME: ld.lld: error: undefined symbol: cblas_dgemm
     '-DHIPBLASLT_ENABLE_CLIENT=OFF'
     '-DORIGAMI_ENABLE_INSTALL=OFF'

--- a/runtime-rocm/rocm-hipblaslt/autobuild/patch
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/patch
@@ -1,0 +1,1 @@
+abinfo "There is currently no need to patch the main project."

--- a/runtime-rocm/rocm-hipblaslt/autobuild/patches/0000-fix-hipblaslt-deps-yaml-cpp.patch
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/patches/0000-fix-hipblaslt-deps-yaml-cpp.patch
@@ -1,0 +1,10 @@
+--- a/_deps/yaml_cpp-src/src/emitterutils.cpp     2025-12-17 07:52:30.597484390 +0000
++++ b/_deps/yaml_cpp-src/src/emitterutils.cpp     2025-12-17 07:52:43.313543920 +0000
+@@ -1,6 +1,7 @@
+ #include <algorithm>
+ #include <iomanip>
+ #include <sstream>
++#include <stdint.h>
+
+ #include "emitterutils.h"
+ #include "exp.h"

--- a/runtime-rocm/rocm-hipblaslt/autobuild/prepare
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/prepare
@@ -12,3 +12,8 @@ export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
 
 abinfo "Install Build Dependence ..."
 pip install -v joblib
+
+BUILD_READY(){
+ abinfo "patch yaml-cpp, fix unknown type name 'uint32_t' "
+ ab_apply_patches "$SRCDIR"/autobuild/patches/0000-fix-hipblaslt-deps-yaml-cpp.patch
+}

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -1,5 +1,6 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblaslt"
 CHKUPDATE="anitya::id=383650"
+ENVREQ="disk=340 total_mem_per_core=1"

--- a/runtime-rocm/rocm-hipfft/spec
+++ b/runtime-rocm/rocm-hipfft/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipfft"

--- a/runtime-rocm/rocm-hipsparse/spec
+++ b/runtime-rocm/rocm-hipsparse/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipsparse"

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -1,5 +1,7 @@
-VER=7.1.0
-REL=1
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rccl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241714"
+ENVREQ="total_mem=70"
+# Note: Disable iGPU/CDNA on ARM64. Reduce build pressure.
+ENVREQ__ARM64="total_mem=50"

--- a/runtime-rocm/rocm-rocprim/spec
+++ b/runtime-rocm/rocm-rocprim/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocprim"

--- a/runtime-rocm/rocm-rocsparse/spec
+++ b/runtime-rocm/rocm-rocsparse/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsparse"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-hipsparse: upgrade to 7.1.1
- rocm-hipfft: upgrade to 7.1.1
- rocm-rocsparse: upgrade to 7.1.1
- rocm-rocprim: upgrade to 7.1.1
- rocm-rccl: upgrade to 7.1.1
- rocm-hipblaslt: upgrade to 7.1.1

Package(s) Affected
-------------------

- rocm-hipblaslt: 7.1.1
- rocm-hipfft: 7.1.1
- rocm-hipsparse: 7.1.1
- rocm-rccl: 7.1.1
- rocm-rocprim: 7.1.1
- rocm-rocsparse: 7.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipblaslt rocm-rccl rocm-rocprim rocm-rocsparse rocm-hipfft rocm-hipsparse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
