### PR TITLE
vkpeak: update to 20260112

### DIFF
--- a/app-utils/vkpeak/spec
+++ b/app-utils/vkpeak/spec
@@ -1,4 +1,4 @@
-VER=20251010
+VER=20260112
 SRCS="git::commit=tags/$VER::https://github.com/nihui/vkpeak"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375832"


### PR DESCRIPTION
Topic Description
-----------------

- vkpeak: update to 20260112

Package(s) Affected
-------------------

- vkpeak: 20260112

Security Update?
----------------

No

Build Order
-----------

```
#buildit vkpeak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
