### PR TITLE
libxml++: update to 5.6.0

### DIFF
--- a/runtime-common/libxml++/autobuild/defines
+++ b/runtime-common/libxml++/autobuild/defines
@@ -5,4 +5,8 @@ BUILDDEP="mm-common"
 PKGDES="C++ bindings for LibXML"
 
 ABTYPE=meson
-MESON_AFTER=("-Dbuild-documentation=false" "-Dbuild-examples=false")
+MESON_AFTER=(
+    "-Dbuild-documentation=false"
+    "-Dbuild-examples=false"
+    "-Dbuild-tests=false"
+)

--- a/runtime-common/libxml++/spec
+++ b/runtime-common/libxml++/spec
@@ -1,4 +1,4 @@
-VER=5.4.0
+VER=5.6.0
 SRCS="git::commit=tags/${VER}::https://github.com/libxmlplusplus/libxmlplusplus.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11129"


### PR DESCRIPTION
Topic Description
-----------------

- libxml++: update to 5.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libxml++: 5.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxml++
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
