### PR TITLE
v2ray-rules-dat: update to 202601042214

### DIFF
--- a/runtime-data/v2ray-rules-dat/spec
+++ b/runtime-data/v2ray-rules-dat/spec
@@ -1,6 +1,6 @@
-VER=202510042211
+VER=202601042214
 SRCS="file::rename=geoip.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geoip.dat \
       file::rename=geosite.dat::https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$VER/geosite.dat"
-CHKSUMS="sha256::ac108c8f3f110df9ef67af07709f2a26599b4ce20570e6ae51cf82ccb495e0ed \
-         sha256::14b26c48c512c664171fb2e46a4b60f6c28f22afff81f4c2a655e10c5701176b"
+CHKSUMS="sha256::e2e9281ca52008da1af611d3198a1c5f3ba0a8a299912445164e73ac35bf6da5 \
+         sha256::76badf9c85bd09d3997ddecf402671fd83106b1ce0b657b67234b1ac6268c12a"
 CHKUPDATE="anitya::id=375331"


### PR DESCRIPTION
Topic Description
-----------------

- v2ray-rules-dat: update to 202601042214
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- v2ray-rules-dat: 202601042214

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2ray-rules-dat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
