### PR TITLE
zhaoxin-linux-graphics-driver: update to 21.00.85

### DIFF
--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,4 +1,4 @@
-From b7838e45375657565d927c74b32c78204f73b113 Mon Sep 17 00:00:00 2001
+From 12f4797c5e3f5cb96a3da9afe93d73c139970c30 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
 Subject: [PATCH 1/9] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,4 +1,4 @@
-From f7319cdfe52aafde9a2574153d63e78397a2ff9b Mon Sep 17 00:00:00 2001
+From a6628ccaee3695b8c8df4f043c609397026caa75 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
 Subject: [PATCH 2/9] chore: dkms: remove useless variables
@@ -11,14 +11,14 @@ Link: https://github.com/dkms-project/dkms/commit/961f9ceac4cf6772cb4c52bf4836a0
  1 file changed, 5 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 6dc8d99..f708c69 100644
+index 000017b..8c6ae33 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,16 +1,12 @@
  PACKAGE_NAME="zx"
- PACKAGE_VERSION=21.00.83
+ PACKAGE_VERSION=21.00.85
  AUTOINSTALL="yes"
--REMAKE_INITRD="yes"
+-#REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1
  
  

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,4 +1,4 @@
-From a7ad39ecceb1bdcfdbac088e93d882f316a8e519 Mon Sep 17 00:00:00 2001
+From 59672e9c71a871279984dc6ad59e59b4205d75e8 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
 Subject: [PATCH 3/9] fix: kernel: 6.15

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,4 +1,4 @@
-From e7d02059b59d52dee6aea48f15e7faebc9bb8b3c Mon Sep 17 00:00:00 2001
+From 44383d6bdf35362f9a9cb27d9537c3301552c647 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
 Subject: [PATCH 4/9] fix: kernel: 6.16

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,4 +1,4 @@
-From fcf1a06cbd68649dd4459c7cb0dde03880ac07fc Mon Sep 17 00:00:00 2001
+From 8bbb635412687794c194c6b38d5ea6d8ddd36863 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
 Subject: [PATCH 5/9] fix: kernel: 6.17
@@ -104,10 +104,10 @@ index 48706c2..6eecac4 100644
          disp_enable_disable_linear_vga(disp_info, linear_status, 1);
  
 diff --git a/src/zx_gem.c b/src/zx_gem.c
-index 4b6e828..4a65c79 100644
+index 9aa8783..cf4c43e 100644
 --- a/src/zx_gem.c
 +++ b/src/zx_gem.c
-@@ -1649,7 +1649,8 @@ static vm_fault_t zx_gem_ram_insert(struct vm_area_struct *vma, unsigned long ad
+@@ -1670,7 +1670,8 @@ static vm_fault_t zx_gem_ram_insert(struct vm_area_struct *vma, unsigned long ad
  
  
          retval= vmf_insert_mixed(vma, address,
@@ -118,7 +118,7 @@ index 4b6e828..4a65c79 100644
  #else
                pfn);
 diff --git a/src/zx_gem.h b/src/zx_gem.h
-index 6acc810..1f49859 100644
+index e42435d..44f6ae7 100644
 --- a/src/zx_gem.h
 +++ b/src/zx_gem.h
 @@ -20,8 +20,9 @@

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,4 +1,4 @@
-From cb9512cdc016c397e39ed999dad64a160f9124d5 Mon Sep 17 00:00:00 2001
+From 88425e26b73c9cd452106ad70921e26c90f32161 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
 Subject: [PATCH 6/9] fix: kernel: 6.18

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,4 +1,4 @@
-From 61d66b0c857fb489b8bb0a0a9e5ecbba911e9188 Mon Sep 17 00:00:00 2001
+From d07cadc3062edd9fba0c6cb547158933b584b2b4 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:34 +0800
 Subject: [PATCH 7/9] chore: import .gitignore from loonggpu-kernel-dkms

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,4 +1,4 @@
-From 77b3bbfed62a6485c8afedc227724c52b0f6c2d9 Mon Sep 17 00:00:00 2001
+From 6ebf2c2c607bc515265e8bf52f6c17b9a43239b7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:48 +0800
 Subject: [PATCH 8/9] refactor (NFC): rename zxfb_create to zx_fbdev_probe

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,4 +1,4 @@
-From bf29a0ab8afd1f5c8d503f32a47f95b8c0fb4c81 Mon Sep 17 00:00:00 2001
+From 566318b3fd7600e3f717de6a7dc1c459f0123301 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 19:07:04 +0800
 Subject: [PATCH 9/9] fix: run DRM default client setup on Linux >= 6.15

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,6 +1,6 @@
-UPSTREAM_VER=21.00.83
+UPSTREAM_VER=21.00.85
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=2509&tag=0&ref=qdxz&pre=0&t=eecb7eac5d344b6d"
-CHKSUMS="sha256::38049d03dcb5d16f393d49a919f4e41b2a81bb910e16f556305d626ce127de22"
+CHKSUMS="sha256::8b96c1fa103350ccc4c74dd02ab516890b085c2c607927cf1e85b5c736566ac2"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- zhaoxin-linux-graphics-driver: update to 21.00.85
    Track DKMS patches at AOSC-Tracking/zx-kernel-dkms @ aosc/v21.00.85
    \(HEAD: 566318b3fd7600e3f717de6a7dc1c459f0123301\)

Package(s) Affected
-------------------

- zhaoxin-linux-graphics-driver-dri: 21.00.85

Security Update?
----------------

No

Build Order
-----------

```
#buildit zhaoxin-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
