### PR TITLE
deno: update to 2.6.8

### DIFF
--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.6.7
+VER=2.6.8
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=145.0.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::bfcec98ec40390c904dd7ac76d823cb5b1fab2fd806a3dd115d4a80cc35910ec \
+CHKSUMS="sha256::61fab2832c0fd946ba40196df267d0f10cb5fc7ac375ca50d95cd463ecb775b2 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.6.8
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.6.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
