### PR TITLE
oath-toolkit: update to 2.6.13

### DIFF
--- a/app-admin/oath-toolkit/autobuild/beyond
+++ b/app-admin/oath-toolkit/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Removing docs ..."
+# FIXME: oath-toolkit does not provide a cli option to disable docs build
+rm -rv "$PKGDIR"/usr/share/gtk-doc/

--- a/app-admin/oath-toolkit/spec
+++ b/app-admin/oath-toolkit/spec
@@ -1,4 +1,4 @@
-VER=2.6.12
+VER=2.6.13
 SRCS="tbl::https://download.savannah.nongnu.org/releases/oath-toolkit/oath-toolkit-$VER.tar.gz"
-CHKSUMS="sha256::cafdf739b1ec4b276441c6aedae6411434bbd870071f66154b909cc6e2d9e8ba"
+CHKSUMS="sha256::5b5d82e9a4455206d24fcbd7ee58bf4c79398a2e67997d80bd45ae927586b18b"
 CHKUPDATE="anitya::id=2515"


### PR DESCRIPTION
Topic Description
-----------------

- oath-toolkit: update to 2.6.13
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- oath-toolkit: 2.6.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit oath-toolkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
