### PR TITLE
openblas: update to 0.3.31

### DIFF
--- a/app-scientific/openblas/spec
+++ b/app-scientific/openblas/spec
@@ -1,4 +1,4 @@
-VER=0.3.30
+VER=0.3.31
 SRCS="git::commit=tags/v$VER::https://github.com/xianyi/OpenBLAS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2540"


### PR DESCRIPTION
Topic Description
-----------------

- openblas: update to 0.3.31
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openblas: 0.3.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit openblas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
