### PR TITLE
loonggl: resurrect the hack previously known as "vga_check.sh"

### DIFF
--- a/runtime-display/loonggl/autobuild/build
+++ b/runtime-display/loonggl/autobuild/build
@@ -28,3 +28,7 @@ ln -sv gsgpu/libgsgpu_glapi.so.0 \
     "$PKGDIR"/usr/lib/libgsgpu_glapi.so.0
 ln -sv loonggpu/libloonggpu_glapi.so.0 \
     "$PKGDIR"/usr/lib/libloonggpu_glapi.so.0
+
+# FIXME: See the loonggl-hack script for this stupidity.
+abinfo "Renaming JSON files for loonggl-hack ..."
+rename 40 60 "$PKGDIR"/usr/share/glvnd/egl_vendor.d/*.json

--- a/runtime-display/loonggl/autobuild/overrides/usr/lib/systemd/system-preset/40-loonggl-hack.preset
+++ b/runtime-display/loonggl/autobuild/overrides/usr/lib/systemd/system-preset/40-loonggl-hack.preset
@@ -1,0 +1,1 @@
+enable loonggl-hack.service

--- a/runtime-display/loonggl/autobuild/overrides/usr/lib/systemd/system/loonggl-hack.service
+++ b/runtime-display/loonggl/autobuild/overrides/usr/lib/systemd/system/loonggl-hack.service
@@ -1,0 +1,11 @@
+[Unit]
+Description="Conditionally Activate LoongGPU EGL Implementation"
+Before=getty-pre.target display-manager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/libexec/loonggl-hack
+
+[Install]
+WantedBy=multi-user.target

--- a/runtime-display/loonggl/autobuild/overrides/usr/libexec/loonggl-hack
+++ b/runtime-display/loonggl/autobuild/overrides/usr/libexec/loonggl-hack
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Public domain.
+# For a brief history of this hack, see:
+# https://github.com/AOSC-Dev/aosc-os-abbs/pull/12410
+
+shopt -s nullglob
+has_loonggpu=0
+udevadm settle
+
+for i in /sys/class/drm/card[0-9]/device/driver; do
+	driver="$(basename $(readlink $i))"
+
+	if [ "$driver" = "loonggpu-dc" ]; then
+		has_loonggpu=1
+	elif [ "$driver" != "hantro" ]; then
+		# If any drm device(s) with a different driver (except a hantro VPU)
+		# are loaded, don't even try LoongGPU EGL implementations.
+		#
+		# The libEGL_{gs,loong}gpu.so drivers provided by the vendor are
+		# known to do stupid things **even with LoongGPU already disabled by
+		# the firmware** (i.e. when the PCI enumeration cannot find one at
+		# all), causing eglinfo to crash, WebKitWebProcess to crash with
+		# WEBKIT_DISABLE_DMABUF_RENDERER=1, and maybe other malfunctions.
+		#
+		# This hack is obviously full of race conditions, making the
+		# system initialization unreliable (yes the systemd unit is already
+		# ordered before getty-pre.target and display-manager.service but
+		# there are still countless ways to invoke libEGL before that unit,
+		# feel free to submit a PR adding more units into Before= if you
+		# need), and making oma have to run this script when this package is
+		# installed, and have to delete 40_{gs,loong}gpu.json when this
+		# package is removed.  This also obviously prevents using LoongGPU
+		# and another graphics card at the same time, but such an attempt
+		# won't work due to all the flaws in the vendor driver anyway.
+		#
+		# So if you've connected two monitors, one on LoongGPU and another
+		# on a different graphics card and then found LoongGPU isn't
+		# working, do NOT report this as a bug to the AOSC maintainers:
+		# the vendor driver just cannot work under such a configuration.
+		#
+		# We already suggested the vendor to open the source of LoongGPU
+		# driver so we can fix libEGL_loonggpu.so for them, but the only
+		# response was a very aggressive comment on Bilibili seemingly from
+		# some guy affilinated with the vendor, claiming "you open source
+		# community knows nothing about graphics and the vendor can do
+		# things much better than you."  But now we can see the vendor guys
+		# even cannot use libglvnd properly (we are pretty sure it's not an
+		# inherent limitation of libglvnd because NVIDIA and even Zhaoxin
+		# works perfectly fine).
+		#
+		# The best thing we can do is just resurrecting this script.
+		# Man, what can I say!  Manba resurrected.
+		has_loonggpu=0
+		break
+	fi
+done
+
+# Note that "$V" is only for debugging purpose (set V=-v).
+for TARGET in /usr/share/glvnd/egl_vendor.d/40_{gs,loong}gpu.json; do
+	if [[ "$has_loonggpu" = 1 ]]; then
+		ln $V -sf "${TARGET/40/60}" "$TARGET"
+	else
+		rm $V -f "$TARGET"
+	fi
+done
+
+# vim: ts=4

--- a/runtime-display/loonggl/autobuild/postinst
+++ b/runtime-display/loonggl/autobuild/postinst
@@ -1,1 +1,8 @@
 rm -f /etc/init.d/vga_check.sh
+
+systemctl preset loonggl-hack.service
+
+if ! systemd-detect-virt -q; then
+	systemctl daemon-reload
+	systemctl restart loonggl-hack.service
+fi

--- a/runtime-display/loonggl/autobuild/prerm
+++ b/runtime-display/loonggl/autobuild/prerm
@@ -1,2 +1,2 @@
-rm -f /usr/share/glvnd/egl_vendor.d/40_loonggpu.json
+rm -f /usr/share/glvnd/egl_vendor.d/40_{gs,loong}gpu.json
 rm -f /etc/init.d/vga_check.sh

--- a/runtime-display/loonggl/spec
+++ b/runtime-display/loonggl/spec
@@ -1,5 +1,5 @@
 UPSTREAM_VER=1.0.2-lnd25.1~rc1.7
-REL=1
+REL=2
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}


### PR DESCRIPTION
Topic Description
-----------------

But with a better naming, "loonggl_hack."

See the long comment in that script for all the reason of this bullsh*t.

Note that this does NOT fix the WebKitWebProcess crash on LG100/200, it only prevents the crash on platforms where LG100/200 is NOT in use.

Package(s) Affected
-------------------

- loonggl: `1.0.2+lnd25.1~rc1.7-2`

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
