### PR TITLE
ltrace: update to 0.8.1

### DIFF
--- a/app-devel/ltrace/autobuild/defines
+++ b/app-devel/ltrace/autobuild/defines
@@ -5,4 +5,4 @@ PKGDES="A debugging program which runs a specified command until the command exi
 
 AUTOTOOLS_AFTER="--with-libunwind=no"
 
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64)"

--- a/app-devel/ltrace/spec
+++ b/app-devel/ltrace/spec
@@ -1,4 +1,4 @@
-VER=0.7.3+git20151111
-SRCS="git::commit=ea8928dab8a0a1f549d0ed8ebc6ec563e9fa1159::https://gitlab.com/cespedes/ltrace.git"
+VER=0.8.1
+SRCS="git::commit=tags/$VER::https://gitlab.com/cespedes/ltrace.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=117364"


### PR DESCRIPTION
Topic Description
-----------------

- ltrace: update to 0.8.1

Package(s) Affected
-------------------

- ltrace: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ltrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
