### PR TITLE
m17n-lib: update to 1.8.6

### DIFF
--- a/runtime-i18n/m17n-lib/spec
+++ b/runtime-i18n/m17n-lib/spec
@@ -1,4 +1,4 @@
-VER=1.8.4
+VER=1.8.6
 SRCS="tbl::https://download.savannah.gnu.org/releases/m17n/m17n-lib-$VER.tar.gz"
-CHKSUMS="sha256::c6a2582c6e4f2a8c2e7a2844fa5c7eb363aad2538b052f203c710649dd421cc8"
+CHKSUMS="sha256::7129fe3b7ad500f88b8af8605ef07b96c87a75ec986a695fffc0a409f44a7c86"
 CHKUPDATE="anitya::id=1870"


### PR DESCRIPTION
Topic Description
-----------------

- m17n-lib: update to 1.8.6
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- m17n-lib: 1.8.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit m17n-lib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
