### PR TITLE
praat: update to 6.4.55

### DIFF
--- a/app-scientific/praat/autobuild/prepare
+++ b/app-scientific/praat/autobuild/prepare
@@ -1,2 +1,4 @@
-abinfo "Copying the right makefile.defs (Linux with PulseAudio + GCC) ..."
-cp -v "$SRCDIR"/makefiles/makefile.defs.linux.pulse-gcc "$SRCDIR"/makefile.defs
+abinfo "Copying the right makefile.defs (Little Endian, Linux with PulseAudio + GCC) ..."
+# NOTE: AOSC OS mainline currently only has little-endian architectures, we'll
+# default to use the LE variant here
+cp -v "$SRCDIR"/makefiles/makefile.defs.linux.pulse-gcc.LE "$SRCDIR"/makefile.defs

--- a/app-scientific/praat/spec
+++ b/app-scientific/praat/spec
@@ -1,4 +1,4 @@
-VER=6.4.49
+VER=6.4.55
 SRCS="git::commit=tags/v$VER::https://github.com/praat/praat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373832"


### PR DESCRIPTION
Topic Description
-----------------

- praat: update to 6.4.55
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- praat: 6.4.55

Security Update?
----------------

No

Build Order
-----------

```
#buildit praat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
