### PR TITLE
pkgsite-tools: update to 0.8.1

### DIFF
--- a/app-utils/pkgsite-tools/spec
+++ b/app-utils/pkgsite-tools/spec
@@ -1,4 +1,4 @@
-VER=0.7.6
+VER=0.8.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/pkgsite-tools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377917"


### PR DESCRIPTION
Topic Description
-----------------

- pkgsite-tools: update to 0.8.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- pkgsite-tools: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgsite-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
