### PR TITLE
waydroid: update to 1.6.1

### DIFF
--- a/app-emulation/waydroid/spec
+++ b/app-emulation/waydroid/spec
@@ -1,4 +1,4 @@
-VER=1.6.0
+VER=1.6.1
 SRCS="git::commit=tags/$VER::https://github.com/waydroid/waydroid"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=314286"


### PR DESCRIPTION
Topic Description
-----------------

- waydroid: update to 1.6.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- waydroid: 1.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit waydroid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
