### PR TITLE
deskflow: update to 1.25.0

### DIFF
--- a/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
+++ b/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
@@ -1,4 +1,4 @@
-From 6940f1b9b93e530f53729e0227b3038d8bc0dbe8 Mon Sep 17 00:00:00 2001
+From 2cb7a54e3106dae7d90af28a7115a7692f446a96 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Fri, 24 Oct 2025 09:49:02 +0800
 Subject: [PATCH] AOSCOS: fix: neuter version checking functionalities
@@ -12,16 +12,16 @@ Subject: [PATCH] AOSCOS: fix: neuter version checking functionalities
  src/lib/gui/Messages.cpp               | 18 ------------------
  src/lib/gui/Messages.h                 |  2 --
  src/lib/gui/dialogs/SettingsDialog.cpp |  3 ---
- src/lib/gui/dialogs/SettingsDialog.ui  | 10 +---------
- 9 files changed, 1 insertion(+), 62 deletions(-)
+ src/lib/gui/dialogs/SettingsDialog.ui  |  8 --------
+ 9 files changed, 61 deletions(-)
 
 diff --git a/src/lib/common/Settings.cpp b/src/lib/common/Settings.cpp
-index e36809ce7..4475e0303 100644
+index 66fdd8443..c0a1e0d93 100644
 --- a/src/lib/common/Settings.cpp
 +++ b/src/lib/common/Settings.cpp
-@@ -112,9 +112,6 @@ QVariant Settings::defaultValue(const QString &key)
+@@ -203,9 +203,6 @@ QVariant Settings::defaultValue(const QString &key)
    if (key == Daemon::Elevate)
-     return Settings::isNativeMode();
+     return !Settings::isPortableMode();
  
 -  if (key == Core::UpdateUrl)
 -    return kUrlUpdateCheck;
@@ -30,18 +30,18 @@ index e36809ce7..4475e0303 100644
      return QStringLiteral("%1/%2-server.conf").arg(Settings::settingsPath(), kAppId);
  
 diff --git a/src/lib/common/Settings.h b/src/lib/common/Settings.h
-index 339779d73..6a475e498 100644
+index e816b69a6..d613d4ecf 100644
 --- a/src/lib/common/Settings.h
 +++ b/src/lib/common/Settings.h
-@@ -49,7 +49,6 @@ public:
+@@ -50,7 +50,6 @@ public:
      inline static const auto ProcessMode = QStringLiteral("core/processMode");
      inline static const auto ScreenName = QStringLiteral("core/screenName");
      inline static const auto StartedBefore = QStringLiteral("core/startedBefore");
 -    inline static const auto UpdateUrl = QStringLiteral("core/updateUrl");
