### PR TITLE
loonggl: add postinst to remove /etc/init.d/vga_check.sh

### DIFF
--- a/runtime-display/loonggl/autobuild/postinst
+++ b/runtime-display/loonggl/autobuild/postinst
@@ -1,0 +1,1 @@
+rm -f /etc/init.d/vga_check.sh

--- a/runtime-display/loonggl/spec
+++ b/runtime-display/loonggl/spec
@@ -1,4 +1,5 @@
 UPSTREAM_VER=1.0.2-lnd25.1~rc1.7
+REL=1
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

This file is removed in 1.0.2 but it's treated as "conffile" so dpkg won't remove it.  The rm command is already in prerm but it won't be run if the user updates directly from 1.0.1 to 1.0.2.

Package(s) Affected
-------------------

- loonggl: `1.0.2+lnd25.1~rc1.7-1`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
