### PR TITLE
loonggpu-kernel-dkms: update to 1.0.2+lnd25.1~rc1.7-1

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-loonggpu-fix-build-without-CONFIG_MMU_NOTIFIER.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-loonggpu-fix-build-without-CONFIG_MMU_NOTIFIER.patch
@@ -1,7 +1,7 @@
 From f460c8ca8791a460c0ee71f7fac8b7deb0ba24bc Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 3 Dec 2025 21:49:13 +0800
-Subject: [PATCH 01/52] loonggpu: fix build without CONFIG_MMU_NOTIFIER
+Subject: [PATCH 01/63] loonggpu: fix build without CONFIG_MMU_NOTIFIER
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-AOSCOS-loonggpu-remove-driver-date.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-AOSCOS-loonggpu-remove-driver-date.patch
@@ -1,7 +1,7 @@
 From 21e6caf7041633c07471c7ce811c879573c6674a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 6 Feb 2025 18:12:15 +0800
-Subject: [PATCH 02/52] AOSCOS: loonggpu: remove driver date
+Subject: [PATCH 02/63] AOSCOS: loonggpu: remove driver date
 
 Following upstream changes.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-AOSCOS-loonggpu-Use-ccflags-y-instead-of-EXTRA_CFLAG.patch
@@ -1,7 +1,7 @@
 From 1c627ce0152ab8aa316f6e2f7e46c1af16ec2b52 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:36:09 +0800
-Subject: [PATCH 03/52] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
+Subject: [PATCH 03/63] AOSCOS: loonggpu: Use ccflags-y instead of EXTRA_CFLAGS
 
 A comment in Kbuild says "using EXTRA_CFLAGS for compatibility with
 kernel older than 2.6.24" which does not make any sense for loonggpu: we

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
@@ -1,7 +1,7 @@
 From bacf7c817b8918ad75a6dc29e6f600a34030edc0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:03:46 +0800
-Subject: [PATCH 04/52] loonggpu: Remove unused fbdev_list field in
+Subject: [PATCH 04/63] loonggpu: Remove unused fbdev_list field in
  gsgpu_framebuffer
 
 This field is referred nowhere.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-Remove-the-unused-loonggpu_fbdev_total_size.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-Remove-the-unused-loonggpu_fbdev_total_size.patch
@@ -1,7 +1,7 @@
 From 7cf3d0579ea32f535bec1e0f389f7a86642e9d80 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:21:48 +0800
-Subject: [PATCH 05/52] loonggpu: Remove the unused loonggpu_fbdev_total_size
+Subject: [PATCH 05/63] loonggpu: Remove the unused loonggpu_fbdev_total_size
  function
 
 It's referred nowhere.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-Improve-fbdev-object-test-helper.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-Improve-fbdev-object-test-helper.patch
@@ -1,7 +1,7 @@
 From 748af3c1737a15afb10cd3df8fe178ffc087d20f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:27:04 +0800
-Subject: [PATCH 06/52] loonggpu: Improve fbdev object-test helper
+Subject: [PATCH 06/63] loonggpu: Improve fbdev object-test helper
 
 Follow the change of our reference implementation, allowing us to
 remove struct gsgpu_fbdev later.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
@@ -1,7 +1,7 @@
 From 01e66c15b6509ba16747a1227b1e2e49a6f5a0ae Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:34:42 +0800
-Subject: [PATCH 07/52] loonggpu: Remove struct gsgpu_fbdev and add some clean
+Subject: [PATCH 07/63] loonggpu: Remove struct gsgpu_fbdev and add some clean
  up code
 
 Both data fields in struct gsgpu_fbdev, the framebuffer and the

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
@@ -1,7 +1,7 @@
 From 6a00a247c2584643df9bc7e6252481bafdc7276b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:50:01 +0800
-Subject: [PATCH 08/52] loonggpu: Move fbdev cleanup code into fb_destroy
+Subject: [PATCH 08/63] loonggpu: Move fbdev cleanup code into fb_destroy
  callback
 
 Fbdev calls struct fb_ops.fb_destroy after cleaning up the final

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-load-callback-from-kms_driver.patch
@@ -1,7 +1,7 @@
 From 1cce053f18fd0b58358a859edc228de599246204 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:10:14 +0800
-Subject: [PATCH 09/52] loonggpu: Remove load callback from kms_driver
+Subject: [PATCH 09/63] loonggpu: Remove load callback from kms_driver
 
 The ".load" callback in "struct drm_driver" is deprecated. In order to
 remove the callback, we have to manually call "gsgpu_driver_load_kms"

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-AOSCOS-loonggpu-Adapt-for-drm_sched_init-struct-para.patch
@@ -1,7 +1,7 @@
 From a49e5fdcad2917b64ac4d32c999ce1ab2d084c93 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 17:59:23 +0800
