### PR TITLE
diffutils: update to 3.12

### DIFF
--- a/app-utils/diffutils/spec
+++ b/app-utils/diffutils/spec
@@ -1,4 +1,4 @@
-VER=3.11
+VER=3.12
 SRCS="tbl::https://ftp.gnu.org/gnu/diffutils/diffutils-$VER.tar.xz"
-CHKSUMS="sha256::a73ef05fe37dd585f7d87068e4a0639760419f810138bd75c61ddaa1f9e2131e"
+CHKSUMS="sha256::7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd"
 CHKUPDATE="anitya::id=436"


### PR DESCRIPTION
Topic Description
-----------------

- diffutils: update to 3.12
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- diffutils: 3.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit diffutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
