### PR TITLE
openssl: update to 3.6.1

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.5.4
+VER=3.6.1
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
+CHKSUMS="sha256::b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.5.4
+VER=3.6.1
 SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
+CHKSUMS="sha256::b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
 CHKUPDATE="anitya::id=2566"

--- a/topics/openssl-3.6.1.toml
+++ b/topics/openssl-3.6.1.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 3.6.1"
+
+[caution]
+default = "Fixes 12 security vulnerabilities disclosed in OpenSSL Security Advisory on January 27, 2026 (1 of high severity)"
+zh_CN = "修复 OpenSSL 在 2026 年 1 月 27 日发布的安全公告中披露的 21 个安全漏洞（含 1 个高危漏洞）"
+
+[packages-v2]
+"openssl" = "< 3.6.1"
+"openssl+32" = "< 3.6.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add openssl-3.6.1.toml
- openssl+32: update to 3.6.1
- openssl: update to 3.6.1

Package(s) Affected
-------------------

- openssl: 3.6.1
- openssl-static: 3.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
