### PR TITLE
debootstrap: update to 1.0.142

### DIFF
--- a/app-utils/debootstrap/spec
+++ b/app-utils/debootstrap/spec
@@ -1,4 +1,4 @@
-VER=1.0.140
+VER=1.0.142
 CHKSUMS="SKIP"
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/installer-team/debootstrap"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- debootstrap: update to 1.0.142
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- debootstrap: 1.0.142

Security Update?
----------------

No

Build Order
-----------

```
#buildit debootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
