### PR TITLE
clash-verge-rev: update to 2.4.5

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From 55569ddb97af6b11c0c3e154aa7ca7462c5fe5a0 Mon Sep 17 00:00:00 2001
+From 5e562e4b9c5ebc69f420009a2b2dfc0aa191a638 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
@@ -9,11 +9,11 @@ Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
  2 files changed, 2 insertions(+), 32 deletions(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 4a50c259..bbb69bc6 100755
+index be6947a7..c5e4886e 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -2,7 +2,7 @@
-   "version": "2.4.4",
+   "version": "2.4.5",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,
@@ -22,7 +22,7 @@ index 4a50c259..bbb69bc6 100755
      "icon": [
        "icons/32x32.png",
 diff --git a/src-tauri/tauri.linux.conf.json b/src-tauri/tauri.linux.conf.json
-index 0d5c0de3..318d0af8 100644
+index 865747be..318d0af8 100644
 --- a/src-tauri/tauri.linux.conf.json
 +++ b/src-tauri/tauri.linux.conf.json
 @@ -1,34 +1,4 @@
@@ -33,7 +33,7 @@ index 0d5c0de3..318d0af8 100644
 -    "targets": ["deb", "rpm"],
 -    "linux": {
 -      "deb": {
--        "depends": ["openssl"],
+-        "depends": ["openssl", "libayatana-appindicator3-1"],
 -        "desktopTemplate": "./packages/linux/clash-verge.desktop",
 -        "provides": ["clash-verge"],
 -        "conflicts": ["clash-verge"],
@@ -42,7 +42,7 @@ index 0d5c0de3..318d0af8 100644
 -        "preRemoveScript": "./packages/linux/pre-remove.sh"
 -      },
 -      "rpm": {
--        "depends": ["openssl"],
+-        "depends": ["openssl", "libayatana-appindicator-gtk3"],
 -        "desktopTemplate": "./packages/linux/clash-verge.desktop",
 -        "provides": ["clash-verge"],
 -        "conflicts": ["clash-verge"],

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
@@ -1,4 +1,4 @@
-From 9804bdd9269a621be9ebf19a22aa4cd9e019efc9 Mon Sep 17 00:00:00 2001
+From f5bebfc75190eed4f771be9fdd997fc6c87c60ef Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 02/13] feat: drop mihomo-alpha support

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
@@ -1,4 +1,4 @@
-From dde41ed035887d30b66ea24e118efbfe4460dce4 Mon Sep 17 00:00:00 2001
+From 0f636cd1ac086c5eaea573b782e5aef91299134f Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
@@ -32,7 +32,7 @@ index 7325d571..a3c5e775 100644
    { name: "service", func: resolveService, retry: 5 },
    { name: "install", func: resolveInstall, retry: 5 },
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index bbb69bc6..e8be2209 100755
+index c5e4886e..6727b3a3 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -13,7 +13,6 @@

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
@@ -1,4 +1,4 @@
-From 0648361722d5475980b8c54614fb27a5a96e5498 Mon Sep 17 00:00:00 2001
+From 1fc7bc121d7c08eba9cf08986f0bdc0bbf8717be Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 04/13] Drop check update feature and update checker component
@@ -8,19 +8,19 @@ Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  src/components/home/system-info-card.tsx      |  65 -------
  src/components/layout/update-button.tsx       |  49 -----
- src/components/setting/mods/update-viewer.tsx | 170 ------------------
+ src/components/setting/mods/update-viewer.tsx | 172 ------------------
  .../setting/setting-verge-advanced.tsx        |  27 +--
  .../setting/setting-verge-basic.tsx           |   3 -
- src/pages/_layout.tsx                         |   2 -
- 6 files changed, 1 insertion(+), 315 deletions(-)
+ src/pages/_layout.tsx                         |   1 -
+ 6 files changed, 1 insertion(+), 316 deletions(-)
  delete mode 100644 src/components/layout/update-button.tsx
  delete mode 100644 src/components/setting/mods/update-viewer.tsx
 
 diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
-index 4ec5f3b1..90689f9f 100644
+index 4fd2fb3e..a4a33507 100644
 --- a/src/components/home/system-info-card.tsx
 +++ b/src/components/home/system-info-card.tsx
-@@ -91,36 +91,6 @@ export const SystemInfoCard = () => {
+@@ -83,36 +83,6 @@ export const SystemInfoCard = () => {
          }
        })
        .catch(console.error);
@@ -57,7 +57,7 @@ index 4ec5f3b1..90689f9f 100644
      return () => {
        if (timeoutId !== undefined) {
          window.clearTimeout(timeoutId);
-@@ -169,23 +139,6 @@ export const SystemInfoCard = () => {
+@@ -161,23 +131,6 @@ export const SystemInfoCard = () => {
      }
    }, [isSidecarMode, isAdminMode, installServiceAndRestartCore]);
  
@@ -81,7 +81,7 @@ index 4ec5f3b1..90689f9f 100644
    // 是否启用自启动
    const autoLaunchEnabled = useMemo(
      () => verge?.enable_auto_launch || false,
-@@ -344,24 +297,6 @@ export const SystemInfoCard = () => {
+@@ -329,24 +282,6 @@ export const SystemInfoCard = () => {
            </Typography>
          </Stack>
          <Divider />
@@ -108,7 +108,7 @@ index 4ec5f3b1..90689f9f 100644
              {t("home.components.systemInfo.fields.vergeVersion")}
 diff --git a/src/components/layout/update-button.tsx b/src/components/layout/update-button.tsx
 deleted file mode 100644
-index d5c8b4ff..00000000
+index 21da3035..00000000
 --- a/src/components/layout/update-button.tsx
 +++ /dev/null
 @@ -1,49 +0,0 @@
@@ -116,10 +116,10 @@ index d5c8b4ff..00000000
 -import { useRef } from "react";
 -import useSWR from "swr";
 -
+-import { DialogRef } from "@/components/base";
 -import { useVerge } from "@/hooks/use-verge";
 -import { checkUpdateSafe } from "@/services/update";
 -
--import { DialogRef } from "../base";
 -import { UpdateViewer } from "../setting/mods/update-viewer";
 -
 -interface Props {
@@ -163,10 +163,10 @@ index d5c8b4ff..00000000
 -};
 diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
 deleted file mode 100644
-index 95e22c4f..00000000
+index 639b7ad8..00000000
 --- a/src/components/setting/mods/update-viewer.tsx
 +++ /dev/null
-@@ -1,170 +0,0 @@
+@@ -1,172 +0,0 @@
 -import { Box, Button, LinearProgress } from "@mui/material";
 -import { relaunch } from "@tauri-apps/plugin-process";
 -import { open as openUrl } from "@tauri-apps/plugin-shell";
@@ -176,6 +176,7 @@ index 95e22c4f..00000000
 -import { useImperativeHandle, useMemo, useRef, useState } from "react";
 -import { useTranslation } from "react-i18next";
 -import ReactMarkdown from "react-markdown";
+-import rehypeRaw from "rehype-raw";
 -import useSWR from "swr";
 -
 -import { BaseDialog, DialogRef } from "@/components/base";
@@ -313,6 +314,7 @@ index 95e22c4f..00000000
 -    >
 -      <Box sx={{ height: "calc(100% - 10px)", overflow: "auto" }}>
 -        <ReactMarkdown
+-          rehypePlugins={[rehypeRaw]}
 -          components={{
 -            a: ({ ...props }) => {
 -              const { children } = props;
@@ -338,10 +340,10 @@ index 95e22c4f..00000000
 -  );
 -}
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index fa214677..4f851077 100644
+index 43f95e32..42df5263 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -25,7 +25,6 @@ import { LiteModeViewer } from "./mods/lite-mode-viewer";
+@@ -24,7 +24,6 @@ import { LiteModeViewer } from "./mods/lite-mode-viewer";
  import { MiscViewer } from "./mods/misc-viewer";
  import { SettingItem, SettingList } from "./mods/setting-comp";
  import { ThemeViewer } from "./mods/theme-viewer";
@@ -349,7 +351,7 @@ index fa214677..4f851077 100644
  
  interface Props {
    onError?: (err: Error) => void;
-@@ -39,24 +38,9 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -38,24 +37,9 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
@@ -374,7 +376,7 @@ index fa214677..4f851077 100644
  
    const onExportDiagnosticInfo = useCallback(async () => {
      await exportDiagnosticInfo();
-@@ -82,7 +66,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -81,7 +65,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -382,7 +384,7 @@ index fa214677..4f851077 100644
        <BackupViewer ref={backupRef} />
        <LiteModeViewer ref={liteModeRef} />
  
-@@ -118,15 +101,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -117,15 +100,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          label={t("settings.components.verge.advanced.fields.openCoreDir")}
        />
  
@@ -400,10 +402,10 @@ index fa214677..4f851077 100644
        <SettingItem
          onClick={openDevTools}
 diff --git a/src/components/setting/setting-verge-basic.tsx b/src/components/setting/setting-verge-basic.tsx
-index b298548d..1a7621bb 100644
+index ab516d31..7a0d52d3 100644
 --- a/src/components/setting/setting-verge-basic.tsx
 +++ b/src/components/setting/setting-verge-basic.tsx
-@@ -22,7 +22,6 @@ import { MiscViewer } from "./mods/misc-viewer";
+@@ -21,7 +21,6 @@ import { MiscViewer } from "./mods/misc-viewer";
  import { SettingItem, SettingList } from "./mods/setting-comp";
  import { ThemeModeSwitch } from "./mods/theme-mode-switch";
  import { ThemeViewer } from "./mods/theme-viewer";
@@ -411,7 +413,7 @@ index b298548d..1a7621bb 100644
  
  interface Props {
    onError?: (err: Error) => void;
-@@ -67,7 +66,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
+@@ -66,7 +65,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
@@ -419,7 +421,7 @@ index b298548d..1a7621bb 100644
    const backupRef = useRef<DialogRef>(null);
  
    const onChangeData = (patch: any) => {
-@@ -89,7 +87,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
+@@ -88,7 +86,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -428,18 +430,10 @@ index b298548d..1a7621bb 100644
  
        <SettingItem label={t("settings.components.verge.basic.fields.language")}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index a5ea23cc..2c5d20d0 100644
+index 9ba2576f..ddbeab0a 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -37,7 +37,6 @@ import { NoticeManager } from "@/components/base/NoticeManager";
- import { WindowControls } from "@/components/controller/window-controller";
- import { LayoutItem } from "@/components/layout/layout-item";
- import { LayoutTraffic } from "@/components/layout/layout-traffic";
--import { UpdateButton } from "@/components/layout/update-button";
- import { useCustomTheme } from "@/components/layout/use-custom-theme";
- import { useI18n } from "@/hooks/use-i18n";
- import { useVerge } from "@/hooks/use-verge";
-@@ -335,7 +334,6 @@ const Layout = () => {
+@@ -353,7 +353,6 @@ const Layout = () => {
                    />
                    <LogoSvg fill={isDark ? "white" : "black"} />
                  </div>

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From afa1cfab6fb7316e0ddd4bfd2c14eafce522269b Mon Sep 17 00:00:00 2001
+From 38a20d4e27e9a5ca9114bfb41f3e837cdf7ed136 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 05/13] Set core binary name as mihomo
@@ -9,10 +9,10 @@ Co-authored-by: eatradish <sakiiily@aosc.io>
  scripts/portable.mjs                          |  7 +++---
  scripts/prebuild.mjs                          |  8 +++----
  src-tauri/packages/windows/installer.nsi      | 24 +++++++++----------
- src-tauri/src/config/verge.rs                 | 14 +++++------
+ src-tauri/src/config/verge.rs                 | 12 +++++-----
  src-tauri/src/enhance/chain.rs                |  2 +-
  .../setting/mods/clash-core-viewer.tsx        |  4 ++--
- 7 files changed, 32 insertions(+), 31 deletions(-)
+ 7 files changed, 31 insertions(+), 30 deletions(-)
 
 diff --git a/scripts/portable-fixed-webview2.mjs b/scripts/portable-fixed-webview2.mjs
 index 1a62be3f..911befb1 100644
@@ -126,10 +126,10 @@ index e6fc4940..f2469ee6 100644
    ${EndIf}
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index ad43af33..84bb4bd4 100644
+index ec03457f..ecb96351 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
-@@ -266,7 +266,7 @@ pub struct IVergeTheme {
+@@ -279,7 +279,7 @@ pub struct IVergeTheme {
  
  impl IVerge {
      /// 有效的clash核心名称
@@ -138,7 +138,7 @@ index ad43af33..84bb4bd4 100644
  
      /// 验证并修正配置文件中的clash_core值
      pub async fn validate_and_fix_config() -> Result<()> {
-@@ -284,19 +284,19 @@ impl IVerge {
+@@ -297,19 +297,19 @@ impl IVerge {
                  logging!(
                      warn,
                      Type::Config,
@@ -162,22 +162,13 @@ index ad43af33..84bb4bd4 100644
              needs_fix = true;
          }
  
-@@ -333,7 +333,7 @@ impl IVerge {
-     }
- 
-     pub fn get_valid_clash_core(&self) -> String {
--        self.clash_core.clone().unwrap_or_else(|| "verge-mihomo".into())
-+        self.clash_core.clone().unwrap_or_else(|| "mihomo".into())
-     }
- 
-     fn get_system_language() -> String {
 @@ -377,7 +377,7 @@ impl IVerge {
          Self {
              app_log_max_size: Some(128),
              app_log_max_count: Some(8),
 -            clash_core: Some("verge-mihomo".into()),
 +            clash_core: Some("mihomo".into()),
-             language: Some(Self::get_system_language()),
+             language: Some(clash_verge_i18n::system_language().into()),
              theme_mode: Some("system".into()),
              #[cfg(not(target_os = "windows"))]
 diff --git a/src-tauri/src/enhance/chain.rs b/src-tauri/src/enhance/chain.rs

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From 744a6dd979b90148fac7db9168a190354b496ec9 Mon Sep 17 00:00:00 2001
+From ee515006bbe7baf54d09ec2f02d1c9e28a4e61ee Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 06/13] feat: always not portable

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,23 +1,20 @@
-From ceaf3e36d3f108307e876230ef60312722cd5b26 Mon Sep 17 00:00:00 2001
+From cabba387c81d0fde4a691206d9b5e84b1337a08f Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 07/13] Set service install/uninstall script path to
  /usr/libexec
 
 ---
- src-tauri/src/core/service.rs | 13 ++++++++-----
- 1 file changed, 8 insertions(+), 5 deletions(-)
+ src-tauri/src/core/service.rs | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 1974473d..8dd9cea4 100644
+index df07e83d..7c01a55f 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -113,10 +113,12 @@ async fn reinstall_service() -> Result<()> {
- 
- #[allow(clippy::unused_async)]
+@@ -94,8 +94,10 @@ fn install_service() -> Result<()> {
  #[cfg(target_os = "linux")]
--async fn uninstall_service() -> Result<()> {
-+pub async fn uninstall_service() -> Result<()> {
+ fn uninstall_service() -> Result<()> {
      logging!(info, Type::Service, "uninstall service");
 +    use std::path::Path;
  
@@ -27,13 +24,9 @@ index 1974473d..8dd9cea4 100644
  
      if !uninstall_path.exists() {
          bail!(format!("uninstaller not found: {uninstall_path:?}"));
-@@ -169,11 +171,12 @@ async fn uninstall_service() -> Result<()> {
- }
- 
+@@ -150,8 +152,10 @@ fn uninstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
--#[allow(clippy::unused_async)]
--async fn install_service() -> Result<()> {
-+pub async fn install_service() -> Result<()> {
+ fn install_service() -> Result<()> {
      logging!(info, Type::Service, "install service");
 +    use std::path::Path;
  

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From 06362ad70d01a7886ffa42ced3577d5a5819731f Mon Sep 17 00:00:00 2001
+From 48a76263e29f6e1a5f697f570c2df99ddd21f4d4 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 08/13] Do not use gcc

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
@@ -1,4 +1,4 @@
-From 45ececffcabebb68d1bd762f14e5b836d153b8a0 Mon Sep 17 00:00:00 2001
+From cbda33e7010c87953679633392aeaaaeb51388cc Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 09/13] Drop "Upgrade core" button
@@ -6,7 +6,8 @@ Subject: [PATCH 09/13] Drop "Upgrade core" button
 ---
  .../setting/mods/clash-core-viewer.tsx        | 30 -------------------
  .../setting/setting-verge-advanced.tsx        |  2 +-
- 2 files changed, 1 insertion(+), 31 deletions(-)
+ src/pages/_layout.tsx                         |  1 -
+ 3 files changed, 1 insertion(+), 32 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
 index ba6d6fb5..14e5b148 100644
@@ -57,10 +58,10 @@ index ba6d6fb5..14e5b148 100644
                variant="contained"
                size="small"
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 4f851077..ced5b782 100644
+index 42df5263..42bd9c8c 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -101,7 +101,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -100,7 +100,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          label={t("settings.components.verge.advanced.fields.openCoreDir")}
        />
  
@@ -69,6 +70,18 @@ index 4f851077..ced5b782 100644
  
        <SettingItem
          onClick={openDevTools}
+diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
+index ddbeab0a..6ef43b3c 100644
+--- a/src/pages/_layout.tsx
++++ b/src/pages/_layout.tsx
+@@ -36,7 +36,6 @@ import { BaseErrorBoundary } from "@/components/base";
+ import { LayoutItem } from "@/components/layout/layout-item";
+ import { LayoutTraffic } from "@/components/layout/layout-traffic";
+ import { NoticeManager } from "@/components/layout/notice-manager";
+-import { UpdateButton } from "@/components/layout/update-button";
+ import { WindowControls } from "@/components/layout/window-controller";
+ import { useI18n } from "@/hooks/use-i18n";
+ import { useVerge } from "@/hooks/use-verge";
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
@@ -1,4 +1,4 @@
-From 6f8b70699941da1fc543b4f99344a3e8ce329a89 Mon Sep 17 00:00:00 2001
+From e7d666307947745ad1d2a305f8db1c97d66a869b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 10/13] fix: drop Open Core Dir function
@@ -33,10 +33,10 @@ index 9a2fe39a..b60f95aa 100644
  #[tauri::command]
  pub async fn open_logs_dir() -> CmdResult<()> {
 diff --git a/src-tauri/src/core/tray/menu_def.rs b/src-tauri/src/core/tray/menu_def.rs
-index 24a488fd..0f10b63e 100644
+index 720bd0a8..95ca1b24 100644
 --- a/src-tauri/src/core/tray/menu_def.rs
 +++ b/src-tauri/src/core/tray/menu_def.rs
-@@ -45,7 +45,6 @@ define_menu! {
+@@ -38,7 +38,6 @@ define_menu! {
      lightweight_mode => LIGHTWEIGHT_MODE, "tray_lightweight_mode", "tray.lightweightMode",
      copy_env => COPY_ENV, "tray_copy_env", "tray.copyEnv",
      conf_dir => CONF_DIR, "tray_conf_dir", "tray.confDir",
@@ -45,10 +45,10 @@ index 24a488fd..0f10b63e 100644
      open_dir => OPEN_DIR, "tray_open_dir", "tray.openDir",
      app_log => APP_LOG, "tray_app_log", "tray.appLog",
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index ea289117..e92c94a5 100644
+index 54bf4978..399a208a 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
-@@ -893,8 +893,6 @@ async fn create_tray_menu(
+@@ -831,8 +831,6 @@ async fn create_tray_menu(
  
      let open_app_dir = &MenuItem::with_id(app_handle, MenuIds::CONF_DIR, &texts.conf_dir, true, None::<&str>)?;
  
@@ -57,7 +57,7 @@ index ea289117..e92c94a5 100644
      let open_logs_dir = &MenuItem::with_id(app_handle, MenuIds::LOGS_DIR, &texts.logs_dir, true, None::<&str>)?;
  
      let open_app_log = &MenuItem::with_id(app_handle, MenuIds::APP_LOG, &texts.app_log, true, None::<&str>)?;
-@@ -906,7 +904,7 @@ async fn create_tray_menu(
+@@ -844,7 +842,7 @@ async fn create_tray_menu(
          MenuIds::OPEN_DIR,
          &texts.open_dir,
          true,
@@ -66,8 +66,8 @@ index ea289117..e92c94a5 100644
      )?;
  
      let restart_clash = &MenuItem::with_id(
-@@ -1008,9 +1006,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
-                 println!("Open directory submenu clicked");
+@@ -955,9 +953,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+             MenuIds::CONF_DIR => {
                  let _ = cmd::open_app_dir().await;
              }
 -            MenuIds::CORE_DIR => {
@@ -77,10 +77,10 @@ index ea289117..e92c94a5 100644
                  let _ = cmd::open_logs_dir().await;
              }
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 42d33c9e..4107cb9a 100644
+index 1752992c..f2a14eff 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -142,7 +142,6 @@ mod app_init {
+@@ -139,7 +139,6 @@ mod app_init {
              cmd::open_app_dir,
              cmd::open_logs_dir,
              cmd::open_web_url,
@@ -89,10 +89,10 @@ index 42d33c9e..4107cb9a 100644
              cmd::open_core_log,
              cmd::get_portable_flag,
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index ced5b782..7333681d 100644
+index 42bd9c8c..c2f420f1 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -9,7 +9,6 @@ import {
+@@ -8,7 +8,6 @@ import {
    exitApp,
    exportDiagnosticInfo,
    openAppDir,
@@ -100,7 +100,7 @@ index ced5b782..7333681d 100644
    openDevTools,
    openLogsDir,
  } from "@/services/cmds";
-@@ -96,11 +95,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -95,11 +94,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          }
        />
  
@@ -113,7 +113,7 @@ index ced5b782..7333681d 100644
  
        <SettingItem
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index 1c227acf..5ea754a7 100644
+index a56af439..e747cc84 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
 @@ -318,10 +318,6 @@ export async function openAppDir() {

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
@@ -1,4 +1,4 @@
-From 0252651095dfd22479c0810b863d744b4b97dcf7 Mon Sep 17 00:00:00 2001
+From 2036caf6404f2fe572629fd308b72ef69792f256 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 11/13] fix: disable GeoData update
@@ -49,10 +49,10 @@ index 7ab56423..b0e945e4 100644
      name: "enableLoopback",
      func: resolveEnableLoopback,
 diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
-index ff182f72..666511e9 100644
+index 3eed3a62..1e02e81f 100644
 --- a/src/components/setting/setting-clash.tsx
 +++ b/src/components/setting/setting-clash.tsx
-@@ -65,14 +65,7 @@ const SettingClash = ({ onError }: Props) => {
+@@ -64,14 +64,7 @@ const SettingClash = ({ onError }: Props) => {
      mutateClash((old) => ({ ...old!, ...patch }), false);
    };
    const onUpdateGeo = async () => {
@@ -68,7 +68,7 @@ index ff182f72..666511e9 100644
    };
  
    // 实现DNS设置开关处理函数
-@@ -279,10 +272,6 @@ const SettingClash = ({ onError }: Props) => {
+@@ -278,10 +271,6 @@ const SettingClash = ({ onError }: Props) => {
          />
        )}
  

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From 7acb0dd210b748be99b85216469cc50667ed2dc4 Mon Sep 17 00:00:00 2001
+From 43db5ea470d00baeb14e57cd91667f4df2b5be5b Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 12/13] Do not sidecar mihomo program
@@ -9,11 +9,11 @@ Subject: [PATCH 12/13] Do not sidecar mihomo program
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/manager/state.rs b/src-tauri/src/core/manager/state.rs
-index e2c9e230..5b88ae69 100644
+index 14668184..f2b8b027 100644
 --- a/src-tauri/src/core/manager/state.rs
 +++ b/src-tauri/src/core/manager/state.rs
-@@ -33,7 +33,7 @@ impl CoreManager {
- 
+@@ -34,7 +34,7 @@ impl CoreManager {
+         let previous_mask = unsafe { tauri_plugin_clash_verge_sysinfo::libc::umask(0o007) };
          let (mut rx, child) = app_handle
              .shell()
 -            .sidecar(clash_core.as_str())?

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
@@ -1,4 +1,4 @@
-From cbabddaf1cae3a6cbda11244ffb68e73478748ee Mon Sep 17 00:00:00 2001
+From c04a13a50f12ce48272de10fb3284818ff8909dc Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Sun, 9 Nov 2025 19:15:18 +0800
 Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
@@ -6,17 +6,17 @@ Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
 Signed-off-by: stydxm <stydxm@outlook.com>
 ---
  Cargo.lock           | 11 -----------
- package.json         | 15 +++++----------
+ package.json         | 13 ++++---------
  scripts/prebuild.mjs |  6 ++++--
  src-tauri/Cargo.toml |  2 +-
  vite.config.mts      |  2 +-
- 5 files changed, 11 insertions(+), 25 deletions(-)
+ 5 files changed, 10 insertions(+), 24 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 7581e385..e9b8ab6f 100644
+index 10804f5c..8d181c98 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -783,7 +783,6 @@ dependencies = [
+@@ -706,7 +706,6 @@ dependencies = [
   "dashmap 6.1.0",
   "dynify",
   "fast-float2",
@@ -24,8 +24,8 @@ index 7581e385..e9b8ab6f 100644
   "futures-channel",
   "futures-concurrency",
   "futures-lite 2.6.1",
-@@ -2519,16 +2518,6 @@ dependencies = [
-  "thiserror 2.0.17",
+@@ -2441,16 +2440,6 @@ dependencies = [
+  "thiserror 2.0.18",
  ]
  
 -[[package]]
@@ -42,11 +42,11 @@ index 7581e385..e9b8ab6f 100644
  name = "fnv"
  version = "1.0.7"
 diff --git a/package.json b/package.json
-index 09318b7a..21000939 100644
+index 6af9d566..632d3884 100644
 --- a/package.json
 +++ b/package.json
-@@ -86,7 +86,7 @@
-     "@types/react": "19.2.7",
+@@ -88,7 +88,7 @@
+     "@types/react": "19.2.8",
      "@types/react-dom": "19.2.3",
      "@vitejs/plugin-legacy": "^7.2.1",
 -    "@vitejs/plugin-react-swc": "^4.2.2",
@@ -54,12 +54,9 @@ index 09318b7a..21000939 100644
      "adm-zip": "^0.5.16",
      "cli-color": "^2.0.4",
      "commander": "^14.0.2",
-@@ -125,15 +125,10 @@
-     ]
-   },
+@@ -130,13 +130,8 @@
    "type": "module",
--  "packageManager": "pnpm@10.26.1",
-+  "packageManager": "pnpm@9.13.2",
+   "packageManager": "pnpm@10.28.0",
    "pnpm": {
 -    "onlyBuiltDependencies": [
 -      "@parcel/watcher",
@@ -99,18 +96,18 @@ index b0e945e4..e63da21a 100644
  
  // =======================
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index f49420a4..00c1e573 100755
+index e7485a09..e3153a9d 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -59,7 +59,7 @@ open = "5.3.3"
+@@ -60,7 +60,7 @@ open = "5.3.3"
  dunce = "1.0.5"
  nanoid = "0.4"
- chrono = "0.4.42"
+ chrono = "0.4.43"
 -boa_engine = "0.21.0"
 +boa_engine = { version = "0.21.0", features = ["xsum"], default-features = false }
  once_cell = { version = "1.21.3", features = ["parking_lot"] }
- port_scanner = "0.1.5"
  delay_timer = "0.11.6"
+ percent-encoding = "2.3.2"
 diff --git a/vite.config.mts b/vite.config.mts
 index a5ef33af..3fc10b22 100644
 --- a/vite.config.mts

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=2.4.4
+VER=2.4.5
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"

--- a/app-proxy/clash-verge-service-ipc/autobuild/postinst
+++ b/app-proxy/clash-verge-service-ipc/autobuild/postinst
@@ -3,5 +3,5 @@ if systemctl is-active --quiet clash-verge-service; then
     echo "Restarting service..."
     systemctl try-restart clash-verge-service
 else
-    echo "Service is not running."
+    echo "Service is not running, skip restart."
 fi

--- a/app-proxy/clash-verge-service-ipc/autobuild/preinst
+++ b/app-proxy/clash-verge-service-ipc/autobuild/preinst
@@ -1,0 +1,10 @@
+if systemctl is-active --quiet clash-verge-service; then
+    echo "Stopping service ..."
+    systemctl stop clash-verge-service
+fi
+
+if [ -f "/usr/libexec/clash-verge-uninstall-service" ]; then
+    echo "Uninstalling service ..."
+    sudo /usr/libexec/clash-verge-uninstall-service
+fi
+systemctl daemon-reload

--- a/app-proxy/clash-verge-service-ipc/spec
+++ b/app-proxy/clash-verge-service-ipc/spec
@@ -1,3 +1,3 @@
-VER=2.0.26
-SRCS="git::commit=tags/v"$VER"::https://github.com/clash-verge-rev/clash-verge-service-ipc"
+VER=2.1.1
+SRCS="git::commit=v$VER::https://github.com/clash-verge-rev/clash-verge-service-ipc"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.4.5
- clash-verge-service-ipc: update to 2.1.1

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-service-ipc clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
