### PR TITLE
ocserv: update to 1.4.0

### DIFF
--- a/app-network/ocserv/spec
+++ b/app-network/ocserv/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=2
+VER=1.4.0
 SRCS="git::commit=tags/$VER::https://gitlab.com/openconnect/ocserv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2527"


### PR DESCRIPTION
Topic Description
-----------------

- ocserv: update to 1.4.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ocserv: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ocserv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
