### PR TITLE
incus: security update to 6.21.0

### DIFF
--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,4 @@
-VER=6.20.0
+VER=6.21.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"

--- a/topics/incus-6.21.0.toml
+++ b/topics/incus-6.21.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "incus 6.21.0"
+
+[caution]
+default = "Fixed two vulnerabilities related to arbitrary command execution and container escape - CVE-2026-23953, CVE-2026-23954 (Severity: High)"
+zh_CN = "修复两处任意命令执行和容器逃逸相关的漏洞，漏洞编号 CVE-2026-23953, CVE-2026-23954（严重性：高）"
+
+[packages-v2]
+"incus" = ">= 6.1.0 && <= 6.20.0 && <= 6.0.5"


### PR DESCRIPTION
Topic Description
-----------------

- incus: security update to 6.21.0
    Fix CVE-2026-23953, CVE-2026-23954
    CVE-2026-23953 Url: https://github.com/advisories/GHSA-x6jc-phwx-hp32
    CVE-2026-23954 Url: https://github.com/advisories/GHSA-7f67-crqm-jgh7

Package(s) Affected
-------------------

- incus: 6.21.0
- incus-agent: 6.21.0

Security Update?
----------------

Yes. #14650

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
