### PR TITLE
brasero: fix build with GCC14

### DIFF
--- a/desktop-gnome/brasero/autobuild/patches/0001-fix-build-with-gcc14.patch
+++ b/desktop-gnome/brasero/autobuild/patches/0001-fix-build-with-gcc14.patch
@@ -1,0 +1,76 @@
+From 5cdefa8c76ddb797bce8b67a3f5767678bd36a5a Mon Sep 17 00:00:00 2001
+From: sid <sidtosh4@gmail.com>
+Date: Mon, 3 Jun 2024 18:51:08 +0100
+Subject: [PATCH] Fix gcc 14.x build failure (due to
+ -Wincompatible-pointer-types)
+
+The changes for 'brasero-drive-properties.c' are kept inline with
+'brasero-burn-options.c' (public API) for the sake of consistency.
+
+Fixes: https://gitlab.gnome.org/GNOME/brasero/-/issues/370
+---
+ libbrasero-burn/brasero-drive-properties.c | 10 +++-------
+ libbrasero-utils/brasero-metadata.c        |  2 +-
+ libbrasero-utils/brasero-pk.c              |  2 +-
+ 3 files changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/libbrasero-burn/brasero-drive-properties.c b/libbrasero-burn/brasero-drive-properties.c
+index cfb2db147..22593cc16 100644
+--- a/libbrasero-burn/brasero-drive-properties.c
++++ b/libbrasero-burn/brasero-drive-properties.c
+@@ -835,23 +835,19 @@ brasero_drive_properties_set_property (GObject *object,
+ 				       GParamSpec *pspec)
+ {
+ 	BraseroDrivePropertiesPrivate *priv;
+-	BraseroBurnSession *session;
+ 
+ 	priv = BRASERO_DRIVE_PROPERTIES_PRIVATE (object);
+ 
+ 	switch (property_id) {
+ 	case PROP_SESSION: /* Readable and only writable at creation time */
+-		/* NOTE: no need to unref a potential previous session since
+-		 * it's only set at construct time */
+-		session = g_value_get_object (value);
+-		priv->session = g_object_ref (session);
++		priv->session = g_object_ref (g_value_get_object (value));
+ 
+ 		brasero_drive_properties_update (BRASERO_DRIVE_PROPERTIES (object));
+-		priv->valid_sig = g_signal_connect (session,
++		priv->valid_sig = g_signal_connect (priv->session,
+ 						    "is-valid",
+ 						    G_CALLBACK (brasero_drive_properties_is_valid_cb),
+ 						    object);
+-		priv->output_sig = g_signal_connect (session,
++		priv->output_sig = g_signal_connect (priv->session,
+ 						     "output-changed",
+ 						     G_CALLBACK (brasero_drive_properties_output_changed_cb),
+ 						     object);
+diff --git a/libbrasero-utils/brasero-metadata.c b/libbrasero-utils/brasero-metadata.c
+index 194336899..ddfce8e7b 100644
+--- a/libbrasero-utils/brasero-metadata.c
++++ b/libbrasero-utils/brasero-metadata.c
+@@ -665,7 +665,7 @@ brasero_metadata_install_missing_plugins (BraseroMetadata *self)
+ 
+ 	context = gst_install_plugins_context_new ();
+ 	gst_install_plugins_context_set_xid (context, brasero_metadata_get_xid (self));
+-	status = gst_install_plugins_async ((gchar **) details->pdata,
++	status = gst_install_plugins_async ((const gchar* const*) details->pdata,
+ 					    context,
+ 					    brasero_metadata_install_plugins_result,
+ 					    downloads);
+diff --git a/libbrasero-utils/brasero-pk.c b/libbrasero-utils/brasero-pk.c
+index aa71901f9..5f5ba21aa 100644
+--- a/libbrasero-utils/brasero-pk.c
++++ b/libbrasero-utils/brasero-pk.c
+@@ -230,7 +230,7 @@ brasero_pk_install_gstreamer_plugin (BraseroPK *package,
+ 
+ 	context = gst_install_plugins_context_new ();
+ 	gst_install_plugins_context_set_xid (context, xid);
+-	status = gst_install_plugins_async ((gchar **) gst_plugins->pdata,
++	status = gst_install_plugins_async ((const gchar* const*) gst_plugins->pdata,
+ 	                                    context,
+ 	                                    brasero_pk_install_gst_plugin_result,
+ 	                                    package);
+-- 
+GitLab
+

--- a/desktop-gnome/brasero/spec
+++ b/desktop-gnome/brasero/spec
@@ -1,5 +1,5 @@
 VER=3.12.3
-REL=1
+REL=2
 SRCS="tbl::https://download.gnome.org/sources/brasero/${VER:0:4}/brasero-$VER.tar.xz"
 CHKSUMS="sha256::87749eae33a141207d1b00be233b6d8045982ed3249ed4b98dae1f3a975fea15"
 CHKUPDATE="anitya::id=9638"


### PR DESCRIPTION
Topic Description
-----------------

- brasero: fix build with GCC14
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- brasero: 1:3.12.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit brasero
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
