### PR TITLE
smplayer: update to 25.6.0

### DIFF
--- a/app-multimedia/smplayer/spec
+++ b/app-multimedia/smplayer/spec
@@ -1,4 +1,4 @@
-VER=24.5.0
+VER=25.6.0
 SRCS="git::commit=tags/v$VER::https://github.com/smplayer-dev/smplayer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5416"


### PR DESCRIPTION
Topic Description
-----------------

- smplayer: update to 25.6.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- smplayer: 25.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit smplayer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
