### PR TITLE
rocm: Libraries without MachineLearning update to 7.2.0[2/3]

### DIFF
--- a/runtime-rocm/rocm-hipfft/spec
+++ b/runtime-rocm/rocm-hipfft/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipfft"

--- a/runtime-rocm/rocm-hipsparse/spec
+++ b/runtime-rocm/rocm-hipsparse/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipsparse"

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/rccl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241714"

--- a/runtime-rocm/rocm-rocprim/spec
+++ b/runtime-rocm/rocm-rocprim/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocprim"

--- a/runtime-rocm/rocm-rocsolver/spec
+++ b/runtime-rocm/rocm-rocsolver/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsolver"

--- a/runtime-rocm/rocm-rocsparse/spec
+++ b/runtime-rocm/rocm-rocsparse/spec
@@ -1,4 +1,4 @@
-VER=7.1.1
+VER=7.2.0
 SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsparse"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocsolver: upgrade to 7.2.0
- rocm-hipsparse: upgrade to 7.2.0
- rocm-hipfft: upgrade to 7.2.0
- rocm-rocsparse: upgrade to 7.2.0
- rocm-rocprim: upgrade to 7.2.0
- rocm-rccl: upgrade to 7.2.0

Package(s) Affected
-------------------

- rocm-hipfft: 7.2.0
- rocm-hipsparse: 7.2.0
- rocm-rccl: 7.2.0
- rocm-rocprim: 7.2.0
- rocm-rocsolver: 7.2.0
- rocm-rocsparse: 7.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-rccl rocm-rocprim rocm-rocsparse rocm-hipfft rocm-hipsparse rocm-rocsolver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
