### PR TITLE
libp11: update to 0.4.16

### DIFF
--- a/app-utils/rng-tools/autobuild/defines
+++ b/app-utils/rng-tools/autobuild/defines
@@ -3,4 +3,7 @@ PKGSEC=utils
 PKGDEP="libgcrypt libp11 opensc"
 PKGDES="Random number generator related utilities"
 
-AUTOTOOLS_AFTER="--without-rtlsdr"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--without-rtlsdr"
+)

--- a/app-utils/rng-tools/spec
+++ b/app-utils/rng-tools/spec
@@ -1,5 +1,5 @@
 VER=6.17
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/nhorman/rng-tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4202"
-REL=1

--- a/runtime-cryptography/libp11/autobuild/defines
+++ b/runtime-cryptography/libp11/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=libp11
 PKGSEC=libs
 PKGDEP="openssl"
-BUILDDEP="doxygen"
 PKGDES="PKCS#11 wrapper library"
 
-AUTOTOOLS_AFTER="--enable-api-doc"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--disable-api-doc"
+)

--- a/runtime-cryptography/libp11/spec
+++ b/runtime-cryptography/libp11/spec
@@ -1,5 +1,4 @@
-VER=0.4.10
-SRCS="tbl::https://github.com/OpenSC/libp11/releases/download/libp11-$VER/libp11-$VER.tar.gz"
-CHKSUMS="sha256::639ea43c3341e267214b712e1e5e12397fd2d350899e673dd1220f3c6b8e3db4"
+VER=0.4.16
+SRCS="git::commit=tags/libp11-$VER::https://github.com/OpenSC/libp11"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1699"
-REL=1

--- a/topics/libp11-0.4.16.toml
+++ b/topics/libp11-0.4.16.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libp11 0.4.16"
+
+[caution]
+default = "Fixes a buffer overflow vulnerabilities - CVE-2010-4523 (Severity: High)"
+zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2010-4523（严重性：高）"
+
+[packages-v2]
+"libp11" = "< 0.4.16"


### PR DESCRIPTION
Topic Description
-----------------

- libp11: update to 0.4.16
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libp11: 0.4.16

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libp11 rng-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
