### PR TITLE
xmlsec: update to 1.3.9

### DIFF
--- a/runtime-common/xmlsec/autobuild/defines
+++ b/runtime-common/xmlsec/autobuild/defines
@@ -5,4 +5,10 @@ BUILDDEP="nss libgcrypt openssl gnutls"
 PKGSEC=libs
 
 ABSHADOW=0
-AUTOTOOLS_AFTER="--disable-static"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--disable-static"
+    "--disable-docs"
+    "--disable-docs-build"
+    "--disable-tmpl-tests"
+)

--- a/runtime-common/xmlsec/spec
+++ b/runtime-common/xmlsec/spec
@@ -1,5 +1,4 @@
-VER=1.2.36
-SRCS="tbl::https://github.com/lsh123/xmlsec/archive/xmlsec-${VER//./_}.tar.gz"
-CHKSUMS="sha256::45b70a715038e9a6412b67a60e8c5d24538e8f2d3c0a6a0051e2fd04dec8bb76"
+VER=1.3.9
+SRCS="git::commit=tags/$VER::https://github.com/lsh123/xmlsec"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5200"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- xmlsec: update to 1.3.9
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- xmlsec: 1.3.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit xmlsec
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
