### PR TITLE
Game n' Emulation Survey (Feb. 1, 2026)

### DIFF
--- a/app-emulation/wine-emukit/autobuild/defines
+++ b/app-emulation/wine-emukit/autobuild/defines
@@ -17,8 +17,5 @@ ABMANCOMPRESS=0
 # Except arm64 (as it also does have the ARM64EC target).
 FAIL_ARCH="!(loongarch64|riscv64)"
 
-# Note: Sync with main `wine' package.
-PKGEPOCH=2
-
 PKGBREAK="latx<=1.5.1~rc1+emukit20240429"
 PKGREP="latx<=1.5.1~rc1+emukit20240429"

--- a/app-emulation/wine-emukit/autobuild/defines
+++ b/app-emulation/wine-emukit/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=wine
 PKGSEC=utils
 # Note: systemd-binfmt is needed for binfmt_misc.
 PKGDEP="systemd"
-PKGDEP__LOONGARCH64="${PKGDEP} latx"
+PKGRECOM="box64 ntsync-enablement"
 PKGDES="Compatibility layer for running programs designed for Microsoft Windows (x86 emulated runtime)"
 
 # Note: This is a binary package, disabling stripping.
@@ -11,8 +11,11 @@ ABSTRIP=0
 # Note: Man pages have already been compresssed once.
 ABMANCOMPRESS=0
 
-# Note: Only allow architectures with x86 emulation runtime (EmuKit).
-FAIL_ARCH="!(loongarch64)"
+# Note: Enable build only for architectures with serviceable x86 emulators
+# (often with dynamic recompiler or JIT).
+#
+# Except arm64 (as it also does have the ARM64EC target).
+FAIL_ARCH="!(loongarch64|riscv64)"
 
 # Note: Sync with main `wine' package.
 PKGEPOCH=2

--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,3 +1,5 @@
+# Note: Sync with main `wine' package.
+EPOCH=3
 __GECKO_VER=2.47.4
 __MONO_VER=10.4.1
 UPSTREAM_VER=11.1

--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,8 +1,8 @@
 __GECKO_VER=2.47.4
-__MONO_VER=9.1.0
-WINE_VER=9.13
-VER=${WINE_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
-SRCS="file::rename=wine.deb::https://repo.aosc.io/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::ab7b87934e0891c081a1e4299e0dc14265bea99b41c1926de746c9b93cf63083"
+__MONO_VER=10.4.1
+UPSTREAM_VER=11.1
+VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
+SRCS="file::rename=wine.deb::https://repo.aosc.io/anthon/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
+CHKSUMS="sha256::87a88ae8768fc6da6aee9383f7f9c1dbd41d291070817ba1d39e8e9c7eddd410"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.

--- a/app-games/steam/autobuild/defines
+++ b/app-games/steam/autobuild/defines
@@ -5,7 +5,8 @@ PKGDEP__with_emulator="curl dbus freetype gdk-pixbuf hicolor-icon-theme zenity l
 PKGDEP__ARM64="${PKGDEP__with_emulator}"
 PKGDEP__LOONGARCH64="${PKGDEP__with_emulator}"
 PKGDEP__RISCV64="${PKGDEP__with_emulator}"
-PKGRECOM__with_emulator="box64"
+PKGRECOM="ntsync-enablement"
+PKGRECOM__with_emulator="${PKGRECOM} box64"
 PKGRECOM__ARM64="${PKGRECOM__with_emulator}"
 PKGRECOM__LOONGARCH64="${PKGRECOM__with_emulator}"
 PKGRECOM__RISCV64="${PKGRECOM__with_emulator}"
@@ -13,6 +14,8 @@ PKGSUG__ARM64="fex"
 PKGSUG__LOONGARCH64="latx"
 PKGDES="Official Steam client for Linux"
 
+# Note: Enable build only for x86 or architectures with serviceable x86
+# emulators (often with dynamic recompiler or JIT).
 FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"
 
 ABTYPE=self

--- a/app-games/steam/spec
+++ b/app-games/steam/spec
@@ -1,5 +1,5 @@
 VER=1.0.0.85
-REL=3
+REL=4
 SRCS="tbl::https://repo.steampowered.com/steam/pool/steam/s/steam/steam_$VER.tar.gz"
 CHKSUMS="sha256::7f2d374a2fb413ced5b8125151456219d918a255872b4bb77016cbccf38bb7f1"
 CHKUPDATE="anitya::id=12318"

--- a/runtime-emulation/ntsync-enablement/autobuild/postinst
+++ b/runtime-emulation/ntsync-enablement/autobuild/postinst
@@ -1,0 +1,7 @@
+if ! systemd-detect-virt --container >/dev/null ; then
+    echo "Loading the NTSYNC (NT synchronization primitive driver) kernel module ..."
+    modprobe ntsync || \
+        echo "
+Warning: The ntsync kernel module does not appear to be available. Skipping ...
+"
+fi

--- a/runtime-emulation/ntsync-enablement/spec
+++ b/runtime-emulation/ntsync-enablement/spec
@@ -1,2 +1,2 @@
-VER=0
+VER=1
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- ntsync-enablement: attempt to modprobe ntsync on installation
- wine-emukit: correct EPOCH
- steam: add ntsync-enablement as RECOM \(for newer Proton/Wine runtimes\)
- wine-emukit: update to 11.1+gecko2.47.4+mono10.4.1
    - Decouple LATX on loongarch64.
    - Add ntsync-enablement as RECOM.
    - Widen range of architectures supported.

Package(s) Affected
-------------------

- ntsync-enablement: 1
- steam: 1.0.0.85-4
- wine: 11.1+gecko2.47.4+mono10.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ntsync-enablement wine-emukit steam
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
