### PR TITLE
acl: update to 2.3.2

### DIFF
--- a/app-utils/acl/spec
+++ b/app-utils/acl/spec
@@ -1,4 +1,4 @@
-VER=2.3.1
+VER=2.3.2
 SRCS="tbl::https://download.savannah.gnu.org/releases/acl/acl-$VER.tar.gz"
-CHKSUMS="sha256::760c61c68901b37fdd5eefeeaf4c0c7a26bdfdd8ac747a1edff1ce0e243c11af"
+CHKSUMS="sha256::5f2bdbad629707aa7d85c623f994aa8a1d2dec55a73de5205bac0bf6058a2f7c"
 CHKUPDATE="anitya::id=16"


### PR DESCRIPTION
Topic Description
-----------------

- acl: update to 2.3.2
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- acl: 2.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit acl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
