### PR TITLE
dhcpcd: update to 10.3.0

### DIFF
--- a/app-network/dhcpcd/spec
+++ b/app-network/dhcpcd/spec
@@ -1,5 +1,4 @@
-VER=10.0.8
-REL=1
+VER=10.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/NetworkConfiguration/dhcpcd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11429"


### PR DESCRIPTION
Topic Description
-----------------

- dhcpcd: update to 10.3.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dhcpcd: 10.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dhcpcd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
