### PR TITLE
liblangtag: update to 0.6.8

### DIFF
--- a/runtime-i18n/liblangtag/autobuild/defines
+++ b/runtime-i18n/liblangtag/autobuild/defines
@@ -3,3 +3,8 @@ PKGSEC=libs
 PKGDEP="glib gobject-introspection libxml2"
 BUILDDEP="gtk-doc"
 PKGDES="Library to access tags for language identification"
+
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--disable-gtk-doc"
+)

--- a/runtime-i18n/liblangtag/spec
+++ b/runtime-i18n/liblangtag/spec
@@ -1,5 +1,4 @@
-VER=0.6.3
-REL=1
-SRCS="tbl::https://bitbucket.org/tagoh/liblangtag/downloads/liblangtag-$VER.tar.bz2"
+VER=0.6.8
+SRCS="git::commit=tags/$VER::https://bitbucket.org/tagoh/liblangtag.git"
 CHKSUMS="sha256::1f12a20a02ec3a8d22e54dedb8b683a43c9c160bda1ba337bf1060607ae733bd"
 CHKUPDATE="anitya::id=1650"


### PR DESCRIPTION
Topic Description
-----------------

- liblangtag: update to 0.6.8
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- liblangtag: 0.6.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit liblangtag
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
