### PR TITLE
rocm: Libraries without MachineLearning update to 7.1.1[3/3], Add supplement math library

### DIFF
--- a/runtime-rocm/rocm-hipblas/spec
+++ b/runtime-rocm/rocm-hipblas/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas"

--- a/runtime-rocm/rocm-hipcub/spec
+++ b/runtime-rocm/rocm-hipcub/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipcub"

--- a/runtime-rocm/rocm-hiprand/spec
+++ b/runtime-rocm/rocm-hiprand/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hiprand"

--- a/runtime-rocm/rocm-hipsolver/autobuild/defines
+++ b/runtime-rocm/rocm-hipsolver/autobuild/defines
@@ -1,0 +1,28 @@
+PKGNAME=rocm-hipsolver
+PKGDES="Radeon Open Compute LAPACK marshalling library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocblas rocm-rocsolver rocm-hipblas rocm-hipsparse"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+# Note: Depends on architecture-specific runtime. Treat as ELF-less.
+ABSPLITDBG=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-hipsolver/autobuild/prepare
+++ b/runtime-rocm/rocm-hipsolver/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-hipsolver/spec
+++ b/runtime-rocm/rocm-hipsolver/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/hipsolver"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipsparselt/autobuild/defines
+++ b/runtime-rocm/rocm-hipsparselt/autobuild/defines
@@ -1,0 +1,36 @@
+PKGNAME=rocm-hipsparselt
+PKGDES="ROCm SPARSE marshalling library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipsparse rocm-hipblaslt"
+BUILDDEP="cmake msgpack-c++ pyyaml"
+
+# FIXME: Segmentation Fault
+#  failed: null sections(STRTAB)
+#  rocm-clr rocclr/elf/elf.cpp:282
+ABSTRIP=0
+
+USECLANG=1
+
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_Fortran_COMPILER=/usr/lib/rocm/lib/llvm/bin/flang'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DBUILD_CLIENTS_SAMPLES=OFF'
+    '-DBUILD_CLIENTS_BENCHMARKS=OFF'
+    '-DBUILD_CLIENTS_TESTS=OFF'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipsparselt/autobuild/prepare
+++ b/runtime-rocm/rocm-hipsparselt/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Install Build Dependence ..."
+pip install -v joblib

--- a/runtime-rocm/rocm-hipsparselt/spec
+++ b/runtime-rocm/rocm-hipsparselt/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/hipsparselt"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-rocsolver/spec
+++ b/runtime-rocm/rocm-rocsolver/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.1.1
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsolver"

--- a/runtime-rocm/rocm-rocthrust/autobuild/defines
+++ b/runtime-rocm/rocm-rocthrust/autobuild/defines
@@ -1,0 +1,28 @@
+PKGNAME=rocm-rocthrust
+PKGDES="Radeon Open Compute Thrust library"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-rocprim"
+BUILDDEP="cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+# Note: Depends on architecture-specific runtime. Treat as ELF-less.
+ABSPLITDBG=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-rocthrust/autobuild/prepare
+++ b/runtime-rocm/rocm-rocthrust/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-rocthrust/spec
+++ b/runtime-rocm/rocm-rocthrust/spec
@@ -1,0 +1,5 @@
+VER=7.1.1
+SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/rocthrust"
+CHKUPDATE="anitya::id=383650"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-hipsparselt: add, 7.1.1
- rocm-hipsolver: add, 7.1.1
- rocm-rocthrust: add, 7.1.1
- rocm-hiprand: upgrade to 7.1.1
- rocm-hipcub: upgrade to 7.1.1
- rocm-hipblas: upgrade to 7.1.1
- rocm-rocsolver: upgrade to 7.1.1

Package(s) Affected
-------------------

- rocm-hipblas: 7.1.1
- rocm-hipcub: 7.1.1
- rocm-hiprand: 7.1.1
- rocm-hipsolver: 7.1.1
- rocm-hipsparselt: 7.1.1
- rocm-rocsolver: 7.1.1
- rocm-rocthrust: 7.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-rocsolver rocm-hipblas rocm-hipcub rocm-hiprand rocm-rocthrust rocm-hipsolver rocm-hipsparselt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
