### PR TITLE
inetutils: update to 2.7

### DIFF
--- a/app-utils/inetutils/autobuild/patches/0001-UPSTREAM-Fix-injection-bug-with-bogus-user-names.patch
+++ b/app-utils/inetutils/autobuild/patches/0001-UPSTREAM-Fix-injection-bug-with-bogus-user-names.patch
@@ -1,0 +1,38 @@
+From 8e72515a42703bad59438ba1b16afb3e92007d06 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 20 Jan 2026 01:10:36 -0800
+Subject: [PATCH 1/7] UPSTREAM: Fix injection bug with bogus user names
+
+Problem reported by Kyu Neushwaistein.
+* telnetd/utility.c (_var_short_name):
+Ignore user names that start with '-' or contain shell metacharacters.
+
+Signed-off-by: Simon Josefsson <simon@josefsson.org>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ telnetd/utility.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/telnetd/utility.c b/telnetd/utility.c
+index 534d683a..4a56622d 100644
+--- a/telnetd/utility.c
++++ b/telnetd/utility.c
+@@ -1733,7 +1733,14 @@ _var_short_name (struct line_expander *exp)
+       return user_name ? xstrdup (user_name) : NULL;
+ 
+     case 'U':
+-      return getenv ("USER") ? xstrdup (getenv ("USER")) : xstrdup ("");
++      {
++	/* Ignore user names starting with '-' or containing shell
++	   metachars, as they can cause trouble.  */
++	char const *u = getenv ("USER");
++	return xstrdup ((u && *u != '-'
++			 && !u[strcspn (u, "\t\n !\"#$&'()*;<=>?[\\^`{|}~")])
++			? u : "");
++      }
+ 
+     default:
+       exp->state = EXP_STATE_ERROR;
+-- 
+2.52.0
+

--- a/app-utils/inetutils/autobuild/patches/0002-UPSTREAM-telnetd-Sanitize-all-variable-expansions.patch
+++ b/app-utils/inetutils/autobuild/patches/0002-UPSTREAM-telnetd-Sanitize-all-variable-expansions.patch
@@ -1,0 +1,83 @@
+From f21604f97030656c19937e238962696a335d8070 Mon Sep 17 00:00:00 2001
+From: Simon Josefsson <simon@josefsson.org>
+Date: Tue, 20 Jan 2026 14:02:39 +0100
+Subject: [PATCH 2/7] UPSTREAM: telnetd: Sanitize all variable expansions
+
+* telnetd/utility.c (sanitize): New function.
+(_var_short_name): Use it for all variables.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ telnetd/utility.c | 32 ++++++++++++++++++--------------
+ 1 file changed, 18 insertions(+), 14 deletions(-)
+
+diff --git a/telnetd/utility.c b/telnetd/utility.c
+index 4a56622d..1e7adb08 100644
+--- a/telnetd/utility.c
++++ b/telnetd/utility.c
+@@ -1684,6 +1684,17 @@ static void _expand_cond (struct line_expander *exp);
+ static void _skip_block (struct line_expander *exp);
+ static void _expand_block (struct line_expander *exp);
+ 
++static char *
++sanitize (const char *u)
++{
++  /* Ignore values starting with '-' or containing shell metachars, as
++     they can cause trouble.  */
++  if (u && *u != '-' && !u[strcspn (u, "\t\n !\"#$&'()*;<=>?[\\^`{|}~")])
++    return u;
++  else
++    return "";
++}
++
+ /* Expand a variable referenced by its short one-symbol name.
+    Input: exp->cp points to the variable name.
+    FIXME: not implemented */
+@@ -1710,13 +1721,13 @@ _var_short_name (struct line_expander *exp)
+       return xstrdup (timebuf);
+ 
+     case 'h':
+-      return xstrdup (remote_hostname);
++      return xstrdup (sanitize (remote_hostname));
+ 
+     case 'l':
+-      return xstrdup (local_hostname);
++      return xstrdup (sanitize (local_hostname));
+ 
+     case 'L':
+-      return xstrdup (line);
++      return xstrdup (sanitize (line));
+ 
+     case 't':
+       q = strchr (line + 1, '/');
+@@ -1724,23 +1735,16 @@ _var_short_name (struct line_expander *exp)
+ 	q++;
+       else
+ 	q = line;
+-      return xstrdup (q);
++      return xstrdup (sanitize (q));
+ 
+     case 'T':
+-      return terminaltype ? xstrdup (terminaltype) : NULL;
++      return terminaltype ? xstrdup (sanitize (terminaltype)) : NULL;
+ 
+     case 'u':
+-      return user_name ? xstrdup (user_name) : NULL;
++      return user_name ? xstrdup (sanitize (user_name)) : NULL;
+ 
+     case 'U':
+-      {
+-	/* Ignore user names starting with '-' or containing shell
+-	   metachars, as they can cause trouble.  */
+-	char const *u = getenv ("USER");
+-	return xstrdup ((u && *u != '-'
+-			 && !u[strcspn (u, "\t\n !\"#$&'()*;<=>?[\\^`{|}~")])
+-			? u : "");
+-      }
++      return xstrdup (sanitize (getenv ("USER")));
+ 
+     default:
+       exp->state = EXP_STATE_ERROR;
+-- 
+2.52.0
+

