### PR TITLE
hotdoc: update to 0.17.4

### DIFF
--- a/app-doc/hotdoc/autobuild/defines
+++ b/app-doc/hotdoc/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=hotdoc
 PKGSEC=doc
-PKGDEP="appdirs cchardet contextlib2 dbus-deviation decorator json-glib llvm \
-        lxml networkx pypkgconfig pyyaml schema toposort wheezy.template"
-BUILDDEP="setuptools"
-PKGDES="A API documentation generator"
+PKGDEP="appdirs backports.entry-points-selectable cchardet dbus-deviation \
+    lxml networkx pypkgconfig pyyaml schema toposort wheezy.template "
+BUILDDEP="nodejs"
+PKGDES="API documentation generator"
 
 ABTYPE=python
 NOPYTHON2=1

--- a/app-doc/hotdoc/autobuild/prepare
+++ b/app-doc/hotdoc/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Applying patches ..."
+git cherry-pick -n adf8518431fafb78c9b47862a0a9a58824b6a421 # Fix build with GCC 15

--- a/app-doc/hotdoc/spec
+++ b/app-doc/hotdoc/spec
@@ -1,4 +1,4 @@
-VER=0.13.7
-SRCS="tbl::https://pypi.io/packages/source/h/hotdoc/hotdoc-$VER.tar.gz"
-CHKSUMS="sha256::1123a659e2c94972c32813ec301191d333db24712a83f7e3d06dd58d47cf0098"
+VER=0.17.4
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/hotdoc/hotdoc"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=102371"

--- a/lang-python/backports.entry-points-selectable/autobuild/defines
+++ b/lang-python/backports.entry-points-selectable/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=backports.entry-points-selectable
+PKGSEC=python
+PKGDEP="coherent.licensed"
+BUILDDEP="setuptools-python3 setuptools-scm"
+PKGDES="Compatibility shim providing selectable entry points for older implementations"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/backports.entry-points-selectable/spec
+++ b/lang-python/backports.entry-points-selectable/spec
@@ -1,0 +1,4 @@
+VER=1.3.0
+SRCS="pypi::version=${VER}::backports.entry-points-selectable"
+CHKSUMS="sha256::17a8b44ae700fba548686dd274ddc91c060371565cd63806c20a1d33911746e6"
+CHKUPDATE="anitya::id=185756"


### PR DESCRIPTION
Topic Description
-----------------

- hotdoc: update to 0.17.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- hotdoc: 0.17.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit hotdoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