-Subject: [PATCH 10/52] AOSCOS: loonggpu: Adapt for drm_sched_init struct
+Subject: [PATCH 10/63] AOSCOS: loonggpu: Adapt for drm_sched_init struct
  params
 
 Since kernel commit 796a9f55a8d1 ("drm/sched: Use struct for

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-AOSCOS-loonggpu-Adapt-for-renaming-of-from_timer-to-.patch
@@ -1,7 +1,7 @@
 From 3d0e8d9ebc4a3869ede63c698ac0fe0c4c4d6bbb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:07:26 +0800
-Subject: [PATCH 11/52] AOSCOS: loonggpu: Adapt for renaming of from_timer to
+Subject: [PATCH 11/63] AOSCOS: loonggpu: Adapt for renaming of from_timer to
  timer_container_of
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-AOSCOS-loonggpu-Adapt-for-renaming-of-del_timer_sync.patch
@@ -1,7 +1,7 @@
 From 301873790c4dfdcdd8d226658265b1b2aa308010 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 21:15:51 +0800
-Subject: [PATCH 12/52] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
+Subject: [PATCH 12/63] AOSCOS: loonggpu: Adapt for renaming of del_timer_sync
  to timer_delete_sync
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Remove-redundant-info-par-assignment.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Remove-redundant-info-par-assignment.patch
@@ -1,7 +1,7 @@
 From 97276ecb618954514ea4526243d7379b681632d6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:59:39 +0800
-Subject: [PATCH 13/52] loonggpu: Remove redundant info->par assignment
+Subject: [PATCH 13/63] loonggpu: Remove redundant info->par assignment
 
 It's already assigned by lg_drm_fb_helper_fill_info (no matter what the
 kernel version is).

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
@@ -1,7 +1,7 @@
 From 1123ffc5969fbf8861f11e7e29d13361b5248d86 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:19:37 +0800
-Subject: [PATCH 14/52] loonggpu: Remove test for !screen_base in fbdev probing
+Subject: [PATCH 14/63] loonggpu: Remove test for !screen_base in fbdev probing
 
 The screen_base field comes from the fbdev BO and contains the fbdev
 framebuffer base address. We get the BO memory via gsgpu_bo_kmap(),

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Correctly-clean-up-failed-display-probing.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-Correctly-clean-up-failed-display-probing.patch
@@ -1,7 +1,7 @@
 From 33cca3026e74bbce7cd33f8c187d091a7e389e52 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:21:28 +0800
-Subject: [PATCH 15/52] loonggpu: Correctly clean up failed display probing
+Subject: [PATCH 15/63] loonggpu: Correctly clean up failed display probing
 
 Improve the fbdev probing function to fully clean up if it failed.
 Allows to remove special cases from fb_destroy as well.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,7 +1,7 @@
 From 9df674776cbe2074ff6535a4e61d3c54e217872a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:21:11 +0800
-Subject: [PATCH 16/52] loonggpu: Implement client-based fbdev emulation
+Subject: [PATCH 16/63] loonggpu: Implement client-based fbdev emulation
 
 Implement fbdev emulation on top of struct drm_client and its helpers.
 Replaces ad-hoc interfaces for restoring and closing fbdev emulation with

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,7 +1,7 @@
 From d93e4dcc7388511ee3100bf481683c9bbdfdd593 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:31:20 +0800
-Subject: [PATCH 17/52] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
+Subject: [PATCH 17/63] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
  call
 
 It's not needed anymore as now the generic drm_client_register() calls

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,7 +1,7 @@
 From 2725f89965f8015c55ab2e57413ccecbe0d28c46 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:35:32 +0800
-Subject: [PATCH 18/52] loonggpu: Disable outputs when releasing fbdev client
+Subject: [PATCH 18/63] loonggpu: Disable outputs when releasing fbdev client
 
 Following up the reference implementation change to avoid potential
 errors.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,7 +1,7 @@
 From d736ed165340c7b6c9fbdfc648780a804a7b2e80 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:58:47 +0800
-Subject: [PATCH 19/52] loonggpu: Run DRM default client setup
+Subject: [PATCH 19/63] loonggpu: Run DRM default client setup
 
 Rework fbdev probing to support fbdev_probe in struct drm_driver
 and remove the old fb_probe callback. Provide an initializer macro

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-bridge-make-is_resolution_valid-static.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-bridge-make-is_resolution_valid-static.patch
@@ -1,7 +1,7 @@
 From f338b5bc81aeb31f1c0686493abf08a14025faf4 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:15:00 +0800
-Subject: [PATCH 20/52] loonggpu-bridge: make is_resolution_valid static
+Subject: [PATCH 20/63] loonggpu-bridge: make is_resolution_valid static
 
 Now it's only used in the TU where we define it.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-bridge-constify-struct-drm_display_mode-poi.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-bridge-constify-struct-drm_display_mode-poi.patch
@@ -1,7 +1,7 @@
 From 73ba877995d2c08941a7f4fd91cab5a4369c2a0d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:31:07 +0800
-Subject: [PATCH 21/52] loonggpu-bridge: constify struct drm_display_mode
+Subject: [PATCH 21/63] loonggpu-bridge: constify struct drm_display_mode
  pointers
 
 Prepare for 6.15 kernel API change.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
@@ -1,7 +1,7 @@
 From 95f25d6bd8769307007a69dce5cf2957315c0089 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:31:22 +0800
-Subject: [PATCH 22/52] loonggpu: bridge: Adapt for recent kernel API changes
+Subject: [PATCH 22/63] loonggpu: bridge: Adapt for recent kernel API changes
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,7 +1,7 @@
 From f1ad51b615599daebae19710c28e49f75d38c43c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 10:49:40 +0800
