### PR TITLE
intel-gpu-tools: update to 2.3

### DIFF
--- a/app-admin/intel-gpu-tools/spec
+++ b/app-admin/intel-gpu-tools/spec
@@ -1,4 +1,4 @@
-VER=2.2
+VER=2.3
 SRCS="tbl::https://www.x.org/archive/individual/app/igt-gpu-tools-$VER.tar.xz"
-CHKSUMS="sha256::88178558b352a5e8a287954cb2eef05d775aedfacf43b88251509ea014b6182d"
+CHKSUMS="sha256::429f2578fb16cff7402e9beb325c5c267ad30a2b7b957343c77e8ea24af03887"
 CHKUPDATE="anitya::id=12378"


### PR DESCRIPTION
Topic Description
-----------------

- intel-gpu-tools: update to 2.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- intel-gpu-tools: 2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gpu-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
