### PR TITLE
gnupg: update to 2.5.16

### DIFF
--- a/app-cryptography/gnupg/autobuild/defines
+++ b/app-cryptography/gnupg/autobuild/defines
@@ -12,6 +12,7 @@ BUILDDEP="transfig"
 # Do NOT let gnupg try to regenerate version string from git
 RECONF=0
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-gpgsm'
     '--enable-scdaemon'

--- a/app-cryptography/gnupg/autobuild/defines.stage2
+++ b/app-cryptography/gnupg/autobuild/defines.stage2
@@ -6,6 +6,7 @@ PKGDEP="bzip2 libgpg-error libgcrypt libassuan libksba \
          npth readline"
 BUILDDEP="transfig"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-maintainer-mode'
     '--enable-gpgtar'

--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,5 +1,4 @@
-VER=2.4.8
-REL=1
+VER=2.5.16
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
-CHKSUMS="sha256::b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616"
+CHKSUMS="sha256::05144040fedb828ced2a6bafa2c4a0479ee4cceacf3b6d68ccc75b175ac13b7e"
 CHKUPDATE="anitya::id=1215"

--- a/runtime-cryptography/libgpg-error/autobuild/defines
+++ b/runtime-cryptography/libgpg-error/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="glibc"
 PKGDES="Support library for GnuPG components"
 PKGPROV="libgpg-error-static"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-static'
     '--enable-install-gpg-error-config'

--- a/runtime-cryptography/libgpg-error/spec
+++ b/runtime-cryptography/libgpg-error/spec
@@ -1,5 +1,4 @@
-VER=1.51
-REL=2
+VER=1.58
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$VER.tar.bz2"
-CHKSUMS="sha256::be0f1b2db6b93eed55369cdf79f19f72750c8c7c39fc20b577e724545427e6b2"
+CHKSUMS="sha256::f943aea9a830a8bd938e5124b579efaece24a3225ff4c3d27611a80ce1260c27"
 CHKUPDATE="anitya::id=1628"

--- a/topics/gnupg-2.5.19.toml
+++ b/topics/gnupg-2.5.19.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "GnuPG 2.5.16"
+
+[caution]
+default = "Fixes a logic vulnerability (CVE-2025-68972, Severity: Medium) and a out-of-bounds write vulnerability (CVE-2025-68973, Severity: High)"
+zh_CN = "修复了一处逻辑漏洞（CVE-2025-68972，严重性：中等）和一处越界写入漏洞（CVE-2025-68973，严重性：高）"
+
+[packages-v2]
+"gnupg" = "< 2.5.16"


### PR DESCRIPTION
Topic Description
-----------------

- gnupg: update to 2.4.9
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gnupg: 2:2.4.9

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libgpg-error gnupg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
