### PR TITLE
power-profiles-daemon: set up alternatives for d-bus services

### DIFF
--- a/app-admin/power-profiles-daemon/autobuild/alternatives
+++ b/app-admin/power-profiles-daemon/autobuild/alternatives
@@ -1,0 +1,4 @@
+alternative /usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service /usr/share/dbus-1/system-services/net.hadess.PowerProfiles-ppd.service 40
+alternative /usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service /usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles-ppd.service 40
+alternative /usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf /usr/share/dbus-1/system.d/net.hadess.PowerProfiles-ppd.conf 40
+alternative /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles-ppd.conf 40

--- a/app-admin/power-profiles-daemon/autobuild/beyond
+++ b/app-admin/power-profiles-daemon/autobuild/beyond
@@ -1,0 +1,10 @@
+# Resolving conflict introduced by PPD DBus service.
+abinfo "Moving ppd dbus related services and configs ..."
+
+mv "$PKGDIR"/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service "$PKGDIR"/usr/share/dbus-1/system-services/net.hadess.PowerProfiles-ppd.service
+
+mv "$PKGDIR"/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service "$PKGDIR"/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles-ppd.service
+
+mv "$PKGDIR"/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf "$PKGDIR"/usr/share/dbus-1/system.d/net.hadess.PowerProfiles-ppd.conf
+
+mv "$PKGDIR"/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf "$PKGDIR"/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles-ppd.conf

--- a/app-admin/tuned/autobuild/alternatives
+++ b/app-admin/tuned/autobuild/alternatives
@@ -1,0 +1,4 @@
+alternative /usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service /usr/share/dbus-1/system-services/net.hadess.PowerProfiles-tuned.service 75
+alternative /usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service /usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles-tuned.service 75
+alternative /usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf /usr/share/dbus-1/system.d/net.hadess.PowerProfiles-tuned.conf 75
+alternative /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf /usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles-tuned.conf 75

--- a/app-admin/tuned/autobuild/beyond
+++ b/app-admin/tuned/autobuild/beyond
@@ -1,4 +1,3 @@
-# Adapted from Fedora.
 abinfo "Creating daemon directory and file templates ..."	
 mkdir -pv \
     "$PKGDIR"/var/lib/tuned \
@@ -19,3 +18,11 @@ for i in \
     rm -rv \
         "$PKGDIR"/usr/lib/tuned/profiles/$i
 done
+
+# Resolving conflict introduced by PPD DBus service.
+abinfo "Moving tuned dbus related services and configs ..."
+
+mv "$PKGDIR"/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service "$PKGDIR"/usr/share/dbus-1/system-services/net.hadess.PowerProfiles-tuned.service
+mv "$PKGDIR"/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service "$PKGDIR"/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles-tuned.service
+mv "$PKGDIR"/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf "$PKGDIR"/usr/share/dbus-1/system.d/net.hadess.PowerProfiles-tuned.conf
+mv "$PKGDIR"/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf "$PKGDIR"/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles-tuned.conf

--- a/app-admin/tuned/autobuild/defines
+++ b/app-admin/tuned/autobuild/defines
@@ -6,8 +6,5 @@ PKGDEP="dbus-python desktop-file-utils dmidecode ethtool gawk hdparm iproute2 \
         util-linux virt-what"
 BUILDDEP="asciidoctor"
 PKGDES="A profile-based system tuning daemon"
-PKGCONFL="power-profiles-daemon"
-PKGREP="power-profiles-daemon"
-PKGBREAK="power-profiles-daemon<=0.30"
 
 ABHOST=noarch


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->
* power-profiles-daemon: set up alternatives for d-bus services
   Co-authored-by: Sam Duan (@samduanx) [exp999@live.cn](mailto:exp999@live.cn)

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->
* power-profiles-daemon: 0.30.0

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit power-profiles-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
