### PR TITLE
superslicer: rebuild for nlopt

### DIFF
--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,5 +1,5 @@
 VER=2.7.61.10
-REL=1
+REL=2
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370825"


### PR DESCRIPTION
Topic Description
-----------------

- superslicer: rebuild for nlopt
    The soname version of nlopt is changed from .0 to .1.
    Fortunately the API remains compatible.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- superslicer: 2.7.61.10-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit superslicer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
