### PR TITLE
msitools: update to 0.106

### DIFF
--- a/app-devel/msitools/spec
+++ b/app-devel/msitools/spec
@@ -1,4 +1,4 @@
-VER=0.101
+VER=0.106
 SRCS="tbl::https://download.gnome.org/sources/msitools/${VER:0:5}/msitools-$VER.tar.xz"
-CHKSUMS="sha256::0cc4d2e0d108fa6f2b4085b9a97dd5bc6d9fcadecdd933f2094f86bafdbe85fe"
+CHKSUMS="sha256::1ed34279cf8080f14f1b8f10e649474125492a089912e7ca70e59dfa2e5a659b"
 CHKUPDATE="anitya::id=17719"


### PR DESCRIPTION
Topic Description
-----------------

- msitools: update to 0.106
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- msitools: 0.106

Security Update?
----------------

No

Build Order
-----------

```
#buildit msitools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
