### PR TITLE
glmark2: enable all variants

### DIFF
--- a/app-benchmarks/glmark2/autobuild/defines
+++ b/app-benchmarks/glmark2/autobuild/defines
@@ -12,7 +12,7 @@ PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 
-MESON_AFTER="-Dflavors=x11-gl,x11-glesv2,drm-gl,wayland-gl,wayland-glesv2,drm-glesv2"
+MESON_AFTER="-Dflavors=x11-gl,x11-gl-egl,x11-glesv2,drm-gl,wayland-gl,wayland-glesv2,drm-glesv2,gbm-gl,gbm-glesv2"
 MESON_AFTER__RETRO="-Dflavors=x11-gl,x11-glesv2,drm-gl,drm-glesv2"
 MESON_AFTER__ARMV4="${MESON_AFTER__RETRO}"
 MESON_AFTER__ARMV6HF="${MESON_AFTER__RETRO}"

--- a/app-benchmarks/glmark2/spec
+++ b/app-benchmarks/glmark2/spec
@@ -1,5 +1,5 @@
 VER=2023.01
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/glmark2/glmark2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8892"


### PR DESCRIPTION
Topic Description
-----------------

- glmark2: enable all variants available for meson build
    This includes GBM variants, which render headlessly just to the VRAM and
    the X11 EGL variant, which uses desktop GL with EGL \(instead of GLX\).
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- glmark2: 1:2023.01-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit glmark2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
