### PR TITLE
libspiro: update to 20240903

### DIFF
--- a/app-creativity/fontforge/autobuild/defines
+++ b/app-creativity/fontforge/autobuild/defines
@@ -5,6 +5,7 @@ PKGDEP="libtool pango giflib libtiff libspiro libxml2 libunicodenames \
         libuninameslist potrace gtkmm-3"
 PKGDES="Outline and bitmap font editor"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
 	"-DENABLE_PYTHON_EXTENSION=ON"
 	"-DENABLE_TILE_PATH=ON"

--- a/app-creativity/fontforge/spec
+++ b/app-creativity/fontforge/spec
@@ -1,4 +1,5 @@
 VER=20251009
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/fontforge/fontforge.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5807"

--- a/runtime-creativity/libspiro/autobuild/defines
+++ b/runtime-creativity/libspiro/autobuild/defines
@@ -2,3 +2,6 @@ PKGNAME=libspiro
 PKGDES="Simplifies the drawing of beautiful curves"
 PKGSEC=libs
 PKGDEP="glibc"
+
+ABTYPE=autotools
+PKGBREAK="fontforge<=20251009 gegl-0.4<=0.4.64"

--- a/runtime-creativity/libspiro/spec
+++ b/runtime-creativity/libspiro/spec
@@ -1,4 +1,4 @@
-VER=0.5.20150702
-SRCS="tbl::https://github.com/fontforge/libspiro/archive/$VER.tar.gz"
-CHKSUMS="sha256::14f761d83c7fa6be31c4e0317251ed1201b367dc5b2a8678e2da179d74938fc7"
+VER=20240903
+SRCS="git::commit=tags/$VER::https://github.com/fontforge/libspiro"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1725"

--- a/runtime-imaging/gegl-0.4/autobuild/defines
+++ b/runtime-imaging/gegl-0.4/autobuild/defines
@@ -3,46 +3,51 @@ PKGSEC=libs
 PKGDEP="babl ffmpeg gexiv2 glib graphviz jasper json-glib lensfun libopenraw \
         libraw librsvg libspiro libtiff libwebp maxflow openexr poppler \
         pygobject-3 sdl2 suitesparse v4l-utils"
-BUILDDEP="asciidoc gtk-doc intltool luajit ruby source-highlight vala"
+BUILDDEP="asciidoc intltool luajit ruby source-highlight vala"
 # FIXME: LuaJIT is not available for these architectures.
 BUILDDEP__PPC64EL="${BUILDDEP/luajit/}"
 BUILDDEP__RISCV64="${BUILDDEP/luajit/}"
 PKGDES="Graph based image processing framework (0.4)"
 
 ABTYPE=meson
-MESON_AFTER="-Ddocs=true \
-             -Dgtk-doc=true \
-             -Dworkshop=false \
-             -Dintrospection=true \
-             -Dgdk-pixbuf=enabled \
-             -Dgraphviz=enabled \
-             -Djasper=enabled \
-             -Dlcms=enabled \
-             -Dlensfun=enabled \
-             -Dlibav=enabled \
-             -Dlibraw=enabled \
-             -Dlibrsvg=enabled \
-             -Dlibspiro=enabled \
-             -Dlibtiff=enabled \
-             -Dlibv4l=enabled \
-             -Dlibv4l2=enabled \
-             -Dlua=enabled \
-             -Dmrg=disabled \
-             -Dmaxflow=enabled \
-             -Dopenexr=enabled \
-             -Dcairo=enabled \
-             -Dpango=enabled \
-             -Dpangocairo=enabled \
-             -Dpoppler=enabled \
-             -Dpygobject=enabled \
-             -Dsdl2=enabled \
-             -Dumfpack=enabled \
-             -Dwebp=enabled"
+MESON_AFTER=(
+        "-Ddocs=false"
+        "-Dgtk-doc=true"
+        "-Dworkshop=false"
+        "-Dintrospection=true"
+        "-Dgdk-pixbuf=enabled"
+        "-Dgraphviz=enabled"
+        "-Djasper=enabled"
+        "-Dlcms=enabled"
+        "-Dlensfun=enabled"
+        "-Dlibav=enabled"
+        "-Dlibraw=enabled"
+        "-Dlibrsvg=enabled"
+        "-Dlibspiro=enabled"
+        "-Dlibtiff=enabled"
+        "-Dlibv4l=enabled"
+        "-Dlibv4l2=enabled"
+        "-Dlua=enabled"
+        "-Dmrg=disabled"
+        "-Dmaxflow=enabled"
+        "-Dopenexr=enabled"
+        "-Dcairo=enabled"
+        "-Dpango=enabled"
+        "-Dpangocairo=enabled"
+        "-Dpoppler=enabled"
+        "-Dpygobject=enabled"
+        "-Dsdl2=enabled"
+        "-Dumfpack=enabled"
+        "-Dwebp=enabled"
+)
 
 # FIXME: No LuaJIT support for these architectures.
-MESON_AFTER__NOLUAJIT="${MESON_AFTER} -Dlua=disabled"
-MESON_AFTER__PPC64EL="${MESON_AFTER__NOLUAJIT}"
-MESON_AFTER__RISCV64="${MESON_AFTER__NOLUAJIT}"
+MESON_AFTER__NOLUAJIT=(
+        "${MESON_AFTER[@]}"
+        "-Dlua=disabled"
+)
+MESON_AFTER__PPC64EL=("${MESON_AFTER__NOLUAJIT[@]}")
+MESON_AFTER__RISCV64=("${MESON_AFTER__NOLUAJIT[@]}")
 
 AB_FLAGS_O3=1
 

--- a/runtime-imaging/gegl-0.4/spec
+++ b/runtime-imaging/gegl-0.4/spec
@@ -1,4 +1,5 @@
 VER=0.4.64
+REL=1
 SRCS="tbl::https://download.gimp.org/pub/gegl/${VER:0:3}/gegl-$VER.tar.xz"
 CHKSUMS="sha256::0de1c9dd22c160d5e4bdfc388d292f03447cca6258541b9a12fed783d0cf7c60"
 CHKUPDATE="anitya::id=229510"

--- a/topics/libspiro-20250903.toml
+++ b/topics/libspiro-20250903.toml
@@ -1,11 +1,11 @@
 security = true
 
 [name]
-default = "libspiro 20250903"
+default = "libspiro 20240903"
 
 [caution]
 default = "Fixes a buffer overflow vulnerabilities - CVE-2019-19847 (Severity: High)"
 zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2019-19847（严重性：高）"
 
 [packages-v2]
-"libspiro" = "< 20250903"
+"libspiro" = "< 20240903"

--- a/topics/libspiro-20250903.toml
+++ b/topics/libspiro-20250903.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libspiro 20250903"
+
+[caution]
+default = "Fixes a buffer overflow vulnerabilities - CVE-2019-19847 (Severity: High)"
+zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2019-19847（严重性：高）"
+
+[packages-v2]
+"libspiro" = "< 20250903"


### PR DESCRIPTION
Topic Description
-----------------

- libspiro: update to 20240903
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libspiro: 20240903

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libspiro fontforge gegl-0.4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
