### PR TITLE
llvm-{20,21}: pick a patch fixing llvmpipe on mips loong

### DIFF
--- a/app-devel/llvm-20/01-runtime/build
+++ b/app-devel/llvm-20/01-runtime/build
@@ -6,7 +6,7 @@ abinfo "Removing certain search path in PATH to avoid issues ..."
 PATH="${PATH/:\/bin/}"
 PATH="${PATH/:\/sbin/}"
 
-CPP_TRIPLE="$(basename /usr/include/c++/*.*/*-aosc-linux-*)"
+CPP_TRIPLE="$(basename /usr/lib/gcc/*-aosc-linux-*)"
 if [[ "$USECLANG" = '1' ]]; then
     abinfo "Selecting ${CPP_TRIPLE} for Clang ..."
     clang -target "${CPP_TRIPLE}" -v

--- a/app-devel/llvm-20/01-runtime/patches/0010-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0010-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
@@ -1,0 +1,98 @@
+From aafe936bb0f965de562a451b189b93455298af1d Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Mon, 5 Jan 2026 11:49:09 +0800
+Subject: [PATCH] [RuntimeDyld][MIPS] Use AT for stub function instead of T9
+
+The stub function is generated for R_MIPS_26 relocation, which could be
+used for local jumping inside a function, and do not expect any
+temporary register to be clobbered.
+
+Use AT instead of T9 for the stub function, otherwise functions using T9
+will be messed up.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ .../RuntimeDyld/RuntimeDyld.cpp               | 56 +++++++++----------
+ 1 file changed, 28 insertions(+), 28 deletions(-)
+
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+index 6de6cc756585..9f8c1dd87c76 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+@@ -1003,45 +1003,45 @@ uint8_t *RuntimeDyldImpl::createStubFunction(uint8_t *Addr,
+     writeBytesUnaligned(0x4c000180, Addr + 16, 4);
+     return Addr;
+   } else if (IsMipsO32ABI || IsMipsN32ABI) {
+-    // 0:   3c190000        lui     t9,%hi(addr).
+-    // 4:   27390000        addiu   t9,t9,%lo(addr).
+-    // 8:   03200008        jr      t9.
++    // 0:   3c010000        lui     at,%hi(addr).
++    // 4:   24210000        addiu   at,at,%lo(addr).
++    // 8:   00200008        jr      at.
+     // c:   00000000        nop.
+-    const unsigned LuiT9Instr = 0x3c190000, AdduiT9Instr = 0x27390000;
++    const unsigned LuiATInstr = 0x3c010000, AdduiATInstr = 0x24210000;
+     const unsigned NopInstr = 0x0;
+-    unsigned JrT9Instr = 0x03200008;
++    unsigned JrATInstr = 0x00200008;
+     if ((AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_32R6 ||
+         (AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_64R6)
+-      JrT9Instr = 0x03200009;
++      JrATInstr = 0x00200009;
+ 
+-    writeBytesUnaligned(LuiT9Instr, Addr, 4);
+-    writeBytesUnaligned(AdduiT9Instr, Addr + 4, 4);
+-    writeBytesUnaligned(JrT9Instr, Addr + 8, 4);
++    writeBytesUnaligned(LuiATInstr, Addr, 4);
++    writeBytesUnaligned(AdduiATInstr, Addr + 4, 4);
++    writeBytesUnaligned(JrATInstr, Addr + 8, 4);
+     writeBytesUnaligned(NopInstr, Addr + 12, 4);
+     return Addr;
+   } else if (IsMipsN64ABI) {
+-    // 0:   3c190000        lui     t9,%highest(addr).
+-    // 4:   67390000        daddiu  t9,t9,%higher(addr).
+-    // 8:   0019CC38        dsll    t9,t9,16.
+-    // c:   67390000        daddiu  t9,t9,%hi(addr).
+-    // 10:  0019CC38        dsll    t9,t9,16.
+-    // 14:  67390000        daddiu  t9,t9,%lo(addr).
+-    // 18:  03200008        jr      t9.
++    // 0:   3c010000        lui     at,%highest(addr).
++    // 4:   64210000        daddiu  at,at,%higher(addr).
++    // 8:   00010C38        dsll    at,at,16.
++    // c:   64210000        daddiu  at,at,%hi(addr).
++    // 10:  00010C38        dsll    at,at,16.
++    // 14:  64210000        daddiu  at,at,%lo(addr).
++    // 18:  00200008        jr      at.
+     // 1c:  00000000        nop.
+-    const unsigned LuiT9Instr = 0x3c190000, DaddiuT9Instr = 0x67390000,
+-                   DsllT9Instr = 0x19CC38;
++    const unsigned LuiATInstr = 0x3c010000, DaddiuATInstr = 0x64210000,
++                   DsllATInstr = 0x10c38;
+     const unsigned NopInstr = 0x0;
+-    unsigned JrT9Instr = 0x03200008;
++    unsigned JrATInstr = 0x00200008;
+     if ((AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_64R6)
+-      JrT9Instr = 0x03200009;
+-
+-    writeBytesUnaligned(LuiT9Instr, Addr, 4);
+-    writeBytesUnaligned(DaddiuT9Instr, Addr + 4, 4);
+-    writeBytesUnaligned(DsllT9Instr, Addr + 8, 4);
+-    writeBytesUnaligned(DaddiuT9Instr, Addr + 12, 4);
+-    writeBytesUnaligned(DsllT9Instr, Addr + 16, 4);
+-    writeBytesUnaligned(DaddiuT9Instr, Addr + 20, 4);
+-    writeBytesUnaligned(JrT9Instr, Addr + 24, 4);
++      JrATInstr = 0x00200009;
++
++    writeBytesUnaligned(LuiATInstr, Addr, 4);
++    writeBytesUnaligned(DaddiuATInstr, Addr + 4, 4);
++    writeBytesUnaligned(DsllATInstr, Addr + 8, 4);
++    writeBytesUnaligned(DaddiuATInstr, Addr + 12, 4);
++    writeBytesUnaligned(DsllATInstr, Addr + 16, 4);
++    writeBytesUnaligned(DaddiuATInstr, Addr + 20, 4);
++    writeBytesUnaligned(JrATInstr, Addr + 24, 4);
+     writeBytesUnaligned(NopInstr, Addr + 28, 4);
+     return Addr;
+   } else if (Arch == Triple::ppc64 || Arch == Triple::ppc64le) {
+-- 
+2.52.0
+

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,5 +1,5 @@
 VER=20.1.8
-REL=3
+REL=4
 
 # Use tarball-based source when possible
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"

--- a/app-devel/llvm-21/01-runtime/build
+++ b/app-devel/llvm-21/01-runtime/build
@@ -6,7 +6,7 @@ abinfo "Removing certain search path in PATH to avoid issues ..."
 PATH="${PATH/:\/bin/}"
 PATH="${PATH/:\/sbin/}"
 
-CPP_TRIPLE="$(basename /usr/include/c++/*.*/*-aosc-linux-*)"
+CPP_TRIPLE="$(basename /usr/lib/gcc/*-aosc-linux-*)"
 if [[ "$USECLANG" = '1' ]]; then
     abinfo "Selecting ${CPP_TRIPLE} for Clang ..."
     clang -target "${CPP_TRIPLE}" -v

--- a/app-devel/llvm-21/01-runtime/patches/0007-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0007-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
@@ -1,0 +1,98 @@
+From aafe936bb0f965de562a451b189b93455298af1d Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Mon, 5 Jan 2026 11:49:09 +0800
+Subject: [PATCH] [RuntimeDyld][MIPS] Use AT for stub function instead of T9
+
+The stub function is generated for R_MIPS_26 relocation, which could be
+used for local jumping inside a function, and do not expect any
+temporary register to be clobbered.
+
+Use AT instead of T9 for the stub function, otherwise functions using T9
+will be messed up.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ .../RuntimeDyld/RuntimeDyld.cpp               | 56 +++++++++----------
+ 1 file changed, 28 insertions(+), 28 deletions(-)
+
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+index 6de6cc756585..9f8c1dd87c76 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+@@ -1003,45 +1003,45 @@ uint8_t *RuntimeDyldImpl::createStubFunction(uint8_t *Addr,
+     writeBytesUnaligned(0x4c000180, Addr + 16, 4);
+     return Addr;
+   } else if (IsMipsO32ABI || IsMipsN32ABI) {
+-    // 0:   3c190000        lui     t9,%hi(addr).
+-    // 4:   27390000        addiu   t9,t9,%lo(addr).
+-    // 8:   03200008        jr      t9.
++    // 0:   3c010000        lui     at,%hi(addr).
++    // 4:   24210000        addiu   at,at,%lo(addr).
++    // 8:   00200008        jr      at.
+     // c:   00000000        nop.
+-    const unsigned LuiT9Instr = 0x3c190000, AdduiT9Instr = 0x27390000;
++    const unsigned LuiATInstr = 0x3c010000, AdduiATInstr = 0x24210000;
+     const unsigned NopInstr = 0x0;
+-    unsigned JrT9Instr = 0x03200008;
++    unsigned JrATInstr = 0x00200008;
+     if ((AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_32R6 ||
+         (AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_64R6)
+-      JrT9Instr = 0x03200009;
++      JrATInstr = 0x00200009;
+ 
+-    writeBytesUnaligned(LuiT9Instr, Addr, 4);
+-    writeBytesUnaligned(AdduiT9Instr, Addr + 4, 4);
+-    writeBytesUnaligned(JrT9Instr, Addr + 8, 4);
++    writeBytesUnaligned(LuiATInstr, Addr, 4);
++    writeBytesUnaligned(AdduiATInstr, Addr + 4, 4);
++    writeBytesUnaligned(JrATInstr, Addr + 8, 4);
+     writeBytesUnaligned(NopInstr, Addr + 12, 4);
+     return Addr;
+   } else if (IsMipsN64ABI) {
+-    // 0:   3c190000        lui     t9,%highest(addr).
+-    // 4:   67390000        daddiu  t9,t9,%higher(addr).
+-    // 8:   0019CC38        dsll    t9,t9,16.
+-    // c:   67390000        daddiu  t9,t9,%hi(addr).
+-    // 10:  0019CC38        dsll    t9,t9,16.
+-    // 14:  67390000        daddiu  t9,t9,%lo(addr).
+-    // 18:  03200008        jr      t9.
++    // 0:   3c010000        lui     at,%highest(addr).
++    // 4:   64210000        daddiu  at,at,%higher(addr).
++    // 8:   00010C38        dsll    at,at,16.
++    // c:   64210000        daddiu  at,at,%hi(addr).
++    // 10:  00010C38        dsll    at,at,16.
++    // 14:  64210000        daddiu  at,at,%lo(addr).
++    // 18:  00200008        jr      at.
+     // 1c:  00000000        nop.
+-    const unsigned LuiT9Instr = 0x3c190000, DaddiuT9Instr = 0x67390000,
+-                   DsllT9Instr = 0x19CC38;
++    const unsigned LuiATInstr = 0x3c010000, DaddiuATInstr = 0x64210000,
++                   DsllATInstr = 0x10c38;
+     const unsigned NopInstr = 0x0;
+-    unsigned JrT9Instr = 0x03200008;
++    unsigned JrATInstr = 0x00200008;
+     if ((AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_64R6)
+-      JrT9Instr = 0x03200009;
+-
+-    writeBytesUnaligned(LuiT9Instr, Addr, 4);
+-    writeBytesUnaligned(DaddiuT9Instr, Addr + 4, 4);
+-    writeBytesUnaligned(DsllT9Instr, Addr + 8, 4);
+-    writeBytesUnaligned(DaddiuT9Instr, Addr + 12, 4);
+-    writeBytesUnaligned(DsllT9Instr, Addr + 16, 4);
+-    writeBytesUnaligned(DaddiuT9Instr, Addr + 20, 4);
+-    writeBytesUnaligned(JrT9Instr, Addr + 24, 4);
++      JrATInstr = 0x00200009;
++
++    writeBytesUnaligned(LuiATInstr, Addr, 4);
++    writeBytesUnaligned(DaddiuATInstr, Addr + 4, 4);
++    writeBytesUnaligned(DsllATInstr, Addr + 8, 4);
++    writeBytesUnaligned(DaddiuATInstr, Addr + 12, 4);
++    writeBytesUnaligned(DsllATInstr, Addr + 16, 4);
++    writeBytesUnaligned(DaddiuATInstr, Addr + 20, 4);
++    writeBytesUnaligned(JrATInstr, Addr + 24, 4);
+     writeBytesUnaligned(NopInstr, Addr + 28, 4);
+     return Addr;
+   } else if (Arch == Triple::ppc64 || Arch == Triple::ppc64le) {
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/spec
+++ b/app-devel/llvm-21/spec
@@ -1,4 +1,5 @@
 VER=21.1.6
+REL=1
 
 # Use tarball-based source when possible
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-21: sync MIPS RuntimeDyld T9 clobbering patch from llvm-20
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- llvm-20: pick a patch to fix llvmpipe crash on Loongson 3A4000
    The code generated by LLVM for llvmpipe when MSA is enabled utilizes T9
    register, which should be expected to be not changing when there's no
    function call; however the RuntimeDyld generated code destructed the
    value of T9.
    Pick a patch that I sent to LLVM upstream to fix it.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- llvm-20: 20.1.8-4
- llvm-21: 21.1.6-1
- llvm-runtime-20: 20.1.8-4
- llvm-runtime-21: 21.1.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-20 llvm-21
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
