### PR TITLE
liblouis: update to 3.36.0

### DIFF
--- a/runtime-a11y/liblouis/autobuild/beyond
+++ b/runtime-a11y/liblouis/autobuild/beyond
@@ -1,4 +1,3 @@
-pushd python
+abinfo "Installing Python bindings ..."
 LD_PRELOAD+=":$SRCDIR/liblouis/.libs/liblouis.so"
-python3 setup.py install --root="$PKGDIR" --prefix="/usr" --optimize=1
-popd
+python3 -m pip install "$SRCDIR"/python --root="$PKGDIR" --prefix="/usr"

--- a/runtime-a11y/liblouis/spec
+++ b/runtime-a11y/liblouis/spec
@@ -1,5 +1,4 @@
-VER=3.12.0
-REL=4
+VER=3.36.0
 SRCS="git::commit=tags/v$VER::https://github.com/liblouis/liblouis.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13112"

--- a/topics/liblouis-3.36.0.toml
+++ b/topics/liblouis-3.36.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "liblouis 3.36.0"
+
+[caution]
+default = "Fixes a buffer overflow vulnerability - CVE-2022-26981 (Severity: High)"
+zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2022-26981（严重性：高）"
+
+[packages-v2]
+"liblouis" = "< 3.36.0"


### PR DESCRIPTION
Topic Description
-----------------

- liblouis: update to 3.36.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- liblouis: 3.36.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit liblouis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