-Subject: [PATCH 23/52] loonggpu: Remove the check against moving pinned BOs
+Subject: [PATCH 23/63] loonggpu: Remove the check against moving pinned BOs
 
 The check is already in the generic code.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-loonggpu-Remove-dead-code.patch
@@ -1,7 +1,7 @@
 From 51f55e065d1c831f4c9328ba6bad59391531196d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 11:18:49 +0800
-Subject: [PATCH 24/52] loonggpu: Remove dead code
+Subject: [PATCH 24/63] loonggpu: Remove dead code
 
 The body of this if statement is obviously unreachable.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,7 +1,7 @@
 From e15b32b4e5274111de7540ac8f2d9246cc53ed52 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 12:11:28 +0800
-Subject: [PATCH 25/52] loonggpu: NFC: Clean up gsgpu_bo_move
+Subject: [PATCH 25/63] loonggpu: NFC: Clean up gsgpu_bo_move
 
 Just use goto to deduplicate some identical code, and wrap a long line
 to make the flow more similar to the reference implementation.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-Handle-tt-moves-properly.patch
@@ -1,7 +1,7 @@
 From a49ecd72568dae45b40b8771fdcf416f2e2ad4d7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:08:07 +0800
-Subject: [PATCH 26/52] loonggpu: Handle tt moves properly
+Subject: [PATCH 26/63] loonggpu: Handle tt moves properly
 
 It seems required since a TTM move refactoring in 2020.  Following up the
 reference implementation change (and several changes after that).

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Use-multihop.patch
@@ -1,7 +1,7 @@
 From 32eb9bcb93e8308cc4ac60652accb500279716f6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:35:15 +0800
-Subject: [PATCH 27/52] loonggpu: Use multihop
+Subject: [PATCH 27/63] loonggpu: Use multihop
 
 Remove the code to move resources directly between
 SYSTEM and VRAM in favour of using the core ttm mulithop code.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,7 +1,7 @@
 From 3c79dba60ac55d0a956be8b9c5f4b15fd027e00a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:42:37 +0800
-Subject: [PATCH 28/52] loonggpu: Drop the unused no_wait_gpu parameter of
+Subject: [PATCH 28/63] loonggpu: Drop the unused no_wait_gpu parameter of
  gsgpu_move_blit
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,7 +1,7 @@
 From a0dbdec6d63231ee099483848e10ef7d0c761306 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:49:20 +0800
-Subject: [PATCH 29/52] loonggpu: Drop lg_ttm_tt_bind
+Subject: [PATCH 29/63] loonggpu: Drop lg_ttm_tt_bind
 
 Get rid of the ttm_tt_populate usage: this symbol is only exported if
 DRM_TTM_KUNIT_TEST which requires COMPILE_TEST on LoongArch.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,7 +1,7 @@
 From cb82dae9e7df70b541de83813f79e6315702480c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:24:23 +0800
-Subject: [PATCH 30/52] loonggpu: Remove an invalid "const" qualifier
+Subject: [PATCH 30/63] loonggpu: Remove an invalid "const" qualifier
 
 You obviously cannot sprintf things into a const char array!
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,7 +1,7 @@
 From 0c9f6f1a16efff6fa92a769bcbc0a8a1bf2694fb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:26:21 +0800
-Subject: [PATCH 31/52] loonggpu: Fix the parameter order of a kmalloc_array
+Subject: [PATCH 31/63] loonggpu: Fix the parameter order of a kmalloc_array
  call
 
 The element size should be the second parameter.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
@@ -1,7 +1,7 @@
 From 265dc93984c2d6513c0618582d898e3eadc60b0a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:18:18 +0800
-Subject: [PATCH 32/52] loonggpu: Pass DRM client ID to drm_sched_job_init
+Subject: [PATCH 32/63] loonggpu: Pass DRM client ID to drm_sched_job_init
 
 Adapt for upstream API change.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
@@ -1,7 +1,7 @@
 From dbed12e7abc816c974220a4ebf9a337eb32d99fc Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:06:53 +0800
-Subject: [PATCH 33/52] loonggpu: Adapt for drm_get_format_info() API change
+Subject: [PATCH 33/63] loonggpu: Adapt for drm_get_format_info() API change
 
 Link: https://git.kernel.org/torvalds/c/0e7d5874fb6b
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Adapt-for-.fb_create-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Adapt-for-.fb_create-API-change.patch
@@ -1,7 +1,7 @@
 From 9d4810ea2718bedf650a29208a0307d3a203b82a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:12:24 +0800
-Subject: [PATCH 34/52] loonggpu: Adapt for .fb_create API change
+Subject: [PATCH 34/63] loonggpu: Adapt for .fb_create API change
 
 Link: https://git.kernel.org/torvalds/c/81112eaac559
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
@@ -1,7 +1,7 @@
 From 4204cca728db4886344052651fe471d8cadbcbf6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:15:46 +0800
-Subject: [PATCH 35/52] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
+Subject: [PATCH 35/63] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API
  change
 
 Link: https://git.kernel.org/torvalds/c/a34cc7bf1034

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
@@ -1,7 +1,7 @@
 From 0bdf30e41cd440d5f34c1a5c8ab1cbf6602dfd41 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:24:55 +0800
