### PR TITLE
zhaoxin-linux-graphics-driver: update to 21.00.86

### DIFF
--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,4 +1,4 @@
-From 12f4797c5e3f5cb96a3da9afe93d73c139970c30 Mon Sep 17 00:00:00 2001
+From 6065be81b4f240969e3f6850fd15ea96203db08c Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
 Subject: [PATCH 1/9] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,4 +1,4 @@
-From a6628ccaee3695b8c8df4f043c609397026caa75 Mon Sep 17 00:00:00 2001
+From f3c87195ce735171e6f6a487beab243e48475156 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
 Subject: [PATCH 2/9] chore: dkms: remove useless variables
@@ -11,12 +11,12 @@ Link: https://github.com/dkms-project/dkms/commit/961f9ceac4cf6772cb4c52bf4836a0
  1 file changed, 5 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 000017b..8c6ae33 100644
+index 10e3350..de2cefb 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,16 +1,12 @@
  PACKAGE_NAME="zx"
- PACKAGE_VERSION=21.00.85
+ PACKAGE_VERSION=21.00.86
  AUTOINSTALL="yes"
 -#REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,4 +1,4 @@
-From 59672e9c71a871279984dc6ad59e59b4205d75e8 Mon Sep 17 00:00:00 2001
+From ff9194d472e29eefd5b1a0c440f81947f5b1d7db Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
 Subject: [PATCH 3/9] fix: kernel: 6.15

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,4 +1,4 @@
-From 44383d6bdf35362f9a9cb27d9537c3301552c647 Mon Sep 17 00:00:00 2001
+From 74abbff6fd42b951de65daaee59716f2f4f3422d Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
 Subject: [PATCH 4/9] fix: kernel: 6.16

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,4 +1,4 @@
-From 8bbb635412687794c194c6b38d5ea6d8ddd36863 Mon Sep 17 00:00:00 2001
+From dd71d8af6ed71866597ea70073c4b5175a82737b Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
 Subject: [PATCH 5/9] fix: kernel: 6.17

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,4 +1,4 @@
-From 88425e26b73c9cd452106ad70921e26c90f32161 Mon Sep 17 00:00:00 2001
+From 0f6cf34ca0dae84d1a4fb384a1589c789117fc1b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
 Subject: [PATCH 6/9] fix: kernel: 6.18

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,4 +1,4 @@
-From d07cadc3062edd9fba0c6cb547158933b584b2b4 Mon Sep 17 00:00:00 2001
+From 685add8c5611e324d78d731233c26c58e398f8b0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:34 +0800
 Subject: [PATCH 7/9] chore: import .gitignore from loonggpu-kernel-dkms

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,4 +1,4 @@
-From 6ebf2c2c607bc515265e8bf52f6c17b9a43239b7 Mon Sep 17 00:00:00 2001
+From 4d190581c59c17c54450e383d0a0c541e3409b3e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:48 +0800
 Subject: [PATCH 8/9] refactor (NFC): rename zxfb_create to zx_fbdev_probe

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,4 +1,4 @@
-From 566318b3fd7600e3f717de6a7dc1c459f0123301 Mon Sep 17 00:00:00 2001
+From 1f2895b78cf6bc047e636f2191d1dae716e2bc4f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 19:07:04 +0800
 Subject: [PATCH 9/9] fix: run DRM default client setup on Linux >= 6.15

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,6 +1,6 @@
-UPSTREAM_VER=21.00.85
+UPSTREAM_VER=21.00.86
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
-SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=2509&tag=0&ref=qdxz&pre=0&t=eecb7eac5d344b6d"
-CHKSUMS="sha256::8b96c1fa103350ccc4c74dd02ab516890b085c2c607927cf1e85b5c736566ac2"
+SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=2509&tag=0&ref=qdxz&pre=0&t=eecb7eac5d344b6d&__for_acbs_hash_url=$UPSTREAM_VER"
+CHKSUMS="sha256::0c0ce66b412dd0f6be6c3a9ed6da168e4ab6fbf64ff127d6bec774f393379cb4"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- zhaoxin-linux-graphics-driver: update to 21.00.86
    Track DKMS patches at AOSC-Tracking/zx-kernel-dkms @ aosc/v21.00.86
    \(HEAD: 1f2895b78cf6bc047e636f2191d1dae716e2bc4f\)

Package(s) Affected
-------------------

- zhaoxin-linux-graphics-driver-dri: 21.00.86

Security Update?
----------------

No

Build Order
-----------

```
#buildit zhaoxin-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
