### PR TITLE
gitea: update to 1.25.4

### DIFF
--- a/app-vcs/gitea/autobuild/build
+++ b/app-vcs/gitea/autobuild/build
@@ -1,4 +1,4 @@
 abinfo "Building the Gitea backend ..."
-make backend                                                    
+make
 abinfo "Installing gitea binary ..."
 install -Dvm755 gitea "$PKGDIR"/usr/bin/gitea

--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,4 +1,4 @@
-VER=1.25.1
-SRCS="tbl::https://github.com/go-gitea/gitea/releases/download/v$VER/gitea-src-$VER.tar.gz"
-CHKSUMS="sha256::127f9d6efce69cc9cbe92b6cf84b98709b458407f9b21c6d15b007d68b656148"
+VER=1.25.4
+SRCS="git::commit=tags/v$VER::https://github.com/go-gitea/gitea"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13537"

--- a/topics/gitea-1.25.4.toml
+++ b/topics/gitea-1.25.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "gitea 1.25.4"
+
+[caution]
+default = "Fixes 2 authentication vulnerabilities - CVE-2025-68938, CVE-2025-69413  (Severity: Medium)"
+zh_CN = "修复 2 处鉴权漏洞，漏洞编号 CVE-2025-68938 和 CVE-2025-69413（严重性：中）"
+
+[packages-v2]
+"gitea" = "< 1.25.4"


### PR DESCRIPTION
Topic Description
-----------------

- gitea: update to 1.25.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gitea: 1.25.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
