### PR TITLE
alsa-lib: update to 1.2.15.2

### DIFF
--- a/runtime-multimedia/alsa-lib/spec
+++ b/runtime-multimedia/alsa-lib/spec
@@ -1,4 +1,4 @@
-VER=1.2.15.1
+VER=1.2.15.2
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-lib-$VER.tar.bz2"
-CHKSUMS="sha256::7f983ca89ca420872ca16e8a9f8f97fb63db6c1c6e2585b91737a08bb03f566c"
+CHKSUMS="sha256::637eefd4966ce738da44464494df2b2894e19778fac2f9e7c47277e2af9297f4"
 CHKUPDATE="anitya::id=38"


### PR DESCRIPTION
Topic Description
-----------------

- alsa-lib: update to 1.2.15.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- alsa-lib: 1.2.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit alsa-lib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
