### PR TITLE
tokei: update to 14.0.0

### DIFF
--- a/app-devel/tokei/autobuild/defines
+++ b/app-devel/tokei/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="gcc-runtime glibc"
 BUILDDEP="llvm rustc"
 PKGDES="Program that allows you to count code, quickly"
 
+ABTYPE=rust
 USECLANG=1
 ABSPLITDBG=0
 NOCARGOAUDIT=1

--- a/app-devel/tokei/spec
+++ b/app-devel/tokei/spec
@@ -1,4 +1,4 @@
-VER=13.0.0
+VER=14.0.0
 SRCS="tbl::https://github.com/XAMPPRocky/tokei/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::b426ab03b8eedf4fe3ea70ca8379a2355981b0e9ca1d0083a66e623858e7e481"
+CHKSUMS="sha256::4e561dbb83ef1b46359714fc623fd45eddfb14821ece63a219470500fdd1cd26"
 CHKUPDATE="anitya::id=13727"


### PR DESCRIPTION
Topic Description
-----------------

- tokei: update to 14.0.0

Package(s) Affected
-------------------

- tokei: 14.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit tokei
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
