### PR TITLE
desktop-base: remove GPU drivers

### DIFF
--- a/meta-bases/desktop-base/autobuild/defines
+++ b/meta-bases/desktop-base/autobuild/defines
@@ -8,10 +8,6 @@ PKGRECOM="noto-fonts noto-cjk-fonts liberation-fonts"
 # included below.
 PKGRECOM="${PKGRECOM} intel-media-driver libva-intel-driver \
           libva-nvidia-driver libva-vdpau-driver libva-utils"
-# Zhaoxin graphics drivers are amd64-only, apparently.
-PKGRECOM__AMD64="${PKGRECOM[@]} \
-                cx4-linux-graphics-driver-dri \
-                zhaoxin-linux-graphics-driver-dri"
-PKGRECOM__LOONGARCH64="${PKGRECOM[@]} liblol loonggpu-driver"
+PKGRECOM__LOONGARCH64="${PKGRECOM[@]} liblol"
 
 ABSPLITDBG=0

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,5 +1,5 @@
 VER=18
-REL=1
+REL=2
 SRCS="git::rename=logo;commit=4fa52e8c97c0e8fbcd2896c5ac6f7b31a694fc65::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
 # FIXME: No release would be made from this repository.

--- a/meta-bases/kernel-base/autobuild/defines
+++ b/meta-bases/kernel-base/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=kernel-base
 PKGSEC=Bases
 PKGRECOM="dracut-ng firmware-free firmware-nonfree linux+kernel kmod openfwwf \
           wireless-regdb"
-PKGRECOM__LOONGARCH64="${PKGRECOM} loonggpu-kernel-dkms"
 PKGRECOM__RETRO="kmod linux+kernel+retro"
 PKGRECOM__I486="${PKGRECOM__RETRO}"
 PKGRECOM__LOONGSON2F="${PKGRECOM__RETRO}"

--- a/meta-bases/kernel-base/spec
+++ b/meta-bases/kernel-base/spec
@@ -1,2 +1,3 @@
 VER=8
+REL=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- kernel-base: remove loonggpu-kernel-dkms
- desktop-base: remove GPU drivers

Package(s) Affected
-------------------

- desktop-base: 18-2
- kernel-base: 8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base kernel-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
