### PR TITLE
opencv: disable VSX3

### DIFF
--- a/runtime-scientific/opencv/autobuild/defines
+++ b/runtime-scientific/opencv/autobuild/defines
@@ -68,5 +68,10 @@ CMAKE_AFTER__RISCV64=(
         "${CMAKE_AFTER[@]}"
         "-DBUILD_opencv_java=OFF"
 )
+CMAKE_AFTER__PPC64EL=(
+        "${CMAKE_AFTER[@]}"
+        "-DCPU_BASELINE=VSX"
+        "-DCPU_DISPATCH=VSX"
+)
 
 NOSTATIC=0

--- a/runtime-scientific/opencv/autobuild/defines.stage2
+++ b/runtime-scientific/opencv/autobuild/defines.stage2
@@ -68,5 +68,10 @@ CMAKE_AFTER__RISCV64=(
         "${CMAKE_AFTER[@]}"
         "-DBUILD_opencv_java=OFF"
 )
+CMAKE_AFTER__PPC64EL=(
+        "${CMAKE_AFTER[@]}"
+        "-DCPU_BASELINE=VSX"
+        "-DCPU_DISPATCH=VSX"
+)
 
 NOSTATIC=0

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -1,5 +1,5 @@
 VER=4.12.0
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/opencv/opencv \
       git::commit=tags/$VER;copy-repo=true;rename=opencv_contrib::https://github.com/opencv/opencv_contrib"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- opencv: disable VSX3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- opencv: 4.12.0-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit opencv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
