### PR TITLE
mupdf: update to 1.27.0

### DIFF
--- a/app-doc/mupdf/autobuild/defines
+++ b/app-doc/mupdf/autobuild/defines
@@ -2,6 +2,4 @@ PKGNAME=mupdf
 PKGSEC=doc
 PKGDEP="curl desktop-file-utils freetype glu gumbo-parser jbig2dec \
         libjpeg-turbo mesa openjpeg openssl tesseract"
-PKGDES="An all-in-one PDF and XPS viewer"
-
-PKGEPOCH=1
+PKGDES="All-in-one PDF and XPS viewer"

--- a/app-doc/mupdf/spec
+++ b/app-doc/mupdf/spec
@@ -1,5 +1,5 @@
-VER=1.24.10
+VER=1.27.0
+EPOCH=1
 SRCS="git::commit=tags/$VER::https://github.com/ArtifexSoftware/mupdf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2034"
-REL=1

--- a/topics/mupdf-1.27.0.toml
+++ b/topics/mupdf-1.27.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "mupdf 1.27.0"
+
+[caution]
+default = "Fixes a denial of service vulnerability (CVE-2025-46206, Severity: Medium) and a null pointer dereference vulnerability (CVE-2025-55780, Severity: High)"
+zh_CN = "修复一处拒绝服务漏洞（CVE-2025-46206，严重性：中）和一处空指针解引用漏洞（CVE-2025-55780，严重性：高）"
+
+[packages-v2]
+"mupdf" = "< 1.27.0"


### PR DESCRIPTION
Topic Description
-----------------

- mupdf: update to 1.27.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- mupdf: 1:1.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mupdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
