### PR TITLE
asciinema: new, 3.1.0

### DIFF
--- a/app-multimedia/asciinema/autobuild/beyond
+++ b/app-multimedia/asciinema/autobuild/beyond
@@ -1,0 +1,13 @@
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/man/*.1 \
+    -t "$PKGDIR"/usr/share/man/man1/
+
+abinfo "Installing shell completion ..."
+install -Dvm644 "$SRCDIR"/completion/asciinema.bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/asciinema.bash
+install -Dvm644 "$SRCDIR"/completion/_asciinema \
+    "$PKGDIR"/usr/share/zsh/site-functions/_asciinema
+install -Dvm644 "$SRCDIR"/completion/asciinema.fish \
+    "$PKGDIR"/usr/share/fish/vendor_completions.d/asciinema.fish
+# FIXME: powershell lacks a system-wide completion script directory
+# FIXME: elvish shell is not packed in AOSC OS yet

--- a/app-multimedia/asciinema/autobuild/defines
+++ b/app-multimedia/asciinema/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME="asciinema"
+PKGDES="Terminal session recorder, streamer, and player"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="rustc llvm"
+PKGSEC="utils"
+ABTYPE="rust"
+USECLANG=1

--- a/app-multimedia/asciinema/autobuild/prepare
+++ b/app-multimedia/asciinema/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "setting temporary manpage & completion scripts installation directory as $SRCDIR ..."
+export ASCIINEMA_GEN_DIR="$SRCDIR"

--- a/app-multimedia/asciinema/spec
+++ b/app-multimedia/asciinema/spec
@@ -1,0 +1,4 @@
+VER=3.1.0
+SRCS="git::commit=tags/v${VER}::https://github.com/asciinema/asciinema"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=116"


### PR DESCRIPTION
Topic Description
-----------------

- asciinema: new, 3.1.0

Package(s) Affected
-------------------

- asciinema: 3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit asciinema
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
