### PR TITLE
kesl-gui: rebuild for Spiral

### DIFF
--- a/runtime-display/xcb-util-image/spec
+++ b/runtime-display/xcb-util-image/spec
@@ -1,4 +1,5 @@
 VER=0.4.1
+REL=1
 SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-image-$VER.tar.xz"
 CHKSUMS="sha256::ccad8ee5dadb1271fd4727ad14d9bd77a64e505608766c4e98267d9aede40d3d"
 CHKUPDATE="anitya::id=5167"

--- a/runtime-display/xcb-util-keysyms/spec
+++ b/runtime-display/xcb-util-keysyms/spec
@@ -1,4 +1,5 @@
 VER=0.4.1
+REL=1
 SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-keysyms-$VER.tar.xz"
 CHKSUMS="sha256::7c260a5294412aed429df1da2f8afd3bd07b7cba3fec772fba15a613a6d5c638"
 CHKUPDATE="anitya::id=5168"

--- a/runtime-display/xcb-util-renderutil/spec
+++ b/runtime-display/xcb-util-renderutil/spec
@@ -1,4 +1,5 @@
 VER=0.3.10
+REL=1
 SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-renderutil-$VER.tar.xz"
 CHKSUMS="sha256::3e15d4f0e22d8ddbfbb9f5d77db43eacd7a304029bf25a6166cc63caa96d04ba"
 CHKUPDATE="anitya::id=5169"

--- a/runtime-display/xcb-util-wm/spec
+++ b/runtime-display/xcb-util-wm/spec
@@ -1,4 +1,5 @@
 VER=0.4.2
+REL=1
 SRCS="tbl::https://xcb.freedesktop.org/dist/xcb-util-wm-$VER.tar.xz"
 CHKSUMS="sha256::62c34e21d06264687faea7edbf63632c9f04d55e72114aa4a57bb95e4f888a0b"
 CHKUPDATE="anitya::id=5170"


### PR DESCRIPTION
Topic Description
-----------------

- kesl-gui: rebuild for Spiral

Package(s) Affected
-------------------

- xcb-util-image: 0.4.1-1
- xcb-util-keysyms: 0.4.1-1
- xcb-util-renderutil: 0.3.10-1
- xcb-util-wm: 0.4.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcb-util-keysyms xcb-util-renderutil xcb-util-wm xcb-util-image
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
