### PR TITLE
yazi: update to 26.1.4

### DIFF
--- a/app-utils/yazi/autobuild/defines
+++ b/app-utils/yazi/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME="yazi"
 PKGDES="A file manager for the terminal"
-PKGDEP="glibc gcc-runtime"
+PKGDEP="glibc gcc-runtime symbols-nerd-font"
 PKGRECOM="jq ffmpegthumbnailer 7-zip poppler fd ripgrep fzf zoxide imagemagick chafa"
 BUILDDEP="rustc imagemagick"
 PKGSEC=utils

--- a/app-utils/yazi/spec
+++ b/app-utils/yazi/spec
@@ -1,4 +1,4 @@
-VER=25.5.31
+VER=26.1.4
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/sxyazi/yazi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370571"


### PR DESCRIPTION
Topic Description
-----------------

- yazi: update to 26.1.4
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- yazi: 26.1.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit yazi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
