### PR TITLE
niri-settings: new, 0+git20260107

### DIFF
--- a/app-utils/niri-settings/autobuild/build
+++ b/app-utils/niri-settings/autobuild/build
@@ -1,0 +1,18 @@
+abinfo "Installing main script"
+install -Dvm755 "$SRCDIR"/niri-settings "$PKGDIR"/usr/bin/niri-settings
+
+abinfo "Installing desktop file"
+install -Dvm644 "$SRCDIR"/niri-settings.desktop "$PKGDIR"/usr/share/applications/niri-settings.desktop
+
+abinfo "Installing python files"
+install -dvm755 "$PKGDIR"/usr/lib/niri-settings/ui
+install -Dvm644 "$SRCDIR"/niri_settings.py "$PKGDIR"/usr/lib/niri-settings/
+install -Dvm644 "$SRCDIR"/ui/*.py "$PKGDIR"/usr/lib/niri-settings/ui
+
+abinfo "Installing translations to standard XDG data directory"
+install -dvm755 "$PKGDIR"/usr/share/niri-settings/translations
+install -Dvm644 "$SRCDIR"/translations/*.qm "$PKGDIR"/usr/share/niri-settings/translations/
+
+abinfo "Installing icon"
+install -dvm755 "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/
+install -Dvm644 "$SRCDIR"/niri-settings.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/niri-settings.svg

--- a/app-utils/niri-settings/autobuild/defines
+++ b/app-utils/niri-settings/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=niri-settings
+PKGSEC=utils
+PKGDEP="hicolor-icon-theme niri pyqt6 python-3 qt-6"
+PKGDES="Configuration GUI for Niri Wayland compositor"
+
+ABTYPE=self
+ABHOST=noarch

--- a/app-utils/niri-settings/spec
+++ b/app-utils/niri-settings/spec
@@ -1,0 +1,3 @@
+VER=0+git20260107
+SRCS="git::commit=66b603cb4f6e61bea439a9732d29586e80af3f54::https://github.com/stefonarch/niri-settings.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- niri-settings: new, 0+git20260107

Package(s) Affected
-------------------

- niri-settings: 0+git20260107

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
