### PR TITLE
krita: update to 5.2.15

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,5 +1,4 @@
-VER=5.2.14
-REL=1
+VER=5.2.15
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
-CHKSUMS="sha256::41770910517a8d4546f7028c4725b3bd44c69d10d328c978a2788dbcc707d3df"
+CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
 CHKUPDATE="anitya::id=10918"


### PR DESCRIPTION
Topic Description
-----------------

- krita: update to 5.2.15
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- krita: 5.2.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit krita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
