### PR TITLE
nfs-utils: update to 2.8.4

### DIFF
--- a/app-utils/nfs-utils/autobuild/defines
+++ b/app-utils/nfs-utils/autobuild/defines
@@ -12,45 +12,47 @@ PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 BUILDDEP="rpcsvc-proto"
 PKGDES="Support programs for Network File Systems"
-BUILDDEP="rpcsvc-proto"
 
+ABTYPE=autotools
 # Note:
 # --enable-gums, Enable support for the GUMS mapping library [default=false].
-AUTOTOOLS_AFTER="--enable-nfsv4 \
-                 --enable-nfsv41 \
-                 --enable-gss \
-                 --enable-svcgss \
-                 --disable-kprefix \
-                 --enable-uuid \
-                 --enable-mount \
-                 --enable-libmount-mount \
-                 --disable-sbin-override \
-                 --enable-junction \
-                 --enable-ipv6 \
-                 --enable-mountconfig \
-                 --enable-nfsdcld \
-                 --enable-nfsdcltrack \
-                 --enable-caps \
-                 --enable-largefile \
-                 --enable-ldap \
-                 --disable-gums \
-                 --with-statedir=/var/lib/nfs \
-                 --with-nfsconfig=/etc/nfs.conf \
-                 --with-statdpath=/var/lib/nfs \
-                 --with-statduser=nobody \
-                 --with-start-statd=/usr/bin/start-statd \
-                 --with-systemd=/usr/lib/systemd/system \
-                 --with-modprobedir=/usr/lib/modprobe.d \
-                 --with-mountfile=/etc/nfsmounts.conf \
-                 --with-tcp-wrappers=no \
-                 --with-krb5=/usr \
-                 --without-gssglue \
-                 --with-pluginpath=/usr/lib/libnfsidmap"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-gss \
-                 --disable-ldap \
-                 --disable-svcgss"
+AUTOTOOLS_AFTER=(
+    '--enable-nfsv4'
+    '--enable-nfsv41'
+    '--enable-gss'
+    '--enable-svcgss'
+    '--disable-kprefix'
+    '--enable-uuid'
+    '--enable-mount'
+    '--enable-libmount-mount'
+    '--disable-sbin-override'
+    '--enable-junction'
+    '--enable-ipv6'
+    '--enable-mountconfig'
+    '--enable-nfsdcld'
+    '--enable-nfsdcltrack'
+    '--enable-caps'
+    '--enable-largefile'
+    '--enable-ldap'
+    '--disable-gums'
+    '--with-statedir=/var/lib/nfs'
+    '--with-nfsconfig=/etc/nfs.conf'
+    '--with-statdpath=/var/lib/nfs'
+    '--with-statduser=nobody'
+    '--with-start-statd=/usr/bin/start-statd'
+    '--with-systemd=/usr/lib/systemd/system'
+    '--with-mountfile=/etc/nfsmounts.conf'
+    '--with-tcp-wrappers=no'
+    '--with-krb5=/usr'
+    '--without-gssglue'
+    '--with-pluginpath=/usr/lib/libnfsidmap'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-gss'
+    '--disable-ldap'
+    '--disable-svcgss'
+)
 AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
@@ -59,6 +61,8 @@ AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+
+# FIXME: fatal error: sockaddr.h: No such file or directory
 ABSHADOW=0
 
 PKGREP="libnfsidmap<=0.27-1"

--- a/app-utils/nfs-utils/spec
+++ b/app-utils/nfs-utils/spec
@@ -1,5 +1,4 @@
-VER=2.6.2
-REL=2
+VER=2.8.4
 SRCS="tbl::https://sourceforge.net/projects/nfs/files/nfs-utils/$VER/nfs-utils-$VER.tar.gz"
-CHKSUMS="sha256::2d8820583dd6a806cd8034d32d890c049a552c58c671a9021cb5d0271bb59eee"
+CHKSUMS="sha256::403c6aed9b8a7cc365df13cbc1358c0b8ed3a14326d1f84a117c42da6dabcd1c"
 CHKUPDATE="anitya::id=2081"


### PR DESCRIPTION
Topic Description
-----------------

- nfs-utils: update to 2.8.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- nfs-utils: 2.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit nfs-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
