### PR TITLE
ghc: update to 9.14.1

### DIFF
--- a/lang-haskell/cabal-install/spec
+++ b/lang-haskell/cabal-install/spec
@@ -1,4 +1,4 @@
-VER=3.10.3.0
+VER=3.16.1.0
 SRCS="git::commit=tags/cabal-install-v$VER::https://github.com/haskell/cabal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243"

--- a/lang-haskell/ghc/autobuild/build.stage2
+++ b/lang-haskell/ghc/autobuild/build.stage2
@@ -1,4 +1,4 @@
-BOOTSTRAP_VER=9.4.8
+BOOTSTRAP_VER=9.12.2
 if ab_match_arch amd64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-x86_64-unknown-linux
 elif ab_match_arch arm64; then

--- a/lang-haskell/ghc/spec
+++ b/lang-haskell/ghc/spec
@@ -1,11 +1,10 @@
-VER=9.4.8
-BOOTSTRAP_VER=9.4.8
+VER=9.12.2
+BOOTSTRAP_VER=9.12.2
 SRCS="tbl::https://www.haskell.org/ghc/dist/$VER/ghc-${VER}-src.tar.xz \
 	tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-x86_64-deb10-linux.tar.xz \
 	tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-aarch64-deb10-linux.tar.xz"
-CHKSUMS="sha256::0bf407eb67fe3e3c24b0f4c8dea8cb63e07f63ca0f76cf2058565143507ab85e \
-         sha256::fc77eaae5b89f29177bf159fd95ce438066ec64a46bf69df61b267102afdb10e \
-         sha256::278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531"
+CHKSUMS="sha256::0e49cd5dde43f348c5716e5de9a5d7a0f8d68d945dc41cf75dfdefe65084f933 \
+         sha256::10a140a55f308df4345976a4371908a124c02e481ab08575ab509ab046e83615 \
+         sha256::6048eae62ede069459398fa6f2e92ab9719e1b83e93a9014e6a410c54ed2755f"
 SUBDIR=ghc-${VER}
 CHKUPDATE="anitya::id=906"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- cabal-install: update to 3.16.1.0
- ghc: update to 9.14.1

Package(s) Affected
-------------------

- cabal-install: 1:3.16.1.0
- ghc: 1:9.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghc:+stage2 cabal-install:+stage2 ghc cabal-install
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
