### PR TITLE
rocm: Libraries without MachineLearning update to 7.2.0[1/3]

### DIFF
--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas-common"

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -1,6 +1,9 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblaslt"
 CHKUPDATE="anitya::id=383650"
-ENVREQ="disk=340 total_mem_per_core=1"
+ENVREQ="disk=340 total_mem_per_core=1 total_mem=30"
+
+# Note: Disable iGPU/CDNA on ARM64. Reduce build pressure.
+ENVREQ__ARM64="disk=170 total_mem_per_core=1 total_mem=30"

--- a/runtime-rocm/rocm-origami/spec
+++ b/runtime-rocm/rocm-origami/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/shared/origami"

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocblas"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocfft"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocrand"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocrand: upgrade to 7.2.0
- rocm-rocfft: upgrade to 7.2.0
- rocm-rocblas: upgrade to 7.2.0
- rocm-hipblaslt: upgrade to 7.2.0
- rocm-origami: upgrade to 7.2.0
- rocm-hipblas-common: upgrade to 7.2.0

Package(s) Affected
-------------------

- rocm-hipblas-common: 7.2.0
- rocm-hipblaslt: 7.2.0
- rocm-origami: 7.2.0
- rocm-rocblas: 7.2.0
- rocm-rocfft: 7.2.0
- rocm-rocrand: 7.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipblas-common rocm-origami rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
