### PR TITLE
curtail: update to 1.14.0

### DIFF
--- a/app-imaging/curtail/spec
+++ b/app-imaging/curtail/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
-REL=1
+VER=1.14.0
 SRCS="git::commit=tags/$VER::https://github.com/Huluti/Curtail.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=312431"


### PR DESCRIPTION
Topic Description
-----------------

- curtail: update to 1.14.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- curtail: 1.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit curtail
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