-   };
-   struct Daemon
-   {
-@@ -61,7 +60,6 @@ public:
+     inline static const auto Display = QStringLiteral("core/display");
+     inline static const auto UseHooks = QStringLiteral("core/useHooks");
+     inline static const auto Language = QStringLiteral("core/language");
+@@ -66,7 +65,6 @@ public:
    struct Gui
    {
      inline static const auto Autohide = QStringLiteral("gui/autoHide");
@@ -49,27 +49,27 @@ index 339779d73..6a475e498 100644
      inline static const auto CloseReminder = QStringLiteral("gui/closeReminder");
      inline static const auto CloseToTray = QStringLiteral("gui/closeToTray");
      inline static const auto LogExpanded = QStringLiteral("gui/logExpanded");
-@@ -172,7 +170,6 @@ private:
+@@ -192,7 +190,6 @@ private:
      , Settings::Core::ProcessMode
      , Settings::Core::ScreenName
      , Settings::Core::StartedBefore
 -    , Settings::Core::UpdateUrl
-     , Settings::Daemon::Command
-     , Settings::Daemon::Elevate
-     , Settings::Daemon::LogFile
-@@ -180,7 +177,6 @@ private:
-     , Settings::Log::Level
+     , Settings::Core::Display
+     , Settings::Core::UseHooks
+     , Settings::Core::UseWlClipboard
+@@ -205,7 +202,6 @@ private:
      , Settings::Log::ToFile
+     , Settings::Log::GuiDebug
      , Settings::Gui::Autohide
 -    , Settings::Gui::AutoUpdateCheck
      , Settings::Gui::CloseReminder
      , Settings::Gui::CloseToTray
      , Settings::Gui::LogExpanded
 diff --git a/src/lib/gui/CMakeLists.txt b/src/lib/gui/CMakeLists.txt
-index 1aabcda25..432704ef6 100644
+index 10d1a88be..4795b66b6 100644
 --- a/src/lib/gui/CMakeLists.txt
 +++ b/src/lib/gui/CMakeLists.txt
-@@ -40,8 +40,6 @@ add_library(${target} STATIC
+@@ -36,8 +36,6 @@ add_library(${target} STATIC
    ScreenSetupModel.h
    Styles.h
    StyleUtils.h
@@ -79,19 +79,19 @@ index 1aabcda25..432704ef6 100644
    config/Screen.cpp
    config/Screen.h
 diff --git a/src/lib/gui/MainWindow.cpp b/src/lib/gui/MainWindow.cpp
-index ba1c82191..b664e5dd7 100644
+index 12b03df80..9439fb69d 100644
 --- a/src/lib/gui/MainWindow.cpp
 +++ b/src/lib/gui/MainWindow.cpp
-@@ -301,8 +301,6 @@ void MainWindow::connectSlots()
+@@ -291,8 +291,6 @@ void MainWindow::connectSlots()
    connect(m_actionRestartCore, &QAction::triggered, this, &MainWindow::resetCore);
    connect(m_actionStopCore, &QAction::triggered, this, &MainWindow::stopCore);
  
 -  connect(&m_versionChecker, &VersionChecker::updateFound, this, &MainWindow::versionCheckerUpdateFound);
 -
- // Mac os tray will only show a menu
- #ifndef Q_OS_MAC
-   connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
-@@ -402,12 +400,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
+   // Mac os tray will only show a menu
+   if (!deskflow::platform::isMac())
+     connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
+@@ -391,12 +389,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
    isVisible() ? hide() : showAndActivate();
  }
  
@@ -104,7 +104,7 @@ index ba1c82191..b664e5dd7 100644
  void MainWindow::coreProcessError(CoreProcess::Error error)
  {
    if (error == CoreProcess::Error::AddressMissing) {
-@@ -672,16 +664,6 @@ void MainWindow::open()
+@@ -660,16 +652,6 @@ void MainWindow::open()
    const auto kCriticalDialogDelay = 100;
    QTimer::singleShot(kCriticalDialogDelay, this, &messages::raiseCriticalDialog);
  
@@ -122,7 +122,7 @@ index ba1c82191..b664e5dd7 100644
      if (ui->rbModeClient->isChecked() && ui->lineHostname->text().isEmpty())
        return;
 diff --git a/src/lib/gui/MainWindow.h b/src/lib/gui/MainWindow.h
-index 79fbcf2d4..9d0844b27 100644
+index 63db153dc..91df18373 100644
 --- a/src/lib/gui/MainWindow.h
 +++ b/src/lib/gui/MainWindow.h
 @@ -16,7 +16,6 @@
@@ -133,7 +133,7 @@ index 79fbcf2d4..9d0844b27 100644
  #include "config/ServerConfig.h"
  #include "gui/core/ClientConnection.h"
  #include "gui/core/CoreProcess.h"
-@@ -99,7 +98,6 @@ private:
+@@ -103,7 +102,6 @@ private:
    void coreProcessError(CoreProcess::Error error);
    void coreConnectionStateChanged(CoreProcess::ConnectionState state);
    void coreProcessStateChanged(CoreProcess::ProcessState state);
@@ -141,7 +141,7 @@ index 79fbcf2d4..9d0844b27 100644
    void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
    void serverConnectionConfigureClient(const QString &clientName);
  
-@@ -169,7 +167,6 @@ private:
+@@ -172,7 +170,6 @@ private:
    inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
    inline static const auto m_nameRegEx = QRegularExpression(QStringLiteral("^[\\w\\-_\\.]{0,255}$"));
  
@@ -150,7 +150,7 @@ index 79fbcf2d4..9d0844b27 100644
    bool m_saveOnExit = true;
    deskflow::gui::core::WaylandWarnings m_waylandWarnings;
 diff --git a/src/lib/gui/Messages.cpp b/src/lib/gui/Messages.cpp
-index f6dc0865f..de061b3fd 100644
+index f41dda93a..e4a0ba451 100644
 --- a/src/lib/gui/Messages.cpp
 +++ b/src/lib/gui/Messages.cpp
 @@ -309,24 +309,6 @@ void showWaylandLibraryError(QWidget *parent)
@@ -192,10 +192,10 @@ index f035e2092..339eb8dfb 100644
  
  } // namespace deskflow::gui::messages
 diff --git a/src/lib/gui/dialogs/SettingsDialog.cpp b/src/lib/gui/dialogs/SettingsDialog.cpp
-index 75e13371f..59caeb58c 100644
+index 4e0ebb774..18041ec10 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.cpp
 +++ b/src/lib/gui/dialogs/SettingsDialog.cpp
-@@ -144,7 +144,6 @@ void SettingsDialog::accept()
+@@ -165,7 +165,6 @@ void SettingsDialog::accept()
    Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
    Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
    Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
@@ -203,15 +203,15 @@ index 75e13371f..59caeb58c 100644
    Settings::setValue(Settings::Core::PreventSleep, ui->cbPreventSleep->isChecked());
    Settings::setValue(Settings::Security::Certificate, ui->lineTlsCertPath->text());
    Settings::setValue(Settings::Security::KeySize, ui->comboTlsKeyLength->currentText().toInt());
-@@ -178,7 +177,6 @@ void SettingsDialog::loadFromConfig()
+@@ -203,7 +202,6 @@ void SettingsDialog::loadFromConfig()
    ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
    ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
    ui->cbElevateDaemon->setChecked(Settings::value(Settings::Daemon::Elevate).toBool());
 -  ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
- 
-   const auto processMode = Settings::value(Settings::Core::ProcessMode).value<Settings::ProcessMode>();
-   ui->groupService->setChecked(processMode == Settings::ProcessMode::Service);
-@@ -262,7 +260,6 @@ void SettingsDialog::updateControls()
+   ui->sbScrollSpeed->setValue(Settings::value(Settings::Client::ScrollSpeed).toInt());
+   ui->cbGuiDebug->setChecked(Settings::value(Settings::Log::GuiDebug).toBool());
+   ui->cbUseWlClipboard->setChecked(Settings::value(Settings::Core::UseWlClipboard).toBool());
+@@ -295,7 +293,6 @@ void SettingsDialog::updateControls()
    ui->comboLogLevel->setEnabled(writable);
    ui->cbLogToFile->setEnabled(writable);
    ui->cbAutoHide->setEnabled(writable);
@@ -220,27 +220,25 @@ index 75e13371f..59caeb58c 100644
    ui->lineTlsCertPath->setEnabled(writable);
    ui->comboTlsKeyLength->setEnabled(writable);
 diff --git a/src/lib/gui/dialogs/SettingsDialog.ui b/src/lib/gui/dialogs/SettingsDialog.ui
-index ca4742a02..848764b45 100644
+index 8bce0d9a4..adffd664b 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.ui
 +++ b/src/lib/gui/dialogs/SettingsDialog.ui
-@@ -77,14 +77,7 @@
+@@ -104,13 +104,6 @@
            <string>App</string>
           </property>
-          <layout class="QVBoxLayout" name="_9">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
 -          <item>
 -           <widget class="QCheckBox" name="cbAutoUpdate">
 -            <property name="text">
--             <string>Check for updates on startup </string>
+-             <string>Check for updates on startup</string>
 -            </property>
 -           </widget>
 -          </item>
--          <item>
-+         <item>
+           <item>
             <widget class="QCheckBox" name="cbAutoHide">
              <property name="text">
-              <string>Hide the window when the app starts</string>
-@@ -641,7 +634,6 @@
-   <tabstop>tabWidget</tabstop>
+@@ -722,7 +715,6 @@
+  <tabstops>
    <tabstop>cbLanguageSync</tabstop>
    <tabstop>cbScrollDirection</tabstop>
 -  <tabstop>cbAutoUpdate</tabstop>
@@ -248,5 +246,5 @@ index ca4742a02..848764b45 100644
    <tabstop>rbIconColorful</tabstop>
    <tabstop>rbIconMono</tabstop>
 -- 
-2.51.0
+2.52.0
 

--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -1,5 +1,4 @@
-VER=1.24.0
+VER=1.25.0
 SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375452"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- deskflow: update to 1.25.0
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- deskflow: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deskflow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
