### PR TITLE
openblas: enable dynamic arch detection for loongarch64

### DIFF
--- a/app-scientific/openblas/autobuild/build
+++ b/app-scientific/openblas/autobuild/build
@@ -4,8 +4,7 @@ if ab_match_arch amd64; then
 elif ab_match_arch arm64; then
     export TARGETCONF="DYNAMIC_ARCH=1 TARGET=ARMV8"
 elif ab_match_arch loongarch64; then
-    # FIXME: LoongArch SIMD not yet supported?
-    export TARGETCONF="TARGET=GENERIC"
+    export TARGETCONF="DYNAMIC_ARCH=1 TARGET=GENERIC"
 elif ab_match_arch loongson3; then
     export TARGETCONF="TARGET=LOONGSON3A"
 elif ab_match_arch ppc64el; then

--- a/app-scientific/openblas/spec
+++ b/app-scientific/openblas/spec
@@ -1,4 +1,5 @@
 VER=0.3.30
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/xianyi/OpenBLAS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2540"


### PR DESCRIPTION
Topic Description
-----------------

- openblas: enable dynamic arch detection for loongarch64
    Performance diffs:
    yuanbao:
    before:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :     4.2828 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :    62.2031 GF
    after:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :    61.8451 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :   385.9555 GF
    stomatopoda:
    before:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :     4.2822 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :    53.0891 GF
    after:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :    61.0555 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :   244.8988 GF

Package(s) Affected
-------------------

- openblas: 0.3.30-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openblas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
