### PR TITLE
libguestfs: update to 1.58.0

### DIFF
--- a/runtime-virtualization/libguestfs/autobuild/defines
+++ b/runtime-virtualization/libguestfs/autobuild/defines
@@ -7,22 +7,21 @@ BUILDDEP="gperf libintl-perl pcre perl-module-build perl-string-shellquote \
           ocaml findlib ocaml-augeas"
 PKGDES="Access and modify virtual machine disk image"
 
+ABTYPE=autotools
 # FIXME: --disable-appliance, missing a lot of dependencies, to re-visit later.
 # FIXME: --disable-ocaml, OCaml bindings fails to build.
 # FIXME: --disable-rust, fails to build with Rust 1.71.1.
+# FIXME: --disable-perl, unknown argument: '-fira-loop-pressure'
 AUTOTOOLS_AFTER=(
     '--disable-werror'
     '--enable-largefile'
-    '--enable-nls'
-    '--disable-rpath'
     '--disable-packet-dump'
     '--enable-fuse'
-    '--enable-daemon'
-    '--enable-install-daemon'
+    '--disable-daemon'
     '--disable-appliance'
     '--enable-appliance-format-auto'
     '--disable-ocaml'
-    '--enable-perl'
+    '--disable-perl'
     '--enable-python'
     '--enable-ruby'
     '--disable-haskell'

--- a/runtime-virtualization/libguestfs/spec
+++ b/runtime-virtualization/libguestfs/spec
@@ -1,5 +1,4 @@
-VER=1.54.1
-REL="4"
+VER=1.58.0
 SRCS="tbl::https://download.libguestfs.org/${VER%.*}-stable/libguestfs-$VER.tar.gz"
-CHKSUMS="sha256::6e3fc6ac192675f7bc2840a561bb36a36d3d5a8dfa7f88ea2f53f8cf602a177e"
+CHKSUMS="sha256::701145c3b631a92166c90bd6100ce00817a9b760c3be1a3404350ac70bb3d7ba"
 CHKUPDATE="anitya::id=229572"


### PR DESCRIPTION
Topic Description
-----------------

- libguestfs: update to 1.58.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libguestfs: 1.58.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libguestfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