--- a/app-utils/inetutils/autobuild/patches/0003-FROMLIST-telnet-telnetd-fix-build-with-GCC-14.patch
+++ b/app-utils/inetutils/autobuild/patches/0003-FROMLIST-telnet-telnetd-fix-build-with-GCC-14.patch
@@ -1,7 +1,7 @@
-From b69d494101ab5d34291b4ec0c49ebd40a01bb4d4 Mon Sep 17 00:00:00 2001
+From dd7be9916436b7f9b4247a5ca8ee2d8e6c002146 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 10 Feb 2025 18:04:09 +0800
-Subject: [PATCH 5/5] FROMLIST: telnet: telnetd: fix build with GCC >= 14
+Subject: [PATCH 3/7] FROMLIST: telnet: telnetd: fix build with GCC >= 14
 
 Link: https://savannah.gnu.org/bugs/?65263
 Signed-off-by: Jeffrey Cliff <themusicgod1>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 12 insertions(+)
 
 diff --git a/am/libcurses.m4 b/am/libcurses.m4
-index 15b5c5e7..276ffa37 100644
+index 3906d234..4fb41f6f 100644
 --- a/am/libcurses.m4
 +++ b/am/libcurses.m4
 @@ -135,6 +135,10 @@ AC_DEFUN([IU_LIB_TERMCAP], [
@@ -44,7 +44,7 @@ index 1efa50ab..cf2c6667 100644
  init_term (char *tname, int *errp)
  {
 diff --git a/telnetd/utility.c b/telnetd/utility.c
-index 4f82042f..7b78e3e3 100644
+index 1e7adb08..490b1253 100644
 --- a/telnetd/utility.c
 +++ b/telnetd/utility.c
 @@ -44,6 +44,10 @@
@@ -59,5 +59,5 @@ index 4f82042f..7b78e3e3 100644
    && defined HAVE_STROPTS_H
  # include <stropts.h>
 -- 
-2.51.0
+2.52.0
 

--- a/app-utils/inetutils/autobuild/patches/0004-DEBIAN-build-Disable-GFDL-info-files-and-useless-man.patch
+++ b/app-utils/inetutils/autobuild/patches/0004-DEBIAN-build-Disable-GFDL-info-files-and-useless-man.patch
@@ -1,7 +1,7 @@
-From f5cf631b91b708c91151e20094eae7b1b402a786 Mon Sep 17 00:00:00 2001
+From 7b2431d57b373e0c9bad4d5a670753abb7418675 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 9 Jun 2010 03:56:08 +0200
-Subject: [PATCH 1/5] DEBIAN: build: Disable GFDL info files and useless man
+Subject: [PATCH 4/7] DEBIAN: build: Disable GFDL info files and useless man
  pages
 
 We do not install the info file due to GFDL, and because it would
@@ -31,7 +31,7 @@ index 144d9fe5..46cae1a1 100644
  
  DISTCLEANFILES = pathdefs.make paths.defs
 diff --git a/configure.ac b/configure.ac
-index fe60ef35..564c3a97 100644
+index 719d9793..2f343daf 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -142,7 +142,6 @@ AC_PROG_RANLIB
@@ -52,5 +52,5 @@ index fe60ef35..564c3a97 100644
  confpaths.h:confpaths.h.in
  ])
 -- 
-2.51.0
+2.52.0
 

--- a/app-utils/inetutils/autobuild/patches/0005-DEBIAN-build-Use-runstatedir-for-run-directory.patch
+++ b/app-utils/inetutils/autobuild/patches/0005-DEBIAN-build-Use-runstatedir-for-run-directory.patch
@@ -1,14 +1,14 @@
-From 80eed508e62e934e9daff447b04ae9ef6d14fbb5 Mon Sep 17 00:00:00 2001
+From 32dbd2bc3c98f0c150a422b5e822a358fb7d52a7 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Sun, 5 Sep 2021 05:00:23 +0200
-Subject: [PATCH 2/5] DEBIAN: build: Use runstatedir for /run directory
+Subject: [PATCH 5/7] DEBIAN: build: Use runstatedir for /run directory
 
 ---
  paths | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/paths b/paths
-index ca363661..e56cc52b 100644
+index 705ff383..93ecf7ab 100644
 --- a/paths
 +++ b/paths
 @@ -77,12 +77,12 @@ PATH_FTPLOGINMESG /etc/motd
@@ -38,5 +38,5 @@ index ca363661..e56cc52b 100644
  PATH_RLOGIN	x $(bindir)/rlogin
  PATH_RSH	x $(bindir)/rsh
 -- 
-2.51.0
+2.52.0
 

--- a/app-utils/inetutils/autobuild/patches/0006-DEBIAN-inetd-Change-protocol-semantics-in-inetd.conf.patch
+++ b/app-utils/inetutils/autobuild/patches/0006-DEBIAN-inetd-Change-protocol-semantics-in-inetd.conf.patch
@@ -1,7 +1,7 @@
-From a2a683c27fcad4cd6b65882c3a185cd4a2875835 Mon Sep 17 00:00:00 2001
+From f76eede2c12c4d5e2e0a3c4b9870114a2ca7c7aa Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Mon, 6 Sep 2010 10:52:27 +0200
-Subject: [PATCH 3/5] DEBIAN: inetd: Change protocol semantics in inetd.conf
+Subject: [PATCH 6/7] DEBIAN: inetd: Change protocol semantics in inetd.conf
 
 Readd parts of the original patch that got botched when applied
 upstream.
@@ -15,7 +15,7 @@ Fixes: commit a12021ee959a88b48cd16e947c671f8f59e29c9d
  1 file changed, 1 deletion(-)
 
 diff --git a/src/inetd.c b/src/inetd.c
-index 52453fbd..10581a77 100644
+index 794b5ca1..64382924 100644
 --- a/src/inetd.c
 +++ b/src/inetd.c
 @@ -1112,7 +1112,6 @@ getconfigent (FILE *fconfig, const char *file, size_t *line)
@@ -27,5 +27,5 @@ index 52453fbd..10581a77 100644
  	      if (strcmp (&sep->se_proto[3], "6only") == 0)
  		sep->se_v4mapped = 0;
 -- 
-2.51.0
+2.52.0
 

--- a/app-utils/inetutils/autobuild/patches/0007-DEBIAN-Use-krb5_auth_con_getsendsubkey-instead-of-kr.patch
+++ b/app-utils/inetutils/autobuild/patches/0007-DEBIAN-Use-krb5_auth_con_getsendsubkey-instead-of-kr.patch
@@ -1,7 +1,7 @@
-From b364fe3c9e97b02e8836b8f0e09e2507c8efdb6f Mon Sep 17 00:00:00 2001
+From d92a614f8e5b5e18675b09e5991529f2d0b5b9cf Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 10 Aug 2022 01:57:24 +0200
-Subject: [PATCH 4/5] DEBIAN: Use krb5_auth_con_getsendsubkey() instead of
+Subject: [PATCH 7/7] DEBIAN: Use krb5_auth_con_getsendsubkey() instead of
  krb5_auth_con_getlocalsubkey()
 
 The latter is not exposed in the headers anymore.
@@ -23,5 +23,5 @@ index 217b64e0..6d993dd3 100644
    /* send size of AP-REQ to the server */
  
 -- 
-2.51.0
+2.52.0
 

--- a/app-utils/inetutils/spec
+++ b/app-utils/inetutils/spec
@@ -1,5 +1,4 @@
-VER=2.6
-REL=2
+VER=2.7
 SRCS="tbl::https://ftp.gnu.org/gnu/inetutils/inetutils-$VER.tar.gz"
-CHKSUMS="sha256::ccaa256e0d646df7f285ff158a3291f37cd1fc8382f3774d22f7254127635da7"
+CHKSUMS="sha256::a156be1cde3c5c0ffefc262180d9369a60484087907aa554c62787d2f40ec086"
 CHKUPDATE="anitya::id=13805"

--- a/topics/inetutils-2.7.toml
+++ b/topics/inetutils-2.7.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "GNU InetUtils 2.7"
+
+[caution]
+default = "Fixes a Remote Authentication Bypass vulnerability in telnetd (Severity: Critical)"
+zh_CN = "修复一处远程鉴权绕过 (Remote Authentication Bypass) 漏洞（严重性：严重）"
+
+[packages-v2]
+"inetutils" = "< 2.7"


### PR DESCRIPTION
Topic Description
-----------------

- inetutils: update to 2.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- inetutils: 2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit inetutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
