### PR TITLE
osinfo-db-tools: update to 1.12.0

### DIFF
--- a/app-admin/osinfo-db-tools/spec
+++ b/app-admin/osinfo-db-tools/spec
@@ -1,4 +1,4 @@
-VER=1.10.0
+VER=1.12.0
 SRCS="tbl::https://releases.pagure.org/libosinfo/osinfo-db-tools-${VER}.tar.xz"
-CHKSUMS="sha256::802cdd53b416706ea5844f046ddcfb658c1b4906b9f940c79ac7abc50981ca68"
+CHKSUMS="sha256::f3315f675d18770f25dea8ed04b20b8fc80efb00f60c37ee5e815f9c3776e7f3"
 CHKUPDATE="anitya::id=226782"


### PR DESCRIPTION
Topic Description
-----------------

- osinfo-db-tools: update to 1.12.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- osinfo-db-tools: 1.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit osinfo-db-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
