### PR TITLE
micro: update to 2.0.15

### DIFF
--- a/app-editors/micro/autobuild/beyond
+++ b/app-editors/micro/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing micro ..."
+install -Dvm644 "$SRCDIR"/assets/packaging/micro.1 \
+    -t "$PKGDIR"/usr/share/man/man1
+install -Dvm644 "$SRCDIR"/assets/packaging/micro.desktop \
+    -t "$PKGDIR"/usr/share/applications
+install -Dvm644 "$SRCDIR"/assets/micro-logo-mark.svg \
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/micro.svg

--- a/app-editors/micro/autobuild/build
+++ b/app-editors/micro/autobuild/build
@@ -1,9 +1,0 @@
-abinfo "Building micro..."
-make
-
-abinfo "Installing micro..."
-install -v -Dm755 "$SRCDIR"/micro "$PKGDIR"/usr/bin/micro
-install -v -Dm644 "$SRCDIR"/assets/packaging/micro.1 -t "$PKGDIR"/usr/share/man/man1
-install -v -Dm644 "$SRCDIR"/assets/packaging/micro.desktop -t "$PKGDIR"/usr/share/applications
-install -v -Dm644 "$SRCDIR"/assets/micro-logo-mark.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/micro.svg
-install -v -Dm644 -t "$PKGDIR"/usr/share/doc/micro "$SRCDIR"/LICENSE "$SRCDIR"/LICENSE-THIRD-PARTY

--- a/app-editors/micro/autobuild/defines
+++ b/app-editors/micro/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=micro
 PKGSEC=editors
 PKGDES="A terminal-based text editor"
-
+PKGDEP="gcc-runtime"
 BUILDDEP="go"
-ABSPLITDBG=0
+
+ABTYPE=gomod
+GO_PACKAGES=('cmd/micro')

--- a/app-editors/micro/autobuild/prepare
+++ b/app-editors/micro/autobuild/prepare
@@ -1,0 +1,6 @@
+abinfo "Setting GO_LDFLAGS ..."
+GO_LDFLAGS=(
+    "-X 'github.com/zyedidia/micro/v2/internal/util.Version=$PKGVER'"
+    "-X 'github.com/zyedidia/micro/v2/internal/util.CommitHash=$(git rev-parse --short HEAD)'"
+    "-X 'github.com/zyedidia/micro/v2/internal/util.CompileDate=$(date +%Y-%m-%d)'"
+)

--- a/app-editors/micro/spec
+++ b/app-editors/micro/spec
@@ -1,5 +1,4 @@
-VER=2.0.14
-SRCS="git::commit=tags/v$VER::https://github.com/zyedidia/micro"
+VER=2.0.15
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/zyedidia/micro"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19017"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- micro: update to 2.0.15

Package(s) Affected
-------------------

- micro: 2.0.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit micro
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
