### PR TITLE
js-128: export CanonicalizedNaNBits to fix gjs builds

### DIFF
--- a/desktop-gnome/gjs/spec
+++ b/desktop-gnome/gjs/spec
@@ -1,4 +1,5 @@
 VER=1.85.1
+REL=1
 SRCS="git::commit=tags/${VER}::https://gitlab.gnome.org/GNOME/gjs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9532"

--- a/lang-js/js-128/autobuild/build
+++ b/lang-js/js-128/autobuild/build
@@ -1,26 +1,16 @@
-export M4=m4
-export AWK=awk
-export AC_MACRODIR="$SRCDIR"/build/autoconf/
+export MOZ_NOSPAM=1
+export MOZBUILD_STATE_PATH="$SRCDIR"/mozbuild
+export MACH_NO_TERMINAL_FOOTER=1
 
-# adapted from Fedora F42
-abinfo "Generating configure script ..."
-# this autoconf.sh is sensitive to the current working directory
-# we need to enter js/src in order to make the script generated correctly
-cd "$SRCDIR"/js/src
-chmod a+x "$SRCDIR"/js/src/configure
+abinfo "Building SpiderMonkey ..."
+"$SRCDIR"/mach build
 
-cd "$SRCDIR"/build
-
-abinfo "Configuring MozJS 102 ..."
-sh "$SRCDIR"/js/src/configure \
-    --prefix=/usr \
-    ${AUTOTOOLS_AFTER}
-
-abinfo "Building MozJS 102 ..."
-make
-
-abinfo "Installing MozJS 102 ..."
-make DESTDIR="$PKGDIR" install
+# Bug 1946524 isn't backported to esr128 yet, so falling back to make for installation.
+#
+# Link: https://phabricator.services.mozilla.com/D243491
+# Link: https://gitlab.archlinux.org/archlinux/packaging/packages/js128/-/blob/a0a2ea7468a0067ccd5e7e4691c0f2f38f20e8fc/PKGBUILD#L152-153
+abinfo "Installing SpiderMonkey ..."
+make -C "$SRCDIR"/obj DESTDIR="$PKGDIR" install
 
 abinfo "Removing all .ajs files from /usr/lib ..."
 rm -v "$PKGDIR"/usr/lib/*.ajs
@@ -31,5 +21,3 @@ find "$PKGDIR"/usr/{lib/pkgconfig,include} -type f \
 
 abinfo "Removing /usr/bin ..."
 rm -rv "$PKGDIR"/usr/bin
-
-cd "$SRCDIR"

--- a/lang-js/js-128/autobuild/defines
+++ b/lang-js/js-128/autobuild/defines
@@ -4,37 +4,33 @@ PKGDEP="nspr readline zlib icu"
 BUILDDEP="autoconf-2.13 rustc llvm cbindgen"
 PKGDES="Mozilla JavaScript interpreter library (mainline, 128)"
 
-AUTOTOOLS_AFTER="--disable-debug
-                 --disable-debug-symbols
-                 --disable-jemalloc
-                 --disable-strip
-                 --enable-hardening
-                 --enable-linker=bfd
-                 --enable-optimize
-                 --enable-readline
-                 --enable-release
-                 --enable-shared-js
-                 --disable-tests
-                 --with-intl-api
-                 --with-system-zlib
-                 --with-system-icu"
+AUTOTOOLS_AFTER=(
+    '--disable-debug'
+    '--disable-debug-symbols'
+    '--disable-jemalloc'
+    '--disable-strip'
+    '--enable-hardening'
+    '--enable-optimize'
+    '--enable-readline'
+    '--enable-release'
+    '--enable-shared-js'
+    '--disable-tests'
+    '--with-intl-api'
+    '--with-system-zlib'
+    '--with-system-icu'
+    '--enable-linker=bfd'
+)
 # FIXME: JIT fails sanity check (as reported by desktop-cinnamon/cjs).
-AUTOTOOLS_AFTER__LOONGSON3=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --target=mips64el-aosc-linux-gnuabi64 \
-                 --host=mips64el-aosc-linux-gnuabi64 \
-                 --disable-jit"
-AUTOTOOLS_AFTER__RISCV64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-jit"
+AUTOTOOLS_AFTER__LOONGSON3=(
+    "${AUTOTOOLS_AFTER}"
+    '--target=mips64el-aosc-linux-gnuabi64'
+    '--host=mips64el-aosc-linux-gnuabi64'
+    '--disable-jit'
+)
+AUTOTOOLS_AFTER__RISCV64=(
+    "${AUTOTOOLS_AFTER}"
+    '--disable-jit'
+    '--enable-linker=lld'
+)
 
-AB_FLAGS_SPECS__ARMV4=0
-AB_FLAGS_SPECS__ARMV6HF=0
-AB_FLAGS_SPECS__ARMV7HF=0
-AB_FLAGS_SPECS__POWERPC=0
-AB_FLAGS_SPECS__PPC64=0
-
-NOLTO=1
-ABSPLITDBG=0
-# FIXME: Does not build with gcc 14.
 USECLANG=1

--- a/lang-js/js-128/autobuild/defines
+++ b/lang-js/js-128/autobuild/defines
@@ -1,36 +1,7 @@
 PKGNAME=js-128
 PKGSEC=libs
 PKGDEP="nspr readline zlib icu"
-BUILDDEP="autoconf-2.13 rustc llvm cbindgen"
+BUILDDEP="python-3 rustc llvm cbindgen"
 PKGDES="Mozilla JavaScript interpreter library (mainline, 128)"
-
-AUTOTOOLS_AFTER=(
-    '--disable-debug'
-    '--disable-debug-symbols'
-    '--disable-jemalloc'
-    '--disable-strip'
-    '--enable-hardening'
-    '--enable-optimize'
-    '--enable-readline'
-    '--enable-release'
-    '--enable-shared-js'
-    '--disable-tests'
-    '--with-intl-api'
-    '--with-system-zlib'
-    '--with-system-icu'
-    '--enable-linker=bfd'
-)
-# FIXME: JIT fails sanity check (as reported by desktop-cinnamon/cjs).
-AUTOTOOLS_AFTER__LOONGSON3=(
-    "${AUTOTOOLS_AFTER}"
-    '--target=mips64el-aosc-linux-gnuabi64'
-    '--host=mips64el-aosc-linux-gnuabi64'
-    '--disable-jit'
-)
-AUTOTOOLS_AFTER__RISCV64=(
-    "${AUTOTOOLS_AFTER}"
-    '--disable-jit'
-    '--enable-linker=lld'
-)
 
 USECLANG=1

--- a/lang-js/js-128/autobuild/mozconfig
+++ b/lang-js/js-128/autobuild/mozconfig
@@ -1,0 +1,19 @@
+ac_add_options --enable-application=js
+
+ac_add_options --prefix=/usr
+ac_add_options --libdir=/usr/lib
+
+ac_add_options --disable-debug
+ac_add_options --disable-debug-symbols
+ac_add_options --disable-jemalloc
+ac_add_options --disable-strip
+ac_add_options --enable-hardening
+ac_add_options --enable-optimize
+ac_add_options --enable-readline
+ac_add_options --enable-release
+ac_add_options --enable-shared-js
+ac_add_options --disable-tests
+ac_add_options --with-intl-api
+ac_add_options --with-system-zlib
+ac_add_options --with-system-icu
+ac_add_options --enable-linker=lld

--- a/lang-js/js-128/autobuild/patches/0001-Bug-Export-CanonicalizedNaNBits-for-inlined-external.patch
+++ b/lang-js/js-128/autobuild/patches/0001-Bug-Export-CanonicalizedNaNBits-for-inlined-external.patch
@@ -1,0 +1,40 @@
+From 99bcd885154ce85670316f4803facf645798e3c6 Mon Sep 17 00:00:00 2001
+From: Rong Bao <webmaster@csmantle.top>
+Date: Sun, 1 Feb 2026 11:59:22 +0800
+Subject: [PATCH] =?UTF-8?q?Bug=20=3F=20-=20Export=20CanonicalizedNaNBits?=
+ =?UTF-8?q?=20for=20inlined=20external=20usage.=20r=3D=3F?=
+
+---
+ js/public/Value.h            | 2 +-
+ js/src/vm/Initialization.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/js/public/Value.h b/js/public/Value.h
+index 98f0f9273b20..80662a771644 100644
+--- a/js/public/Value.h
++++ b/js/public/Value.h
+@@ -451,7 +451,7 @@ constexpr uint64_t CanonicalizedNaNSignificand = 0x8000000000000;
+ #endif
+ 
+ #if defined(JS_RUNTIME_CANONICAL_NAN)
+-extern uint64_t CanonicalizedNaNBits;
++extern MOZ_EXPORT uint64_t CanonicalizedNaNBits;
+ #else
+ constexpr uint64_t CanonicalizedNaNBits =
+     mozilla::SpecificNaNBits<double, detail::CanonicalizedNaNSignBit,
+diff --git a/js/src/vm/Initialization.cpp b/js/src/vm/Initialization.cpp
+index 3c9f72ab1d3f..52ebe6a2aa19 100644
+--- a/js/src/vm/Initialization.cpp
++++ b/js/src/vm/Initialization.cpp
+@@ -68,7 +68,7 @@ static void CheckMessageParameterCounts() {
+ 
+ #if defined(JS_RUNTIME_CANONICAL_NAN)
+ namespace JS::detail {
+-uint64_t CanonicalizedNaNBits;
++MOZ_EXPORT uint64_t CanonicalizedNaNBits;
+ }  // namespace JS::detail
+ #endif
+ 
+-- 
+2.52.0
+

--- a/lang-js/js-128/autobuild/prepare
+++ b/lang-js/js-128/autobuild/prepare
@@ -18,6 +18,37 @@ sed -i 's/icu-i18n/icu-uc &/' js/moz.configure
 abinfo "Adapted from FC43: Fixup permissions"
 chmod -x third_party/rust/bumpalo/src/lib.rs
 
+if ab_match_arch riscv64; then
+    abinfo "Disabling JIT for riscv64 ..."
+    echo "ac_add_options --disable-jit" \
+        >> "$SRCDIR"/autobuild/mozconfig
+elif ab_match_arch loongson3; then
+    abinfo "Setting toolchains for loongson3 ..."
+    echo "ac_add_options --host=mips64el-aosc-linux-gnuabi64" \
+        >> "$SRCDIR"/autobuild/mozconfig
+    echo "ac_add_options --target=mips64el-aosc-linux-gnuabi64" \
+        >> "$SRCDIR"/autobuild/mozconfig
+
+    abinfo "Disabling JIT for loongson3 ..."
+    echo "ac_add_options --disable-jit" \
+        >> "$SRCDIR"/autobuild/mozconfig
+fi
+
+abinfo "Setting object file directory ..."
+echo "mk_add_options MOZ_OBJDIR=${SRCDIR}/obj" \
+    >> "$SRCDIR"/autobuild/mozconfig
+
+cp -v "$SRCDIR"/{autobuild/,}mozconfig
+
+abinfo 'Making sure $SHELL is set ...'
+export SHELL=/bin/bash
+
+abinfo "Removing existing obj directory ..."
+rm -rfv "$SRCDIR"/obj-*
+
+abinfo "Setting MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=pip for installing Python dependencies ..."
+export MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=pip
+
 # FIXME: mozbuild.configure.options.InvalidOptionError: RUSTFLAGS takes 1 value
 # Ref: https://src.fedoraproject.org/rpms/redhat-rpm-config/pull-request/243.
 abinfo "Unsetting RUSTFLAGS to workaround the broken Mozilla build system ..."

--- a/lang-js/js-128/spec
+++ b/lang-js/js-128/spec
@@ -1,4 +1,5 @@
 VER=128.14.0
+REL=1
 SRCS="https://ftp.mozilla.org/pub/firefox/releases/${VER}esr/source/firefox-${VER}esr.source.tar.xz"
 CHKSUMS="sha256::93b9ef6229f41cb22ff109b95bbf61a78395a0fe4b870192eeca22947cb09a53"
 CHKUPDATE="html::url=https://ftp.mozilla.org/pub/firefox/releases/;pattern=(128\.\d+\.\d+)esr"


### PR DESCRIPTION
Topic Description
-----------------

- gjs: rebuild for js-128
- js-128: export CanonicalizedNaNBits to fix gjs builds
    Link: https://bugzilla.mozilla.org/show_bug.cgi?id=2013747

Package(s) Affected
-------------------

- gjs: 1.85.1-1
- js-128: 128.14.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit js-128 gjs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
