### PR TITLE
deno: update to 2.6.4

### DIFF
--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.6.3
+VER=2.6.4
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=142.2.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::f1f631687b9949000b91b480982859a5557b398009f0a6a62d05c88fd4def5fb \
+CHKSUMS="sha256::c89734eb43279219914e28bbef81927bf9cef275c8132a3dec880f3c3257653d \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.6.4
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
