### PR TITLE
lego: update to 4.31.0

### DIFF
--- a/app-web/lego/spec
+++ b/app-web/lego/spec
@@ -1,4 +1,4 @@
-VER=4.28.0
+VER=4.31.0
 SRCS="git::commit=tags/v$VER::https://github.com/go-acme/lego"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20764"


### PR DESCRIPTION
Topic Description
-----------------

- lego: update to 4.31.0

Package(s) Affected
-------------------

- lego: 4.31.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lego
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
