### PR TITLE
opentabletdriver: update to 0.6.6.2

### DIFF
--- a/runtime-devices/opentabletdriver/spec
+++ b/runtime-devices/opentabletdriver/spec
@@ -1,4 +1,4 @@
-VER=0.6.5.1
+VER=0.6.6.2
 SRCS="git::commit=tags/v$VER::https://github.com/OpenTabletDriver/OpenTabletDriver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241822"


### PR DESCRIPTION
Topic Description
-----------------

- opentabletdriver: update to 0.6.6.2
    Co-authored-by: 董冠泽 \(@grayawa\)

Package(s) Affected
-------------------

- opentabletdriver: 0.6.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentabletdriver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
