### PR TITLE
coreutils: fix a bug causing cp to hang on sparse file in ext4

### DIFF
--- a/app-utils/coreutils/autobuild/patches/0001-copy-fix-possible-infinite-loop-with-SEEK_HOLE.patch
+++ b/app-utils/coreutils/autobuild/patches/0001-copy-fix-possible-infinite-loop-with-SEEK_HOLE.patch
@@ -1,0 +1,36 @@
+From 5914dd428717a1a019e55da91bca7b863f92e534 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A1draig=20Brady?= <P@draigBrady.com>
+Date: Sun, 4 Jan 2026 12:45:46 +0000
+Subject: [PATCH] copy: fix possible infinite loop with SEEK_HOLE
+
+Commit v9.8-95-g4c0cf3864 intended to initialize
+ext_start to src_pos, as was described at:
+https://lists.gnu.org/r/coreutils/2025-11/msg00035.html
+However ipos was inadvertently used, which is only
+valid the first time through the loop.
+
+* src/copy-file-data.c (lseek_copy): Use scan_inference->hole_start
+only with the initial offset passed to lseek_copy().
+Reported at https://github.com/coreutils/coreutils/issues/159
+
+(cherry picked from commit bd528f923482223649aa84be7d131e69356149da)
+---
+ src/copy-file-data.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/copy-file-data.c b/src/copy-file-data.c
+index c88b10cb3..f03ede5fe 100644
+--- a/src/copy-file-data.c
++++ b/src/copy-file-data.c
+@@ -338,7 +338,7 @@ lseek_copy (int src_fd, int dest_fd, char **abuf, idx_t buf_size,
+   for (off_t ext_start = scan_inference->ext_start;
+        0 <= ext_start && ext_start < max_ipos; )
+     {
+-      off_t ext_end = (ext_start == ipos
++      off_t ext_end = (ext_start == src_pos
+                        ? scan_inference->hole_start
+                        : lseek (src_fd, ext_start, SEEK_HOLE));
+       if (0 <= ext_end)
+-- 
+2.52.0
+

--- a/app-utils/coreutils/spec
+++ b/app-utils/coreutils/spec
@@ -1,4 +1,5 @@
 VER=9.9
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/coreutils/coreutils-$VER.tar.xz"
 CHKSUMS="sha256::19bcb6ca867183c57d77155eae946c5eced88183143b45ca51ad7d26c628ca75"
 CHKUPDATE="anitya::id=343"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Backport a fix against the bug causing cp to hang on sparse file in ext4.

Package(s) Affected
-------------------

coreutils: `9.9-1`

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit coreutils
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
