### PR TITLE
binsider: update to 0.3.1

### DIFF
--- a/app-devel/binsider/autobuild/defines
+++ b/app-devel/binsider/autobuild/defines
@@ -1,5 +1,5 @@
-PKGNAME="binsider"
-PKGDES="A toolkit to perform analysis on binaries"
+PKGNAME=binsider
+PKGDES="Toolkit to perform analysis on binaries"
 PKGDEP="glibc gcc-runtime"
 BUILDDEP="rustc llvm"
 PKGSEC="devel"
@@ -9,8 +9,7 @@ USECLANG=1
 # FIXME: No lurk-cli support yet.
 CARGO_AFTER__LOONGSON3="--no-default-features"
 CARGO_AFTER__LOONGARCH64="--no-default-features"
+CARGO_AFTER__LOONGARCH64_NOSIMD="--no-default-features"
 CARGO_AFTER__PPC64EL="--no-default-features"
-
-# FIXME: ld.lld does not support arch:
-USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1
+CARGO_AFTER__ARM64="--no-default-features"
+CARGO_AFTER__RISCV64="--no-default-features"

--- a/app-devel/binsider/spec
+++ b/app-devel/binsider/spec
@@ -1,4 +1,4 @@
-VER=0.2.1
+VER=0.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/orhun/binsider"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374403"


### PR DESCRIPTION
Topic Description
-----------------

- binsider: update to 0.3.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- binsider: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binsider
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
