### PR TITLE
loonggpu-kernel-dkms: update to 1.0.2+lnd25.1~rc1.7-2

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,4 +1,4 @@
-From 9df674776cbe2074ff6535a4e61d3c54e217872a Mon Sep 17 00:00:00 2001
+From 879da03e2d4c86d23e3c7d87e4f1342227ea9c2e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:21:11 +0800
 Subject: [PATCH 16/63] loonggpu: Implement client-based fbdev emulation
@@ -27,10 +27,10 @@ Link: https://git.kernel.org/torvalds/c/e317a69fe891
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
  include/loonggpu_mode.h    |   3 +-
- loonggpu/loonggpu_device.c |  13 ++---
+ loonggpu/loonggpu_device.c |   3 +-
  loonggpu/loonggpu_drv.c    |   8 ++-
  loonggpu/loonggpu_fb.c     | 112 ++++++++++++++++++++++++++-----------
- 4 files changed, 90 insertions(+), 46 deletions(-)
+ 4 files changed, 86 insertions(+), 40 deletions(-)
 
 diff --git a/include/loonggpu_mode.h b/include/loonggpu_mode.h
 index 87fea79..b0b75d3 100644
@@ -47,30 +47,26 @@ index 87fea79..b0b75d3 100644
  bool loonggpu_fbdev_robj_is_fb(struct loonggpu_device *adev, struct loonggpu_bo *robj);
  int loonggpu_align_pitch(struct loonggpu_device *adev, int width, int bpp, bool tiled);
 diff --git a/loonggpu/loonggpu_device.c b/loonggpu/loonggpu_device.c
-index a838973..d480ac6 100644
+index a838973..af7fbf8 100644
 --- a/loonggpu/loonggpu_device.c
 +++ b/loonggpu/loonggpu_device.c
