### PR TITLE
blender: bump REL due to openimagedenoise update to 2.3.0

### DIFF
--- a/app-creativity/blender/spec
+++ b/app-creativity/blender/spec
@@ -1,5 +1,5 @@
 VER=4.0.2
-REL=5
+REL=6
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
 CHKSUMS="sha256::aaa0e729da7591cfbf45772af76345977daaa7b11a0af35d98f9313e246077a3"
 CHKUPDATE="anitya::id=201"

--- a/runtime-imaging/openimagedenoise/autobuild/defines
+++ b/runtime-imaging/openimagedenoise/autobuild/defines
@@ -7,3 +7,5 @@ BUILDDEP="ispc"
 ABTYPE=cmakeninja
 CMAKE_AFTER="-DPYTHON_EXECUTABLE=/usr/bin/python3"
 FAIL_ARCH="!(amd64|arm64)"
+
+PKGBREAK="blender<=4.0.2-5"

--- a/runtime-imaging/openimagedenoise/spec
+++ b/runtime-imaging/openimagedenoise/spec
@@ -1,4 +1,5 @@
 VER=2.3.0
+REL=1
 SRCS="tbl::https://github.com/OpenImageDenoise/oidn/releases/download/v${VER}/oidn-${VER}.src.tar.gz"
 CHKSUMS="sha256::cce3010962ec84e0ba1acd8c9055a3d8de402fedb1b463517cfeb920a276e427"
 CHKUPDATE="anitya::id=19531"


### PR DESCRIPTION
Topic Description
-----------------

- blender: bump REL due to openimagedenoise update to 2.3.0
- openimagedenoise: break blender<=4.0.2-5

Package(s) Affected
-------------------

- blender: 4.0.2-6
- openimagedenoise: 2.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openimagedenoise blender
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
