### PR TITLE
loonggpu-kernel-dkms: add a modprobe.d conf to always load it before loongson

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/overrides/usr/lib/modprobe.d/loonggpu.conf
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/overrides/usr/lib/modprobe.d/loonggpu.conf
@@ -1,0 +1,1 @@
+softdep loongson pre: loonggpu

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -1,5 +1,5 @@
 UPSTREAM_VER=1.0.2-lnd25.1~rc1.7
-REL=2
+REL=3
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

We used loongson.ls7a2000_support to ensure loongson (upstream DC driver with a very bad name) not to get the way of loonggpu.  But when loonggpu is not installed or fails to work we actually want to use loongson as a fallback.

Add a modprobe.d conf file to ensure loading loonggpu before loongson so we can remove ls7a2000_support later and make the fallback work.  The disadvantage is we cannot use "modprobe.blacklist=loonggpu" anymore: we need to use a custom and not so intuitive "loonggpu.support=0" instead. But overall I still think it will be a win.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: `1.0.2-lnd25.1~rc1.7-3`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`
