### PR TITLE
normaliz: update to 3.11.0

### DIFF
--- a/app-scientific/normaliz/spec
+++ b/app-scientific/normaliz/spec
@@ -1,4 +1,4 @@
-VER=3.10.5
+VER=3.11.0
 SRCS="tbl::https://github.com/Normaliz/Normaliz/releases/download/v$VER/normaliz-$VER.tar.gz"
-CHKSUMS="sha256::58492cfbfebb2ee5702969a03c3c73a2cebcbca2262823416ca36e7b77356a44"
+CHKSUMS="sha256::14441981afce3546c1c0f12b490714da3564af7a60d12ac0a494f9d2382d1a01"
 CHKUPDATE="anitya::id=7722"


### PR DESCRIPTION
Topic Description
-----------------

- normaliz: update to 3.11.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- normaliz: 3.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit normaliz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
