### PR TITLE
cni-plugins: security update to 1.9.0

### DIFF
--- a/runtime-containers/cni-plugins/spec
+++ b/runtime-containers/cni-plugins/spec
@@ -1,5 +1,4 @@
-VER=1.7.1
-REL=1
+VER=1.9.0
 SRCS="git::commit=tags/v$VER::https://github.com/containernetworking/plugins.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=96794"

--- a/topics/cni-plugins-1.9.0.toml
+++ b/topics/cni-plugins-1.9.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "cni-plugins 1.9.0"
+
+[caution]
+default = "Fixes an information exposure vulnerability - CVE-2025-67499 (Severity: Moderate)"
+zh_CN = "修复一处信息泄露漏洞，漏洞编号 CVE-2025-67499（严重性：中）"
+
+[packages-v2]
+"cni-plugins" = ">= 1.6.0 && < 1.9.0"


### PR DESCRIPTION
Topic Description
-----------------

- cni-plugins: security update to 1.9.0
    Fix CVE-2025-67499.
    Link: https://github.com/containernetworking/plugins/security/advisories/GHSA-jv3w-x3r3-g6rm

Package(s) Affected
-------------------

- cni-plugins: 1.9.0

Security Update?
----------------

Yes, #14618

Build Order
-----------

```
#buildit cni-plugins
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
