### PR TITLE
keepassxc: update to v2.7.11

### DIFF
--- a/app-utils/keepassxc/autobuild/defines
+++ b/app-utils/keepassxc/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=keepassxc
 PKGSEC=utils
 PKGDES="A cross-platform community-driven port for Keepass"
 PKGDEP="argon2 libgcrypt libsodium qrencode qt-5 quazip x11-lib \
-        yubikey-personalization zlib botan"
+        yubikey-manager zlib botan"
 BUILDDEP="asciidoctor minizip"
 
 CMAKE_AFTER="-DWITH_XC_ALL=ON \

--- a/app-utils/keepassxc/autobuild/patches/0001-Fedora-fix-GNOME-quirks-on-Wayland-sessions.patch
+++ b/app-utils/keepassxc/autobuild/patches/0001-Fedora-fix-GNOME-quirks-on-Wayland-sessions.patch
@@ -1,6 +1,6 @@
 --- a/src/main.cpp
 +++ b/src/main.cpp
-@@ -48,8 +48,26 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+@@ -49,8 +49,26 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
  #include <windows.h>
  #endif
  
@@ -26,4 +26,4 @@
 +
      QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
  
- #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/app-utils/keepassxc/spec
+++ b/app-utils/keepassxc/spec
@@ -1,4 +1,4 @@
-VER=2.7.10
+VER=2.7.11
 SRCS="https://github.com/keepassxreboot/keepassxc/releases/download/${VER}/keepassxc-${VER}-src.tar.xz"
-CHKSUMS="sha256::5ce76d6440986c24842585f019d5f3cadc166fa71fc911a4fe97b8bbc4819dfa"
+CHKSUMS="sha256::ce76b02d396369726aaf695bb46b79c0cc41a0c4f9ec806bde1233cb22e6ef62"
 CHKUPDATE="anitya::id=15656"


### PR DESCRIPTION
Topic Description
-----------------

- keepassxc: update to v2.7.11
    rename dep botan-3 to botan, yubikey-personalization to yubikey-manager
    Signed-off-by: Ayden Meng <aydenmeng@yeah.net>

Package(s) Affected
-------------------

- keepassxc: 2.7.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit keepassxc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
