### PR TITLE
zvm: update to 0.8.13

### DIFF
--- a/lang-ziglang/zvm/autobuild/defines
+++ b/lang-ziglang/zvm/autobuild/defines
@@ -1,8 +1,5 @@
 PKGNAME=zvm
 PKGSEC=devel
-PKGDES="A tool for managing Zig installs"
+PKGDEP="glibc"
 BUILDDEP="go"
-
-# FIXME: Autobuild does not yet support splitting debug symbols out of Go
-# executables.
-ABSPLITDBG=0
+PKGDES="Utility to manage Zig installs"

--- a/lang-ziglang/zvm/autobuild/patches/0001-UPSTREAM-upped-version.patch
+++ b/lang-ziglang/zvm/autobuild/patches/0001-UPSTREAM-upped-version.patch
@@ -1,0 +1,26 @@
+From 5d756620437062ea45b90f40a77dc2f4918190f9 Mon Sep 17 00:00:00 2001
+From: Tristan Isham <tristan@isham.co>
+Date: Mon, 26 Jan 2026 16:22:42 -0500
+Subject: [PATCH] UPSTREAM: upped version
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ cli/meta/version.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cli/meta/version.go b/cli/meta/version.go
+index acb84e1..e824d1a 100644
+--- a/cli/meta/version.go
++++ b/cli/meta/version.go
+@@ -9,7 +9,7 @@ import (
+ )
+ 
+ const (
+-	VERSION = "v0.8.12"
++	VERSION = "v0.8.13"
+ 
+ 	// VERSION = "v0.0.0" // For testing zvm upgrade
+ 
+-- 
+2.52.0
+

--- a/lang-ziglang/zvm/spec
+++ b/lang-ziglang/zvm/spec
@@ -1,5 +1,4 @@
-VER=0.8.11
-REL=2
+VER=0.8.13
 SRCS="git::commit=tags/v$VER::https://github.com/tristanisham/zvm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=363557"


### PR DESCRIPTION
Topic Description
-----------------

- zvm: update to 0.8.13
    Co-authored-by: xtex \(@xtexx\) <xtexchooser@duck.com>

Package(s) Affected
-------------------

- zvm: 0.8.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit zvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
