### PR TITLE
box64: update to 0.4.0+git20260125

### DIFF
--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,5 +1,5 @@
-VER=0.4.0
+VER=0.4.0+git20260125
 # Note: copy-repo is required for "box64 -v" to show the commit hash
-SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ptitSeb/box64.git"
+SRCS="git::commit=0eb0f9decb0b7e560005b30c11e019f18805eec2;copy-repo=true::https://github.com/ptitSeb/box64.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368953"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.4.0+git20260125

Package(s) Affected
-------------------

- box64: 0.4.0+git20260125

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
