### PR TITLE
mariadb: update to 12.1.2

### DIFF
--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,5 +1,4 @@
-VER=11.7.2
-REL=2
-SRCS="git::commit=tags/mariadb-$VER::https://github.com/MariaDB/server"
+VER=12.1.2
+SRCS="git::commit=tags/mariadb-$VER;copy-repo=true::https://github.com/MariaDB/server"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1887"


### PR DESCRIPTION
Topic Description
-----------------

- mariadb: update to 12.1.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- mariadb: 12.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mariadb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
