### PR TITLE
mdadm: update to 4.4

### DIFF
--- a/app-admin/mdadm/spec
+++ b/app-admin/mdadm/spec
@@ -1,5 +1,4 @@
-VER=4.2
-REL=2
+VER=4.4
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/raid/mdadm/mdadm-$VER.tar.xz"
-CHKSUMS="sha256::461c215670864bb74a4d1a3620684aa2b2f8296dffa06743f26dda5557acf01d"
+CHKSUMS="sha256::9b488f35ed153df99924b5fe41eed380e8512de8f18a118628cacdd681b1d573"
 CHKUPDATE="anitya::id=1958"


### PR DESCRIPTION
Topic Description
-----------------

- mdadm: update to 4.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mdadm: 4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mdadm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
