### PR TITLE
opcua-asyncio: new, 1.1.8

### DIFF
--- a/lang-python/aiofiles/autobuild/defines
+++ b/lang-python/aiofiles/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=aiofiles
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="hatchling hatch-vcs setuptools python-build python-installer"
+PKGDES="file support for asyncio"
+
+ABTYPE=pep517
+
+ABSPLITDBG=0

--- a/lang-python/aiofiles/spec
+++ b/lang-python/aiofiles/spec
@@ -1,0 +1,4 @@
+VER=25.1.0
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/Tinche/aiofiles.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=12743"

--- a/lang-python/opcua-asyncio/autobuild/defines
+++ b/lang-python/opcua-asyncio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=opcua-asyncio
+PKGSEC=python
+PKGDEP="python-3 dateutil aiofiles pytz"
+BUILDDEP="hatchling setuptools python-build python-installer"
+PKGDES="asyncio-based asynchronous OPC UA client and server based on python-opcua"
+
+ABTYPE=pep517
+
+ABSPLITDBG=0

--- a/lang-python/opcua-asyncio/spec
+++ b/lang-python/opcua-asyncio/spec
@@ -1,0 +1,4 @@
+VER=1.1.8
+SRCS="git::commit=tags/v${VER}::https://github.com/FreeOpcUa/opcua-asyncio.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=131612"


### PR DESCRIPTION
Topic Description
-----------------

- opcua-asyncio: new, 1.1.8
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- opcua-asyncio: 1:1.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit opcua-asyncio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
