### PR TITLE
pulseaudio: drop gconf dep

### DIFF
--- a/app-multimedia/pulseaudio/autobuild/defines
+++ b/app-multimedia/pulseaudio/autobuild/defines
@@ -1,21 +1,19 @@
 PKGNAME=pulseaudio
 PKGSEC=sound
-PKGDEP="attr avahi bluez dbus fftw json-c libtool soxr orc \
-        rtkit sbc speex tdb webrtc-audio-processing jack libasyncns \
-        libsndfile openssl systemd libsamplerate gconf lirc
-        libfdk-aac ffmpeg libldac"
+PKGDEP="attr avahi bluez dbus fftw json-c libtool soxr orc rtkit sbc \
+        speex tdb webrtc-audio-processing jack libasyncns libsndfile \
+        openssl systemd libsamplerate lirc libfdk-aac ffmpeg libldac"
 PKGSUG="alsa-plugins"
-BUILDDEP="check intltool doxygen pulseaudio"
-PKGDES="A full featured, general-purpose sound server"
+BUILDDEP="check intltool pulseaudio"
+PKGDES="General-purpose sound server"
 
 MESON_AFTER=(
-	"-Ddoxygen=false"
-	"-Dudevrulesdir=/usr/lib/udev/rules.d"
-        "-Dtcpwrap=disabled"
+    '-Ddoxygen=false'
+    '-Dudevrulesdir=/usr/lib/udev/rules.d'
+    '-Dtcpwrap=disabled'
 )
 
 PKGREP="pulseaudio-modules-bt"
 PKGBREAK="pulseaudio-modules-bt"
 # Note: Extra Provides for Spiral (Debian compatibility).
 PKGPROV="pulseaudio-utils_spiral"
-NOLTO=1

--- a/app-multimedia/pulseaudio/autobuild/defines.stage2
+++ b/app-multimedia/pulseaudio/autobuild/defines.stage2
@@ -1,16 +1,17 @@
 PKGNAME=pulseaudio
 PKGSEC=sound
-PKGDEP="attr avahi bluez dbus fftw json-c libtool soxr orc \
-        rtkit sbc speex tdb webrtc-audio-processing jack libasyncns \
-        libsndfile openssl systemd libsamplerate gconf lirc
-        libfdk-aac libldac"
+PKGDEP="attr avahi bluez dbus fftw json-c libtool soxr orc rtkit sbc \
+        speex tdb webrtc-audio-processing jack libasyncns libsndfile \
+        openssl systemd libsamplerate lirc libfdk-aac libldac"
 PKGSUG="alsa-plugins"
 # doxygen is available in stage 2 before building this
 BUILDDEP="check intltool doxygen"
-PKGDES="A full featured, general-purpose sound server"
+PKGDES="General-purpose sound server"
 
-MESON_AFTER="-D udevrulesdir=/usr/lib/udev/rules.d \
-             -D tcpwrap=disabled"
+MESON_AFTER=(
+    '-Dudevrulesdir=/usr/lib/udev/rules.d'
+    '-Dtcpwrap=disabled'
+)
+
 PKGREP="pulseaudio-modules-bt"
 PKGBREAK="pulseaudio-modules-bt"
-NOLTO=1

--- a/app-multimedia/pulseaudio/spec
+++ b/app-multimedia/pulseaudio/spec
@@ -1,7 +1,7 @@
 UPSTREAM_VER=17.0
 XRDP_VER=0.7
 VER=${UPSTREAM_VER}+xrdp${XRDP_VER}
-REL=4
+REL=5
 SRCS="tbl::https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${UPSTREAM_VER}.tar.xz \
       git::commit=tags/v${XRDP_VER};rename=pulseaudio-module-xrdp::https://github.com/neutrinolabs/pulseaudio-module-xrdp"
 CHKSUMS="sha256::053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5


### PR DESCRIPTION
Topic Description
-----------------

- pulseaudio: drop gconf dep
    This should expell gconf from a standard installation.

Package(s) Affected
-------------------

- pulseaudio: 17.0+xrdp0.7-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit pulseaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
