### PR TITLE
feishin: fix default mpv params and use mpv as default playback backend

### DIFF
--- a/app-multimedia/feishin/autobuild/patches/0001-mpv-settings-use-usr-bin-mpv-as-default-path.patch
+++ b/app-multimedia/feishin/autobuild/patches/0001-mpv-settings-use-usr-bin-mpv-as-default-path.patch
@@ -1,33 +1,61 @@
-From 9ab217341b8c4ceb2afbccbaa9e102f7bf42ac94 Mon Sep 17 00:00:00 2001
-From: Kaiyang Wu <self@origincode.me>
-Date: Tue, 3 Jun 2025 05:47:00 -0700
-Subject: [PATCH 1/2] mpv-settings: use /usr/bin/mpv as default path
+From def7bb6e2a9d8786ac499d059a204763597f0eda Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Sun, 25 Jan 2026 15:16:40 -0800
+Subject: [PATCH 1/3] mpv-settings: use /usr/bin/mpv as default path
 
-Signed-off-by: Kaiyang Wu <self@origincode.me>
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
- .../components/playback/mpv-settings.tsx      | 20 ++++++++++++-------
- 1 file changed, 13 insertions(+), 7 deletions(-)
+ src/main/features/core/player/index.ts         |  2 +-
+ .../audio-player/engine/mpv-player-engine.tsx  |  4 ----
+ .../components/playback/mpv-settings.tsx       | 18 ++++++++++++------
+ src/renderer/store/settings.store.ts           |  4 ++--
+ 4 files changed, 15 insertions(+), 13 deletions(-)
 
+diff --git a/src/main/features/core/player/index.ts b/src/main/features/core/player/index.ts
+index 4ecb1145..edd89ce7 100644
+--- a/src/main/features/core/player/index.ts
++++ b/src/main/features/core/player/index.ts
+@@ -68,7 +68,7 @@ const mpvLog = (
+     }
+ };
+ 
+-const MPV_BINARY_PATH = store.get('mpv_path') as string | undefined;
++const MPV_BINARY_PATH = store.get('mpv_path') as string | '/usr/bin/mpv';
+ 
+ const prefetchPlaylistParams = [
+     '--prefetch-playlist=no',
+diff --git a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+index 7726772b..3d100f39 100644
+--- a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
++++ b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+@@ -108,10 +108,6 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
+ 
+             const extraParameters: string[] = [...mpvExtraParameters];
+ 
+-            if (audioDeviceId) {
+-                extraParameters.push(`--audio-device=${audioDeviceId}`);
+-            }
+-
+             await mpvPlayer?.initialize({
+                 extraParameters,
+                 properties,
 diff --git a/src/renderer/features/settings/components/playback/mpv-settings.tsx b/src/renderer/features/settings/components/playback/mpv-settings.tsx
-index c54e17be..d0881cfc 100644
+index c54e17be..495ae214 100644
 --- a/src/renderer/features/settings/components/playback/mpv-settings.tsx
 +++ b/src/renderer/features/settings/components/playback/mpv-settings.tsx
-@@ -39,19 +39,21 @@ export const MpvSettings = memo(() => {
-     const [mpvPath, setMpvPath] = useState(
-         (localSettings?.get('mpv_path') as string | undefined) || '',
-     );
-+    
+@@ -36,8 +36,10 @@ export const MpvSettings = memo(() => {
+     // const { pause } = usePlayerControls();
+     // const { clearQueue } = useQueueControls();
+ 
 +    const defaultMpvPath = '/usr/bin/mpv';
++
+     const [mpvPath, setMpvPath] = useState(
+-        (localSettings?.get('mpv_path') as string | undefined) || '',
++        (localSettings?.get('mpv_path') as string | undefined) || defaultMpvPath,
+     );
  
      const handleSetMpvPath = async (clear?: boolean) => {
-         if (clear) {
--            localSettings?.set('mpv_path', undefined);
--            setMpvPath('');
-+            localSettings?.set('mpv_path', defaultMpvPath);
-+            setMpvPath(defaultMpvPath);
-             return;
-         }
- 
+@@ -50,8 +52,8 @@ export const MpvSettings = memo(() => {
          const result = await localSettings?.openFileSelector();
  
          if (result === null) {
@@ -55,6 +83,21 @@ index c54e17be..d0881cfc 100644
          };
  
          getMpvPath();
+diff --git a/src/renderer/store/settings.store.ts b/src/renderer/store/settings.store.ts
+index e7463c0e..d90181f0 100644
+--- a/src/renderer/store/settings.store.ts
++++ b/src/renderer/store/settings.store.ts
+@@ -1536,8 +1536,8 @@ const initialState: SettingsState = {
+         transcode: {
+             enabled: false,
+         },
+-        type: PlayerType.WEB,
+-        webAudio: true,
++        type: PlayerType.LOCAL,
++        webAudio: false,
+     },
+     queryBuilder: {
+         tag: [],
 -- 
 2.52.0
 

--- a/app-multimedia/feishin/autobuild/patches/0002-remove-remote-analytics.patch
+++ b/app-multimedia/feishin/autobuild/patches/0002-remove-remote-analytics.patch
@@ -1,7 +1,7 @@
-From 1ab705a1dcb4c0258209d7df75cbe80a4d7add2a Mon Sep 17 00:00:00 2001
+From 8be1a0cd65f940fb4c4c0285d67723cd8ba3f6b3 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sun, 18 Jan 2026 23:28:14 -0800
-Subject: [PATCH 2/2] remove remote analytics
+Subject: [PATCH 2/3] remove remote analytics
 
 Signed-off-by: Kaiyang Wu <self@origincode.me>
 ---

--- a/app-multimedia/feishin/autobuild/patches/0003-loongarch64-patch-electron-version.patch.loongarch64
+++ b/app-multimedia/feishin/autobuild/patches/0003-loongarch64-patch-electron-version.patch.loongarch64
@@ -1,7 +1,7 @@
-From 69d4a3165d903b3bfee8bb585ce55b530031ed48 Mon Sep 17 00:00:00 2001
+From 48d514d7284231b673048e26e62aafd9c5a84fb4 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Fri, 23 Jan 2026 15:30:03 +0800
-Subject: [PATCH] loongarch64: patch electron version
+Subject: [PATCH 3/3] loongarch64: patch electron version
 
 ---
  electron-builder.yml | 2 +-

--- a/app-multimedia/feishin/spec
+++ b/app-multimedia/feishin/spec
@@ -2,4 +2,4 @@ VER=1.3.0
 SRCS="git::commit=tags/v${VER}::https://github.com/jeffvli/feishin"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368971"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- feishin: fix default mpv params and use mpv as default playback backend
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- feishin: 1.3.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit feishin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
