### PR TITLE
git-credential-oauth: update to 0.17.1

### DIFF
--- a/app-vcs/git-credential-oauth/spec
+++ b/app-vcs/git-credential-oauth/spec
@@ -1,4 +1,4 @@
-VER=0.17.0
+VER=0.17.1
 SRCS="git::commit=tags/v$VER::https://github.com/hickford/git-credential-oauth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301894"


### PR DESCRIPTION
Topic Description
-----------------

- git-credential-oauth: update to 0.17.1
    Co-authored-by: Rong "Mantle" Bao \(@CSharperMantle\) <webmaster@csmantle.top>

Package(s) Affected
-------------------

- git-credential-oauth: 0.17.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-credential-oauth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
