### PR TITLE
libmodbus: new, 3.1.11

### DIFF
--- a/runtime-network/libmodbus/autobuild/defines
+++ b/runtime-network/libmodbus/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=libmodbus
+PKGSEC=net
+PKGDEP="glibc"
+PKGDES="groovy modbus library"
+
+ABTYPE=autotools

--- a/runtime-network/libmodbus/spec
+++ b/runtime-network/libmodbus/spec
@@ -1,0 +1,4 @@
+VER=3.1.11
+SRCS="git::commit=tags/v${VER}::https://github.com/stephane/libmodbus.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=9728"


### PR DESCRIPTION
Topic Description
-----------------

- libmodbus: new, 3.1.11
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- libmodbus: 3.1.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmodbus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
