### PR TITLE
ropy: new, 0.2.0~beta

### DIFF
--- a/app-utils/ropy/autobuild/defines
+++ b/app-utils/ropy/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="ropy"
+PKGDES="A Clipboard manager"
+PKGDEP="cairo freetype gcc-runtime gdk-pixbuf \
+        glib glibc gtk-3 libxcb libxkbcommon \
+        pango xdotool"
+BUILDDEP="rustc llvm"
+PKGSEC="utils"
+
+USECLANG=1

--- a/app-utils/ropy/autobuild/patches/0001-fix-ensure-init-gtk-and-build-tray-icon-on-same-thre.patch
+++ b/app-utils/ropy/autobuild/patches/0001-fix-ensure-init-gtk-and-build-tray-icon-on-same-thre.patch
@@ -1,0 +1,33 @@
+From 95885daf4a1b819237e3a465fcb323e53704f812 Mon Sep 17 00:00:00 2001
+From: eatradish <sakiiily@aosc.io>
+Date: Mon, 12 Jan 2026 16:33:14 +0800
+Subject: [PATCH] fix: ensure init gtk and build tray icon on same thread on
+ linux...
+
+... fix #33
+---
+ src/gui/tray.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/gui/tray.rs b/src/gui/tray.rs
+index 6dee67b..ce2458f 100644
+--- a/src/gui/tray.rs
++++ b/src/gui/tray.rs
+@@ -67,12 +67,14 @@ pub fn start_tray_handler(
+     let bg_executor = async_app.background_executor().clone();
+     let bg_executor_clone = bg_executor.clone();
+ 
++    #[cfg(not(target_os = "linux"))]
+     start_tray_handler_inner(settings, tx, bg_executor_clone);
+ 
+     #[cfg(target_os = "linux")]
+     bg_executor
+         .spawn(async move {
+             gtk::init().expect("Failed to init gtk modules");
++            start_tray_handler_inner(settings, tx, bg_executor_clone);
+             gtk::main();
+         })
+         .detach();
+-- 
+2.52.0
+

--- a/app-utils/ropy/spec
+++ b/app-utils/ropy/spec
@@ -1,0 +1,4 @@
+VER=0.2.0~beta
+SRCS="git::commit=tags/${VER/\~/-}::https://github.com/StudentWeis/ropy"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=388033"


### PR DESCRIPTION
Topic Description
-----------------

- ropy: new, 0.2.0\~beta

Package(s) Affected
-------------------

- ropy: 0.2.0~beta

Security Update?
----------------

No

Build Order
-----------

```
#buildit ropy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
