### PR TITLE
distrobox: update to 1.8.2.2

### DIFF
--- a/app-utils/distrobox/spec
+++ b/app-utils/distrobox/spec
@@ -1,4 +1,4 @@
-VER=1.8.2.0
+VER=1.8.2.2
 SRCS="git::commit=tags/$VER::https://github.com/89luca89/distrobox"
 CHKUPDATE="anitya::id=242098"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- distrobox: update to 1.8.2.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- distrobox: 1.8.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit distrobox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
