### PR TITLE
expat: update to 2.7.4

### DIFF
--- a/runtime-common/expat/autobuild/beyond
+++ b/runtime-common/expat/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Installing manpage xmlwf.1 ..."
-install -Dvm644 "$SRCDIR"/doc/xmlwf.1 "$PKGDIR"/usr/share/man/man1/xmlwf.1

--- a/runtime-common/expat/autobuild/defines
+++ b/runtime-common/expat/autobuild/defines
@@ -1,12 +1,11 @@
 PKGNAME=expat
 PKGDEP="glibc"
 PKGSEC=libs
-PKGDES="A stream-oriented C library for parsing XML"
+PKGDES="Stream-oriented C library for parsing XML"
 
-# FIXME:
-#
-# configure: error: Plain autoreconf/autoheader does not cut it, please use
-# ./buildconf.sh or imitate its effect through other means, so that file
-# expat_config.h.in no longer defines macro SIZEOF_VOID_P, as that would break
-# multilib support.  Thank you.
-RECONF=0
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DEXPAT_BUILD_DOCS=OFF"
+    "-DEXPAT_BUILD_EXAMPLES=OFF"
+    "-DEXPAT_BUILD_TESTS=OFF"
+)

--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,5 @@
-VER=2.7.2
-SRCS="tbl::https://github.com/libexpat/libexpat/releases/download/R_${VER//./_}/expat-$VER.tar.xz"
-CHKSUMS="sha256::21b778b34ec837c2ac285aef340f9fb5fa063a811b21ea4d2412a9702c88995c"
+VER=2.7.4
+SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"
+SUBDIR="expat/expat"

--- a/runtime-optenv32/expat+32/autobuild/defines
+++ b/runtime-optenv32/expat+32/autobuild/defines
@@ -1,8 +1,14 @@
 PKGNAME=expat+32
-PKGDES="A stream oriented C library for parsing XML (32-bit x86 runtime)"
+PKGDES="Stream-oriented C library for parsing XML (32-bit x86 runtime)"
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 glibc+32"
 BUILDDEP="devel-base+32"
 
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DEXPAT_BUILD_DOCS=OFF"
+    "-DEXPAT_BUILD_EXAMPLES=OFF"
+    "-DEXPAT_BUILD_TESTS=OFF"
+)
 RECONF=0
 ABHOST=optenv32

--- a/runtime-optenv32/expat+32/spec
+++ b/runtime-optenv32/expat+32/spec
@@ -1,4 +1,5 @@
-VER=2.7.2
-SRCS="tbl::https://github.com/libexpat/libexpat/releases/download/R_${VER//./_}/expat-$VER.tar.xz"
-CHKSUMS="sha256::21b778b34ec837c2ac285aef340f9fb5fa063a811b21ea4d2412a9702c88995c"
+VER=2.7.4
+SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"
+SUBDIR="expat+32/expat"

--- a/topics/expat-2.7.4.toml
+++ b/topics/expat-2.7.4.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Expat 2.7.4"
+
+[caution]
+default = "Fixes a denial of service vulnerability (CVE-2025-66382, Severity: Medium), a null pointer dereference vulnerability (CVE-2026-24515, Severity: Critical), and a integer overflow vulnerability (CVE-2026-25210, Severity: Medium)"
+zh_CN = "修复了一个拒绝服务漏洞（CVE-2025-66382，严重性：中等）、一个空指针解引用漏洞（CVE-2026-24515，严重性：严重），以及一个整数溢出漏洞（CVE-2026-25210，严重性：中等）"
+
+[packages-v2]
+"expat" = "< 2.7.4"
+"expat+32" = "< 2.7.4"


### PR DESCRIPTION
Topic Description
-----------------

- expat: update to 2.7.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- expat: 2.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
