### PR TITLE
cuda: update to 13.1.1

### DIFF
--- a/app-devel/cuda/autobuild/build
+++ b/app-devel/cuda/autobuild/build
@@ -95,3 +95,9 @@ for i in "${CUDA_LIBS[@]}"; do
 		-e "s/@LIB@/${LIB}/g" \
 		-e "s/@DESC@/${DESC}/g" > "$CONFIG"
 done
+
+abinfo "Patching headers for glibc 2.42 ...."
+patch \
+    -d "$PKGDIR" \
+    -Np1 -i \
+    "$SRCDIR"/autobuild/patches/0001-Fix-compatibility-with-glibc-2.42.patch.headers."$ARCH"

--- a/app-devel/cuda/autobuild/patches/0001-Fix-compatibility-with-glibc-2.42.patch.headers.amd64
+++ b/app-devel/cuda/autobuild/patches/0001-Fix-compatibility-with-glibc-2.42.patch.headers.amd64
@@ -1,0 +1,28 @@
+Link: https://forums.developer.nvidia.com/t/fedora-43-and-nvcc-cuda13-1-error-exception-specification-is-incompatible-rsqrt-rsqrtf/354510
+Link: https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/commit/c36d77ac1d8e60fcd97490f8e432a8d034ddcc10
+
+===
+
+diff --git a/usr/lib/cuda/targets/x86_64-linux/include/crt/math_functions.h b/usr/lib/cuda/targets/x86_64-linux/include/crt/math_functions.h
+index a083253..b811f97 100644
+--- a/usr/lib/cuda/targets/x86_64-linux/include/crt/math_functions.h
++++ b/usr/lib/cuda/targets/x86_64-linux/include/crt/math_functions.h
+@@ -594,7 +594,7 @@ extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double         __cdecl sqrt(
+  *
+  * \note_accuracy_double
+  */
+-extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt(double x);
++extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt(double x) noexcept(true);
+
+ /**
+  * \ingroup CUDA_MATH_SINGLE
+@@ -618,7 +618,7 @@ extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt
+  *
+  * \note_accuracy_single
+  */
+-extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ float                  rsqrtf(float x);
++extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ float                  rsqrtf(float x) noexcept(true);
+
+ #if defined(__QNX__) && !defined(_LIBCPP_VERSION)
+ namespace std {
+

--- a/app-devel/cuda/autobuild/patches/0001-Fix-compatibility-with-glibc-2.42.patch.headers.arm64
+++ b/app-devel/cuda/autobuild/patches/0001-Fix-compatibility-with-glibc-2.42.patch.headers.arm64
@@ -1,0 +1,28 @@
+Link: https://forums.developer.nvidia.com/t/fedora-43-and-nvcc-cuda13-1-error-exception-specification-is-incompatible-rsqrt-rsqrtf/354510
+Link: https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/commit/c36d77ac1d8e60fcd97490f8e432a8d034ddcc10
+
+===
+
+diff --git a/usr/lib/cuda/targets/sbsa-linux/include/crt/math_functions.h b/usr/lib/cuda/targets/sbsa-linux/include/crt/math_functions.h
+index a083253..b811f97 100644
+--- a/usr/lib/cuda/targets/sbsa-linux/include/crt/math_functions.h
++++ b/usr/lib/cuda/targets/sbsa-linux/include/crt/math_functions.h
+@@ -594,7 +594,7 @@ extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double         __cdecl sqrt(
+  *
+  * \note_accuracy_double
+  */
+-extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt(double x);
++extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt(double x) noexcept(true);
+
+ /**
+  * \ingroup CUDA_MATH_SINGLE
+@@ -618,7 +618,7 @@ extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt
+  *
+  * \note_accuracy_single
+  */
+-extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ float                  rsqrtf(float x);
++extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ float                  rsqrtf(float x) noexcept(true);
+
+ #if defined(__QNX__) && !defined(_LIBCPP_VERSION)
+ namespace std {
+

--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,10 @@
-UPSTREAM_VER=13.1.0
-MIN_DRIVER_VER=590.44.01
+UPSTREAM_VER=13.1.1
+MIN_DRIVER_VER=590.48.01
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::6b4fdf2694b3d7afbc526f26412b4cf4f050b202324455053307310f53b323a7"
+CHKSUMS__AMD64="sha256::24ff323723722781436804b392a48f691cb40de9808095d3e2192d0db6dfb8e4"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::06cda49a7031b1c99f784237be5c852619379cbba9555036045044b9ddc99240"
+CHKSUMS__ARM64="sha256::8adcd5d4b3e1e70f7420959b97514c0c97ec729da248d54902174c4d229bfd2c"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 13.1.1
    Introduce a patch from Arch Linux to fix application building with glibc 2.42.
    Link: https://forums.developer.nvidia.com/t/fedora-43-and-nvcc-cuda13-1-error-exception-specification-is-incompatible-rsqrt-rsqrtf/354510
    Link: https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/commit/c36d77ac1d8e60fcd97490f8e432a8d034ddcc10

Package(s) Affected
-------------------

- cuda: 13.1.1+590.48.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
