### PR TITLE
ghc: update to 9.12.2

### DIFF
--- a/lang-haskell/cabal-install/autobuild/build
+++ b/lang-haskell/cabal-install/autobuild/build
@@ -2,12 +2,12 @@ abinfo "Building Cabal using existing Cabal ..."
 cabal update
 cabal v2-build -j \
 	--prefix=/usr \
-	--project-file=cabal.project.release \
+	--project-file=cabal.release.project \
 	cabal-install
 
 abinfo "Installing Cabal ..."
 cabal v2-install -j \
 	--install-method=copy \
 	--installdir="$PKGDIR"/usr/bin \
-	--project-file=cabal.project.release \
+	--project-file=cabal.release.project \
 	cabal-install

--- a/lang-haskell/cabal-install/spec
+++ b/lang-haskell/cabal-install/spec
@@ -1,4 +1,4 @@
-VER=3.10.3.0
+VER=3.16.1.0
 SRCS="git::commit=tags/cabal-install-v$VER::https://github.com/haskell/cabal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243"

--- a/lang-haskell/ghc/autobuild/build
+++ b/lang-haskell/ghc/autobuild/build
@@ -2,7 +2,8 @@ abinfo "Configuring ghc ..."
 export PYTHON=/usr/bin/python3
 "$SRCDIR"/configure --prefix=/usr \
             --with-system-libffi \
-            --disable-numa
+            --disable-numa \
+            --disable-ld-override LD=mold
 
 abinfo "Building ghc using hadrian ..."
 cabal update

--- a/lang-haskell/ghc/autobuild/build.stage2
+++ b/lang-haskell/ghc/autobuild/build.stage2
@@ -1,4 +1,4 @@
-BOOTSTRAP_VER=9.4.8
+BOOTSTRAP_VER=9.12.2
 if ab_match_arch amd64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-x86_64-unknown-linux
 elif ab_match_arch arm64; then

--- a/lang-haskell/ghc/autobuild/defines
+++ b/lang-haskell/ghc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ghc
 PKGSEC=haskell
 PKGDEP="perl gmp gcc-runtime libffi numactl ncurses"
-BUILDDEP="docbook-xsl libxslt sphinx ghc cabal-install"
+BUILDDEP="docbook-xsl libxslt sphinx ghc cabal-install mold"
 PKGDES="The Glasgow Haskell Compiler"
 
 NOSTATIC=0

--- a/lang-haskell/ghc/autobuild/patches/0001-hp2ps-Utilities.c-include-stdlib.h-instead-of-extern-malloc.patch
+++ b/lang-haskell/ghc/autobuild/patches/0001-hp2ps-Utilities.c-include-stdlib.h-instead-of-extern-malloc.patch
@@ -1,0 +1,37 @@
+From 7596675e470699f6184e13c08b268972028bc868 Mon Sep 17 00:00:00 2001
+From: Jens Petersen <juhpetersen@gmail.com>
+Date: Tue, 28 Jan 2025 09:32:55 +0000
+Subject: [PATCH] hp2ps Utilities.c: include stdlib.h instead of extern malloc
+ and realloc
+
+---
+ utils/hp2ps/Utilities.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/utils/hp2ps/Utilities.c b/utils/hp2ps/Utilities.c
+index f79ddd827154..fc0fdd1e30a5 100644
+--- a/utils/hp2ps/Utilities.c
++++ b/utils/hp2ps/Utilities.c
+@@ -1,10 +1,9 @@
+ #include "Main.h"
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include "Error.h"
+ 
+-extern void* malloc();
+-
+ char*
+ Basename(char *name)
+ {
+@@ -89,7 +88,6 @@ void *
+ xrealloc(void *p, size_t n)
+ {
+     void *r;
+-    extern void *realloc();
+ 
+     r = realloc(p, n);
+     if (!r) {
+-- 
+GitLab
+

--- a/lang-haskell/ghc/autobuild/prepare
+++ b/lang-haskell/ghc/autobuild/prepare
@@ -1,0 +1,1 @@
+echo "allow-newer: all" >> "$SRCDIR"/hadrian/cabal.project.local

--- a/lang-haskell/ghc/spec
+++ b/lang-haskell/ghc/spec
@@ -1,11 +1,10 @@
-VER=9.4.8
-BOOTSTRAP_VER=9.4.8
+VER=9.12.2
+BOOTSTRAP_VER=9.12.2
 SRCS="tbl::https://www.haskell.org/ghc/dist/$VER/ghc-${VER}-src.tar.xz \
 	tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-x86_64-deb10-linux.tar.xz \
 	tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-aarch64-deb10-linux.tar.xz"
-CHKSUMS="sha256::0bf407eb67fe3e3c24b0f4c8dea8cb63e07f63ca0f76cf2058565143507ab85e \
-         sha256::fc77eaae5b89f29177bf159fd95ce438066ec64a46bf69df61b267102afdb10e \
-         sha256::278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531"
+CHKSUMS="sha256::0e49cd5dde43f348c5716e5de9a5d7a0f8d68d945dc41cf75dfdefe65084f933 \
+         sha256::10a140a55f308df4345976a4371908a124c02e481ab08575ab509ab046e83615 \
+         sha256::6048eae62ede069459398fa6f2e92ab9719e1b83e93a9014e6a410c54ed2755f"
 SUBDIR=ghc-${VER}
 CHKUPDATE="anitya::id=906"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- cabal-install: update to 3.16.1.0
- ghc: update to 9.12.2

Package(s) Affected
-------------------

- cabal-install: 1:3.16.1.0
- ghc: 1:9.12.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghc:+stage2 ghc cabal-install
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
