### PR TITLE
bubblewrap: update to 0.11.0

### DIFF
--- a/app-admin/bubblewrap/spec
+++ b/app-admin/bubblewrap/spec
@@ -1,4 +1,4 @@
-VER=0.10.0
+VER=0.11.0
 SRCS="tbl::https://github.com/projectatomic/bubblewrap/releases/download/v$VER/bubblewrap-$VER.tar.xz"
-CHKSUMS="sha256::65d92cf44a63a51e1b7771f70c05013dce5bd6b0b2841c4b4be54b0c45565471"
+CHKSUMS="sha256::988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646"
 CHKUPDATE="anitya::id=10937"


### PR DESCRIPTION
Topic Description
-----------------

- bubblewrap: update to 0.11.0
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- bubblewrap: 0.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bubblewrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
