### PR TITLE
rustc: update to 1.93.0

### DIFF
--- a/lang-rust/rustc/autobuild/prepare
+++ b/lang-rust/rustc/autobuild/prepare
@@ -46,6 +46,7 @@ sanitizers = true
 profiler = true
 vendor = true
 print-step-timings = true
+docs = false
 EOF
 
 # FIXME: Uncomment this if we have the last version built and ready.

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,8 +1,7 @@
-VER=1.92.0
-REL=1
+VER=1.93.0
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::ebee170bfe4c4dfc59521a101de651e5534f4dae889756a5c97ca9ea40d0c307"
+CHKSUMS="sha256::e30d898272c587a22f77679f03c5e8192b5645c7c9ccc3407ad1106761507cea"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.93.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rustc: 1:1.93.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
