### PR TITLE
typos: update to 1.42.0

### DIFF
--- a/app-utils/typos/autobuild/defines
+++ b/app-utils/typos/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=typos
-PKGDES="A tool to find and correct spelling mistakes (typos) in source code"
+PKGDES="Tool to find and correct spelling mistakes (typos) in source code"
 PKGDEP="glibc gcc-runtime"
 PKGSEC="utils"
 BUILDDEP="rustc llvm"

--- a/app-utils/typos/spec
+++ b/app-utils/typos/spec
@@ -1,4 +1,4 @@
-VER=1.40.0
+VER=1.42.0
 SRCS="git::commit=tags/v$VER::https://github.com/crate-ci/typos"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373489"


### PR DESCRIPTION
Topic Description
-----------------

- typos: update to 1.42.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- typos: 1.42.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit typos
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
