### PR TITLE
libeconf: update to 0.8.3

### DIFF
--- a/runtime-common/libeconf/autobuild/defines
+++ b/runtime-common/libeconf/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=libeconf
 PKGSEC=libs
 PKGDEP="glibc"
-BUILDDEP="doxygen"
-PKGDES="A library to parse and manage key=value configuration files"
+PKGDES="Library to parse and manage K-V configuration files"
 
-ABTYPE=meson
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DBUILD_DOCUMENTATION=OFF"
+)

--- a/runtime-common/libeconf/autobuild/defines.stage2
+++ b/runtime-common/libeconf/autobuild/defines.stage2
@@ -1,6 +1,9 @@
 PKGNAME=libeconf
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="A library to parse and manage key=value configuration files"
+PKGDES="Library to parse and manage K-V configuration files"
 
-ABTYPE=meson
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DBUILD_DOCUMENTATION=OFF"
+)

--- a/runtime-common/libeconf/spec
+++ b/runtime-common/libeconf/spec
@@ -1,5 +1,4 @@
-VER=0.5.0
-REL=2
-SRCS="tbl::https://github.com/openSUSE/libeconf/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::d6f794418a8f3ea2932bfaa33576ee604328edf7aff0c5ada1ffc74ef0362e3a"
+VER=0.8.3
+SRCS="git::commit=tags/v$VER::https://github.com/openSUSE/libeconf"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21922"

--- a/topics/libeconf-0.8.3.toml
+++ b/topics/libeconf-0.8.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libeconf 0.8.3"
+
+[caution]
+default = "Fixes 2 buffer overflow vulnerabilities - CVE-2023-22652, CVE-2023-32181 (Severity: Medium)"
+zh_CN = "修复 2 个缓冲区溢出漏洞，漏洞编号 CVE-2023-22652, CVE-2023-32181（严重性：中）"
+
+[packages-v2]
+"libeconf" = "< 0.8.3"


### PR DESCRIPTION
Topic Description
-----------------

- libeconf: update to 0.8.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libeconf: 0.8.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libeconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
