### PR TITLE
libpano13: update to 2.9.23

### DIFF
--- a/runtime-imaging/libpano13/autobuild/defines
+++ b/runtime-imaging/libpano13/autobuild/defines
@@ -1,9 +1,6 @@
 PKGNAME=libpano13
 PKGSEC=libs
-PKGDEP="libpng libtiff"
-BUILDDEP="cmake"
-PKGDES="Library for manipulating panoramic images"
+PKGDEP="libjpeg-turbo libpng libtiff zlib"
+PKGDES="Library and utilities to manipulate panoramic images"
 
-ABTYPE="cmake"
-CMAKE_AFTER="-DSUPPORT_JAVA_PROGRAMS=0"
-ABSHADOW=no
+ABTYPE=cmakeninja

--- a/runtime-imaging/libpano13/autobuild/prepare
+++ b/runtime-imaging/libpano13/autobuild/prepare
@@ -1,1 +1,0 @@
-export CFLAGS="${CFLAGS} -lm"

--- a/runtime-imaging/libpano13/spec
+++ b/runtime-imaging/libpano13/spec
@@ -1,5 +1,4 @@
-VER=2.9.19
-REL=1
-SRCS="tbl::https://sourceforge.net/projects/panotools/files/libpano13/libpano13-$VER/libpano13-$VER.tar.gz"
-CHKSUMS="sha256::037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8"
+VER=2.9.23
+SRCS="tbl::https://sourceforge.net/projects/panotools/files/libpano13/libpano13-$VER/libpano13-$VER.tar.gz/download"
+CHKSUMS="sha256::e7c076d37a14c39434962115e47ddbe18452ca3de5ce40e2aaefa7cf5815ea28"
 CHKUPDATE="anitya::id=230121"


### PR DESCRIPTION
Topic Description
-----------------

- libpano13: update to 2.9.23
    - This version fixes build with GCC 15.
    - Clean up dependencies, options, and hacks.

Package(s) Affected
-------------------

- libpano13: 2.9.23

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpano13
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
