### PR TITLE
iosevka-fonts: update to 34.0.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=33.3.6
+VER=34.0.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::6f4e2e562463bf416dfd99f7490c61da6d40ac2c21d757300c8a4b6f2484c919 \
-         sha256::fd998e85c4c289de52919d2a71eccd465b1e4583ac08744436e0a7c6a1dd66a3 \
-         sha256::f4e88e9b85d63a39ff61a96fdfb4703523cffeecf9e4bd62856dbc7449cd3321 \
-         sha256::4f76e2b2955364ded0b302baf4081fc63cc08fe4c82c4abf4c7c1e6f8611e239 \
-         sha256::6ebde0105a707f3e7612028afc9b693f9972006f1abfb85976524f28dd35bf88 \
-         sha256::2f0590f097d2b15e17500241e06e0adcf43301a50b1ea81840b2f3b3db08d1b9 \
-         sha256::d0545c063f133a2c56628a4e3e5e196bfcaab9eb3ca7bb73403dba642a4a08f8 \
-         sha256::f08c2488b6f288c6f2a3cb8668ca6906d0e4ea7f4d6e5c4ad2c79c73156cc717 \
-         sha256::e945a6e5eb396da80d72d03d11fe6995505d4b7ce1c1a9bb266e96f7980d1591 \
-         sha256::9196bb8e4e433087c191580a32e73b4c9abf4781711a2035af8195aa67f29065 \
-         sha256::60ebaeb43ac0c1459cef6be88a251252742077ee5db22757b4287a5c62027a18 \
-         sha256::b41a37dbe27883e44cd1fcbd1664c12f03e6fc2d6aa5119aa74f76f7569e76a5 \
-         sha256::711d0ec94bea61efbdac656674d73de0fdabbc8053aa102a58607a48f7a3b04c \
-         sha256::3003ffe201d804e9214b864ab8a42c24c0cea5a77d5323b00ae2457b371530f1 \
-         sha256::c07aee8c07ccc1f604d6cbf9ab2e766f4f11bbd7b84b8acabd0fc677d9d7f183 \
-         sha256::8781f0d6323d3d066667852bdd24c9beb70811e23cac2db530ae97693507565a \
-         sha256::48d13f102fd8b183ec63818c338a5688fa2be015c57024a06fbedb9203276dfb \
-         sha256::def49b4095dd80772d6605359f294a8b041f5021d47a6d4018d37092900e3963 \
-         sha256::b2c146eaaff8dd511409f3491083dc7c57f46ed26ead3781ee633e9e60ab93ce \
-         sha256::89f1c423ae8f155aed3a3b2883bd703bae12f860cf1cb937d9930424d288aab0 \
-         sha256::35541783e8c041e367a3c3a024f577b51b4c7fcf019b49b2c3bcf54208fe9548 \
-         sha256::d861052de4bafa02ff7a9d69f7216e5c16dc7978658659c698d061a5206ff036 \
-         sha256::97f6d996d219e0385be04a329f64a02930089e637c28eeec2d78b3dd4ab45b47 \
-         sha256::9faacb9215d879259fe4ddfc1a5a79bcb6b5b069ced7d1282926e2e3f2d3fbca \
+CHKSUMS="sha256::1b07d0d2651950ad963e8306e987eb82e6ad0ed265d93127c7e860be2ce27734 \
+         sha256::2d7057ec6a10597c53d429bdc7c05d9d80eb397be475c468193d152760c9c4ca \
+         sha256::34c7bb88f953df4f6a405fc785cf82cefd3d2f2b8cd9ccee60bfffda29c15111 \
+         sha256::a578a55637589a70e57b00843e435b3478e3846e05c52dab3093f23b0d9d8ae7 \
+         sha256::ef5fb6ebb95588c8fbf31cecf64d3cef95556e0910e7ee52121898d5a76087c2 \
+         sha256::cf20593cdbe4b3a8f2882f682d7a13b5ab150b1410feed17cb2237a7bee6b726 \
+         sha256::c0d3cbbf7c6484ba447baa9fa546bd50579f15184d91e6636a16876c3e05627d \
+         sha256::e929a5b3a1a6ed78a1b9c40c9b02edd1af08dc719a1373dc8402d935a3e1f363 \
+         sha256::e6d081422e6f6406793c5b8120e250e86038907ead448974ed60573833127ce8 \
+         sha256::3b2d6c08bc75b1e50f1369046641502e16d74b8a43aa3cd25dc40f4f52fffec0 \
+         sha256::cda36237b6e4420f6fcde6fa064313e20dcfc1f80262fddbf1fe243dcc1779c8 \
+         sha256::629481dbb539d0eda4921b4d389daf5a1f183831c097051c0b26e1ecbe090efc \
+         sha256::c2e59194544a46ecd9aa1642ff1e6bfc5d8e1cfe1ccbd0231b4fe6a80a68d98a \
+         sha256::4530081558969d2a436ca3d1e71b82891c73da6143ae030fb689f4ad8d7e119f \
+         sha256::d63d5b33f062cd913ec32991b84e3f668098b93a01182d211fc5506296aa4fe2 \
+         sha256::b7c11a203c531575c3f95921a2a3c958f9459eba495cf3a12bc61791ab7b2e94 \
+         sha256::b70bbfb60ce27392f1574522b960f4efb737ef4ebbfc3a1b4b28dac13a8ccc9a \
+         sha256::e03e5fab5fee5dda10516189a20147f45dcde3a400c450809cb849af99c52447 \
+         sha256::26df2d3ef214cbbe0e693cf6bdcbf19deeb1f58ec668b7ec61652863d771a7ff \
+         sha256::96b777a152fe5bc50ebbd64e0ce0cc0f3d2b49bedc70cc7f8c004ca190a1e6f0 \
+         sha256::10d5e23a0ff9355dd4361d7a636059b11976ab08099f6de3a9c881b9128fbcfa \
+         sha256::05f7f1d5efe56ff7f1fcff8c21c2b84da4be44fe9b63d4abbc2e3950b242c585 \
+         sha256::ee4225046e9509ba77fd5505f6a1940b7138410f83bf84b974751bc15191c458 \
+         sha256::85f31752d692f26f8a55a890579c892a03870e15016db659a916b97c3e515333 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.0.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
