### PR TITLE
netpbm: update to 10.86.48

### DIFF
--- a/app-utils/netpbm/autobuild/beyond
+++ b/app-utils/netpbm/autobuild/beyond
@@ -3,3 +3,7 @@ rm -v "$PKGDIR"/usr/share/man/man5/pbm.5
 rm -v "$PKGDIR"/usr/share/man/man5/pgm.5
 rm -v "$PKGDIR"/usr/bin/pnmtopng
 rm -v "$PKGDIR"/usr/bin/pngtopnm
+
+abinfo "Dropping unexpected files ..."
+rm -rv "$PKGDIR"/usr/staticlink
+rm -rv "$PKGDIR"/usr/sharedlink

--- a/app-utils/netpbm/autobuild/build
+++ b/app-utils/netpbm/autobuild/build
@@ -1,9 +1,27 @@
 abinfo "Building netpbm ..."
+# FIXME: error: bool cannot be defined via typedef
+export CFLAGS="$CFLAGS -std=gnu17"
 make CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}" \
      LDFLAGS="${LDFLAGS}"
+
+abinfo "Building man pages ..."
+pushd "$SRCDIR"/userguide
+rm -f *.manual-pages
+rm -f *.manfix
+for i in *.html ; do	
+  python3 ../buildtools/makeman ${i}
+done
+for i in 1 3 5 ; do
+  mkdir -pv man/man${i}
+  mv *.${i} man/man${i}
+done
+popd
 
 abinfo "Installing netpbm ..."
 make pkgdir="$PKGDIR"/usr \
      PKGMANDIR=share/man \
      install-run \
      install-dev
+
+abinfo "Installing man pages ..."
+cp -rv "$SRCDIR"/userguide/man "$PKGDIR"/usr/share

--- a/app-utils/netpbm/autobuild/defines
+++ b/app-utils/netpbm/autobuild/defines
@@ -2,8 +2,6 @@ PKGNAME=netpbm
 PKGSEC=libs
 PKGDEP="perl libpng libtiff libxml2"
 BUILDDEP="jbigkit"
-PKGDES="A toolkit for manipulation of graphic files"
+PKGDES="Toolkit for manipulation of graphic files"
 
-NOPARALLEL=1
-
-PKGEPOCH=1
+ABTYPE=self

--- a/app-utils/netpbm/autobuild/prepare
+++ b/app-utils/netpbm/autobuild/prepare
@@ -2,3 +2,6 @@ abinfo "Appending -fPIC to fix build ..."
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 export LDFLAGS="${LDFLAGS} -fPIC"
+
+abinfo "Moving userguide ..."
+mv -v "$SRCDIR"/../netpbm "$SRCDIR"/userguide

--- a/app-utils/netpbm/spec
+++ b/app-utils/netpbm/spec
@@ -1,5 +1,10 @@
-VER=10.73.34
-SRCS="tbl::https://sourceforge.net/projects/netpbm/files/super_stable/$VER/netpbm-$VER.tgz"
-CHKSUMS="sha256::880bf47e68037e7d0f180032806ba05524138c7523b1e87309ad702a546a19fb"
+VER=10.86.48
+EPOCH=1
+SRCS="tbl::https://sourceforge.net/projects/netpbm/files/super_stable/$VER/netpbm-$VER.tgz
+    svn::commit=5122::https://svn.code.sf.net/p/netpbm/code/userguide"
+# r5122 corresponds to 10.86.48
+# https://sourceforge.net/p/netpbm/code/commit_browser
+CHKSUMS="sha256::709a98e871aeae892437274d68833c804dd41a4b8daf8fd978cac2782da4148a
+    SKIP"
 CHKUPDATE="anitya::id=2069"
-REL=1
+SUBDIR="netpbm-$VER"


### PR DESCRIPTION
Topic Description
-----------------

- netpbm: update to 10.86.48
    Signed-off-by: stydxm stydxm@outlook.com

Package(s) Affected
-------------------

- netpbm: 10.86.48

Security Update?
----------------

No

Build Order
-----------

```
#buildit netpbm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
