### PR TITLE
iotop: update to 1.31

### DIFF
--- a/app-utils/iotop/autobuild/defines
+++ b/app-utils/iotop/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=iotop
 PKGSEC=utils
 PKGDEP="ncurses"
-PKGDES="A top-like utility for checking I/O load"
+PKGDES="Top-like utility for checking I/O load"
 PKGPROV="iotop-c"

--- a/app-utils/iotop/spec
+++ b/app-utils/iotop/spec
@@ -1,4 +1,4 @@
-VER=1.30
+VER=1.31
 SRCS="git::commit=tags/v$VER::https://github.com/Tomas-M/iotop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=259120"


### PR DESCRIPTION
Topic Description
-----------------

- iotop: update to 1.31
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iotop: 1.31

Security Update?
----------------

No

Build Order
-----------

```
#buildit iotop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
