### PR TITLE
winetricks: update to 20260125

### DIFF
--- a/app-emulation/winetricks/spec
+++ b/app-emulation/winetricks/spec
@@ -1,4 +1,4 @@
-VER=20250102
+VER=20260125
 SRCS="git::commit=tags/$VER::https://github.com/Winetricks/winetricks"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7258"


### PR DESCRIPTION
Topic Description
-----------------

- winetricks: update to 20260125
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- winetricks: 20260125

Security Update?
----------------

No

Build Order
-----------

```
#buildit winetricks
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
