### PR TITLE
ddrescue: update to 1.30

### DIFF
--- a/app-utils/ddrescue/spec
+++ b/app-utils/ddrescue/spec
@@ -1,4 +1,4 @@
-VER=1.29.1
+VER=1.30
 SRCS="tbl::https://ftp.gnu.org/gnu/ddrescue/ddrescue-$VER.tar.lz"
-CHKSUMS="sha256::ddd7d45df026807835a2ec6ab9c365df2ef19e8de1a50ffe6886cd391e04dd75"
+CHKSUMS="sha256::2264622d309d6c87a1cfc19148292b8859a688e9bc02d4702f5cd4f288745542"
 CHKUPDATE="anitya::id=410"


### PR DESCRIPTION
Topic Description
-----------------

- ddrescue: update to 1.30
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ddrescue: 1.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit ddrescue
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
