### PR TITLE
libde265: update to 1.0.16

### DIFF
--- a/runtime-multimedia/libde265/autobuild/defines
+++ b/runtime-multimedia/libde265/autobuild/defines
@@ -4,6 +4,9 @@ PKGDEP="gcc-runtime"
 BUILDDEP="gdk-pixbuf qt-5"
 PKGSEC=libs
 
+ABTYPE=autotools
 ABSHADOW=0
 # encoder is disabled by default from 1.0.10. Enabling it here.
-AUTOTOOLS_AFTER='--enable-encoder'
+AUTOTOOLS_AFTER=(
+    '--enable-encoder'
+)

--- a/runtime-multimedia/libde265/autobuild/defines.stage2
+++ b/runtime-multimedia/libde265/autobuild/defines.stage2
@@ -4,5 +4,8 @@ PKGDEP="gcc-runtime"
 BUILDDEP="gdk-pixbuf"
 PKGSEC=libs
 
+ABTYPE=autotools
 # Note: sherlock265 requires Qt.
-AUTOTOOLS_AFTER="--disable-sherlock265"
+AUTOTOOLS_AFTER=(
+    "--disable-sherlock265"
+)

--- a/runtime-multimedia/libde265/spec
+++ b/runtime-multimedia/libde265/spec
@@ -1,4 +1,4 @@
-VER=1.0.15
-SRCS="tbl::https://github.com/strukturag/libde265/releases/download/v${VER}/libde265-${VER}.tar.gz"
-CHKSUMS="sha256::00251986c29d34d3af7117ed05874950c875dd9292d016be29d3b3762666511d"
+VER=1.0.16
+SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libde265"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11239"

--- a/topics/libde265-1.0.16.toml
+++ b/topics/libde265-1.0.16.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libde265 1.0.16"
+
+[caution]
+default = "Fixes 2 heap buffer overflow vulnerabilities - CVE-2024-38949, CVE-2024-38950  (Severity: Medium)"
+zh_CN = "修复 2 处堆缓冲区溢出漏洞，漏洞编号 CVE-2024-38949 和 CVE-2024-38950（严重性：中）"
+
+[packages-v2]
+"libde265" = "< 1.0.16"


### PR DESCRIPTION
Topic Description
-----------------

- libde265: update to 1.0.16
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libde265: 1.0.16

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libde265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
