### PR TITLE
vscode: update to 1.108.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.108.0
+VER=1.108.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::1722e0cf7b72a6806c9dc24b755067635d4831ff6f927f1a93642052cc4a364f"
-CHKSUMS__ARM64="sha256::d0814934fd8a95a9e2b0f639677201562c18416d59baacf26498d2070b2ab67a"
+CHKSUMS__AMD64="sha256::2d85644eb40afd2d8d3a7515c406a72e673afcb2ead39e7134b326f1a840bcb6"
+CHKSUMS__ARM64="sha256::d0f7ffb37a81666a49eb5200ed7bbe5b6432a670414e8b7528a553638c309cd8"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.108.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.108.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
