### PR TITLE
linyaps: update to 1.11.1

### DIFF
--- a/app-admin/linyaps/spec
+++ b/app-admin/linyaps/spec
@@ -1,4 +1,4 @@
-VER=1.10.0
+VER=1.11.1
 SRCS="git::commit=tags/$VER::https://github.com/OpenAtom-Linyaps/linyaps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372461"


### PR DESCRIPTION
Topic Description
-----------------

- linyaps: update to 1.11.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- linyaps: 1.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linyaps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
