### PR TITLE
qgnomeplatform: update to 0.9.2

### DIFF
--- a/desktop-gnome/qgnomeplatform/spec
+++ b/desktop-gnome/qgnomeplatform/spec
@@ -1,4 +1,4 @@
-VER=0.8.4
+VER=0.9.2
 SRCS="tbl::https://github.com/MartinBriza/QGnomePlatform/archive/$VER.tar.gz"
-CHKSUMS="sha256::c648331f47b095d90594fc986a6c0bc885b846e0e9f5c10b6a1ba6a58d004686"
+CHKSUMS="sha256::9446c0d68faccdd0e44039b2089ab4524939a47cfe8c34e50b0368c2b58a5552"
 CHKUPDATE="anitya::id=9611"


### PR DESCRIPTION
Topic Description
-----------------

- qgnomeplatform: update to 0.9.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- qgnomeplatform: 0.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qgnomeplatform
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
