### PR TITLE
adguardhome: update to 0.107.71

### DIFF
--- a/app-web/adguardhome/spec
+++ b/app-web/adguardhome/spec
@@ -1,4 +1,4 @@
-VER=0.107.69
+VER=0.107.71
 SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301521"


### PR DESCRIPTION
Topic Description
-----------------

- adguardhome: update to 0.107.71
    Co-authored-by: 董冠泽 \(@grayawa\)

Package(s) Affected
-------------------

- adguardhome: 0.107.71

Security Update?
----------------

No

Build Order
-----------

```
#buildit adguardhome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
