### PR TITLE
ccls: update to 0.20250815.1

### DIFF
--- a/app-devel/ccls/autobuild/defines
+++ b/app-devel/ccls/autobuild/defines
@@ -1,12 +1,12 @@
 PKGNAME=ccls
 PKGSEC=devel
-PKGDEP="llvm-19"
+PKGDEP="llvm"
 PKGDES="C/C++ language server supporting cross references, hierarchies, completion and semantic highlighting"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
     "-DCMAKE_INSTALL_PREFIX=/usr"
     "-DSYSTEM_CLANG=ON"
     "-DUSE_SHARED_LLVM=ON"
     "-DLLVM_ENABLE_RTTI=ON"
 )
-ABTYPE=cmakeninja

--- a/app-devel/ccls/spec
+++ b/app-devel/ccls/spec
@@ -1,4 +1,4 @@
-VER=0.20241108
+VER=0.20250815.1
 SRCS="git::commit=tags/$VER::https://github.com/MaskRay/ccls"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19536"


### PR DESCRIPTION
Topic Description
-----------------

- ccls: update to 0.20250815.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- ccls: 0.20250815.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ccls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
