### PR TITLE
obconf: fix build

### DIFF
--- a/desktop-wm/obconf/autobuild/defines
+++ b/desktop-wm/obconf/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=obconf
-PKGDES="A GTK+2 based configuration tool for the Openbox window manager"
+PKGDES="Configuration tool for the Openbox window manager"
 PKGDEP="openbox gtk-2 libglade desktop-file-utils"
 PKGSEC=x11

--- a/desktop-wm/obconf/autobuild/patches/0001-c99.patch
+++ b/desktop-wm/obconf/autobuild/patches/0001-c99.patch
@@ -1,0 +1,47 @@
+Avoid implicit function declarations
+
+For compatibility with future compilers which do not support them
+by default.
+
+Include <ctype.h> for toupper, "moveresize.h" for
+moveresize_setup_tab, and add a desktops_setup_tab prototype to
+"desktops.h" because it is called from main.c.
+
+Submitted upstream: <https://bugzilla.icculus.org/show_bug.cgi?id=6671>
+
+diff --git a/src/appearance.c b/src/appearance.c
+index 4fb3f0c12ad9b143..da39273a16a3aea7 100644
+--- a/src/appearance.c
++++ b/src/appearance.c
+@@ -21,6 +21,8 @@
+ #include "tree.h"
+ #include "preview_update.h"
+ 
++#include <ctype.h>
++
+ static gboolean mapping = FALSE;
+ 
+ static RrFont *read_font(GtkFontButton *w, const gchar *place, gboolean def);
+diff --git a/src/desktops.h b/src/desktops.h
+index 1ba3e366d41f5c3d..5f7e32321dbfa3c4 100644
+--- a/src/desktops.h
++++ b/src/desktops.h
+@@ -24,5 +24,6 @@
+ 
+ void desktops_setup_num(GtkWidget *w);
+ void desktops_setup_names(GtkWidget *w);
++void desktops_setup_tab(void);
+ 
+ #endif
+diff --git a/src/main.c b/src/main.c
+index d7e34469ecc72914..017603537c1f8de1 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -28,6 +28,7 @@
+ #include "dock.h"
+ #include "preview_update.h"
+ #include "gettext.h"
++#include "moveresize.h"
+ 
+ #include <gdk/gdkx.h>
+ #define SN_API_NOT_YET_FROZEN

--- a/desktop-wm/obconf/spec
+++ b/desktop-wm/obconf/spec
@@ -1,5 +1,5 @@
 VER=2.0.4
-REL=5
+REL=6
 SRCS="tbl::http://openbox.org/dist/obconf/obconf-$VER.tar.gz"
 CHKSUMS="sha256::71a3e5f4ee246a27421ba85044f09d449f8de22680944ece9c471cd46a9356b9"
 CHKUPDATE="anitya::id=8784"


### PR DESCRIPTION
Topic Description
-----------------

- obconf: fix build
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- obconf: 2.0.4-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit obconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
