### PR TITLE
snappy: re-enable rtti to fix folly

### DIFF
--- a/runtime-common/snappy/autobuild/patches/0001-AOSCOS-re-enable-rtti-for-downstream-compatibility.patch
+++ b/runtime-common/snappy/autobuild/patches/0001-AOSCOS-re-enable-rtti-for-downstream-compatibility.patch
@@ -1,0 +1,28 @@
+From c8091b96487616b50d13f1be62141c9823671dc6 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Wed, 14 Jan 2026 14:38:20 +0800
+Subject: [PATCH] AOSCOS: re-enable rtti for downstream compatibility
+
+/usr/bin/ld: libfolly.so.0.58.0-dev: undefined reference to `typeinfo for snappy::Source'
+---
+ CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cd71a47..4aed305 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -81,10 +81,6 @@ else(MSVC)
+   # Disable C++ exceptions.
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(MSVC)
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make
+-- 
+2.52.0
+

--- a/runtime-common/snappy/spec
+++ b/runtime-common/snappy/spec
@@ -1,4 +1,5 @@
 VER=1.2.2
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/google/snappy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4844"


### PR DESCRIPTION
Topic Description
-----------------

- snappy: re-enable rtti to fix folly
    symptoms:
    link-time: /usr/bin/ld: libfolly.so.0.58.0-dev: undefined reference to \`typeinfo for snappy::Source'
    runtime: watchman: symbol lookup error: /usr/lib/libfolly.so.0.58.0-dev: undefined symbol: _ZTIN6snappy6SourceE

Package(s) Affected
-------------------

- snappy: 1.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit snappy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
