### PR TITLE
yubikey-manager: add missing deps

### DIFF
--- a/app-devices/yubikey-manager/autobuild/defines
+++ b/app-devices/yubikey-manager/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=yubikey-manager
 PKGSEC=admin
-PKGDEP="click pcsclite ccid swig pyscard \
+PKGDEP="click pcsclite ccid swig pyscard backports.tarfile importlib-metadata \
         fido2 pyopenssl"
 BUILDDEP="poetry-core"
 PKGDES="Command line and GUI tool for configuring YubiKeys, over all transports"

--- a/app-devices/yubikey-manager/spec
+++ b/app-devices/yubikey-manager/spec
@@ -1,5 +1,5 @@
 VER=5.8.0
-REL=1
+REL=2
 SRCS="pypi::version=$VER::yubikey-manager"
 CHKSUMS="sha256::3af0da65e1fdd46763c94ee74e2da55a4b6e7771da776c197f5f4b4581738560"
 CHKUPDATE="anitya::id=67946"

--- a/lang-python/backports.tarfile/autobuild/defines
+++ b/lang-python/backports.tarfile/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=backports.tarfile
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3 setuptools-scm coherent.licensed"
+PKGDES="Backport of CPython tarfile module"
+
+NOPYTHON2=1
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/backports.tarfile/spec
+++ b/lang-python/backports.tarfile/spec
@@ -1,0 +1,4 @@
+VER=1.2.0
+SRCS="pypi::version=$VER::backports.tarfile"
+CHKSUMS="sha256::d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991"
+CHKUPDATE="anitya::id=374500"

--- a/lang-python/importlib-metadata/autobuild/defines
+++ b/lang-python/importlib-metadata/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=importlib-metadata
+PKGSEC=python
+PKGDEP="python-3 zipp"
+BUILDDEP="setuptools-python3 setuptools-scm coherent.licensed"
+PKGDES="Library to access metadata for Python packages"
+
+NOPYTHON2=1
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/importlib-metadata/spec
+++ b/lang-python/importlib-metadata/spec
@@ -1,0 +1,4 @@
+VER=8.7.1
+SRCS="pypi::version=$VER::importlib-metadata"
+CHKSUMS="sha256::49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"
+CHKUPDATE="anitya::id=50323"

--- a/lang-python/zipp/autobuild/defines
+++ b/lang-python/zipp/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=zipp
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3 setuptools-scm coherent.licensed"
+PKGDES="Backport of pathlib-compatible object wrapper for ZIP files"
+
+NOPYTHON2=1
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/zipp/spec
+++ b/lang-python/zipp/spec
@@ -1,0 +1,4 @@
+VER=3.23.0
+SRCS="pypi::version=$VER::zipp"
+CHKSUMS="sha256::a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"
+CHKUPDATE="anitya::id=63514"


### PR DESCRIPTION
Topic Description
-----------------

- yubikey-manager: add missing backports.tarfile dep
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- backports.tarfile: new, 1.2.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- backports.tarfile: 1.2.0
- yubikey-manager: 5.8.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit backports.tarfile zipp importlib-metadata yubikey-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
