### PR TITLE
mxml: update to 3.3.1

### DIFF
--- a/app-multimedia/zynaddsubfx/autobuild/defines
+++ b/app-multimedia/zynaddsubfx/autobuild/defines
@@ -2,9 +2,13 @@ PKGNAME=zynaddsubfx
 PKGDES="Open source software synthesizer capable of making a countless number of instruments."
 PKGSEC=sound
 PKGDEP="fltk portaudio fftw lash mxml jack x11-lib gcc-runtime liblo"
-BUILDDEP="cmake mesa setconf"
+BUILDDEP="mesa setconf"
+
+ABTYPE=cmakeninja
 # Zynaddsubfx build process needs a utility from original fltk
-CMAKE_AFTER="-DDefaultOutput=jack \
-             -DDefaultInput=jack \
-             -DGuiModule=fltk \
-             -DCompileTests=OFF"
+CMAKE_AFTER=(
+    "-DDefaultOutput=jack"
+    "-DDefaultInput=jack"
+    "-DGuiModule=fltk"
+    "-DCompileTests=OFF"
+)

--- a/app-multimedia/zynaddsubfx/spec
+++ b/app-multimedia/zynaddsubfx/spec
@@ -1,5 +1,5 @@
 VER=3.0.6
+REL=3
 SRCS="git::commit=tags/${VER}::https://github.com/zynaddsubfx/zynaddsubfx.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10598"
-REL=2

--- a/app-web/lurch/spec
+++ b/app-web/lurch/spec
@@ -1,5 +1,5 @@
 VER=0.7.0
-REL=1
-SRCS="https://github.com/gkdr/lurch/releases/download/v${VER}/lurch-${VER}-src.tar.gz"
-CHKSUMS="sha256::1ff595407f72deaa3b83e07d9695c64a4310e1bf38f86811e8b524a7bc7c5a8d"
+REL=2
+SRCS="git::commit=tags/v$VER::https://github.com/gkdr/lurch"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231948"

--- a/runtime-common/mxml/autobuild/defines
+++ b/runtime-common/mxml/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=mxml
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="A small XML parsing library"
+PKGDES="Tiny XML parsing library"
 
+ABTYPE=autotools
 ABSHADOW=0
 RECONF=0
+PKGBREAK="lurch<=0.7.0-1 zynaddsubfx<=3.0.6-2"

--- a/runtime-common/mxml/spec
+++ b/runtime-common/mxml/spec
@@ -1,4 +1,4 @@
-VER=3.2
-SRCS="tbl::https://github.com/michaelrsweet/mxml/releases/download/v$VER/mxml-$VER.tar.gz"
-CHKSUMS="sha256::b894f6c64964f2e77902564c17ba00f5d077a7a24054e7c1937903b0bd42c974"
+VER=3.3.1
+SRCS="git::commit=tags/v$VER::https://github.com/michaelrsweet/mxml"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13545"

--- a/topics/mxml-4.0.4.toml
+++ b/topics/mxml-4.0.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Mini-XML 3.3.1"
+
+[caution]
+default = "Fixes a memory leak vulnerabilities (Severity: High) and a buffer overflow vulnerabilities (Severity: High)"
+zh_CN = "修复一个内存泄漏漏洞（严重性：高）和一个缓冲区溢出漏洞（严重性：高）"
+
+[packages-v2]
+"mxml" = "< 3.3.1"


### PR DESCRIPTION
Topic Description
-----------------

- mxml: update to 4.0.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- mxml: 4.0.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit mxml lurch zynaddsubfx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
