### PR TITLE
openixcard: update to 1.1.8

### DIFF
--- a/app-devel/openixcard/spec
+++ b/app-devel/openixcard/spec
@@ -1,4 +1,4 @@
-VER=1.0.1
+VER=1.1.8
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/YuzukiTsuru/OpenixCard"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=247325"


### PR DESCRIPTION
Topic Description
-----------------

- openixcard: update to 1.1.8
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- openixcard: 1.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit openixcard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
