### PR TITLE
busybox: add manpage install in beyond

### DIFF
--- a/app-utils/busybox/autobuild/beyond
+++ b/app-utils/busybox/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing man page ..."
+install -Dvm644 "$SRCDIR"/docs/busybox.1 \
+    "$PKGDIR"/usr/share/man/man1/busybox.1

--- a/app-utils/busybox/spec
+++ b/app-utils/busybox/spec
@@ -1,5 +1,5 @@
 VER=1.37.0
-REL=1
+REL=2
 SRCS="tbl::https://busybox.net/downloads/busybox-$VER.tar.bz2"
 CHKSUMS="sha256::3311dff32e746499f4df0d5df04d7eb396382d7e108bb9250e7b519b837043a4"
 CHKUPDATE="anitya::id=230"


### PR DESCRIPTION
Topic Description
-----------------

- busybox: add manpage install in beyond

Package(s) Affected
-------------------

- busybox: 1.37.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit busybox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
