### PR TITLE
libtasn1: update to 4.21.0

### DIFF
--- a/runtime-cryptography/libtasn1/autobuild/defines
+++ b/runtime-cryptography/libtasn1/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=libtasn1
-PKGDES="A highly portable C library that encodes and decodes DER/BER data following an ASN.1 schema"
+PKGDES="Portable C library that encodes and decodes DER/BER data following an ASN.1 schema"
 PKGDEP="glibc"
-BUILDDEP="gtk-doc"
 PKGSEC=libs
 
 RECONF=0
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--disable-doc'
+)

--- a/runtime-cryptography/libtasn1/autobuild/defines.stage2
+++ b/runtime-cryptography/libtasn1/autobuild/defines.stage2
@@ -1,5 +1,5 @@
 PKGNAME=libtasn1
-PKGDES="A highly portable C library that encodes and decodes DER/BER data following an ASN.1 schema"
+PKGDES="Portable C library that encodes and decodes DER/BER data following an ASN.1 schema"
 PKGDEP="glibc"
 PKGSEC=libs
 

--- a/runtime-cryptography/libtasn1/spec
+++ b/runtime-cryptography/libtasn1/spec
@@ -1,4 +1,4 @@
-VER=4.20.0
+VER=4.21.0
 SRCS="tbl::https://ftp.gnu.org/gnu/libtasn1/libtasn1-$VER.tar.gz"
-CHKSUMS="sha256::92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c"
+CHKSUMS="sha256::1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87"
 CHKUPDATE="anitya::id=1734"

--- a/runtime-optenv32/libtasn1+32/autobuild/defines
+++ b/runtime-optenv32/libtasn1+32/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=libtasn1+32
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 glibc+32"
-BUILDDEP="devel-base+32 gtk-doc"
-PKGDES="A highly portable C library that encodes and decodes DER/BER data following an ASN.1 schema (32-bit x86 runtime)"
+BUILDDEP="devel-base+32"
+PKGDES="Portable C library that encodes and decodes DER/BER data following an ASN.1 schema (32-bit x86 runtime)"
 
 ABHOST=optenv32
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--disable-doc'
+)

--- a/runtime-optenv32/libtasn1+32/spec
+++ b/runtime-optenv32/libtasn1+32/spec
@@ -1,4 +1,4 @@
-VER=4.20.0
+VER=4.21.0
 SRCS="tbl::https://ftp.gnu.org/gnu/libtasn1/libtasn1-$VER.tar.gz"
-CHKSUMS="sha256::92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c"
+CHKSUMS="sha256::1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87"
 CHKUPDATE="anitya::id=1734"

--- a/topics/libtasn1-4.21.0.toml
+++ b/topics/libtasn1-4.21.0.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libtasn1 4.21.0"
+
+[caution]
+default = "Fixes a stack-based buffer overflow vulnerability - CVE-2025-13151 (Severity: High)"
+zh_CN = "修复一个基于栈的缓冲区溢出漏洞，漏洞编号 CVE-2025-13151（严重性：高）"
+
+[packages-v2]
+"libtasn1" = "4.21.0"
+"libtasn1+32" = "4.21.0"


### PR DESCRIPTION
Topic Description
-----------------

- libtasn1: update to 4.21.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libtasn1: 4.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtasn1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
