### PR TITLE
imake: update to 1.0.11

### DIFF
--- a/app-devel/imake/spec
+++ b/app-devel/imake/spec
@@ -1,16 +1,15 @@
-__IMAKE_VER=1.0.10
+__IMAKE_VER=1.0.11
 __GCCMAKEDEP_VER=1.0.4
 __LNDIR_VER=1.0.5
 __MAKEDEPEND_VER=1.0.9
 __CF_VER=1.0.8
 VER=${__IMAKE_VER}
-REL=1
 SRCS="tbl::http://xorg.freedesktop.org/releases/individual/util/imake-${__IMAKE_VER}.tar.xz \
       tbl::http://xorg.freedesktop.org/releases/individual/util/gccmakedep-${__GCCMAKEDEP_VER}.tar.xz \
       tbl::http://xorg.freedesktop.org/releases/individual/util/lndir-${__LNDIR_VER}.tar.xz \
       tbl::http://xorg.freedesktop.org/releases/individual/util/makedepend-${__MAKEDEPEND_VER}.tar.xz \
       tbl::http://xorg.freedesktop.org/releases/individual/util/xorg-cf-files-${__CF_VER}.tar.xz"
-CHKSUMS="sha256::75decbcea8d7b354cf36adc9675e53c4790ee3de56a14bd87b42c8e8aad2ecf5 \
+CHKSUMS="sha256::55955527eaebe94633e4083d4fe5f2160a65fe4c6dafdee48b89fea5f1ca8a78 \
          sha256::5088f98769fb63c326e9b9d2cb7c9f4a630a2801dd1da06971d0829176cf25b6 \
          sha256::3b65577a5575cce095664f5492164a96941800fe6290a123731d47f3e7104ddb \
          sha256::92d0deb659fff6d8ddbc1d27fc4ca8ceb2b6dbe15d73f0a04edc09f1c5782dd4 \


### PR DESCRIPTION
Topic Description
-----------------

- imake: update to 1.0.11
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- imake: 1.0.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit imake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
