### PR TITLE
libarchive: update to 3.8.5

### DIFF
--- a/runtime-common/libarchive/spec
+++ b/runtime-common/libarchive/spec
@@ -1,4 +1,4 @@
-VER=3.8.4
+VER=3.8.5
 SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
-CHKSUMS="sha256::b2c75b132a0ec43274d2867221befcb425034cd038e465afbfad09911abb1abb"
+CHKSUMS="sha256::8a60f3a7bfd59c54ce82ae805a93dba65defd04148c3333b7eaa2102f03b7ffd"
 CHKUPDATE="anitya::id=1558"


### PR DESCRIPTION
Topic Description
-----------------

- libarchive: update to 3.8.5
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- libarchive: 1:3.8.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libarchive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
