### PR TITLE
fcitx5-pinyin-moegirl: update to 20260109

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20251210
+VER=20260109
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::9ce545715ee42105ebcf9bcacdb31a24f448936d31f3ea4ec423a06028a239a9
-         sha256::3f8000c00a649c4695e0f167ebfe6ba5ac29d223867431fe9ae622f91fe212b9
+CHKSUMS="sha256::c4667bb3110b3e53e8dbba120a80d742b96282499cc3f7c37b1205b7f4b4aea7
+         sha256::4bccd04c730c145d03eee5bb38600ea475d62b52a0827659e9b96fa9d70628ce
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260109

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260109
- rime-pinyin-moegirl: 20260109

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
