### PR TITLE
mpd: update to 0.24.7

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,5 +1,4 @@
-VER=0.24.6
-REL=2
+VER=0.24.7
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
-CHKSUMS="sha256::8ce34a010577feb42999a96d867325c6d38bf7ae1b7a57f878d7e548c1fd1fa9"
+CHKSUMS="sha256::47c4f146f39a09979ca65d232063d7df566b101c5b36ca8895083f9f278b0460"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.24.7
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- mpd: 0.24.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
