### PR TITLE
tigervnc: update Xserver to 21.1.21 and inject rpath for vncviewer

### DIFF
--- a/app-network/tigervnc/autobuild/beyond
+++ b/app-network/tigervnc/autobuild/beyond
@@ -17,3 +17,6 @@ make install \
 
 abinfo "Removing the libvnc.so extension that won't work with system Xorg ..."
 rm -v "$PKGDIR"/usr/lib/xorg/modules/extensions/libvnc.so
+
+abinfo "Injecting rpath to find FLTK 1.3 shared objects ..."
+patchelf --set-rpath /usr/lib/fltk1.3 "$PKGDIR"/usr/bin/vncviewer

--- a/app-network/tigervnc/autobuild/defines
+++ b/app-network/tigervnc/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=tigervnc
 PKGSEC=net
 PKGDEP="fltk-1.3 gnutls libgcrypt mesa libjpeg-turbo pixman x11-app \
         xkeyboard-config ffmpeg libxcvt xinit"
-BUILDDEP="x11-font x11-app x11-proto cmake imagemagick nasm"
+BUILDDEP="x11-font x11-app x11-proto cmake imagemagick nasm patchelf"
 PKGDES="Suite of VNC servers and clients"
 
 ABTYPE=cmakeninja

--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,10 +1,9 @@
 UPSTREAM_VER=1.15.0
-XORG_VER=21.1.19
-REL=1
+XORG_VER=21.1.21
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::ca6b38181685d7d7c935d0597cfe35ee8df4d0fbf8ac63301541e037e8b08f07"
+         sha256::c0cbe5545b3f645bae6024b830d1d1154a956350683a4e52b2fff5b0fa1ab519"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update Xserver to 21.1.21 and inject rpath for vncviewer
    TigerVNC viewer only supports FLTK 1.3, which is now intentionally
    installed to /usr/lib/fltk1.3. However the binary isn't built with
    rpath, thus the FLTK 1.3 libraries couldn't be found.
    Inject rpath with patchelf.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- tigervnc: 1.15.0+xserver21.1.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