-Subject: [PATCH 36/52] loonggpu: Pass along the format info from .fb_create()
+Subject: [PATCH 36/63] loonggpu: Pass along the format info from .fb_create()
  to drm_helper_mode_fill_fb_struct()
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
@@ -1,7 +1,7 @@
 From 825a77fc23af418dd0a98101dc94ec930fad3456 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:20:01 +0800
-Subject: [PATCH 37/52] loonggpu: Adapt for the rename of
+Subject: [PATCH 37/63] loonggpu: Adapt for the rename of
  DRM_GPU_SCHED_STAT_NOMINAL to DRM_GPU_SCHED_STAT_RESET
 
 Link: https://git.kernel.org/torvalds/c/0a5dc1b67ef5

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Don-t-directly-use-ttm_bo_get.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Don-t-directly-use-ttm_bo_get.patch
@@ -1,7 +1,7 @@
 From 5ae476b092245722042d376f94a9da150cbc1790 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:23:20 +0800
-Subject: [PATCH 38/52] loonggpu: Don't directly use ttm_bo_get
+Subject: [PATCH 38/63] loonggpu: Don't directly use ttm_bo_get
 
 Adapt for upstream API change which made this function internal.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Get-rid-of-drm_sched_job.id.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Get-rid-of-drm_sched_job.id.patch
@@ -1,7 +1,7 @@
 From 6b3cfcd1826cc6b821061ca5cd15e405cab26fd0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 27 Aug 2025 10:31:29 +0800
-Subject: [PATCH 39/52] loonggpu: Get rid of drm_sched_job.id
+Subject: [PATCH 39/63] loonggpu: Get rid of drm_sched_job.id
 
 It's removed in the upstream kernel.  I don't bother to add a #ifdef for
 kernel version check here because our users don't care about tracing

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-bridge-alloc-bridge-phy-using-devm_drm_brid.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-bridge-alloc-bridge-phy-using-devm_drm_brid.patch
@@ -1,7 +1,7 @@
 From f199268c63ea3a06af2f2f954dcc479324d77fed Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 5 Dec 2025 09:19:11 +0800
-Subject: [PATCH 40/52] loonggpu-bridge: alloc bridge phy using
+Subject: [PATCH 40/63] loonggpu-bridge: alloc bridge phy using
  devm_drm_bridge_alloc
 
 It's mandatory since Linux 6.17.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
@@ -1,7 +1,7 @@
 From 70916cf6a67c8c2557c8cd6a4f5862398c94e7f2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 13 Oct 2025 11:37:06 +0800
-Subject: [PATCH 41/52] loonggpu: Get rid of ida_simple_get and
+Subject: [PATCH 41/63] loonggpu: Get rid of ida_simple_get and
  ida_simple_remove
 
 They'd been a deprecated wrapper of ida_alloc_range and ida_free since

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-drop-LG_ZONE_MANAGED_PAGES.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-drop-LG_ZONE_MANAGED_PAGES.patch
@@ -1,7 +1,7 @@
 From 6b7cb1fcf679d83b22c58dfd5f47cbb12da987b3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 2 Dec 2025 15:16:13 +0800
