### PR TITLE
uboot-tools: update to 2026.01

### DIFF
--- a/app-utils/uboot-tools/spec
+++ b/app-utils/uboot-tools/spec
@@ -1,4 +1,4 @@
-VER=2025.10
+VER=2026.01
 SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
-CHKSUMS="sha256::b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a"
+CHKSUMS="sha256::b60d5865cefdbc75da8da4156c56c458e00de75a49b80c1a2e58a96e30ad0d54"
 CHKUPDATE="anitya::id=5022"


### PR DESCRIPTION
Topic Description
-----------------

- uboot-tools: update to 2026.01
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- uboot-tools: 2026.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit uboot-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
