### PR TITLE
vscode: update to 1.108.2

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.108.1
+VER=1.108.2
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::2d85644eb40afd2d8d3a7515c406a72e673afcb2ead39e7134b326f1a840bcb6"
-CHKSUMS__ARM64="sha256::d0f7ffb37a81666a49eb5200ed7bbe5b6432a670414e8b7528a553638c309cd8"
+CHKSUMS__AMD64="sha256::af054638b3f0638ad117f636d8ca559e0b310d69d9369365c7f631fe81e0e7d1"
+CHKSUMS__ARM64="sha256::848f3571c51c69533c263e5a774e9ef3b200dcc6a23c3be5bbbe291f9dabce6a"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.108.2
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.108.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
