### PR TITLE
witr: update to 0.2.0

### DIFF
--- a/app-utils/witr/spec
+++ b/app-utils/witr/spec
@@ -1,4 +1,4 @@
-VER=0.1.8
+VER=0.2.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/pranshuparmar/witr.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=387856"


### PR DESCRIPTION
Topic Description
-----------------

- witr: update to 0.2.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- witr: 0.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit witr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
