### PR TITLE
podofo: update to 1.0.3

### DIFF
--- a/app-doc/calibre/autobuild/defines
+++ b/app-doc/calibre/autobuild/defines
@@ -6,7 +6,7 @@ PKGDEP="hunspell hyphen icu libmtp snowball libusb libwmf mathjax mtdev optipng 
         netifaces pillow psutils pycryptodome pygments regex zeroconf zstandard \
         pyqt6 pyqt6-webengine liberation-fonts uchardet udisks-2 unrardll zstd \
         poppler fonttools speech-dispatcher python-xxhash pychm sgmllib3k espeak-ng onnxruntime"
-BUILDDEP="cmake pyqt-builder sip xdg-utils"
+BUILDDEP="pyqt-builder sip xdg-utils"
 PKGDES="E-book converter and library manager"
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd)"

--- a/app-doc/calibre/spec
+++ b/app-doc/calibre/spec
@@ -1,4 +1,4 @@
-VER=8.15.0
+VER=8.16.2
 SRCS="tbl::https://download.calibre-ebook.com/$VER/calibre-$VER.tar.xz"
-CHKSUMS="sha256::5a7bfe4bfe1a8de6eef3bf91fa97edf4a6bffec0f5d92b07ebed675d5c7f5eb4"
+CHKSUMS="sha256::0187d04354f53cc0741141da026977ee30a77efa0c37b1839bde0588222c1c6c"
 CHKUPDATE="anitya::id=6141"

--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,4 +1,5 @@
 VER=1.6.5
+REL=1
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::09bdb736a8ff8a437191458a36d847cc0adeca0fc059cf696474e0ba6f59ac6a"
 CHKUPDATE="anitya::id=4773"

--- a/runtime-doc/podofo/autobuild/defines
+++ b/runtime-doc/podofo/autobuild/defines
@@ -1,12 +1,14 @@
 PKGNAME=podofo
 PKGSEC=libs
-PKGDES="A C++ library to work with the PDF file format"
+PKGDES="C++ library to work with the PDF file format"
 PKGDEP="lua openssl fontconfig libtiff libidn libjpeg-turbo"
-PKGBREAK="calibre<=5.30.0-3 gdal<=3.8.4-1 scribus<=1.6.1"
+PKGBREAK="calibre<=8.15.0 gdal<=3.12.1 scribus<=1.6.5"
 
-CMAKE_AFTER="-DCMAKE_INSTALL_PREFIX=/usr \
-             -DPODOFO_HAVE_JPEG_LIB=1 \
-             -DPODOFO_HAVE_PNG_LIB=1 \
-             -DPODOFO_HAVE_TIFF_LIB=1"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DCMAKE_INSTALL_PREFIX=/usr"
+    "-DPODOFO_HAVE_JPEG_LIB=1"
+    "-DPODOFO_HAVE_PNG_LIB=1"
+    "-DPODOFO_HAVE_TIFF_LIB=1"
+)
 
-NOLTO__LOONGSON3=1

--- a/runtime-doc/podofo/spec
+++ b/runtime-doc/podofo/spec
@@ -1,4 +1,4 @@
-VER=0.10.3
+VER=1.0.3
 SRCS="git::commit=tags/$VER::https://github.com/podofo/podofo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10527"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,4 +1,5 @@
 VER=3.12.1
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/OSGeo/gdal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=881"

--- a/topics/podofo-1.0.3.toml
+++ b/topics/podofo-1.0.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "podofo 1.0.3"
+
+[caution]
+default = "Fixes a denial of service vulnerability - CVE-2025-46205 (Severity: High)"
+zh_CN = "修复一处拒绝服务漏洞，漏洞编号 CVE-2025-46205（严重性：高）"
+
+[packages-v2]
+"podofo" = "< 1.0.3"


### PR DESCRIPTION
Topic Description
-----------------

- podofo: update to 1.0.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- podofo: 1.0.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit podofo calibre gdal scribus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
