### PR TITLE
matio: update to 1.5.30

### DIFF
--- a/runtime-imaging/libvips/autobuild/defines
+++ b/runtime-imaging/libvips/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libvips
 PKGSEC=libs
-PKGDES="An image processing library"
+PKGDES="Image processing library"
 PKGDEP="gcc-runtime glibc glib expat zlib libarchive fftw cfitsio cgif \
         libimagequant libexif libjpeg-turbo libpng libwebp pango fontconfig \
         libtiff librsvg cairo lcms2 openexr openjpeg highway nifti matio"
@@ -11,8 +11,7 @@ ABTYPE=meson
 MESON_AFTER=(
     '-Dexamples=false'
     '-Ddocs=false'
-    # FIXME: temporarily disabled due to libvips/libvips#4654
-    # '-Dvapi=true'
+    '-Dvapi=true'
     '-Dnifti-prefix-dir=/usr'
     '-Dpdfium=disabled'
     '-Dquantizr=disabled'

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,4 +1,4 @@
-VER=8.17.3
+VER=8.18.0
 SRCS="git::commit=tags/v$VER::https://github.com/libvips/libvips"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5097"

--- a/runtime-scientific/matio/autobuild/defines
+++ b/runtime-scientific/matio/autobuild/defines
@@ -3,4 +3,9 @@ PKGSEC=libs
 PKGDES="MATLAB MAT file I/O library"
 PKGDEP="glibc hdf5 zlib"
 
-CMAKE_AFTER="-DMATIO_BUILD_TESTING=OFF"
+ABTYPE=autotools
+CMAKE_AFTER=(
+    "--enable-shared"
+    "--with-hdf5"
+)
+PKGBREAK="libvips<=8.17.3"

--- a/runtime-scientific/matio/spec
+++ b/runtime-scientific/matio/spec
@@ -1,5 +1,4 @@
-VER=1.5.28
-REL=1
+VER=1.5.30
 SRCS="git::commit=tags/v$VER::https://github.com/tbeu/matio"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1893"

--- a/topics/matio-1.5.30.toml
+++ b/topics/matio-1.5.30.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "MATIO 1.5.30"
+
+[caution]
+default = "Fixes 2 buffer overflow vulnerabilities (CVE-2025-2337 and CVE-2025-2338, Severity: Medium) and a heap memory corruption vulnerability (CVE-2025-50343, Severity: Unknown)"
+zh_CN = "修复 2 个缓冲区溢出漏洞（CVE-2025-2337 和 CVE-2025-2338，严重性：中）和一个堆内存损坏漏洞（CVE-2025-50343，严重性：未知）"
+
+[packages-v2]
+"matio" = "< 1.5.30"


### PR DESCRIPTION
Topic Description
-----------------

- matio: update to 1.5.30
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- matio: 1.5.30

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit matio libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
