### PR TITLE
patatt: update to 0.7.0

### DIFF
--- a/app-devel/patatt/spec
+++ b/app-devel/patatt/spec
@@ -1,5 +1,4 @@
-VER=0.6.3
-REL="2"
+VER=0.7.0
 SRCS="tbl::https://pypi.io/packages/source/p/patatt/patatt-$VER.tar.gz"
-CHKSUMS="sha256::980826f6529d2576c267ca1f564d5bef046cb47e54215bb598ed6c4b9b2d0a28"
+CHKSUMS="sha256::f7b2be8a15f251fbbc90c6b734ab910654a7a9d184369ce9e77b6d26e43b9eea"
 CHKUPDATE="anitya::id=199204"


### PR DESCRIPTION
Topic Description
-----------------

- patatt: update to 0.7.0
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- patatt: 0.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit patatt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
