### PR TITLE
vscodium: update to 1.108.10359

### DIFF
--- a/app-editors/vscodium/autobuild/patches/0004-fix-package.json-replace-tsgo-with-tsc-in-package-sc.patch.loongarch64
+++ b/app-editors/vscodium/autobuild/patches/0004-fix-package.json-replace-tsgo-with-tsc-in-package-sc.patch.loongarch64
@@ -24,7 +24,7 @@ index 0000000..ef66749
 +     "compile": "npm run gulp compile",
 +-    "compile-check-ts-native": "tsgo --project ./src/tsconfig.json --noEmit --skipLibCheck",
 ++    "compile-check-ts-native": "tsc --project ./src/tsconfig.json --noEmit --skipLibCheck",
-+     "watch": "npm-run-all -lp watch-client watch-extensions",
++     "watch": "npm-run-all2 -lp watch-client watch-extensions",
 +     "watchd": "deemon npm run watch",
 +     "watch-webd": "deemon npm run watch-web",
 +@@ -44,11 +44,11 @@
@@ -42,7 +42,7 @@ index 0000000..ef66749
 ++    "define-class-fields-check": "node build/lib/propertyInitOrderChecker.ts && tsc --project src/tsconfig.defineClassFields.json",
 +     "update-distro": "node build/npm/update-distro.ts",
 +     "web": "echo 'npm run web' is replaced by './scripts/code-server' or './scripts/code-web'",
-+     "compile-cli": "gulp compile-cli",
++     "compile-cli": "npm run gulp compile-cli",
 -- 
 2.52.0
 

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.107.18605
+VER=1.108.10359
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.108.10359
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscodium: 1.108.10359

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