-@@ -1433,14 +1433,12 @@ int loonggpu_device_init(struct loonggpu_device *adev,
+@@ -1433,6 +1433,7 @@ int loonggpu_device_init(struct loonggpu_device *adev,
  		max_MBps = 8; /* Allow 8 MB/s. */
  	/* Get a log2 for easy divisions. */
  	adev->mm_stats.log2_max_MBps = ilog2(max(1u, max_MBps));
--	if (adev->family_type != CHIP_NO_GPU) {
--		r = loonggpu_ib_pool_init(adev);
--		if (r) {
--			dev_err(adev->dev, "IB initialization failed (%d).\n", r);
--			goto failed;
--		}
 +
-+	r = loonggpu_ib_pool_init(adev);
-+	if (r) {
-+		dev_err(adev->dev, "IB initialization failed (%d).\n", r);
-+		goto failed;
+ 	if (adev->family_type != CHIP_NO_GPU) {
+ 		r = loonggpu_ib_pool_init(adev);
+ 		if (r) {
+@@ -1440,7 +1441,6 @@ int loonggpu_device_init(struct loonggpu_device *adev,
+ 			goto failed;
+ 		}
  	}
 -	loonggpu_fbdev_init(adev);
  
  	r = loonggpu_pm_sysfs_init(adev);
  	if (r)
-@@ -1520,7 +1518,6 @@ void loonggpu_device_fini(struct loonggpu_device *adev)
+@@ -1520,7 +1520,6 @@ void loonggpu_device_fini(struct loonggpu_device *adev)
  
  	loonggpu_ib_pool_fini(adev);
  	loonggpu_fence_driver_fini(adev);

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,4 +1,4 @@
-From d93e4dcc7388511ee3100bf481683c9bbdfdd593 Mon Sep 17 00:00:00 2001
+From 97803fa7d7c6da7145e7dd84f9ebbeedc5b8f6f6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:31:20 +0800
 Subject: [PATCH 17/63] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,4 +1,4 @@
-From 2725f89965f8015c55ab2e57413ccecbe0d28c46 Mon Sep 17 00:00:00 2001
+From 65af8110130bf9e785dc8745b4442f9a10530adf Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:35:32 +0800
 Subject: [PATCH 18/63] loonggpu: Disable outputs when releasing fbdev client

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,4 +1,4 @@
-From d736ed165340c7b6c9fbdfc648780a804a7b2e80 Mon Sep 17 00:00:00 2001
+From 4af981c40cf4dd7a5a1fae77fa4061af1af65f8f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:58:47 +0800
 Subject: [PATCH 19/63] loonggpu: Run DRM default client setup

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-bridge-make-is_resolution_valid-static.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-bridge-make-is_resolution_valid-static.patch
@@ -1,4 +1,4 @@
-From f338b5bc81aeb31f1c0686493abf08a14025faf4 Mon Sep 17 00:00:00 2001
+From 153e10193966980eb58727786fa693dbb7e00fb0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:15:00 +0800
 Subject: [PATCH 20/63] loonggpu-bridge: make is_resolution_valid static

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-bridge-constify-struct-drm_display_mode-poi.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-bridge-constify-struct-drm_display_mode-poi.patch
@@ -1,4 +1,4 @@
-From 73ba877995d2c08941a7f4fd91cab5a4369c2a0d Mon Sep 17 00:00:00 2001
+From 377990c6cd7471b2796a1d4c8f49bac26f4d090c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:31:07 +0800
 Subject: [PATCH 21/63] loonggpu-bridge: constify struct drm_display_mode

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-loonggpu-bridge-Adapt-for-recent-kernel-API-changes.patch
@@ -1,4 +1,4 @@
-From 95f25d6bd8769307007a69dce5cf2957315c0089 Mon Sep 17 00:00:00 2001
+From 88b6f8e384fc498be06ed0fe069379671a5e8e55 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:31:22 +0800
 Subject: [PATCH 22/63] loonggpu: bridge: Adapt for recent kernel API changes

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,4 +1,4 @@
-From f1ad51b615599daebae19710c28e49f75d38c43c Mon Sep 17 00:00:00 2001
+From eb206dcbb61ecd321618a294a22845268a90684e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 10:49:40 +0800
 Subject: [PATCH 23/63] loonggpu: Remove the check against moving pinned BOs

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-loonggpu-Remove-dead-code.patch
@@ -1,4 +1,4 @@
-From 51f55e065d1c831f4c9328ba6bad59391531196d Mon Sep 17 00:00:00 2001
+From bba343bba190d5cbda96fd8db8a30338ab064832 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 11:18:49 +0800
 Subject: [PATCH 24/63] loonggpu: Remove dead code

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,4 +1,4 @@
-From e15b32b4e5274111de7540ac8f2d9246cc53ed52 Mon Sep 17 00:00:00 2001
+From 1c3893412785083145813f372e093a4154f4c941 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 12:11:28 +0800
 Subject: [PATCH 25/63] loonggpu: NFC: Clean up gsgpu_bo_move

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-Handle-tt-moves-properly.patch
@@ -1,4 +1,4 @@
-From a49ecd72568dae45b40b8771fdcf416f2e2ad4d7 Mon Sep 17 00:00:00 2001
+From e1206162f4d839518bb1e682327dc101141b4109 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:08:07 +0800
 Subject: [PATCH 26/63] loonggpu: Handle tt moves properly

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Use-multihop.patch
@@ -1,4 +1,4 @@
-From 32eb9bcb93e8308cc4ac60652accb500279716f6 Mon Sep 17 00:00:00 2001
+From e6233c6c3448d917fcb6b011b36aaad8d2799bed Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:35:15 +0800
 Subject: [PATCH 27/63] loonggpu: Use multihop

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,4 +1,4 @@
-From 3c79dba60ac55d0a956be8b9c5f4b15fd027e00a Mon Sep 17 00:00:00 2001
+From 6a5ce707c0a2de3e22fc0c83d442e9eb3fe62da0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:42:37 +0800
 Subject: [PATCH 28/63] loonggpu: Drop the unused no_wait_gpu parameter of

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,4 +1,4 @@
-From a0dbdec6d63231ee099483848e10ef7d0c761306 Mon Sep 17 00:00:00 2001
+From 111c8a69f6360043b426e52a83b002911b854aeb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:49:20 +0800
 Subject: [PATCH 29/63] loonggpu: Drop lg_ttm_tt_bind

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,4 +1,4 @@
-From cb82dae9e7df70b541de83813f79e6315702480c Mon Sep 17 00:00:00 2001
+From 49296109bcb6512a8eec6fb1362f93cb6cbe1d6b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:24:23 +0800
 Subject: [PATCH 30/63] loonggpu: Remove an invalid "const" qualifier

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,4 +1,4 @@
-From 0c9f6f1a16efff6fa92a769bcbc0a8a1bf2694fb Mon Sep 17 00:00:00 2001
+From 4660a9c2eeb6f93f83a45e1248568e4eeea278b6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:26:21 +0800
 Subject: [PATCH 31/63] loonggpu: Fix the parameter order of a kmalloc_array

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-Pass-DRM-client-ID-to-drm_sched_job_init.patch
@@ -1,4 +1,4 @@
-From 265dc93984c2d6513c0618582d898e3eadc60b0a Mon Sep 17 00:00:00 2001
+From 870cc757e6295611b7497c4744bc397d8b7f6306 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:18:18 +0800
 Subject: [PATCH 32/63] loonggpu: Pass DRM client ID to drm_sched_job_init

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Adapt-for-drm_get_format_info-API-change.patch
@@ -1,4 +1,4 @@
-From dbed12e7abc816c974220a4ebf9a337eb32d99fc Mon Sep 17 00:00:00 2001
+From d6a1b9ccdf8482f48cce075dd40100aec1a01aea Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:06:53 +0800
 Subject: [PATCH 33/63] loonggpu: Adapt for drm_get_format_info() API change

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Adapt-for-.fb_create-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-Adapt-for-.fb_create-API-change.patch
@@ -1,4 +1,4 @@
-From 9d4810ea2718bedf650a29208a0307d3a203b82a Mon Sep 17 00:00:00 2001
+From 37e3bbbcf4dab6314b339d49fef4a31653c38d47 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:12:24 +0800
 Subject: [PATCH 34/63] loonggpu: Adapt for .fb_create API change

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-Adapt-for-drm_helper_mode_fill_fb_struct-AP.patch
@@ -1,4 +1,4 @@
-From 4204cca728db4886344052651fe471d8cadbcbf6 Mon Sep 17 00:00:00 2001
+From f9f90788ca821ba0369cebcf22b49ae13be69ded Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:15:46 +0800
 Subject: [PATCH 35/63] loonggpu: Adapt for drm_helper_mode_fill_fb_struct API

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-Pass-along-the-format-info-from-.fb_create-.patch
@@ -1,4 +1,4 @@
-From 0bdf30e41cd440d5f34c1a5c8ab1cbf6602dfd41 Mon Sep 17 00:00:00 2001
+From 1edfef1d74ea7eda182da72c688aee977280b059 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 20:24:55 +0800
 Subject: [PATCH 36/63] loonggpu: Pass along the format info from .fb_create()

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-Adapt-for-the-rename-of-DRM_GPU_SCHED_STAT_.patch
@@ -1,4 +1,4 @@
-From 825a77fc23af418dd0a98101dc94ec930fad3456 Mon Sep 17 00:00:00 2001
+From e0129fd9e6216a19dfcd15074fb8cbcc8c8fa985 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:20:01 +0800
 Subject: [PATCH 37/63] loonggpu: Adapt for the rename of

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Don-t-directly-use-ttm_bo_get.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Don-t-directly-use-ttm_bo_get.patch
@@ -1,4 +1,4 @@
-From 5ae476b092245722042d376f94a9da150cbc1790 Mon Sep 17 00:00:00 2001
+From 8f6aaa4f18eb65fcf2a4710a34dbfc329979a5c7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 15 Aug 2025 23:23:20 +0800
 Subject: [PATCH 38/63] loonggpu: Don't directly use ttm_bo_get

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Get-rid-of-drm_sched_job.id.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-Get-rid-of-drm_sched_job.id.patch
@@ -1,4 +1,4 @@
-From 6b3cfcd1826cc6b821061ca5cd15e405cab26fd0 Mon Sep 17 00:00:00 2001
+From 60e5b28ef826c9dda7394209a5d05cac509d0ae3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 27 Aug 2025 10:31:29 +0800
 Subject: [PATCH 39/63] loonggpu: Get rid of drm_sched_job.id

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-bridge-alloc-bridge-phy-using-devm_drm_brid.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-bridge-alloc-bridge-phy-using-devm_drm_brid.patch
@@ -1,4 +1,4 @@
-From f199268c63ea3a06af2f2f954dcc479324d77fed Mon Sep 17 00:00:00 2001
+From f5d54fe13636d48480093772905487cd5fb3429a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 5 Dec 2025 09:19:11 +0800
 Subject: [PATCH 40/63] loonggpu-bridge: alloc bridge phy using

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-Get-rid-of-ida_simple_get-and-ida_simple_re.patch
@@ -1,4 +1,4 @@
-From 70916cf6a67c8c2557c8cd6a4f5862398c94e7f2 Mon Sep 17 00:00:00 2001
+From 63cf78ed55e455ffd7e6444b217aa4f2dfe2ddf3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 13 Oct 2025 11:37:06 +0800
 Subject: [PATCH 41/63] loonggpu: Get rid of ida_simple_get and

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-drop-LG_ZONE_MANAGED_PAGES.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-drop-LG_ZONE_MANAGED_PAGES.patch
@@ -1,4 +1,4 @@
-From 6b7cb1fcf679d83b22c58dfd5f47cbb12da987b3 Mon Sep 17 00:00:00 2001
+From 2b4069852b4ffe7544953318cc352294e54813a9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 2 Dec 2025 15:16:13 +0800
 Subject: [PATCH 42/63] loonggpu: drop LG_ZONE_MANAGED_PAGES

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-ensure-clearing-the-mapping-field-of-ttm-pa.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-ensure-clearing-the-mapping-field-of-ttm-pa.patch
@@ -1,4 +1,4 @@
-From 04f32107fba7ea7c186acf017970215af5de3297 Mon Sep 17 00:00:00 2001
+From 215bbeab0832d29d60852de0084f30a1ddf1b654 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 27 Nov 2025 20:07:59 +0800
 Subject: [PATCH 43/63] loonggpu: ensure clearing the mapping field of ttm

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,4 +1,4 @@
-From 958483d34fc9420a5001b67fbeb1922fadaafef6 Mon Sep 17 00:00:00 2001
+From 69c19c84907c60ff802880a42952071894c5619e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 16:10:04 +0800
 Subject: [PATCH 44/63] loonggpu: Handle the different drm_client_setup.h

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
@@ -1,4 +1,4 @@
-From d6e628a42ed2b2dbec719473ff2434475910adfb Mon Sep 17 00:00:00 2001
+From f562c610aa069ea13c73878c41c831175d902ecb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 28 Dec 2025 18:18:19 +0800
 Subject: [PATCH 45/63] loonggpu: Handle the error from gsgpu_driver_load_kms

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
@@ -1,4 +1,4 @@
-From 5f4a4dfbf43fa3eb824afba7f764e6b2b6d6b232 Mon Sep 17 00:00:00 2001
+From 77aa8da3758d869784953a9400fe9fb00fb2fe11 Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:28:47 +0800
 Subject: [PATCH 46/63] loonggpu: fix typo mistake in

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,4 +1,4 @@
-From 7a687c04dd2f12f533770819f8d9800e26a07bcd Mon Sep 17 00:00:00 2001
+From b21628bb053147b80362b22982d1b35dbe924c3e Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:33:29 +0800
 Subject: [PATCH 47/63] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-Drop-CLEAN-from-dkms.conf.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-loonggpu-Drop-CLEAN-from-dkms.conf.patch
@@ -1,4 +1,4 @@
-From dbb51a756731b785533369ca80a845fcb007e2f8 Mon Sep 17 00:00:00 2001
+From 2e3466537c4450373081724fab1b4cfce045df00 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 4 Nov 2025 11:26:37 +0800
 Subject: [PATCH 48/63] loonggpu: Drop CLEAN= from dkms.conf

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-bridge-remove-calls-to-drm_do_get_edid.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-bridge-remove-calls-to-drm_do_get_edid.patch
@@ -1,4 +1,4 @@
-From 5883ee8afd65e46c658031ef25d5de5ecfe5361a Mon Sep 17 00:00:00 2001
+From 88e117c44ca7a45c4c9565af9d511ff9c942e21f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 18:18:06 +0800
 Subject: [PATCH 49/63] loonggpu-bridge: remove calls to drm_do_get_edid

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-don-t-return-an-error-if-backlight-initiali.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0050-loonggpu-don-t-return-an-error-if-backlight-initiali.patch
@@ -1,4 +1,4 @@
-From 0940ea1e54e209d8e8fa97e2ebaa8bf98da62e34 Mon Sep 17 00:00:00 2001
+From 5901fce08e5b4d50910424c822f1ef34f85fd3d5 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 22:06:18 +0800
 Subject: [PATCH 50/63] loonggpu: don't return an error if backlight

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-backlight-get-PWM-correctly-and-skip-GPIO-f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0051-loonggpu-backlight-get-PWM-correctly-and-skip-GPIO-f.patch
@@ -1,4 +1,4 @@
-From 5eab1f32f0bb922ea61f0a253621112f5f0c881e Mon Sep 17 00:00:00 2001
+From ca7dbc898932d45f8348b43512c280ae2e580f96 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 22:22:22 +0800
 Subject: [PATCH 51/63] loonggpu: backlight: get PWM correctly and skip GPIO

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0052-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
@@ -1,4 +1,4 @@
-From bf51952757eab83ed34a63215efbbebad0d16fe3 Mon Sep 17 00:00:00 2001
+From c2a2c20ddd5be8e524a03032fcafaa83939f92d2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 30 Oct 2025 10:12:33 +0800
 Subject: [PATCH 52/63] loonggpu: Only build a dummy if page size is 4 KiB

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0053-bridge_phy-add-conditional-compilation-for-linux-6.1.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0053-bridge_phy-add-conditional-compilation-for-linux-6.1.patch
@@ -1,4 +1,4 @@
-From 64a8a33a3d04355267a9382c1819884a2e2467ff Mon Sep 17 00:00:00 2001
+From 622f51a657aae158979aa9f42570d9f8cfb5aa0e Mon Sep 17 00:00:00 2001
 From: elysia-best <a.elysia@proton.me>
 Date: Sat, 3 Jan 2026 11:42:21 +0800
 Subject: [PATCH 53/63] bridge_phy: add conditional compilation for linux 6.12

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0054-loonggpu-bridge-remove-redundant-bridge-func-vptr-as.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0054-loonggpu-bridge-remove-redundant-bridge-func-vptr-as.patch
@@ -1,4 +1,4 @@
-From 744e74f493957046246dae27824ea1a5334abf36 Mon Sep 17 00:00:00 2001
+From 0cd774f3ca90e4ade292c7e5eb9496d943e71a35 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 14:12:17 +0800
 Subject: [PATCH 54/63] loonggpu-bridge: remove redundant bridge func vptr

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0055-loonggpu-bridge-make-bridge_phy_alloc-return-ERR_PTR.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0055-loonggpu-bridge-make-bridge_phy_alloc-return-ERR_PTR.patch
@@ -1,4 +1,4 @@
-From 4061fc04dd3ef24609eeedd875085d71eed4a3cf Mon Sep 17 00:00:00 2001
+From 787e73645dbff887013c0a1f0ec60545e98116d6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 14:18:26 +0800
 Subject: [PATCH 55/63] loonggpu-bridge: make bridge_phy_alloc() return

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0056-loonggpu-bridge-make-some-functions-static.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0056-loonggpu-bridge-make-some-functions-static.patch
@@ -1,4 +1,4 @@
-From 5e91829b501d30214ecd487004b2907b26f26992 Mon Sep 17 00:00:00 2001
+From 551eef6095a1aaa153d93f2625eba1e85c9f808a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 14:29:47 +0800
 Subject: [PATCH 56/63] loonggpu-bridge: make some functions static

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0057-loonggpu-adapt-for-ttm_device_init-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0057-loonggpu-adapt-for-ttm_device_init-API-change.patch
@@ -1,4 +1,4 @@
-From 1ce69436ada6a01efb51a0d03378c026f7ac5ad5 Mon Sep 17 00:00:00 2001
+From feceac8195f12bede8b5909614553d38099d7c55 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 10 Dec 2025 14:58:46 +0800
 Subject: [PATCH 57/63] loonggpu: adapt for ttm_device_init API change

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0058-loonggpu-conftest-add-fms-extensions-to-CFLAGS.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0058-loonggpu-conftest-add-fms-extensions-to-CFLAGS.patch
@@ -1,4 +1,4 @@
-From 5ca258f0b54e1fe0bc3c719f399552e0ad0a42f7 Mon Sep 17 00:00:00 2001
+From 4922d31dc8764c7e44979de86e10459c071b1e4b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 15:14:56 +0800
 Subject: [PATCH 58/63] loonggpu: conftest: add -fms-extensions to CFLAGS

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0059-loonggpu-Drop-the-call-to-drm_fb_helper_alloc_info.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0059-loonggpu-Drop-the-call-to-drm_fb_helper_alloc_info.patch
@@ -1,4 +1,4 @@
-From d8a9cd0719635ac10749b13e248e6543e62aa2ef Mon Sep 17 00:00:00 2001
+From 3d615fca1d3a11939017760ef00f3be45276f91e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 10 Dec 2025 15:34:32 +0800
 Subject: [PATCH 59/63] loonggpu: Drop the call to drm_fb_helper_alloc_info

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0060-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0060-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
@@ -1,4 +1,4 @@
-From 22de20a43b2ce0a7fd17aa5dd9c5b80f4a734b6a Mon Sep 17 00:00:00 2001
+From aa39f57e7350876fb07cc78895161fb126a249c0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 11 Dec 2025 09:49:49 +0800
 Subject: [PATCH 60/63] loonggpu: use ttm_resource_manager_cleanup instead of

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0061-loonggpu-handle-the-rename-of-ttm_bo_put-to-ttm_bo_f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0061-loonggpu-handle-the-rename-of-ttm_bo_put-to-ttm_bo_f.patch
@@ -1,4 +1,4 @@
-From 6c0deeaacb0e27cd0df8ce812f2bf43e297b55c5 Mon Sep 17 00:00:00 2001
+From a73965c16f7d58df27bfacf6e86f5fb681563a9b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 15:38:35 +0800
 Subject: [PATCH 61/63] loonggpu: handle the rename of ttm_bo_put to

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0062-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0062-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
@@ -1,4 +1,4 @@
-From 2208abc9487bfab9e1db16c3e98e022e213c63a3 Mon Sep 17 00:00:00 2001
+From 75c9df0a1e123181e621ac1467034adebac7d4bb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 10 Dec 2025 17:12:38 +0800
 Subject: [PATCH 62/63] loonggpu: remove gsgpu_driver_lastclose_kms on Linux >=

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0063-loonggpu-handle-the-pci_resize_resource-API-change-i.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0063-loonggpu-handle-the-pci_resize_resource-API-change-i.patch
@@ -1,4 +1,4 @@
-From 75eb3ff25ac9b36a66dbf6d7f9858981cd57aff9 Mon Sep 17 00:00:00 2001
+From 99f2fbb24d09ad0068029eeee26ae45f32e18660 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 15:55:57 +0800
 Subject: [PATCH 63/63] loonggpu: handle the pci_resize_resource API change in
@@ -15,7 +15,7 @@ Signed-off-by: Xi Ruoyao <xry111@xry111.site>
  1 file changed, 5 insertions(+)
 
 diff --git a/loonggpu/loonggpu_device.c b/loonggpu/loonggpu_device.c
-index d480ac6..90917dc 100644
+index af7fbf8..36af4d0 100644
 --- a/loonggpu/loonggpu_device.c
 +++ b/loonggpu/loonggpu_device.c
 @@ -446,11 +446,16 @@ int loonggpu_device_resize_fb_bar(struct loonggpu_device *adev)

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -1,5 +1,5 @@
 UPSTREAM_VER=1.0.2-lnd25.1~rc1.7
-REL=1
+REL=2
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- Fix an incorrect rebase of "loonggpu: Implement client-based fbdev emulation" to avoid a crash on 7A1000.
- Note that only the DC of 7A1000 is supported by the upstream (Loongnix), the Vivante GC1000 GPU is out of the scope.
- Tracking AOSC patches at AOSC-Tracking/loonggpu-kernel-dkms @ aosc/v1.0.2-lnd25.1-rc1.7 (HEAD: 99f2fbb24d09ad0068029eeee26ae45f32e18660).

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: `1.0.2+lnd25.1~rc1.7-2`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`