### PR TITLE
opentrace: new, 1.5.1

### DIFF
--- a/app-network/opentrace/autobuild/beyond
+++ b/app-network/opentrace/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing PDB files..."
+find "$PKGDIR"/usr/lib/opentrace/ -name "*.pdb" -delete -print

--- a/app-network/opentrace/autobuild/build
+++ b/app-network/opentrace/autobuild/build
@@ -1,0 +1,8 @@
+abinfo "Build OpenTrace"
+dotnet publish "$SRCDIR"/OpenTrace.csproj -c Release \
+    -o "$PKGDIR"/usr/lib/opentrace \
+    --no-self-contained
+
+abinfo "Deploy files"
+chmod 0755 "$PKGDIR"/usr/lib/opentrace/'OpenTrace'
+install -Dm644 "$SRCDIR"/Assets/Icons/icon.png "$PKGDIR"/usr/share/pixmaps/opentrace.png

--- a/app-network/opentrace/autobuild/defines
+++ b/app-network/opentrace/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=opentrace
+PKGSEC=net
+PKGDES="GUI tool for visual route tracking"
+PKGDEP="desktop-file-utils libnotify webkit2gtk nexttrace dotnet-runtime-8.0"
+BUILDDEP="dotnet-sdk-8.0"
+
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-network/opentrace/autobuild/overrides/usr/bin/opentrace
+++ b/app-network/opentrace/autobuild/overrides/usr/bin/opentrace
@@ -1,0 +1,4 @@
+#!/bin/bash
+PREFIX="/usr/lib/opentrace"
+export DOTNET_ROOT="/usr/lib/dotnet"
+exec "${PREFIX}"/OpenTrace

--- a/app-network/opentrace/autobuild/overrides/usr/share/applications/opentrace.desktop
+++ b/app-network/opentrace/autobuild/overrides/usr/share/applications/opentrace.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=OpenTrace
+Comment=GUI tool for visual route tracking
+Exec=/usr/bin/opentrace %U
+Icon=opentrace
+Type=Application
+StartupNotify=true
+StartupWMClass=OpenTrace
+Terminal=false
+Categories=Network;
+Keywords=traceroute;network;nexttrace;

--- a/app-network/opentrace/spec
+++ b/app-network/opentrace/spec
@@ -1,0 +1,4 @@
+VER=1.5.1
+SRCS="git::commit=tags/v$VER::https://github.com/Archeb/opentrace.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=356728"


### PR DESCRIPTION
Topic Description
-----------------

- opentrace: new, 1.5.1

Package(s) Affected
-------------------

- opentrace: 1.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