-Subject: [PATCH 42/52] loonggpu: drop LG_ZONE_MANAGED_PAGES
+Subject: [PATCH 42/63] loonggpu: drop LG_ZONE_MANAGED_PAGES
 
 With commit 959b0886256b ("mm: constify zone related test/getter
 function"), the argument to `zone_managed_pages()' is now `const'.

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-ensure-clearing-the-mapping-field-of-ttm-pa.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-ensure-clearing-the-mapping-field-of-ttm-pa.patch
@@ -1,7 +1,7 @@
 From 04f32107fba7ea7c186acf017970215af5de3297 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 27 Nov 2025 20:07:59 +0800
-Subject: [PATCH 43/52] loonggpu: ensure clearing the mapping field of ttm
+Subject: [PATCH 43/63] loonggpu: ensure clearing the mapping field of ttm
  pages
 
 As the name of "lg_ttm_unmap_and_unpopulate_pages" suggests, it should

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,7 +1,7 @@
 From 958483d34fc9420a5001b67fbeb1922fadaafef6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 16:10:04 +0800
-Subject: [PATCH 44/52] loonggpu: Handle the different drm_client_setup.h
+Subject: [PATCH 44/63] loonggpu: Handle the different drm_client_setup.h
  location in 6.12
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
@@ -1,7 +1,7 @@
 From d6e628a42ed2b2dbec719473ff2434475910adfb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 28 Dec 2025 18:18:19 +0800
-Subject: [PATCH 45/52] loonggpu: Handle the error from gsgpu_driver_load_kms
+Subject: [PATCH 45/63] loonggpu: Handle the error from gsgpu_driver_load_kms
  correctly
 
 With a 4KiB-page kernel, gsgpu_gart_init will fail because it requires

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
@@ -1,7 +1,7 @@
 From 5f4a4dfbf43fa3eb824afba7f764e6b2b6d6b232 Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:28:47 +0800
-Subject: [PATCH 46/52] loonggpu: fix typo mistake in
+Subject: [PATCH 46/63] loonggpu: fix typo mistake in
  include/gsgpu_ttm_resource_helper.h
 
 ---

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,7 +1,7 @@
 From 7a687c04dd2f12f533770819f8d9800e26a07bcd Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:33:29 +0800
-Subject: [PATCH 47/52] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
+Subject: [PATCH 47/63] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
  switched to c23
 
 ---

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-Drop-CLEAN-from-dkms.conf.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-Drop-CLEAN-from-dkms.conf.patch
@@ -1,7 +1,7 @@
 From dbb51a756731b785533369ca80a845fcb007e2f8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 4 Nov 2025 11:26:37 +0800
-Subject: [PATCH 48/52] loonggpu: Drop CLEAN= from dkms.conf
+Subject: [PATCH 48/63] loonggpu: Drop CLEAN= from dkms.conf
 
 It's unneeded and deprecated in the recent dkms release.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-bridge-remove-calls-to-drm_do_get_edid.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-bridge-remove-calls-to-drm_do_get_edid.patch
@@ -1,7 +1,7 @@
 From 5883ee8afd65e46c658031ef25d5de5ecfe5361a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 18:18:06 +0800
-Subject: [PATCH 49/52] loonggpu-bridge: remove calls to drm_do_get_edid
+Subject: [PATCH 49/63] loonggpu-bridge: remove calls to drm_do_get_edid
 
 It's removed in 6.10 kernel release.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-don-t-return-an-error-if-backlight-initiali.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-don-t-return-an-error-if-backlight-initiali.patch
@@ -1,7 +1,7 @@
 From 0940ea1e54e209d8e8fa97e2ebaa8bf98da62e34 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 22:06:18 +0800
-Subject: [PATCH 50/52] loonggpu: don't return an error if backlight
+Subject: [PATCH 50/63] loonggpu: don't return an error if backlight
  initialization fails
 
 If this returns an error, the load of loonggpu will fail.  But in fact

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-backlight-get-PWM-correctly-and-skip-GPIO-f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-backlight-get-PWM-correctly-and-skip-GPIO-f.patch
@@ -1,7 +1,7 @@
 From 5eab1f32f0bb922ea61f0a253621112f5f0c881e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 22:22:22 +0800
-Subject: [PATCH 51/52] loonggpu: backlight: get PWM correctly and skip GPIO
+Subject: [PATCH 51/63] loonggpu: backlight: get PWM correctly and skip GPIO
  for now
 
 This should make backlight control at least usable with AOSC 6.16.1-rc1

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
@@ -1,7 +1,7 @@
 From bf51952757eab83ed34a63215efbbebad0d16fe3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 30 Oct 2025 10:12:33 +0800
-Subject: [PATCH 52/52] loonggpu: Only build a dummy if page size is 4 KiB
+Subject: [PATCH 52/63] loonggpu: Only build a dummy if page size is 4 KiB
 
 The hack [1] is not enough as when we install a kernel package (like
 linux-kernel-6.17.1), the postinstall script of the kernel package still

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0053-bridge_phy-add-conditional-compilation-for-linux-6.1.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0053-bridge_phy-add-conditional-compilation-for-linux-6.1.patch
@@ -1,0 +1,43 @@
+From 64a8a33a3d04355267a9382c1819884a2e2467ff Mon Sep 17 00:00:00 2001
+From: elysia-best <a.elysia@proton.me>
+Date: Sat, 3 Jan 2026 11:42:21 +0800
+Subject: [PATCH 53/63] bridge_phy: add conditional compilation for linux 6.12
+
+Function `devm_drm_bridge_alloc()` was introduced in Linux 6.16. In previous version, we should use `devm_kzalloc()` instead of `devm_drm_bridge_alloc()`.
+
+Refer to https://github.com/torvalds/linux/commit/0cc6aadd7fc1e629b715ea3d1ba537ef2da95eec
+
+Signed-off-by: Elysia <a.elysia@proton.me>
+---
+ loonggpu-bridge/bridge_phy.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/loonggpu-bridge/bridge_phy.c b/loonggpu-bridge/bridge_phy.c
+index 74fe48f..195441d 100644
+--- a/loonggpu-bridge/bridge_phy.c
++++ b/loonggpu-bridge/bridge_phy.c
+@@ -759,6 +759,7 @@ struct loonggpu_bridge_phy *bridge_phy_alloc(struct loonggpu_dc_bridge *dc_bridg
+ 	struct connector_resource *connector_res =
+ 			dc_bridge->adev->dc->link_info[index].connector;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+ 	bridge_phy = devm_drm_bridge_alloc(dc_bridge->adev->dev,
+ 					   struct loonggpu_bridge_phy,
+ 					   bridge, &bridge_funcs);
+@@ -766,6 +767,13 @@ struct loonggpu_bridge_phy *bridge_phy_alloc(struct loonggpu_dc_bridge *dc_bridg
+ 		DRM_ERROR("Failed to alloc loonggpu bridge phy!\n");
+ 		return bridge_phy;
+ 	}
++#else
++	bridge_phy = devm_kzalloc(dc_bridge->adev->dev, sizeof(*bridge_phy), GFP_KERNEL);
++	if (!bridge_phy) {
++		DRM_ERROR("Failed to alloc loonggpu bridge phy!\n");
++		return bridge_phy;
++	}
++#endif
+ 
+ 	bridge_phy->display_pipe_index = dc_bridge->display_pipe_index;
+ 	bridge_phy->bridge.driver_private = bridge_phy;
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0054-loonggpu-bridge-remove-redundant-bridge-func-vptr-as.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0054-loonggpu-bridge-remove-redundant-bridge-func-vptr-as.patch
@@ -1,0 +1,30 @@
+From 744e74f493957046246dae27824ea1a5334abf36 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 3 Jan 2026 14:12:17 +0800
+Subject: [PATCH 54/63] loonggpu-bridge: remove redundant bridge func vptr
+ assignment
+
+On Linux >= 6.16, devm_drm_bridge_alloc() already assigns it.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu-bridge/bridge_phy.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/loonggpu-bridge/bridge_phy.c b/loonggpu-bridge/bridge_phy.c
+index 195441d..e0e5eb5 100644
+--- a/loonggpu-bridge/bridge_phy.c
++++ b/loonggpu-bridge/bridge_phy.c
+@@ -373,7 +373,9 @@ static int bridge_phy_bind(struct loonggpu_bridge_phy *phy)
+ {
+ 	int ret;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ 	phy->bridge.funcs = &bridge_funcs;
++#endif
+ 	drm_bridge_add(&phy->bridge);
+ 	ret = lg_drm_bridge_attach(phy->encoder, &phy->bridge, NULL, 0);
+ 	if (ret) {
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0055-loonggpu-bridge-make-bridge_phy_alloc-return-ERR_PTR.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0055-loonggpu-bridge-make-bridge_phy_alloc-return-ERR_PTR.patch
@@ -1,0 +1,30 @@
+From 4061fc04dd3ef24609eeedd875085d71eed4a3cf Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 3 Jan 2026 14:18:26 +0800
+Subject: [PATCH 55/63] loonggpu-bridge: make bridge_phy_alloc() return
+ ERR_PTR(-ENOMEM) instead of NULL on alloc failure
+
+Some logics for 7a2000 and 2k3000 are checking the return value with
+IS_ERR.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu-bridge/bridge_phy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/loonggpu-bridge/bridge_phy.c b/loonggpu-bridge/bridge_phy.c
+index e0e5eb5..487b5bf 100644
+--- a/loonggpu-bridge/bridge_phy.c
++++ b/loonggpu-bridge/bridge_phy.c
+@@ -773,7 +773,7 @@ struct loonggpu_bridge_phy *bridge_phy_alloc(struct loonggpu_dc_bridge *dc_bridg
+ 	bridge_phy = devm_kzalloc(dc_bridge->adev->dev, sizeof(*bridge_phy), GFP_KERNEL);
+ 	if (!bridge_phy) {
+ 		DRM_ERROR("Failed to alloc loonggpu bridge phy!\n");
+-		return bridge_phy;
++		return ERR_PTR(-ENOMEM);
+ 	}
+ #endif
+ 
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0056-loonggpu-bridge-make-some-functions-static.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0056-loonggpu-bridge-make-some-functions-static.patch
@@ -1,0 +1,43 @@
+From 5e91829b501d30214ecd487004b2907b26f26992 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 3 Jan 2026 14:29:47 +0800
+Subject: [PATCH 56/63] loonggpu-bridge: make some functions static
+
+They are only used in the TU where the function is defined.  Thus we
+can make them static to fix some missing prototype warnings.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu-bridge/it66121_drv.c | 2 +-
+ loonggpu/loonggpu_dc_dp.c     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/loonggpu-bridge/it66121_drv.c b/loonggpu-bridge/it66121_drv.c
+index 8062dd2..22d2e34 100644
+--- a/loonggpu-bridge/it66121_drv.c
++++ b/loonggpu-bridge/it66121_drv.c
+@@ -26,7 +26,7 @@ DEFINE_SIMPLE_REG_SEQ_FUNC(afe_high)
+ DEFINE_SIMPLE_REG_SEQ_FUNC(afe_low)
+ DEFINE_SIMPLE_REG_SEQ_FUNC(hdmi)
+ 
+-int it66121_hdmi_output_mode(struct loonggpu_bridge_phy *phy, int mode)
++static int it66121_hdmi_output_mode(struct loonggpu_bridge_phy *phy, int mode)
+ {
+ 	if ((enum hdmi_mode)mode == HDMI_MODE_NORMAL) {
+ 		SIMPLE_REG_SEQ_FUNC(hdmi)(phy);
+diff --git a/loonggpu/loonggpu_dc_dp.c b/loonggpu/loonggpu_dc_dp.c
+index aff48e0..aea2cb7 100644
+--- a/loonggpu/loonggpu_dc_dp.c
++++ b/loonggpu/loonggpu_dc_dp.c
+@@ -852,7 +852,7 @@ int ls2k3000_dp_resume(struct loonggpu_dc_crtc *crtc, int intf)
+ 	return 0;
+ }
+ 
+-int ls2k3000_dp_aux_detect_status(struct loonggpu_dc_crtc *crtc, int intf)
++static int ls2k3000_dp_aux_detect_status(struct loonggpu_dc_crtc *crtc, int intf)
+ {
+ 	struct loonggpu_device *adev = crtc->dc->adev;
+ 	struct connector_resource *connector_res;
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0057-loonggpu-adapt-for-ttm_device_init-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0057-loonggpu-adapt-for-ttm_device_init-API-change.patch
@@ -1,0 +1,36 @@
+From 1ce69436ada6a01efb51a0d03378c026f7ac5ad5 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 14:58:46 +0800
+Subject: [PATCH 57/63] loonggpu: adapt for ttm_device_init API change
+
+Link: https://git.kernel.org/torvalds/c/77e19f8d3297
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/loonggpu_helper.h | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/include/loonggpu_helper.h b/include/loonggpu_helper.h
+index c6dd605..82cd586 100644
+--- a/include/loonggpu_helper.h
++++ b/include/loonggpu_helper.h
+@@ -103,7 +103,16 @@ static inline int lg_loonggpu_ttm_bo_device_init(struct loonggpu_device *adev,
+ 					#endif
+ 					     )
+ {
+-#if defined(LG_DRM_TTM_TTM_DEVICE_H_PRESENT)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++	return ttm_device_init(&adev->mman.bdev,
++				driver, adev->dev,
++				adev->ddev->anon_inode->i_mapping,
++				adev->ddev->vma_offset_manager,
++				(adev->need_swiotlb ?
++				 TTM_ALLOCATION_POOL_USE_DMA_ALLOC : 0) |
++				(dma_addressing_limited(adev->dev) ?
++				 TTM_ALLOCATION_POOL_USE_DMA32 : 0));
++#elif defined(LG_DRM_TTM_TTM_DEVICE_H_PRESENT)
+ 	return ttm_device_init(&adev->mman.bdev,
+ 				driver, adev->dev,
+ 				adev->ddev->anon_inode->i_mapping,
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0058-loonggpu-conftest-add-fms-extensions-to-CFLAGS.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0058-loonggpu-conftest-add-fms-extensions-to-CFLAGS.patch
@@ -1,0 +1,31 @@
+From 5ca258f0b54e1fe0bc3c719f399552e0ad0a42f7 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 3 Jan 2026 15:14:56 +0800
+Subject: [PATCH 58/63] loonggpu: conftest: add -fms-extensions to CFLAGS
+
+Since Linux 6.19, some constructs in the (non-UAPI) headers uses the
+Go-like unnamed member, that -fms-extensions enables.
+
+Link: https://git.kernel.org/torvalds/c/c4781dc3d1cf
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ conftest.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index d7d0219..6eba116 100755
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -89,7 +89,8 @@ build_cflags() {
+     BASE_CFLAGS="-O2 -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM \
+--Wno-implicit-function-declaration -Wno-strict-prototypes -std=gnu11"
++-Wno-implicit-function-declaration -Wno-strict-prototypes -std=gnu11 \
++-fms-extensions"
+ 
+     if [ "$OUTPUT" != "$SOURCES" ]; then
+         OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0059-loonggpu-Drop-the-call-to-drm_fb_helper_alloc_info.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0059-loonggpu-Drop-the-call-to-drm_fb_helper_alloc_info.patch
@@ -1,0 +1,32 @@
+From d8a9cd0719635ac10749b13e248e6543e62aa2ef Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 15:34:32 +0800
+Subject: [PATCH 59/63] loonggpu: Drop the call to drm_fb_helper_alloc_info
+
+On Linux >= 6.19 it's called by the DRM generic code and no longer
+exported for the drivers.
+
+Link: https://git.kernel.org/torvalds/c/63c971af4036
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/loonggpu_helper.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/loonggpu_helper.h b/include/loonggpu_helper.h
+index 82cd586..90132af 100644
+--- a/include/loonggpu_helper.h
++++ b/include/loonggpu_helper.h
+@@ -527,7 +527,9 @@ static inline void lg_ttm_bo_unlock_delayed_workqueue(struct loonggpu_device *ad
+ 
+ static inline struct fb_info *lg_drm_fb_helper_alloc_info(struct drm_fb_helper *helper)
+ {
+-#if defined(LG_DRM_FB_HELPER_ALLOC_INFO)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++	return helper->info;
++#elif defined(LG_DRM_FB_HELPER_ALLOC_INFO)
+ 	return drm_fb_helper_alloc_info(helper);
+ #else
+ 	return drm_fb_helper_alloc_fbi(helper);
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0060-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0060-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
@@ -1,0 +1,31 @@
+From 22de20a43b2ce0a7fd17aa5dd9c5b80f4a734b6a Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Dec 2025 09:49:49 +0800
+Subject: [PATCH 60/63] loonggpu: use ttm_resource_manager_cleanup instead of
+ manually inlining it
+
+It should work since Linux 5.9.  And inlining an outdated copy causes a
+build failure on Linux 6.19.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu/loonggpu_ttm.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/loonggpu/loonggpu_ttm.c b/loonggpu/loonggpu_ttm.c
+index 2fd79b0..050fd08 100644
+--- a/loonggpu/loonggpu_ttm.c
++++ b/loonggpu/loonggpu_ttm.c
+@@ -1875,8 +1875,7 @@ void loonggpu_ttm_set_buffer_funcs_status(struct loonggpu_device *adev, bool ena
+ 		}
+ 	} else {
+ 		drm_sched_entity_destroy(&adev->mman.entity);
+-		dma_fence_put(man->move);
+-		man->move = NULL;
++		ttm_resource_manager_cleanup(man);
+ 	}
+ 
+ 	/* this just adjusts TTM size idea, which sets lpfn to the correct value */
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0061-loonggpu-handle-the-rename-of-ttm_bo_put-to-ttm_bo_f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0061-loonggpu-handle-the-rename-of-ttm_bo_put-to-ttm_bo_f.patch
@@ -1,0 +1,31 @@
+From 6c0deeaacb0e27cd0df8ce812f2bf43e297b55c5 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 3 Jan 2026 15:38:35 +0800
+Subject: [PATCH 61/63] loonggpu: handle the rename of ttm_bo_put to
+ ttm_bo_fini
+
+Link: https://git.kernel.org/torvalds/c/ed7a4397f55b
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu/loonggpu_gem.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/loonggpu/loonggpu_gem.c b/loonggpu/loonggpu_gem.c
+index b441934..79f419b 100644
+--- a/loonggpu/loonggpu_gem.c
++++ b/loonggpu/loonggpu_gem.c
+@@ -81,7 +81,11 @@ void loonggpu_gem_object_free(struct drm_gem_object *gobj)
+ 
+ 	if (robj) {
+ 		loonggpu_mn_unregister(robj);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++		ttm_bo_fini(&robj->tbo);
++#else
+ 		ttm_bo_put(&robj->tbo);
++#endif
+ 	}
+ }
+ 
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0062-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0062-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
@@ -1,0 +1,44 @@
+From 2208abc9487bfab9e1db16c3e98e022e213c63a3 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Dec 2025 17:12:38 +0800
+Subject: [PATCH 62/63] loonggpu: remove gsgpu_driver_lastclose_kms on Linux >=
+ 6.12
+
+This is not used on Linux >= 6.12, and it fails to build on Linux 6.19.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu/loonggpu_kms.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/loonggpu/loonggpu_kms.c b/loonggpu/loonggpu_kms.c
+index 42371eb..d34c0a6 100644
+--- a/loonggpu/loonggpu_kms.c
++++ b/loonggpu/loonggpu_kms.c
+@@ -6,6 +6,7 @@
+ #include <linux/slab.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/pci.h>
++#include <linux/version.h>
+ #include <drm/drm_debugfs.h>
+ #include "loonggpu_gtt_mgr_helper.h"
+ 
+@@ -536,6 +537,7 @@ static int loonggpu_info_ioctl(struct drm_device *dev, void *data, struct drm_fi
+ }
+ 
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ /*
+  * Outdated mess for old drm with Xorg being in charge (void function now).
+  */
+@@ -551,6 +553,7 @@ void loonggpu_driver_lastclose_kms(struct drm_device *dev)
+ 	drm_fb_helper_lastclose(dev);
+ 	vga_switcheroo_process_delayed_switch();
+ }
++#endif
+ 
+ /**
+  * loonggpu_driver_open_kms - drm callback for open
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0063-loonggpu-handle-the-pci_resize_resource-API-change-i.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0063-loonggpu-handle-the-pci_resize_resource-API-change-i.patch
@@ -1,0 +1,40 @@
+From 75eb3ff25ac9b36a66dbf6d7f9858981cd57aff9 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 3 Jan 2026 15:55:57 +0800
+Subject: [PATCH 63/63] loonggpu: handle the pci_resize_resource API change in
+ Linux 6.19
+
+The loonggpu_device_resize_fb_bar() function seems not used as at now so
+I'm unsure if the change is correct (see TODO).
+
+Link: https://git.kernel.org/torvalds/c/db92e3fef53e
+Link: https://git.kernel.org/torvalds/c/337b1b566db0
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu/loonggpu_device.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/loonggpu/loonggpu_device.c b/loonggpu/loonggpu_device.c
+index d480ac6..90917dc 100644
+--- a/loonggpu/loonggpu_device.c
++++ b/loonggpu/loonggpu_device.c
+@@ -446,11 +446,16 @@ int loonggpu_device_resize_fb_bar(struct loonggpu_device *adev)
+ 	pci_write_config_word(adev->pdev, PCI_COMMAND,
+ 			      cmd & ~PCI_COMMAND_MEMORY);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++	/* TODO: do we need to preserve some BAR(s) via the 4th parameter?  */
++	r = pci_resize_resource(adev->pdev, 0, rbar_size, 0);
++#else
+ 	pci_release_resource(adev->pdev, 3);
+ 
+ 	pci_release_resource(adev->pdev, 0);
+ 
+ 	r = pci_resize_resource(adev->pdev, 0, rbar_size);
++#endif
+ 	if (r == -ENOSPC)
+ 		DRM_INFO("Not enough PCI address space for a large BAR.");
+ 	else if (r && r != -ENOTSUPP)
+-- 
+2.52.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=1.0.2-lnd25.1~rc1.7
+REL=1
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}


### PR DESCRIPTION
Topic Description
-----------------

- Add compatibility for Linux 6.19-rc3 and 6.12.
- Tracking AOSC patches at AOSC-Tracking/loonggpu-kernel-dkms @ aosc/v1.0.2-lnd25.1-rc1
  (HEAD: 2576e56ec0fbbc72562c187429f908c6e36e89de).

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: `1.0.2+lnd25.1~rc1.7-1`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
