### PR TITLE
x265: fix build, multi-bitdepth for all, LoongArch SIMD optimisation

### DIFF
--- a/runtime-multimedia/x265/autobuild/build
+++ b/runtime-multimedia/x265/autobuild/build
@@ -1,45 +1,52 @@
-mkdir build{-10,-12}
+abinfo "Creating build directories ..."
+mkdir -pv "$BLDDIR"{,-1{0,2}}
 
-# High bit-depth support adapted from Arch Linux,
-# limited to x86_64 (amd64).
-if ! ab_match_arch amd64; then
-	cd build
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DENABLE_SHARED=TRUE \
-                ${CMAKE_AFTER}
-	make
-	make install DESTDIR="$PKGDIR"
-else
-	cd build-12
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DHIGH_BIT_DEPTH=TRUE \
-		-DMAIN12=TRUE \
-		-DEXPORT_C_API=FALSE \
-		-DENABLE_CLI=FALSE \
-		-DENABLE_SHARED=FALSE ${CMAKE_AFTER}
-	make
-	cd ../build-10
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DHIGH_BIT_DEPTH=TRUE \
-		-DEXPORT_C_API=FALSE \
-		-DENABLE_CLI=FALSE \
-		-DENABLE_SHARED=FALSE ${CMAKE_AFTER}
-	make
-	cd ../build
-	ln -s ../build-10/libx265.a libx265_main10.a
-	ln -s ../build-12/libx265.a libx265_main12.a
-	cmake ../source ${CMAKE_DEF[@]} \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DENABLE_SHARED=TRUE \
-		-DEXTRA_LIB='x265_main10.a;x265_main12.a' \
-		-DEXTRA_LINK_FLAGS=-L. \
-		-DLINKED_10BIT=TRUE \
-		-DLINKED_12BIT=TRUE ${CMAKE_AFTER}
-	make
-	make install DESTDIR="$PKGDIR"
-fi
+abinfo "Configuring x265 (12-bit depth) ..."
+cd "$BLDDIR"-12
+cmake "$SRCDIR"/source \
+    ${CMAKE_DEF[@]} \
+    -DENABLE_HDR10_PLUS=ON \
+    -DHIGH_BIT_DEPTH=ON \
+    -DMAIN12=ON \
+    -DEXPORT_C_API=OFF \
+    -DENABLE_CLI=OFF \
+    -DENABLE_SHARED=OFF
 
-cd "$SRCDIR"
+abinfo "Builing x265 (12-bit depth) ..."
+make
+
+abinfo "Configuring x265 (10-bit depth) ..."
+cd "$BLDDIR"-10
+cmake "$SRCDIR"/source \
+    ${CMAKE_DEF[@]} \
+    -DENABLE_HDR10_PLUS=ON \
+    -DHIGH_BIT_DEPTH=ON \
+    -DEXPORT_C_API=OFF \
+    -DENABLE_CLI=OFF \
+    -DENABLE_SHARED=OFF
+
+abinfo "Building x265 (10-bit depth) ..."
+make
+
+abinfo "Configuring x265 (main, linked against 10/12-bit depth versions) ..."
+cd "$BLDDIR"
+ln -sv "$BLDDIR"-10/libx265.a \
+    libx265_main10.a
+ln -sv "$BLDDIR"-12/libx265.a \
+    libx265_main12.a
+cmake "$SRCDIR"/source \
+    ${CMAKE_DEF[@]} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DENABLE_HDR10_PLUS=ON \
+    -DEXTRA_LIB='x265_main10.a;x265_main12.a' \
+    -DEXTRA_LINK_FLAGS=-L. \
+    -DLINKED_10BIT=ON \
+    -DLINKED_12BIT=ON \
+    -DENABLE_SHARED=ON
+
+abinfo "Building x265 (main, linked against 10/12-bit depth versions) ..."
+make
+
+abinfo "Installing x265 (main, linked against 10/12-bit depth versions) ..."
+make install \
+    DESTDIR="$PKGDIR"

--- a/runtime-multimedia/x265/autobuild/defines
+++ b/runtime-multimedia/x265/autobuild/defines
@@ -2,13 +2,7 @@ PKGNAME=x265
 PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
-PKGDES="Open source H265/HEVC video encoder"
-
-# some applications might want this e.g. sunshine
-CMAKE_AFTER="-DENABLE_HDR10_PLUS=ON"
-CMAKE_AFTER__PPC64=" \
-             ${CMAKE_AFTER} \
-             -DENABLE_ALTIVEC=OFF"
+PKGDES="H265/HEVC video encoder"
 
 PKGBREAK="avidemux<=2.8.1 digikam<=7.9.0-2 vlc<=3.0.20-3 xpra<=5.0.8 \
           gstreamer<=1.22.0-5 ffmpeg<=4.4.4-3 libheif<=1.17.6-1"

--- a/runtime-multimedia/x265/autobuild/patches/0001-ARCHLINUX-Fix-build-with-GCC-15.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0001-ARCHLINUX-Fix-build-with-GCC-15.patch
@@ -1,7 +1,7 @@
 From 0d8214d6fc8fd0697ca67040c7279105fba01451 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 5 Jun 2025 21:45:58 +0200
-Subject: [PATCH] ARCHLINUX: Fix build with GCC 15
+Subject: [PATCH 01/15] ARCHLINUX: Fix build with GCC 15
 
 Signed-off-by: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
 

--- a/runtime-multimedia/x265/autobuild/patches/0001-ARCHLINUX-Fix-build-with-GCC-15.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0001-ARCHLINUX-Fix-build-with-GCC-15.patch
@@ -1,0 +1,28 @@
+From 0d8214d6fc8fd0697ca67040c7279105fba01451 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 5 Jun 2025 21:45:58 +0200
+Subject: [PATCH] ARCHLINUX: Fix build with GCC 15
+
+Signed-off-by: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+
+Link: https://gitlab.archlinux.org/archlinux/packaging/packages/x265/-/blob/9d27978355453de977f7ac88144857525a2fb5cc/0001-Fix-build-with-GCC-15.patch
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/dynamicHDR10/json11/json11.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/source/dynamicHDR10/json11/json11.cpp b/source/dynamicHDR10/json11/json11.cpp
+index 762577735..74f990a51 100644
+--- a/source/dynamicHDR10/json11/json11.cpp
++++ b/source/dynamicHDR10/json11/json11.cpp
+@@ -25,6 +25,7 @@
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>
++#include <cstdint>
+ 
+ #if _MSC_VER
+ #pragma warning(disable: 4510) //const member cannot be default initialized
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0002-BACKPORT-FROMLIST-LoongArch64-Add-loongarch-support.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0002-BACKPORT-FROMLIST-LoongArch64-Add-loongarch-support.patch
@@ -1,0 +1,267 @@
+From 07cbb78aff934f4d718cc155aaecf6678ade76ce Mon Sep 17 00:00:00 2001
+From: yuanhecai <yuanhecai@loongson.cn>
+Date: Mon, 5 Feb 2024 17:06:16 +0800
+Subject: [PATCH 02/15] BACKPORT: FROMLIST: LoongArch64: Add loongarch support
+
+Lsx and Lasx optimizations are automatically enabled by detecting
+the characteristics of the CPU.
+
+Change-Id: I22de05163adb075856722d37f15ac8469ba5c6b0
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/CMakeLists.txt        | 45 ++++++++++++++++++++++++++++++++++--
+ source/cmake/FindLASX.cmake  | 14 +++++++++++
+ source/cmake/FindLSX.cmake   | 14 +++++++++++
+ source/common/CMakeLists.txt |  7 ++++--
+ source/common/cpu.cpp        | 31 +++++++++++++++++++++++--
+ source/test/testbench.cpp    |  2 ++
+ source/x265.h                |  4 ++++
+ 7 files changed, 111 insertions(+), 6 deletions(-)
+ create mode 100644 source/cmake/FindLASX.cmake
+ create mode 100644 source/cmake/FindLSX.cmake
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index ab5ddfeb7..785015ec1 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -51,6 +51,9 @@ list(FIND ARM_ALIASES "${SYSPROC}" ARMMATCH)
+ list(FIND ARM64_ALIASES "${SYSPROC}" ARM64MATCH)
+ set(POWER_ALIASES powerpc64 powerpc64le ppc64 ppc64le)
+ list(FIND POWER_ALIASES "${SYSPROC}" POWERMATCH)
++set(LOONGARCH64_ALIASES loongarch64)
++list(FIND LOONGARCH64_ALIASES "${SYSPROC}" LOONGARCH64MATCH)
++
+ if(X86MATCH GREATER "-1")
+     set(X86 1)
+     add_definitions(-DX265_ARCH_X86=1)
+@@ -88,6 +91,10 @@ elseif(ARM64MATCH GREATER "-1")
+     message(STATUS "Detected ARM64 target processor")
+     set(ARM64 1)
+     add_definitions(-DX265_ARCH_ARM64=1 -DHAVE_NEON)
++elseif(LOONGARCH64MATCH GREATER "-1")
++    set(LOONGARCH64 1)
++    add_definitions(-DLOONGARCH64=1 -DX265_ARCH_LOONGARCH64=1)
++    message(STATUS "Detected LOONGARCH64 target processor")
+ else()
+     message(STATUS "CMAKE_SYSTEM_PROCESSOR value `${CMAKE_SYSTEM_PROCESSOR}` is unknown")
+     message(STATUS "Please add this value near ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}")
+@@ -286,6 +293,23 @@ if(GCC)
+ 	list(APPEND ARM_ARGS -DPIC)
+ 	endif()
+     add_definitions(${ARM_ARGS})
++    if(LOONGARCH64)
++        set(LOONGARCH64_ARGS -fPIC)
++
++        find_package(LSX)
++        find_package(LASX)
++
++        if(SUPPORTS_LSX)
++            add_definitions(-DHAVE_LSX=1)
++        endif()
++
++        if(SUPPORTS_LASX)
++            add_definitions(-DHAVE_LASX=1)
++        endif()
++
++    endif()
++    add_definitions(${LOONGARCH64_ARGS})
++
+     if(FPROFILE_GENERATE)
+         if(INTEL_CXX)
+             add_definitions(-prof-gen -prof-dir="${CMAKE_CURRENT_BINARY_DIR}")
+@@ -410,7 +434,7 @@ if(EXTRA_LIB)
+ endif(EXTRA_LIB)
+ mark_as_advanced(EXTRA_LIB EXTRA_LINK_FLAGS)
+ 
+-if(X64 OR ARM64 OR PPC64)
++if(X64 OR ARM64 OR PPC64 OR LOONGARCH64)
+     # NOTE: We only officially support high-bit-depth compiles of x265
+     # on 64bit architectures. Main10 plus large resolution plus slow
+     # preset plus 32bit address space usually means malloc failure.  You
+@@ -419,7 +443,7 @@ if(X64 OR ARM64 OR PPC64)
+     # license" so to speak.  If it breaks you get to keep both halves.
+     # You will need to disable assembly manually.
+     option(HIGH_BIT_DEPTH "Store pixel samples as 16bit values (Main10/Main12)" OFF)
+-endif(X64 OR ARM64 OR PPC64)
++endif(X64 OR ARM64 OR PPC64 OR LOONGARCH64)
+ if(HIGH_BIT_DEPTH)
+     option(MAIN12 "Support Main12 instead of Main10" OFF)
+     if(MAIN12)
+@@ -523,6 +547,10 @@ if(POWER)
+     endif()
+ endif()
+ 
++if(LOONGARCH64)
++    list(APPEND ASM_FLAGS -DHIGH_BIT_DEPTH=0 -DBIT_DEPTH=8 -DX265_NS=${X265_NS})
++endif(LOONGARCH64)
++
+ include(Version) # determine X265_VERSION and X265_LATEST_TAG
+ include_directories(. common encoder "${PROJECT_BINARY_DIR}")
+ 
+@@ -640,6 +668,19 @@ if((MSVC_IDE OR XCODE OR GCC) AND ENABLE_ASSEMBLY)
+                 COMMAND ${NASM_EXECUTABLE} ARGS ${NASM_FLAGS} ${ASM_SRC} -o ${ASM}.${SUFFIX}
+                 DEPENDS ${ASM_SRC})
+         endforeach()
++    elseif(LOONGARCH64)
++    # compile LOONGARCH arch asm files here
++        enable_language(ASM)
++        foreach(ASM ${LOONGARCH64_ASMS})
++            set(ASM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/common/loongarch64/${ASM})
++            list(APPEND ASM_SRCS ${ASM_SRC})
++            list(APPEND ASM_OBJS ${ASM}.${SUFFIX})
++            add_custom_command(
++                OUTPUT ${ASM}.${SUFFIX}
++                COMMAND ${CMAKE_CXX_COMPILER}
++                ARGS ${LOONGARCH64_ARGS} -c ${ASM_SRC} -o ${ASM}.${SUFFIX}
++                DEPENDS ${ASM_SRC})
++        endforeach()
+     endif()
+ endif()
+ source_group(ASM FILES ${ASM_SRCS})
+diff --git a/source/cmake/FindLASX.cmake b/source/cmake/FindLASX.cmake
+new file mode 100644
+index 000000000..6f635c042
+--- /dev/null
++++ b/source/cmake/FindLASX.cmake
+@@ -0,0 +1,14 @@
++include(FindPackageHandleStandardArgs)
++
++if(LOONGARCH64)
++
++    set(CHECK_LASX_CODE "
++        int main(int argc, char **argv) {
++            __asm__ volatile (
++               \"xvadd.w $xr0, $xr1, $xr1\"
++            );
++           return 0; }")
++
++    check_cxx_source_compiles("${CHECK_LASX_CODE}" SUPPORTS_LASX)
++
++endif()
+diff --git a/source/cmake/FindLSX.cmake b/source/cmake/FindLSX.cmake
+new file mode 100644
+index 000000000..a7c3e4198
+--- /dev/null
++++ b/source/cmake/FindLSX.cmake
+@@ -0,0 +1,14 @@
++include(FindPackageHandleStandardArgs)
++
++if(LOONGARCH64)
++
++    set(CHECK_LSX_CODE "
++        int main(int argc, char **argv) {
++            __asm__ volatile (
++               \"vadd.w $vr0, $vr1, $vr1\"
++            );
++            return 0; }")
++
++    check_cxx_source_compiles("${CHECK_LSX_CODE}" SUPPORTS_LSX)
++
++endif()
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index 184b94127..ec526593b 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -133,7 +133,6 @@ if(POWER)
+     endif()
+ endif()
+ 
+-
+ # set_target_properties can't do list expansion
+ string(REPLACE ";" " " VERSION_FLAGS "${VFLAGS}")
+ set_source_files_properties(version.cpp PROPERTIES COMPILE_FLAGS ${VERSION_FLAGS})
+@@ -144,7 +143,11 @@ if(HAVE_STRTOK_R)
+ endif()
+ 
+ if(GCC AND CC_HAS_NO_NARROWING)
+-    set_source_files_properties(cpu.cpp PROPERTIES COMPILE_FLAGS -Wno-narrowing)
++    if(ENABLE_ASSEMBLY)
++        set_source_files_properties(cpu.cpp PROPERTIES COMPILE_FLAGS "-DENABLE_ASSEMBLY=1 -Wno-narrowing")
++    else()
++        set_source_files_properties(cpu.cpp PROPERTIES COMPILE_FLAGS -Wno-narrowing)
++    endif()
+ endif()
+ if(WIN32)
+     set(WINXP winxp.h winxp.cpp)
+diff --git a/source/common/cpu.cpp b/source/common/cpu.cpp
+index 6cf0a5312..fd0e72af8 100644
+--- a/source/common/cpu.cpp
++++ b/source/common/cpu.cpp
+@@ -117,7 +117,9 @@ const cpu_name_t cpu_names[] =
+ #endif
+ #elif X265_ARCH_POWER8
+     { "Altivec",         X265_CPU_ALTIVEC },
+-
++#elif X265_ARCH_LOONGARCH64
++    { "LSX",             X265_CPU_LSX},
++    { "LASX",            X265_CPU_LASX},
+ #endif // if X265_ARCH_X86
+     { "", 0 },
+ };
+@@ -414,7 +416,32 @@ uint32_t cpu_detect(bool benableavx512)
+ #endif
+ }
+ 
+-#else // if X265_ARCH_POWER8
++#elif X265_ARCH_LOONGARCH64
++
++#include <sys/auxv.h>
++
++#define LA_HWCAP_LSX    ( 1U << 4 )
++#define LA_HWCAP_LASX   ( 1U << 5 )
++
++uint32_t cpu_detect( bool benableavx512 )
++{
++    uint32_t flags = 0;
++#if ENABLE_ASSEMBLY
++    uint32_t hwcap = (uint32_t)getauxval( AT_HWCAP );
++#if HAVE_LSX
++    if( hwcap & LA_HWCAP_LSX )
++        flags |= X265_CPU_LSX;
++#endif
++#if HAVE_LASX
++    if( hwcap & LA_HWCAP_LASX )
++        flags |= X265_CPU_LASX;
++#endif
++#endif
++
++    return flags;
++}
++
++#else // if X265_ARCH_LOONGARCH64
+ 
+ uint32_t cpu_detect(bool benableavx512)
+ {
+diff --git a/source/test/testbench.cpp b/source/test/testbench.cpp
+index ddcfd6139..688daa74b 100644
+--- a/source/test/testbench.cpp
++++ b/source/test/testbench.cpp
+@@ -177,6 +177,8 @@ int main(int argc, char *argv[])
+         { "SVE2", X265_CPU_SVE2 },
+         { "SVE", X265_CPU_SVE },
+         { "FastNeonMRC", X265_CPU_FAST_NEON_MRC },
++        { "LSX", X265_CPU_LSX },
++        { "LASX", X265_CPU_LASX },
+         { "", 0 },
+     };
+ 
+diff --git a/source/x265.h b/source/x265.h
+index 4452526ae..4ebad9a6f 100644
+--- a/source/x265.h
++++ b/source/x265.h
+@@ -545,6 +545,10 @@ typedef enum
+ /* IBM Power8 */
+ #define X265_CPU_ALTIVEC         0x0000001
+ 
++/* LOONGARCH */
++#define X265_CPU_LSX             0x0000001
++#define X265_CPU_LASX            0x0000002
++
+ #define X265_MAX_SUBPEL_LEVEL   7
+ 
+ /* Log level */
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0003-FROMLIST-LoongArch64-Optimize-functions-in-loopfilte.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0003-FROMLIST-LoongArch64-Optimize-functions-in-loopfilte.patch
@@ -1,0 +1,2338 @@
+From c55772bb32b5d5f5c27daa02d4dfbbb099c8b523 Mon Sep 17 00:00:00 2001
+From: Hao Chen <chenhao@loongson.cn>
+Date: Thu, 30 May 2024 19:26:19 +0800
+Subject: [PATCH 03/15] FROMLIST: LoongArch64: Optimize functions in loopfilter
+ module
+
+Optimize functions in loopfilter module with lsx and lasx.
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/CMakeLists.txt                        |    2 +
+ source/common/CMakeLists.txt                 |   19 +
+ source/common/loongarch64/asm-primitives.cpp |   71 +
+ source/common/loongarch64/loongson_asm.S     |  769 ++++++++++
+ source/common/loongarch64/loopfilter.S       | 1324 ++++++++++++++++++
+ source/common/loongarch64/loopfilter.h       |   57 +
+ source/test/testharness.h                    |    5 +
+ 7 files changed, 2247 insertions(+)
+ create mode 100644 source/common/loongarch64/asm-primitives.cpp
+ create mode 100644 source/common/loongarch64/loongson_asm.S
+ create mode 100644 source/common/loongarch64/loopfilter.S
+ create mode 100644 source/common/loongarch64/loopfilter.h
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 785015ec1..bb5ed3fbc 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -410,6 +410,8 @@ elseif(NASM_FOUND AND X86)
+         message(STATUS "Found Nasm ${NASM_VERSION_STRING} to build assembly primitives")
+         option(ENABLE_ASSEMBLY "Enable use of assembly coded primitives" ON)
+     endif()
++elseif(LOONGARCH64)
++    option(ENABLE_ASSEMBLY "Enable use of assembly coded primitives" ON)
+ else()
+     option(ENABLE_ASSEMBLY "Enable use of assembly coded primitives" OFF)
+ endif()
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index ec526593b..b18482349 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -133,6 +133,25 @@ if(POWER)
+     endif()
+ endif()
+ 
++if(ENABLE_ASSEMBLY AND LOONGARCH64)
++    if(GCC AND (CMAKE_CXX_FLAGS_RELEASE MATCHES "-O3"))
++        message(STATUS "Detected CXX compiler using -O3 optimization level")
++    endif()
++
++    set(C_SRCS asm-primitives.cpp loopfilter.h)
++    enable_language(ASM)
++
++    # add loongarch assembly/intrinsic files here
++    set(A_SRCS loopfilter.S)
++
++    set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
++    foreach(SRC ${C_SRCS})
++        set(ASM_PRIMITIVES ${ASM_PRIMITIVES} loongarch64/${SRC})
++    endforeach()
++    source_group(Assembly FILES ${ASM_PRIMITIVES})
++
++endif(ENABLE_ASSEMBLY AND LOONGARCH64)
++
+ # set_target_properties can't do list expansion
+ string(REPLACE ";" " " VERSION_FLAGS "${VFLAGS}")
+ set_source_files_properties(version.cpp PROPERTIES COMPILE_FLAGS ${VERSION_FLAGS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+new file mode 100644
+index 000000000..53ba228a7
+--- /dev/null
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -0,0 +1,71 @@
++/*****************************************************************************
++ * Copyright (C) 2013-2024 MulticoreWare, Inc
++ *
++ * Authors: Hao Chen <chenhao@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "common.h"
++#include "primitives.h"
++#include "x265.h"
++#include "cpu.h"
++#include "loopfilter.h"
++
++namespace X265_NS {
++// private x265 namespace
++
++
++void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
++{
++#if HAVE_LSX
++    if (cpuMask & X265_CPU_LSX)
++    {
++        // loopfilter
++        p.saoCuOrgE0 = PFX(saoCuOrgE0_lsx);
++        p.saoCuOrgE1 = PFX(saoCuOrgE1_lsx);
++        p.saoCuOrgE1_2Rows = PFX(saoCuOrgE1_2Rows_lsx);
++        p.saoCuOrgE2[0] = PFX(saoCuOrgE2_lsx);
++        p.saoCuOrgE2[1] = PFX(saoCuOrgE2_lsx);
++        p.saoCuOrgE3[0] = PFX(saoCuOrgE3_lsx);
++        p.saoCuOrgE3[1] = PFX(saoCuOrgE3_lsx);
++        p.saoCuOrgB0 = PFX(saoCuOrgB0_lsx);
++        p.sign = PFX(calSign_lsx);
++        p.pelFilterLumaStrong[0] = PFX(pelFilterLumaStrong_V_lsx);
++        p.pelFilterLumaStrong[1] = PFX(pelFilterLumaStrong_H_lsx);
++        p.pelFilterChroma[0] = PFX(pelFilterChroma_V_lsx);
++        p.pelFilterChroma[1] = PFX(pelFilterChroma_H_lsx);
++        p.saoCuStatsE0 = PFX(saoCuStatsE0_lsx);
++        p.saoCuStatsE1 = PFX(saoCuStatsE1_lsx);
++        p.saoCuStatsE2 = PFX(saoCuStatsE2_lsx);
++        p.saoCuStatsE3 = PFX(saoCuStatsE3_lsx);
++        p.saoCuStatsBO = PFX(saoCuStatsB0_lsx);
++
++    }
++#endif /* HAVE_LSX */
++
++#if HAVE_LASX
++    if (cpuMask & X265_CPU_LASX)
++    {
++        // loopfilter
++        p.sign = PFX(calSign_lasx);
++    }
++#endif /* HAVE_LASX */
++}
++
++}
+diff --git a/source/common/loongarch64/loongson_asm.S b/source/common/loongarch64/loongson_asm.S
+new file mode 100644
+index 000000000..c00082ab1
+--- /dev/null
++++ b/source/common/loongarch64/loongson_asm.S
+@@ -0,0 +1,769 @@
++/*
++*****************************************************************************
++* loongson_asm.S: loongson asm abstraction layer
++*****************************************************************************
++* Copyright (c) 2024 Loongson Technology Corporation Limited
++* Copyright (C) 2013-2024 MulticoreWarae, Inc
++*
++* Authors: gxw <guxiwei-hf@loongson.cn>
++*          Shiyou Yin<yinshiyou-hf@loongson.cn>
++*
++* Permission to use, copy, modify, and/or distribute this software for any
++* purpose with or without fee is hereby granted, provided that the above
++* copyright notice and this permission notice appear in all copies.
++*
++* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++*****************************************************************************
++*/
++
++/*
++ * This file is a LoongArch assembly helper file and available under ISC
++ * license. It provides a large number of macros and alias to simplify
++ * writing assembly code, especially for LSX and LASX optimizations.
++ *
++ * Any one can modify it or add new features for his/her own purposes.
++ * Contributing a patch will be appreciated as it might be useful for
++ * others as well. Send patches to loongson contributor mentioned above.
++ *
++ * MAJOR version: Usage changes, incompatible with previous version.
++ * MINOR version: Add new macros/functions, or bug fixes.
++ * MICRO version: Comment changes or implementation changes.
++ */
++
++#define LML_VERSION_MAJOR 0
++#define LML_VERSION_MINOR 4
++#define LML_VERSION_MICRO 0
++
++#define ASM_PREF
++#define DEFAULT_ALIGN    5
++
++.macro function name, align=DEFAULT_ALIGN
++.macro endfunc
++    jirl    $r0, $r1, 0x0
++    .size ASM_PREF\name, . - ASM_PREF\name
++    .purgem endfunc
++.endm
++.text ;
++.align \align ;
++.globl ASM_PREF\name ;
++.type  ASM_PREF\name, @function ;
++ASM_PREF\name: ;
++.endm
++
++.macro  const name, align=DEFAULT_ALIGN
++    .macro endconst
++    .size  \name, . - \name
++    .purgem endconst
++    .endm
++.section .rodata
++.align   \align
++\name:
++.endm
++
++/*
++ *============================================================================
++ * LoongArch register alias
++ *============================================================================
++ */
++
++#define a0 $a0
++#define a1 $a1
++#define a2 $a2
++#define a3 $a3
++#define a4 $a4
++#define a5 $a5
++#define a6 $a6
++#define a7 $a7
++
++#define t0 $t0
++#define t1 $t1
++#define t2 $t2
++#define t3 $t3
++#define t4 $t4
++#define t5 $t5
++#define t6 $t6
++#define t7 $t7
++#define t8 $t8
++
++#define s0 $s0
++#define s1 $s1
++#define s2 $s2
++#define s3 $s3
++#define s4 $s4
++#define s5 $s5
++#define s6 $s6
++#define s7 $s7
++#define s8 $s8
++
++#define zero $zero
++#define sp   $sp
++#define ra   $ra
++
++#define fa0  $fa0
++#define fa1  $fa1
++#define fa2  $fa2
++#define fa3  $fa3
++#define fa4  $fa4
++#define fa5  $fa5
++#define fa6  $fa6
++#define fa7  $fa7
++#define ft0  $ft0
++#define ft1  $ft1
++#define ft2  $ft2
++#define ft3  $ft3
++#define ft4  $ft4
++#define ft5  $ft5
++#define ft6  $ft6
++#define ft7  $ft7
++#define ft8  $ft8
++#define ft9  $ft9
++#define ft10 $ft10
++#define ft11 $ft11
++#define ft12 $ft12
++#define ft13 $ft13
++#define ft14 $ft14
++#define ft15 $ft15
++#define fs0  $fs0
++#define fs1  $fs1
++#define fs2  $fs2
++#define fs3  $fs3
++#define fs4  $fs4
++#define fs5  $fs5
++#define fs6  $fs6
++#define fs7  $fs7
++
++#define f0  $f0
++#define f1  $f1
++#define f2  $f2
++#define f3  $f3
++#define f4  $f4
++#define f5  $f5
++#define f6  $f6
++#define f7  $f7
++#define f8  $f8
++#define f9  $f9
++#define f10 $f10
++#define f11 $f11
++#define f12 $f12
++#define f13 $f13
++#define f14 $f14
++#define f15 $f15
++#define f16 $f16
++#define f17 $f17
++#define f18 $f18
++#define f19 $f19
++#define f20 $f20
++#define f21 $f21
++#define f22 $f22
++#define f23 $f23
++#define f24 $f24
++#define f25 $f25
++#define f26 $f26
++#define f27 $f27
++#define f28 $f28
++#define f29 $f29
++#define f30 $f30
++#define f31 $f31
++
++#define vr0 $vr0
++#define vr1 $vr1
++#define vr2 $vr2
++#define vr3 $vr3
++#define vr4 $vr4
++#define vr5 $vr5
++#define vr6 $vr6
++#define vr7 $vr7
++#define vr8 $vr8
++#define vr9 $vr9
++#define vr10 $vr10
++#define vr11 $vr11
++#define vr12 $vr12
++#define vr13 $vr13
++#define vr14 $vr14
++#define vr15 $vr15
++#define vr16 $vr16
++#define vr17 $vr17
++#define vr18 $vr18
++#define vr19 $vr19
++#define vr20 $vr20
++#define vr21 $vr21
++#define vr22 $vr22
++#define vr23 $vr23
++#define vr24 $vr24
++#define vr25 $vr25
++#define vr26 $vr26
++#define vr27 $vr27
++#define vr28 $vr28
++#define vr29 $vr29
++#define vr30 $vr30
++#define vr31 $vr31
++
++#define xr0 $xr0
++#define xr1 $xr1
++#define xr2 $xr2
++#define xr3 $xr3
++#define xr4 $xr4
++#define xr5 $xr5
++#define xr6 $xr6
++#define xr7 $xr7
++#define xr8 $xr8
++#define xr9 $xr9
++#define xr10 $xr10
++#define xr11 $xr11
++#define xr12 $xr12
++#define xr13 $xr13
++#define xr14 $xr14
++#define xr15 $xr15
++#define xr16 $xr16
++#define xr17 $xr17
++#define xr18 $xr18
++#define xr19 $xr19
++#define xr20 $xr20
++#define xr21 $xr21
++#define xr22 $xr22
++#define xr23 $xr23
++#define xr24 $xr24
++#define xr25 $xr25
++#define xr26 $xr26
++#define xr27 $xr27
++#define xr28 $xr28
++#define xr29 $xr29
++#define xr30 $xr30
++#define xr31 $xr31
++
++/*
++ *============================================================================
++ * LSX/LASX synthesize instructions
++ *============================================================================
++ */
++
++/*
++ * Description : Dot product of byte vector elements
++ * Arguments   : Inputs  - vj, vk
++ *               Outputs - vd
++ *               Return Type - halfword
++ */
++.macro vdp2.h.bu vd, vj, vk
++    vmulwev.h.bu      \vd,    \vj,    \vk
++    vmaddwod.h.bu     \vd,    \vj,    \vk
++.endm
++
++.macro vdp2.h.bu.b vd, vj, vk
++    vmulwev.h.bu.b    \vd,    \vj,    \vk
++    vmaddwod.h.bu.b   \vd,    \vj,    \vk
++.endm
++
++.macro vdp2.w.h vd, vj, vk
++    vmulwev.w.h       \vd,    \vj,    \vk
++    vmaddwod.w.h      \vd,    \vj,    \vk
++.endm
++
++.macro xvdp2.h.bu xd, xj, xk
++    xvmulwev.h.bu    \xd,    \xj,    \xk
++    xvmaddwod.h.bu   \xd,    \xj,    \xk
++.endm
++
++.macro xvdp2.h.bu.b xd, xj, xk
++    xvmulwev.h.bu.b    \xd,  \xj,    \xk
++    xvmaddwod.h.bu.b   \xd,  \xj,    \xk
++.endm
++
++.macro xvdp2.w.h xd, xj, xk
++    xvmulwev.w.h       \xd,  \xj,    \xk
++    xvmaddwod.w.h      \xd,  \xj,    \xk
++.endm
++
++/*
++ * Description : Dot product & addition of halfword vector elements
++ * Arguments   : Inputs  - vj, vk
++ *               Outputs - vd
++ *               Return Type - twice size of input
++ */
++.macro vdp2add.h.bu vd, vj, vk
++    vmaddwev.h.bu     \vd,    \vj,    \vk
++    vmaddwod.h.bu     \vd,    \vj,    \vk
++.endm
++
++.macro vdp2add.h.bu.b vd, vj, vk
++    vmaddwev.h.bu.b   \vd,    \vj,    \vk
++    vmaddwod.h.bu.b   \vd,    \vj,    \vk
++.endm
++
++.macro vdp2add.w.h vd, vj, vk
++    vmaddwev.w.h      \vd,    \vj,    \vk
++    vmaddwod.w.h      \vd,    \vj,    \vk
++.endm
++
++.macro xvdp2add.h.bu.b xd, xj, xk
++    xvmaddwev.h.bu.b   \xd,  \xj,    \xk
++    xvmaddwod.h.bu.b   \xd,  \xj,    \xk
++.endm
++
++.macro xvdp2add.w.h xd, xj, xk
++    xvmaddwev.w.h      \xd,  \xj,    \xk
++    xvmaddwod.w.h      \xd,  \xj,    \xk
++.endm
++
++/*
++ * Description : Range element vj[i] to vk[i] ~ vj[i]
++ * clip: vj > vk ? vj : vk && vj < va ? vj : va
++ */
++.macro vclip.h  vd,  vj, vk, va
++    vmax.h    \vd,  \vj,   \vk
++    vmin.h    \vd,  \vd,   \va
++.endm
++
++.macro vclip.w  vd,  vj, vk, va
++    vmax.w    \vd,  \vj,   \vk
++    vmin.w    \vd,  \vd,   \va
++.endm
++
++.macro xvclip.h  xd,  xj, xk, xa
++    xvmax.h    \xd,  \xj,   \xk
++    xvmin.h    \xd,  \xd,   \xa
++.endm
++
++.macro xvclip.w  xd,  xj, xk, xa
++    xvmax.w    \xd,  \xj,   \xk
++    xvmin.w    \xd,  \xd,   \xa
++.endm
++
++/*
++ * Description : Range element vj[i] to 0 ~ 255
++ * clip255: vj < 255 ? vj : 255 && vj > 0 ? vj : 0
++ */
++.macro vclip255.h  vd, vj
++    vmaxi.h   \vd,   \vj,  0
++    vsat.hu   \vd,   \vd,  7
++.endm
++
++.macro vclip255.w  vd, vj
++    vmaxi.w   \vd,   \vj,  0
++    vsat.wu   \vd,   \vd,  7
++.endm
++
++.macro xvclip255.h  xd, xj
++    xvmaxi.h   \xd,   \xj,  0
++    xvsat.hu   \xd,   \xd,  7
++.endm
++
++.macro xvclip255.w  xd, xj
++    xvmaxi.w   \xd,   \xj,  0
++    xvsat.wu   \xd,   \xd,  7
++.endm
++
++/*
++ * Description : Store elements of vector
++ * vd : Data vector to be stroed
++ * rk : Address of data storage
++ * ra : Offset of address
++ * si : Index of data in vd
++ */
++.macro vstelmx.b vd, rk, ra, si
++    add.d      \rk,  \rk,  \ra
++    vstelm.b   \vd,  \rk,  0, \si
++.endm
++
++.macro vstelmx.h vd, rk, ra, si
++    add.d      \rk,  \rk,  \ra
++    vstelm.h   \vd,  \rk,  0, \si
++.endm
++
++.macro vstelmx.w vd, rk, ra, si
++    add.d      \rk,  \rk,  \ra
++    vstelm.w   \vd,  \rk,  0, \si
++.endm
++
++.macro vstelmx.d  vd, rk, ra, si
++    add.d      \rk,  \rk,  \ra
++    vstelm.d   \vd,  \rk,  0, \si
++.endm
++
++.macro vmov xd, xj
++    vor.v  \xd,  \xj,  \xj
++.endm
++
++.macro xmov xd, xj
++    xvor.v  \xd,  \xj,  \xj
++.endm
++
++.macro xvstelmx.d  xd, rk, ra, si
++    add.d      \rk, \rk,  \ra
++    xvstelm.d  \xd, \rk,  0, \si
++.endm
++
++/*
++ *============================================================================
++ * LSX/LASX custom macros
++ *============================================================================
++ */
++
++/*
++ * Load 4 float, double, V128, v256 elements with stride.
++ */
++.macro FLDS_LOADX_4 src, stride, stride2, stride3, out0, out1, out2, out3
++    fld.s     \out0,    \src,    0
++    fldx.s    \out1,    \src,    \stride
++    fldx.s    \out2,    \src,    \stride2
++    fldx.s    \out3,    \src,    \stride3
++.endm
++
++.macro FLDD_LOADX_4 src, stride, stride2, stride3, out0, out1, out2, out3
++    fld.d     \out0,    \src,    0
++    fldx.d    \out1,    \src,    \stride
++    fldx.d    \out2,    \src,    \stride2
++    fldx.d    \out3,    \src,    \stride3
++.endm
++
++.macro LSX_LOADX_4 src, stride, stride2, stride3, out0, out1, out2, out3
++    vld     \out0,    \src,    0
++    vldx    \out1,    \src,    \stride
++    vldx    \out2,    \src,    \stride2
++    vldx    \out3,    \src,    \stride3
++.endm
++
++.macro LASX_LOADX_4 src, stride, stride2, stride3, out0, out1, out2, out3
++    xvld    \out0,    \src,    0
++    xvldx   \out1,    \src,    \stride
++    xvldx   \out2,    \src,    \stride2
++    xvldx   \out3,    \src,    \stride3
++.endm
++
++/*
++ * Description : Transpose 4x4 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ */
++.macro LSX_TRANSPOSE4x4_H in0, in1, in2, in3, out0, out1, out2, out3, \
++                          tmp0, tmp1
++    vilvl.h   \tmp0,  \in1,   \in0
++    vilvl.h   \tmp1,  \in3,   \in2
++    vilvl.w   \out0,  \tmp1,  \tmp0
++    vilvh.w   \out2,  \tmp1,  \tmp0
++    vilvh.d   \out1,  \out0,  \out0
++    vilvh.d   \out3,  \out0,  \out2
++.endm
++
++/*
++ * Description : Transpose 4x4 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     :
++ * Example     :
++ *               1, 2, 3, 4            1, 5, 9,13
++ *               5, 6, 7, 8    to      2, 6,10,14
++ *               9,10,11,12  =====>    3, 7,11,15
++ *              13,14,15,16            4, 8,12,16
++ */
++.macro LSX_TRANSPOSE4x4_W in0, in1, in2, in3, out0, out1, out2, out3, \
++                          tmp0, tmp1
++
++    vilvl.w    \tmp0,   \in1,    \in0
++    vilvh.w    \out1,   \in1,    \in0
++    vilvl.w    \tmp1,   \in3,    \in2
++    vilvh.w    \out3,   \in3,    \in2
++
++    vilvl.d    \out0,   \tmp1,   \tmp0
++    vilvl.d    \out2,   \out3,   \out1
++    vilvh.d    \out3,   \out3,   \out1
++    vilvh.d    \out1,   \tmp1,   \tmp0
++.endm
++
++/*
++ * Description : Transpose 8x8 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ */
++.macro LSX_TRANSPOSE8x8_H in0, in1, in2, in3, in4, in5, in6, in7, out0, out1,   \
++                          out2, out3, out4, out5, out6, out7, tmp0, tmp1, tmp2, \
++                          tmp3, tmp4, tmp5, tmp6, tmp7
++    vilvl.h      \tmp0,    \in6,   \in4
++    vilvl.h      \tmp1,    \in7,   \in5
++    vilvl.h      \tmp2,    \in2,   \in0
++    vilvl.h      \tmp3,    \in3,   \in1
++
++    vilvl.h      \tmp4,    \tmp1,  \tmp0
++    vilvh.h      \tmp5,    \tmp1,  \tmp0
++    vilvl.h      \tmp6,    \tmp3,  \tmp2
++    vilvh.h      \tmp7,    \tmp3,  \tmp2
++
++    vilvh.h      \tmp0,    \in6,   \in4
++    vilvh.h      \tmp1,    \in7,   \in5
++    vilvh.h      \tmp2,    \in2,   \in0
++    vilvh.h      \tmp3,    \in3,   \in1
++
++    vpickev.d    \out0,    \tmp4,  \tmp6
++    vpickod.d    \out1,    \tmp4,  \tmp6
++    vpickev.d    \out2,    \tmp5,  \tmp7
++    vpickod.d    \out3,    \tmp5,  \tmp7
++
++    vilvl.h      \tmp4,    \tmp1,  \tmp0
++    vilvh.h      \tmp5,    \tmp1,  \tmp0
++    vilvl.h      \tmp6,    \tmp3,  \tmp2
++    vilvh.h      \tmp7,    \tmp3,  \tmp2
++
++    vpickev.d    \out4,    \tmp4,  \tmp6
++    vpickod.d    \out5,    \tmp4,  \tmp6
++    vpickev.d    \out6,    \tmp5,  \tmp7
++    vpickod.d    \out7,    \tmp5,  \tmp7
++.endm
++
++/*
++ * Description : Transpose 16x8 block with byte elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ */
++.macro LASX_TRANSPOSE16X8_B in0, in1, in2, in3, in4, in5, in6, in7,        \
++                            in8, in9, in10, in11, in12, in13, in14, in15,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7,\
++                            tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7
++    xvilvl.b   \tmp0,    \in2,     \in0
++    xvilvl.b   \tmp1,    \in3,     \in1
++    xvilvl.b   \tmp2,    \in6,     \in4
++    xvilvl.b   \tmp3,    \in7,     \in5
++    xvilvl.b   \tmp4,    \in10,    \in8
++    xvilvl.b   \tmp5,    \in11,    \in9
++    xvilvl.b   \tmp6,    \in14,    \in12
++    xvilvl.b   \tmp7,    \in15,    \in13
++    xvilvl.b   \out0,    \tmp1,    \tmp0
++    xvilvh.b   \out1,    \tmp1,    \tmp0
++    xvilvl.b   \out2,    \tmp3,    \tmp2
++    xvilvh.b   \out3,    \tmp3,    \tmp2
++    xvilvl.b   \out4,    \tmp5,    \tmp4
++    xvilvh.b   \out5,    \tmp5,    \tmp4
++    xvilvl.b   \out6,    \tmp7,    \tmp6
++    xvilvh.b   \out7,    \tmp7,    \tmp6
++    xvilvl.w   \tmp0,    \out2,    \out0
++    xvilvh.w   \tmp2,    \out2,    \out0
++    xvilvl.w   \tmp4,    \out3,    \out1
++    xvilvh.w   \tmp6,    \out3,    \out1
++    xvilvl.w   \tmp1,    \out6,    \out4
++    xvilvh.w   \tmp3,    \out6,    \out4
++    xvilvl.w   \tmp5,    \out7,    \out5
++    xvilvh.w   \tmp7,    \out7,    \out5
++    xvilvl.d   \out0,    \tmp1,    \tmp0
++    xvilvh.d   \out1,    \tmp1,    \tmp0
++    xvilvl.d   \out2,    \tmp3,    \tmp2
++    xvilvh.d   \out3,    \tmp3,    \tmp2
++    xvilvl.d   \out4,    \tmp5,    \tmp4
++    xvilvh.d   \out5,    \tmp5,    \tmp4
++    xvilvl.d   \out6,    \tmp7,    \tmp6
++    xvilvh.d   \out7,    \tmp7,    \tmp6
++.endm
++
++/*
++ * Description : Transpose 4x4 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ */
++.macro LASX_TRANSPOSE4x4_H in0, in1, in2, in3, out0, out1, out2, out3, \
++                           tmp0, tmp1
++    xvilvl.h   \tmp0,  \in1,   \in0
++    xvilvl.h   \tmp1,  \in3,   \in2
++    xvilvl.w   \out0,  \tmp1,  \tmp0
++    xvilvh.w   \out2,  \tmp1,  \tmp0
++    xvilvh.d   \out1,  \out0,  \out0
++    xvilvh.d   \out3,  \out0,  \out2
++.endm
++
++/*
++ * Description : Transpose 4x8 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ */
++.macro LASX_TRANSPOSE4x8_H in0, in1, in2, in3, out0, out1, out2, out3, \
++                           tmp0, tmp1
++    xvilvl.h      \tmp0,    \in2,   \in0
++    xvilvl.h      \tmp1,    \in3,   \in1
++    xvilvl.h      \out2,    \tmp1,  \tmp0
++    xvilvh.h      \out3,    \tmp1,  \tmp0
++
++    xvilvl.d      \out0,    \out2,  \out2
++    xvilvh.d      \out1,    \out2,  \out2
++    xvilvl.d      \out2,    \out3,  \out3
++    xvilvh.d      \out3,    \out3,  \out3
++.endm
++
++/*
++ * Description : Transpose 8x8 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ */
++.macro LASX_TRANSPOSE8x8_H in0, in1, in2, in3, in4, in5, in6, in7,         \
++                           out0, out1, out2, out3, out4, out5, out6, out7, \
++                           tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7
++    xvilvl.h     \tmp0,   \in6,     \in4
++    xvilvl.h     \tmp1,   \in7,     \in5
++    xvilvl.h     \tmp2,   \in2,     \in0
++    xvilvl.h     \tmp3,   \in3,     \in1
++
++    xvilvl.h     \tmp4,   \tmp1,    \tmp0
++    xvilvh.h     \tmp5,   \tmp1,    \tmp0
++    xvilvl.h     \tmp6,   \tmp3,    \tmp2
++    xvilvh.h     \tmp7,   \tmp3,    \tmp2
++
++    xvilvh.h     \tmp0,   \in6,     \in4
++    xvilvh.h     \tmp1,   \in7,     \in5
++    xvilvh.h     \tmp2,   \in2,     \in0
++    xvilvh.h     \tmp3,   \in3,     \in1
++
++    xvpickev.d   \out0,   \tmp4,    \tmp6
++    xvpickod.d   \out1,   \tmp4,    \tmp6
++    xvpickev.d   \out2,   \tmp5,    \tmp7
++    xvpickod.d   \out3,   \tmp5,    \tmp7
++
++    xvilvl.h     \tmp4,   \tmp1,    \tmp0
++    xvilvh.h     \tmp5,   \tmp1,    \tmp0
++    xvilvl.h     \tmp6,   \tmp3,    \tmp2
++    xvilvh.h     \tmp7,   \tmp3,    \tmp2
++
++    xvpickev.d   \out4,   \tmp4,    \tmp6
++    xvpickod.d   \out5,   \tmp4,    \tmp6
++    xvpickev.d   \out6,   \tmp5,    \tmp7
++    xvpickod.d   \out7,   \tmp5,    \tmp7
++.endm
++
++/*
++ * Description : Transpose 2x4x4 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ */
++.macro LASX_TRANSPOSE2x4x4_H in0, in1, in2, in3, out0, out1, out2, out3, \
++                             tmp0, tmp1, tmp2
++    xvilvh.h   \tmp1,    \in0,     \in1
++    xvilvl.h   \out1,    \in0,     \in1
++    xvilvh.h   \tmp0,    \in2,     \in3
++    xvilvl.h   \out3,    \in2,     \in3
++
++    xvilvh.w   \tmp2,    \out3,    \out1
++    xvilvl.w   \out3,    \out3,    \out1
++
++    xvilvl.w   \out2,    \tmp0,    \tmp1
++    xvilvh.w   \tmp1,    \tmp0,    \tmp1
++
++    xvilvh.d   \out0,    \out2,    \out3
++    xvilvl.d   \out2,    \out2,    \out3
++    xvilvh.d   \out1,    \tmp1,    \tmp2
++    xvilvl.d   \out3,    \tmp1,    \tmp2
++.endm
++
++/*
++ * Description : Transpose 4x4 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     :
++ * Example     :
++ *               1, 2, 3, 4,  1, 2, 3, 4        1,5, 9,13, 1,5, 9,13
++ *               5, 6, 7, 8,  5, 6, 7, 8   to   2,6,10,14, 2,6,10,14
++ *               9,10,11,12,  9,10,11,12 =====> 3,7,11,15, 3,7,11,15
++ *              13,14,15,16, 13,14,15,16        4,8,12,16, 4,8,12,16
++ */
++.macro LASX_TRANSPOSE4x4_W in0, in1, in2, in3, out0, out1, out2, out3, \
++                           tmp0, tmp1
++
++    xvilvl.w    \tmp0,   \in1,    \in0
++    xvilvh.w    \out1,   \in1,    \in0
++    xvilvl.w    \tmp1,   \in3,    \in2
++    xvilvh.w    \out3,   \in3,    \in2
++
++    xvilvl.d    \out0,   \tmp1,   \tmp0
++    xvilvl.d    \out2,   \out3,   \out1
++    xvilvh.d    \out3,   \out3,   \out1
++    xvilvh.d    \out1,   \tmp1,   \tmp0
++.endm
++
++/*
++ * Description : Transpose 8x8 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6,
++ *               _out7
++ * Example     : LASX_TRANSPOSE8x8_W
++ *         in0 : 1,2,3,4,5,6,7,8
++ *         in1 : 2,2,3,4,5,6,7,8
++ *         in2 : 3,2,3,4,5,6,7,8
++ *         in3 : 4,2,3,4,5,6,7,8
++ *         in4 : 5,2,3,4,5,6,7,8
++ *         in5 : 6,2,3,4,5,6,7,8
++ *         in6 : 7,2,3,4,5,6,7,8
++ *         in7 : 8,2,3,4,5,6,7,8
++ *
++ *        out0 : 1,2,3,4,5,6,7,8
++ *        out1 : 2,2,2,2,2,2,2,2
++ *        out2 : 3,3,3,3,3,3,3,3
++ *        out3 : 4,4,4,4,4,4,4,4
++ *        out4 : 5,5,5,5,5,5,5,5
++ *        out5 : 6,6,6,6,6,6,6,6
++ *        out6 : 7,7,7,7,7,7,7,7
++ *        out7 : 8,8,8,8,8,8,8,8
++ */
++.macro LASX_TRANSPOSE8x8_W in0, in1, in2, in3, in4, in5, in6, in7,\
++                           out0, out1, out2, out3, out4, out5, out6, out7,\
++                           tmp0, tmp1, tmp2, tmp3
++    xvilvl.w    \tmp0,   \in2,    \in0
++    xvilvl.w    \tmp1,   \in3,    \in1
++    xvilvh.w    \tmp2,   \in2,    \in0
++    xvilvh.w    \tmp3,   \in3,    \in1
++    xvilvl.w    \out0,   \tmp1,   \tmp0
++    xvilvh.w    \out1,   \tmp1,   \tmp0
++    xvilvl.w    \out2,   \tmp3,   \tmp2
++    xvilvh.w    \out3,   \tmp3,   \tmp2
++
++    xvilvl.w    \tmp0,   \in6,    \in4
++    xvilvl.w    \tmp1,   \in7,    \in5
++    xvilvh.w    \tmp2,   \in6,    \in4
++    xvilvh.w    \tmp3,   \in7,    \in5
++    xvilvl.w    \out4,   \tmp1,   \tmp0
++    xvilvh.w    \out5,   \tmp1,   \tmp0
++    xvilvl.w    \out6,   \tmp3,   \tmp2
++    xvilvh.w    \out7,   \tmp3,   \tmp2
++
++    xmov        \tmp0,   \out0
++    xmov        \tmp1,   \out1
++    xmov        \tmp2,   \out2
++    xmov        \tmp3,   \out3
++    xvpermi.q   \out0,   \out4,   0x02
++    xvpermi.q   \out1,   \out5,   0x02
++    xvpermi.q   \out2,   \out6,   0x02
++    xvpermi.q   \out3,   \out7,   0x02
++    xvpermi.q   \out4,   \tmp0,   0x31
++    xvpermi.q   \out5,   \tmp1,   0x31
++    xvpermi.q   \out6,   \tmp2,   0x31
++    xvpermi.q   \out7,   \tmp3,   0x31
++.endm
++
++/*
++ * Description : Transpose 4x4 block with double-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Example     : LASX_TRANSPOSE4x4_D
++ *         in0 : 1,2,3,4
++ *         in1 : 1,2,3,4
++ *         in2 : 1,2,3,4
++ *         in3 : 1,2,3,4
++ *
++ *        out0 : 1,1,1,1
++ *        out1 : 2,2,2,2
++ *        out2 : 3,3,3,3
++ *        out3 : 4,4,4,4
++ */
++.macro LASX_TRANSPOSE4x4_D in0, in1, in2, in3, out0, out1, out2, out3, \
++                           tmp0, tmp1
++    xvilvl.d    \tmp0,   \in1,    \in0
++    xvilvh.d    \out1,   \in1,    \in0
++    xvilvh.d    \tmp1,   \in3,    \in2
++    xvilvl.d    \out2,   \in3,    \in2
++
++    xvor.v      \out0,   \tmp0,   \tmp0
++    xvor.v      \out3,   \tmp1,   \tmp1
++
++    xvpermi.q   \out0,   \out2,   0x02
++    xvpermi.q   \out2,   \tmp0,   0x31
++    xvpermi.q   \out3,   \out1,   0x31
++    xvpermi.q   \out1,   \tmp1,   0x02
++.endm
+diff --git a/source/common/loongarch64/loopfilter.S b/source/common/loongarch64/loopfilter.S
+new file mode 100644
+index 000000000..42536616c
+--- /dev/null
++++ b/source/common/loongarch64/loopfilter.S
+@@ -0,0 +1,1324 @@
++/*
++*****************************************************************************
++* Copyright (C) 2013-2024 MulticoreWare, Inc
++*
++* Authors: Hao Chen <chenhao@loongson.cn>
++*
++* This program is free software; you can redistribute it and/or modify
++* it under the terms of the GNU General Public License as published by
++* the Free Software Foundation; either version 2 of the License, or
++* (at your option) any later version.
++*
++* This program is distributed in the hope that it will be useful,
++* but WITHOUT ANY WARRANTY; without even the implied warranty of
++* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++* GNU General Public License for more details.
++*
++* You should have received a copy of the GNU General Public License
++* along with this program; if not, write to the Free Software
++* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++*
++* This program is also available under a commercial proprietary license.
++* For more information, contact us at license @ x265.com.
++*****************************************************************************
++*/
++
++#include "loongson_asm.S"
++
++const shuf
++.byte 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30
++endconst
++
++/*x265_saoCuOrgE0_lsx(pixel * rec, int8_t * offsetEo, int width,
++                      int8_t* signLeft, intptr_t stride)
++*/
++function x265_saoCuOrgE0_lsx
++    la.local     t2,    shuf
++    vldrepl.b    vr0,   a3,    0
++    vldi         vr10,  1
++    vld          vr11,  a1,    0
++    vld          vr12,  t2,    0
++    move         t0,    a0
++    move         t1,    a2
++.loop_e0:
++    vld          vr1,   t0,    0
++    vld          vr2,   t0,    1
++    vslt.bu      vr3,   vr2,   vr1
++    vslt.bu      vr4,   vr1,   vr2
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vshuf.b      vr7,   vr6,   vr0,   vr12
++    vadd.b       vr8,   vr7,   vr5
++    vreplvei.b   vr0,   vr6,   15
++    vaddi.bu     vr9,   vr8,   2
++    vshuf.b      vr7,   vr11,  vr11,  vr9
++    vaddwev.h.bu.b  vr8,   vr1,   vr7
++    vaddwod.h.bu.b  vr9,   vr1,   vr7
++    vssrani.bu.h vr9,   vr8,   0
++    vshuf4i.w    vr3,   vr9,   0x4E
++    vilvl.b      vr4,   vr3,   vr9
++    vst          vr4,   t0,    0
++    addi.d       t1,    t1,    -16
++    addi.d       t0,    t0,    16
++    bnez         t1,    .loop_e0
++    vldrepl.b    vr0,   a3,    1
++    add.d        t0,    a0,    a4
++.loopH_e0:
++    vld          vr1,   t0,    0
++    vld          vr2,   t0,    1
++    vslt.bu      vr3,   vr2,   vr1
++    vslt.bu      vr4,   vr1,   vr2
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vshuf.b      vr7,   vr6,   vr0,   vr12
++    vadd.b       vr8,   vr7,   vr5
++    vreplvei.b   vr0,   vr6,   15
++    vaddi.bu     vr9,   vr8,   2
++    vshuf.b      vr7,   vr11,  vr11,  vr9
++    vaddwev.h.bu.b  vr8,   vr1,   vr7
++    vaddwod.h.bu.b  vr9,   vr1,   vr7
++    vssrani.bu.h vr9,   vr8,   0
++    vshuf4i.w    vr3,   vr9,   0x4E
++    vilvl.b      vr4,   vr3,   vr9
++    vst          vr4,   t0,    0
++    addi.d       a2,    a2,    -16
++    addi.d       t0,    t0,    16
++    bnez         a2,    .loopH_e0
++endfunc
++
++/*x265_saoCuOrgE1_lsx(pixel* rec, int8_t* upBuff1,
++                      int8_t* offsetEo, intptr_t stride, int width)
++*/
++function x265_saoCuOrgE1_lsx
++    vldi         vr10,  1
++    vld          vr11,  a2,    0
++    srli.d       t0,    a4,    4
++.loop_e1:
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a3
++    vld          vr2,   a1,    0
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x4E
++    addi.d       t0,    t0,    -1
++    vilvl.b      vr7,   vr5,   vr4
++    vst          vr6,   a1,    0
++    vst          vr7,   a0,    0
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    16
++    bnez         t0,    .loop_e1
++endfunc
++
++/*x265_saoCuOrgE1_2Rows_lsx(pixel* rec, int8_t* upBuff1, int8_t* offsetEo,
++                            intptr_t stride, int width)
++*/
++function x265_saoCuOrgE1_2Rows_lsx
++    vldi         vr10,  1
++    vld          vr11,  a2,    0
++    srli.d       t0,    a4,    4
++    move         t1,    a0
++    move         t2,    a1
++    move         t3,    t0
++.loop_2rows_e1:
++    vld          vr0,   t1,    0
++    vldx         vr1,   t1,    a3
++    vld          vr2,   t2,    0
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x4E
++    addi.d       t0,    t0,    -1
++    vilvl.b      vr7,   vr5,   vr4
++    vst          vr6,   t2,    0
++    vst          vr7,   t1,    0
++    addi.d       t2,    t2,    16
++    addi.d       t1,    t1,    16
++    bnez         t0,    .loop_2rows_e1
++    add.d        a0,    a0,    a3
++.loopH_2rows_e1:
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a3
++    vld          vr2,   a1,    0
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x0E
++    addi.d       t3,    t3,    -1
++    vilvl.b      vr7,   vr5,   vr4
++    vst          vr6,   a1,    0
++    vst          vr7,   a0,    0
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    16
++    bnez         t3,    .loopH_2rows_e1
++endfunc
++
++/*x265_saoCuOrgE2_lsx(pixel * rec, int8_t * bufft, int8_t * buff1,
++                      int8_t * offsetEo, int width, intptr_t stride)
++*/
++function x265_saoCuOrgE2_lsx
++    vldi         vr10,  1
++    vld          vr11,  a3,    0
++    srli.d       t0,    a4,    4
++    andi         t1,    a4,    0xF
++    addi.d       a5,    a5,    1
++    addi.d       a1,    a1,    1
++    beqz         t0,    .loop_end_e2
++.loop_e2:
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a5
++    vld          vr2,   a2,    0
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x04E
++    addi.d       t0,    t0,    -1
++    vilvl.b      vr7,   vr5,   vr4
++    vst          vr6,   a1,    0
++    vst          vr7,   a0,    0
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    16
++    addi.d       a2,    a2,    16
++    blt          zero,  t0,    .loop_e2
++.loop_end_e2:
++    beqz         t1,    .end_e2
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a5
++    vld          vr2,   a2,    0
++    andi         t3,    t1,    0x8
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x4E
++    vilvl.b      vr7,   vr5,   vr4
++    beqz         t3,    .e2_res
++    fst.d        f6,    a1,    0
++    fst.d        f7,    a0,    0
++    addi.d       a1,    a1,    8
++    addi.d       a0,    a0,    8
++    addi.d       t1,    t1,    -8
++    vshuf4i.w    vr6,   vr6,   0x4E
++    vshuf4i.w    vr7,   vr7,   0x4E
++    beqz         t1,    .end_e2
++.e2_res:
++    vilvl.d      vr7,   vr7,   vr6
++.loop_e2_res:
++    vstelm.b     vr7,   a1,    0,    0
++    vstelm.b     vr7,   a0,    0,    8
++    addi.d       a1,    a1,    1
++    addi.d       a0,    a0,    1
++    addi.d       t1,    t1,    -1
++    vbsrl.v      vr7,   vr7,   1
++    blt          zero,  t1,    .loop_e2_res
++.end_e2:
++endfunc
++
++/*x265_saoCuOrgE3_lsx(pixel *rec, int8_t *upBuff1, int8_t *offsetEo,
++                      intptr_t stride, int startX, int endX)
++*/
++function x265_saoCuOrgE3_lsx
++    add.d        a1,    a1,    a4
++    addi.d       a4,    a4,    1
++    vldi         vr10,  1
++    vld          vr11,  a2,    0
++    sub.d        t0,    a5,    a4
++    add.d        a0,    a0,    a4
++    srli.d       t1,    t0,    4
++    andi         t2,    t0,    0xF
++    beqz         t1,    .loop_end_e3
++.loop_e3:
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a3
++    vld          vr2,   a1,    1
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x04E
++    addi.d       t1,    t1,    -1
++    vilvl.b      vr7,   vr5,   vr4
++    vst          vr6,   a1,    0
++    vst          vr7,   a0,    0
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    16
++    blt          zero,  t1,    .loop_e3
++.loop_end_e3:
++    beqz         t2,    .end_e3
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a3
++    vld          vr2,   a1,    1
++    andi         t3,    t2,    0x8
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vshuf.b      vr9,   vr11,  vr11,   vr8
++    vaddwev.h.bu.b  vr3,   vr0,   vr9
++    vaddwod.h.bu.b  vr4,   vr0,   vr9
++    vssrani.bu.h vr4,   vr3,   0
++    vshuf4i.w    vr5,   vr4,   0x4E
++    vilvl.b      vr7,   vr5,   vr4
++    beqz         t3,    .e3_res
++    fst.d        f6,    a1,    0
++    fst.d        f7,    a0,    0
++    addi.d       a1,    a1,    8
++    addi.d       a0,    a0,    8
++    addi.d       t2,    t2,    -8
++    vshuf4i.w    vr6,   vr6,   0x4E
++    vshuf4i.w    vr7,   vr7,   0x4E
++    beqz         t2,    .end_e3
++.e3_res:
++    vilvl.d      vr7,   vr7,   vr6
++.loop_e3_res:
++    vstelm.b     vr7,   a1,    0,    0
++    vstelm.b     vr7,   a0,    0,    8
++    addi.d       a1,    a1,    1
++    addi.d       a0,    a0,    1
++    addi.d       t2,    t2,    -1
++    vbsrl.v      vr7,   vr7,   1
++    blt          zero,  t2,    .loop_e3_res
++.end_e3:
++endfunc
++
++/*x265_saoCuOrgB0_lsx(pixel* rec, const int8_t* offset, int ctuWidth,
++                      int ctuHeight, intptr_t stride)
++*/
++function x265_saoCuOrgB0_lsx
++    srli.d       t0,    a3,    1
++    srli.d       t1,    a2,    4
++    slli.d       t2,    a4,    1
++    andi         t3,    a3,    1
++    vld          vr0,   a1,    0
++    vld          vr1,   a1,    16
++    beqz         t0,    .loopH_b0_end
++.loopH_b0:
++    move         t4,    a0
++    move         t5,    t1
++.loopW_b0:
++    vld          vr2,   t4,    0
++    vldx         vr3,   t4,    a4
++    vsrli.b      vr4,   vr2,   3
++    vsrli.b      vr5,   vr3,   3
++    vshuf.b      vr6,   vr1,   vr0,  vr4
++    vshuf.b      vr7,   vr1,   vr0,  vr5
++    vaddwev.h.bu.b  vr8,  vr2,  vr6
++    vaddwev.h.bu.b  vr10, vr3,  vr7
++    vaddwod.h.bu.b  vr9,  vr2,  vr6
++    vaddwod.h.bu.b  vr11, vr3,  vr7
++    vssrani.bu.h vr10,  vr8,   0
++    vssrani.bu.h vr11,  vr9,   0
++    vilvl.b      vr12,  vr11,  vr10
++    vilvh.b      vr13,  vr11,  vr10
++    vst          vr12,  t4,    0
++    vstx         vr13,  t4,    a4
++    addi.d       t5,    t5,    -1
++    addi.d       t4,    t4,    16
++    blt          zero,  t5,    .loopW_b0
++    addi.d       t0,    t0,    -1
++    add.d        a0,    a0,    t2
++    blt          zero,  t0,    .loopH_b0
++.loopH_b0_end:
++    beqz         t3,    .end_b0
++.loopW1_b0:
++    vld          vr2,   a0,    0
++    vsrli.b      vr4,   vr2,   3
++    vshuf.b      vr6,   vr1,   vr0,  vr4
++    vaddwev.h.bu.b  vr8,  vr2,  vr6
++    vaddwod.h.bu.b  vr10, vr2,  vr6
++    vssrani.bu.h vr10,  vr8,   0
++    vshuf4i.w    vr11,  vr10,  0x4E
++    vilvl.b      vr12,  vr11,  vr10
++    vst          vr12,  a0,    0
++    addi.d       t1,    t1,    -1
++    addi.d       a0,    a0,    16
++    blt          zero,  t1,    .loopW1_b0
++.end_b0:
++endfunc
++
++/* x265_calSign_lsx(int8_t *dst, const pixel *src1, const pixel *src2, const int endX) */
++function x265_calSign_lsx
++    srli.d       t0,    a3,    4
++    andi         t1,    a3,    15
++    vldi         vr10,  1
++    beqz         t0,    .loop_sign_lsx_end
++.loop_sign_lsx:
++    vld          vr0,   a1,    0
++    vld          vr1,   a2,    0
++    addi.d       t0,    t0,    -1
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vst          vr5,   a0,    0
++    addi.d       a1,    a1,    16
++    addi.d       a2,    a2,    16
++    addi.d       a0,    a0,    16
++    blt          zero,  t0,    .loop_sign_lsx
++.loop_sign_lsx_end:
++    beqz         t1,    .end_sign_lsx
++    vld          vr0,   a1,    0
++    vld          vr1,   a2,    0
++    andi         t2,    t1,    8
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    beqz         t2,    .loop_sign_res_lsx
++    fst.d        f5,    a0,    0
++    addi.d       t1,    t1,    -8
++    addi.d       a0,    a0,    8
++    vshuf4i.w    vr5,   vr5,   0x4E
++    beqz         t1,    .end_sign_lsx
++.loop_sign_res_lsx:
++    vstelm.b     vr5,   a0,    0,    0
++    addi.d       t1,    t1,    -1
++    addi.d       a0,    a0,    1
++    vbsrl.v      vr5,   vr5,   1
++    blt          zero,  t1,    .loop_sign_res_lsx
++.end_sign_lsx:
++endfunc
++
++/* x265_calSign_lasx(int8_t *dst, const pixel *src1, const pixel *src2, const int endX) */
++function x265_calSign_lasx
++    srli.d       t0,    a3,    5
++    andi         t1,    a3,    31
++    xvldi        xr10,  1
++    beqz         t0,    .loop_sign_lasx_end
++.loop_sign_lasx:
++    xvld         xr0,   a1,    0
++    xvld         xr1,   a2,    0
++    addi.d       t0,    t0,    -1
++    xvslt.bu     xr3,   xr1,   xr0
++    xvslt.bu     xr4,   xr0,   xr1
++    xvand.v      xr3,   xr3,   xr10
++    xvor.v       xr5,   xr3,   xr4
++    xvst         xr5,   a0,    0
++    addi.d       a1,    a1,    32
++    addi.d       a2,    a2,    32
++    addi.d       a0,    a0,    32
++    blt          zero,  t0,    .loop_sign_lasx
++.loop_sign_lasx_end:
++    beqz         t1,    .end_sign_lasx
++    xvld         xr0,   a1,    0
++    xvld         xr1,   a2,    0
++    andi         t2,    t1,    16
++    xvslt.bu     xr3,   xr1,   xr0
++    xvslt.bu     xr4,   xr0,   xr1
++    xvand.v      xr3,   xr3,   xr10
++    xvor.v       xr5,   xr3,   xr4
++    beqz         t2,    .loop_sign_res_lasx
++    vst          vr5,   a0,    0
++    addi.d       t1,    t1,    -16
++    addi.d       a0,    a0,    16
++    xvpermi.d    xr5,   xr5,   0x4E
++    beqz         t1,    .end_sign_lasx
++.loop_sign_res_lasx:
++    vstelm.b     vr5,   a0,    0,    0
++    addi.d       t1,    t1,    -1
++    addi.d       a0,    a0,    1
++    vbsrl.v      vr5,   vr5,   1
++    blt          zero,  t1,    .loop_sign_res_lasx
++.end_sign_lasx:
++endfunc
++
++/* x265_pelFilterLumaStrong_V_lsx(pixel* src, intptr_t srcStep, intptr_t offset,
++                                  int32_t tcP, int32_t tcQ)
++*/
++function x265_pelFilterLumaStrong_V_lsx
++    addi.d       a0,    a0,    -3
++    vreplgr2vr.h vr0,   a3   //tcP
++    vreplgr2vr.h vr1,   a4   //tcQ
++    add.d        t0,    a0,    a1
++    add.d        t1,    t0,    a1
++    add.d        t2,    t1,    a1
++    vilvl.d      vr0,   vr1,   vr0  //[tcP, tcQ]
++    vldi         vr10,  0
++    vneg.h       vr1,   vr0         //[-tcP, -tcQ]
++
++    fld.d        f2,    a0,    -1   //src[m0,m1, m2, m3, m4, m5,m6, m7]
++    fld.d        f3,    t0,    -1
++    fld.d        f4,    t1,    -1
++    fld.d        f5,    t2,    -1
++
++    vilvl.b      vr6,   vr3,   vr2 //[m0, m0, ... m3, m3, m4, m4 ... m7, m7]
++    vilvl.b      vr7,   vr5,   vr4 //[m0, m0]
++
++    vpackev.h    vr2,   vr7,   vr6 //[m0, m2, m4, m6]
++    vpackod.h    vr3,   vr7,   vr6 //[m1, m3, m5, m7]
++
++    vilvl.b      vr4,   vr10,  vr2  //[m0, m2]
++    vilvh.b      vr5,   vr10,  vr2  //[m4, m6]
++    vilvl.b      vr6,   vr10,  vr3  //[m1, m3]
++    vilvh.b      vr7,   vr10,  vr3  //[m5, m7]
++
++    vadd.h       vr8,   vr4,   vr6  //[m0+m1, m2+m3]
++    vadd.h       vr9,   vr5,   vr7  //[m4+m5, m6+m7]
++
++    vshuf4i.w    vr11,  vr8,   0x4E //[m2+m3, m0+m1]
++    vslli.h      vr14,  vr8,   1    //2*[m0+m1, m2+m3]
++    vslli.h      vr15,  vr9,   1    //2*[m4+m5, m6+m7]
++    vadd.h       vr2,   vr5,   vr6  //[m1+m4, m6+m3]
++    vadd.h       vr12,  vr9,   vr11 //[m2+m3+m4+m5, m0+m1+m6+m7]
++    vpermi.w     vr15,  vr14,  0xE4 //2*[m0+m1, m6+m7]
++
++    vpermi.w     vr9,   vr8,   0x4E //[m2+m3, m4+m5]
++    vpermi.w     vr7,   vr4,   0x4E //[m2, m5]
++    vshuf4i.w    vr5,   vr5,   0x4E //[m6, m4]
++    vshuf4i.w    vr12,  vr12,  0x44 //[m2+m3+m4+m5, m2+m3+m4+m5]
++    vadd.h       vr3,   vr2,   vr9  //[m1+m2+m3+m4, m3+m4+m5+m6]
++    vilvl.d      vr11,  vr5,   vr6  //[m1, m6]
++    vilvh.d      vr13,  vr5,   vr6  //[m3, m4]
++    vsrlri.h     vr4,   vr3,   2    //([m1+m2+m3+m4, m3+m4+m5+m6]+2)>>2
++    vadd.h       vr5,   vr15,  vr3  //[2m0+2m1+m1+m2+m3+m4, m3+m4+m5+m6+2m6+2m7]
++    vadd.h       vr6,   vr12,  vr3  //[m1+2m2+2m3+2m4+m5, m2+2m3+2m4+2m5+m6]
++    vsrlri.h     vr5,   vr5,   3
++    vsrlri.h     vr6,   vr6,   3
++    vsub.h       vr4,   vr4,   vr7  //([m1+m2+m3+m4, m3+m4+m5+m6]+2)>>2 - [m2, m5]
++    vsub.h       vr5,   vr5,   vr11 //([2m0+2m1+m1+m2+m3+m4, m3+m4+m5+m6+2m6+2m7]+4)>>3 - [m1, m6]
++    vsub.h       vr6,   vr6,   vr13 //([m1+2m2+2m3+2m4+m5, m2+2m3+2m4+2m5+m6]+4)>>3 - [m3, m4]
++    vclip.h      vr3,   vr4,   vr1,   vr0  //[-2, 1]
++    vclip.h      vr2,   vr5,   vr1,   vr0  //[-3, 2]
++    vclip.h      vr4,   vr6,   vr1,   vr0  //[-1, 0]
++
++    vadd.h       vr2,   vr2,   vr11   //[-3, 2]
++    vadd.h       vr3,   vr3,   vr7    //[-2, 1]
++    vadd.h       vr4,   vr4,   vr13   //[-1, 0]
++    vpackev.b    vr5,   vr3,   vr2    //[-3,-2, 2, 1]
++    vshuf4i.w    vr14,  vr4,   0x4E   //[0, -1]
++    vpackev.b    vr6,   vr2,   vr3    //[-2,-3, 1, 2]
++    vpackev.b    vr7,   vr14,  vr4    //[-1, 0, 0, -1]
++    vilvl.h      vr8,   vr7,   vr5    //[-3,-2,-1,0]
++    vstelm.w     vr8,   a0,    0,     0
++    vstelm.w     vr8,   t0,    0,     1
++    vstelm.w     vr8,   t1,    0,     2
++    vstelm.w     vr8,   t2,    0,     3
++    vstelm.h     vr6,   a0,    4,     4
++    vstelm.h     vr6,   t0,    4,     5
++    vstelm.h     vr6,   t1,    4,     6
++    vstelm.h     vr6,   t2,    4,     7
++endfunc
++
++function x265_pelFilterLumaStrong_H_lsx
++    slli.d       t0,    a2,    1    //offset * 2
++    slli.d       t2,    a2,    2    //offset * 4
++    add.d        t1,    a2,    t0   //offset * 3
++    vreplgr2vr.h vr0,   a3   //tcP
++    vreplgr2vr.h vr1,   a4   //tcQ
++    sub.d        t3,    a0,    t2
++    vilvl.d      vr0,   vr1,   vr0  //[tcP, tcQ]
++    vldi         vr10,  0
++    vneg.h       vr1,   vr0         //[-tcP, -tcQ]
++
++    fld.s        f2,    t3,    0    //[m0]
++    fldx.s       f3,    t3,    a2   //[m1]
++    fldx.s       f4,    t3,    t0   //[m2]
++    fldx.s       f5,    t3,    t1   //[m3]
++    fld.s        f6,    a0,    0    //[m4]
++    fldx.s       f7,    a0,    a2   //[m5]
++    fldx.s       f8,    a0,    t0   //[m6]
++    fldx.s       f9,    a0,    t1   //[m7]
++
++    vilvl.w      vr11,  vr4,   vr2  //[m0, m2]
++    vilvl.w      vr12,  vr8,   vr6  //[m4, m6]
++    vilvl.w      vr13,  vr5,   vr3  //[m1, m3]
++    vilvl.w      vr14,  vr9,   vr7  //[m5, m7]
++
++    vilvl.b      vr4,   vr10,  vr11  //[m0, m2]
++    vilvl.b      vr5,   vr10,  vr12  //[m4, m6]
++    vilvl.b      vr6,   vr10,  vr13  //[m1, m3]
++    vilvl.b      vr7,   vr10,  vr14  //[m5, m7]
++
++    vadd.h       vr8,   vr4,   vr6  //[m0+m1, m2+m3]
++    vadd.h       vr9,   vr5,   vr7  //[m4+m5, m6+m7]
++
++    vshuf4i.w    vr11,  vr8,   0x4E //[m2+m3, m0+m1]
++    vslli.h      vr14,  vr8,   1    //2*[m0+m1, m2+m3]
++    vslli.h      vr15,  vr9,   1    //2*[m4+m5, m6+m7]
++    vadd.h       vr2,   vr5,   vr6  //[m1+m4, m6+m3]
++    vadd.h       vr12,  vr9,   vr11 //[m2+m3+m4+m5, m0+m1+m6+m7]
++    vpermi.w     vr15,  vr14,  0xE4 //2*[m0+m1, m6+m7]
++
++    vpermi.w     vr9,   vr8,   0x4E //[m2+m3, m4+m5]
++    vpermi.w     vr7,   vr4,   0x4E //[m2, m5]
++    vshuf4i.w    vr5,   vr5,   0x4E //[m6, m4]
++    vshuf4i.w    vr12,  vr12,  0x44 //[m2+m3+m4+m5, m2+m3+m4+m5]
++    vadd.h       vr3,   vr2,   vr9  //[m1+m2+m3+m4, m3+m4+m5+m6]
++    vilvl.d      vr11,  vr5,   vr6  //[m1, m6]
++    vilvh.d      vr13,  vr5,   vr6  //[m3, m4]
++    vsrlri.h     vr4,   vr3,   2    //([m1+m2+m3+m4, m3+m4+m5+m6]+2)>>2
++    vadd.h       vr5,   vr15,  vr3  //[2m0+2m1+m1+m2+m3+m4, m3+m4+m5+m6+2m6+2m7]
++    vadd.h       vr6,   vr12,  vr3  //[m1+2m2+2m3+2m4+m5, m2+2m3+2m4+2m5+m6]
++    vsrlri.h     vr5,   vr5,   3
++    vsrlri.h     vr6,   vr6,   3
++    vsub.h       vr4,   vr4,   vr7  //([m1+m2+m3+m4, m3+m4+m5+m6]+2)>>2 - [m2, m5]
++    vsub.h       vr5,   vr5,   vr11 //([2m0+2m1+m1+m2+m3+m4, m3+m4+m5+m6+2m6+2m7]+4)>>3 - [m1, m6]
++    vsub.h       vr6,   vr6,   vr13 //([m1+2m2+2m3+2m4+m5, m2+2m3+2m4+2m5+m6]+4)>>3 - [m3, m4]
++    vclip.h      vr3,   vr4,   vr1,   vr0  //[-2, 1]
++    vclip.h      vr2,   vr5,   vr1,   vr0  //[-3, 2]
++    vclip.h      vr4,   vr6,   vr1,   vr0  //[-1, 0]
++
++    vadd.h       vr2,   vr2,   vr11   //[-3, 2]
++    vadd.h       vr3,   vr3,   vr7    //[-2, 1]
++    vadd.h       vr4,   vr4,   vr13   //[-1, 0]
++
++    sub.d        t3,    a0,    t1   //-offset*3
++    sub.d        t4,    a0,    t0   //-offset*2
++    sub.d        t5,    a0,    a2   //-offset
++    add.d        t6,    a0,    a2   //offset
++    add.d        t7,    a0,    t0   //offset*2
++    vpickev.b    vr5,   vr3,   vr2   //[-3, 2, -2, 1]
++    vpickev.b    vr6,   vr10,  vr4   //[-1, 0]
++
++    vstelm.w     vr5,   t3,    0,    0
++    vstelm.w     vr5,   t4,    0,    2
++    vstelm.w     vr5,   t6,    0,    3
++    vstelm.w     vr5,   t7,    0,    1
++    vstelm.w     vr6,   t5,    0,    0
++    vstelm.w     vr6,   a0,    0,    1
++endfunc
++
++/*x265_pelFilterChroma_V_lsx(pixel* src, intptr_t srcStep, intptr_t offset,
++                             int32_t tc, int32_t maskP, int32_t maskQ)
++*/
++function x265_pelFilterChroma_V_lsx
++    addi.d       a0,    a0,    -1
++    vreplgr2vr.h vr0,   a3   //tcP
++    vldi         vr10,  0
++    add.d        t0,    a0,    a1
++    add.d        t1,    t0,    a1
++    add.d        t2,    t1,    a1
++    vneg.h       vr1,   vr0         //[-tcP, -tcQ]
++    vreplgr2vr.h vr2,   a4   //maskP
++    vreplgr2vr.h vr3,   a5   //maskQ
++
++    fld.s        f4,    a0,    -1   //src[m2, m3, m4, m5]
++    fld.s        f5,    t0,    -1
++    fld.s        f6,    t1,    -1
++    fld.s        f7,    t2,    -1
++
++    vilvl.b      vr8,   vr5,   vr4   //[m2, m2, m3, m3, m4, m4, m5, m5]
++    vilvl.b      vr9,   vr7,   vr6
++    vilvl.h      vr11,  vr9,   vr8   //[m2, m3, m4, m5]
++
++    vilvl.b      vr4,   vr10,  vr11  //[m2, m3]
++    vilvh.b      vr6,   vr10,  vr11  //[m4, m5]
++    vbsrl.v      vr5,   vr4,   8     //[m3]
++    vbsrl.v      vr7,   vr6,   8     //[m5]
++
++    vsub.h       vr8,   vr6,   vr5   //[m4-m3]
++    vsub.h       vr9,   vr4,   vr7   //[m2-m5]
++    vslli.h      vr8,   vr8,   2     //[m4-m3] * 4
++    vadd.h       vr11,  vr8,   vr9
++    vsrari.h     vr12,  vr11,  3
++    vclip.h      vr13,  vr12,  vr1,  vr0  //[delta]
++    vand.v       vr14,  vr13,  vr2   //-offset
++    vand.v       vr15,  vr13,  vr3   //0
++    vadd.h       vr8,   vr5,   vr14
++    vsub.h       vr9,   vr6,   vr15
++
++    vilvl.h      vr11,  vr9,   vr8
++    vmaxi.h      vr13,  vr11,  0
++    vsat.hu      vr14,  vr13,  7
++    vpickev.b    vr12,  vr10,  vr14
++    vstelm.h     vr12,  a0,    0,     0
++    vstelm.h     vr12,  t0,    0,     1
++    vstelm.h     vr12,  t1,    0,     2
++    vstelm.h     vr12,  t2,    0,     3
++endfunc
++
++function x265_pelFilterChroma_H_lsx
++    slli.d       t0,    a2,    1    //offset * 2
++    vreplgr2vr.h vr0,   a3   //tcP
++    vldi         vr10,  0
++    sub.d        t1,    a0,    t0
++    vneg.h       vr1,   vr0         //[-tcP, -tcQ]
++    vreplgr2vr.h vr2,   a4   //maskP
++    vreplgr2vr.h vr3,   a5   //maskQ
++
++    fld.s        f4,    t1,    0   //src[m2]
++    fldx.s       f5,    t1,    a2  //src[m3]
++    fld.s        f6,    a0,    0   //src[m4]
++    fldx.s       f7,    a0,    a2  //src[m5]
++
++    vilvl.b      vr4,   vr10,  vr4
++    vilvl.b      vr5,   vr10,  vr5
++    vilvl.b      vr6,   vr10,  vr6
++    vilvl.b      vr7,   vr10,  vr7
++
++    vsub.h       vr8,   vr6,   vr5   //[m4-m3]
++    vsub.h       vr9,   vr4,   vr7   //[m2-m5]
++    vslli.h      vr8,   vr8,   2     //[m4-m3] * 4
++    vadd.h       vr11,  vr8,   vr9
++    vsrari.h     vr12,  vr11,  3
++    vclip.h      vr13,  vr12,  vr1,  vr0  //[delta]
++    vand.v       vr14,  vr13,  vr2   //-offset
++    vand.v       vr15,  vr13,  vr3   //0
++    vadd.h       vr8,   vr5,   vr14
++    vsub.h       vr9,   vr6,   vr15
++
++    vssrani.bu.h vr9,   vr8,   0
++    fstx.s       f9,    t1,    a2
++    vstelm.w     vr9,   a0,    0,    2
++endfunc
++
++.macro STATS_COUNT in0, in1, i0, i1
++    vpickve2gr.b t4,    \in0,  \i0
++    vpickve2gr.h t8,    \in1,  \i1
++    ldx.w        t6,    sp,    t4
++    ldx.w        t7,    t5,    t4
++    add.w        t6,    t6,    t8
++    addi.w       t7,    t7,    1
++    stx.w        t6,    sp,    t4
++    stx.w        t7,    t5,    t4
++.endm
++
++/*x265_saoCuStatsE0_lsx(const int16_t *diff, const pixel *rec, intptr_t stride, int endX,
++                        int endY, int32_t *stats, int32_t *count)
++*/
++function x265_saoCuStatsE0_lsx
++    la.local     t2,    shuf
++    addi.d       sp,    sp,    -48
++    vldi         vr10,  1
++    vldi         vr11,  0
++    vld          vr12,  t2,    0
++    addi.d       t5,    sp,    20
++    vst          vr11,  sp,    0
++    vst          vr11,  sp,    16
++    vst          vr11,  sp,    32
++.loopS_Y_e0:
++    ld.bu        t3,    a1,    0
++    ld.bu        t4,    a1,    -1
++    addi.d       a7,    zero,  -1
++    sltu         t7,    t3,    t4   //rec[0] < rec[-1] ? 1:0
++    sltu         t6,    t4,    t3   //rec[-1] < rec[0] ? 1:0
++    maskeqz      t8,    a7,    t7
++    or           t6,    t6,    t8
++    vreplgr2vr.b vr0,   t6
++    srli.d       t0,    a3,    4
++    move         t3,    a1
++    move         t2,    a0
++    beqz         t0,    .ResS_X_e0
++.loopS_X_e0:
++    vld          vr1,   t3,    0
++    vld          vr2,   t3,    1
++    vld          vr13,  t2,    0
++    vld          vr14,  t2,    16
++    vslt.bu      vr3,   vr2,   vr1
++    vslt.bu      vr4,   vr1,   vr2
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4   //signRight
++    vneg.b       vr6,   vr5          //signLeft
++    vshuf.b      vr7,   vr6,   vr0,   vr12
++    vadd.b       vr8,   vr7,   vr5
++    vreplvei.b   vr0,   vr6,   15
++    vaddi.bu     vr9,   vr8,   2    //edgeType
++    vslli.b      vr9,   vr9,   2
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    STATS_COUNT vr9, vr14, 8,  0
++    STATS_COUNT vr9, vr14, 9,  1
++    STATS_COUNT vr9, vr14, 10, 2
++    STATS_COUNT vr9, vr14, 11, 3
++    STATS_COUNT vr9, vr14, 12, 4
++    STATS_COUNT vr9, vr14, 13, 5
++    STATS_COUNT vr9, vr14, 14, 6
++    STATS_COUNT vr9, vr14, 15, 7
++    addi.d       t0,    t0,    -1
++    addi.d       t3,    t3,    16
++    addi.d       t2,    t2,    32
++    bnez         t0,    .loopS_X_e0
++.ResS_X_e0:
++    andi         t1,    a3,    15
++    beqz         t1,    .endS_X_e0
++    addi.d       t4,    zero,  8
++    vld          vr1,   t3,    0
++    vld          vr2,   t3,    1
++    vld          vr13,  t2,    0
++    vld          vr14,  t2,    16
++    vslt.bu      vr3,   vr2,   vr1
++    vslt.bu      vr4,   vr1,   vr2
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4   //signRight
++    vneg.b       vr6,   vr5          //signLeft
++    vshuf.b      vr7,   vr6,   vr0,   vr12
++    vadd.b       vr8,   vr7,   vr5
++    vreplvei.b   vr0,   vr6,   15
++    vaddi.bu     vr9,   vr8,   2    //edgeType
++    vslli.b      vr9,   vr9,   2
++    blt          t1,    t4,    .resS_X_e0
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    addi.d       t1,    t1,    -8
++    beqz         t1,    .endS_X_e0
++    vmov         vr13,  vr14
++    vbsrl.v      vr9,   vr9,   8
++.resS_X_e0:
++    vpickve2gr.b t4,    vr9,   0
++    vpickve2gr.h t8,    vr13,  0
++    ldx.w        t6,    sp,    t4
++    ldx.w        t7,    t5,    t4
++    add.w        t6,    t6,    t8
++    addi.w       t7,    t7,    1
++    stx.w        t6,    sp,    t4
++    stx.w        t7,    t5,    t4
++    vbsrl.v      vr9,   vr9,   1
++    vbsrl.v      vr13,  vr13,  2
++    addi.d       t1,    t1,    -1
++    bnez         t1,    .resS_X_e0
++.endS_X_e0:
++    addi.d       a4,    a4,    -1
++    add.d        a1,    a1,    a2
++    addi.d       a0,    a0,    128
++    bnez         a4,    .loopS_Y_e0
++    vld          vr1,   sp,    0
++    vld          vr2,   t5,    0
++    vld          vr3,   a5,    0
++    vld          vr4,   a6,    0
++    vshuf4i.w    vr5,   vr1,   0xD2
++    vshuf4i.w    vr6,   vr2,   0xD2
++    vadd.w       vr5,   vr5,   vr3
++    vadd.w       vr6,   vr6,   vr4
++    ld.w         t2,    a5,    16
++    ld.w         t3,    a6,    16
++    ld.w         t4,    sp,    16
++    ld.w         t6,    t5,    16
++    add.w        t2,    t2,    t4
++    add.w        t3,    t3,    t6
++    vst          vr5,   a5,    0
++    vst          vr6,   a6,    0
++    st.w         t2,    a5,    16
++    st.w         t3,    a6,    16
++    addi.d       sp,    sp,    48
++endfunc
++
++/*x265_saoCuStatsE1_lsx(const int16_t *diff, const pixel *rec, intptr_t stride, int8_t *upBuff1,
++                        int endx, int endY, int32_t *stats, int32_t *count)
++*/
++function x265_saoCuStatsE1_lsx
++    addi.d       sp,    sp,    -64
++    srli.d       t2,    a4,    4
++    andi         t3,    a4,    15
++    vldi         vr10,  1
++    vldi         vr11,  0
++    vst          vr11,  sp,    0
++    vst          vr11,  sp,    16
++    vst          vr11,  sp,    32
++    st.d         a0,    sp,    40
++    st.d         a1,    sp,    48
++    st.d         a3,    sp,    56
++    addi.d       t5,    sp,    20
++.loopS_Y_e1:
++    ld.d         a0,    sp,    40
++    ld.d         a1,    sp,    48
++    ld.d         a3,    sp,    56
++    move         t0,    t2
++    move         t1,    t3
++    beqz         t0,    .ResS_X_e1
++.loopS_X_e1:
++    vld          vr0,   a1,    0
++    vldx         vr1,   a1,    a2
++    vld          vr2,   a3,    0
++    vld          vr13,  a0,    0
++    vld          vr14,  a0,    16
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vst          vr6,   a3,    0
++    vslli.b      vr9,   vr8,   2
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    STATS_COUNT vr9, vr14, 8,  0
++    STATS_COUNT vr9, vr14, 9,  1
++    STATS_COUNT vr9, vr14, 10, 2
++    STATS_COUNT vr9, vr14, 11, 3
++    STATS_COUNT vr9, vr14, 12, 4
++    STATS_COUNT vr9, vr14, 13, 5
++    STATS_COUNT vr9, vr14, 14, 6
++    STATS_COUNT vr9, vr14, 15, 7
++    addi.d       t0,    t0,    -1
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    32
++    addi.d       a3,    a3,    16
++    bnez         t0,    .loopS_X_e1
++.ResS_X_e1:
++    beqz         t1,    .endS_X_e1
++    addi.d       t4,    zero,  8
++    vld          vr0,   a1,    0
++    vldx         vr1,   a1,    a2
++    vld          vr2,   a3,    0
++    vld          vr13,  a0,    0
++    vld          vr14,  a0,    16
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vslli.b      vr9,   vr8,   2
++    blt          t1,    t4,    .resS_X_e1
++    fst.d        f6,    a3,    0
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    addi.d       t1,    t1,    -8
++    addi.d       a3,    a3,    8
++    beqz         t1,    .endS_X_e1
++    vmov         vr13,  vr14
++    vbsrl.v      vr9,   vr9,   8
++    vbsrl.v      vr6,   vr6,   8
++.resS_X_e1:
++    vpickve2gr.b t4,    vr9,   0
++    vpickve2gr.h t8,    vr13,  0
++    ldx.w        t6,    sp,    t4
++    ldx.w        t7,    t5,    t4
++    add.w        t6,    t6,    t8
++    addi.w       t7,    t7,    1
++    stx.w        t6,    sp,    t4
++    stx.w        t7,    t5,    t4
++    vstelm.b     vr6,   a3,    0,   0
++    vbsrl.v      vr9,   vr9,   1
++    vbsrl.v      vr13,  vr13,  2
++    vbsrl.v      vr6,   vr6,   1
++    addi.d       t1,    t1,    -1
++    addi.d       a3,    a3,    1
++    bnez         t1,    .resS_X_e1
++.endS_X_e1:
++    ld.d         a0,    sp,    40
++    ld.d         a1,    sp,    48
++    addi.d       a5,    a5,    -1
++    addi.d       a0,    a0,    128
++    add.d        a1,    a1,    a2
++    st.d         a0,    sp,    40
++    st.d         a1,    sp,    48
++    bnez         a5,    .loopS_Y_e1
++    vld          vr1,   sp,    0
++    vld          vr2,   t5,    0
++    vld          vr3,   a6,    0
++    vld          vr4,   a7,    0
++    vshuf4i.w    vr5,   vr1,   0xD2
++    vshuf4i.w    vr6,   vr2,   0xD2
++    vadd.w       vr5,   vr5,   vr3
++    vadd.w       vr6,   vr6,   vr4
++    ld.w         t2,    a6,    16
++    ld.w         t3,    a7,    16
++    ld.w         t4,    sp,    16
++    ld.w         t6,    t5,    16
++    add.w        t2,    t2,    t4
++    add.w        t3,    t3,    t6
++    vst          vr5,   a6,    0
++    vst          vr6,   a7,    0
++    st.w         t2,    a6,    16
++    st.w         t3,    a7,    16
++    addi.d       sp,    sp,    64
++endfunc
++
++/*x265_saoCuStatsE2_lsx(const int16_t *diff, const pixel *rec, intptr_t stride, int8_t *upBuff1,
++                        int8_t *upBufft, int endX, int endY, int32_t *stats, int32_t *count)
++*/
++function x265_saoCuStatsE2_lsx
++    addi.d       sp,    sp,    -72
++    srli.d       t2,    a5,    4
++    andi         t3,    a5,    15
++    addi.d       a5,    a2,    1
++    vldi         vr10,  1
++    vldi         vr11,  0
++    vst          vr11,  sp,    0
++    vst          vr11,  sp,    16
++    vst          vr11,  sp,    32
++    st.d         a0,    sp,    40
++    st.d         a1,    sp,    48
++    st.d         a3,    sp,    56  //upBuff1
++    st.d         a4,    sp,    64  //upBufft
++    addi.d       t5,    sp,    20
++.loopS_Y_e2:
++    ld.d         a0,    sp,    40
++    ld.d         a1,    sp,    48
++    ld.d         a3,    sp,    56
++    ld.d         a4,    sp,    64
++    ldx.bu       t0,    a1,    a2
++    ld.bu        t1,    a1,    -1
++    addi.d       t4,    zero,  -1
++    sltu         t7,    t0,    t1
++    sltu         t6,    t1,    t0
++    maskeqz      t8,    t4,    t7
++    or           t6,    t6,    t8
++    st.b         t6,    a4,    0
++    move         t0,    t2
++    move         t1,    t3
++    beqz         t0,    .ResS_X_e2
++.loopS_X_e2:
++    vld          vr0,   a1,    0
++    vldx         vr1,   a1,    a5
++    vld          vr13,  a0,    0
++    vld          vr14,  a0,    16
++    vld          vr2,   a3,    0
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vst          vr6,   a4,    1
++    vslli.b      vr9,   vr8,   2
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    STATS_COUNT vr9, vr14, 8,  0
++    STATS_COUNT vr9, vr14, 9,  1
++    STATS_COUNT vr9, vr14, 10, 2
++    STATS_COUNT vr9, vr14, 11, 3
++    STATS_COUNT vr9, vr14, 12, 4
++    STATS_COUNT vr9, vr14, 13, 5
++    STATS_COUNT vr9, vr14, 14, 6
++    STATS_COUNT vr9, vr14, 15, 7
++    addi.d       t0,    t0,    -1
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    32
++    addi.d       a3,    a3,    16
++    addi.d       a4,    a4,    16
++    bnez         t0,    .loopS_X_e2
++.ResS_X_e2:
++    beqz         t1,    .endS_X_e2
++    addi.d       t4,    zero,  8
++    vld          vr0,   a1,    0
++    vldx         vr1,   a1,    a5
++    vld          vr2,   a3,    0
++    vld          vr13,  a0,    0
++    vld          vr14,  a0,    16
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vslli.b      vr9,   vr8,   2
++    blt          t1,    t4,    .resS_X_e2
++    fst.d        f6,    a4,    1
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    addi.d       t1,    t1,    -8
++    beqz         t1,    .endS_X_e2
++    vmov         vr13,  vr14
++    addi.d       a4,    a4,    8
++    vbsrl.v      vr9,   vr9,   8
++    vbsrl.v      vr6,   vr6,   8
++.resS_X_e2:
++    vpickve2gr.b t4,    vr9,   0
++    vpickve2gr.h t8,    vr13,  0
++    ldx.w        t6,    sp,    t4
++    ldx.w        t7,    t5,    t4
++    add.w        t6,    t6,    t8
++    addi.w       t7,    t7,    1
++    stx.w        t6,    sp,    t4
++    stx.w        t7,    t5,    t4
++    vstelm.b     vr6,   a4,    1,   0
++    vbsrl.v      vr9,   vr9,   1
++    vbsrl.v      vr13,  vr13,  2
++    vbsrl.v      vr6,   vr6,   1
++    addi.d       t1,    t1,    -1
++    addi.d       a4,    a4,    1
++    bnez         t1,    .resS_X_e2
++.endS_X_e2:
++    ld.d         a0,    sp,    40
++    ld.d         a1,    sp,    48
++    ld.d         a3,    sp,    56
++    ld.d         a4,    sp,    64
++    addi.d       a6,    a6,    -1
++    addi.d       a0,    a0,    128
++    add.d        a1,    a1,    a2
++    st.d         a0,    sp,    40
++    st.d         a1,    sp,    48
++    st.d         a4,    sp,    56
++    st.d         a3,    sp,    64
++    bnez         a6,    .loopS_Y_e2
++    ld.d         t0,    sp,    72
++    vld          vr1,   sp,    0
++    vld          vr2,   t5,    0
++    vld          vr3,   a7,    0
++    vld          vr4,   t0,    0
++    vshuf4i.w    vr5,   vr1,   0xD2
++    vshuf4i.w    vr6,   vr2,   0xD2
++    vadd.w       vr5,   vr5,   vr3
++    vadd.w       vr6,   vr6,   vr4
++    ld.w         t2,    a7,    16
++    ld.w         t3,    t0,    16
++    ld.w         t4,    sp,    16
++    ld.w         t6,    t5,    16
++    add.w        t2,    t2,    t4
++    add.w        t3,    t3,    t6
++    vst          vr5,   a7,    0
++    vst          vr6,   t0,    0
++    st.w         t2,    a7,    16
++    st.w         t3,    t0,    16
++    addi.d       sp,    sp,    72
++endfunc
++
++/*x265_saoCuStatsE3_lsx(const int16_t *diff, const pixel *rec, intptr_t stride, int8_t *upBuff1,
++                        int endX, int endY, int32_t *stats, int32_t *count)
++*/
++function x265_saoCuStatsE3_lsx
++    addi.d       sp,    sp,    -64
++    srli.d       t2,    a4,    4
++    addi.d       t3,    a2,    -1
++    vldi         vr10,  1
++    vldi         vr11,  0
++    vst          vr11,  sp,    0
++    vst          vr11,  sp,    16
++    vst          vr11,  sp,    32
++    st.d         a0,    sp,    40
++    st.d         a1,    sp,    48
++    st.d         a3,    sp,    56
++    addi.d       t5,    sp,    20
++.loopS_Y_e3:
++    ld.d         a0,    sp,    40
++    ld.d         a1,    sp,    48
++    ld.d         a3,    sp,    56
++    move         t0,    t2
++    andi         t1,    a4,    15
++    beqz         t0,    .ResS_X_e3
++.loopS_X_e3:
++    vld          vr0,   a1,    0
++    vldx         vr1,   a1,    t3
++    vld          vr2,   a3,    0
++    vld          vr13,  a0,    0
++    vld          vr14,  a0,    16
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vst          vr6,   a3,    -1
++    vslli.b      vr9,   vr8,   2
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    STATS_COUNT vr9, vr14, 8,  0
++    STATS_COUNT vr9, vr14, 9,  1
++    STATS_COUNT vr9, vr14, 10, 2
++    STATS_COUNT vr9, vr14, 11, 3
++    STATS_COUNT vr9, vr14, 12, 4
++    STATS_COUNT vr9, vr14, 13, 5
++    STATS_COUNT vr9, vr14, 14, 6
++    STATS_COUNT vr9, vr14, 15, 7
++    addi.d       t0,    t0,    -1
++    addi.d       a1,    a1,    16
++    addi.d       a0,    a0,    32
++    addi.d       a3,    a3,    16
++    bnez         t0,    .loopS_X_e3
++.ResS_X_e3:
++    beqz         t1,    .endS_X_e3
++    addi.d       t4,    zero,  8
++    vld          vr0,   a1,    0
++    vldx         vr1,   a1,    t3
++    vld          vr2,   a3,    0
++    vld          vr13,  a0,    0
++    vld          vr14,  a0,    16
++    add.d        a1,    a1,    t1
++    vslt.bu      vr3,   vr1,   vr0
++    vslt.bu      vr4,   vr0,   vr1
++    vand.v       vr3,   vr3,   vr10
++    vor.v        vr5,   vr3,   vr4
++    vneg.b       vr6,   vr5
++    vadd.b       vr7,   vr5,   vr2
++    vaddi.bu     vr8,   vr7,   2
++    vslli.b      vr9,   vr8,   2
++    blt          t1,    t4,    .resS_X_e3
++    fst.d        f6,    a3,    -1
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT vr9, vr13, \i, \i
++.endr
++    addi.d       t1,    t1,    -8
++    addi.d       a3,    a3,    8
++    beqz         t1,    .endS_X_e3
++    vmov         vr13,  vr14
++    vbsrl.v      vr9,   vr9,   8
++    vbsrl.v      vr6,   vr6,   8
++.resS_X_e3:
++    vpickve2gr.b t4,    vr9,   0
++    vpickve2gr.h t8,    vr13,  0
++    ldx.w        t6,    sp,    t4
++    ldx.w        t7,    t5,    t4
++    add.w        t6,    t6,    t8
++    addi.w       t7,    t7,    1
++    stx.w        t6,    sp,    t4
++    stx.w        t7,    t5,    t4
++    vstelm.b     vr6,   a3,    -1,   0
++    vbsrl.v      vr9,   vr9,   1
++    vbsrl.v      vr13,  vr13,  2
++    vbsrl.v      vr6,   vr6,   1
++    addi.d       t1,    t1,    -1
++    addi.d       a3,    a3,    1
++    bnez         t1,    .resS_X_e3
++.endS_X_e3:
++    ldx.bu       t0,    a1,    t3
++    ld.bu        t1,    a1,    0
++    addi.d       t4,    zero,  -1
++    sltu         t7,    t0,    t1
++    sltu         t6,    t1,    t0
++    maskeqz      t8,    t4,    t7
++    addi.d       a5,    a5,    -1
++    or           t6,    t6,    t8
++    st.b         t6,    a3,    -1
++    ld.d         a0,    sp,    40
++    ld.d         a1,    sp,    48
++    addi.d       a0,    a0,    128
++    add.d        a1,    a1,    a2
++    st.d         a0,    sp,    40
++    st.d         a1,    sp,    48
++    bnez         a5,    .loopS_Y_e3
++    vld          vr1,   sp,    0
++    vld          vr2,   t5,    0
++    vld          vr3,   a6,    0
++    vld          vr4,   a7,    0
++    vshuf4i.w    vr5,   vr1,   0xD2
++    vshuf4i.w    vr6,   vr2,   0xD2
++    vadd.w       vr5,   vr5,   vr3
++    vadd.w       vr6,   vr6,   vr4
++    ld.w         t2,    a6,    16
++    ld.w         t3,    a7,    16
++    ld.w         t4,    sp,    16
++    ld.w         t6,    t5,    16
++    add.w        t2,    t2,    t4
++    add.w        t3,    t3,    t6
++    vst          vr5,   a6,    0
++    vst          vr6,   a7,    0
++    st.w         t2,    a6,    16
++    st.w         t3,    a7,    16
++    addi.d       sp,    sp,    64
++endfunc
++
++.macro STATS_COUNT_B in0, in1, i0, i1
++    vpickve2gr.b  t3,  \in0,   \i0
++    vpickve2gr.h  t6,  \in1,   \i1
++    ldx.w         t7,  a5,     t3
++    ldx.w         t8,  a6,     t3
++    add.w         t7,  t7,     t6
++    addi.w        t8,  t8,     1
++    stx.w         t7,  a5,     t3
++    stx.w         t8,  a6,     t3
++.endm
++/*x265_saoCuStatsB0_lsx(const int16_t *diff, const pixel *rec, intptr_t stride,
++                        int endX, int endY, int32_t *stats, int32_t *count)
++*/
++function x265_saoCuStatsB0_lsx
++    srli.d       t2,    a3,    4
++    addi.d       a7,    zero,  8
++.loopS_Y_b0:
++    move         t0,    t2
++    andi         t1,    a3,    15
++    move         t5,    a1
++    move         t4,    a0
++    beqz         t0,    .ResS_X_b0
++.loopS_X_b0:
++    vld          vr0,   t5,    0
++    vld          vr2,   t4,    0
++    vld          vr3,   t4,    16
++    vsrli.b      vr4,   vr0,   3
++    vslli.b      vr5,   vr4,   2
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT_B vr5, vr2, \i, \i
++.endr
++    STATS_COUNT_B vr5, vr3, 8,  0
++    STATS_COUNT_B vr5, vr3, 9,  1
++    STATS_COUNT_B vr5, vr3, 10, 2
++    STATS_COUNT_B vr5, vr3, 11, 3
++    STATS_COUNT_B vr5, vr3, 12, 4
++    STATS_COUNT_B vr5, vr3, 13, 5
++    STATS_COUNT_B vr5, vr3, 14, 6
++    STATS_COUNT_B vr5, vr3, 15, 7
++    addi.d       t0,    t0,    -1
++    addi.d       t5,    t5,    16
++    addi.d       t4,    t4,    32
++    bnez         t0,    .loopS_X_b0
++.ResS_X_b0:
++    beqz         t1,    .endS_X_b0
++    vld          vr0,   t5,    0
++    vld          vr2,   t4,    0
++    vld          vr3,   t4,    16
++    vsrli.b      vr4,   vr0,   3
++    vslli.b      vr5,   vr4,   2
++    blt          t1,    a7,    .resS_X_b0
++.irp i, 0, 1, 2, 3, 4, 5, 6, 7
++    STATS_COUNT_B vr5, vr2, \i, \i
++.endr
++    addi.d       t1,    t1,    -8
++    beqz         t1,    .endS_X_b0
++    vmov         vr2,   vr3
++    vbsrl.v      vr5,   vr5,   8
++.resS_X_b0:
++    STATS_COUNT_B vr5, vr2,  0,  0
++    vbsrl.v      vr5,   vr5,   1
++    vbsrl.v      vr2,   vr2,   2
++    addi.d       t1,    t1,    -1
++    bnez         t1,    .resS_X_b0
++.endS_X_b0:
++    addi.d       a4,    a4,    -1
++    add.d        a1,    a1,    a2
++    addi.d       a0,    a0,    128
++    bnez         a4,    .loopS_Y_b0
++endfunc
+diff --git a/source/common/loongarch64/loopfilter.h b/source/common/loongarch64/loopfilter.h
+new file mode 100644
+index 000000000..85534bb5d
+--- /dev/null
++++ b/source/common/loongarch64/loopfilter.h
+@@ -0,0 +1,57 @@
++/*****************************************************************************
++ * Copyright (C) 2013-2024 MulticoreWare, Inc
++ *
++ * Authors: Hao Chen <chenhao@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_LOOPFILTER_H
++#define X265_LOOPFILTER_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++#define DECL_SAO(cpu) \
++    void PFX(saoCuOrgE0_ ## cpu)(pixel * rec, int8_t * offsetEo, int endX, int8_t* signLeft, intptr_t stride); \
++    void PFX(saoCuOrgE1_ ## cpu)(pixel* rec, int8_t* upBuff1, int8_t* offsetEo, intptr_t stride, int width); \
++    void PFX(saoCuOrgE1_2Rows_ ## cpu)(pixel* rec, int8_t* upBuff1, int8_t* offsetEo, intptr_t stride, int width); \
++    void PFX(saoCuOrgE2_ ## cpu)(pixel* rec, int8_t* pBufft, int8_t* pBuff1, int8_t* offsetEo, int lcuWidth, intptr_t stride); \
++    void PFX(saoCuOrgE3_ ## cpu)(pixel *rec, int8_t *upBuff1, int8_t *m_offsetEo, intptr_t stride, int startX, int endX); \
++    void PFX(saoCuOrgB0_ ## cpu)(pixel* rec, const int8_t* offsetBo, int ctuWidth, int ctuHeight, intptr_t stride); \
++    void PFX(calSign_ ## cpu)(int8_t *dst, const pixel *src1, const pixel *src2, const int endX); \
++    void PFX(saoCuStatsE0_ ## cpu)(const int16_t *diff, const pixel * rec, intptr_t stride,  int endX, int endY, int32_t *stats, int32_t *count); \
++    void PFX(saoCuStatsE1_ ## cpu)(const int16_t *diff, const pixel *rec, intptr_t stride, int8_t *upBuff1, int endX, int endY, int32_t *stats, int32_t *count); \
++    void PFX(saoCuStatsE2_ ## cpu)(const int16_t *diff, const pixel *rec, intptr_t stride, int8_t *upBuff1, int8_t *upBufft, int endX, int endY, int32_t *stats, int32_t *count); \
++    void PFX(saoCuStatsE3_ ## cpu)(const int16_t *diff, const pixel *rec, intptr_t stride, int8_t *upBuff1, int endX, int endY, int32_t *stats, int32_t *count); \
++    void PFX(saoCuStatsB0_ ## cpu)(const int16_t *diff, const pixel *rec, intptr_t stride, int endX, int endY, int32_t *stats, int32_t *count); \
++
++DECL_SAO(lsx);
++
++void PFX(calSign_lasx)(int8_t *dst, const pixel *src1, const pixel *src2, const int endX);
++void PFX(pelFilterLumaStrong_V_lsx)(pixel* src, intptr_t srcStep, intptr_t offset, int32_t tcP, int32_t tcQ);
++void PFX(pelFilterLumaStrong_H_lsx)(pixel* src, intptr_t srcStep, intptr_t offset, int32_t tcP, int32_t tcQ);
++void PFX(pelFilterChroma_V_lsx)(pixel* src, intptr_t srcStep, intptr_t offset, int32_t tc, int32_t maskP, int32_t maskQ);
++void PFX(pelFilterChroma_H_lsx)(pixel* src, intptr_t srcStep, intptr_t offset, int32_t tc, int32_t maskP, int32_t maskQ);
++
++#ifdef __cplusplus
++}
++#endif /*__cplusplus*/
++
++#endif // ifndef X265_LOOPFILTER_H
+diff --git a/source/test/testharness.h b/source/test/testharness.h
+index 5b8e274b1..9342ac416 100644
+--- a/source/test/testharness.h
++++ b/source/test/testharness.h
+@@ -89,6 +89,9 @@ static inline uint32_t __rdtsc(void)
+     a = clock();
+ #elif  X265_ARCH_ARM64
+     asm volatile("mrs %0, cntvct_el0" : "=r"(a));
++#elif  X265_ARCH_LOONGARCH64
++    uint32_t id = 0;
++    asm volatile("rdtime.d  %0,  %1": "=r"(a), "=r"(id));
+ #endif
+     return a;
+ }
+@@ -138,6 +141,8 @@ int PFX(stack_pagealign)(int (*func)(), int align);
+  * needs an explicit asm check because it only sometimes crashes in normal use. */
+ intptr_t PFX(checkasm_call)(intptr_t (*func)(), int *ok, ...);
+ float PFX(checkasm_call_float)(float (*func)(), int *ok, ...);
++#elif (X265_ARCH_LOONGARCH64)
++int PFX(stack_pagealign)(int (*func)(), int align);
+ #elif (X265_ARCH_ARM == 0 && X265_ARCH_ARM64 == 0)
+ #define PFX(stack_pagealign)(func, align) func()
+ #endif
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0004-FROMLIST-LoongArch64-Add-assembly-check-tool.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0004-FROMLIST-LoongArch64-Add-assembly-check-tool.patch
@@ -1,0 +1,325 @@
+From 290c9203d8570aaf677fb5f4251ee00ca0e2cb8a Mon Sep 17 00:00:00 2001
+From: guxiwei <guxiwei-hf@loongson.cn>
+Date: Thu, 30 May 2024 20:25:22 +0800
+Subject: [PATCH 04/15] FROMLIST: LoongArch64: Add assembly check tool
+
+1. Check if Registers are Saved and Restored
+2. Check if 32-bit Integer Parameters are Properly
+   Converted to 64-bit Integers
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/test/CMakeLists.txt         |  11 ++
+ source/test/checkasm-loongarch64.S | 237 +++++++++++++++++++++++++++++
+ source/test/testharness.h          |  21 +++
+ 3 files changed, 269 insertions(+)
+ create mode 100644 source/test/checkasm-loongarch64.S
+
+diff --git a/source/test/CMakeLists.txt b/source/test/CMakeLists.txt
+index 260195f53..1da47dd67 100644
+--- a/source/test/CMakeLists.txt
++++ b/source/test/CMakeLists.txt
+@@ -37,6 +37,17 @@ if(POWER)
+     set(NASM_SRC)
+ endif(POWER)
+ 
++# add LoongArch64 assembly files
++if(LOONGARCH64)
++    enable_language(ASM)
++    set(NASM_SRC checkasm-loongarch64.S)
++    add_custom_command(
++        OUTPUT checkasm-loongarch64.obj
++        COMMAND ${CMAKE_CXX_COMPILER}
++        ARGS ${NASM_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/checkasm-loongarch64.S -o checkasm-loongarch64.obj
++        DEPENDS checkasm-loongarch64.S)
++endif(LOONGARCH64)
++
+ add_executable(TestBench ${NASM_SRC}
+     testbench.cpp testharness.h
+     pixelharness.cpp pixelharness.h
+diff --git a/source/test/checkasm-loongarch64.S b/source/test/checkasm-loongarch64.S
+new file mode 100644
+index 000000000..b5a3bd0b3
+--- /dev/null
++++ b/source/test/checkasm-loongarch64.S
+@@ -0,0 +1,237 @@
++/****************************************************************************
++ * checkasm-loongarch64.S: assembly check tool
++ *****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: guxiwei <guxiwei@loongson-hf.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ ******************************************************************************/
++
++#include "../common/loongarch64/loongson_asm.S"
++
++const register_init, align=4
++.quad 0x21f86d66c8ca00ce
++.quad 0x75b6ba21077c48ad
++.quad 0xed56bb2dcb3c7736
++.quad 0x8bda43d3fd1a7e06
++.quad 0xb64a9c9e5d318408
++.quad 0xdf9a54b303f1d3a3
++.quad 0x4a75479abd64e097
++.quad 0x249214109d5d1c88
++.quad 0x1a1b2550a612b48c
++.quad 0x79445c159ce79064
++.quad 0x2eed899d5a28ddcd
++.quad 0x86b2536fcd8cf636
++.quad 0xb0856806085e7943
++.quad 0x3f2bf84fc0fcca4e
++.quad 0xacbd382dcf5b8de2
++.quad 0xd229e1f5b281303f
++.quad 0x71aeaff20b095fd9
++.quad 0xab63e2e11fa38ed9
++endconst
++
++const error_message
++.asciz "failed to preserve register"
++endconst
++
++.text
++
++// max number of args used by any x265 asm function.
++#define MAX_ARGS 15
++
++#define CLOBBER_STACK ((8*MAX_ARGS + 15) & ~15)
++
++// Fill dirty data at stack space
++function x265_checkasm_stack_clobber
++    move    t0,     sp
++    addi.d  t1,     zero,   CLOBBER_STACK
++1:
++    st.d    a0,     sp,     0x00
++    st.d    a1,     sp,    -0x08
++    addi.d  sp,     sp,    -0x10
++    addi.d  t1,     t1,    -0x10
++    blt     zero,   t1,     1b
++    move    sp,     t0
++endfunc
++
++#define ARG_STACK ((8*(MAX_ARGS - 8) + 15) & ~15)
++
++.macro check_reg_gr reg1
++    ld.d    t0,     t1,      0
++    xor     t0,     $s\reg1, t0
++    or      t3,     t3,      t0
++    addi.d  t1,     t1,      8
++.endm
++
++.macro check_reg_fr reg1
++    ld.d        t0,     t1,     0
++    movfr2gr.d  t4,     $fs\reg1
++    xor         t0,     t0,     t4
++    or          t3,     t3,     t0
++    addi.d      t1,     t1,     8
++.endm
++
++.macro CHECK_ASM_CALL TYPE
++function x265_\TYPE
++    // Saved s0 - s8, fs0 - fs7
++    move    t4,     sp
++    addi.d  sp,     sp,     -136
++    st.d    s0,     sp,     0
++    st.d    s1,     sp,     8
++    st.d    s2,     sp,     16
++    st.d    s3,     sp,     24
++    st.d    s4,     sp,     32
++    st.d    s5,     sp,     40
++    st.d    s6,     sp,     48
++    st.d    s7,     sp,     56
++    st.d    s8,     sp,     64
++    fst.d   fs0,    sp,     72
++    fst.d   fs1,    sp,     80
++    fst.d   fs2,    sp,     88
++    fst.d   fs3,    sp,     96
++    fst.d   fs4,    sp,     104
++    fst.d   fs5,    sp,     112
++    fst.d   fs6,    sp,     120
++    fst.d   fs7,    sp,     128
++
++    la.local    t1,   register_init
++    ld.d    s0,     t1,     0
++    ld.d    s1,     t1,     8
++    ld.d    s2,     t1,     16
++    ld.d    s3,     t1,     24
++    ld.d    s4,     t1,     32
++    ld.d    s5,     t1,     40
++    ld.d    s6,     t1,     48
++    ld.d    s7,     t1,     56
++    ld.d    s8,     t1,     64
++    fld.d   fs0,    t1,     72
++    fld.d   fs1,    t1,     80
++    fld.d   fs2,    t1,     88
++    fld.d   fs3,    t1,     96
++    fld.d   fs4,    t1,     104
++    fld.d   fs5,    t1,     112
++    fld.d   fs6,    t1,     120
++    fld.d   fs7,    t1,     128
++
++    addi.d  sp,     sp,     -16
++    st.d    a1,     sp,     0 // ok
++    st.d    ra,     sp,     8 // Ret address
++
++    addi.d  sp,     sp,     -ARG_STACK
++
++    addi.d  t0,     zero,   8*8
++    xor     t1,     t1,     t1
++.rept MAX_ARGS - 8
++    // Skip the first 8 args, that are loaded into registers
++    ldx.d   t2,     t4,     t0
++    stx.d   t2,     sp,     t1
++    addi.d  t0,     t0,     8
++    addi.d  t1,     t1,     8
++.endr
++    move    t3,     a0  // Func
++    ld.d    a0,     t4,     0
++    ld.d    a1,     t4,     8
++    ld.d    a2,     t4,     16
++    ld.d    a3,     t4,     24
++    ld.d    a4,     t4,     32
++    ld.d    a5,     t4,     40
++    ld.d    a6,     t4,     48
++    ld.d    a7,     t4,     56
++
++    jirl    ra,     t3,     0
++
++    addi.d  sp,     sp,     ARG_STACK
++    ld.d    t2,     sp,     0 // ok
++    ld.d    ra,     sp,     8 // Ret address
++    addi.d  sp,     sp,     16
++
++    la.local    t1,   register_init
++    xor         t3,   t3,   t3
++
++    check_reg_gr 0
++    check_reg_gr 1
++    check_reg_gr 2
++    check_reg_gr 3
++    check_reg_gr 4
++    check_reg_gr 5
++    check_reg_gr 6
++    check_reg_gr 7
++    check_reg_gr 8
++
++    check_reg_fr 0
++    check_reg_fr 1
++    check_reg_fr 2
++    check_reg_fr 3
++    check_reg_fr 4
++    check_reg_fr 5
++    check_reg_fr 6
++    check_reg_fr 7
++
++    beqz    t3,     0f
++
++    st.d        zero,   t2,     0x00 // Set OK to 0
++    la.local    a0,     error_message
++    addi.d      sp,     sp,     -8
++    st.d        ra,     sp,     0
++    bl          puts
++    ld.d        ra,     sp,     0
++    addi.d      sp,     sp,     8
++0:
++    ld.d    s0,     sp,     0
++    ld.d    s1,     sp,     8
++    ld.d    s2,     sp,     16
++    ld.d    s3,     sp,     24
++    ld.d    s4,     sp,     32
++    ld.d    s5,     sp,     40
++    ld.d    s6,     sp,     48
++    ld.d    s7,     sp,     56
++    ld.d    s8,     sp,     64
++    fld.d   fs0,    sp,     72
++    fld.d   fs1,    sp,     80
++    fld.d   fs2,    sp,     88
++    fld.d   fs3,    sp,     96
++    fld.d   fs4,    sp,     104
++    fld.d   fs5,    sp,     112
++    fld.d   fs6,    sp,     120
++    fld.d   fs7,    sp,     128
++    addi.d  sp,     sp,     136
++endfunc
++.endm
++
++CHECK_ASM_CALL checkasm_call
++CHECK_ASM_CALL checkasm_call_float
++
++// Align the stack pointer to the page size
++function x265_stack_pagealign
++    move    t0,   sp
++    addi.d  sp,   sp,  -16
++
++    srli.d  sp,   sp,   12
++    slli.d  sp,   sp,   12 // Set sp align to 4K
++
++    sub.d   sp,   sp,   a1 // Add user offset, default is 0
++
++    st.d    t0,   sp,   0
++    st.d    ra,   sp,   8 // Store origin sp and ret address
++
++    jirl    ra,   a0,   0
++
++    ld.d    ra,   sp,   8
++    ld.d    sp,   sp,   0 // Restore sp and ret address
++endfunc
+diff --git a/source/test/testharness.h b/source/test/testharness.h
+index 9342ac416..d8d6936cb 100644
+--- a/source/test/testharness.h
++++ b/source/test/testharness.h
+@@ -143,6 +143,11 @@ intptr_t PFX(checkasm_call)(intptr_t (*func)(), int *ok, ...);
+ float PFX(checkasm_call_float)(float (*func)(), int *ok, ...);
+ #elif (X265_ARCH_LOONGARCH64)
+ int PFX(stack_pagealign)(int (*func)(), int align);
++
++/* detect when callee-saved regs aren't saved
++ * needs an explicit asm check because it only sometimes crashes in normal use. */
++intptr_t PFX(checkasm_call)(intptr_t (*func)(), int *ok, ...);
++float PFX(checkasm_call_float)(float (*func)(), int *ok, ...);
+ #elif (X265_ARCH_ARM == 0 && X265_ARCH_ARM64 == 0)
+ #define PFX(stack_pagealign)(func, align) func()
+ #endif
+@@ -176,6 +181,22 @@ void PFX(checkasm_stack_clobber)(uint64_t clobber, ...);
+ #elif ARCH_X86
+ #define checked(func, ...) PFX(checkasm_call)((intptr_t(*)())func, &m_ok, __VA_ARGS__);
+ #define checked_float(func, ...) PFX(checkasm_call_float)((float(*)())func, &m_ok, __VA_ARGS__);
++#elif X265_ARCH_LOONGARCH64
++void PFX(checkasm_stack_clobber)(uint64_t clobber, ...);
++#define checked(func, ...) ( \
++        m_ok = 1, m_rand = (rand() & 0xffff) * 0x0001000100010001ULL, \
++        PFX(checkasm_stack_clobber)(m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, \
++                                    m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, \
++                                    m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand), /* max_args+8 */ \
++        PFX(checkasm_call)((intptr_t(*)())func, &m_ok, 0, 0, 0, 0, 0, 0, __VA_ARGS__))
++
++#define checked_float(func, ...) ( \
++        m_ok = 1, m_rand = (rand() & 0xffff) * 0x0001000100010001ULL, \
++        PFX(checkasm_stack_clobber)(m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, \
++                                    m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, \
++                                    m_rand, m_rand, m_rand, m_rand, m_rand, m_rand, m_rand), /* max_args+8 */ \
++        PFX(checkasm_call_float)((float(*)())func, &m_ok, 0, 0, 0, 0, 0, 0, __VA_ARGS__))
++#define reportfail() if (!m_ok) { fflush(stdout); fprintf(stderr, "stack clobber check failed at %s:%d", __FILE__, __LINE__); abort(); }
+ 
+ #else // if X86_64
+ #define checked(func, ...) func(__VA_ARGS__)
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0005-FROMLIST-LoongArch64-Optimize-functions-in-ipfilter-.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0005-FROMLIST-LoongArch64-Optimize-functions-in-ipfilter-.patch
@@ -1,0 +1,15102 @@
+From 6c490b992c16c04cf0b57aac37c59b821a3eaa85 Mon Sep 17 00:00:00 2001
+From: Hao Chen <chenhao@loongson.cn>
+Date: Fri, 31 May 2024 09:53:35 +0800
+Subject: [PATCH 05/15] FROMLIST: LoongArch64: Optimize functions in ipfilter
+ module
+
+Optimize functions in ipfilter module with lsx and lasx.
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |     4 +-
+ source/common/loongarch64/asm-primitives.cpp |   203 +
+ source/common/loongarch64/ipfilter8.S        | 14675 +++++++++++++++++
+ source/common/loongarch64/ipfilter8.h        |   143 +
+ 4 files changed, 15023 insertions(+), 2 deletions(-)
+ create mode 100644 source/common/loongarch64/ipfilter8.S
+ create mode 100644 source/common/loongarch64/ipfilter8.h
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index b18482349..a57a3675a 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -138,11 +138,11 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+         message(STATUS "Detected CXX compiler using -O3 optimization level")
+     endif()
+ 
+-    set(C_SRCS asm-primitives.cpp loopfilter.h)
++    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S)
++    set(A_SRCS loopfilter.S ipfilter8.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 53ba228a7..947568ae6 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -26,10 +26,51 @@
+ #include "x265.h"
+ #include "cpu.h"
+ #include "loopfilter.h"
++#include "ipfilter8.h"
+ 
+ namespace X265_NS {
+ // private x265 namespace
+ 
++#define LUMA(W, H, CPU) \
++    p.pu[LUMA_ ## W ## x ## H].luma_vpp     = PFX(interp_8tap_vert_pp_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].luma_vps     = PFX(interp_8tap_vert_ps_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].luma_vsp     = PFX(interp_8tap_vert_sp_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].luma_vss     = PFX(interp_8tap_vert_ss_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].luma_hpp     = PFX(interp_8tap_horiz_pp_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].luma_hps     = PFX(interp_8tap_horiz_ps_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].luma_hvpp     = PFX(interp_8tap_hv_pp_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].convert_p2s[NONALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].convert_p2s[ALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU);
++
++#define CHROMA_420(W, H, CPU) \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].filter_hpp = PFX(interp_4tap_horiz_pp_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].filter_hps = PFX(interp_4tap_horiz_ps_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].filter_vpp = PFX(interp_4tap_vert_pp_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].filter_vps = PFX(interp_4tap_vert_ps_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].filter_vsp = PFX(interp_4tap_vert_sp_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].filter_vss = PFX(interp_4tap_vert_ss_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].p2s[NONALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].p2s[ALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU);
++
++#define CHROMA_422(W, H, CPU) \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].filter_hpp = PFX(interp_4tap_horiz_pp_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].filter_hps = PFX(interp_4tap_horiz_ps_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].filter_vpp = PFX(interp_4tap_vert_pp_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].filter_vps = PFX(interp_4tap_vert_ps_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].filter_vsp = PFX(interp_4tap_vert_sp_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].filter_vss = PFX(interp_4tap_vert_ss_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].p2s[NONALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].p2s[ALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU);
++
++#define CHROMA_444(W, H, CPU) \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].filter_hpp = PFX(interp_4tap_horiz_pp_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].filter_hps = PFX(interp_4tap_horiz_ps_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].filter_vpp = PFX(interp_4tap_vert_pp_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].filter_vps = PFX(interp_4tap_vert_ps_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].filter_vsp = PFX(interp_4tap_vert_sp_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].filter_vss = PFX(interp_4tap_vert_ss_ ## W ## x ## H ## _ ##CPU);  \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].p2s[NONALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].p2s[ALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU);
+ 
+ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ {
+@@ -56,6 +97,109 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.saoCuStatsE3 = PFX(saoCuStatsE3_lsx);
+         p.saoCuStatsBO = PFX(saoCuStatsB0_lsx);
+ 
++        // ipfilter
++        LUMA(4,  4,  lsx)
++        LUMA(4,  8,  lsx)
++        LUMA(4,  16, lsx)
++        LUMA(8,  4,  lsx)
++        LUMA(8,  8,  lsx)
++        LUMA(8,  16, lsx)
++        LUMA(8,  32, lsx)
++        LUMA(12, 16, lsx)
++        LUMA(16, 4,  lsx)
++        LUMA(16, 8,  lsx)
++        LUMA(16, 12, lsx)
++        LUMA(16, 16, lsx)
++        LUMA(16, 32, lsx)
++        LUMA(16, 64, lsx)
++        LUMA(24, 32, lsx)
++        LUMA(32, 8,  lsx)
++        LUMA(32, 16, lsx)
++        LUMA(32, 24, lsx)
++        LUMA(32, 32, lsx)
++        LUMA(32, 64, lsx)
++        LUMA(48, 64, lsx)
++        LUMA(64, 16, lsx)
++        LUMA(64, 32, lsx)
++        LUMA(64, 48, lsx)
++        LUMA(64, 64, lsx)
++
++        CHROMA_420(2,  4,  lsx)
++        CHROMA_420(2,  8,  lsx)
++        CHROMA_420(4,  2,  lsx)
++        CHROMA_420(4,  4,  lsx)
++        CHROMA_420(4,  8,  lsx)
++        CHROMA_420(4,  16, lsx)
++        CHROMA_420(6,  8,  lsx)
++        CHROMA_420(8,  2,  lsx)
++        CHROMA_420(8,  4,  lsx)
++        CHROMA_420(8,  6,  lsx)
++        CHROMA_420(8,  8,  lsx)
++        CHROMA_420(8,  16, lsx)
++        CHROMA_420(8,  32, lsx)
++        CHROMA_420(12, 16, lsx)
++        CHROMA_420(16, 4,  lsx)
++        CHROMA_420(16, 8,  lsx)
++        CHROMA_420(16, 12, lsx)
++        CHROMA_420(16, 16, lsx)
++        CHROMA_420(16, 32, lsx)
++        CHROMA_420(24, 32, lsx)
++        CHROMA_420(32, 8,  lsx)
++        CHROMA_420(32, 16, lsx)
++        CHROMA_420(32, 24, lsx)
++        CHROMA_420(32, 32, lsx)
++
++        CHROMA_422(2,  4,  lsx)
++        CHROMA_422(2,  8,  lsx)
++        CHROMA_422(2,  16, lsx)
++        CHROMA_422(4,  4,  lsx)
++        CHROMA_422(4,  8,  lsx)
++        CHROMA_422(4,  16, lsx)
++        CHROMA_422(4,  32, lsx)
++        CHROMA_422(6,  16, lsx)
++        CHROMA_422(8,  4,  lsx)
++        CHROMA_422(8,  8,  lsx)
++        CHROMA_422(8,  12, lsx)
++        CHROMA_422(8,  16, lsx)
++        CHROMA_422(8,  32, lsx)
++        CHROMA_422(8,  64, lsx)
++        CHROMA_422(12, 32, lsx)
++        CHROMA_422(16, 8,  lsx)
++        CHROMA_422(16, 16, lsx)
++        CHROMA_422(16, 24, lsx)
++        CHROMA_422(16, 32, lsx)
++        CHROMA_422(16, 64, lsx)
++        CHROMA_422(24, 64, lsx)
++        CHROMA_422(32, 16, lsx)
++        CHROMA_422(32, 32, lsx)
++        CHROMA_422(32, 48, lsx)
++        CHROMA_422(32, 64, lsx)
++
++        CHROMA_444(4,  4,  lsx)
++        CHROMA_444(4,  8,  lsx)
++        CHROMA_444(4,  16, lsx)
++        CHROMA_444(8,  4,  lsx)
++        CHROMA_444(8,  8,  lsx)
++        CHROMA_444(8,  16, lsx)
++        CHROMA_444(8,  32, lsx)
++        CHROMA_444(12, 16, lsx)
++        CHROMA_444(16, 4,  lsx)
++        CHROMA_444(16, 8,  lsx)
++        CHROMA_444(16, 12, lsx)
++        CHROMA_444(16, 16, lsx)
++        CHROMA_444(16, 32, lsx)
++        CHROMA_444(16, 64, lsx)
++        CHROMA_444(24, 32, lsx)
++        CHROMA_444(32, 8,  lsx)
++        CHROMA_444(32, 16, lsx)
++        CHROMA_444(32, 24, lsx)
++        CHROMA_444(32, 32, lsx)
++        CHROMA_444(32, 64, lsx)
++        CHROMA_444(48, 64, lsx)
++        CHROMA_444(64, 16, lsx)
++        CHROMA_444(64, 32, lsx)
++        CHROMA_444(64, 48, lsx)
++        CHROMA_444(64, 64, lsx)
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -64,6 +208,65 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+     {
+         // loopfilter
+         p.sign = PFX(calSign_lasx);
++
++        // ipfilter
++        LUMA(16, 4,  lasx)
++        LUMA(16, 8,  lasx)
++        LUMA(16, 12, lasx)
++        LUMA(16, 16, lasx)
++        LUMA(16, 32, lasx)
++        LUMA(16, 64, lasx)
++        LUMA(24, 32, lasx)
++        LUMA(32, 8,  lasx)
++        LUMA(32, 16, lasx)
++        LUMA(32, 24, lasx)
++        LUMA(32, 32, lasx)
++        LUMA(32, 64, lasx)
++        LUMA(48, 64, lasx)
++        LUMA(64, 16, lasx)
++        LUMA(64, 32, lasx)
++        LUMA(64, 48, lasx)
++        LUMA(64, 64, lasx)
++
++        CHROMA_420(16, 4,  lasx)
++        CHROMA_420(16, 8,  lasx)
++        CHROMA_420(16, 12, lasx)
++        CHROMA_420(16, 16, lasx)
++        CHROMA_420(16, 32, lasx)
++        CHROMA_420(24, 32, lasx)
++        CHROMA_420(32, 8,  lasx)
++        CHROMA_420(32, 16, lasx)
++        CHROMA_420(32, 24, lasx)
++        CHROMA_420(32, 32, lasx)
++
++        CHROMA_422(16, 8,  lasx)
++        CHROMA_422(16, 16, lasx)
++        CHROMA_422(16, 24, lasx)
++        CHROMA_422(16, 32, lasx)
++        CHROMA_422(16, 64, lasx)
++        CHROMA_422(24, 64, lasx)
++        CHROMA_422(32, 16, lasx)
++        CHROMA_422(32, 32, lasx)
++        CHROMA_422(32, 48, lasx)
++        CHROMA_422(32, 64, lasx)
++
++        CHROMA_444(16, 4,  lasx)
++        CHROMA_444(16, 8,  lasx)
++        CHROMA_444(16, 12, lasx)
++        CHROMA_444(16, 16, lasx)
++        CHROMA_444(16, 32, lasx)
++        CHROMA_444(16, 64, lasx)
++        CHROMA_444(24, 32, lasx)
++        CHROMA_444(32, 8,  lasx)
++        CHROMA_444(32, 16, lasx)
++        CHROMA_444(32, 24, lasx)
++        CHROMA_444(32, 32, lasx)
++        CHROMA_444(32, 64, lasx)
++        CHROMA_444(48, 64, lasx)
++        CHROMA_444(64, 16, lasx)
++        CHROMA_444(64, 32, lasx)
++        CHROMA_444(64, 48, lasx)
++        CHROMA_444(64, 64, lasx)
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/ipfilter8.S b/source/common/loongarch64/ipfilter8.S
+new file mode 100644
+index 000000000..636fd0690
+--- /dev/null
++++ b/source/common/loongarch64/ipfilter8.S
+@@ -0,0 +1,14675 @@
++/*
++*****************************************************************************
++* Copyright (C) 2024 MulticoreWare, Inc
++*
++* Authors: Hao Chen <chenhao@loongson.cn>
++*
++* This program is free software; you can redistribute it and/or modify
++* it under the terms of the GNU General Public License as published by
++* the Free Software Foundation; either version 2 of the License, or
++* (at your option) any later version.
++*
++* This program is distributed in the hope that it will be useful,
++* but WITHOUT ANY WARRANTY; without even the implied warranty of
++* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++* GNU General Public License for more details.
++*
++* You should have received a copy of the GNU General Public License
++* along with this program; if not, write to the Free Software
++* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++*
++* This program is also available under a commercial proprietary license.
++* For more information, contact us at license @ x265.com.
++*****************************************************************************
++*/
++
++#include "loongson_asm.S"
++
++const g_lumaFilter
++.byte 0, 0, 0, 0, 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 0, 0
++.byte 0, 0, 0, 0, 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 0, 0
++.byte -1, -1, 4, 4, -10, -10, 58, 58, 17, 17, -5, -5, 1, 1, 0, 0
++.byte -1, -1, 4, 4, -10, -10, 58, 58, 17, 17, -5, -5, 1, 1, 0, 0
++.byte -1, -1, 4, 4, -11, -11, 40, 40, 40, 40, -11, -11, 4, 4, -1, -1
++.byte -1, -1, 4, 4, -11, -11, 40, 40, 40, 40, -11, -11, 4, 4, -1, -1
++.byte 0, 0, 1, 1, -5, -5, 17, 17, 58, 58, -10, -10, 4, 4, -1, -1
++.byte 0, 0, 1, 1, -5, -5, 17, 17, 58, 58, -10, -10, 4, 4, -1, -1
++.short 0, 0, 0, 64, 0, 0, 0, 0
++.short -1, 4, -10, 58, 17, -5, 1, 0
++.short -1, 4, -11, 40, 40, -11, 4, -1
++.short 0, 1, -5, 17, 58, -10, 4, -1
++endconst
++
++const g_chromaFilter
++.byte 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 64, 64, 0, 0, 0, 0
++.byte 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 64, 64, 0, 0, 0, 0
++.byte -2, -2, 58, 58, 10, 10, -2, -2, -2, -2, 58, 58, 10, 10, -2, -2
++.byte -2, -2, 58, 58, 10, 10, -2, -2, -2, -2, 58, 58, 10, 10, -2, -2
++.byte -4, -4, 54, 54, 16, 16, -2, -2, -4, -4, 54, 54, 16, 16, -2, -2
++.byte -4, -4, 54, 54, 16, 16, -2, -2, -4, -4, 54, 54, 16, 16, -2, -2
++.byte -6, -6, 46, 46, 28, 28, -4, -4, -6, -6, 46, 46, 28, 28, -4, -4
++.byte -6, -6, 46, 46, 28, 28, -4, -4, -6, -6, 46, 46, 28, 28, -4, -4
++.byte -4, -4, 36, 36, 36, 36, -4, -4, -4, -4, 36, 36, 36, 36, -4, -4
++.byte -4, -4, 36, 36, 36, 36, -4, -4, -4, -4, 36, 36, 36, 36, -4, -4
++.byte -4, -4, 28, 28, 46, 46, -6, -6, -4, -4, 28, 28, 46, 46, -6, -6
++.byte -4, -4, 28, 28, 46, 46, -6, -6, -4, -4, 28, 28, 46, 46, -6, -6
++.byte -2, -2, 16, 16, 54, 54, -4, -4, -2, -2, 16, 16, 54, 54, -4, -4
++.byte -2, -2, 16, 16, 54, 54, -4, -4, -2, -2, 16, 16, 54, 54, -4, -4
++.byte -2, -2, 10, 10, 58, 58, -2, -2, -2, -2, 10, 10, 58, 58, -2, -2
++.byte -2, -2, 10, 10, 58, 58, -2, -2, -2, -2, 10, 10, 58, 58, -2, -2
++.short 0, 64, 0, 0
++.short -2, 58, 10, -2
++.short -4, 54, 16, -2
++.short -6, 46, 28, -4
++.short -4, 36, 36, -4
++.short -4, 28, 46, -6
++.short -2, 16, 54, -4
++.short -2, 10, 58, -2
++endconst
++
++const h_psOffset
++.short -8192, -8192, -8192, -8192, -8192, -8192, -8192, -8192
++.short -8192, -8192, -8192, -8192, -8192, -8192, -8192, -8192
++.word 526336, 526336, 526336, 526336, 526336, 526336, 526336, 526336
++endconst
++
++.macro PROCESS_LUMA in0, in1, in2, in3, in4, in5, in6, in7, out0,   \
++                    tmp0, tmp1, tmp2, tmp3
++    vhaddw.w.h   \in0,   \in0,  \in0
++    vhaddw.w.h   \in1,   \in1,  \in1
++    vhaddw.w.h   \in2,   \in2,  \in2
++    vhaddw.w.h   \in3,   \in3,  \in3
++    vhaddw.w.h   \in4,   \in4,  \in4
++    vhaddw.w.h   \in5,   \in5,  \in5
++    vhaddw.w.h   \in6,   \in6,  \in6
++    vhaddw.w.h   \in7,   \in7,  \in7
++    vpickev.h    \tmp0,  \in1,  \in0
++    vpickev.h    \tmp1,  \in3,  \in2
++    vpickev.h    \tmp2,  \in5,  \in4
++    vpickev.h    \tmp3,  \in7,  \in6
++    vhaddw.w.h   \tmp0,  \tmp0, \tmp0
++    vhaddw.w.h   \tmp1,  \tmp1, \tmp1
++    vhaddw.w.h   \tmp2,  \tmp2, \tmp2
++    vhaddw.w.h   \tmp3,  \tmp3, \tmp3
++    vpickev.h    \in0,   \tmp1, \tmp0
++    vpickev.h    \in1,   \tmp3, \tmp2
++    vhaddw.w.h   \in0,   \in0,  \in0
++    vhaddw.w.h   \in1,   \in1,  \in1
++    vpickev.h    \out0,  \in1,  \in0
++.endm
++
++.macro VMULW4_H in0, in1, mul0, mul1, out0, out1, out2, out3
++    vmulwev.h.bu.b  \out0, \in0, \mul0
++    vmulwod.h.bu.b  \out1, \in0, \mul0
++    vmulwev.h.bu.b  \out2, \in1, \mul1
++    vmulwod.h.bu.b  \out3, \in1, \mul1
++.endm
++
++.macro VMADDW4_H in0, in1, mul0, mul1, out0, out1, out2, out3
++    vmaddwev.h.bu.b  \out0, \in0, \mul0
++    vmaddwod.h.bu.b  \out1, \in0, \mul0
++    vmaddwev.h.bu.b  \out2, \in1, \mul1
++    vmaddwod.h.bu.b  \out3, \in1, \mul1
++.endm
++
++.macro FILTER_HORIZ_LUMA_4xN  h
++function x265_interp_8tap_horiz_pp_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    vldx         vr10,  t6,    t7
++    addi.d       t0,    zero,  \h/4
++.loopH_4x\h:
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr20, vr15, vr16, vr17, vr18
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr21, vr15, vr16, vr17, vr18
++
++    vssrarni.bu.h vr21, vr20, 6
++    vstelm.w     vr21,  a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.w     vr21,  a2,    0,    1
++    add.d        a2,    a2,    a3
++    vstelm.w     vr21,  a2,    0,    2
++    add.d        a2,    a2,    a3
++    vstelm.w     vr21,  a2,    0,    3
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopH_4x\h
++endfunc
++.endm
++
++FILTER_HORIZ_LUMA_4xN  4
++FILTER_HORIZ_LUMA_4xN  8
++FILTER_HORIZ_LUMA_4xN  16
++
++.macro FILTER_HORIZ_LUMA_8xN  h
++function x265_interp_8tap_horiz_pp_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    vldx         vr10,  t6,    t7
++    addi.d       t0,    zero,  \h/2
++.loopH_8x\h:
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr20, vr15, vr16, vr17, vr18
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr21, vr15, vr16, vr17, vr18
++
++    vssrarni.bu.h vr21, vr20, 6
++    vstelm.d     vr21,  a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.d     vr21,  a2,    0,    1
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopH_8x\h
++endfunc
++.endm
++
++FILTER_HORIZ_LUMA_8xN 4
++FILTER_HORIZ_LUMA_8xN 8
++FILTER_HORIZ_LUMA_8xN 16
++FILTER_HORIZ_LUMA_8xN 32
++
++function x265_interp_8tap_horiz_pp_12x16_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    vldx         vr10,  t6,    t7
++    addi.d       t0,    zero,  16
++.loopH_12x16:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvh.b      vr19,  vr1,   vr0
++    vilvh.b      vr21,  vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr20, vr15, vr16, vr17, vr18
++
++    VMULW4_H vr19, vr21, vr10, vr10, vr15, vr16, vr17, vr18
++
++    vhaddw.w.h   vr15,  vr15,  vr15
++    vhaddw.w.h   vr16,  vr16,  vr16
++    vhaddw.w.h   vr17,  vr17,  vr17
++    vhaddw.w.h   vr18,  vr18,  vr18
++    vpickev.h    vr0,   vr16,  vr15
++    vpickev.h    vr1,   vr18,  vr17
++    vhaddw.w.h   vr0,   vr0,   vr0
++    vhaddw.w.h   vr1,   vr1,   vr1
++    vpickev.h    vr2,   vr1,   vr0
++    vhaddw.w.h   vr3,   vr2,   vr2
++    vpickev.h    vr5,   vr10,  vr3
++    add.d        a0,    a0,    a1
++
++    vssrarni.bu.h vr5, vr20, 6
++    vstelm.d     vr5,   a2,    0,    0
++    vstelm.w     vr5,   a2,    8,    2
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopH_12x16
++endfunc
++
++function x265_interp_8tap_horiz_pp_24x32_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    vldx         vr10,  t6,    t7
++    addi.d       t0,    zero,  32
++.loopH_24x32:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vld          vr20,  a0,    1
++    vld          vr21,  a0,    2
++    vld          vr22,  a0,    3
++    vld          vr23,  a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr21,  vr20
++    vilvl.b      vr17,  vr23,  vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr19, vr15, vr16, vr17, vr18
++
++    vilvh.b      vr4,   vr1,    vr0
++    vilvh.b      vr5,   vr3,    vr2
++    vilvh.b      vr16,  vr21,   vr20
++    vilvh.b      vr17,  vr23,   vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr20, vr15, vr16, vr17, vr18
++
++    vssrarni.bu.h vr20, vr19,  6
++
++    fld.d        f0,    a0,    13
++    fld.d        f1,    a0,    14
++    fld.d        f2,    a0,    15
++    fld.d        f3,    a0,    16
++    fld.d        f19,   a0,    17
++    fld.d        f21,   a0,    18
++    fld.d        f22,   a0,    19
++    fld.d        f23,   a0,    20
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr21,  vr19
++    vilvl.b      vr17,  vr23,  vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr19, vr15, vr16, vr17, vr18
++
++    vssrarni.bu.h vr21, vr19,  6
++
++    vst          vr20,  a2,    0
++    vstelm.d     vr21,  a2,    16,  0
++    addi.d       t0,    t0,    -1
++    add.d        a0,    a0,    a1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopH_24x32
++endfunc
++
++.macro FILTER_HORIZ_LUMA_WxN  w, h, rep
++function x265_interp_8tap_horiz_pp_\w\()x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    vldx         vr10,  t6,    t7
++    addi.d       t0,    zero,  \h
++.loopH_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    vld          vr0,   t1,    -3
++    vld          vr1,   t1,    -2
++    vld          vr2,   t1,    -1
++    vld          vr3,   t1,    0
++    vld          vr20,  t1,    1
++    vld          vr21,  t1,    2
++    vld          vr22,  t1,    3
++    vld          vr23,  t1,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr21,  vr20
++    vilvl.b      vr17,  vr23,  vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr19, vr15, vr16, vr17, vr18
++
++    vilvh.b      vr4,   vr1,   vr0
++    vilvh.b      vr5,   vr3,   vr2
++    vilvh.b      vr16,  vr21,  vr20
++    vilvh.b      vr17,  vr23,  vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr20, vr15, vr16, vr17, vr18
++
++    addi.d        t1,   t1,    16
++    vssrarni.bu.h vr20, vr19,  6
++    vst           vr20, t2,    0
++    addi.d        t2,   t2,    16
++.endr
++    addi.d        t0,   t0,    -1
++    add.d         a0,   a0,    a1
++    add.d         a2,   a2,    a3
++    blt           zero, t0,    .loopH_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_LUMA_WxN 16, 4,  1
++FILTER_HORIZ_LUMA_WxN 16, 8,  1
++FILTER_HORIZ_LUMA_WxN 16, 12, 1
++FILTER_HORIZ_LUMA_WxN 16, 16, 1
++FILTER_HORIZ_LUMA_WxN 16, 32, 1
++FILTER_HORIZ_LUMA_WxN 16, 64, 1
++FILTER_HORIZ_LUMA_WxN 32, 8,  2
++FILTER_HORIZ_LUMA_WxN 32, 16, 2
++FILTER_HORIZ_LUMA_WxN 32, 24, 2
++FILTER_HORIZ_LUMA_WxN 32, 32, 2
++FILTER_HORIZ_LUMA_WxN 32, 64, 2
++FILTER_HORIZ_LUMA_WxN 48, 64, 3
++FILTER_HORIZ_LUMA_WxN 64, 16, 4
++FILTER_HORIZ_LUMA_WxN 64, 32, 4
++FILTER_HORIZ_LUMA_WxN 64, 48, 4
++FILTER_HORIZ_LUMA_WxN 64, 64, 4
++
++.macro FILTER_HORIZ_PS_4xN  h
++function x265_interp_8tap_horiz_ps_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h/2
++    beqz         a5,    .loopS_4x\h
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    3
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    vhaddw.w.h   vr6,   vr6,   vr6
++    vhaddw.w.h   vr7,   vr7,   vr7
++    vhaddw.w.h   vr8,   vr8,   vr8
++    vhaddw.w.h   vr9,   vr9,   vr9
++    vpickev.h    vr12,  vr7,   vr6
++    vpickev.h    vr13,  vr9,   vr8
++    vhaddw.w.h   vr12,  vr12,  vr12
++    vhaddw.w.h   vr13,  vr13,  vr13
++    vpickev.h    vr14,  vr13,  vr12
++    vhaddw.w.h   vr14,  vr14,  vr14
++    vpickev.h    vr20,  vr11,  vr14
++    vadd.h       vr21,  vr20,  vr11
++    add.d        a0,    a0,    a1
++    fst.d        f21,   a2,    0
++    add.d        a2,    a2,    a3
++.loopS_4x\h:
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f16,   a0,    -3
++    fld.d        f17,   a0,    -2
++    fld.d        f18,   a0,    -1
++    fld.d        f19,   a0,    0
++    vilvl.b      vr4,   vr17,  vr16
++    vilvl.b      vr5,   vr19,  vr18
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++
++    vadd.h       vr21,  vr20,  vr11
++    addi.d       t0,    t0,    -1
++    vstelm.d     vr21,  a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.d     vr21,  a2,    0,    1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4x\h
++endfunc
++.endm
++
++FILTER_HORIZ_PS_4xN  4
++FILTER_HORIZ_PS_4xN  8
++FILTER_HORIZ_PS_4xN  16
++
++.macro FILTER_HORIZ_PS_8xN  h
++function x265_interp_8tap_horiz_ps_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h/2
++    beqz         a5,    .loopS_8x\h
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    3
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++
++    vadd.h       vr21,  vr20,  vr11
++    vst          vr21,  a2,    0
++    add.d        a2,    a2,    a3
++.loopS_8x\h:
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr21, vr16, vr17, vr18, vr19
++
++    vadd.h       vr20,  vr20,  vr11
++    vadd.h       vr21,  vr21,  vr11
++    vst          vr20,  a2,    0
++    add.d        a2,    a2,    a3
++    vst          vr21,  a2,    0
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_8x\h
++endfunc
++.endm
++
++FILTER_HORIZ_PS_8xN 4
++FILTER_HORIZ_PS_8xN 8
++FILTER_HORIZ_PS_8xN 16
++FILTER_HORIZ_PS_8xN 32
++
++function x265_interp_8tap_horiz_ps_12x16_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  16
++    beqz         a5,    .loopS_12x16
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_12x16:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvh.b      vr21,  vr1,   vr0
++    vilvh.b      vr22,  vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++    VMULW4_H vr21, vr22, vr10, vr10, vr15, vr16, vr17, vr18
++
++    vhaddw.w.h   vr15,  vr15,  vr15
++    vhaddw.w.h   vr16,  vr16,  vr16
++    vhaddw.w.h   vr17,  vr17,  vr17
++    vhaddw.w.h   vr18,  vr18,  vr18
++    vpickev.h    vr0,   vr16,  vr15
++    vpickev.h    vr1,   vr18,  vr17
++    vhaddw.w.h   vr0,   vr0,   vr0
++    vhaddw.w.h   vr1,   vr1,   vr1
++    vpickev.h    vr2,   vr1,   vr0
++    vhaddw.w.h   vr3,   vr2,   vr2
++    vpickev.h    vr5,   vr10,  vr3
++    vadd.h       vr20,  vr20,  vr11
++    vadd.h       vr21,  vr5,   vr11
++
++    add.d        a0,    a0,    a1
++    vst          vr20,  a2,    0
++    fst.d        f21,   a2,    16
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_12x16
++endfunc
++
++function x265_interp_8tap_horiz_ps_24x32_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    addi.d       sp,    sp,    -16
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    vldx         vr10,  t6,    t7
++    vld          vr24,  t5,    0
++    addi.d       t0,    zero,  32
++    beqz         a5,    .loopS_24x32
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_24x32:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vld          vr20,  a0,    1
++    vld          vr21,  a0,    2
++    vld          vr22,  a0,    3
++    vld          vr23,  a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr21,  vr20
++    vilvl.b      vr17,  vr23,  vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr25, vr15, vr16, vr17, vr18
++
++    vilvh.b      vr4,   vr1,    vr0
++    vilvh.b      vr5,   vr3,    vr2
++    vilvh.b      vr16,  vr21,   vr20
++    vilvh.b      vr17,  vr23,   vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr20, vr15, vr16, vr17, vr18
++
++    fld.d        f0,    a0,    13
++    fld.d        f1,    a0,    14
++    fld.d        f2,    a0,    15
++    fld.d        f3,    a0,    16
++    fld.d        f19,   a0,    17
++    fld.d        f21,   a0,    18
++    fld.d        f22,   a0,    19
++    fld.d        f23,   a0,    20
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr21,  vr19
++    vilvl.b      vr17,  vr23,  vr22
++
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr11, vr12, vr13, vr14
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr11, vr12, vr13, vr14, \
++                 vr19, vr15, vr16, vr17, vr18
++
++    vadd.h       vr0,   vr25,  vr24
++    vadd.h       vr1,   vr20,  vr24
++    vadd.h       vr2,   vr19,  vr24
++
++    vst          vr0,   a2,    0
++    vst          vr1,   a2,    16
++    vst          vr2,   a2,    32
++    addi.d       t0,    t0,    -1
++    add.d        a0,    a0,    a1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_24x32
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    addi.d       sp,    sp,    16
++endfunc
++
++.macro FILTER_HORIZ_PS_WxN  w, h, rep
++function x265_interp_8tap_horiz_ps_\w\()x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    addi.d       sp,    sp,    -8
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    fst.d        f24,   sp,    0
++    beqz         a5,    .loopS_\w\()x\h
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    vld          vr0,   t1,    -3
++    vld          vr1,   t1,    -2
++    vld          vr2,   t1,    -1
++    vld          vr3,   t1,    0
++    vld          vr20,  t1,    1
++    vld          vr21,  t1,    2
++    vld          vr22,  t1,    3
++    vld          vr23,  t1,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr21,  vr20
++    vilvl.b      vr17,  vr23,  vr22
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr24, vr16, vr17, vr18, vr19
++
++    vilvh.b      vr4,   vr1,   vr0
++    vilvh.b      vr5,   vr3,   vr2
++    vilvh.b      vr16,  vr21,  vr20
++    vilvh.b      vr17,  vr23,  vr22
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr21, vr16, vr17, vr18, vr19
++
++    vadd.h       vr0,   vr24,  vr11
++    vadd.h       vr1,   vr21,  vr11
++
++    addi.d       t1,    t1,    16
++    vst          vr0,   t2,    0
++    vst          vr1,   t2,    16
++    addi.d       t2,    t2,    32
++.endr
++    addi.d       t0,    t0,    -1
++    add.d        a0,    a0,    a1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_\w\()x\h
++    fld.d        f24,   sp,    0
++    addi.d       sp,    sp,    8
++endfunc
++.endm
++
++FILTER_HORIZ_PS_WxN 16, 4,  1
++FILTER_HORIZ_PS_WxN 16, 8,  1
++FILTER_HORIZ_PS_WxN 16, 12, 1
++FILTER_HORIZ_PS_WxN 16, 16, 1
++FILTER_HORIZ_PS_WxN 16, 32, 1
++FILTER_HORIZ_PS_WxN 16, 64, 1
++FILTER_HORIZ_PS_WxN 48, 64, 3
++FILTER_HORIZ_PS_WxN 32, 8,  2
++FILTER_HORIZ_PS_WxN 32, 16, 2
++FILTER_HORIZ_PS_WxN 32, 24, 2
++FILTER_HORIZ_PS_WxN 32, 32, 2
++FILTER_HORIZ_PS_WxN 32, 64, 2
++FILTER_HORIZ_PS_WxN 64, 16, 4
++FILTER_HORIZ_PS_WxN 64, 32, 4
++FILTER_HORIZ_PS_WxN 64, 48, 4
++FILTER_HORIZ_PS_WxN 64, 64, 4
++
++function x265_interp_8tap_vert_pp_4x4_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++    vmulwev.h.bu.b   vr9,  vr0,  vr16   //0, 2
++    vmulwod.h.bu.b   vr10, vr0,  vr16   //1, 3
++    VMADDW4_H vr1, vr2, vr17, vr18, vr9 vr10, vr9, vr10
++    VMADDW4_H vr3, vr4, vr19, vr20, vr9 vr10, vr9, vr10
++    VMADDW4_H vr5, vr6, vr21, vr22, vr9 vr10, vr9, vr10
++    vmaddwev.h.bu.b  vr9,  vr7,  vr23
++    vmaddwod.h.bu.b  vr10, vr7,  vr23
++    vssrarni.bu.h    vr10, vr9,  6
++    vstelm.w         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   3
++endfunc
++
++function x265_interp_8tap_vert_pp_4x8_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    add.d        t6,    a0,    t3
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++    VMULW4_H  vr0, vr4, vr16, vr16, vr8, vr9, vr13, vr14
++    VMADDW4_H vr1, vr5, vr17, vr17, vr8, vr9, vr13, vr14
++    VMADDW4_H vr2, vr6, vr18, vr18, vr8, vr9, vr13, vr14
++    VMADDW4_H vr3, vr7, vr19, vr19, vr8, vr9, vr13, vr14
++
++    fldx.s       f0,    a0,    t2   //11
++    fld.s        f1,    t6,    0    //12
++    fldx.s       f2,    t6,    a1   //13
++    fldx.s       f3,    t6,    t1   //14
++
++    vilvl.b      vr15,  vr0,   vr10  //10, 11
++    vilvl.b      vr0,   vr1,   vr0   //11, 12
++    vilvl.d      vr11,  vr15,  vr11  //8,9,10,11
++    vilvl.d      vr12,  vr0,   vr12  //9,10,11,12
++
++    VMADDW4_H vr4, vr11, vr20, vr20, vr8, vr9, vr13, vr14
++    VMADDW4_H vr5, vr12, vr21, vr21, vr8, vr9, vr13, vr14
++
++    vilvl.b      vr4,   vr2,   vr1  //12, 13
++    vilvl.b      vr5,   vr3,   vr2  //13, 14
++    vilvl.d      vr1,   vr4,   vr15 //10,11,12,13
++    vilvl.d      vr2,   vr5,   vr0  //11,12,13,14
++
++    VMADDW4_H vr6, vr1, vr22, vr22, vr8, vr9, vr13, vr14
++    VMADDW4_H vr7, vr2, vr23, vr23, vr8, vr9, vr13, vr14
++
++    vssrarni.bu.h    vr9,  vr8,  6
++    vssrarni.bu.h    vr14, vr13, 6
++    vstelm.w         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,   3
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   3
++endfunc
++
++function x265_interp_8tap_vert_pp_4x16_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    add.d        t6,    a0,    t3
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++    VMULW4_H  vr0, vr4, vr16, vr16, vr8, vr9, vr13, vr14
++    VMADDW4_H vr1, vr5, vr17, vr17, vr8, vr9, vr13, vr14
++    VMADDW4_H vr2, vr6, vr18, vr18, vr8, vr9, vr13, vr14
++    VMADDW4_H vr3, vr7, vr19, vr19, vr8, vr9, vr13, vr14
++
++    fldx.s       f0,    a0,    t2   //11
++    fld.s        f1,    t6,    0    //12
++    fldx.s       f2,    t6,    a1   //13
++    fldx.s       f3,    t6,    t1   //14
++
++    add.d        a0,    t6,    t3
++    vilvl.b      vr15,  vr0,   vr10  //10, 11
++    vilvl.b      vr0,   vr1,   vr0   //11, 12
++    vilvl.d      vr11,  vr15,  vr11  //8,9,10,11
++    vilvl.d      vr12,  vr0,   vr12  //9,10,11,12
++
++    VMADDW4_H vr4, vr11, vr20, vr20, vr8, vr9, vr13, vr14
++    VMADDW4_H vr5, vr12, vr21, vr21, vr8, vr9, vr13, vr14
++
++    vilvl.b      vr4,   vr2,   vr1  //12, 13
++    vilvl.b      vr5,   vr3,   vr2  //13, 14
++    vilvl.d      vr1,   vr4,   vr15 //10,11,12,13
++    vilvl.d      vr2,   vr5,   vr0  //11,12,13,14
++
++    VMADDW4_H vr6, vr1, vr22, vr22, vr8, vr9, vr13, vr14
++    VMADDW4_H vr7, vr2, vr23, vr23, vr8, vr9, vr13, vr14
++
++    vssrarni.bu.h    vr9,  vr8,  6
++    vssrarni.bu.h    vr14, vr13, 6
++    vstelm.w         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,   3
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   3
++    add.d            a2,   a2,   a3
++
++    fldx.s       f6,    t6,    t2   //15
++    fld.s        f7,    a0,    0    //16
++    fldx.s       f10,   a0,    a1   //17
++    add.d        t6,    a0,    t3
++    vilvl.b      vr8,   vr6,   vr3  //14, 15
++    vilvl.b      vr9,   vr7,   vr6  //15, 16
++
++    vilvl.d      vr4,   vr8,   vr4  //12,13,14,15
++    vilvl.d      vr5,   vr9,   vr5  //13,14,15,16
++
++    VMULW4_H  vr11, vr4, vr16, vr16, vr0, vr3, vr13, vr14
++    VMADDW4_H vr12, vr5, vr17, vr17, vr0, vr3, vr13, vr14
++
++    fldx.s       f11,   a0,    t1   //18
++    fldx.s       f12,   a0,    t2   //19
++    vilvl.b      vr7,   vr10,  vr7  //16, 17
++    vilvl.b      vr15,  vr11,  vr10 //17, 18
++    vilvl.d      vr8,   vr7,   vr8  //14,15,16,17
++    vilvl.d      vr9,   vr15,  vr9  //15,16,17,18
++
++    VMADDW4_H vr1, vr8, vr18, vr18, vr0, vr3, vr13, vr14
++    VMADDW4_H vr2, vr9, vr19, vr19, vr0, vr3, vr13, vr14
++
++    fld.s        f1,    t6,    0    //20
++    fldx.s       f2,    t6,    a1   //21
++
++    vilvl.b      vr11,  vr12,  vr11 //18,19
++    vilvl.b      vr6,   vr1,   vr12 //19,20
++    vilvl.d      vr7,   vr11,  vr7  //16,17,18,19
++    vilvl.d      vr15,  vr6,   vr15 //17,18,19,20
++
++    VMADDW4_H vr4, vr7, vr20, vr20, vr0, vr3, vr13, vr14
++    VMADDW4_H vr5, vr15, vr21, vr21, vr0, vr3, vr13, vr14
++
++    fldx.s       f4,    t6,    t1   //22
++    vilvl.b      vr1,   vr2,   vr1  //20, 21
++    vilvl.b      vr5,   vr4,   vr2  //21, 22
++    vilvl.d      vr11,  vr1,   vr11 //18,19,20,21
++    vilvl.d      vr6,   vr5,   vr6  //19,20,21,22
++
++    VMADDW4_H vr8, vr11, vr22, vr22, vr0, vr3, vr13, vr14
++    VMADDW4_H vr9, vr6, vr23, vr23, vr0, vr3, vr13, vr14
++
++    vssrarni.bu.h vr3,  vr0,  6
++    vssrarni.bu.h vr14, vr13, 6
++    vstelm.w         vr3,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr3,  a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr3,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr3,  a2,   0,   3
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr14, a2,   0,   3
++endfunc
++
++.macro FILTER_VERT_PP_8xN  h
++function x265_interp_8tap_vert_pp_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    addi.d       t0,    zero,  \h/4
++    addi.d       sp,    sp,    -24
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++
++    add.d        a0,    t6,    t3
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++    fldx.d       f11,   t6,    t2   //3
++
++    fld.d        f12,   a0,    0    //4
++    fldx.d       f13,   a0,    a1   //5
++    fldx.d       f14,   a0,    t1   //6
++
++    add.d        t6,    a0,    t2
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++    vilvl.b      vr4,   vr13,  vr12 //4,5
++    vilvl.b      vr5,   vr14,  vr13 //5,6
++.loopV_8x\h:
++    fld.d        f15,   t6,    0    //7
++    fldx.d       f24,   t6,    a1   //8
++    fldx.d       f25,   t6,    t1   //9
++    fldx.d       f26,   t6,    t2   //10
++    VMULW4_H vr0, vr2, vr16, vr16, vr10, vr11, vr12, vr13
++    vilvl.b      vr6,   vr15,  vr14 //6,7
++    vilvl.b      vr7,   vr24,  vr15 //7,8
++    vilvl.b      vr8,   vr25,  vr24 //8,9
++    vilvl.b      vr9,   vr26,  vr25 //9,10
++
++    VMADDW4_H vr1, vr3, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr4, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr5, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr4, vr6, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr7, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr8, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr9, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr2,  vr6,  vr6
++    vor.v            vr3,  vr7,  vr7
++    vor.v            vr4,  vr8,  vr8
++    vor.v            vr5,  vr9,  vr9
++    vor.v            vr14, vr26, vr26
++    vssrarni.bu.h    vr11, vr10, 6
++    vssrarni.bu.h    vr13, vr12, 6
++    vstelm.d         vr11, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr11, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   1
++    add.d            t6,   t6,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_8x\h
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    addi.d           sp,   sp,   24
++endfunc
++.endm
++
++FILTER_VERT_PP_8xN 4
++FILTER_VERT_PP_8xN 8
++FILTER_VERT_PP_8xN 16
++FILTER_VERT_PP_8xN 32
++
++function x265_interp_8tap_vert_pp_12x16_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    addi.d       t0,    zero,  8
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    add.d        a0,    t6,    t3
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.loopV_12x16:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++    VMULW4_H  vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr4, vr5, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr6, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr7, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr8, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++
++    vssrarni.bu.h    vr12, vr10, 6
++    vssrarni.bu.h    vr13, vr11, 6
++    vilvl.b          vr14, vr13, vr12
++    vilvh.b          vr15, vr13, vr12
++    vstelm.d         vr14, a2,   0,   0
++    vstelm.w         vr14, a2,   8,   2
++    add.d            a2,   a2,   a3
++    vstelm.d         vr15, a2,   0,   0
++    vstelm.w         vr15, a2,   8,   2
++    add.d            t6,   t6,   t1
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_12x16
++endfunc
++
++.macro FILTER_VERT_PP_16xN  h
++function x265_interp_8tap_vert_pp_16x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    add.d        a0,    t6,    t3
++    slli.d       t7,    a3,    1
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.loopV_16x\h:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++    VMULW4_H  vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr4, vr5, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr6, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr7, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr8, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++
++    vssrarni.bu.h    vr12, vr10, 6
++    vssrarni.bu.h    vr13, vr11, 6
++    vilvl.b          vr14, vr13, vr12
++    vilvh.b          vr15, vr13, vr12
++    vst              vr14, a2,   0
++    vstx             vr15, a2,   a3
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .loopV_16x\h
++endfunc
++.endm
++
++FILTER_VERT_PP_16xN 4
++FILTER_VERT_PP_16xN 8
++FILTER_VERT_PP_16xN 12
++FILTER_VERT_PP_16xN 16
++FILTER_VERT_PP_16xN 32
++FILTER_VERT_PP_16xN 64
++
++function x265_interp_8tap_vert_pp_24x32_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -64
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++    fst.d        f29,   sp,    40
++    fst.d        f30,   sp,    48
++    fst.d        f31,   sp,    56
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    fld.d        f30,   t6,    0
++    fldx.d       f10,   t6,    a1
++    fldx.d       f31,   t6,    t1
++    fldx.d       f12,   t6,    t2
++    addi.d       t6,    a0,    16
++
++    vilvl.b      vr9,   vr10,  vr30  //0,1
++    vilvl.b      vr10,  vr31,  vr10  //1,2
++    vilvl.b      vr11,  vr12,  vr31  //2,3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    fld.d        f30,   t6,    0
++    fldx.d       f14,   t6,    a1
++    fldx.d       f15,   t6,    t1
++
++    vilvl.b      vr12,  vr30,  vr12  //3,4
++    vilvl.b      vr13,  vr14,  vr30  //4,5
++    vilvl.b      vr14,  vr15,  vr14  //5,6
++    add.d        a0,    a0,    t2
++.loopV_24x32:
++    addi.d       t6,    a0,    16
++    vld          vr7,   a0,    0   //7
++    vldx         vr8,   a0,    a1  //8
++    fld.d        f28,   t6,    0
++    fldx.d       f29,   t6,    a1
++    vilvl.b      vr30,  vr28,  vr15  //6,7
++    vilvl.b      vr31,  vr29,  vr28  //7,8
++    vor.v        vr15,  vr29,  vr29
++    VMULW4_H  vr0, vr1, vr16, vr16, vr24, vr25, vr26, vr27
++    vmulwev.h.bu.b vr28, vr9, vr16
++    vmulwod.h.bu.b vr29, vr9, vr16
++    VMADDW4_H vr1, vr2, vr17, vr17, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr10, vr17
++    vmaddwod.h.bu.b vr29, vr10, vr17
++    VMADDW4_H vr2, vr3, vr18, vr18, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr11, vr18
++    vmaddwod.h.bu.b vr29, vr11, vr18
++    VMADDW4_H vr3, vr4, vr19, vr19, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr12, vr19
++    vmaddwod.h.bu.b vr29, vr12, vr19
++    VMADDW4_H vr4, vr5, vr20, vr20, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr13, vr20
++    vmaddwod.h.bu.b vr29, vr13, vr20
++    VMADDW4_H vr5, vr6, vr21, vr21, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr14, vr21
++    vmaddwod.h.bu.b vr29, vr14, vr21
++    VMADDW4_H vr6, vr7, vr22, vr22, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr30, vr22
++    vmaddwod.h.bu.b vr29, vr30, vr22
++    VMADDW4_H vr7, vr8, vr23, vr23, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr31, vr23
++    vmaddwod.h.bu.b vr29, vr31, vr23
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++
++    vssrarni.bu.h    vr26, vr24, 6
++    vssrarni.bu.h    vr27, vr25, 6
++    vssrarni.bu.h    vr29, vr28, 6
++
++    vor.v            vr9,  vr11, vr11
++    vor.v            vr10, vr12, vr12
++    vor.v            vr11, vr13, vr13
++    vor.v            vr12, vr14, vr14
++    vor.v            vr13, vr30, vr30
++    vor.v            vr14, vr31, vr31
++
++    vilvl.b          vr24, vr27, vr26
++    vilvh.b          vr25, vr27, vr26
++    vst              vr24, a2,   0
++    vstelm.d         vr29, a2,   16,   0
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    vst              vr25, a2,   0
++    vstelm.d         vr29, a2,   16,   1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_24x32
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    fld.d        f29,   sp,    40
++    fld.d        f30,   sp,    48
++    fld.d        f31,   sp,    56
++    addi.d       sp,    sp,    64
++endfunc
++
++.macro FILTER_VERT_PP_32xN  h
++function x265_interp_8tap_vert_pp_32x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -32
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++    vldx         vr10,  t6,    t1
++    vldx         vr11,  t6,    t2
++    addi.d       t6,    a0,    16
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    vld          vr12,  t6,    0
++    vldx         vr13,  t6,    a1
++    vldx         vr14,  t6,    t1
++    add.d        a0,    a0,    t2
++.loopV_32x\h:
++    vld          vr7,   a0,    0   //7
++    vld          vr15,  a0,    16  //7
++    VMULW4_H  vr0, vr8, vr16, vr16, vr24, vr25, vr26, vr27
++    VMADDW4_H vr1, vr9, vr17, vr17, vr24, vr25, vr26, vr27
++    VMADDW4_H vr2, vr10, vr18, vr18, vr24, vr25, vr26, vr27
++    VMADDW4_H vr3, vr11, vr19, vr19, vr24, vr25, vr26, vr27
++    VMADDW4_H vr4, vr12, vr20, vr20, vr24, vr25, vr26, vr27
++    VMADDW4_H vr5, vr13, vr21, vr21, vr24, vr25, vr26, vr27
++    VMADDW4_H vr6, vr14, vr22, vr22, vr24, vr25, vr26, vr27
++    VMADDW4_H vr7, vr15, vr23, vr23, vr24, vr25, vr26, vr27
++
++    vor.v            vr0,  vr1,  vr1
++    vor.v            vr1,  vr2,  vr2
++    vor.v            vr2,  vr3,  vr3
++    vor.v            vr3,  vr4,  vr4
++    vor.v            vr4,  vr5,  vr5
++    vor.v            vr5,  vr6,  vr6
++    vor.v            vr6,  vr7,  vr7
++
++    vssrarni.bu.h    vr26, vr24, 6
++    vssrarni.bu.h    vr27, vr25, 6
++
++    vor.v            vr8,  vr9,  vr9
++    vor.v            vr9,  vr10, vr10
++    vor.v            vr10, vr11, vr11
++    vor.v            vr11, vr12, vr12
++    vor.v            vr12, vr13, vr13
++    vor.v            vr13, vr14, vr14
++    vor.v            vr14, vr15, vr15
++    vilvl.b          vr24, vr27, vr26
++    vilvh.b          vr25, vr27, vr26
++    vst              vr24, a2,   0
++    vst              vr25, a2,   16
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_32x\h
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    addi.d       sp,    sp,    32
++endfunc
++.endm
++
++FILTER_VERT_PP_32xN 8
++FILTER_VERT_PP_32xN 16
++FILTER_VERT_PP_32xN 24
++FILTER_VERT_PP_32xN 32
++FILTER_VERT_PP_32xN 64
++
++function x265_interp_8tap_vert_pp_48x64_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++.loopV_48x64:
++    add.d        t5,    a0,    a1
++    VMULW4_H  vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    vmulwev.h.bu.b  vr12,  vr2,  vr16
++    vmulwod.h.bu.b  vr13,  vr2,  vr16
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    vor.v        vr0,   vr4,   vr4
++    vor.v        vr1,   vr5,   vr5
++    vor.v        vr2,   vr6,   vr6
++    VMADDW4_H vr4, vr5, vr17, vr17, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr17
++    vmaddwod.h.bu.b vr13, vr6,  vr17
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr18, vr18, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr18
++    vmaddwod.h.bu.b vr13, vr6,  vr18
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr19, vr19, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr19
++    vmaddwod.h.bu.b vr13, vr6,  vr19
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr20, vr20, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr20
++    vmaddwod.h.bu.b vr13, vr6,  vr20
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr21, vr21, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr21
++    vmaddwod.h.bu.b vr13, vr6,  vr21
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr22, vr22, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr22
++    vmaddwod.h.bu.b vr13, vr6,  vr22
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    VMADDW4_H vr4, vr5, vr23, vr23, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr23
++    vmaddwod.h.bu.b vr13, vr6,  vr23
++
++    vssrarni.bu.h    vr10, vr8,  6
++    vssrarni.bu.h    vr11, vr9,  6
++    vssrarni.bu.h    vr14, vr12, 6
++    vssrarni.bu.h    vr15, vr13, 6
++
++    vilvl.b          vr8,  vr11, vr10   //0
++    vilvh.b          vr9,  vr11, vr10   //16
++    vilvl.b          vr12, vr15, vr14   //32
++
++    vst              vr8,  a2,   0
++    vst              vr9,  a2,   16
++    vst              vr12, a2,   32
++    addi.d           t0,   t0,   -1
++    add.d            a0,   a0,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_48x64
++endfunc
++
++.macro FILTER_VERT_PP_64xN  h
++function x265_interp_8tap_vert_pp_64x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++.loopV_64x\h:
++    add.d        t5,    a0,    a1
++    VMULW4_H  vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMULW4_H  vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    vor.v        vr0,   vr4,   vr4
++    vor.v        vr1,   vr5,   vr5
++    vor.v        vr2,   vr6,   vr6
++    vor.v        vr3,   vr7,   vr7
++    VMADDW4_H vr4, vr5, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr18, vr18, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr19, vr19, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr20, vr20, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr20, vr20, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr21, vr21, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr21, vr21, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr22, vr22, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr22, vr22, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    VMADDW4_H vr4, vr5, vr23, vr23, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr23, vr23, vr12, vr13, vr14, vr15
++
++    vssrarni.bu.h    vr10, vr8,  6
++    vssrarni.bu.h    vr11, vr9,  6
++    vssrarni.bu.h    vr14, vr12, 6
++    vssrarni.bu.h    vr15, vr13, 6
++
++    vilvl.b          vr8,  vr11, vr10   //0
++    vilvh.b          vr9,  vr11, vr10   //16
++    vilvl.b          vr12, vr15, vr14   //32
++    vilvh.b          vr13, vr15, vr14   //48
++
++    vst              vr8,  a2,   0
++    vst              vr9,  a2,   16
++    vst              vr12, a2,   32
++    vst              vr13, a2,   48
++    addi.d           t0,   t0,   -1
++    add.d            a0,   a0,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_64x\h
++endfunc
++.endm
++
++FILTER_VERT_PP_64xN 16
++FILTER_VERT_PP_64xN 32
++FILTER_VERT_PP_64xN 48
++FILTER_VERT_PP_64xN 64
++
++.macro XMULW4_H in0, in1, mul0, mul1, out0, out1, out2, out3
++    xvmulwev.h.bu.b  \out0, \in0, \mul0
++    xvmulwod.h.bu.b  \out1, \in0, \mul0
++    xvmulwev.h.bu.b  \out2, \in1, \mul1
++    xvmulwod.h.bu.b  \out3, \in1, \mul1
++.endm
++
++.macro XMADDW4_H in0, in1, mul0, mul1, out0, out1, out2, out3
++    xvmaddwev.h.bu.b  \out0, \in0, \mul0
++    xvmaddwod.h.bu.b  \out1, \in0, \mul0
++    xvmaddwev.h.bu.b  \out2, \in1, \mul1
++    xvmaddwod.h.bu.b  \out3, \in1, \mul1
++.endm
++
++.macro FILTER_VERT_PP_16xN_LASX  h
++function x265_interp_8tap_vert_pp_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++
++    add.d        a0,    t6,    t3
++    slli.d       t7,    a3,    1
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++    xvpermi.q    xr0,   xr1,   0x2  //0, 1
++    xvpermi.q    xr1,   xr2,   0x2  //1, 2
++    xvpermi.q    xr2,   xr3,   0x2  //2, 3
++    xvpermi.q    xr3,   xr4,   0x2  //3, 4
++    xvpermi.q    xr4,   xr5,   0x2  //4, 5
++    xvpermi.q    xr5,   xr6,   0x2  //5, 6
++.lasx_loopV_16x\h:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++    xvpermi.q    xr6,   xr7,   0x2  //6, 7
++    xvpermi.q    xr7,   xr8,   0x2  //7, 8
++    xvmulwev.h.bu.b  xr10, xr0, xr16
++    xvmulwod.h.bu.b  xr11, xr0, xr16
++    XMADDW4_H xr1, xr2, xr17, xr18, xr10, xr11, xr10, xr11
++    XMADDW4_H xr3, xr4, xr19, xr20, xr10, xr11, xr10, xr11
++    XMADDW4_H xr5, xr6, xr21, xr22, xr10, xr11, xr10, xr11
++    xvmaddwev.h.bu.b xr10, xr7, xr23
++    xvmaddwod.h.bu.b xr11, xr7, xr23
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++
++    xvssrarni.bu.h   xr11, xr10, 6
++    xvpermi.d        xr12, xr11, 0xB1
++    add.d            t6,   t6,   t1
++    xvilvl.b         xr13, xr12, xr11
++    addi.d           t0,   t0,   -1
++    xvpermi.d        xr14, xr13, 0x4E
++    vst              vr13, a2,   0
++    vstx             vr14, a2,   a3
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .lasx_loopV_16x\h
++endfunc
++.endm
++
++FILTER_VERT_PP_16xN_LASX  4
++FILTER_VERT_PP_16xN_LASX  8
++FILTER_VERT_PP_16xN_LASX  12
++FILTER_VERT_PP_16xN_LASX  16
++FILTER_VERT_PP_16xN_LASX  32
++FILTER_VERT_PP_16xN_LASX  64
++
++function x265_interp_8tap_vert_pp_24x32_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++
++    add.d        a0,    t6,    t3
++    xvld         xr0,   t6,    0    //0
++    xvldx        xr1,   t6,    a1   //1
++    xvldx        xr2,   t6,    t1   //2
++    xvldx        xr3,   t6,    t2   //3
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.lasx_loopV_24x32:
++    xvld         xr7,   t6,    0   //7
++    xvldx        xr8,   t6,    a1  //8
++    XMULW4_H  xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADDW4_H xr4, xr5, xr20, xr20, xr10, xr11, xr12, xr13
++    XMADDW4_H xr5, xr6, xr21, xr21, xr10, xr11, xr12, xr13
++    XMADDW4_H xr6, xr7, xr22, xr22, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7, xr8, xr23, xr23, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++
++    xvssrarni.bu.h   xr12, xr10, 6
++    xvssrarni.bu.h   xr13, xr11, 6
++    add.d            t7,   a2,   a3
++    xvilvl.b         xr14, xr13, xr12
++    xvilvh.b         xr15, xr13, xr12
++    vst              vr14, a2,   0
++    xvstelm.d        xr14, a2,   16,  2
++    vst              vr15, t7,   0
++    xvstelm.d        xr15, t7,   16,  2
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   t7,   a3
++    blt              zero, t0,   .lasx_loopV_24x32
++endfunc
++
++function x265_interp_8tap_vert_pp_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  32
++    addi.d       sp,    sp,    -64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++    fst.d        f29,   sp,    40
++    fst.d        f30,   sp,    48
++    fst.d        f31,   sp,    56
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++    xvldx        xr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    vld          vr9,   t6,    0
++    vldx         vr10,  t6,    a1
++    vldx         vr11,  t6,    t1
++    vldx         vr12,  t6,    t2
++    addi.d       t6,    a0,    32
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++
++    vld          vr13,  t6,    0
++    vldx         vr14,  t6,    a1
++    vldx         vr15,  t6,    t1
++    add.d        a0,    a0,    t2
++    xvpermi.q    xr9,   xr10,  0x2
++    xvpermi.q    xr10,  xr11,  0x2
++    xvpermi.q    xr11,  xr12,  0x2
++    xvpermi.q    xr12,  xr13,  0x2
++    xvpermi.q    xr13,  xr14,  0x2
++    xvpermi.q    xr14,  xr15,  0x2
++.lasx_loopV_48x64:
++    addi.d       t6,    a0,    32
++    xvld         xr7,   a0,    0   //7
++    xvldx        xr8,   a0,    a1  //8
++    vld          vr24,  t6,    0
++    vldx         vr25,  t6,    a1
++    xvpermi.q    xr15,  xr24,  0x2
++    xvpermi.q    xr24,  xr25,  0x2
++    XMULW4_H  xr0, xr1, xr16, xr16, xr26, xr27, xr28, xr29
++    xvmulwev.h.bu.b  xr30, xr9,  xr16
++    xvmulwod.h.bu.b  xr31, xr9,  xr16
++    XMADDW4_H xr1, xr2, xr17, xr17, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr10, xr17
++    xvmaddwod.h.bu.b xr31, xr10, xr17
++    XMADDW4_H xr2, xr3, xr18, xr18, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr11, xr18
++    xvmaddwod.h.bu.b xr31, xr11, xr18
++    XMADDW4_H xr3, xr4, xr19, xr19, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr12, xr19
++    xvmaddwod.h.bu.b xr31, xr12, xr19
++    XMADDW4_H xr4, xr5, xr20, xr20, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr13, xr20
++    xvmaddwod.h.bu.b xr31, xr13, xr20
++    XMADDW4_H xr5, xr6, xr21, xr21, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr14, xr21
++    xvmaddwod.h.bu.b xr31, xr14, xr21
++    XMADDW4_H xr6, xr7, xr22, xr22, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr15, xr22
++    xvmaddwod.h.bu.b xr31, xr15, xr22
++    XMADDW4_H xr7, xr8, xr23, xr23, xr26, xr27, xr28, xr29
++    xvmaddwev.h.bu.b xr30, xr24, xr23
++    xvmaddwod.h.bu.b xr31, xr24, xr23
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++    xvor.v           xr9,  xr11, xr11
++    xvor.v           xr10, xr12, xr12
++    xvor.v           xr11, xr13, xr13
++    xvor.v           xr12, xr14, xr14
++    xvor.v           xr13, xr15, xr15
++    xvor.v           xr14, xr24, xr24
++    xvor.v           xr15, xr25, xr25
++
++    xvssrarni.bu.h   xr31, xr30, 6
++    xvssrarni.bu.h   xr28, xr26, 6
++    xvssrarni.bu.h   xr29, xr27, 6
++    xvpermi.d        xr30, xr31, 0xB1
++    add.d            t7,   a2,   a3
++    xvilvl.b         xr26, xr29, xr28
++    xvilvh.b         xr27, xr29, xr28
++    xvilvl.b         xr7,  xr30, xr31
++    xvst             xr26, a2,   0
++    vst              vr7,  a2,   32
++    xvpermi.d        xr8,  xr7,  0x4E
++    add.d            a0,   a0,   t1
++    xvst             xr27, t7,   0
++    vst              vr8,  t7,   32
++    addi.d           t0,   t0,   -1
++    add.d            a2,   t7,   a3
++    blt              zero, t0,   .lasx_loopV_48x64
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    fld.d        f29,   sp,    40
++    fld.d        f30,   sp,    48
++    fld.d        f31,   sp,    56
++    addi.d       sp,    sp,    64
++endfunc
++
++.macro FILTER_VERT_PP_32xN_LASX  h
++function x265_interp_8tap_vert_pp_32x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++
++    add.d        a0,    t6,    t3
++    slli.d       t7,    a3,    1
++    xvld         xr0,   t6,    0    //0
++    xvldx        xr1,   t6,    a1   //1
++    xvldx        xr2,   t6,    t1   //2
++    xvldx        xr3,   t6,    t2   //3
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.lasx_loopV_32x\h:
++    xvld         xr7,   t6,    0   //7
++    xvldx        xr8,   t6,    a1  //8
++    XMULW4_H  xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADDW4_H xr4, xr5, xr20, xr20, xr10, xr11, xr12, xr13
++    XMADDW4_H xr5, xr6, xr21, xr21, xr10, xr11, xr12, xr13
++    XMADDW4_H xr6, xr7, xr22, xr22, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7, xr8, xr23, xr23, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++
++    xvssrarni.bu.h   xr12, xr10, 6
++    xvssrarni.bu.h   xr13, xr11, 6
++    xvilvl.b         xr14, xr13, xr12
++    xvilvh.b         xr15, xr13, xr12
++    xvst             xr14, a2,   0
++    xvstx            xr15, a2,   a3
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .lasx_loopV_32x\h
++endfunc
++.endm
++
++FILTER_VERT_PP_32xN_LASX 8
++FILTER_VERT_PP_32xN_LASX 16
++FILTER_VERT_PP_32xN_LASX 24
++FILTER_VERT_PP_32xN_LASX 32
++FILTER_VERT_PP_32xN_LASX 64
++
++.macro FILTER_VERT_PP_64xN_LASX  h
++function x265_interp_8tap_vert_pp_64x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -32
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++    xvldx        xr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    xvld         xr8,   t6,    0
++    xvldx        xr9,   t6,    a1
++    xvldx        xr10,  t6,    t1
++    xvldx        xr11,  t6,    t2
++    addi.d       t6,    a0,    32
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++
++    xvld         xr12,  t6,    0
++    xvldx        xr13,  t6,    a1
++    xvldx        xr14,  t6,    t1
++    add.d        a0,    a0,    t2
++.lasx_loopV_64x\h:
++    xvld         xr7,   a0,    0   //7
++    xvld         xr15,  a0,    32  //7
++    XMULW4_H  xr0, xr8, xr16, xr16, xr24, xr25, xr26, xr27
++    XMADDW4_H xr1, xr9, xr17, xr17, xr24, xr25, xr26, xr27
++    XMADDW4_H xr2, xr10, xr18, xr18, xr24, xr25, xr26, xr27
++    XMADDW4_H xr3, xr11, xr19, xr19, xr24, xr25, xr26, xr27
++    XMADDW4_H xr4, xr12, xr20, xr20, xr24, xr25, xr26, xr27
++    XMADDW4_H xr5, xr13, xr21, xr21, xr24, xr25, xr26, xr27
++    XMADDW4_H xr6, xr14, xr22, xr22, xr24, xr25, xr26, xr27
++    XMADDW4_H xr7, xr15, xr23, xr23, xr24, xr25, xr26, xr27
++
++    xvor.v           xr0,  xr1,  xr1
++    xvor.v           xr1,  xr2,  xr2
++    xvor.v           xr2,  xr3,  xr3
++    xvor.v           xr3,  xr4,  xr4
++    xvor.v           xr4,  xr5,  xr5
++    xvor.v           xr5,  xr6,  xr6
++    xvor.v           xr6,  xr7,  xr7
++
++    xvssrarni.bu.h   xr26, xr24, 6
++    xvssrarni.bu.h   xr27, xr25, 6
++
++    xvor.v           xr8,  xr9,  xr9
++    xvor.v           xr9,  xr10, xr10
++    xvor.v           xr10, xr11, xr11
++    xvor.v           xr11, xr12, xr12
++    xvor.v           xr12, xr13, xr13
++    xvor.v           xr13, xr14, xr14
++    xvor.v           xr14, xr15, xr15
++
++    xvilvl.b         xr24, xr27, xr26
++    xvilvh.b         xr25, xr27, xr26
++    xvst             xr24, a2,   0
++    xvst             xr25, a2,   32
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_64x\h
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    addi.d       sp,    sp,    32
++endfunc
++.endm
++
++FILTER_VERT_PP_64xN_LASX 16
++FILTER_VERT_PP_64xN_LASX 32
++FILTER_VERT_PP_64xN_LASX 48
++FILTER_VERT_PP_64xN_LASX 64
++
++function x265_interp_8tap_vert_ps_4x4_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    addi.d       sp,    sp,    -8
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr24,  t4,    0
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++    vor.v        vr9,   vr24,  vr24
++    vor.v        vr10,  vr24,  vr24
++    VMADDW4_H vr0, vr1, vr16, vr17, vr9, vr10, vr9, vr10
++    VMADDW4_H vr2, vr3, vr18, vr19, vr9, vr10, vr9, vr10
++    VMADDW4_H vr4, vr5, vr20, vr21, vr9, vr10, vr9, vr10
++    VMADDW4_H vr6, vr7, vr22, vr23, vr9, vr10, vr9, vr10
++    vstelm.d         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr10, a2,   0,   1
++    fld.d            f24,  sp,   0
++    addi.d           sp,   sp,   8
++endfunc
++
++function x265_interp_8tap_vert_ps_4x8_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    addi.d       sp,    sp,    -8
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr24,  t4,    0
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    add.d        t6,    a0,    t3
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++.irp x, vr8, vr9, vr13, vr14
++    vor.v        \x,    vr24,  vr24
++.endr
++    VMADDW4_H vr0, vr4, vr16, vr16, vr8, vr9, vr13, vr14
++    VMADDW4_H vr1, vr5, vr17, vr17, vr8, vr9, vr13, vr14
++    VMADDW4_H vr2, vr6, vr18, vr18, vr8, vr9, vr13, vr14
++    VMADDW4_H vr3, vr7, vr19, vr19, vr8, vr9, vr13, vr14
++
++    fldx.s       f0,    a0,    t2   //11
++    fld.s        f1,    t6,    0    //12
++    fldx.s       f2,    t6,    a1   //13
++    fldx.s       f3,    t6,    t1   //14
++
++    vilvl.b      vr15,  vr0,   vr10  //10, 11
++    vilvl.b      vr0,   vr1,   vr0   //11, 12
++    vilvl.d      vr11,  vr15,  vr11  //8,9,10,11
++    vilvl.d      vr12,  vr0,   vr12  //9,10,11,12
++
++    VMADDW4_H vr4, vr11, vr20, vr20, vr8, vr9, vr13, vr14
++    VMADDW4_H vr5, vr12, vr21, vr21, vr8, vr9, vr13, vr14
++
++    vilvl.b      vr4,   vr2,   vr1  //12, 13
++    vilvl.b      vr5,   vr3,   vr2  //13, 14
++    vilvl.d      vr1,   vr4,   vr15 //10,11,12,13
++    vilvl.d      vr2,   vr5,   vr0  //11,12,13,14
++
++    VMADDW4_H vr6, vr1, vr22, vr22, vr8, vr9, vr13, vr14
++    VMADDW4_H vr7, vr2, vr23, vr23, vr8, vr9, vr13, vr14
++
++    vstelm.d         vr8,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr8,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr14, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr14, a2,   0,   1
++    fld.d            f24,  sp,   0
++    addi.d           sp,   sp,   8
++endfunc
++
++function x265_interp_8tap_vert_ps_4x16_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    addi.d       sp,    sp,    -8
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr24,  t4,    0
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    add.d        t6,    a0,    t3
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++.irp x, vr8, vr9, vr13, vr14
++    vor.v        \x,    vr24,  vr24
++.endr
++    VMADDW4_H vr0, vr4, vr16, vr16, vr8, vr9, vr13, vr14
++    VMADDW4_H vr1, vr5, vr17, vr17, vr8, vr9, vr13, vr14
++    VMADDW4_H vr2, vr6, vr18, vr18, vr8, vr9, vr13, vr14
++    VMADDW4_H vr3, vr7, vr19, vr19, vr8, vr9, vr13, vr14
++
++    fldx.s       f0,    a0,    t2   //11
++    fld.s        f1,    t6,    0    //12
++    fldx.s       f2,    t6,    a1   //13
++    fldx.s       f3,    t6,    t1   //14
++
++    add.d        a0,    t6,    t3
++    vilvl.b      vr15,  vr0,   vr10  //10, 11
++    vilvl.b      vr0,   vr1,   vr0   //11, 12
++    vilvl.d      vr11,  vr15,  vr11  //8,9,10,11
++    vilvl.d      vr12,  vr0,   vr12  //9,10,11,12
++
++    VMADDW4_H vr4, vr11, vr20, vr20, vr8, vr9, vr13, vr14
++    VMADDW4_H vr5, vr12, vr21, vr21, vr8, vr9, vr13, vr14
++
++    vilvl.b      vr4,   vr2,   vr1  //12, 13
++    vilvl.b      vr5,   vr3,   vr2  //13, 14
++    vilvl.d      vr1,   vr4,   vr15 //10,11,12,13
++    vilvl.d      vr2,   vr5,   vr0  //11,12,13,14
++
++    VMADDW4_H vr6, vr1, vr22, vr22, vr8, vr9, vr13, vr14
++    VMADDW4_H vr7, vr2, vr23, vr23, vr8, vr9, vr13, vr14
++
++    vstelm.d         vr8,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr8,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr14, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr14, a2,   0,   1
++    add.d            a2,   a2,   a3
++
++    fldx.s       f6,    t6,    t2   //15
++    fld.s        f7,    a0,    0    //16
++    fldx.s       f10,   a0,    a1   //17
++    add.d        t6,    a0,    t3
++    vilvl.b      vr8,   vr6,   vr3  //14, 15
++    vilvl.b      vr9,   vr7,   vr6  //15, 16
++
++    vilvl.d      vr4,   vr8,   vr4  //12,13,14,15
++    vilvl.d      vr5,   vr9,   vr5  //13,14,15,16
++
++.irp x, vr0, vr3, vr13, vr14
++    vor.v        \x,    vr24,  vr24
++.endr
++    VMADDW4_H vr11, vr4, vr16, vr16, vr0, vr3, vr13, vr14
++    VMADDW4_H vr12, vr5, vr17, vr17, vr0, vr3, vr13, vr14
++
++    fldx.s       f11,   a0,    t1   //18
++    fldx.s       f12,   a0,    t2   //19
++    vilvl.b      vr7,   vr10,  vr7  //16, 17
++    vilvl.b      vr15,  vr11,  vr10 //17, 18
++    vilvl.d      vr8,   vr7,   vr8  //14,15,16,17
++    vilvl.d      vr9,   vr15,  vr9  //15,16,17,18
++
++    VMADDW4_H vr1, vr8, vr18, vr18, vr0, vr3, vr13, vr14
++    VMADDW4_H vr2, vr9, vr19, vr19, vr0, vr3, vr13, vr14
++
++    fld.s        f1,    t6,    0    //20
++    fldx.s       f2,    t6,    a1   //21
++
++    vilvl.b      vr11,  vr12,  vr11 //18,19
++    vilvl.b      vr6,   vr1,   vr12 //19,20
++    vilvl.d      vr7,   vr11,  vr7  //16,17,18,19
++    vilvl.d      vr15,  vr6,   vr15 //17,18,19,20
++
++    VMADDW4_H vr4, vr7, vr20, vr20, vr0, vr3, vr13, vr14
++    VMADDW4_H vr5, vr15, vr21, vr21, vr0, vr3, vr13, vr14
++
++    fldx.s       f4,    t6,    t1   //22
++    vilvl.b      vr1,   vr2,   vr1  //20, 21
++    vilvl.b      vr5,   vr4,   vr2  //21, 22
++    vilvl.d      vr11,  vr1,   vr11 //18,19,20,21
++    vilvl.d      vr6,   vr5,   vr6  //19,20,21,22
++
++    VMADDW4_H vr8, vr11, vr22, vr22, vr0, vr3, vr13, vr14
++    VMADDW4_H vr9, vr6, vr23, vr23, vr0, vr3, vr13, vr14
++
++    vstelm.d         vr0,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr3,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr0,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr3,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr14, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr14, a2,   0,   1
++    fld.d            f24,  sp,   0
++    addi.d           sp,   sp,   8
++endfunc
++
++.macro FILTER_VERT_PS_8xN  h
++function x265_interp_8tap_vert_ps_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    addi.d       sp,    sp,    -32
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    addi.d       t0,    zero,  \h/4
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr27,  t4,    0
++
++    add.d        a0,    t6,    t3
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++    fldx.d       f11,   t6,    t2   //3
++
++    fld.d        f12,   a0,    0    //4
++    fldx.d       f13,   a0,    a1   //5
++    fldx.d       f14,   a0,    t1   //6
++
++    add.d        t6,    a0,    t2
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++    vilvl.b      vr4,   vr13,  vr12 //4,5
++    vilvl.b      vr5,   vr14,  vr13 //5,6
++.loopV_ps_8x\h:
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr27,  vr27
++.endr
++    fld.d        f15,   t6,    0    //7
++    fldx.d       f24,   t6,    a1   //8
++    fldx.d       f25,   t6,    t1   //9
++    fldx.d       f26,   t6,    t2   //10
++    VMADDW4_H vr0, vr2, vr16, vr16, vr10, vr11, vr12, vr13
++    vilvl.b      vr6,   vr15,  vr14 //6,7
++    vilvl.b      vr7,   vr24,  vr15 //7,8
++    vilvl.b      vr8,   vr25,  vr24 //8,9
++    vilvl.b      vr9,   vr26,  vr25 //9,10
++
++    VMADDW4_H vr1, vr3, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr4, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr5, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr4, vr6, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr7, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr8, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr9, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr2,  vr6,  vr6
++    vor.v            vr3,  vr7,  vr7
++    vor.v            vr4,  vr8,  vr8
++    vor.v            vr5,  vr9,  vr9
++    vor.v            vr14, vr26, vr26
++    vst              vr10, a2,   0
++    add.d            a2,   a2,   a3
++    vst              vr11, a2,   0
++    add.d            a2,   a2,   a3
++    vst              vr12, a2,   0
++    add.d            a2,   a2,   a3
++    vst              vr13, a2,   0
++    add.d            t6,   t6,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_ps_8x\h
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    fld.d            f27,  sp,   24
++    addi.d           sp,   sp,   32
++endfunc
++.endm
++
++FILTER_VERT_PS_8xN 4
++FILTER_VERT_PS_8xN 8
++FILTER_VERT_PS_8xN 16
++FILTER_VERT_PS_8xN 32
++
++function x265_interp_8tap_vert_ps_12x16_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    addi.d       t0,    zero,  8
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr15,  t4,    0
++
++    add.d        a0,    t6,    t3
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.loopV_ps_12x16:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr4, vr5, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr6, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr7, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr8, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++
++    vilvl.h          vr9,  vr11, vr10  //0,1,2,3,4,5,6,7
++    vilvh.h          vr14, vr11, vr10  //8,9,10,11
++    vilvl.h          vr10, vr13, vr12
++    vilvh.h          vr11, vr13, vr12
++
++    vst              vr9,  a2,   0
++    vstelm.d         vr14, a2,   16,  0
++    add.d            a2,   a2,   a3
++    vst              vr10, a2,   0
++    vstelm.d         vr11, a2,   16,  0
++    add.d            t6,   t6,   t1
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_ps_12x16
++endfunc
++
++.macro FILTER_VERT_PS_16xN  h
++function x265_interp_8tap_vert_ps_16x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr15,  t4,    0
++
++    add.d        a0,    t6,    t3
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.loopV_ps_16x\h:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr4, vr5, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr6, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr7, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr8, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++
++    vilvl.h          vr9,  vr11, vr10
++    vilvh.h          vr14, vr11, vr10
++    vilvl.h          vr7,  vr13, vr12
++    vilvh.h          vr8,  vr13, vr12
++    vst              vr9,  a2,   0
++    vst              vr14, a2,   16
++    add.d            a2,   a2,   a3
++    vst              vr7,  a2,   0
++    vst              vr8,  a2,   16
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_16x\h
++endfunc
++.endm
++
++FILTER_VERT_PS_16xN 4
++FILTER_VERT_PS_16xN 8
++FILTER_VERT_PS_16xN 16
++FILTER_VERT_PS_16xN 12
++FILTER_VERT_PS_16xN 32
++FILTER_VERT_PS_16xN 64
++
++function x265_interp_8tap_vert_ps_24x32_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -64
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++    fst.d        f29,   sp,    40
++    fst.d        f30,   sp,    48
++    fst.d        f31,   sp,    56
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    fld.d        f30,   t6,    0
++    fldx.d       f10,   t6,    a1
++    fldx.d       f31,   t6,    t1
++    fldx.d       f12,   t6,    t2
++    addi.d       t6,    a0,    16
++
++    vilvl.b      vr9,   vr10,  vr30  //0,1
++    vilvl.b      vr10,  vr31,  vr10  //1,2
++    vilvl.b      vr11,  vr12,  vr31  //2,3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    fld.d        f30,   t6,    0
++    fldx.d       f14,   t6,    a1
++    fldx.d       f15,   t6,    t1
++
++    vilvl.b      vr12,  vr30,  vr12  //3,4
++    vilvl.b      vr13,  vr14,  vr30  //4,5
++    vilvl.b      vr14,  vr15,  vr14  //5,6
++    add.d        a0,    a0,    t2
++.loopV_ps_24x32:
++    addi.d       t6,    a0,    16
++    vld          vr7,   a0,    0   //7
++    vldx         vr8,   a0,    a1  //8
++    fld.d        f28,   t6,    0
++    fldx.d       f29,   t6,    a1
++    vld          vr24,  t4,    0
++    vilvl.b      vr30,  vr28,  vr15  //6,7
++    vilvl.b      vr31,  vr29,  vr28  //7,8
++    vor.v        vr15,  vr29,  vr29
++    vor.v        vr25,  vr24,  vr24
++    vor.v        vr26,  vr24,  vr24
++    vor.v        vr27,  vr24,  vr24
++    vor.v        vr28,  vr24,  vr24
++    vor.v        vr29,  vr24,  vr24
++
++    VMADDW4_H vr0, vr1, vr16, vr16, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr9, vr16
++    vmaddwod.h.bu.b vr29, vr9, vr16
++    VMADDW4_H vr1, vr2, vr17, vr17, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr10, vr17
++    vmaddwod.h.bu.b vr29, vr10, vr17
++    VMADDW4_H vr2, vr3, vr18, vr18, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr11, vr18
++    vmaddwod.h.bu.b vr29, vr11, vr18
++    VMADDW4_H vr3, vr4, vr19, vr19, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr12, vr19
++    vmaddwod.h.bu.b vr29, vr12, vr19
++    VMADDW4_H vr4, vr5, vr20, vr20, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr13, vr20
++    vmaddwod.h.bu.b vr29, vr13, vr20
++    VMADDW4_H vr5, vr6, vr21, vr21, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr14, vr21
++    vmaddwod.h.bu.b vr29, vr14, vr21
++    VMADDW4_H vr6, vr7, vr22, vr22, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr30, vr22
++    vmaddwod.h.bu.b vr29, vr30, vr22
++    VMADDW4_H vr7, vr8, vr23, vr23, vr24, vr25, vr26, vr27
++    vmaddwev.h.bu.b vr28, vr31, vr23
++    vmaddwod.h.bu.b vr29, vr31, vr23
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++
++    vor.v            vr9,  vr11, vr11
++    vor.v            vr10, vr12, vr12
++    vor.v            vr11, vr13, vr13
++    vor.v            vr12, vr14, vr14
++    vor.v            vr13, vr15, vr15
++    vor.v            vr13, vr30, vr30
++    vor.v            vr14, vr31, vr31
++
++    vilvl.h          vr7,  vr25, vr24
++    vilvh.h          vr8,  vr25, vr24
++    vilvl.h          vr30, vr27, vr26
++    vilvh.h          vr31, vr27, vr26
++
++    vst              vr7,  a2,   0
++    vst              vr8,  a2,   16
++    vst              vr28, a2,   32
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    vst              vr30, a2,   0
++    vst              vr31, a2,   16
++    vst              vr29, a2,   32
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_24x32
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    fld.d        f29,   sp,    40
++    fld.d        f30,   sp,    48
++    fld.d        f31,   sp,    56
++    addi.d       sp,    sp,    64
++endfunc
++
++.macro FILTER_VERT_PS_32xN  h
++function x265_interp_8tap_vert_ps_32x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -40
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr28,  t4,    0
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++    vldx         vr10,  t6,    t1
++    vldx         vr11,  t6,    t2
++    addi.d       t6,    a0,    16
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    vld          vr12,  t6,    0
++    vldx         vr13,  t6,    a1
++    vldx         vr14,  t6,    t1
++    add.d        a0,    a0,    t2
++.loopV_ps_32x\h:
++    vld          vr7,   a0,    0   //7
++    vld          vr15,  a0,    16  //7
++.irp x, vr24, vr25, vr26, vr27
++    vor.v        \x,    vr28,  vr28
++.endr
++    VMADDW4_H vr0, vr8, vr16, vr16, vr24, vr25, vr26, vr27
++    VMADDW4_H vr1, vr9, vr17, vr17, vr24, vr25, vr26, vr27
++    VMADDW4_H vr2, vr10, vr18, vr18, vr24, vr25, vr26, vr27
++    VMADDW4_H vr3, vr11, vr19, vr19, vr24, vr25, vr26, vr27
++    VMADDW4_H vr4, vr12, vr20, vr20, vr24, vr25, vr26, vr27
++    VMADDW4_H vr5, vr13, vr21, vr21, vr24, vr25, vr26, vr27
++    VMADDW4_H vr6, vr14, vr22, vr22, vr24, vr25, vr26, vr27
++    VMADDW4_H vr7, vr15, vr23, vr23, vr24, vr25, vr26, vr27
++
++    vor.v            vr0,  vr1,  vr1
++    vor.v            vr1,  vr2,  vr2
++    vor.v            vr2,  vr3,  vr3
++    vor.v            vr3,  vr4,  vr4
++    vor.v            vr4,  vr5,  vr5
++    vor.v            vr5,  vr6,  vr6
++    vor.v            vr6,  vr7,  vr7
++
++    vor.v            vr8,  vr9,  vr9
++    vor.v            vr9,  vr10, vr10
++    vor.v            vr10, vr11, vr11
++    vor.v            vr11, vr12, vr12
++    vor.v            vr12, vr13, vr13
++    vor.v            vr13, vr14, vr14
++    vor.v            vr14, vr15, vr15
++
++    vilvl.h          vr7,  vr25, vr24
++    vilvh.h          vr24, vr25, vr24
++    vilvl.h          vr15, vr27, vr26
++    vilvh.h          vr26, vr27, vr26
++    vst              vr7,  a2,   0
++    vst              vr24, a2,   16
++    vst              vr15, a2,   32
++    vst              vr26, a2,   48
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_32x\h
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    addi.d       sp,    sp,    40
++endfunc
++.endm
++
++FILTER_VERT_PS_32xN 8
++FILTER_VERT_PS_32xN 16
++FILTER_VERT_PS_32xN 24
++FILTER_VERT_PS_32xN 32
++FILTER_VERT_PS_32xN 64
++
++function x265_interp_8tap_vert_ps_48x64_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vld          vr15,  t4,    0
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++.loopV_ps_48x64:
++    add.d        t5,    a0,    a1
++    vor.v        vr8,   vr15,  vr15
++    vor.v        vr9,   vr15,  vr15
++    vor.v        vr10,  vr15,  vr15
++    vor.v        vr11,  vr15,  vr15
++    vor.v        vr12,  vr15,  vr15
++    vor.v        vr13,  vr15,  vr15
++    VMADDW4_H vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b  vr12,  vr2,  vr16
++    vmaddwod.h.bu.b  vr13,  vr2,  vr16
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    vor.v        vr0,   vr4,   vr4
++    vor.v        vr1,   vr5,   vr5
++    vor.v        vr2,   vr6,   vr6
++    VMADDW4_H vr4, vr5, vr17, vr17, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr17
++    vmaddwod.h.bu.b vr13, vr6,  vr17
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr18, vr18, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr18
++    vmaddwod.h.bu.b vr13, vr6,  vr18
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr19, vr19, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr19
++    vmaddwod.h.bu.b vr13, vr6,  vr19
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr20, vr20, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr20
++    vmaddwod.h.bu.b vr13, vr6,  vr20
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr21, vr21, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr21
++    vmaddwod.h.bu.b vr13, vr6,  vr21
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr22, vr22, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr22
++    vmaddwod.h.bu.b vr13, vr6,  vr22
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    VMADDW4_H vr4, vr5, vr23, vr23, vr8, vr9, vr10, vr11
++    vmaddwev.h.bu.b vr12, vr6,  vr23
++    vmaddwod.h.bu.b vr13, vr6,  vr23
++
++    vilvl.h          vr4,  vr9,  vr8
++    vilvh.h          vr5,  vr9,  vr8
++    vilvl.h          vr6,  vr11, vr10
++    vilvh.h          vr7,  vr11, vr10
++    vilvl.h          vr8,  vr13, vr12
++    vilvh.h          vr9,  vr13, vr12
++
++    vst              vr4,  a2,   0
++    vst              vr5,  a2,   16
++    vst              vr6,  a2,   32
++    vst              vr7,  a2,   48
++    vst              vr8,  a2,   64
++    vst              vr9,  a2,   80
++    addi.d           t0,   t0,   -1
++    add.d            a0,   a0,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_48x64
++endfunc
++
++.macro FILTER_VERT_PS_64xN  h
++function x265_interp_8tap_vert_ps_64x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    addi.d       sp,    sp,    -8
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vldrepl.b    vr20,  t5,    8
++    vldrepl.b    vr21,  t5,    10
++    vldrepl.b    vr22,  t5,    12
++    vldrepl.b    vr23,  t5,    14
++    vld          vr24,  t4,    0
++
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++.loopV_ps_64x\h:
++    add.d        t5,    a0,    a1
++.irp x, vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15
++    vor.v        \x,    vr24,  vr24
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMADDW4_H vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    vor.v        vr0,   vr4,   vr4
++    vor.v        vr1,   vr5,   vr5
++    vor.v        vr2,   vr6,   vr6
++    vor.v        vr3,   vr7,   vr7
++    VMADDW4_H vr4, vr5, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr18, vr18, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr19, vr19, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr20, vr20, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr20, vr20, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr21, vr21, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr21, vr21, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADDW4_H vr4, vr5, vr22, vr22, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr22, vr22, vr12, vr13, vr14, vr15
++    vld          vr4,   t5,    0
++    vld          vr5,   t5,    16
++    vld          vr6,   t5,    32
++    vld          vr7,   t5,    48
++    VMADDW4_H vr4, vr5, vr23, vr23, vr8, vr9, vr10, vr11
++    VMADDW4_H vr6, vr7, vr23, vr23, vr12, vr13, vr14, vr15
++
++    vilvl.h          vr4,  vr9,  vr8
++    vilvh.h          vr5,  vr9,  vr8
++    vilvl.h          vr6,  vr11, vr10
++    vilvh.h          vr7,  vr11, vr10
++    vilvl.h          vr8,  vr13, vr12
++    vilvh.h          vr9,  vr13, vr12
++    vilvl.h          vr10, vr15, vr14
++    vilvh.h          vr11, vr15, vr14
++    vst              vr4,  a2,   0
++    vst              vr5,  a2,   16
++    vst              vr6,  a2,   32
++    vst              vr7,  a2,   48
++    vst              vr8,  a2,   64
++    vst              vr9,  a2,   80
++    vst              vr10, a2,   96
++    vst              vr11, a2,   112
++    addi.d           t0,   t0,   -1
++    add.d            a0,   a0,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_64x\h
++    fld.d            f24,  sp,   0
++    addi.d           sp,   sp,   8
++endfunc
++.endm
++
++FILTER_VERT_PS_64xN 16
++FILTER_VERT_PS_64xN 32
++FILTER_VERT_PS_64xN 48
++FILTER_VERT_PS_64xN 64
++
++.macro FILTER_VERT_PS_16xN_LASX  h
++function x265_interp_8tap_vert_ps_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++    xvld         xr15,  t4,    0
++
++    slli.d       t7,    a3,    1
++    add.d        a0,    t6,    t3
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++    xvpermi.q    xr0,   xr1,   2
++    xvpermi.q    xr1,   xr2,   2
++    xvpermi.q    xr2,   xr3,   2
++    xvpermi.q    xr3,   xr4,   2
++    xvpermi.q    xr4,   xr5,   2
++    xvpermi.q    xr5,   xr6,   2
++.lasx_loopV_ps_16x\h:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++    xvpermi.q    xr6,   xr7,   2
++    xvpermi.q    xr7,   xr8,   2
++    xvor.v       xr10,  xr15,  xr15
++    xvor.v       xr11,  xr15,  xr15
++    XMADDW4_H xr0, xr1, xr16, xr17, xr10, xr11, xr10, xr11
++    XMADDW4_H xr2, xr3, xr18, xr19, xr10, xr11, xr10, xr11
++    XMADDW4_H xr4, xr5, xr20, xr21, xr10, xr11, xr10, xr11
++    XMADDW4_H xr6, xr7, xr22, xr23, xr10, xr11, xr10, xr11
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++
++    xvilvl.h         xr12, xr11, xr10
++    xvilvh.h         xr13, xr11, xr10
++    xvor.v           xr9,  xr12, xr12
++    xvpermi.q        xr12, xr13, 0x2
++    xvpermi.q        xr9,  xr13, 0x13
++
++    xvst             xr12, a2,   0
++    xvstx            xr9,  a2,   a3
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   t1
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .lasx_loopV_ps_16x\h
++endfunc
++.endm
++
++FILTER_VERT_PS_16xN_LASX  4
++FILTER_VERT_PS_16xN_LASX  8
++FILTER_VERT_PS_16xN_LASX  12
++FILTER_VERT_PS_16xN_LASX  16
++FILTER_VERT_PS_16xN_LASX  32
++FILTER_VERT_PS_16xN_LASX  64
++
++function x265_interp_8tap_vert_ps_24x32_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++    xvld         xr15,  t4,    0
++
++    add.d        a0,    t6,    t3
++    xvld         xr0,   t6,    0    //0
++    xvldx        xr1,   t6,    a1   //1
++    xvldx        xr2,   t6,    t1   //2
++    xvldx        xr3,   t6,    t2   //3
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.lasx_loopV_ps_24x32:
++    xvld         xr7,   t6,    0   //7
++    xvldx        xr8,   t6,    a1  //8
++.irp x, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr15,  xr15
++.endr
++    XMADDW4_H xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADDW4_H xr4, xr5, xr20, xr20, xr10, xr11, xr12, xr13
++    XMADDW4_H xr5, xr6, xr21, xr21, xr10, xr11, xr12, xr13
++    XMADDW4_H xr6, xr7, xr22, xr22, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7, xr8, xr23, xr23, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++
++    xvpermi.d        xr10, xr10, 0xD8
++    xvpermi.d        xr11, xr11, 0xD8
++    xvpermi.d        xr12, xr12, 0xD8
++    xvpermi.d        xr13, xr13, 0xD8
++    xvilvl.h         xr9,  xr11, xr10
++    xvilvh.h         xr14, xr11, xr10
++    xvilvl.h         xr7,  xr13, xr12
++    xvilvh.h         xr8,  xr13, xr12
++
++    xvst             xr9,  a2,   0
++    vst              vr14, a2,   32
++    add.d            a2,   a2,   a3
++    xvst             xr7,  a2,   0
++    vst              vr8,  a2,   32
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   t1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_24x32
++endfunc
++
++function x265_interp_8tap_vert_ps_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  32
++    addi.d       sp,    sp,    -64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++    fst.d        f29,   sp,    40
++    fst.d        f30,   sp,    48
++    fst.d        f31,   sp,    56
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++    xvldx        xr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    vld          vr9,   t6,    0
++    vldx         vr10,  t6,    a1
++    vldx         vr11,  t6,    t1
++    vldx         vr12,  t6,    t2
++    addi.d       t6,    a0,    32
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++
++    vld          vr13,  t6,    0
++    vldx         vr14,  t6,    a1
++    vldx         vr15,  t6,    t1
++    add.d        a0,    a0,    t2
++    xvpermi.q    xr9,   xr10,  0x2
++    xvpermi.q    xr10,  xr11,  0x2
++    xvpermi.q    xr11,  xr12,  0x2
++    xvpermi.q    xr12,  xr13,  0x2
++    xvpermi.q    xr13,  xr14,  0x2
++    xvpermi.q    xr14,  xr15,  0x2
++.lasx_loopV_ps_48x64:
++    addi.d       t6,    a0,    32
++    xvld         xr26,  t4,    0
++    xvld         xr7,   a0,    0   //7
++    xvldx        xr8,   a0,    a1  //8
++    vld          vr24,  t6,    0
++    vldx         vr25,  t6,    a1
++.irp x, xr27, xr28, xr29, xr30, xr31
++    xvor.v       \x,    xr26,  xr26
++.endr
++    xvpermi.q    xr15,  xr24,  0x2
++    xvpermi.q    xr24,  xr25,  0x2
++    XMADDW4_H xr0,  xr1,  xr16, xr16, xr26, xr27, xr28, xr29
++    XMADDW4_H xr9,  xr1,  xr16, xr17, xr30, xr31, xr26, xr27
++    XMADDW4_H xr2,  xr10, xr17, xr17, xr28, xr29, xr30, xr31
++    XMADDW4_H xr2,  xr3,  xr18, xr18, xr26, xr27, xr28, xr29
++    XMADDW4_H xr11, xr3,  xr18, xr19, xr30, xr31, xr26, xr27
++    XMADDW4_H xr4,  xr12, xr19, xr19, xr28, xr29, xr30, xr31
++    XMADDW4_H xr4,  xr5,  xr20, xr20, xr26, xr27, xr28, xr29
++    XMADDW4_H xr13, xr5,  xr20, xr21, xr30, xr31, xr26, xr27
++    XMADDW4_H xr6,  xr14, xr21, xr21, xr28, xr29, xr30, xr31
++    XMADDW4_H xr6,  xr7,  xr22, xr22, xr26, xr27, xr28, xr29
++    XMADDW4_H xr15, xr7,  xr22, xr23, xr30, xr31, xr26, xr27
++    XMADDW4_H xr8,  xr24, xr23, xr23, xr28, xr29, xr30, xr31
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++    xvor.v           xr9,  xr11, xr11
++    xvor.v           xr10, xr12, xr12
++    xvor.v           xr11, xr13, xr13
++    xvor.v           xr12, xr14, xr14
++    xvor.v           xr13, xr15, xr15
++    xvor.v           xr14, xr24, xr24
++    xvor.v           xr15, xr25, xr25
++
++    xvpermi.d        xr26, xr26, 0xD8
++    xvpermi.d        xr27, xr27, 0xD8
++    xvpermi.d        xr28, xr28, 0xD8
++    xvpermi.d        xr29, xr29, 0xD8
++    xvilvl.h         xr7,  xr27, xr26
++    xvilvh.h         xr8,  xr27, xr26
++    xvilvl.h         xr24, xr29, xr28
++    xvilvh.h         xr25, xr29, xr28
++    xvilvl.h         xr26, xr31, xr30
++    xvilvh.h         xr27, xr31, xr30
++    xvor.v           xr28, xr26, xr26
++    xvpermi.q        xr26, xr27, 0x2
++    xvpermi.q        xr28, xr27, 0x13
++
++    xvst             xr7,  a2,   0
++    xvst             xr8,  a2,   32
++    xvst             xr26, a2,   64
++    add.d            a2,   a2,   a3
++    xvst             xr24, a2,   0
++    xvst             xr25, a2,   32
++    xvst             xr28, a2,   64
++    addi.d           t0,   t0,   -1
++    add.d            a0,   a0,   t1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_48x64
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    fld.d        f29,   sp,    40
++    fld.d        f30,   sp,    48
++    fld.d        f31,   sp,    56
++    addi.d       sp,    sp,    64
++endfunc
++
++.macro FILTER_VERT_PS_32xN_LASX  h
++function x265_interp_8tap_vert_ps_32x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++    xvld         xr15,  t4,    0
++
++    add.d        a0,    t6,    t3
++    xvld         xr0,   t6,    0    //0
++    xvldx        xr1,   t6,    a1   //1
++    xvldx        xr2,   t6,    t1   //2
++    xvldx        xr3,   t6,    t2   //3
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.lasx_loopV_ps_32x\h:
++    xvld         xr7,   t6,    0   //7
++    xvldx        xr8,   t6,    a1  //8
++.irp x, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr15,  xr15
++.endr
++    XMADDW4_H xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADDW4_H xr4, xr5, xr20, xr20, xr10, xr11, xr12, xr13
++    XMADDW4_H xr5, xr6, xr21, xr21, xr10, xr11, xr12, xr13
++    XMADDW4_H xr6, xr7, xr22, xr22, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7, xr8, xr23, xr23, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr3,  xr5,  xr5
++    xvor.v           xr4,  xr6,  xr6
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++
++    xvpermi.d        xr10, xr10, 0xD8
++    xvpermi.d        xr11, xr11, 0xD8
++    xvpermi.d        xr12, xr12, 0xD8
++    xvpermi.d        xr13, xr13, 0xD8
++    xvilvl.h         xr9,  xr11, xr10
++    xvilvh.h         xr14, xr11, xr10
++    xvilvl.h         xr7,  xr13, xr12
++    xvilvh.h         xr8,  xr13, xr12
++
++    xvst             xr9,  a2,   0
++    xvst             xr14, a2,   32
++    add.d            a2,   a2,   a3
++    xvst             xr7,  a2,   0
++    xvst             xr8,  a2,   32
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   t1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_32x\h
++endfunc
++.endm
++
++FILTER_VERT_PS_32xN_LASX 8
++FILTER_VERT_PS_32xN_LASX 16
++FILTER_VERT_PS_32xN_LASX 24
++FILTER_VERT_PS_32xN_LASX 32
++FILTER_VERT_PS_32xN_LASX 64
++
++.macro FILTER_VERT_PS_64xN_LASX  h
++function x265_interp_8tap_vert_ps_64x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -40
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvldrepl.b   xr20,  t5,    8
++    xvldrepl.b   xr21,  t5,    10
++    xvldrepl.b   xr22,  t5,    12
++    xvldrepl.b   xr23,  t5,    14
++    xvld         xr28,  t4,    0
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++    xvldx        xr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    xvld         xr8,   t6,    0
++    xvldx        xr9,   t6,    a1
++    xvldx        xr10,  t6,    t1
++    xvldx        xr11,  t6,    t2
++    addi.d       t6,    a0,    32
++
++    xvld         xr4,   a0,    0    //4
++    xvldx        xr5,   a0,    a1   //5
++    xvldx        xr6,   a0,    t1   //6
++
++    xvld         xr12,  t6,    0
++    xvldx        xr13,  t6,    a1
++    xvldx        xr14,  t6,    t1
++    add.d        a0,    a0,    t2
++.lasx_loopV_ps_64x\h:
++    xvld         xr7,   a0,    0   //7
++    xvld         xr15,  a0,    32  //7
++.irp x, xr24, xr25, xr26, xr27
++    xvor.v       \x,    xr28,  xr28
++.endr
++    XMADDW4_H xr0, xr8, xr16, xr16, xr24, xr25, xr26, xr27
++    XMADDW4_H xr1, xr9, xr17, xr17, xr24, xr25, xr26, xr27
++    XMADDW4_H xr2, xr10, xr18, xr18, xr24, xr25, xr26, xr27
++    XMADDW4_H xr3, xr11, xr19, xr19, xr24, xr25, xr26, xr27
++    XMADDW4_H xr4, xr12, xr20, xr20, xr24, xr25, xr26, xr27
++    XMADDW4_H xr5, xr13, xr21, xr21, xr24, xr25, xr26, xr27
++    XMADDW4_H xr6, xr14, xr22, xr22, xr24, xr25, xr26, xr27
++    XMADDW4_H xr7, xr15, xr23, xr23, xr24, xr25, xr26, xr27
++
++    xvor.v           xr0,  xr1,  xr1
++    xvor.v           xr1,  xr2,  xr2
++    xvor.v           xr2,  xr3,  xr3
++    xvor.v           xr3,  xr4,  xr4
++    xvor.v           xr4,  xr5,  xr5
++    xvor.v           xr5,  xr6,  xr6
++    xvor.v           xr6,  xr7,  xr7
++
++    xvpermi.d        xr24, xr24, 0xD8
++    xvpermi.d        xr25, xr25, 0xD8
++    xvpermi.d        xr26, xr26, 0xD8
++    xvpermi.d        xr27, xr27, 0xD8
++    xvor.v           xr8,  xr9,  xr9
++    xvor.v           xr9,  xr10, xr10
++    xvor.v           xr10, xr11, xr11
++    xvor.v           xr11, xr12, xr12
++    xvor.v           xr12, xr13, xr13
++    xvor.v           xr13, xr14, xr14
++    xvor.v           xr14, xr15, xr15
++    xvilvl.h         xr7,  xr25, xr24
++    xvilvh.h         xr24, xr25, xr24
++    xvilvl.h         xr15, xr27, xr26
++    xvilvh.h         xr26, xr27, xr26
++    xvst             xr7,  a2,   0
++    xvst             xr24, a2,   32
++    xvst             xr15, a2,   64
++    xvst             xr26, a2,   96
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_64x\h
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    addi.d       sp,    sp,    40
++endfunc
++.endm
++
++FILTER_VERT_PS_64xN_LASX 16
++FILTER_VERT_PS_64xN_LASX 32
++FILTER_VERT_PS_64xN_LASX 48
++FILTER_VERT_PS_64xN_LASX 64
++
++.macro FILTER_TO_SHORT_2xN  h
++function x265_filterPixelToShort_2x\h\()_lsx
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    addi.d       t0,    zero,  \h/4
++    vld          vr10,  t4,    0
++.loop_short_2x\h:
++    fld.s        f0,    a0,     0
++    fldx.s       f1,    a0,     a1
++    fldx.s       f2,    a0,     t1
++    fldx.s       f3,    a0,     t2
++    vilvl.h      vr4,   vr1,    vr0
++    vilvl.h      vr5,   vr3,    vr2
++    vilvl.w      vr6,   vr5,    vr4
++    add.d        a0,    a0,     t3
++    vsllwil.hu.bu vr7,  vr6,  6
++    vadd.h       vr8,   vr7,    vr10
++    addi.d       t0,    t0,     -1
++    vstelm.w     vr8,   a2,     0,   0
++    add.d        a2,    a2,     a3
++    vstelm.w     vr8,   a2,     0,   1
++    add.d        a2,    a2,     a3
++    vstelm.w     vr8,   a2,     0,   2
++    add.d        a2,    a2,     a3
++    vstelm.w     vr8,   a2,     0,   3
++    add.d        a2,    a2,     a3
++    blt          zero,  t0,     .loop_short_2x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_2xN 4
++FILTER_TO_SHORT_2xN 8
++FILTER_TO_SHORT_2xN 16
++
++.macro FILTER_TO_SHORT_4xN  h
++function x265_filterPixelToShort_4x\h\()_lsx
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t4,    h_psOffset
++    addi.d       t0,    zero,  \h/2
++    vld          vr10,  t4,    0
++.loop_short_4x\h:
++    fld.s        f0,    a0,     0
++    fldx.s       f1,    a0,     a1
++    vilvl.w      vr4,   vr1,    vr0
++    add.d        a0,    a0,     t1
++    vsllwil.hu.bu vr5,  vr4,  6
++    vadd.h       vr6,   vr5,    vr10
++    addi.d       t0,    t0,     -1
++    vstelm.d     vr6,   a2,     0,   0
++    add.d        a2,    a2,     a3
++    vstelm.d     vr6,   a2,     0,   1
++    add.d        a2,    a2,     a3
++    blt          zero,  t0,     .loop_short_4x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_4xN 2
++FILTER_TO_SHORT_4xN 4
++FILTER_TO_SHORT_4xN 8
++FILTER_TO_SHORT_4xN 16
++FILTER_TO_SHORT_4xN 32
++
++.macro FILTER_TO_SHORT_6xN  h
++function x265_filterPixelToShort_6x\h\()_lsx
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t4,    h_psOffset
++    addi.d       t0,    zero,  \h/2
++    vld          vr10,  t4,    0
++.loop_short_6x\h:
++    fld.d        f0,    a0,     0
++    fldx.d       f1,    a0,     a1
++    addi.d       t0,    t0,     -1
++    vsllwil.hu.bu vr2,  vr0,  6
++    vsllwil.hu.bu vr3,  vr1,  6
++    vadd.h       vr4,   vr2,    vr10
++    vadd.h       vr5,   vr3,    vr10
++    vstelm.d     vr4,   a2,     0,    0
++    vstelm.w     vr4,   a2,     8,    2
++    add.d        a2,    a2,     a3
++    add.d        a0,    a0,     t1
++    vstelm.d     vr5,   a2,     0,    0
++    vstelm.w     vr5,   a2,     8,    2
++    add.d        a2,    a2,     a3
++    blt          zero,  t0,     .loop_short_6x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_6xN 8
++FILTER_TO_SHORT_6xN 16
++
++.macro FILTER_TO_SHORT_8xN  h
++function x265_filterPixelToShort_8x\h\()_lsx
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t2,    a3,    1
++    slli.d       t3,    a3,    2
++    la.local     t4,    h_psOffset
++    addi.d       t0,    zero,  \h/2
++    vld          vr10,  t4,    0
++.loop_short_8x\h:
++    fld.d        f0,    a0,     0
++    fldx.d       f1,    a0,     a1
++    addi.d       t0,    t0,     -1
++    vsllwil.hu.bu vr2,  vr0,  6
++    vsllwil.hu.bu vr3,  vr1,  6
++    vadd.h       vr4,   vr2,    vr10
++    vadd.h       vr5,   vr3,    vr10
++    vst          vr4,   a2,     0
++    vstx         vr5,   a2,     t2
++    add.d        a0,    a0,     t1
++    add.d        a2,    a2,     t3
++    blt          zero,  t0,     .loop_short_8x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_8xN 2
++FILTER_TO_SHORT_8xN 4
++FILTER_TO_SHORT_8xN 6
++FILTER_TO_SHORT_8xN 8
++FILTER_TO_SHORT_8xN 12
++FILTER_TO_SHORT_8xN 16
++FILTER_TO_SHORT_8xN 32
++FILTER_TO_SHORT_8xN 64
++
++.macro FILTER_TO_SHORT_12xN  h
++function x265_filterPixelToShort_12x\h\()_lsx
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t2,    a3,    1
++    la.local     t4,    h_psOffset
++    addi.d       t0,    zero,  \h/2
++    vld          vr10,  t4,    0
++.loop_short_12x\h:
++    vld          vr0,   a0,     0
++    vldx         vr1,   a0,     a1
++    addi.d       t0,    t0,     -1
++    vilvh.w      vr2,   vr1,    vr0
++    vsllwil.hu.bu vr3,  vr0,  6
++    vsllwil.hu.bu vr4,  vr1,  6
++    vsllwil.hu.bu vr5,  vr2,  6
++    vadd.h       vr6,   vr3,    vr10
++    vadd.h       vr7,   vr4,    vr10
++    vadd.h       vr8,   vr5,    vr10
++
++    vst          vr6,   a2,     0
++    vstelm.d     vr8,   a2,     16,   0
++    add.d        a0,    a0,     t1
++    add.d        a2,    a2,     t2
++    vst          vr7,   a2,     0
++    vstelm.d     vr8,   a2,     16,   1
++    add.d        a2,    a2,     t2
++    blt          zero,  t0,     .loop_short_12x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_12xN 16
++FILTER_TO_SHORT_12xN 32
++
++.macro FILTER_TO_SHORT_WxN  w, h, rep
++function x265_filterPixelToShort_\w\()x\h\()_lsx
++    slli.d       t1,    a1,    1   //src_stride*2
++    slli.d       t3,    a1,    2   //src_stride*4
++    slli.d       a3,    a3,    1   //dst_stride
++    la.local     t7,    h_psOffset
++    add.d        t2,    a1,    t1  //src_stride*3
++    addi.d       t0,    zero,  \h/4
++    slli.d       a4,    a3,    2   //dst_stride*4
++    vld          vr9,   t7,    0
++.loop_short_\w\()x\h:
++    move         t7,    a0
++    move         t8,    a2
++.rept \rep
++    vld          vr0,   t7,    0
++    vldx         vr1,   t7,    a1
++    vldx         vr2,   t7,    t1
++    vldx         vr3,   t7,    t2
++
++    vexth.hu.bu  vr4,   vr0
++    vexth.hu.bu  vr5,   vr1
++    vexth.hu.bu  vr6,   vr2
++    vexth.hu.bu  vr7,   vr3
++
++    vsllwil.hu.bu vr10, vr0,  6
++    vsllwil.hu.bu vr11, vr1,  6
++    vsllwil.hu.bu vr12, vr2,  6
++    vsllwil.hu.bu vr13, vr3,  6
++
++    vslli.h      vr14,  vr4,  6
++    vslli.h      vr15,  vr5,  6
++    vslli.h      vr16,  vr6,  6
++    vslli.h      vr17,  vr7,  6
++
++    vadd.h       vr0,   vr10, vr9
++    vadd.h       vr1,   vr11, vr9
++    vadd.h       vr2,   vr12, vr9
++    vadd.h       vr3,   vr13, vr9
++
++    vadd.h       vr4,   vr14, vr9
++    vadd.h       vr5,   vr15, vr9
++    vadd.h       vr6,   vr16, vr9
++    vadd.h       vr7,   vr17, vr9
++
++    add.d        t4,    t8,   a3
++    vst          vr0,   t8,   0
++    vst          vr4,   t8,   16
++    add.d        t5,    t4,   a3
++    vst          vr1,   t4,   0
++    vst          vr5,   t4,   16
++    add.d        t6,    t5,   a3
++    vst          vr2,   t5,   0
++    vst          vr6,   t5,   16
++    vst          vr3,   t6,   0
++    vst          vr7,   t6,   16
++    addi.d       t7,    t7,   16
++    addi.d       t8,    t8,   32
++.endr
++    addi.d       t0,    t0,   -1
++    add.d        a0,    a0,   t3
++    add.d        a2,    a2,   a4
++    blt          zero,  t0,   .loop_short_\w\()x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_WxN 16, 4,  1
++FILTER_TO_SHORT_WxN 16, 8,  1
++FILTER_TO_SHORT_WxN 16, 12, 1
++FILTER_TO_SHORT_WxN 16, 16, 1
++FILTER_TO_SHORT_WxN 16, 24, 1
++FILTER_TO_SHORT_WxN 16, 32, 1
++FILTER_TO_SHORT_WxN 16, 64, 1
++
++FILTER_TO_SHORT_WxN 32, 8,  2
++FILTER_TO_SHORT_WxN 32, 16, 2
++FILTER_TO_SHORT_WxN 32, 24, 2
++FILTER_TO_SHORT_WxN 32, 32, 2
++FILTER_TO_SHORT_WxN 32, 48, 2
++FILTER_TO_SHORT_WxN 32, 64, 2
++
++FILTER_TO_SHORT_WxN 48, 64, 3
++
++FILTER_TO_SHORT_WxN 64, 16, 4
++FILTER_TO_SHORT_WxN 64, 32, 4
++FILTER_TO_SHORT_WxN 64, 48, 4
++FILTER_TO_SHORT_WxN 64, 64, 4
++
++.macro FILTER_TO_SHORT_WxN_LASX  w, h, rep
++function x265_filterPixelToShort_\w\()x\h\()_lasx
++    slli.d       t1,    a1,    1   //src_stride*2
++    slli.d       t3,    a1,    2   //src_stride*4
++    slli.d       a3,    a3,    1   //dst_stride
++    la.local     t7,    h_psOffset
++    add.d        t2,    a1,    t1  //src_stride*3
++    addi.d       t0,    zero,  \h/4
++    slli.d       t4,    a3,    1   //dst_stride*2
++    slli.d       t6,    a3,    2   //dst_stride*4
++    add.d        t5,    t4,    a3  //dst_stride*3
++    xvld         xr9,   t7,    0
++.loop_short_lasx_\w\()x\h:
++    move         t7,    a0
++    move         t8,    a2
++.rept \rep
++    vld          vr0,   t7,    0
++    vldx         vr1,   t7,    a1
++    vldx         vr2,   t7,    t1
++    vldx         vr3,   t7,    t2
++
++    vext2xv.hu.bu xr4,  xr0
++    vext2xv.hu.bu xr5,  xr1
++    vext2xv.hu.bu xr6,  xr2
++    vext2xv.hu.bu xr7,  xr3
++
++    xvslli.h     xr10,  xr4,  6
++    xvslli.h     xr11,  xr5,  6
++    xvslli.h     xr12,  xr6,  6
++    xvslli.h     xr13,  xr7,  6
++
++    xvadd.h      xr0,   xr10, xr9
++    xvadd.h      xr1,   xr11, xr9
++    xvadd.h      xr2,   xr12, xr9
++    xvadd.h      xr3,   xr13, xr9
++
++    xvst         xr0,   t8,   0
++    xvstx        xr1,   t8,   a3
++    xvstx        xr2,   t8,   t4
++    xvstx        xr3,   t8,   t5
++    addi.d       t7,    t7,   16
++    addi.d       t8,    t8,   32
++.endr
++    addi.d       t0,    t0,   -1
++    add.d        a0,    a0,   t3
++    add.d        a2,    a2,   t6
++    blt          zero,  t0,   .loop_short_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_WxN_LASX 16, 4,  1
++FILTER_TO_SHORT_WxN_LASX 16, 8,  1
++FILTER_TO_SHORT_WxN_LASX 16, 12, 1
++FILTER_TO_SHORT_WxN_LASX 16, 16, 1
++FILTER_TO_SHORT_WxN_LASX 16, 24, 1
++FILTER_TO_SHORT_WxN_LASX 16, 32, 1
++FILTER_TO_SHORT_WxN_LASX 16, 64, 1
++
++FILTER_TO_SHORT_WxN_LASX 32, 8,  2
++FILTER_TO_SHORT_WxN_LASX 32, 16, 2
++FILTER_TO_SHORT_WxN_LASX 32, 24, 2
++FILTER_TO_SHORT_WxN_LASX 32, 32, 2
++FILTER_TO_SHORT_WxN_LASX 32, 48, 2
++FILTER_TO_SHORT_WxN_LASX 32, 64, 2
++
++FILTER_TO_SHORT_WxN_LASX 48, 64, 3
++
++FILTER_TO_SHORT_WxN_LASX 64, 16, 4
++FILTER_TO_SHORT_WxN_LASX 64, 32, 4
++FILTER_TO_SHORT_WxN_LASX 64, 48, 4
++FILTER_TO_SHORT_WxN_LASX 64, 64, 4
++
++.macro FILTER_TO_SHORT_24xN  h
++function x265_filterPixelToShort_24x\h\()_lsx
++    slli.d       t1,    a1,    1   //src_stride*2
++    slli.d       t3,    a1,    2   //src_stride*4
++    slli.d       a3,    a3,    1   //dst_stride
++    la.local     t7,    h_psOffset
++    add.d        t2,    a1,    t1  //src_stride*3
++    addi.d       t0,    zero,  \h/4
++    slli.d       a4,    a3,    2   //dst_stride*4
++    vld          vr9,   t7,    0
++.loop_short_24x\h:
++    addi.d       t7,    a0,    16
++    vld          vr0,   a0,    0
++    vldx         vr1,   a0,    a1
++    vldx         vr2,   a0,    t1
++    vldx         vr3,   a0,    t2
++    fld.d        f18,   t7,    0
++    fldx.d       f19,   t7,    a1
++    fldx.d       f20,   t7,    t1
++    fldx.d       f21,   t7,    t2
++
++    vexth.hu.bu  vr4,   vr0
++    vexth.hu.bu  vr5,   vr1
++    vexth.hu.bu  vr6,   vr2
++    vexth.hu.bu  vr7,   vr3
++
++    vsllwil.hu.bu vr10, vr0,  6
++    vsllwil.hu.bu vr11, vr1,  6
++    vsllwil.hu.bu vr12, vr2,  6
++    vsllwil.hu.bu vr13, vr3,  6
++
++    vslli.h      vr14,  vr4,  6
++    vslli.h      vr15,  vr5,  6
++    vslli.h      vr16,  vr6,  6
++    vslli.h      vr17,  vr7,  6
++
++    vsllwil.hu.bu vr18, vr18, 6
++    vsllwil.hu.bu vr19, vr19, 6
++    vsllwil.hu.bu vr20, vr20, 6
++    vsllwil.hu.bu vr21, vr21, 6
++
++    vadd.h       vr0,   vr10, vr9
++    vadd.h       vr1,   vr11, vr9
++    vadd.h       vr2,   vr12, vr9
++    vadd.h       vr3,   vr13, vr9
++
++    vadd.h       vr4,   vr14, vr9
++    vadd.h       vr5,   vr15, vr9
++    vadd.h       vr6,   vr16, vr9
++    vadd.h       vr7,   vr17, vr9
++
++    vadd.h       vr18,  vr18, vr9
++    vadd.h       vr19,  vr19, vr9
++    vadd.h       vr20,  vr20, vr9
++    vadd.h       vr21,  vr21, vr9
++
++    add.d        t4,    a2,   a3
++    vst          vr0,   a2,   0
++    vst          vr4,   a2,   16
++    vst          vr18,  a2,   32
++    add.d        t5,    t4,   a3
++    vst          vr1,   t4,   0
++    vst          vr5,   t4,   16
++    vst          vr19,  t4,   32
++    add.d        t6,    t5,   a3
++    vst          vr2,   t5,   0
++    vst          vr6,   t5,   16
++    vst          vr20,  t5,   32
++    vst          vr3,   t6,   0
++    vst          vr7,   t6,   16
++    vst          vr21,  t6,   32
++    addi.d       t0,    t0,   -1
++    add.d        a0,    a0,   t3
++    add.d        a2,    a2,   a4
++    blt          zero,  t0,   .loop_short_24x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_24xN  32
++FILTER_TO_SHORT_24xN  64
++
++.macro FILTER_TO_SHORT_24xN_LASX  h
++function x265_filterPixelToShort_24x\h\()_lasx
++    slli.d       t1,    a1,    1   //src_stride*2
++    slli.d       t3,    a1,    2   //src_stride*4
++    slli.d       a3,    a3,    1   //dst_stride
++    la.local     t7,    h_psOffset
++    add.d        t2,    a1,    t1  //src_stride*3
++    addi.d       t0,    zero,  \h/4
++    slli.d       a4,    a3,    2   //dst_stride*4
++    xvld         xr9,   t7,    0
++.loop_short_lasx_24x\h:
++    xvld         xr0,   a0,    0
++    xvldx        xr1,   a0,    a1
++    xvldx        xr2,   a0,    t1
++    xvldx        xr3,   a0,    t2
++
++    xvpermi.d    xr0,   xr0,   0xD8
++    xvpermi.d    xr1,   xr1,   0xD8
++    xvpermi.d    xr2,   xr2,   0xD8
++    xvpermi.d    xr3,   xr3,   0xD8
++    xvilvh.d     xr4,   xr1,   xr0
++    xvilvh.d     xr5,   xr3,   xr2
++
++    xvsllwil.hu.bu xr10, xr0,  6
++    xvsllwil.hu.bu xr11, xr1,  6
++    vext2xv.hu.bu  xr14, xr4
++    vext2xv.hu.bu  xr15, xr5
++    xvsllwil.hu.bu xr12, xr2,  6
++    xvsllwil.hu.bu xr13, xr3,  6
++
++    xvslli.h       xr16, xr14, 6
++    xvslli.h       xr17, xr15, 6
++
++    xvadd.h        xr0,  xr10, xr9
++    xvadd.h        xr1,  xr11, xr9
++    xvadd.h        xr2,  xr12, xr9
++    xvadd.h        xr3,  xr13, xr9
++    xvadd.h        xr4,  xr16, xr9
++    xvadd.h        xr5,  xr17, xr9
++
++    add.d          t4,   a2,   a3
++    xvst           xr0,  a2,   0
++    vst            vr4,  a2,   32
++    xvpermi.d      xr6,  xr4,  0x4E
++    xvpermi.d      xr7,  xr5,  0x4E
++    add.d          t5,   t4,   a3
++    xvst           xr1,  t4,   0
++    vst            vr6,  t4,   32
++    add.d          t6,   t5,   a3
++    xvst           xr2,  t5,   0
++    vst            vr5,  t5,   32
++    xvst           xr3,  t6,   0
++    vst            vr7,  t6,   32
++    addi.d         t0,    t0,   -1
++    add.d          a0,    a0,   t3
++    add.d          a2,    a2,   a4
++    blt            zero,  t0,   .loop_short_lasx_24x\h
++endfunc
++.endm
++
++FILTER_TO_SHORT_24xN_LASX  32
++FILTER_TO_SHORT_24xN_LASX  64
++
++.macro VMULW4_W  in0, in1, mul0, mul1, out0, out1, out2, out3
++    vmulwev.w.h   \out0,  \in0,  \mul0
++    vmulwod.w.h   \out1,  \in0,  \mul0
++    vmulwev.w.h   \out2,  \in1,  \mul1
++    vmulwod.w.h   \out3,  \in1,  \mul1
++.endm
++
++.macro VMADD4_W  in0, in1, mul0, mul1, out0, out1, out2, out3
++    vmaddwev.w.h   \out0,  \in0,  \mul0
++    vmaddwod.w.h   \out1,  \in0,  \mul0
++    vmaddwev.w.h   \out2,  \in1,  \mul1
++    vmaddwod.w.h   \out3,  \in1,  \mul1
++.endm
++
++.macro FILTER_HV_PP_4xN  h
++function x265_interp_8tap_hv_pp_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0   //-8192
++    addi.d       t0,    zero,  \h/2
++    addi.d       sp,    sp,    -(8 * (\h + 7))
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t2,    t0,    3
++    sub.d        a0,    a0,    t1
++    addi.d       t6,    t6,    128
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H  vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    vhaddw.w.h   vr6,   vr6,   vr6
++    vhaddw.w.h   vr7,   vr7,   vr7
++    vhaddw.w.h   vr8,   vr8,   vr8
++    vhaddw.w.h   vr9,   vr9,   vr9
++    vpickev.h    vr12,  vr7,   vr6
++    vpickev.h    vr13,  vr9,   vr8
++    vhaddw.w.h   vr12,  vr12,  vr12
++    vhaddw.w.h   vr13,  vr13,  vr13
++    vpickev.h    vr14,  vr13,  vr12
++    vhaddw.w.h   vr14,  vr14,  vr14
++    vpickev.h    vr20,  vr11,  vr14
++    vadd.h       vr21,  vr20,  vr11
++    add.d        a0,    a0,    a1
++    fst.d        f21,   sp,    0
++    addi.d       t3,    sp,    8
++.loop_hv_ps_4x\h:
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H  vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f16,    a0,   -3
++    fld.d        f17,    a0,   -2
++    fld.d        f18,    a0,   -1
++    fld.d        f19,    a0,   0
++    vilvl.b      vr4,   vr17,  vr16
++    vilvl.b      vr5,   vr19,  vr18
++    add.d        a0,    a0,    a1
++    VMULW4_H  vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++
++    vadd.h       vr21,  vr20,  vr11
++    addi.d       t2,    t2,    -1
++    vstelm.d     vr21,  t3,    0,    0
++    vstelm.d     vr21,  t3,    8,    1
++    addi.d       t3,    t3,    16
++    blt          zero,  t2,    .loop_hv_ps_4x\h
++    add.d        t7,    t6,    t8
++    vld          vr11,  t5,    32  //526336
++    vldrepl.h    vr16,  t7,    0
++    vldrepl.h    vr17,  t7,    2
++    vldrepl.h    vr18,  t7,    4
++    vldrepl.h    vr19,  t7,    6
++    vldrepl.h    vr20,  t7,    8
++    vldrepl.h    vr21,  t7,    10
++    vldrepl.h    vr22,  t7,    12
++    vldrepl.h    vr23,  t7,    14
++    addi.d       t3,    sp,    64
++    vld          vr0,   sp,    0   //0, 1
++    vld          vr1,   sp,    8   //1, 2
++    vld          vr2,   sp,    16  //2, 3
++    vld          vr3,   sp,    24  //3, 4
++    vld          vr4,   sp,    32  //4, 5
++    vld          vr5,   sp,    40  //5, 6
++    vld          vr6,   sp,    48  //6, 7
++    vld          vr7,   sp,    56  //7, 8
++.loop_hv_sp_4x\h:
++    vld          vr8,   t3,    0   //8, 9
++    vld          vr9,   t3,    8   //9, 10
++    vor.v        vr12,  vr11,  vr11
++    vor.v        vr13,  vr11,  vr11
++    VMADD4_W vr0, vr1, vr16, vr17, vr12, vr13, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr19, vr12, vr13, vr12, vr13
++    VMADD4_W vr4, vr5, vr20, vr21, vr12, vr13, vr12, vr13
++    VMADD4_W vr6, vr7, vr22, vr23, vr12, vr13, vr12, vr13
++    vssrani.h.w   vr13, vr12, 12
++    vor.v         vr0,  vr2,  vr2
++    vor.v         vr1,  vr3,  vr3
++    vssrani.bu.h  vr10, vr13, 0
++    vor.v         vr2,  vr4,  vr4
++    vor.v         vr3,  vr5,  vr5
++    vbsrl.v       vr14, vr10, 4
++    vor.v         vr4,  vr6,  vr6
++    vor.v         vr5,  vr7,  vr7
++    vilvl.b       vr15, vr14, vr10
++    vor.v         vr6,  vr8,  vr8
++    vor.v         vr7,  vr9,  vr9
++    vstelm.w      vr15, a2,   0,  0
++    addi.d        t0,   t0,   -1
++    add.d         a2,   a2,   a3
++    addi.d        t3,   t3,   16
++    vstelm.w      vr15, a2,   0,  1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loop_hv_sp_4x\h
++    addi.d        sp,   sp,   8 * (\h + 7)
++endfunc
++.endm
++
++FILTER_HV_PP_4xN  4
++FILTER_HV_PP_4xN  8
++FILTER_HV_PP_4xN  16
++
++.macro FILTER_HV_PP_8xN  h
++function x265_interp_8tap_hv_pp_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h/2
++    addi.d       sp,    sp,    -(16 * (\h + 7))
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t2,    t0,    3
++    addi.d       t6,    t6,    128
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H  vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H  vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++
++    vadd.h       vr21,  vr20,  vr11
++    vst          vr21,  sp,    0
++    addi.d       t3,    sp,    16
++.loop_hv_ps_8x\h:
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H  vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H  vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr20, vr16, vr17, vr18, vr19
++
++    fld.d        f0,    a0,    -3
++    fld.d        f1,    a0,    -2
++    fld.d        f2,    a0,    -1
++    fld.d        f3,    a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H  vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H  vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                 vr21, vr16, vr17, vr18, vr19
++
++    vadd.h       vr20,  vr20,  vr11
++    vadd.h       vr21,  vr21,  vr11
++    vst          vr20,  t3,    0
++    vst          vr21,  t3,    16
++    addi.d       t2,    t2,    -1
++    addi.d       t3,    t3,    32
++    blt          zero,  t2,    .loop_hv_ps_8x\h
++    add.d        t7,    t6,    t8
++    vld          vr11,  t5,    32
++    vldrepl.h    vr16,  t7,    0
++    vldrepl.h    vr17,  t7,    2
++    vldrepl.h    vr18,  t7,    4
++    vldrepl.h    vr19,  t7,    6
++    vldrepl.h    vr20,  t7,    8
++    vldrepl.h    vr21,  t7,    10
++    vldrepl.h    vr22,  t7,    12
++    vldrepl.h    vr23,  t7,    14
++    addi.d       t3,    sp,    128
++    vld          vr0,   sp,    0
++    vld          vr1,   sp,    16
++    vld          vr2,   sp,    32
++    vld          vr3,   sp,    48
++    vld          vr4,   sp,    64
++    vld          vr5,   sp,    80
++    vld          vr6,   sp,    96
++    vld          vr7,   sp,    112
++.loop_hv_sp_8x\h:
++    vld          vr8,   t3,    0
++    vld          vr9,   t3,    16
++.irp x, vr10, vr12, vr13, vr14
++    vor.v        \x,    vr11,  vr11
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr10, vr12, vr13, vr14
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr12, vr13, vr14
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr12, vr13, vr14
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr20, vr20, vr10, vr12, vr13, vr14
++    VMADD4_W vr5, vr6, vr21, vr21, vr10, vr12, vr13, vr14
++    VMADD4_W vr6, vr7, vr22, vr22, vr10, vr12, vr13, vr14
++    VMADD4_W vr7, vr8, vr23, vr23, vr10, vr12, vr13, vr14
++    vssrani.h.w  vr13,  vr10,  12
++    vssrani.h.w  vr14,  vr12,  12
++    vor.v        vr0,   vr2,   vr2
++    vor.v        vr1,   vr3,   vr3
++    vor.v        vr2,   vr4,   vr4
++    vor.v        vr3,   vr5,   vr5
++    vssrani.bu.h vr14,  vr13,  0
++    vor.v        vr4,   vr6,   vr6
++    vor.v        vr5,   vr7,   vr7
++    vbsrl.v      vr15,  vr14,  8
++    vor.v        vr6,   vr8,   vr8
++    vor.v        vr7,   vr9,   vr9
++    vilvl.b      vr10,  vr15,  vr14
++    addi.d       t0,    t0,    -1
++    addi.d       t3,    t3,    32
++    fst.d        f10,   a2,    0
++    add.d        a2,    a2,    a3
++    vstelm.d     vr10,  a2,    0,    1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loop_hv_sp_8x\h
++    addi.d       sp,    sp,    16 * (\h + 7)
++endfunc
++.endm
++
++FILTER_HV_PP_8xN 4
++FILTER_HV_PP_8xN 8
++FILTER_HV_PP_8xN 16
++FILTER_HV_PP_8xN 32
++
++.macro PROCESS_LUMA_HV in0, in1, in2, in3, in4, in5, in6, in7, out0,   \
++                       tmp0, tmp1, tmp2, tmp3
++    vhaddw.w.h   \in0,   \in0,  \in0
++    vhaddw.w.h   \in1,   \in1,  \in1
++    vhaddw.w.h   \in2,   \in2,  \in2
++    vhaddw.w.h   \in3,   \in3,  \in3
++    vhaddw.w.h   \in4,   \in4,  \in4
++    vhaddw.w.h   \in5,   \in5,  \in5
++    vhaddw.w.h   \in6,   \in6,  \in6
++    vhaddw.w.h   \in7,   \in7,  \in7
++    vpickev.h    \tmp0,  \in1,  \in0
++    vpickev.h    \tmp1,  \in3,  \in2
++    vpickev.h    \tmp2,  \in5,  \in4
++    vpickev.h    \tmp3,  \in7,  \in6
++    vhaddw.w.h   \tmp0,  \tmp0, \tmp0
++    vhaddw.w.h   \tmp1,  \tmp1, \tmp1
++    vhaddw.w.h   \tmp2,  \tmp2, \tmp2
++    vhaddw.w.h   \tmp3,  \tmp3, \tmp3
++    vpickev.h    \in0,   \tmp1, \tmp0
++    vpickev.h    \in1,   \tmp3, \tmp2
++    vhaddw.w.h   \in0,   \in0,  \in0
++    vhaddw.w.h   \in1,   \in1,  \in1
++    vpackev.h    \out0,  \in1,  \in0
++.endm
++
++function x265_interp_8tap_hv_pp_12x16_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  16
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       sp,    sp,    -(24*23)-32
++    sub.d        a0,    a0,    t1
++    addi.d       t2,    t0,    7
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    addi.d       t3,    sp,    32
++    addi.d       t4,    sp,    (16*23)+32
++    addi.d       t6,    t6,    128
++.loop_hv_ps_12x16:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvh.b      vr21,  vr1,   vr0
++    vilvh.b      vr22,  vr3,   vr2
++    VMULW4_H  vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    1
++    fld.d        f1,    a0,    2
++    fld.d        f2,    a0,    3
++    fld.d        f3,    a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    add.d        a0,    a0,    a1
++    VMULW4_H  vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA_HV vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                    vr20, vr16, vr17, vr18, vr19
++
++    VMULW4_H vr21, vr22, vr10, vr10, vr6, vr7, vr8, vr9
++
++    vhaddw.w.h   vr6,   vr6,   vr6
++    vhaddw.w.h   vr7,   vr7,   vr7
++    vhaddw.w.h   vr8,   vr8,   vr8
++    vhaddw.w.h   vr9,   vr9,   vr9
++    vpickev.h    vr12,  vr7,   vr6
++    vpickev.h    vr13,  vr9,   vr8
++    vhaddw.w.h   vr12,  vr12,  vr12
++    vhaddw.w.h   vr13,  vr13,  vr13
++    vpickev.h    vr14,  vr13,  vr12
++    vhaddw.w.h   vr14,  vr14,  vr14
++    vpickev.h    vr21,  vr11,  vr14
++
++    vadd.h       vr20,  vr20,  vr11
++    vadd.h       vr21,  vr21,  vr11
++    vst          vr20,  t3,    0
++    fst.d        f21,   t4,    0
++    addi.d       t2,    t2,    -1
++    addi.d       t3,    t3,    16
++    addi.d       t4,    t4,    8
++    blt          zero,  t2,    .loop_hv_ps_12x16
++    add.d        t7,    t6,    t8
++    vld          vr11,  t5,    32
++    vldrepl.h    vr16,  t7,    0
++    vldrepl.h    vr17,  t7,    2
++    vldrepl.h    vr18,  t7,    4
++    vldrepl.h    vr19,  t7,    6
++    vldrepl.h    vr20,  t7,    8
++    vldrepl.h    vr21,  t7,    10
++    vldrepl.h    vr22,  t7,    12
++    vldrepl.h    vr23,  t7,    14
++    addi.d       t3,    sp,    128+32
++    addi.d       t4,    sp,    (16*23)+32
++    vld          vr0,   sp,    32   //0,0
++    vld          vr1,   sp,    16+32  //1,1
++    vld          vr2,   sp,    32+32  //2,2
++    vld          vr3,   sp,    48+32  //3,3
++    vld          vr4,   sp,    64+32  //4,4
++    vld          vr5,   sp,    80+32  //5,5
++    vld          vr6,   sp,    96+32  //6,6
++    vld          vr7,   sp,    112+32 //7,7
++.loop_hv_sp_12x16:
++    vld          vr8,   t4,    0   //0,1
++    vld          vr9,   t4,    16  //2,3
++    vld          vr10,  t4,    32  //4,5
++    vld          vr12,  t4,    48  //6,7
++    vilvl.h      vr13,  vr9,   vr8  //0, 2, 0, 2
++    vilvh.h      vr14,  vr9,   vr8  //1, 3, 1, 3
++    vilvl.h      vr24,  vr12,  vr10 //4, 6, 4, 6
++    vilvh.h      vr25,  vr12,  vr10 //5, 7, 5, 7
++    vor.v        vr15,  vr11,  vr11
++    vor.v        vr26,  vr11,  vr11
++    vor.v        vr27,  vr11,  vr11
++    vmaddwev.w.h vr15,  vr0,   vr16  //0
++    vmaddwod.w.h vr26,  vr0,   vr16
++    vmaddwev.w.h vr27,  vr13,  vr16
++    vmaddwev.w.h vr15,  vr1,   vr17  //1
++    vmaddwod.w.h vr26,  vr1,   vr17
++    vmaddwev.w.h vr27,  vr14,  vr17
++    vmaddwev.w.h vr15,  vr2,   vr18  //2
++    vmaddwod.w.h vr26,  vr2,   vr18
++    vmaddwod.w.h vr27,  vr13,  vr18
++    vmaddwev.w.h vr15,  vr3,   vr19  //3
++    vmaddwod.w.h vr26,  vr3,   vr19
++    vmaddwod.w.h vr27,  vr14,  vr19
++    vmaddwev.w.h vr15,  vr4,   vr20  //4
++    vmaddwod.w.h vr26,  vr4,   vr20
++    vmaddwev.w.h vr27,  vr24,  vr20
++    vmaddwev.w.h vr15,  vr5,   vr21  //5
++    vmaddwod.w.h vr26,  vr5,   vr21
++    vmaddwev.w.h vr27,  vr25,  vr21
++    vmaddwev.w.h vr15,  vr6,   vr22  //6
++    vmaddwod.w.h vr26,  vr6,   vr22
++    vmaddwod.w.h vr27,  vr24,  vr22
++    vmaddwev.w.h vr15,  vr7,   vr23  //7
++    vmaddwod.w.h vr26,  vr7,   vr23
++    vmaddwod.w.h vr27,  vr25,  vr23
++    vor.v        vr0,   vr1,   vr1
++    vor.v        vr1,   vr2,   vr2
++    vor.v        vr2,   vr3,   vr3
++    vor.v        vr3,   vr4,   vr4
++    vssrani.h.w  vr26,  vr15,  12
++    vssrani.h.w  vr8,   vr27,  12
++    vor.v        vr4,   vr5,   vr5
++    vor.v        vr5,   vr6,   vr6
++    vor.v        vr6,   vr7,   vr7
++    vssrani.bu.h vr8,   vr26,  0
++    vld          vr7,   t3,    0
++    addi.d       t4,    t4,    8
++    addi.d       t3,    t3,    16
++    vstelm.d     vr8,   a2,    0,    0
++    vstelm.w     vr8,   a2,    8,    2
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loop_hv_sp_12x16
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    addi.d       sp,    sp,    (24*23)+32
++endfunc
++
++function x265_interp_8tap_hv_pp_24x32_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t2,    zero,  7 + 32
++    addi.d       t0,    zero,  32
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t4,    zero,  39 * 48
++    sub.d        a0,    a0,    t1
++    sub.d        sp,    sp,    t4
++    addi.d       t6,    t6,    128
++    move         t7,    sp
++.loop_hv_ps_24x32:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    vld          vr20,  a0,    1
++    vld          vr21,  a0,    2
++    vld          vr22,  a0,    3
++    vld          vr23,  a0,    4
++    vilvl.b      vr4,   vr21,  vr20
++    vilvl.b      vr5,   vr23,  vr22
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA_HV vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                    vr19, vr16, vr17, vr18, vr4
++
++    vilvh.b      vr4,   vr1,   vr0
++    vilvh.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    vilvh.b      vr4,   vr21,  vr20
++    vilvh.b      vr5,   vr23,  vr22
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA_HV vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                    vr20, vr16, vr17, vr18, vr4
++
++    fld.d        f0,    a0,    13
++    fld.d        f1,    a0,    14
++    fld.d        f2,    a0,    15
++    fld.d        f3,    a0,    16
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    fld.d        f0,    a0,    17
++    fld.d        f1,    a0,    18
++    fld.d        f2,    a0,    19
++    fld.d        f3,    a0,    20
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    VMULW4_H vr4, vr5, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA_HV vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                    vr21, vr16, vr17, vr18, vr4
++
++    vadd.h       vr19,  vr19,  vr11
++    vadd.h       vr20,  vr20,  vr11
++    vadd.h       vr21,  vr21,  vr11
++
++    vst          vr19,  t7,    0
++    vst          vr20,  t7,    16
++    vst          vr21,  t7,    32
++    addi.d       t7,    t7,    48
++    addi.d       t2,    t2,    -1
++    add.d        a0,    a0,    a1
++    blt          zero,  t2,    .loop_hv_ps_24x32
++    add.d        t6,    t6,    t8
++    move         t7,    sp
++    vld          vr11,  t5,    32
++    vldrepl.h    vr16,  t6,    0
++    vldrepl.h    vr17,  t6,    2
++    vldrepl.h    vr18,  t6,    4
++    vldrepl.h    vr19,  t6,    6
++    vldrepl.h    vr20,  t6,    8
++    vldrepl.h    vr21,  t6,    10
++    vldrepl.h    vr22,  t6,    12
++    vldrepl.h    vr23,  t6,    14
++.loop_hv_sp_24x32:
++.irp x, vr8, vr9, vr12, vr13, vr14, vr15
++    vor.v        \x,    vr11,  vr11
++.endr
++    vld          vr0,   t7,    0
++    vld          vr1,   t7,    16
++    vld          vr2,   t7,    32
++    vld          vr3,   t7,    0  + 48
++    vld          vr4,   t7,    16 + 48
++    vld          vr5,   t7,    32 + 48
++    VMADD4_W vr0, vr1, vr16, vr16, vr8, vr9, vr12, vr13
++    VMADD4_W vr2, vr3, vr16, vr17, vr14, vr15, vr8, vr9
++    VMADD4_W vr4, vr5, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr0,   t7,    0  + 48 * 2
++    vld          vr1,   t7,    16 + 48 * 2
++    vld          vr2,   t7,    32 + 48 * 2
++    vld          vr3,   t7,    0  + 48 * 3
++    vld          vr4,   t7,    16 + 48 * 3
++    vld          vr5,   t7,    32 + 48 * 3
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr19, vr14, vr15, vr8, vr9
++    VMADD4_W vr4, vr5, vr19, vr19, vr12, vr13, vr14, vr15
++    vld          vr0,   t7,    0  + 48 * 4
++    vld          vr1,   t7,    16 + 48 * 4
++    vld          vr2,   t7,    32 + 48 * 4
++    vld          vr3,   t7,    0  + 48 * 5
++    vld          vr4,   t7,    16 + 48 * 5
++    vld          vr5,   t7,    32 + 48 * 5
++    VMADD4_W vr0, vr1, vr20, vr20, vr8, vr9, vr12, vr13
++    VMADD4_W vr2, vr3, vr20, vr21, vr14, vr15, vr8, vr9
++    VMADD4_W vr4, vr5, vr21, vr21, vr12, vr13, vr14, vr15
++    vld          vr0,   t7,    0  + 48 * 6
++    vld          vr1,   t7,    16 + 48 * 6
++    vld          vr2,   t7,    32 + 48 * 6
++    vld          vr3,   t7,    0  + 48 * 7
++    vld          vr4,   t7,    16 + 48 * 7
++    vld          vr5,   t7,    32 + 48 * 7
++    VMADD4_W vr0, vr1, vr22, vr22, vr8, vr9, vr12, vr13
++    VMADD4_W vr2, vr3, vr22, vr23, vr14, vr15, vr8, vr9
++    VMADD4_W vr4, vr5, vr23, vr23, vr12, vr13, vr14, vr15
++    vssrani.h.w  vr9,   vr8,   12
++    vssrani.h.w  vr13,  vr12,  12
++    vssrani.h.w  vr15,  vr14,  12
++    addi.d       t7,    t7,    48
++    vssrani.bu.h vr13,  vr9,   0
++    vssrani.bu.h vr14,  vr15,  0
++    vst          vr13,  a2,    0
++    vstelm.d     vr14,  a2,    16,   0
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loop_hv_sp_24x32
++    add.d        sp,    sp,    t4
++endfunc
++
++.macro FILTER_HV_PP_WxN  w, h, rep, s
++function x265_interp_8tap_hv_pp_\w\()x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    addi.d       sp,    sp,    -8
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t2,    t0,    7
++    fst.d        f24,   sp,    0
++    addi.d       t3,    zero,  \s
++    mul.d        t4,    t3,    t2
++    sub.d        a0,    a0,    t1
++    addi.d       t6,    t6,    128
++    sub.d        sp,    sp,    t4
++    move         t7,    sp
++.loop_hv_ps_\w\()x\h:
++    move         t1,    a0
++.rept \rep
++    vld          vr0,   t1,    -3
++    vld          vr1,   t1,    -2
++    vld          vr2,   t1,    -1
++    vld          vr3,   t1,    0
++    vld          vr21,  t1,    1
++    vld          vr22,  t1,    2
++    vld          vr23,  t1,    3
++    vld          vr24,  t1,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr16,  vr22,  vr21
++    vilvl.b      vr17,  vr24,  vr23
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA_HV vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                    vr20, vr16, vr17, vr18, vr19
++
++    vilvh.b      vr4,   vr1,   vr0
++    vilvh.b      vr5,   vr3,   vr2
++    vilvh.b      vr16,  vr22,  vr21
++    vilvh.b      vr17,  vr24,  vr23
++    VMULW4_H vr4, vr5, vr10, vr10, vr6, vr7, vr8, vr9
++    VMULW4_H vr16, vr17, vr10, vr10, vr12, vr13, vr14, vr15
++
++    PROCESS_LUMA_HV vr6, vr7, vr8, vr9, vr12, vr13, vr14, vr15, \
++                    vr21, vr16, vr17, vr18, vr19
++
++    vadd.h       vr20,  vr20,  vr11
++    vadd.h       vr21,  vr21,  vr11
++
++    addi.d       t1,    t1,    16
++    vst          vr20,  t7,    0
++    vst          vr21,  t7,    16
++    addi.d       t7,    t7,    32
++.endr
++    addi.d       t2,    t2,    -1
++    add.d        a0,    a0,    a1
++    blt          zero,  t2,    .loop_hv_ps_\w\()x\h
++    add.d        t6,    t6,    t8
++    move         t7,    sp
++    vld          vr11,  t5,    32
++    vldrepl.h    vr16,  t6,    0
++    vldrepl.h    vr17,  t6,    2
++    vldrepl.h    vr18,  t6,    4
++    vldrepl.h    vr19,  t6,    6
++    vldrepl.h    vr20,  t6,    8
++    vldrepl.h    vr21,  t6,    10
++    vldrepl.h    vr22,  t6,    12
++    vldrepl.h    vr23,  t6,    14
++.loop_hv_sp_\w\()x\h:
++    move         t2,    a2
++.rept \rep
++    vor.v        vr8,   vr11,  vr11
++    vor.v        vr9,   vr11,  vr11
++    vor.v        vr12,  vr11,  vr11
++    vor.v        vr13,  vr11,  vr11
++    vld          vr0,   t7,    0
++    vld          vr1,   t7,    16
++    vld          vr2,   t7,    0  + \s
++    vld          vr3,   t7,    16 + \s
++    vld          vr4,   t7,    0  + \s * 2
++    vld          vr5,   t7,    16 + \s * 2
++    vld          vr6,   t7,    0  + \s * 3
++    vld          vr7,   t7,    16 + \s * 3
++    VMADD4_W vr0, vr1, vr16, vr16, vr8, vr9, vr12, vr13
++    VMADD4_W vr2, vr3, vr17, vr17, vr8, vr9, vr12, vr13
++    VMADD4_W vr4, vr5, vr18, vr18, vr8, vr9, vr12, vr13
++    VMADD4_W vr6, vr7, vr19, vr19, vr8, vr9, vr12, vr13
++    vld          vr0,   t7,    0  + \s * 4
++    vld          vr1,   t7,    16 + \s * 4
++    vld          vr2,   t7,    0  + \s * 5
++    vld          vr3,   t7,    16 + \s * 5
++    vld          vr4,   t7,    0  + \s * 6
++    vld          vr5,   t7,    16 + \s * 6
++    vld          vr6,   t7,    0  + \s * 7
++    vld          vr7,   t7,    16 + \s * 7
++    VMADD4_W vr0, vr1, vr20, vr20, vr8, vr9, vr12, vr13
++    VMADD4_W vr2, vr3, vr21, vr21, vr8, vr9, vr12, vr13
++    VMADD4_W vr4, vr5, vr22, vr22, vr8, vr9, vr12, vr13
++    VMADD4_W vr6, vr7, vr23, vr23, vr8, vr9, vr12, vr13
++    vssrani.h.w  vr9,   vr8,   12
++    vssrani.h.w  vr13,  vr12,  12
++    addi.d       t7,    t7,    32
++    vssrani.bu.h vr13,  vr9,   0
++    vst          vr13,  t2,    0
++    addi.d       t2,    t2,    16
++.endr
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loop_hv_sp_\w\()x\h
++    add.d        sp,    sp,    t4
++    fld.d        f24,   sp,    0
++    addi.d       sp,    sp,    8
++endfunc
++.endm
++
++FILTER_HV_PP_WxN 16, 4,  1, 32
++FILTER_HV_PP_WxN 16, 8,  1, 32
++FILTER_HV_PP_WxN 16, 12, 1, 32
++FILTER_HV_PP_WxN 16, 16, 1, 32
++FILTER_HV_PP_WxN 16, 32, 1, 32
++FILTER_HV_PP_WxN 16, 64, 1, 32
++FILTER_HV_PP_WxN 32, 8,  2, 64
++FILTER_HV_PP_WxN 32, 16, 2, 64
++FILTER_HV_PP_WxN 32, 24, 2, 64
++FILTER_HV_PP_WxN 32, 32, 2, 64
++FILTER_HV_PP_WxN 32, 64, 2, 64
++FILTER_HV_PP_WxN 48, 64, 3, 96
++FILTER_HV_PP_WxN 64, 16, 4, 128
++FILTER_HV_PP_WxN 64, 32, 4, 128
++FILTER_HV_PP_WxN 64, 48, 4, 128
++FILTER_HV_PP_WxN 64, 64, 4, 128
++
++.macro PROCESS_LUMA_LASX in0, in1, in2, in3, in4, in5, in6, in7, out0, out1 \
++                         tmp0, tmp1, tmp2, tmp3
++    xvhaddw.w.h   \in0,   \in0,  \in0
++    xvhaddw.w.h   \in1,   \in1,  \in1
++    xvhaddw.w.h   \in2,   \in2,  \in2
++    xvhaddw.w.h   \in3,   \in3,  \in3
++    xvhaddw.w.h   \in4,   \in4,  \in4
++    xvhaddw.w.h   \in5,   \in5,  \in5
++    xvhaddw.w.h   \in6,   \in6,  \in6
++    xvhaddw.w.h   \in7,   \in7,  \in7
++    xvpickev.h    \tmp0,  \in1,  \in0
++    xvpickev.h    \tmp1,  \in3,  \in2
++    xvpickev.h    \tmp2,  \in5,  \in4
++    xvpickev.h    \tmp3,  \in7,  \in6
++    xvhaddw.w.h   \tmp0,  \tmp0, \tmp0
++    xvhaddw.w.h   \tmp1,  \tmp1, \tmp1
++    xvhaddw.w.h   \tmp2,  \tmp2, \tmp2
++    xvhaddw.w.h   \tmp3,  \tmp3, \tmp3
++    xvpickev.h    \in0,   \tmp1, \tmp0
++    xvpickev.h    \in1,   \tmp3, \tmp2
++    xvhaddw.w.h   \out0,  \in0,  \in0
++    xvhaddw.w.h   \out1,  \in1,  \in1
++.endm
++
++.macro XMULW4_W  in0, in1, mul0, mul1, out0, out1, out2, out3
++    xvmulwev.w.h   \out0,  \in0,  \mul0
++    xvmulwod.w.h   \out1,  \in0,  \mul0
++    xvmulwev.w.h   \out2,  \in1,  \mul1
++    xvmulwod.w.h   \out3,  \in1,  \mul1
++.endm
++
++.macro XMADD4_W  in0, in1, mul0, mul1, out0, out1, out2, out3
++    xvmaddwev.w.h   \out0,  \in0,  \mul0
++    xvmaddwod.w.h   \out1,  \in0,  \mul0
++    xvmaddwev.w.h   \out2,  \in1,  \mul1
++    xvmaddwod.w.h   \out3,  \in1,  \mul1
++.endm
++
++.macro FILTER_HV_PP_16xN_LASX  h
++function x265_interp_8tap_hv_pp_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t2,    t0,    7
++    addi.d       t3,    zero,  32
++    mul.d        t4,    t3,    t2
++    sub.d        a0,    a0,    t1
++    addi.d       t6,    t6,    128
++    sub.d        sp,    sp,    t4
++    move         t7,    sp
++.loop_hv_ps_lasx_16x\h:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vld          vr20,  a0,    1
++    vld          vr21,  a0,    2
++    vld          vr22,  a0,    3
++    vld          vr23,  a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr6,   vr21,  vr20
++    vilvl.b      vr7,   vr23,  vr22
++    vilvh.b      vr8,   vr1,   vr0
++    vilvh.b      vr9,   vr3,   vr2
++    vilvh.b      vr12,  vr21,  vr20
++    vilvh.b      vr13,  vr23,  vr22
++
++    xvpermi.q    xr8,   xr4,   0x20
++    xvpermi.q    xr9,   xr5,   0x20
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr4, xr5, xr6, xr7, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    xvpackev.h   xr0,   xr21,  xr20
++    xvadd.h      xr2,   xr0,   xr11
++
++    xvst         xr2,   t7,    0
++    addi.d       t7,    t7,    32
++    addi.d       t2,    t2,    -1
++    add.d        a0,    a0,    a1
++    blt          zero,  t2,    .loop_hv_ps_lasx_16x\h
++    add.d        t6,    t6,    t8
++    slli.d       t2,    a3,    1
++    move         t7,    sp
++    xvld         xr11,  t5,    32
++    xvldrepl.h   xr16,  t6,    0
++    xvldrepl.h   xr17,  t6,    2
++    xvldrepl.h   xr18,  t6,    4
++    xvldrepl.h   xr19,  t6,    6
++    xvldrepl.h   xr20,  t6,    8
++    xvldrepl.h   xr21,  t6,    10
++    xvldrepl.h   xr22,  t6,    12
++    xvldrepl.h   xr23,  t6,    14
++.loop_hv_sp_lasx_16x\h:
++    xvor.v       xr12,  xr11,  xr11
++    xvor.v       xr13,  xr11,  xr11
++    xvor.v       xr14,  xr11,  xr11
++    xvor.v       xr15,  xr11,  xr11
++    xvld         xr0,   t7,    0
++    xvld         xr1,   t7,    32 * 1
++    xvld         xr2,   t7,    32 * 2
++    xvld         xr3,   t7,    32 * 3
++    xvld         xr4,   t7,    32 * 4
++    xvld         xr5,   t7,    32 * 5
++    xvld         xr6,   t7,    32 * 6
++    xvld         xr7,   t7,    32 * 7
++    xvld         xr8,   t7,    32 * 8
++    XMADD4_W xr0, xr1, xr16, xr16, xr12, xr13, xr14, xr15
++    XMADD4_W xr1, xr2, xr17, xr17, xr12, xr13, xr14, xr15
++    XMADD4_W xr2, xr3, xr18, xr18, xr12, xr13, xr14, xr15
++    XMADD4_W xr3, xr4, xr19, xr19, xr12, xr13, xr14, xr15
++    XMADD4_W xr4, xr5, xr20, xr20, xr12, xr13, xr14, xr15
++    XMADD4_W xr5, xr6, xr21, xr21, xr12, xr13, xr14, xr15
++    XMADD4_W xr6, xr7, xr22, xr22, xr12, xr13, xr14, xr15
++    XMADD4_W xr7, xr8, xr23, xr23, xr12, xr13, xr14, xr15
++    xvssrani.h.w  xr13,  xr12,  12
++    xvssrani.h.w  xr15,  xr14,  12
++    addi.d        t7,    t7,    64
++    xvssrani.bu.h xr15,  xr13,  0
++    addi.d        t0,    t0,    -2
++    xvpermi.d     xr13,  xr15,  0xD8
++    xvpermi.d     xr14,  xr15,  0x8D
++    vst           vr13,  a2,    0
++    vstx          vr14,  a2,    a3
++    add.d         a2,    a2,    t2
++    blt           zero,  t0,    .loop_hv_sp_lasx_16x\h
++    add.d         sp,    sp,    t4
++endfunc
++.endm
++
++FILTER_HV_PP_16xN_LASX  4
++FILTER_HV_PP_16xN_LASX  8
++FILTER_HV_PP_16xN_LASX  12
++FILTER_HV_PP_16xN_LASX  16
++FILTER_HV_PP_16xN_LASX  32
++FILTER_HV_PP_16xN_LASX  64
++
++function x265_interp_8tap_hv_pp_24x32_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  32
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t2,    t0,    7
++    addi.d       t3,    zero,  48
++    mul.d        t4,    t3,    t2
++    sub.d        a0,    a0,    t1
++    addi.d       t6,    t6,    128
++    sub.d        sp,    sp,    t4
++    move         t7,    sp
++.loop_hv_ps_lasx_24x32:
++    xvld         xr0,   a0,    -3
++    xvld         xr1,   a0,    -2
++    xvld         xr2,   a0,    -1
++    xvld         xr3,   a0,    0
++    xvld         xr20,  a0,    1
++    xvld         xr21,  a0,    2
++    xvld         xr22,  a0,    3
++    xvld         xr23,  a0,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    xvpermi.q    xr12,  xr8,   0x20
++    xvpermi.q    xr13,  xr9,   0x20
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++.irp x, xr14, xr15, xr16, xr17
++    xvhaddw.w.h  \x,    \x,    \x
++.endr
++    xvpickev.h   xr4,   xr15,  xr14
++    xvpickev.h   xr5,   xr17,  xr16
++    xvhaddw.w.h  xr4,   xr4,   xr4
++    xvhaddw.w.h  xr5,   xr5,   xr5
++    xvpickev.h   xr6,   xr5,   xr4
++    xvhaddw.w.h  xr22,  xr6,   xr6
++    xvpermi.d    xr0,   xr20,  0x4E
++    xvpermi.d    xr1,   xr21,  0x4E
++    xvpermi.q    xr20,  xr22,  0x2
++    xvpermi.q    xr21,  xr22,  0x12
++
++    xvpackev.h   xr2,   xr21,  xr20
++    vpickev.h    vr3,   vr1,   vr0
++
++    xvadd.h      xr4,   xr2,   xr11
++    xvadd.h      xr5,   xr3,   xr11
++
++    xvst         xr4,   t7,    0
++    vst          vr5,   t7,    32
++    addi.d       t7,    t7,    48
++    addi.d       t2,    t2,    -1
++    add.d        a0,    a0,    a1
++    blt          zero,  t2,    .loop_hv_ps_lasx_24x32
++    add.d        t6,    t6,    t8
++    move         t7,    sp
++    xvld         xr11,  t5,    32
++    xvldrepl.h   xr16,  t6,    0
++    xvldrepl.h   xr17,  t6,    2
++    xvldrepl.h   xr18,  t6,    4
++    xvldrepl.h   xr19,  t6,    6
++    xvldrepl.h   xr20,  t6,    8
++    xvldrepl.h   xr21,  t6,    10
++    xvldrepl.h   xr22,  t6,    12
++    xvldrepl.h   xr23,  t6,    14
++.loop_hv_sp_lasx_24x32:
++    xvor.v       xr8,   xr11,  xr11
++    xvor.v       xr9,   xr11,  xr11
++    xvor.v       xr12,  xr11,  xr11
++    xvld         xr0,   t7,    0
++    vld          vr1,   t7,    32
++    xvld         xr2,   t7,    0  + 48
++    vld          vr3,   t7,    32 + 48
++    xvld         xr4,   t7,    0  + 48 * 2
++    vld          vr5,   t7,    32 + 48 * 2
++    xvld         xr6,   t7,    0  + 48 * 3
++    vld          vr7,   t7,    32 + 48 * 3
++.irp x, xr1, xr3, xr5, xr7
++    xvpermi.d    \x,    \x,    0xD8
++.endr
++    xvilvl.h     xr13,  xr3,   xr1
++    xvilvl.h     xr14,  xr7,   xr5
++
++    xvmaddwev.w.h xr8,  xr0,   xr16
++    xvmaddwod.w.h xr9,  xr0,   xr16
++    xvmaddwev.w.h xr12, xr13,  xr16
++    xvmaddwev.w.h xr8,  xr2,   xr17
++    xvmaddwod.w.h xr9,  xr2,   xr17
++    xvmaddwod.w.h xr12, xr13,  xr17
++    xvmaddwev.w.h xr8,  xr4,   xr18
++    xvmaddwod.w.h xr9,  xr4,   xr18
++    xvmaddwev.w.h xr12, xr14,  xr18
++    xvmaddwev.w.h xr8,  xr6,   xr19
++    xvmaddwod.w.h xr9,  xr6,   xr19
++    xvmaddwod.w.h xr12, xr14,  xr19
++
++    xvld         xr0,   t7,    0  + 48 * 4
++    vld          vr1,   t7,    32 + 48 * 4
++    xvld         xr2,   t7,    0  + 48 * 5
++    vld          vr3,   t7,    32 + 48 * 5
++    xvld         xr4,   t7,    0  + 48 * 6
++    vld          vr5,   t7,    32 + 48 * 6
++    xvld         xr6,   t7,    0  + 48 * 7
++    vld          vr7,   t7,    32 + 48 * 7
++.irp x, xr1, xr3, xr5, xr7
++    xvpermi.d    \x,    \x,    0xD8
++.endr
++    xvilvl.h     xr13,  xr3,   xr1
++    xvilvl.h     xr14,  xr7,   xr5
++
++    xvmaddwev.w.h xr8,  xr0,   xr20
++    xvmaddwod.w.h xr9,  xr0,   xr20
++    xvmaddwev.w.h xr12, xr13,  xr20
++    xvmaddwev.w.h xr8,  xr2,   xr21
++    xvmaddwod.w.h xr9,  xr2,   xr21
++    xvmaddwod.w.h xr12, xr13,  xr21
++    xvmaddwev.w.h xr8,  xr4,   xr22
++    xvmaddwod.w.h xr9,  xr4,   xr22
++    xvmaddwev.w.h xr12, xr14,  xr22
++    xvmaddwev.w.h xr8,  xr6,   xr23
++    xvmaddwod.w.h xr9,  xr6,   xr23
++    xvmaddwod.w.h xr12, xr14,  xr23
++
++    xvpermi.d     xr13,  xr12,  0x4E
++    xvssrani.h.w  xr9,   xr8,   12
++    xvssrani.h.w  xr13,  xr12,  12
++    addi.d        t7,    t7,    48
++    xvssrani.bu.h xr13,  xr9,   0
++    addi.d        t0,    t0,    -1
++    xvpermi.d     xr14,  xr13,  0xD8
++    vst           vr14,  a2,    0
++    xvstelm.d     xr14,  a2,    16,  2
++    add.d         a2,    a2,    a3
++    blt           zero,  t0,    .loop_hv_sp_lasx_24x32
++    add.d         sp,    sp,    t4
++endfunc
++
++function x265_interp_8tap_hv_pp_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  64
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t2,    t0,    7
++    addi.d       t3,    zero,  96
++    mul.d        t4,    t3,    t2
++    sub.d        a0,    a0,    t1
++    addi.d       t6,    t6,    128
++    sub.d        sp,    sp,    t4
++    move         t7,    sp
++.loop_hv_ps_lasx_48x64:
++    xvld         xr0,   a0,    -3
++    xvld         xr1,   a0,    -2
++    xvld         xr2,   a0,    -1
++    xvld         xr3,   a0,    0
++    xvld         xr20,  a0,    1
++    xvld         xr21,  a0,    2
++    xvld         xr22,  a0,    3
++    xvld         xr23,  a0,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr22, xr23, xr4, xr5, xr6, xr7
++
++    xvpackev.h   xr0,   xr21,  xr20
++    xvpackev.h   xr1,   xr23,  xr22
++    xvadd.h      xr2,   xr0,   xr11
++    xvadd.h      xr3,   xr1,   xr11
++    xvor.v       xr4,   xr2,   xr2
++    xvpermi.q    xr2,   xr3,   0x2
++    xvpermi.q    xr4,   xr3,   0x13
++
++    xvst         xr2,   t7,    0
++    xvst         xr4,   t7,    32
++
++    vld          vr0,   a0,    29
++    vld          vr1,   a0,    30
++    vld          vr2,   a0,    31
++    vld          vr3,   a0,    32
++    vld          vr20,  a0,    33
++    vld          vr21,  a0,    34
++    vld          vr22,  a0,    35
++    vld          vr23,  a0,    36
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr6,   vr21,  vr20
++    vilvl.b      vr7,   vr23,  vr22
++    vilvh.b      vr8,   vr1,   vr0
++    vilvh.b      vr9,   vr3,   vr2
++    vilvh.b      vr12,  vr21,  vr20
++    vilvh.b      vr13,  vr23,  vr22
++
++    xvpermi.q    xr8,   xr4,   0x20
++    xvpermi.q    xr9,   xr5,   0x20
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr4, xr5, xr6, xr7, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    xvpackev.h   xr0,   xr21,  xr20
++    xvadd.h      xr2,   xr0,   xr11
++
++    xvst         xr2,   t7,    64
++    addi.d       t7,    t7,    96
++    addi.d       t2,    t2,    -1
++    add.d        a0,    a0,    a1
++    blt          zero,  t2,    .loop_hv_ps_lasx_48x64
++    add.d        t6,    t6,    t8
++    move         t7,    sp
++    xvld         xr11,  t5,    32
++    xvldrepl.h   xr16,  t6,    0
++    xvldrepl.h   xr17,  t6,    2
++    xvldrepl.h   xr18,  t6,    4
++    xvldrepl.h   xr19,  t6,    6
++    xvldrepl.h   xr20,  t6,    8
++    xvldrepl.h   xr21,  t6,    10
++    xvldrepl.h   xr22,  t6,    12
++    xvldrepl.h   xr23,  t6,    14
++.loop_hv_sp_lasx_48x64:
++.irp x, xr8, xr9, xr12, xr13, xr14, xr15
++    xvor.v       \x,    xr11,  xr11
++.endr
++    xvld         xr0,   t7,    0
++    xvld         xr1,   t7,    32
++    xvld         xr2,   t7,    64
++    xvld         xr3,   t7,    0  + 96
++    xvld         xr4,   t7,    32 + 96
++    xvld         xr5,   t7,    64 + 96
++    XMADD4_W xr0, xr1, xr16, xr16, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr2,  xr16
++    xvmaddwod.w.h xr15,  xr2,  xr16
++    XMADD4_W xr3, xr4, xr17, xr17, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr5,  xr17
++    xvmaddwod.w.h xr15,  xr5,  xr17
++    xvld         xr0,   t7,    0  + 96 * 2
++    xvld         xr1,   t7,    32 + 96 * 2
++    xvld         xr2,   t7,    64 + 96 * 2
++    xvld         xr3,   t7,    0  + 96 * 3
++    xvld         xr4,   t7,    32 + 96 * 3
++    xvld         xr5,   t7,    64 + 96 * 3
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr2,  xr18
++    xvmaddwod.w.h xr15,  xr2,  xr18
++    XMADD4_W xr3, xr4, xr19, xr19, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr5,  xr19
++    xvmaddwod.w.h xr15,  xr5,  xr19
++    xvld         xr0,   t7,    0  + 96 * 4
++    xvld         xr1,   t7,    32 + 96 * 4
++    xvld         xr2,   t7,    64 + 96 * 4
++    xvld         xr3,   t7,    0  + 96 * 5
++    xvld         xr4,   t7,    32 + 96 * 5
++    xvld         xr5,   t7,    64 + 96 * 5
++    XMADD4_W xr0, xr1, xr20, xr20, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr2,  xr20
++    xvmaddwod.w.h xr15,  xr2,  xr20
++    XMADD4_W xr3, xr4, xr21, xr21, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr5,  xr21
++    xvmaddwod.w.h xr15,  xr5,  xr21
++    xvld         xr0,   t7,    0  + 96 * 6
++    xvld         xr1,   t7,    32 + 96 * 6
++    xvld         xr2,   t7,    64 + 96 * 6
++    xvld         xr3,   t7,    0  + 96 * 7
++    xvld         xr4,   t7,    32 + 96 * 7
++    xvld         xr5,   t7,    64 + 96 * 7
++    XMADD4_W xr0, xr1, xr22, xr22, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr2,  xr22
++    xvmaddwod.w.h xr15,  xr2,  xr22
++    XMADD4_W xr3, xr4, xr23, xr23, xr8, xr9, xr12, xr13
++    xvmaddwev.w.h xr14,  xr5,  xr23
++    xvmaddwod.w.h xr15,  xr5,  xr23
++
++    xvssrani.h.w  xr9,   xr8,  12
++    xvssrani.h.w  xr13,  xr12, 12
++    xvssrani.h.w  xr15,  xr14, 12
++
++    xvssrani.bu.h xr13,  xr9,   0
++    xvssrani.bu.h xr7,   xr15,  0
++    xvpermi.d     xr8,   xr13,  0xD8
++    xvpermi.d     xr9,   xr7,   0xD8
++    xvst          xr8,   a2,    0
++    vst           vr9,   a2,    32
++    addi.d        t0,    t0,    -1
++    addi.d        t7,    t7,    96
++    add.d         a2,    a2,    a3
++    blt           zero,  t0,    .loop_hv_sp_lasx_48x64
++    add.d         sp,    sp,    t4
++endfunc
++
++.macro FILTER_HV_PP_WxN_LASX  w, h, rep, s
++function x265_interp_8tap_hv_pp_\w\()x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t8,    a5,    4
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    alsl.d       t1,    a1,    a1,   1
++    addi.d       t2,    t0,    7
++    addi.d       t3,    zero,  \s
++    mul.d        t4,    t3,    t2
++    sub.d        a0,    a0,    t1
++    addi.d       t6,    t6,    128
++    sub.d        sp,    sp,    t4
++    move         t7,    sp
++.loop_hv_ps_lasx_\w\()x\h:
++    move         t1,    a0
++.rept \rep
++    xvld         xr0,   t1,    -3
++    xvld         xr1,   t1,    -2
++    xvld         xr2,   t1,    -1
++    xvld         xr3,   t1,    0
++    xvld         xr20,  t1,    1
++    xvld         xr21,  t1,    2
++    xvld         xr22,  t1,    3
++    xvld         xr23,  t1,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr22, xr23, xr4, xr5, xr6, xr7
++
++    xvpackev.h   xr0,   xr21,  xr20
++    xvpackev.h   xr1,   xr23,  xr22
++    xvadd.h      xr2,   xr0,   xr11
++    xvadd.h      xr3,   xr1,   xr11
++    xvor.v       xr4,   xr2,   xr2
++    xvpermi.q    xr2,   xr3,   0x2
++    xvpermi.q    xr4,   xr3,   0x13
++
++    addi.d       t1,    t1,    32
++    xvst         xr2,   t7,    0
++    xvst         xr4,   t7,    32
++    addi.d       t7,    t7,    64
++.endr
++    addi.d       t2,    t2,    -1
++    add.d        a0,    a0,    a1
++    blt          zero,  t2,    .loop_hv_ps_lasx_\w\()x\h
++    add.d        t6,    t6,    t8
++    move         t7,    sp
++    xvld         xr11,  t5,    32
++    xvldrepl.h   xr16,  t6,    0
++    xvldrepl.h   xr17,  t6,    2
++    xvldrepl.h   xr18,  t6,    4
++    xvldrepl.h   xr19,  t6,    6
++    xvldrepl.h   xr20,  t6,    8
++    xvldrepl.h   xr21,  t6,    10
++    xvldrepl.h   xr22,  t6,    12
++    xvldrepl.h   xr23,  t6,    14
++.loop_hv_sp_lasx_\w\()x\h:
++    move         t2,    a2
++.rept \rep
++    xvor.v       xr8,   xr11,  xr11
++    xvor.v       xr9,   xr11,  xr11
++    xvor.v       xr12,  xr11,  xr11
++    xvor.v       xr13,  xr11,  xr11
++    xvld         xr0,   t7,    0
++    xvld         xr1,   t7,    32
++    xvld         xr2,   t7,    0  + \s
++    xvld         xr3,   t7,    32 + \s
++    xvld         xr4,   t7,    0  + \s * 2
++    xvld         xr5,   t7,    32 + \s * 2
++    xvld         xr6,   t7,    0  + \s * 3
++    xvld         xr7,   t7,    32 + \s * 3
++    XMADD4_W xr0, xr1, xr16, xr16, xr8, xr9, xr12, xr13
++    XMADD4_W xr2, xr3, xr17, xr17, xr8, xr9, xr12, xr13
++    XMADD4_W xr4, xr5, xr18, xr18, xr8, xr9, xr12, xr13
++    XMADD4_W xr6, xr7, xr19, xr19, xr8, xr9, xr12, xr13
++    xvld         xr0,   t7,    0  + \s * 4
++    xvld         xr1,   t7,    32 + \s * 4
++    xvld         xr2,   t7,    0  + \s * 5
++    xvld         xr3,   t7,    32 + \s * 5
++    xvld         xr4,   t7,    0  + \s * 6
++    xvld         xr5,   t7,    32 + \s * 6
++    xvld         xr6,   t7,    0  + \s * 7
++    xvld         xr7,   t7,    32 + \s * 7
++    XMADD4_W xr0, xr1, xr20, xr20, xr8, xr9, xr12, xr13
++    XMADD4_W xr2, xr3, xr21, xr21, xr8, xr9, xr12, xr13
++    XMADD4_W xr4, xr5, xr22, xr22, xr8, xr9, xr12, xr13
++    XMADD4_W xr6, xr7, xr23, xr23, xr8, xr9, xr12, xr13
++    xvssrani.h.w  xr9,   xr8,   12
++    xvssrani.h.w  xr13,  xr12,  12
++    addi.d        t7,    t7,    64
++    xvssrani.bu.h xr13,  xr9,   0
++    xvpermi.d     xr14,  xr13,  0xD8
++    xvst          xr14,  t2,    0
++    addi.d        t2,    t2,    32
++.endr
++    addi.d        t0,    t0,    -1
++    add.d         a2,    a2,    a3
++    blt           zero,  t0,    .loop_hv_sp_lasx_\w\()x\h
++    add.d         sp,    sp,    t4
++endfunc
++.endm
++
++FILTER_HV_PP_WxN_LASX 32, 8,  1, 64
++FILTER_HV_PP_WxN_LASX 32, 16, 1, 64
++FILTER_HV_PP_WxN_LASX 32, 24, 1, 64
++FILTER_HV_PP_WxN_LASX 32, 32, 1, 64
++FILTER_HV_PP_WxN_LASX 32, 64, 1, 64
++FILTER_HV_PP_WxN_LASX 64, 16, 2, 128
++FILTER_HV_PP_WxN_LASX 64, 32, 2, 128
++FILTER_HV_PP_WxN_LASX 64, 48, 2, 128
++FILTER_HV_PP_WxN_LASX 64, 64, 2, 128
++
++.macro FILTER_HORIZ_LUMA_16xN_LASX  h
++function x265_interp_8tap_horiz_pp_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    xvldx        xr10,  t6,    t7
++    addi.d       t0,    zero,  \h
++.loopH_lasx_16x\h:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vld          vr20,  a0,    1
++    vld          vr21,  a0,    2
++    vld          vr22,  a0,    3
++    vld          vr23,  a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr6,   vr21,  vr20
++    vilvl.b      vr7,   vr23,  vr22
++    vilvh.b      vr8,   vr1,   vr0
++    vilvh.b      vr9,   vr3,   vr2
++    vilvh.b      vr12,  vr21,  vr20
++    vilvh.b      vr13,  vr23,  vr22
++
++    xvpermi.q    xr8,   xr4,   0x20
++    xvpermi.q    xr9,   xr5,   0x20
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr4, xr5, xr6, xr7, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    xvpickev.h     xr0,  xr21,  xr20
++    xvssrarni.bu.h xr1,  xr0,   6
++    addi.d         t0,   t0,    -1
++    xvpermi.d      xr2,  xr1,   0xD8
++    add.d          a0,   a0,    a1
++    vst            vr2,  a2,    0
++    add.d          a2,   a2,    a3
++    blt            zero, t0,    .loopH_lasx_16x\h
++endfunc
++.endm
++
++FILTER_HORIZ_LUMA_16xN_LASX 4
++FILTER_HORIZ_LUMA_16xN_LASX 8
++FILTER_HORIZ_LUMA_16xN_LASX 12
++FILTER_HORIZ_LUMA_16xN_LASX 16
++FILTER_HORIZ_LUMA_16xN_LASX 32
++FILTER_HORIZ_LUMA_16xN_LASX 64
++
++function x265_interp_8tap_horiz_pp_24x32_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    xvldx        xr10,  t6,    t7
++    addi.d       t0,    zero,  32
++.loopH_lasx_24x32:
++    xvld          xr0,   a0,    -3
++    xvld          xr1,   a0,    -2
++    xvld          xr2,   a0,    -1
++    xvld          xr3,   a0,    0
++    xvld          xr20,  a0,    1
++    xvld          xr21,  a0,    2
++    xvld          xr22,  a0,    3
++    xvld          xr23,  a0,    4
++    xvilvl.b      xr4,   xr1,   xr0
++    xvilvl.b      xr5,   xr3,   xr2
++    xvilvl.b      xr6,   xr21,  xr20
++    xvilvl.b      xr7,   xr23,  xr22
++    xvilvh.b      xr8,   xr1,   xr0
++    xvilvh.b      xr9,   xr3,   xr2
++    xvilvh.b      xr12,  xr21,  xr20
++    xvilvh.b      xr13,  xr23,  xr22
++
++    xvpermi.q    xr12,  xr8,   0x20
++    xvpermi.q    xr13,  xr9,   0x20
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++.irp x, xr14, xr15, xr16, xr17
++    xvhaddw.w.h  \x,    \x,    \x
++.endr
++    xvpickev.h   xr4,   xr15,  xr14
++    xvpickev.h   xr5,   xr17,  xr16
++    xvhaddw.w.h  xr4,   xr4,   xr4
++    xvhaddw.w.h  xr5,   xr5,   xr5
++    xvpickev.h   xr6,   xr5,   xr4
++    xvhaddw.w.h  xr22,  xr6,   xr6
++    xvpermi.d    xr0,   xr22,  0x4E
++
++    xvpickev.h   xr2,   xr21,  xr20
++    vpickev.h    vr3,   vr0,   vr22
++
++    xvssrarni.bu.h xr3,  xr2,   6
++    addi.d         t0,   t0,    -1
++    add.d          a0,   a0,    a1
++    vst            vr3,  a2,    0
++    xvstelm.d      xr3,  a2,    16,  2
++    add.d          a2,   a2,    a3
++    blt            zero, t0,    .loopH_lasx_24x32
++endfunc
++
++function x265_interp_8tap_horiz_pp_48x64_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    xvldx        xr10,  t6,    t7
++    addi.d       t0,    zero,  64
++.loopH_lasx_48x64:
++    xvld         xr0,   a0,    -3
++    xvld         xr1,   a0,    -2
++    xvld         xr2,   a0,    -1
++    xvld         xr3,   a0,    0
++    xvld         xr20,  a0,    1
++    xvld         xr21,  a0,    2
++    xvld         xr22,  a0,    3
++    xvld         xr23,  a0,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr22, xr23, xr4, xr5, xr6, xr7
++
++    xvpickev.h     xr0,  xr21,  xr20
++    xvpickev.h     xr1,  xr23,  xr22
++
++    xvssrarni.bu.h xr1,  xr0,   6
++    addi.d         t0,   t0,    -1
++    xvst           xr1,  a2,    0
++
++    vld            vr0,  a0,    29
++    vld            vr1,  a0,    30
++    vld            vr2,  a0,    31
++    vld            vr3,  a0,    32
++    vld            vr20, a0,    33
++    vld            vr21, a0,    34
++    vld            vr22, a0,    35
++    vld            vr23, a0,    36
++    vilvl.b        vr4,  vr1,   vr0
++    vilvl.b        vr5,  vr3,   vr2
++    vilvl.b        vr6,  vr21,  vr20
++    vilvl.b        vr7,  vr23,  vr22
++    vilvh.b        vr8,  vr1,   vr0
++    vilvh.b        vr9,  vr3,   vr2
++    vilvh.b        vr12, vr21,  vr20
++    vilvh.b        vr13, vr23,  vr22
++
++    xvpermi.q      xr8,  xr4,   0x20
++    xvpermi.q      xr9,  xr5,   0x20
++    xvpermi.q      xr12, xr6,   0x20
++    xvpermi.q      xr13, xr7,   0x20
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr4, xr5, xr6, xr7, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++    xvpickev.h     xr0,  xr21,  xr20
++    xvssrarni.bu.h xr1,  xr0,   6
++    add.d          a0,   a0,    a1
++    xvpermi.d      xr2,  xr1,   0xD8
++    vst            vr2,  a2,    32
++    add.d          a2,   a2,    a3
++    blt            zero, t0,    .loopH_lasx_48x64
++endfunc
++
++.macro FILTER_HORIZ_LUMA_WxN_LASX  w, h, rep
++function x265_interp_8tap_horiz_pp_\w\()x\h\()_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_lumaFilter
++    xvldx        xr10,  t6,    t7
++    addi.d       t0,    zero,  \h
++.loopH_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    xvld         xr0,   t1,    -3
++    xvld         xr1,   t1,    -2
++    xvld         xr2,   t1,    -1
++    xvld         xr3,   t1,    0
++    xvld         xr20,  t1,    1
++    xvld         xr21,  t1,    2
++    xvld         xr22,  t1,    3
++    xvld         xr23,  t1,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr22, xr23, xr4, xr5, xr6, xr7
++
++
++    xvpickev.h     xr0,  xr21,  xr20
++    xvpickev.h     xr1,  xr23,  xr22
++
++    xvssrarni.bu.h xr1,  xr0,   6
++    addi.d         t1,   t1,    32
++    xvst           xr1,  t2,    0
++    addi.d         t2,   t2,    32
++.endr
++    addi.d        t0,   t0,    -1
++    add.d         a0,   a0,    a1
++    add.d         a2,   a2,    a3
++    blt           zero, t0,    .loopH_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_LUMA_WxN_LASX 32, 8,  1
++FILTER_HORIZ_LUMA_WxN_LASX 32, 16, 1
++FILTER_HORIZ_LUMA_WxN_LASX 32, 24, 1
++FILTER_HORIZ_LUMA_WxN_LASX 32, 32, 1
++FILTER_HORIZ_LUMA_WxN_LASX 32, 64, 1
++FILTER_HORIZ_LUMA_WxN_LASX 64, 16, 2
++FILTER_HORIZ_LUMA_WxN_LASX 64, 32, 2
++FILTER_HORIZ_LUMA_WxN_LASX 64, 48, 2
++FILTER_HORIZ_LUMA_WxN_LASX 64, 64, 2
++
++.macro FILTER_HORIZ_PS_16xN_LASX  h
++function x265_interp_8tap_horiz_ps_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    beqz         a5,    .loopS_lasx_16x\h
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_lasx_16x\h:
++    vld          vr0,   a0,    -3
++    vld          vr1,   a0,    -2
++    vld          vr2,   a0,    -1
++    vld          vr3,   a0,    0
++    vld          vr20,  a0,    1
++    vld          vr21,  a0,    2
++    vld          vr22,  a0,    3
++    vld          vr23,  a0,    4
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr6,   vr21,  vr20
++    vilvl.b      vr7,   vr23,  vr22
++    vilvh.b      vr8,   vr1,   vr0
++    vilvh.b      vr9,   vr3,   vr2
++    vilvh.b      vr12,  vr21,  vr20
++    vilvh.b      vr13,  vr23,  vr22
++
++    xvpermi.q    xr8,   xr4,   0x20
++    xvpermi.q    xr9,   xr5,   0x20
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr4, xr5, xr6, xr7, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    xvpickev.h   xr0,   xr21,  xr20
++    xvadd.h      xr2,   xr0,   xr11
++    add.d        a0,    a0,    a1
++    addi.d       t0,    t0,    -1
++    xvst         xr2,   a2,    0
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_lasx_16x\h
++endfunc
++.endm
++
++FILTER_HORIZ_PS_16xN_LASX 4
++FILTER_HORIZ_PS_16xN_LASX 8
++FILTER_HORIZ_PS_16xN_LASX 12
++FILTER_HORIZ_PS_16xN_LASX 16
++FILTER_HORIZ_PS_16xN_LASX 32
++FILTER_HORIZ_PS_16xN_LASX 64
++
++function x265_interp_8tap_horiz_ps_24x32_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  32
++    beqz         a5,    .loopS_lasx_24x32
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_lasx_24x32:
++    xvld         xr0,   a0,    -3
++    xvld         xr1,   a0,    -2
++    xvld         xr2,   a0,    -1
++    xvld         xr3,   a0,    0
++    xvld         xr20,  a0,    1
++    xvld         xr21,  a0,    2
++    xvld         xr22,  a0,    3
++    xvld         xr23,  a0,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    xvpermi.q    xr12,  xr8,   0x20
++    xvpermi.q    xr13,  xr9,   0x20
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++.irp x, xr14, xr15, xr16, xr17
++    xvhaddw.w.h  \x,    \x,    \x
++.endr
++    xvpickev.h   xr4,   xr15,  xr14
++    xvpickev.h   xr5,   xr17,  xr16
++    xvhaddw.w.h  xr4,   xr4,   xr4
++    xvhaddw.w.h  xr5,   xr5,   xr5
++    xvpickev.h   xr6,   xr5,   xr4
++    xvhaddw.w.h  xr22,  xr6,   xr6
++    xvpermi.d    xr0,   xr20,  0x4E
++    xvpermi.d    xr1,   xr21,  0x4E
++    xvpermi.q    xr20,  xr22,  0x2
++    xvpermi.q    xr21,  xr22,  0x12
++
++    xvpickev.h   xr2,   xr21,  xr20
++    vpickev.h    vr3,   vr1,   vr0
++
++    xvadd.h      xr4,   xr2,   xr11
++    xvadd.h      xr5,   xr3,   xr11
++    xvst         xr4,   a2,    0
++    vst          vr5,   a2,    32
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    add.d        a0,    a0,    a1
++    blt          zero,  t0,    .loopS_lasx_24x32
++endfunc
++
++function x265_interp_8tap_horiz_ps_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  64
++    beqz         a5,    .loopS_lasx_48x64
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_lasx_48x64:
++    xvld         xr0,   a0,    -3
++    xvld         xr1,   a0,    -2
++    xvld         xr2,   a0,    -1
++    xvld         xr3,   a0,    0
++    xvld         xr20,  a0,    1
++    xvld         xr21,  a0,    2
++    xvld         xr22,  a0,    3
++    xvld         xr23,  a0,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr22, xr23, xr4, xr5, xr6, xr7
++
++    xvpickev.h   xr0,   xr21,  xr20
++    xvpickev.h   xr1,   xr23,  xr22
++    xvadd.h      xr2,   xr0,   xr11
++    xvadd.h      xr3,   xr1,   xr11
++    xvor.v       xr4,   xr2,   xr2
++    xvpermi.q    xr2,   xr3,   0x2
++    xvpermi.q    xr4,   xr3,   0x13
++
++    xvst         xr2,   a2,    0
++    xvst         xr4,   a2,    32
++
++    vld          vr0,   a0,    29
++    vld          vr1,   a0,    30
++    vld          vr2,   a0,    31
++    vld          vr3,   a0,    32
++    vld          vr20,  a0,    33
++    vld          vr21,  a0,    34
++    vld          vr22,  a0,    35
++    vld          vr23,  a0,    36
++    vilvl.b      vr4,   vr1,   vr0
++    vilvl.b      vr5,   vr3,   vr2
++    vilvl.b      vr6,   vr21,  vr20
++    vilvl.b      vr7,   vr23,  vr22
++    vilvh.b      vr8,   vr1,   vr0
++    vilvh.b      vr9,   vr3,   vr2
++    vilvh.b      vr12,  vr21,  vr20
++    vilvh.b      vr13,  vr23,  vr22
++
++    xvpermi.q    xr8,   xr4,   0x20
++    xvpermi.q    xr9,   xr5,   0x20
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr4, xr5, xr6, xr7, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    xvpickev.h   xr0,   xr21,  xr20
++    xvadd.h      xr2,   xr0,   xr11
++    addi.d       t0,    t0,    -1
++    add.d        a0,    a0,    a1
++    xvst         xr2,   a2,    64
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_lasx_48x64
++endfunc
++
++.macro FILTER_HORIZ_PS_WxN_LASX  w, h, rep
++function x265_interp_8tap_horiz_ps_\w\()x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    la.local     t5,    h_psOffset
++    xvldx        xr10,  t6,    t7
++    xvld         xr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    beqz         a5,    .loopS_lasx_\w\()x\h
++    alsl.d       t1,    a1,    a1,   1
++    sub.d        a0,    a0,    t1
++    addi.d       t0,    t0,    7
++.loopS_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    xvld         xr0,   t1,    -3
++    xvld         xr1,   t1,    -2
++    xvld         xr2,   t1,    -1
++    xvld         xr3,   t1,    0
++    xvld         xr20,  t1,    1
++    xvld         xr21,  t1,    2
++    xvld         xr22,  t1,    3
++    xvld         xr23,  t1,    4
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr20, xr21, xr4, xr5, xr6, xr7
++
++    XMULW4_H xr8, xr9, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr12, xr13, xr10, xr10, xr14, xr15, xr16, xr17
++
++    PROCESS_LUMA_LASX xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++                      xr22, xr23, xr4, xr5, xr6, xr7
++
++    xvpickev.h   xr0,   xr21,  xr20
++    xvpickev.h   xr1,   xr23,  xr22
++    xvadd.h      xr2,   xr0,   xr11
++    xvadd.h      xr3,   xr1,   xr11
++    xvor.v       xr4,   xr2,   xr2
++    xvpermi.q    xr2,   xr3,   0x2
++    xvpermi.q    xr4,   xr3,   0x13
++
++    addi.d       t1,    t1,    32
++    xvst         xr2,   t2,    0
++    xvst         xr4,   t2,    32
++    addi.d       t2,    t2,    64
++.endr
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    add.d        a0,    a0,    a1
++    blt          zero,  t0,    .loopS_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_PS_WxN_LASX 32, 8,  1
++FILTER_HORIZ_PS_WxN_LASX 32, 16, 1
++FILTER_HORIZ_PS_WxN_LASX 32, 24, 1
++FILTER_HORIZ_PS_WxN_LASX 32, 32, 1
++FILTER_HORIZ_PS_WxN_LASX 32, 64, 1
++FILTER_HORIZ_PS_WxN_LASX 64, 16, 2
++FILTER_HORIZ_PS_WxN_LASX 64, 32, 2
++FILTER_HORIZ_PS_WxN_LASX 64, 48, 2
++FILTER_HORIZ_PS_WxN_LASX 64, 64, 2
++
++.macro FILTER_VERT_SP_4xN  h
++function x265_interp_8tap_vert_sp_4x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    addi.d       sp,    sp,    -32
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/4
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr27,  t4,    32
++
++    add.d        a0,    t6,    t3
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++    fldx.d       f11,   t6,    t2   //3
++
++    fld.d        f12,   a0,    0    //4
++    fldx.d       f13,   a0,    a1   //5
++    fldx.d       f14,   a0,    t1   //6
++
++    add.d        t6,    a0,    t2
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vilvl.h      vr4,   vr13,  vr12 //4,5
++    vilvl.h      vr5,   vr14,  vr13 //5,6
++.loopV_sp_4x\h:
++    fld.d        f15,   t6,    0    //7
++    fldx.d       f24,   t6,    a1   //8
++    fldx.d       f25,   t6,    t1   //9
++    fldx.d       f26,   t6,    t2   //10
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr27,  vr27
++.endr
++    VMADD4_W vr0, vr2, vr16, vr16, vr10, vr11, vr12, vr13
++    vilvl.h      vr6,   vr15,  vr14 //6,7
++    vilvl.h      vr7,   vr24,  vr15 //7,8
++    vilvl.h      vr8,   vr25,  vr24 //8,9
++    vilvl.h      vr9,   vr26,  vr25 //9,10
++
++    VMADD4_W vr1, vr3, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr4, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr5, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr6, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADD4_W vr5, vr7, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADD4_W vr6, vr8, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADD4_W vr7, vr9, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr2,  vr6,  vr6
++    vor.v            vr3,  vr7,  vr7
++    vssrani.h.w      vr11, vr10, 12
++    vssrani.h.w      vr13, vr12, 12
++    vor.v            vr4,  vr8,  vr8
++    vor.v            vr5,  vr9,  vr9
++    vssrani.bu.h     vr13, vr11, 0
++    vor.v            vr14, vr26, vr26
++    vstelm.w         vr13, a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr13, a2,   0,  1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr13, a2,   0,  2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr13, a2,   0,  3
++    add.d            t6,   t6,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_sp_4x\h
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    fld.d            f27,  sp,   24
++    addi.d           sp,   sp,   32
++endfunc
++.endm
++
++FILTER_VERT_SP_4xN 4
++FILTER_VERT_SP_4xN 8
++FILTER_VERT_SP_4xN 16
++
++.macro FILTER_VERT_SP_8xN  h
++function x265_interp_8tap_vert_sp_8x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr15,  t4,    32
++
++    add.d        a0,    t6,    t3
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.loopV_sp_8x\h:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADD4_W vr5, vr6, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADD4_W vr6, vr7, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADD4_W vr7, vr8, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vssrani.h.w      vr12, vr10, 12
++    vssrani.h.w      vr13, vr11, 12
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vssrani.bu.h     vr13, vr12, 0
++    vor.v            vr6,  vr8,  vr8
++    vbsrl.v          vr10, vr13, 8
++    vilvl.b          vr11, vr10, vr13
++
++    vstelm.d         vr11, a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr11, a2,   0,  1
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_sp_8x\h
++endfunc
++.endm
++
++FILTER_VERT_SP_8xN 4
++FILTER_VERT_SP_8xN 8
++FILTER_VERT_SP_8xN 16
++FILTER_VERT_SP_8xN 32
++
++function x265_interp_8tap_vert_sp_12x16_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -40
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr28,  t4,    32
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    fld.d        f8,    t6,    0
++    fldx.d       f9,    t6,    a1
++    fldx.d       f10,   t6,    t1
++    fldx.d       f11,   t6,    t2
++    addi.d       t6,    a0,    16
++
++    vilvl.h      vr8,   vr27,  vr8
++    vilvl.h      vr9,   vr27,  vr9
++    vilvl.h      vr10,  vr27,  vr10
++    vilvl.h      vr11,  vr27,  vr11
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    fld.d        f12,   t6,    0
++    fldx.d       f13,   t6,    a1
++    fldx.d       f14,   t6,    t1
++    add.d        a0,    a0,    t2
++    vilvl.h      vr12,  vr27,  vr12
++    vilvl.h      vr13,  vr27,  vr13
++    vilvl.h      vr14,  vr27,  vr14
++.loopV_sp_12x16:
++    vld          vr7,   a0,   0   //7
++    fld.d        f15,   a0,   16  //7
++    vor.v        vr24,  vr28, vr28
++    vor.v        vr25,  vr28, vr28
++    vor.v        vr26,  vr28, vr28
++    vilvl.h      vr15,  vr27, vr15
++    vmaddwev.w.h  vr24, vr0,  vr16
++    vmaddwod.w.h  vr25, vr0,  vr16
++    vmaddwev.w.h  vr26, vr8,  vr16
++
++    vmaddwev.w.h  vr24, vr1,  vr17
++    vmaddwod.w.h  vr25, vr1,  vr17
++    vmaddwev.w.h  vr26, vr9,  vr17
++
++    vmaddwev.w.h  vr24, vr2,  vr18
++    vmaddwod.w.h  vr25, vr2,  vr18
++    vmaddwev.w.h  vr26, vr10, vr18
++
++    vmaddwev.w.h  vr24, vr3,  vr19
++    vmaddwod.w.h  vr25, vr3,  vr19
++    vmaddwev.w.h  vr26, vr11, vr19
++
++    vmaddwev.w.h  vr24, vr4,  vr20
++    vmaddwod.w.h  vr25, vr4,  vr20
++    vmaddwev.w.h  vr26, vr12, vr20
++
++    vmaddwev.w.h  vr24, vr5,  vr21
++    vmaddwod.w.h  vr25, vr5,  vr21
++    vmaddwev.w.h  vr26, vr13, vr21
++
++    vmaddwev.w.h  vr24, vr6,  vr22
++    vmaddwod.w.h  vr25, vr6,  vr22
++    vmaddwev.w.h  vr26, vr14, vr22
++
++    vmaddwev.w.h  vr24, vr7,  vr23
++    vmaddwod.w.h  vr25, vr7,  vr23
++    vmaddwev.w.h  vr26, vr15, vr23
++
++    vor.v            vr0,  vr1,  vr1
++    vor.v            vr1,  vr2,  vr2
++    vor.v            vr2,  vr3,  vr3
++    vor.v            vr3,  vr4,  vr4
++    vor.v            vr4,  vr5,  vr5
++    vor.v            vr5,  vr6,  vr6
++    vor.v            vr6,  vr7,  vr7
++
++    vssrani.h.w      vr26, vr24, 12
++    vssrani.h.w      vr27, vr25, 12
++    vor.v            vr8,  vr9,  vr9
++    vor.v            vr9,  vr10, vr10
++    vor.v            vr10, vr11, vr11
++    vilvl.h          vr24, vr27, vr26
++    vor.v            vr11, vr12, vr12
++    vor.v            vr12, vr13, vr13
++    vssrani.bu.h     vr26, vr24, 0
++    vor.v            vr13, vr14, vr14
++    vor.v            vr14, vr15, vr15
++
++    vstelm.d         vr26, a2,   0,  0
++    vstelm.w         vr26, a2,   8,  3
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_sp_12x16
++    fld.d            f24,  sp,    0
++    fld.d            f25,  sp,    8
++    fld.d            f26,  sp,    16
++    fld.d            f27,  sp,    24
++    fld.d            f28,  sp,    32
++    addi.d           sp,   sp,    40
++endfunc
++
++.macro FILTER_VERT_SP_16xN  h
++function x265_interp_8tap_vert_sp_16x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -40
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr28,  t4,    32
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++    vldx         vr10,  t6,    t1
++    vldx         vr11,  t6,    t2
++    addi.d       t6,    a0,    16
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    vld          vr12,  t6,    0
++    vldx         vr13,  t6,    a1
++    vldx         vr14,  t6,    t1
++    add.d        a0,    a0,    t2
++.loopV_sp_16x\h:
++    vld          vr7,   a0,    0   //7
++    vld          vr15,  a0,    16  //7
++.irp x, vr24, vr25, vr26, vr27
++    vor.v        \x,    vr28,  vr28
++.endr
++    VMADD4_W vr0, vr8, vr16, vr16, vr24, vr25, vr26, vr27
++    VMADD4_W vr1, vr9, vr17, vr17, vr24, vr25, vr26, vr27
++    VMADD4_W vr2, vr10, vr18, vr18, vr24, vr25, vr26, vr27
++    VMADD4_W vr3, vr11, vr19, vr19, vr24, vr25, vr26, vr27
++    VMADD4_W vr4, vr12, vr20, vr20, vr24, vr25, vr26, vr27
++    VMADD4_W vr5, vr13, vr21, vr21, vr24, vr25, vr26, vr27
++    VMADD4_W vr6, vr14, vr22, vr22, vr24, vr25, vr26, vr27
++    VMADD4_W vr7, vr15, vr23, vr23, vr24, vr25, vr26, vr27
++
++    vor.v            vr0,  vr1,  vr1
++    vor.v            vr1,  vr2,  vr2
++    vor.v            vr2,  vr3,  vr3
++    vor.v            vr3,  vr4,  vr4
++    vor.v            vr4,  vr5,  vr5
++    vor.v            vr5,  vr6,  vr6
++    vor.v            vr6,  vr7,  vr7
++
++    vssrani.h.w      vr26, vr24, 12
++    vssrani.h.w      vr27, vr25, 12
++    vor.v            vr8,  vr9,  vr9
++    vor.v            vr9,  vr10, vr10
++    vor.v            vr10, vr11, vr11
++    vilvl.h          vr24, vr27, vr26
++    vilvh.h          vr25, vr27, vr26
++    vor.v            vr11, vr12, vr12
++    vor.v            vr12, vr13, vr13
++    vssrani.bu.h     vr25, vr24, 0
++    vor.v            vr13, vr14, vr14
++    vor.v            vr14, vr15, vr15
++
++    vst              vr25, a2,   0
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_sp_16x\h
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    fld.d            f27,  sp,   24
++    fld.d            f28,  sp,   32
++    addi.d           sp,   sp,   40
++endfunc
++.endm
++
++FILTER_VERT_SP_16xN 4
++FILTER_VERT_SP_16xN 8
++FILTER_VERT_SP_16xN 12
++FILTER_VERT_SP_16xN 16
++FILTER_VERT_SP_16xN 32
++FILTER_VERT_SP_16xN 64
++
++function x265_interp_8tap_vert_sp_24x32_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  32
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr7,   t4,    32
++
++.loopV_sp_24x32:
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    add.d        t5,    a0,    a1
++.irp x, vr8, vr9, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr7,   vr7
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr16
++    vmaddwod.w.h vr13,  vr2, vr16
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr17
++    vmaddwod.w.h vr13,  vr2, vr17
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr18
++    vmaddwod.w.h vr13,  vr2, vr18
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr19
++    vmaddwod.w.h vr13,  vr2, vr19
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr20, vr20, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr20
++    vmaddwod.w.h vr13,  vr2, vr20
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr21, vr21, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr21
++    vmaddwod.w.h vr13,  vr2, vr21
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr22, vr22, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr22
++    vmaddwod.w.h vr13,  vr2, vr22
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    VMADD4_W vr0, vr1, vr23, vr23, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr23
++    vmaddwod.w.h vr13,  vr2, vr23
++
++    vssrani.h.w  vr10, vr8,  12
++    vssrani.h.w  vr11, vr9,  12
++    vssrani.h.w  vr13, vr12, 12
++
++    vilvl.h      vr8, vr11, vr10
++    vilvh.h      vr9, vr11, vr10
++    vssrani.bu.h vr14, vr13, 0
++    vssrani.bu.h vr9,  vr8,  0
++    vbsrl.v      vr12, vr14, 4
++    vilvl.b      vr5,  vr12, vr14
++    vst          vr9,  a2,   0
++    vstelm.d     vr5,  a2,   16,  0
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_sp_24x32
++endfunc
++
++function x265_interp_8tap_vert_sp_48x64_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    addi.d       sp,    sp,    -24
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr7,   t4,    32
++
++.loopV_sp_48x64:
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++    vld          vr4,   a0,    64
++    vld          vr5,   a0,    80
++    add.d        t5,    a0,    a1
++.irp x, vr6, vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, vr24, vr25, vr26
++    vor.v        \x,    vr7,   vr7
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr16, vr16, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr16, vr16, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr17, vr17, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr17, vr17, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr18, vr18, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr18, vr18, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr19, vr19, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr19, vr19, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr20, vr20, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr20, vr20, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr20, vr20, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr21, vr21, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr21, vr21, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr21, vr21, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr22, vr22, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr22, vr22, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr22, vr22, vr15, vr24, vr25, vr26
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    VMADD4_W vr0, vr1, vr23, vr23, vr6, vr8, vr9, vr10
++    VMADD4_W vr2, vr3, vr23, vr23, vr11, vr12, vr13, vr14
++    VMADD4_W vr4, vr5, vr23, vr23, vr15, vr24, vr25, vr26
++
++    vssrani.h.w  vr9,  vr6,  12
++    vssrani.h.w  vr10, vr8,  12
++    vssrani.h.w  vr13, vr11, 12
++    vssrani.h.w  vr14, vr12, 12
++    vssrani.h.w  vr25, vr15, 12
++    vssrani.h.w  vr26, vr24, 12
++
++    vssrani.bu.h vr13, vr9,  0
++    vssrani.bu.h vr14, vr10, 0
++    vilvl.h      vr10, vr26, vr25
++    vilvh.h      vr11, vr26, vr25
++
++    vilvl.b      vr0,  vr14, vr13
++    vilvh.b      vr1,  vr14, vr13
++    vssrani.bu.h vr11, vr10, 0
++    vst          vr0,  a2,   0
++    vst          vr1,  a2,   16
++    vst          vr11, a2,   32
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_sp_48x64
++    fld.d        f24,  sp,   0
++    fld.d        f25,  sp,   8
++    fld.d        f26,  sp,   16
++    addi.d       sp,   sp,   24
++endfunc
++
++.macro FILTER_VERT_SP_WxN  w, h, rep
++function x265_interp_8tap_vert_sp_\w\()x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vld          vr7,   t4,    32
++
++.loopV_sp_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    vld          vr0,   t1,    0
++    vld          vr1,   t1,    16
++    vld          vr2,   t1,    32
++    vld          vr3,   t1,    48
++    add.d        t5,    t1,    a1
++.irp x, vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15
++    vor.v        \x,    vr7,   vr7
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr18, vr18, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr19, vr19, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr20, vr20, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr20, vr20, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr21, vr21, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr21, vr21, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr22, vr22, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr22, vr22, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    VMADD4_W vr0, vr1, vr23, vr23, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr23, vr23, vr12, vr13, vr14, vr15
++
++    vssrani.h.w  vr10, vr8,  12
++    vssrani.h.w  vr11, vr9,  12
++    vssrani.h.w  vr14, vr12, 12
++    vssrani.h.w  vr15, vr13, 12
++    vssrani.bu.h vr14, vr10, 0
++    vssrani.bu.h vr15, vr11, 0
++    addi.d       t1,   t1,   64
++    vilvl.b      vr4,  vr15, vr14
++    vilvh.b      vr5,  vr15, vr14
++    vst          vr4,  t2,   0
++    vst          vr5,  t2,   16
++    addi.d       t2,   t2,   32
++.endr
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_sp_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_SP_WxN 32, 8,  1
++FILTER_VERT_SP_WxN 32, 16, 1
++FILTER_VERT_SP_WxN 32, 24, 1
++FILTER_VERT_SP_WxN 32, 32, 1
++FILTER_VERT_SP_WxN 32, 64, 1
++FILTER_VERT_SP_WxN 64, 16, 2
++FILTER_VERT_SP_WxN 64, 32, 2
++FILTER_VERT_SP_WxN 64, 48, 2
++FILTER_VERT_SP_WxN 64, 64, 2
++
++.macro FILTER_VERT_SP_16xN_LASX  h
++function x265_interp_8tap_vert_sp_16x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++
++    slli.d       t7,    a3,    1
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++    xvld         xr15,  t4,    32
++
++    add.d        a0,    t6,    t3
++    xvld         xr0,   t6,    0
++    xvldx        xr1,   t6,    a1
++    xvldx        xr2,   t6,    t1
++    xvldx        xr3,   t6,    t2
++    xvld         xr4,   a0,    0
++    xvldx        xr5,   a0,    a1
++    xvldx        xr6,   a0,    t1
++    add.d        t6,    a0,    t2
++.loopV_sp_lasx_16x\h:
++    xvld         xr7,   t6,    0
++    xvldx        xr8,   t6,    a1
++.irp x, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr15,  xr15
++.endr
++    XMADD4_W xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADD4_W xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADD4_W xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADD4_W xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADD4_W xr4, xr5, xr20, xr20, xr10, xr11, xr12, xr13
++    XMADD4_W xr5, xr6, xr21, xr21, xr10, xr11, xr12, xr13
++    XMADD4_W xr6, xr7, xr22, xr22, xr10, xr11, xr12, xr13
++    XMADD4_W xr7, xr8, xr23, xr23, xr10, xr11, xr12, xr13
++
++    xvor.v        xr0,  xr2,  xr2
++    xvor.v        xr1,  xr3,  xr3
++    xvor.v        xr2,  xr4,  xr4
++    xvor.v        xr3,  xr5,  xr5
++    xvor.v        xr4,  xr6,  xr6
++    xvor.v        xr5,  xr7,  xr7
++    xvor.v        xr6,  xr8,  xr8
++    xvssrani.h.w  xr12, xr10, 12
++    xvssrani.h.w  xr13, xr11, 12
++    xvilvl.h      xr10, xr13, xr12
++    xvilvh.h      xr11, xr13, xr12
++    xvssrani.bu.h xr11, xr10, 0
++    addi.d        t0,   t0,   -1
++    xvpermi.d     xr12, xr11, 0xD8
++    xvpermi.d     xr13, xr11, 0x8D
++    add.d         t6,   t6,   t1
++    vst           vr12, a2,   0
++    vstx          vr13, a2,   a3
++    add.d         a2,   a2,   t7
++    blt           zero, t0,   .loopV_sp_lasx_16x\h
++endfunc
++.endm
++
++FILTER_VERT_SP_16xN_LASX 4
++FILTER_VERT_SP_16xN_LASX 8
++FILTER_VERT_SP_16xN_LASX 12
++FILTER_VERT_SP_16xN_LASX 16
++FILTER_VERT_SP_16xN_LASX 32
++FILTER_VERT_SP_16xN_LASX 64
++
++function x265_interp_8tap_vert_sp_24x32_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -64
++
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++    fst.d        f29,   sp,    40
++    fst.d        f30,   sp,    48
++    fst.d        f31,   sp,    56
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0
++    xvldx        xr1,   a0,    a1
++    xvldx        xr2,   a0,    t1
++    xvldx        xr3,   a0,    t2
++
++    add.d        a0,    a0,    t3
++    vld          vr9,   t6,    0
++    vldx         vr10,  t6,    a1
++    vldx         vr11,  t6,    t1
++    vldx         vr12,  t6,    t2
++    addi.d       t6,    a0,    32
++
++    xvld         xr4,   a0,    0
++    xvldx        xr5,   a0,    a1
++    xvldx        xr6,   a0,    t1
++
++    vld          vr13,  t6,    0
++    vldx         vr14,  t6,    a1
++    vldx         vr15,  t6,    t1
++    add.d        a0,    a0,    t2
++    xvpermi.q    xr9,   xr10,  0x2
++    xvpermi.q    xr10,  xr11,  0x2
++    xvpermi.q    xr11,  xr12,  0x2
++    xvpermi.q    xr12,  xr13,  0x2
++    xvpermi.q    xr13,  xr14,  0x2
++    xvpermi.q    xr14,  xr15,  0x2
++.loopV_sp_lasx_24x32:
++    addi.d       t6,    a0,    32
++    xvld         xr26,  t4,    32
++    xvld         xr7,   a0,    0
++    xvldx        xr8,   a0,    a1
++    vld          vr24,  t6,    0
++    vldx         vr25,  t6,    a1
++.irp x, xr27, xr28, xr29, xr30, xr31
++    xvor.v       \x,    xr26,  xr26
++.endr
++    xvpermi.q    xr15,  xr24,  0x2
++    xvpermi.q    xr24,  xr25,  0x2
++    XMADD4_W xr0,  xr1,  xr16, xr16, xr26, xr27, xr28, xr29
++    XMADD4_W xr9,  xr1,  xr16, xr17, xr30, xr31, xr26, xr27
++    XMADD4_W xr2,  xr10, xr17, xr17, xr28, xr29, xr30, xr31
++    XMADD4_W xr2,  xr3,  xr18, xr18, xr26, xr27, xr28, xr29
++    XMADD4_W xr11, xr3,  xr18, xr19, xr30, xr31, xr26, xr27
++    XMADD4_W xr4,  xr12, xr19, xr19, xr28, xr29, xr30, xr31
++    XMADD4_W xr4,  xr5,  xr20, xr20, xr26, xr27, xr28, xr29
++    XMADD4_W xr13, xr5,  xr20, xr21, xr30, xr31, xr26, xr27
++    XMADD4_W xr6,  xr14, xr21, xr21, xr28, xr29, xr30, xr31
++    XMADD4_W xr6,  xr7,  xr22, xr22, xr26, xr27, xr28, xr29
++    XMADD4_W xr15, xr7,  xr22, xr23, xr30, xr31, xr26, xr27
++    XMADD4_W xr8,  xr24, xr23, xr23, xr28, xr29, xr30, xr31
++
++    xvor.v        xr0,  xr2,  xr2
++    xvor.v        xr1,  xr3,  xr3
++    xvor.v        xr2,  xr4,  xr4
++    xvor.v        xr3,  xr5,  xr5
++    xvor.v        xr4,  xr6,  xr6
++    xvor.v        xr5,  xr7,  xr7
++    xvor.v        xr6,  xr8,  xr8
++    xvor.v        xr9,  xr11, xr11
++    xvor.v        xr10, xr12, xr12
++    xvor.v        xr11, xr13, xr13
++    xvor.v        xr12, xr14, xr14
++    xvor.v        xr13, xr15, xr15
++    xvor.v        xr14, xr24, xr24
++    xvor.v        xr15, xr25, xr25
++
++    xvssrani.h.w  xr31, xr30, 12
++    xvssrani.h.w  xr28, xr26, 12
++    xvssrani.h.w  xr29, xr27, 12
++    xvpermi.d     xr30, xr31, 0xB1
++    xvilvl.h      xr7,  xr29, xr28
++    xvilvh.h      xr8,  xr29, xr28
++    xvilvl.h      xr24, xr30, xr31
++    addi.d        t0,   t0,   -1
++    xvssrani.bu.h xr8,  xr7,  0
++    xvssrani.bu.h xr25, xr24, 0
++    xvpermi.d     xr26, xr8,  0xD8
++    xvpermi.d     xr27, xr8,  0x8D
++    vst           vr26, a2,   0
++    xvstelm.d     xr25, a2,   16,   0
++    add.d         a2,   a2,   a3
++    add.d         a0,   a0,   t1
++    vst           vr27, a2,   0
++    xvstelm.d     xr25, a2,   16,   2
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_sp_lasx_24x32
++    fld.d         f24,  sp,   0
++    fld.d         f25,  sp,   8
++    fld.d         f26,  sp,   16
++    fld.d         f27,  sp,   24
++    fld.d         f28,  sp,   32
++    fld.d         f29,  sp,   40
++    fld.d         f30,  sp,   48
++    fld.d         f31,  sp,   56
++    addi.d        sp,   sp,   64
++endfunc
++
++function x265_interp_8tap_vert_sp_48x64_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++    xvld         xr7,   t4,    32
++
++.loopV_sp_lasx_48x64:
++    xvld         xr0,   a0,    0
++    xvld         xr1,   a0,    32
++    xvld         xr2,   a0,    64
++    add.d        t5,    a0,    a1
++    xvor.v       xr8,   xr7,   xr7
++    xvor.v       xr9,   xr7,   xr7
++    xvor.v       xr10,  xr7,   xr7
++    xvor.v       xr11,  xr7,   xr7
++    xvor.v       xr12,  xr7,   xr7
++    xvor.v       xr13,  xr7,   xr7
++    XMADD4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr16
++    xvmaddwod.w.h xr13, xr2,   xr16
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr17
++    xvmaddwod.w.h xr13, xr2,   xr17
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr18
++    xvmaddwod.w.h xr13, xr2,   xr18
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr19
++    xvmaddwod.w.h xr13, xr2,   xr19
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr20, xr20, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr20
++    xvmaddwod.w.h xr13, xr2,   xr20
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr21, xr21, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr21
++    xvmaddwod.w.h xr13, xr2,   xr21
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr22, xr22, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr22
++    xvmaddwod.w.h xr13, xr2,   xr22
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    XMADD4_W xr0, xr1, xr23, xr23, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr23
++    xvmaddwod.w.h xr13, xr2,   xr23
++
++    xvssrani.h.w  xr13, xr12, 12
++    xvssrani.h.w  xr10, xr8,  12
++    xvssrani.h.w  xr11, xr9,  12
++    xvpermi.d     xr14, xr13, 0xB1
++    xvilvl.h      xr3,  xr11, xr10
++    xvilvh.h      xr4,  xr11, xr10
++    xvilvl.h      xr5,  xr14, xr13
++    xvssrani.bu.h xr4,  xr3,  0
++    xvssrani.bu.h xr6,  xr5,  0
++    xvpermi.d     xr0,  xr4,  0xD8
++    xvpermi.d     xr1,  xr6,  0xD8
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    xvst          xr0,  a2,   0
++    vst           vr1,  a2,   32
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_sp_lasx_48x64
++endfunc
++
++.macro FILTER_VERT_SP_WxN_LASX  w, h, rep
++function x265_interp_8tap_vert_sp_\w\()x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++    xvld         xr7,   t4,    32
++
++.loopV_sp_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    xvld         xr0,   t1,    0
++    xvld         xr1,   t1,    32
++    add.d        t5,    t1,    a1
++    xvor.v       xr8,   xr7,   xr7
++    xvor.v       xr9,   xr7,   xr7
++    xvor.v       xr10,  xr7,   xr7
++    xvor.v       xr11,  xr7,   xr7
++    XMADD4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr20, xr20, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr21, xr21, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr22, xr22, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    XMADD4_W xr0, xr1, xr23, xr23, xr8, xr9, xr10, xr11
++
++    xvssrani.h.w  xr10, xr8,  12
++    xvssrani.h.w  xr11, xr9,  12
++    addi.d        t1,   t1,   64
++    xvilvl.h      xr12, xr11, xr10
++    xvilvh.h      xr13, xr11, xr10
++    xvssrani.bu.h xr13, xr12, 0
++    xvpermi.d     xr14, xr13, 0xD8
++    xvst          xr14, t2,   0
++    addi.d        t2,   t2,   32
++.endr
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_sp_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_SP_WxN_LASX 32, 8,  1
++FILTER_VERT_SP_WxN_LASX 32, 16, 1
++FILTER_VERT_SP_WxN_LASX 32, 24, 1
++FILTER_VERT_SP_WxN_LASX 32, 32, 1
++FILTER_VERT_SP_WxN_LASX 32, 64, 1
++FILTER_VERT_SP_WxN_LASX 64, 16, 2
++FILTER_VERT_SP_WxN_LASX 64, 32, 2
++FILTER_VERT_SP_WxN_LASX 64, 48, 2
++FILTER_VERT_SP_WxN_LASX 64, 64, 2
++
++.macro FILTER_VERT_SS_4xN  h
++function x265_interp_8tap_vert_ss_4x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_lumaFilter
++    addi.d       sp,    sp,    -24
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/4
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++
++    add.d        a0,    t6,    t3
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++    fldx.d       f11,   t6,    t2   //3
++
++    fld.d        f12,   a0,    0    //4
++    fldx.d       f13,   a0,    a1   //5
++    fldx.d       f14,   a0,    t1   //6
++
++    add.d        t6,    a0,    t2
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vilvl.h      vr4,   vr13,  vr12 //4,5
++    vilvl.h      vr5,   vr14,  vr13 //5,6
++.loopV_ss_4x\h:
++    fld.d        f15,   t6,    0    //7
++    fldx.d       f24,   t6,    a1   //8
++    fldx.d       f25,   t6,    t1   //9
++    fldx.d       f26,   t6,    t2   //10
++    VMULW4_W vr0, vr2, vr16, vr16, vr10, vr11, vr12, vr13
++    vilvl.h      vr6,   vr15,  vr14 //6,7
++    vilvl.h      vr7,   vr24,  vr15 //7,8
++    vilvl.h      vr8,   vr25,  vr24 //8,9
++    vilvl.h      vr9,   vr26,  vr25 //9,10
++
++    VMADD4_W vr1, vr3, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr4, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr5, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr6, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADD4_W vr5, vr7, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADD4_W vr6, vr8, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADD4_W vr7, vr9, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr2,  vr6,  vr6
++    vor.v            vr3,  vr7,  vr7
++    vssrani.h.w      vr11, vr10, 6
++    vssrani.h.w      vr13, vr12, 6
++    vor.v            vr4,  vr8,  vr8
++    vor.v            vr5,  vr9,  vr9
++    vor.v            vr14, vr26, vr26
++    vstelm.d         vr11, a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr11, a2,   0,  1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr13, a2,   0,  1
++    add.d            t6,   t6,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_ss_4x\h
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    addi.d           sp,   sp,   24
++endfunc
++.endm
++
++FILTER_VERT_SS_4xN 4
++FILTER_VERT_SS_4xN 8
++FILTER_VERT_SS_4xN 16
++
++.macro FILTER_VERT_SS_8xN  h
++function x265_interp_8tap_vert_ss_8x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       t4,    a3,    1
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++
++    add.d        a0,    t6,    t3
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++    vldx         vr3,   t6,    t2   //3
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++    add.d        t6,    a0,    t2
++
++.loopV_ss_8x\h:
++    vld          vr7,   t6,    0   //7
++    vldx         vr8,   t6,    a1  //8
++    VMULW4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADD4_W vr5, vr6, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADD4_W vr6, vr7, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADD4_W vr7, vr8, vr23, vr23, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr3,  vr5,  vr5
++    vssrani.h.w      vr12, vr10, 6
++    vssrani.h.w      vr13, vr11, 6
++    vor.v            vr4,  vr6,  vr6
++    vor.v            vr5,  vr7,  vr7
++    vilvl.h          vr10, vr13, vr12
++    vilvh.h          vr11, vr13, vr12
++    vor.v            vr6,  vr8,  vr8
++
++    vst              vr10, a2,   0
++    vstx             vr11, a2,   a3
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t4
++    blt              zero, t0,   .loopV_ss_8x\h
++endfunc
++.endm
++
++FILTER_VERT_SS_8xN 4
++FILTER_VERT_SS_8xN 8
++FILTER_VERT_SS_8xN 16
++FILTER_VERT_SS_8xN 32
++
++function x265_interp_8tap_vert_ss_12x16_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -32
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++    vldi         vr27,  0
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    fld.d        f8,    t6,    0
++    fldx.d       f9,    t6,    a1
++    fldx.d       f10,   t6,    t1
++    fldx.d       f11,   t6,    t2
++    addi.d       t6,    a0,    16
++
++    vilvl.h      vr8,   vr27,  vr8
++    vilvl.h      vr9,   vr27,  vr9
++    vilvl.h      vr10,  vr27,  vr10
++    vilvl.h      vr11,  vr27,  vr11
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    fld.d        f12,   t6,    0
++    fldx.d       f13,   t6,    a1
++    fldx.d       f14,   t6,    t1
++    add.d        a0,    a0,    t2
++    vilvl.h      vr12,  vr27,  vr12
++    vilvl.h      vr13,  vr27,  vr13
++    vilvl.h      vr14,  vr27,  vr14
++.loopV_ss_12x16:
++    vld          vr7,   a0,    0   //7
++    fld.d        f15,   a0,    16  //7
++    vilvl.h      vr15,  vr27, vr15
++    vmulwev.w.h  vr24,  vr0,  vr16
++    vmulwod.w.h  vr25,  vr0,  vr16
++    vmulwev.w.h  vr26,  vr8,  vr16
++
++    vmaddwev.w.h vr24,  vr1,  vr17
++    vmaddwod.w.h vr25,  vr1,  vr17
++    vmaddwev.w.h vr26,  vr9,  vr17
++
++    vmaddwev.w.h vr24,  vr2,  vr18
++    vmaddwod.w.h vr25,  vr2,  vr18
++    vmaddwev.w.h vr26,  vr10, vr18
++
++    vmaddwev.w.h vr24,  vr3,  vr19
++    vmaddwod.w.h vr25,  vr3,  vr19
++    vmaddwev.w.h vr26,  vr11, vr19
++
++    vmaddwev.w.h vr24,  vr4,  vr20
++    vmaddwod.w.h vr25,  vr4,  vr20
++    vmaddwev.w.h vr26,  vr12, vr20
++
++    vmaddwev.w.h vr24,  vr5,  vr21
++    vmaddwod.w.h vr25,  vr5,  vr21
++    vmaddwev.w.h vr26,  vr13, vr21
++
++    vmaddwev.w.h vr24,  vr6,  vr22
++    vmaddwod.w.h vr25,  vr6,  vr22
++    vmaddwev.w.h vr26,  vr14, vr22
++
++    vmaddwev.w.h vr24,  vr7,  vr23
++    vmaddwod.w.h vr25,  vr7,  vr23
++    vmaddwev.w.h vr26,  vr15, vr23
++
++    vor.v            vr0,  vr1,  vr1
++    vor.v            vr1,  vr2,  vr2
++    vor.v            vr2,  vr3,  vr3
++    vor.v            vr3,  vr4,  vr4
++    vor.v            vr4,  vr5,  vr5
++    vor.v            vr5,  vr6,  vr6
++    vor.v            vr6,  vr7,  vr7
++
++    vssrani.h.w      vr26, vr24, 6
++    vssrani.h.w      vr27, vr25, 6
++    vor.v            vr8,  vr9,  vr9
++    vor.v            vr9,  vr10, vr10
++    vor.v            vr10, vr11, vr11
++    vilvl.h          vr24, vr27, vr26
++    vor.v            vr11, vr12, vr12
++    vor.v            vr12, vr13, vr13
++    vor.v            vr13, vr14, vr14
++    vor.v            vr14, vr15, vr15
++
++    vst              vr24, a2,   0
++    vstelm.d         vr26, a2,   16,  1
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ss_12x16
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    fld.d            f27,  sp,   24
++    addi.d           sp,   sp,   32
++endfunc
++
++.macro FILTER_VERT_SS_16xN  h
++function x265_interp_8tap_vert_ss_16x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -32
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    vldx         vr3,   a0,    t2   //3
++
++    add.d        a0,    a0,    t3
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++    vldx         vr10,  t6,    t1
++    vldx         vr11,  t6,    t2
++    addi.d       t6,    a0,    16
++
++    vld          vr4,   a0,    0    //4
++    vldx         vr5,   a0,    a1   //5
++    vldx         vr6,   a0,    t1   //6
++
++    vld          vr12,  t6,    0
++    vldx         vr13,  t6,    a1
++    vldx         vr14,  t6,    t1
++    add.d        a0,    a0,    t2
++.loopV_ss_16x\h:
++    vld          vr7,   a0,    0   //7
++    vld          vr15,  a0,    16  //7
++    VMULW4_W vr0, vr8, vr16, vr16, vr24, vr25, vr26, vr27
++    VMADD4_W vr1, vr9, vr17, vr17, vr24, vr25, vr26, vr27
++    VMADD4_W vr2, vr10, vr18, vr18, vr24, vr25, vr26, vr27
++    VMADD4_W vr3, vr11, vr19, vr19, vr24, vr25, vr26, vr27
++    VMADD4_W vr4, vr12, vr20, vr20, vr24, vr25, vr26, vr27
++    VMADD4_W vr5, vr13, vr21, vr21, vr24, vr25, vr26, vr27
++    VMADD4_W vr6, vr14, vr22, vr22, vr24, vr25, vr26, vr27
++    VMADD4_W vr7, vr15, vr23, vr23, vr24, vr25, vr26, vr27
++
++    vor.v            vr0,  vr1,  vr1
++    vor.v            vr1,  vr2,  vr2
++    vor.v            vr2,  vr3,  vr3
++    vor.v            vr3,  vr4,  vr4
++    vor.v            vr4,  vr5,  vr5
++    vor.v            vr5,  vr6,  vr6
++    vor.v            vr6,  vr7,  vr7
++
++    vssrani.h.w      vr26, vr24, 6
++    vssrani.h.w      vr27, vr25, 6
++    vor.v            vr8,  vr9,  vr9
++    vor.v            vr9,  vr10, vr10
++    vor.v            vr10, vr11, vr11
++    vilvl.h          vr24, vr27, vr26
++    vilvh.h          vr25, vr27, vr26
++    vor.v            vr11, vr12, vr12
++    vor.v            vr12, vr13, vr13
++    vor.v            vr13, vr14, vr14
++    vor.v            vr14, vr15, vr15
++
++    vst              vr24, a2,   0
++    vst              vr25, a2,   16
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ss_16x\h
++    fld.d            f24,  sp,   0
++    fld.d            f25,  sp,   8
++    fld.d            f26,  sp,   16
++    fld.d            f27,  sp,   24
++    addi.d           sp,   sp,   32
++endfunc
++.endm
++
++FILTER_VERT_SS_16xN 4
++FILTER_VERT_SS_16xN 8
++FILTER_VERT_SS_16xN 12
++FILTER_VERT_SS_16xN 16
++FILTER_VERT_SS_16xN 32
++FILTER_VERT_SS_16xN 64
++
++function x265_interp_8tap_vert_ss_24x32_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  32
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++
++.loopV_ss_24x32:
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    add.d        t5,    a0,    a1
++    VMULW4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    vmulwev.w.h vr12,  vr2, vr16
++    vmulwod.w.h vr13,  vr2, vr16
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr17
++    vmaddwod.w.h vr13,  vr2, vr17
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr18
++    vmaddwod.w.h vr13,  vr2, vr18
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr19
++    vmaddwod.w.h vr13,  vr2, vr19
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr20, vr20, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr20
++    vmaddwod.w.h vr13,  vr2, vr20
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr21, vr21, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr21
++    vmaddwod.w.h vr13,  vr2, vr21
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr22, vr22, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr22
++    vmaddwod.w.h vr13,  vr2, vr22
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    VMADD4_W vr0, vr1, vr23, vr23, vr8, vr9, vr10, vr11
++    vmaddwev.w.h vr12,  vr2, vr23
++    vmaddwod.w.h vr13,  vr2, vr23
++
++    vssrani.h.w  vr10, vr8,  6
++    vssrani.h.w  vr11, vr9,  6
++    vssrani.h.w  vr13, vr12, 6
++
++    vilvl.h      vr8,  vr11, vr10
++    vilvh.h      vr9,  vr11, vr10
++    vbsrl.v      vr12, vr13, 8
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    vilvl.h      vr10, vr12, vr13
++
++    vst          vr8,  a2,   0
++    vst          vr9,  a2,   16
++    vst          vr10, a2,   32
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_ss_24x32
++endfunc
++
++function x265_interp_8tap_vert_ss_48x64_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    addi.d       sp,    sp,    -16
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++
++.loopV_ss_48x64:
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++    vld          vr4,   a0,    64
++    vld          vr5,   a0,    80
++    add.d        t5,    a0,    a1
++    VMULW4_W vr0, vr1, vr16, vr16, vr6, vr7, vr8, vr9
++    VMULW4_W vr2, vr3, vr16, vr16, vr10, vr11, vr12, vr13
++    VMULW4_W vr4, vr5, vr16, vr16, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr17, vr17, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr18, vr18, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr19, vr19, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr20, vr20, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr20, vr20, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr20, vr20, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr21, vr21, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr21, vr21, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr21, vr21, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr22, vr22, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr22, vr22, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr22, vr22, vr14, vr15, vr24, vr25
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    VMADD4_W vr0, vr1, vr23, vr23, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr3, vr23, vr23, vr10, vr11, vr12, vr13
++    VMADD4_W vr4, vr5, vr23, vr23, vr14, vr15, vr24, vr25
++
++    vssrani.h.w  vr8,  vr6,  6
++    vssrani.h.w  vr9,  vr7,  6
++    vssrani.h.w  vr12, vr10, 6
++    vssrani.h.w  vr13, vr11, 6
++    vssrani.h.w  vr24, vr14, 6
++    vssrani.h.w  vr25, vr15, 6
++
++    vilvl.h      vr6,  vr9,  vr8
++    vilvh.h      vr7,  vr9,  vr8
++    vilvl.h      vr10, vr13, vr12
++    vilvh.h      vr11, vr13, vr12
++    vilvl.h      vr14, vr25, vr24
++    vilvh.h      vr15, vr25, vr24
++    vst          vr6,  a2,   0
++    vst          vr7,  a2,   16
++    vst          vr10, a2,   32
++    vst          vr11, a2,   48
++    vst          vr14, a2,   64
++    vst          vr15, a2,   80
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_ss_48x64
++    fld.d        f24,  sp,   0
++    fld.d        f25,  sp,   8
++    addi.d       sp,   sp,   16
++endfunc
++
++.macro FILTER_VERT_SS_WxN  w, h, rep
++function x265_interp_8tap_vert_ss_\w\()x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    vldrepl.h    vr16,  t5,    0 + 128
++    vldrepl.h    vr17,  t5,    2 + 128
++    vldrepl.h    vr18,  t5,    4 + 128
++    vldrepl.h    vr19,  t5,    6 + 128
++    vldrepl.h    vr20,  t5,    8 + 128
++    vldrepl.h    vr21,  t5,    10 + 128
++    vldrepl.h    vr22,  t5,    12 + 128
++    vldrepl.h    vr23,  t5,    14 + 128
++
++.loopV_ss_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    vld          vr0,   t1,    0
++    vld          vr1,   t1,    16
++    vld          vr2,   t1,    32
++    vld          vr3,   t1,    48
++    add.d        t5,    t1,    a1
++    VMULW4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMULW4_W vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr18, vr18, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr19, vr19, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr20, vr20, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr20, vr20, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr21, vr21, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr21, vr21, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr22, vr22, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr22, vr22, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    VMADD4_W vr0, vr1, vr23, vr23, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr23, vr23, vr12, vr13, vr14, vr15
++
++    vssrani.h.w  vr10, vr8,  6
++    vssrani.h.w  vr11, vr9,  6
++    vssrani.h.w  vr14, vr12, 6
++    vssrani.h.w  vr15, vr13, 6
++    addi.d       t1,   t1,   64
++    vilvl.h      vr4,  vr11, vr10
++    vilvh.h      vr5,  vr11, vr10
++    vilvl.h      vr6,  vr15, vr14
++    vilvh.h      vr7,  vr15, vr14
++    vst          vr4,  t2,   0
++    vst          vr5,  t2,   16
++    vst          vr6,  t2,   32
++    vst          vr7,  t2,   48
++    addi.d       t2,   t2,   64
++.endr
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_ss_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_SS_WxN 32, 8,  1
++FILTER_VERT_SS_WxN 32, 16, 1
++FILTER_VERT_SS_WxN 32, 24, 1
++FILTER_VERT_SS_WxN 32, 32, 1
++FILTER_VERT_SS_WxN 32, 64, 1
++FILTER_VERT_SS_WxN 64, 16, 2
++FILTER_VERT_SS_WxN 64, 32, 2
++FILTER_VERT_SS_WxN 64, 48, 2
++FILTER_VERT_SS_WxN 64, 64, 2
++
++.macro FILTER_VERT_SS_16xN_LASX  h
++function x265_interp_8tap_vert_ss_16x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    t2  //src -= 3 * srcStride
++    slli.d       t7,    a3,    1
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++
++    add.d        a0,    t6,    t3
++    xvld         xr0,   t6,    0
++    xvldx        xr1,   t6,    a1
++    xvldx        xr2,   t6,    t1
++    xvldx        xr3,   t6,    t2
++    xvld         xr4,   a0,    0
++    xvldx        xr5,   a0,    a1
++    xvldx        xr6,   a0,    t1
++    add.d        t6,    a0,    t2
++.loopV_ss_lasx_16x\h:
++    xvld         xr7,   t6,    0
++    xvldx        xr8,   t6,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADD4_W xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADD4_W xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADD4_W xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADD4_W xr4, xr5, xr20, xr20, xr10, xr11, xr12, xr13
++    XMADD4_W xr5, xr6, xr21, xr21, xr10, xr11, xr12, xr13
++    XMADD4_W xr6, xr7, xr22, xr22, xr10, xr11, xr12, xr13
++    XMADD4_W xr7, xr8, xr23, xr23, xr10, xr11, xr12, xr13
++
++    xvor.v        xr0,  xr2,  xr2
++    xvor.v        xr1,  xr3,  xr3
++    xvor.v        xr2,  xr4,  xr4
++    xvor.v        xr3,  xr5,  xr5
++    xvor.v        xr4,  xr6,  xr6
++    xvor.v        xr5,  xr7,  xr7
++    xvor.v        xr6,  xr8,  xr8
++    xvssrani.h.w  xr12, xr10, 6
++    xvssrani.h.w  xr13, xr11, 6
++    xvilvl.h      xr14, xr13, xr12
++    xvilvh.h      xr15, xr13, xr12
++    addi.d        t0,   t0,   -1
++    xvst          xr14, a2,   0
++    xvstx         xr15, a2,   a3
++    add.d         t6,   t6,   t1
++    add.d         a2,   a2,   t7
++    blt           zero, t0,   .loopV_ss_lasx_16x\h
++endfunc
++.endm
++
++FILTER_VERT_SS_16xN_LASX 4
++FILTER_VERT_SS_16xN_LASX 8
++FILTER_VERT_SS_16xN_LASX 12
++FILTER_VERT_SS_16xN_LASX 16
++FILTER_VERT_SS_16xN_LASX 32
++FILTER_VERT_SS_16xN_LASX 64
++
++function x265_interp_8tap_vert_ss_24x32_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  16
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++    addi.d       sp,    sp,    -64
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++    fst.d        f29,   sp,    40
++    fst.d        f30,   sp,    48
++    fst.d        f31,   sp,    56
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0
++    xvldx        xr1,   a0,    a1
++    xvldx        xr2,   a0,    t1
++    xvldx        xr3,   a0,    t2
++
++    add.d        a0,    a0,    t3
++    vld          vr9,   t6,    0
++    vldx         vr10,  t6,    a1
++    vldx         vr11,  t6,    t1
++    vldx         vr12,  t6,    t2
++    addi.d       t6,    a0,    32
++
++    xvld         xr4,   a0,    0
++    xvldx        xr5,   a0,    a1
++    xvldx        xr6,   a0,    t1
++
++    vld          vr13,  t6,    0
++    vldx         vr14,  t6,    a1
++    vldx         vr15,  t6,    t1
++    add.d        a0,    a0,    t2
++    xvpermi.q    xr9,   xr10,  0x2
++    xvpermi.q    xr10,  xr11,  0x2
++    xvpermi.q    xr11,  xr12,  0x2
++    xvpermi.q    xr12,  xr13,  0x2
++    xvpermi.q    xr13,  xr14,  0x2
++    xvpermi.q    xr14,  xr15,  0x2
++.loopV_ss_lasx_24x32:
++    addi.d       t6,    a0,    32
++    xvld         xr7,   a0,    0
++    xvldx        xr8,   a0,    a1
++    vld          vr24,  t6,    0
++    vldx         vr25,  t6,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr26, xr27, xr28, xr29
++    xvmulwev.w.h xr30,  xr9,   xr16
++    xvmulwod.w.h xr31,  xr9,   xr16
++    xvpermi.q    xr15,  xr24,  0x2
++    xvpermi.q    xr24,  xr25,  0x2
++    XMADD4_W xr1, xr2, xr17, xr17, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr10, xr17
++    xvmaddwod.w.h xr31,  xr10, xr17
++    XMADD4_W xr2, xr3, xr18, xr18, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr11, xr18
++    xvmaddwod.w.h xr31,  xr11, xr18
++    XMADD4_W xr3, xr4, xr19, xr19, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr12, xr19
++    xvmaddwod.w.h xr31,  xr12, xr19
++    XMADD4_W xr4, xr5, xr20, xr20, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr13, xr20
++    xvmaddwod.w.h xr31,  xr13, xr20
++    XMADD4_W xr5, xr6, xr21, xr21, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr14, xr21
++    xvmaddwod.w.h xr31,  xr14, xr21
++    XMADD4_W xr6, xr7, xr22, xr22, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr15, xr22
++    xvmaddwod.w.h xr31,  xr15, xr22
++    XMADD4_W xr7, xr8, xr23, xr23, xr26, xr27, xr28, xr29
++    xvmaddwev.w.h xr30,  xr24, xr23
++    xvmaddwod.w.h xr31,  xr24, xr23
++
++    xvor.v        xr0,  xr2,  xr2
++    xvor.v        xr1,  xr3,  xr3
++    xvor.v        xr2,  xr4,  xr4
++    xvor.v        xr3,  xr5,  xr5
++    xvor.v        xr4,  xr6,  xr6
++    xvor.v        xr5,  xr7,  xr7
++    xvor.v        xr6,  xr8,  xr8
++    xvor.v        xr9,  xr11, xr11
++    xvor.v        xr10, xr12, xr12
++    xvor.v        xr11, xr13, xr13
++    xvor.v        xr12, xr14, xr14
++    xvor.v        xr13, xr15, xr15
++    xvor.v        xr14, xr24, xr24
++    xvor.v        xr15, xr25, xr25
++    xvssrani.h.w  xr31, xr30, 6
++    xvssrani.h.w  xr28, xr26, 6
++    xvssrani.h.w  xr29, xr27, 6
++    xvpermi.d     xr30, xr31, 0xB1
++    xvilvl.h      xr7,  xr29, xr28
++    xvilvh.h      xr8,  xr29, xr28
++    xvilvl.h      xr24, xr30, xr31
++    addi.d        t0,   t0,   -1
++    xvst          xr7,  a2,   0
++    vst           vr24, a2,   32
++    add.d         a2,   a2,   a3
++    xvpermi.d     xr25, xr24, 0x4E
++    add.d         a0,   a0,   t1
++    xvst          xr8,  a2,   0
++    vst           vr25, a2,   32
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_ss_lasx_24x32
++    fld.d         f24,  sp,   0
++    fld.d         f25,  sp,   8
++    fld.d         f26,  sp,   16
++    fld.d         f27,  sp,   24
++    fld.d         f28,  sp,   32
++    fld.d         f29,  sp,   40
++    fld.d         f30,  sp,   48
++    fld.d         f31,  sp,   56
++    addi.d        sp,   sp,   64
++endfunc
++
++function x265_interp_8tap_vert_ss_48x64_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++.loopV_ss_lasx_48x64:
++    xvld         xr0,   a0,    0
++    xvld         xr1,   a0,    32
++    xvld         xr2,   a0,    64
++    add.d        t5,    a0,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvmulwev.w.h xr12,  xr2,   xr16
++    xvmulwod.w.h xr13,  xr2,   xr16
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr17
++    xvmaddwod.w.h xr13, xr2,   xr17
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr18
++    xvmaddwod.w.h xr13, xr2,   xr18
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr19
++    xvmaddwod.w.h xr13, xr2,   xr19
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr20, xr20, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr20
++    xvmaddwod.w.h xr13, xr2,   xr20
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr21, xr21, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr21
++    xvmaddwod.w.h xr13, xr2,   xr21
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr22, xr22, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr22
++    xvmaddwod.w.h xr13, xr2,   xr22
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    XMADD4_W xr0, xr1, xr23, xr23, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr23
++    xvmaddwod.w.h xr13, xr2,   xr23
++
++    xvssrani.h.w  xr13, xr12, 6
++    xvssrani.h.w  xr10, xr8,  6
++    xvssrani.h.w  xr11, xr9,  6
++    xvpermi.d     xr14, xr13, 0xB1
++    xvilvl.h      xr3,  xr11, xr10
++    xvilvh.h      xr4,  xr11, xr10
++    xvilvl.h      xr5,  xr14, xr13
++    xvst          xr3,  a2,   0
++    xvst          xr4,  a2,   32
++    xvst          xr5,  a2,   64
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_ss_lasx_48x64
++endfunc
++
++.macro FILTER_VERT_SS_WxN_LASX  w, h, rep
++function x265_interp_8tap_vert_ss_\w\()x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    4
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_lumaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    t2  //src -= 3 * srcStride
++
++    xvldrepl.h   xr16,  t5,    0 + 128
++    xvldrepl.h   xr17,  t5,    2 + 128
++    xvldrepl.h   xr18,  t5,    4 + 128
++    xvldrepl.h   xr19,  t5,    6 + 128
++    xvldrepl.h   xr20,  t5,    8 + 128
++    xvldrepl.h   xr21,  t5,    10 + 128
++    xvldrepl.h   xr22,  t5,    12 + 128
++    xvldrepl.h   xr23,  t5,    14 + 128
++
++.loopV_ss_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    xvld         xr0,   t1,    0
++    xvld         xr1,   t1,    32
++    add.d        t5,    t1,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr20, xr20, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr21, xr21, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr22, xr22, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    XMADD4_W xr0, xr1, xr23, xr23, xr8, xr9, xr10, xr11
++
++    xvssrani.h.w  xr10, xr8,  6
++    xvssrani.h.w  xr11, xr9,  6
++    addi.d        t1,   t1,   64
++    xvilvl.h      xr12, xr11, xr10
++    xvilvh.h      xr13, xr11, xr10
++    xvst          xr12, t2,   0
++    xvst          xr13, t2,   32
++    addi.d        t2,   t2,   64
++.endr
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_ss_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_SS_WxN_LASX 32, 8,  1
++FILTER_VERT_SS_WxN_LASX 32, 16, 1
++FILTER_VERT_SS_WxN_LASX 32, 24, 1
++FILTER_VERT_SS_WxN_LASX 32, 32, 1
++FILTER_VERT_SS_WxN_LASX 32, 64, 1
++FILTER_VERT_SS_WxN_LASX 64, 16, 2
++FILTER_VERT_SS_WxN_LASX 64, 32, 2
++FILTER_VERT_SS_WxN_LASX 64, 48, 2
++FILTER_VERT_SS_WxN_LASX 64, 64, 2
++
++.macro PROCESS_4TAP_LUMA in0, in1, in2, in3, in4, in5, in6, in7, \
++                         out0, out1, tmp0, tmp1, tmp2, tmp3
++    vhaddw.w.h   \in0,   \in0,  \in0
++    vhaddw.w.h   \in1,   \in1,  \in1
++    vhaddw.w.h   \in2,   \in2,  \in2
++    vhaddw.w.h   \in3,   \in3,  \in3
++    vhaddw.w.h   \in4,   \in4,  \in4
++    vhaddw.w.h   \in5,   \in5,  \in5
++    vhaddw.w.h   \in6,   \in6,  \in6
++    vhaddw.w.h   \in7,   \in7,  \in7
++    vpickev.h    \tmp0,  \in1,  \in0
++    vpickev.h    \tmp1,  \in3,  \in2
++    vpickev.h    \tmp2,  \in5,  \in4
++    vpickev.h    \tmp3,  \in7,  \in6
++    vhaddw.w.h   \tmp0,  \tmp0, \tmp0
++    vhaddw.w.h   \tmp1,  \tmp1, \tmp1
++    vhaddw.w.h   \tmp2,  \tmp2, \tmp2
++    vhaddw.w.h   \tmp3,  \tmp3, \tmp3
++    vpickev.h    \out0,  \tmp1, \tmp0
++    vpickev.h    \out1,  \tmp3, \tmp2
++.endm
++
++.macro FILTER_HORIZ_4TAP_LUMA_2xN  h
++function x265_interp_4tap_horiz_pp_2x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t2,    a1,    1
++    slli.d       t4,    a1,    2
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/4
++    add.d        t3,    t2,    a1
++    addi.d       t1,    a0,    -1
++    vldx         vr10,  t6,    t7
++.loopH_4tap_2x\h:
++    fld.s        f0,    t1,    0
++    fld.s        f1,    a0,    0
++    fldx.s       f2,    t1,    a1
++    fldx.s       f3,    a0,    a1
++    fldx.s       f4,    t1,    t2
++    fldx.s       f5,    a0,    t2
++    fldx.s       f6,    t1,    t3
++    fldx.s       f7,    a0,    t3
++
++    vilvl.b      vr11,  vr2,   vr0
++    vilvl.b      vr12,  vr3,   vr1
++    vilvl.b      vr13,  vr6,   vr4
++    vilvl.b      vr14,  vr7,   vr5
++
++    vilvl.d      vr0,   vr12,  vr11
++    vilvl.d      vr1,   vr14,  vr13
++
++    VMULW4_H vr0, vr1, vr10, vr10, vr4, vr5, vr6, vr7
++
++    vhaddw.w.h   vr11,  vr4,   vr4
++    vhaddw.w.h   vr12,  vr5,   vr5
++    vhaddw.w.h   vr13,  vr6,   vr6
++    vhaddw.w.h   vr14,  vr7,   vr7
++
++    vpickev.h    vr0,   vr12,  vr11
++    vpickev.h    vr1,   vr14,  vr13
++    vhaddw.w.h   vr2,   vr0,   vr0
++    vhaddw.w.h   vr3,   vr1,   vr1
++
++    vpickev.h    vr4,   vr3,   vr2
++    add.d        a0,    a0,    t4
++    vssrarni.bu.h vr5,  vr4,   6
++    add.d        t1,    t1,    t4
++    vstelm.h     vr5,   a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.h     vr5,   a2,    0,    1
++    add.d        a2,    a2,    a3
++    vstelm.h     vr5,   a2,    0,    2
++    add.d        a2,    a2,    a3
++    vstelm.h     vr5,   a2,    0,    3
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopH_4tap_2x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_2xN  4
++FILTER_HORIZ_4TAP_LUMA_2xN  8
++FILTER_HORIZ_4TAP_LUMA_2xN  16
++
++function x265_interp_4tap_horiz_pp_4x2_lsx
++    slli.d       t7,    a4,    5
++    add.d        t0,    a0,    a1
++    la.local     t6,    g_chromaFilter
++    vldx         vr10,  t6,    t7
++    fld.s        f0,    a0,    -1
++    fld.s        f1,    a0,    0
++    fld.s        f2,    a0,    1
++    fld.s        f3,    a0,    2
++    fld.s        f4,    t0,    -1
++    fld.s        f5,    t0,    0
++    fld.s        f6,    t0,    1
++    fld.s        f7,    t0,    2
++
++    vilvl.b      vr11,  vr2,   vr0
++    vilvl.b      vr12,  vr3,   vr1
++    vilvl.b      vr13,  vr6,   vr4
++    vilvl.b      vr14,  vr7,   vr5
++
++    vilvl.d      vr0,   vr12,  vr11
++    vilvl.d      vr1,   vr14,  vr13
++
++    VMULW4_H vr0, vr1, vr10, vr10, vr11, vr12, vr13, vr14
++
++    vhaddw.w.h   vr2,   vr11,  vr11
++    vhaddw.w.h   vr3,   vr12,  vr12
++    vhaddw.w.h   vr4,   vr13,  vr13
++    vhaddw.w.h   vr5,   vr14,  vr14
++
++    vpickev.h    vr0,   vr3,   vr2
++    vpickev.h    vr1,   vr5,   vr4
++    vhaddw.w.h   vr6,   vr0,   vr0
++    vhaddw.w.h   vr7,   vr1,   vr1
++    vpickev.h    vr8,   vr7,   vr6
++
++    vssrarni.bu.h vr9,  vr8,  6
++    vstelm.w     vr9,  a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.w     vr9,  a2,    0,    1
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++endfunc
++
++.macro FILTER_HORIZ_4TAP_LUMA_4xN  h
++function x265_interp_4tap_horiz_pp_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/4
++    vldx         vr10,  t6,    t7
++.loopH_4tap_4x\h:
++    fld.s        f0,    a0,    -1
++    fld.s        f1,    a0,    0
++    fld.s        f2,    a0,    1
++    fld.s        f3,    a0,    2
++    add.d        a0,    a0,    a1
++    vilvl.b      vr11,  vr2,   vr0
++    vilvl.b      vr12,  vr3,   vr1
++    fld.s        f4,    a0,    -1
++    fld.s        f5,    a0,    0
++    fld.s        f6,    a0,    1
++    fld.s        f7,    a0,    2
++    add.d        a0,    a0,    a1
++    vilvl.b      vr13,  vr6,   vr4
++    vilvl.b      vr14,  vr7,   vr5
++    fld.d        f0,    a0,    -1
++    fld.d        f1,    a0,    0
++    fld.d        f2,    a0,    1
++    fld.d        f3,    a0,    2
++    add.d        a0,    a0,    a1
++    vilvl.b      vr15,  vr2,   vr0
++    vilvl.b      vr16,  vr3,   vr1
++    fld.d        f4,    a0,    -1
++    fld.d        f5,    a0,    0
++    fld.d        f6,    a0,    1
++    fld.d        f7,    a0,    2
++    add.d        a0,    a0,    a1
++    vilvl.b      vr17,  vr6,   vr4
++    vilvl.b      vr18,  vr7,   vr5
++
++    vilvl.d      vr0,   vr12,  vr11
++    vilvl.d      vr1,   vr14,  vr13
++    vilvl.d      vr2,   vr16,  vr15
++    vilvl.d      vr3,   vr18,  vr17
++
++    VMULW4_H vr0, vr1, vr10, vr10, vr11, vr12, vr13, vr14
++    VMULW4_H vr2, vr3, vr10, vr10, vr15, vr16, vr17, vr18
++
++    PROCESS_4TAP_LUMA vr11, vr12, vr13, vr14, vr15, vr16, vr17, vr18, \
++                      vr20, vr21, vr0, vr1, vr2, vr3
++
++    vssrarni.bu.h vr21, vr20, 6
++    vstelm.w     vr21,  a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.w     vr21,  a2,    0,    1
++    add.d        a2,    a2,    a3
++    vstelm.w     vr21,  a2,    0,    2
++    add.d        a2,    a2,    a3
++    vstelm.w     vr21,  a2,    0,    3
++    addi.d       t0,    t0,    -1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopH_4tap_4x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_4xN  4
++FILTER_HORIZ_4TAP_LUMA_4xN  8
++FILTER_HORIZ_4TAP_LUMA_4xN  16
++FILTER_HORIZ_4TAP_LUMA_4xN  32
++
++.macro FILTER_HORIZ_4TAP_LUMA_6xN  h
++function x265_interp_4tap_horiz_pp_6x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    vldx         vr10,  t6,    t7
++.loopH_4tap_6x\h:
++    add.d        t2,    a0,    a1
++    fld.d        f0,    a0,    -1
++    fld.d        f1,    a0,    0
++    fld.d        f2,    a0,    1
++    fld.d        f3,    a0,    2
++    fld.d        f4,    t2,    -1
++    fld.d        f5,    t2,    0
++    fld.d        f6,    t2,    1
++    fld.d        f7,    t2,    2
++
++    vilvl.b      vr11,  vr2,   vr0
++    vilvl.b      vr12,  vr3,   vr1
++    vilvl.b      vr13,  vr6,   vr4
++    vilvl.b      vr14,  vr7,   vr5
++
++    VMULW4_H vr11, vr12, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr13, vr14, vr10, vr10, vr4, vr5, vr6, vr7
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.w.h   \x, \x, \x
++.endr
++
++    vpickev.h       vr11, vr1,  vr0
++    vpickev.h       vr12, vr3,  vr2
++    vpickev.h       vr13, vr5,  vr4
++    vpickev.h       vr14, vr7,  vr6
++
++.irp x, vr11, vr12, vr13, vr14
++    vhaddw.w.h   \x, \x, \x
++.endr
++
++    vpackev.h       vr8,  vr12, vr11
++    vpackev.h       vr9,  vr14, vr13
++    add.d           a0,   t2,   a1
++    vssrarni.bu.h   vr9,  vr8,  6
++    vshuf4i.h       vr11, vr9,  0xd8
++    vstelm.w        vr11, a2,   0,    0
++    vstelm.h        vr11, a2,   4,    2
++    add.d           a2,   a2,   a3
++    vstelm.w        vr11, a2,   0,    2
++    vstelm.h        vr11, a2,   4,    6
++    addi.d          t0,   t0,   -1
++    add.d           a2,   a2,   a3
++    blt             zero, t0,   .loopH_4tap_6x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_6xN 8
++FILTER_HORIZ_4TAP_LUMA_6xN 16
++
++.macro FILTER_HORIZ_4TAP_LUMA_8xN  h
++function x265_interp_4tap_horiz_pp_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    vldx         vr10,  t6,    t7
++.loopH_4tap_8x\h:
++    add.d        t2,    a0,    a1
++    fld.d        f0,    a0,    -1
++    fld.d        f1,    a0,    0
++    fld.d        f2,    a0,    1
++    fld.d        f3,    a0,    2
++    fld.d        f4,    t2,    -1
++    fld.d        f5,    t2,    0
++    fld.d        f6,    t2,    1
++    fld.d        f7,    t2,    2
++
++    vilvl.b      vr11,  vr2,   vr0
++    vilvl.b      vr12,  vr3,   vr1
++    vilvl.b      vr13,  vr6,   vr4
++    vilvl.b      vr14,  vr7,   vr5
++
++    VMULW4_H vr11, vr12, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr13, vr14, vr10, vr10, vr4, vr5, vr6, vr7
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.w.h   \x, \x, \x
++.endr
++
++    vpickev.h       vr11, vr1,  vr0
++    vpickev.h       vr12, vr3,  vr2
++    vpickev.h       vr13, vr5,  vr4
++    vpickev.h       vr14, vr7,  vr6
++
++.irp x, vr11, vr12, vr13, vr14
++    vhaddw.w.h   \x, \x, \x
++.endr
++
++    vpackev.h       vr8,  vr12, vr11
++    vpackev.h       vr9,  vr14, vr13
++    add.d           a0,   t2,   a1
++    vssrarni.bu.h   vr9,  vr8,  6
++    vshuf4i.h       vr11, vr9,  0xd8
++    vstelm.d        vr11, a2,   0,    0
++    add.d           a2,   a2,   a3
++    vstelm.d        vr11, a2,   0,    1
++    addi.d          t0,   t0,   -1
++    add.d           a2,   a2,   a3
++    blt             zero, t0,   .loopH_4tap_8x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_8xN 2
++FILTER_HORIZ_4TAP_LUMA_8xN 4
++FILTER_HORIZ_4TAP_LUMA_8xN 6
++FILTER_HORIZ_4TAP_LUMA_8xN 8
++FILTER_HORIZ_4TAP_LUMA_8xN 12
++FILTER_HORIZ_4TAP_LUMA_8xN 16
++FILTER_HORIZ_4TAP_LUMA_8xN 32
++FILTER_HORIZ_4TAP_LUMA_8xN 64
++
++.macro FILTER_HORIZ_4TAP_LUMA_12xN h
++function x265_interp_4tap_horiz_pp_12x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    vldx         vr10,  t6,    t7
++.loopH_4tap_12x\h:
++    add.d        t1,    a0,    a1
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    vld          vr4,   t1,    -1
++    vld          vr5,   t1,    0
++    vld          vr6,   t1,    1
++    vld          vr7,   t1,    2
++
++    vilvh.w      vr8,   vr4,   vr0
++    vilvh.w      vr9,   vr5,   vr1
++    vilvh.w      vr11,  vr6,   vr2
++    vilvh.w      vr12,  vr7,   vr3
++
++    vilvl.b      vr13,  vr1,   vr0
++    vilvl.b      vr14,  vr3,   vr2
++    vilvl.b      vr15,  vr5,   vr4
++    vilvl.b      vr16,  vr7,   vr6
++    vilvl.b      vr17,  vr9,   vr8
++    vilvl.b      vr18,  vr12,  vr11
++
++    VMULW4_H vr13, vr14, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr15, vr16, vr10, vr10, vr4, vr5, vr6, vr7
++    VMULW4_H vr17, vr18, vr10, vr10, vr19, vr20, vr21, vr22
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, vr19, vr20, vr21, vr22
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h      vr11, vr2,  vr0
++    vpickev.h      vr12, vr3,  vr1
++    vpickev.h      vr13, vr6,  vr4
++    vpickev.h      vr14, vr7,  vr5
++    vpickev.h      vr15, vr21, vr19
++    vpickev.h      vr16, vr22, vr20
++
++.irp x, vr11, vr12, vr15, vr16, vr13, vr14
++    vhaddw.w.h \x, \x, \x
++.endr
++
++    vpackev.h      vr0,  vr12, vr11
++    vpackev.h      vr1,  vr16, vr15
++    vpackev.h      vr2,  vr14, vr13
++
++    vssrarni.bu.h  vr1,  vr0,  6
++    vssrarni.bu.h  vr3,  vr2,  6
++
++    vshuf4i.h      vr4,  vr1,  0xD8
++    vshuf4i.h      vr5,  vr3,  0xD8
++    vstelm.d       vr4,  a2,   0,    0
++    vstelm.w       vr4,  a2,   8,    2
++    add.d          a2,   a2,   a3
++    add.d          a0,   t1,   a1
++    addi.d         t0,   t0,   -1
++    vstelm.d       vr5,  a2,   0,    0
++    vstelm.w       vr4,  a2,   8,    3
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopH_4tap_12x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_12xN  16
++FILTER_HORIZ_4TAP_LUMA_12xN  32
++
++.macro FILTER_HORIZ_4TAP_LUMA_16xN  h
++function x265_interp_4tap_horiz_pp_16x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    vldx         vr10,  t6,    t7
++.loopH_4tap_16x\h:
++    add.d        t1,    a0,    a1
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    vld          vr4,   t1,    -1
++    vld          vr5,   t1,    0
++    vld          vr6,   t1,    1
++    vld          vr7,   t1,    2
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++    vilvl.b      vr13,  vr5,   vr4
++    vilvl.b      vr14,  vr7,   vr6
++    vilvh.b      vr15,  vr5,   vr4
++    vilvh.b      vr16,  vr7,   vr6
++
++    VMULW4_H vr8, vr9, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr11, vr12, vr10, vr10, vr4, vr5, vr6, vr7
++    VMULW4_H vr13, vr14, vr10, vr10, vr8, vr9, vr17, vr18
++    VMULW4_H vr15, vr16, vr10, vr10, vr19, vr20, vr21, vr22
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7,\
++     vr8, vr9, vr17, vr18, vr19, vr20, vr21, vr22
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h      vr11, vr2,  vr0
++    vpickev.h      vr12, vr3,  vr1
++    vpickev.h      vr13, vr6,  vr4
++    vpickev.h      vr14, vr7,  vr5
++    vpickev.h      vr15, vr17, vr8
++    vpickev.h      vr16, vr18, vr9
++    vpickev.h      vr0,  vr21, vr19
++    vpickev.h      vr1,  vr22, vr20
++
++.irp x, vr11, vr12, vr13, vr14, vr15, vr16, vr0, vr1
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpackev.h      vr2,  vr12, vr11
++    vpackev.h      vr3,  vr14, vr13
++    vpackev.h      vr4,  vr16, vr15
++    vpackev.h      vr5,  vr1,  vr0
++
++    vssrarni.bu.h  vr3,  vr2,  6
++    vssrarni.bu.h  vr5,  vr4,  6
++
++    vshuf4i.h      vr6,  vr3,  0xD8
++    vshuf4i.h      vr7,  vr5,  0xD8
++
++    vst            vr6,  a2,    0
++    vstx           vr7,  a2,    a3
++    addi.d         t0,   t0,    -1
++    add.d          a0,   t1,    a1
++    add.d          a2,   a2,    t3
++    blt            zero, t0,    .loopH_4tap_16x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_16xN 4
++FILTER_HORIZ_4TAP_LUMA_16xN 8
++FILTER_HORIZ_4TAP_LUMA_16xN 12
++FILTER_HORIZ_4TAP_LUMA_16xN 16
++FILTER_HORIZ_4TAP_LUMA_16xN 24
++FILTER_HORIZ_4TAP_LUMA_16xN 32
++FILTER_HORIZ_4TAP_LUMA_16xN 64
++
++.macro FILTER_HORIZ_4TAP_LUMA_24xN h
++function x265_interp_4tap_horiz_pp_24x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h
++    vldx         vr10,  t6,    t7
++.loopH_4tap_24x\h:
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    fld.d        f4,    a0,    15
++    fld.d        f5,    a0,    16
++    fld.d        f6,    a0,    17
++    fld.d        f7,    a0,    18
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++    vilvl.b      vr13,  vr5,   vr4
++    vilvl.b      vr14,  vr7,   vr6
++
++    VMULW4_H vr8, vr9, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr11, vr12, vr10, vr10, vr4, vr5, vr6, vr7
++    VMULW4_H vr13, vr14, vr10, vr10, vr8, vr9, vr17, vr18
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, vr8, vr9, vr17, vr18
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h      vr11, vr2,  vr0
++    vpickev.h      vr12, vr3,  vr1
++    vpickev.h      vr13, vr6,  vr4
++    vpickev.h      vr14, vr7,  vr5
++    vpickev.h      vr15, vr17, vr8
++    vpickev.h      vr16, vr18, vr9
++
++.irp x, vr11, vr12, vr13, vr14, vr15, vr16
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpackev.h      vr2,  vr12, vr11
++    vpackev.h      vr3,  vr14, vr13
++    vpackev.h      vr4,  vr16, vr15
++
++    vssrarni.bu.h  vr3,  vr2,  6
++    vssrarni.bu.h  vr5,  vr4,  6
++
++    vshuf4i.h      vr6,  vr3,  0xD8
++    vshuf4i.h      vr7,  vr5,  0xD8
++
++    vst            vr6,  a2,   0
++    vstelm.d       vr7,  a2,   16,   0
++    add.d          a0,   a0,   a1
++    addi.d         t0,   t0,   -1
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopH_4tap_24x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_24xN  32
++FILTER_HORIZ_4TAP_LUMA_24xN  64
++
++.macro FILTER_HORIZ_4TAP_LUMA_WxN  w, h, rep
++function x265_interp_4tap_horiz_pp_\w\()x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h
++    vldx         vr10,  t6,    t7
++.loopH_4tap_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept  \rep
++    vld          vr0,   t1,    -1
++    vld          vr1,   t1,    0
++    vld          vr2,   t1,    1
++    vld          vr3,   t1,    2
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++
++    VMULW4_H vr8, vr9, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr11, vr12, vr10, vr10, vr4, vr5, vr6, vr7
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h      vr11, vr2,  vr0
++    vpickev.h      vr12, vr3,  vr1
++    vpickev.h      vr13, vr6,  vr4
++    vpickev.h      vr14, vr7,  vr5
++
++.irp x, vr11, vr12, vr13, vr14
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpackev.h      vr2,  vr12, vr11
++    vpackev.h      vr3,  vr14, vr13
++
++    vssrarni.bu.h  vr3,  vr2,  6
++    addi.d         t1,   t1,   16
++    vshuf4i.h      vr6,  vr3,  0xD8
++    vst            vr6,  t2,   0
++    addi.d         t2,   t2,   16
++.endr
++    addi.d         t0,   t0,   -1
++    add.d          a0,   a0,   a1
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopH_4tap_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_WxN 32, 8,  2
++FILTER_HORIZ_4TAP_LUMA_WxN 32, 16, 2
++FILTER_HORIZ_4TAP_LUMA_WxN 32, 24, 2
++FILTER_HORIZ_4TAP_LUMA_WxN 32, 32, 2
++FILTER_HORIZ_4TAP_LUMA_WxN 32, 48, 2
++FILTER_HORIZ_4TAP_LUMA_WxN 32, 64, 2
++
++FILTER_HORIZ_4TAP_LUMA_WxN 48, 64, 3
++
++FILTER_HORIZ_4TAP_LUMA_WxN 64, 16, 4
++FILTER_HORIZ_4TAP_LUMA_WxN 64, 32, 4
++FILTER_HORIZ_4TAP_LUMA_WxN 64, 48, 4
++FILTER_HORIZ_4TAP_LUMA_WxN 64, 64, 4
++
++.macro FILTER_HORIZ_4TAP_LUMA_16xN_LASX  h
++function x265_interp_4tap_horiz_pp_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    xvldx        xr10,  t6,    t7
++.loopH_4tap_lasx_16x\h:
++    add.d        t1,    a0,    a1
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    vld          vr4,   t1,    -1
++    vld          vr5,   t1,    0
++    vld          vr6,   t1,    1
++    vld          vr7,   t1,    2
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++
++    vilvl.b      vr13,  vr5,   vr4
++    vilvl.b      vr14,  vr7,   vr6
++    vilvh.b      vr15,  vr5,   vr4
++    vilvh.b      vr16,  vr7,   vr6
++
++    xvpermi.q    xr13,  xr8,   0x20
++    xvpermi.q    xr14,  xr9,   0x20
++    xvpermi.q    xr15,  xr11,  0x20
++    xvpermi.q    xr16,  xr12,  0x20
++    XMULW4_H xr13, xr14, xr10, xr10, xr8, xr9, xr17, xr18
++    XMULW4_H xr15, xr16, xr10, xr10, xr19, xr20, xr21, xr22
++
++.irp x, xr8, xr9, xr17, xr18, xr19, xr20, xr21, xr22
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h     xr15, xr17, xr8
++    xvpickev.h     xr16, xr18, xr9
++    xvpickev.h     xr0,  xr21, xr19
++    xvpickev.h     xr1,  xr22, xr20
++
++.irp x, xr15, xr16, xr0, xr1
++    xvhaddw.w.h   \x, \x, \x
++.endr
++
++    xvpackev.h     xr4,  xr16, xr15
++    xvpackev.h     xr5,  xr1,  xr0
++
++    xvssrarni.bu.h xr5,  xr4,  6
++
++    xvshuf4i.h     xr6,  xr5,  0xD8
++    addi.d         t0,   t0,    -1
++    add.d          a0,   t1,    a1
++    xvpermi.d      xr7,  xr6,  0x4E
++
++    vst            vr6,  a2,    0
++    vstx           vr7,  a2,    a3
++    add.d          a2,   a2,    t3
++    blt            zero, t0,    .loopH_4tap_lasx_16x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 4
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 8
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 12
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 16
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 24
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 32
++FILTER_HORIZ_4TAP_LUMA_16xN_LASX 64
++
++.macro FILTER_HORIZ_4TAP_LUMA_24xN_LASX h
++function x265_interp_4tap_horiz_pp_24x\h\()_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    xvldx        xr10,  t6,    t7
++.loopH_4tap_lasx_24x\h:
++    add.d        t1,    a0,    a1
++    xvld         xr0,   a0,    -1
++    xvld         xr1,   a0,    0
++    xvld         xr2,   a0,    1
++    xvld         xr3,   a0,    2
++    xvld         xr20,  t1,    -1
++    xvld         xr21,  t1,    0
++    xvld         xr22,  t1,    1
++    xvld         xr23,  t1,    2
++
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    xvpermi.q    xr12,  xr8,   0x20
++    xvpermi.q    xr13,  xr9,   0x20
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++    XMULW4_H xr12, xr13, xr10, xr10, xr18, xr19, xr20, xr21
++
++.irp x, xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, xr18, xr19, xr20, xr21
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h      xr4, xr2,  xr0
++    xvpickev.h      xr5, xr3,  xr1
++    xvpickev.h      xr6, xr16, xr14
++    xvpickev.h      xr7, xr17, xr15
++    xvpickev.h      xr8, xr20, xr18
++    xvpickev.h      xr9, xr21, xr19
++
++.irp x, xr4, xr5, xr6, xr7, xr8, xr9
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpackev.h     xr0,  xr5,  xr4
++    xvpackev.h     xr2,  xr9,  xr8
++    xvpackev.h     xr1,  xr7,  xr6
++    xvpermi.d      xr3,  xr2,  0x4E
++
++    xvssrarni.bu.h xr1,  xr0,  6
++    vssrarni.bu.h  vr3,  vr2,  6
++
++    xvshuf4i.h     xr4,  xr1,  0xD8
++    vshuf4i.h      vr5,  vr3,  0xD8
++
++    add.d          t2,   a2,   a3
++    xvilvl.d       xr6,  xr5,  xr4
++    xvilvh.d       xr7,  xr5,  xr4
++    vst            vr6,  a2,   0
++    xvstelm.d      xr6,  a2,   16,   2
++    add.d          a0,   t1,   a1
++    addi.d         t0,   t0,   -1
++    vst            vr7,  t2,   0
++    xvstelm.d      xr7,  t2,   16,   2
++    add.d          a2,   t2,   a3
++    blt            zero, t0,   .loopH_4tap_lasx_24x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_24xN_LASX  32
++FILTER_HORIZ_4TAP_LUMA_24xN_LASX  64
++
++function x265_interp_4tap_horiz_pp_48x64_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  64
++    xvldx        xr10,  t6,    t7
++.loopH_4tap_lasx_48x64:
++    xvld         xr0,   a0,    -1
++    xvld         xr1,   a0,    0
++    xvld         xr2,   a0,    1
++    xvld         xr3,   a0,    2
++    vld          vr20,  a0,    31
++    vld          vr21,  a0,    32
++    vld          vr22,  a0,    33
++    vld          vr23,  a0,    34
++
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    vilvl.b      vr6,   vr21,  vr20
++    vilvl.b      vr7,   vr23,  vr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    vilvh.b      vr12,  vr21,  vr20
++    vilvh.b      vr13,  vr23,  vr22
++
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr8, xr9, xr10, xr10, xr14, xr15, xr16, xr17
++    XMULW4_H xr12, xr13, xr10, xr10, xr18, xr19, xr20, xr21
++
++.irp x, xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, xr18, xr19, xr20, xr21
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h   xr4,  xr2,  xr0
++    xvpickev.h   xr5,  xr3,  xr1
++    xvpickev.h   xr6,  xr16, xr14
++    xvpickev.h   xr7,  xr17, xr15
++    xvpickev.h   xr8,  xr20, xr18
++    xvpickev.h   xr9,  xr21, xr19
++
++.irp x, xr4, xr5, xr6, xr7, xr8, xr9
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpackev.h     xr0,  xr5,  xr4
++    xvpackev.h     xr2,  xr9,  xr8
++    xvpackev.h     xr1,  xr7,  xr6
++    xvpermi.d      xr3,  xr2,  0x4E
++
++    xvssrarni.bu.h xr1,  xr0,  6
++    vssrarni.bu.h  vr3,  vr2,  6
++
++    xvshuf4i.h     xr4,  xr1,  0xD8
++    vshuf4i.h      vr5,  vr3,  0xD8
++
++    xvst           xr4,  a2,   0
++    vst            vr5,  a2,   32
++    addi.d         t0,   t0,   -1
++    add.d          a0,   a0,   a1
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopH_4tap_lasx_48x64
++endfunc
++
++.macro FILTER_HORIZ_4TAP_LUMA_WxN_LASX  w, h, rep
++function x265_interp_4tap_horiz_pp_\w\()x\h\()_lasx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    addi.d       t0,    zero,  \h/2
++    xvldx        xr10,  t6,    t7
++    slli.d       t3,    a1,    1
++    slli.d       t4,    a3,    1
++.loopH_4tap_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept  \rep
++    add.d        t5,    t1,    a1
++    xvld         xr0,   t1,    -1
++    xvld         xr1,   t1,    0
++    xvld         xr2,   t1,    1
++    xvld         xr3,   t1,    2
++    xvld         xr20,  t5,    -1
++    xvld         xr21,  t5,    0
++    xvld         xr22,  t5,    1
++    xvld         xr23,  t5,    2
++
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr21,  xr20
++    xvilvl.b     xr7,   xr23,  xr22
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr21,  xr20
++    xvilvh.b     xr13,  xr23,  xr22
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++    XMULW4_H xr12, xr13, xr10, xr10, xr18, xr19, xr20, xr21
++
++.irp x, xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, \
++     xr4, xr5, xr6, xr7, xr18, xr19, xr20, xr21
++    xvhaddw.w.h  \x, \x, \x
++.endr
++    xvpickev.h   xr8,  xr2,  xr0
++    xvpickev.h   xr9,  xr3,  xr1
++    xvpickev.h   xr12, xr16, xr14
++    xvpickev.h   xr13, xr17, xr15
++    xvpickev.h   xr0,  xr6,  xr4
++    xvpickev.h   xr1,  xr7,  xr5
++    xvpickev.h   xr2,  xr20, xr18
++    xvpickev.h   xr3,  xr21, xr19
++
++.irp x, xr8, xr9, xr12, xr13, xr0, xr1, xr2, xr3
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpackev.h     xr4,  xr9,  xr8
++    xvpackev.h     xr5,  xr13, xr12
++    xvpackev.h     xr6,  xr1,  xr0
++    xvpackev.h     xr7,  xr3,  xr2
++
++    xvssrarni.bu.h xr5,  xr4,  6
++    xvssrarni.bu.h xr7,  xr6,  6
++
++    xvshuf4i.h     xr0,  xr5,  0xD8
++    xvshuf4i.h     xr1,  xr7,  0xD8
++
++    xvilvl.d       xr2,  xr1,  xr0
++    xvilvh.d       xr3,  xr1,  xr0
++    addi.d         t1,   t1,   32
++    xvst           xr2,  t2,   0
++    xvstx          xr3,  t2,   a3
++    addi.d         t2,   t2,   32
++.endr
++    addi.d         t0,   t0,   -1
++    add.d          a0,   a0,   t3
++    add.d          a2,   a2,   t4
++    blt            zero, t0,   .loopH_4tap_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 32, 8,  1
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 32, 16, 1
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 32, 24, 1
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 32, 32, 1
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 32, 48, 1
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 32, 64, 1
++
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 64, 16, 2
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 64, 32, 2
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 64, 48, 2
++FILTER_HORIZ_4TAP_LUMA_WxN_LASX 64, 64, 2
++
++.macro FILTER_HORIZ_4TAP_PS_2xN  h
++function x265_interp_4tap_horiz_ps_2x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    slli.d       t2,    a1,    1  //srcStride*2
++    slli.d       t4,    a1,    2  //srcStride*4
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h/4
++    add.d        t3,    t2,    a1  //srcStride*3
++    beqz         a5,    .loopS_4tap_2x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t1,    a0,    -1
++    fld.s        f1,    a0,    0
++    fldx.s       f3,    a0,    a1
++    fldx.s       f5,    a0,    t2
++    fld.s        f0,    t1,    0
++    fldx.s       f2,    t1,    a1
++    fldx.s       f4,    t1,    t2
++    vilvl.b      vr6,   vr2,   vr0
++    vilvl.b      vr7,   vr3,   vr1
++    vilvl.w      vr9,   vr5,   vr4
++    vilvl.d      vr8,   vr7,   vr6
++    vilvl.b      vr3,   vr4,   vr9
++    vmulwev.h.bu.b vr0, vr8,   vr10
++    vmulwod.h.bu.b vr1, vr8,   vr10
++    vmulwev.h.bu.b vr2, vr3,   vr10
++    vhaddw.w.h   vr0,   vr0,   vr0
++    vhaddw.w.h   vr1,   vr1,   vr1
++    vhaddw.w.h   vr2,   vr2,   vr2
++    vpickev.h    vr3,   vr1,   vr0
++    vpickev.h    vr4,   vr5,   vr2
++    vhaddw.w.h   vr3,   vr3,   vr3
++    vhaddw.w.h   vr4,   vr4,   vr4
++    vpickev.h    vr5,   vr4,   vr3
++    vadd.h       vr6,   vr5,   vr11
++    add.d        a0,    a0,    t3
++    vstelm.w     vr6,   a2,    0,   0
++    add.d        a2,    a2,    a3
++    vstelm.w     vr6,   a2,    0,   1
++    add.d        a2,    a2,    a3
++    vstelm.w     vr6,   a2,    0,   2
++    add.d        a2,    a2,    a3
++.loopS_4tap_2x\h:
++    addi.d       t1,    a0,    -1
++    fld.s        f1,    a0,    0
++    fldx.s       f3,    a0,    a1
++    fldx.s       f5,    a0,    t2
++    fldx.s       f7,    a0,    t3
++    fld.s        f0,    t1,    0
++    fldx.s       f2,    t1,    a1
++    fldx.s       f4,    t1,    t2
++    fldx.s       f6,    t1,    t3
++    add.d        a0,    a0,    t4
++    vilvl.b      vr12,  vr2,   vr0
++    vilvl.b      vr13,  vr3,   vr1
++    vilvl.b      vr14,  vr6,   vr4
++    vilvl.b      vr15,  vr7,   vr5
++    vilvl.d      vr8,   vr13,  vr12
++    vilvl.d      vr9,   vr15,  vr14
++
++    VMULW4_H  vr8, vr9, vr10, vr10, vr0, vr1, vr2, vr3
++.irp x, vr0, vr1, vr2, vr3
++    vhaddw.w.h  \x, \x, \x
++.endr
++    vpickev.h    vr4,   vr1,   vr0
++    vpickev.h    vr5,   vr3,   vr2
++    vhaddw.w.h   vr4,   vr4,   vr4
++    vhaddw.w.h   vr5,   vr5,   vr5
++    vpickev.h    vr6,   vr5,   vr4
++    vadd.h       vr7,   vr6,   vr11
++    addi.d       t0,    t0,    -1
++    vstelm.w     vr7,   a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.w     vr7,   a2,    0,    1
++    add.d        a2,    a2,    a3
++    vstelm.w     vr7,   a2,    0,    2
++    add.d        a2,    a2,    a3
++    vstelm.w     vr7,   a2,    0,    3
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4tap_2x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_2xN  4
++FILTER_HORIZ_4TAP_PS_2xN  8
++FILTER_HORIZ_4TAP_PS_2xN  16
++
++.macro FILTER_HORIZ_4TAP_PS_4xN  h
++function x265_interp_4tap_horiz_ps_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h/2
++    beqz         a5,    .loopS_4tap_4x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    1
++
++    fld.s        f0,    a0,    -1
++    fld.s        f1,    a0,    0
++    fld.s        f2,    a0,    1
++    fld.s        f3,    a0,    2
++    vilvl.b      vr4,   vr2,   vr0
++    vilvl.b      vr5,   vr3,   vr1
++    vilvl.d      vr6,   vr5,   vr4
++    vmulwev.h.bu.b vr7, vr6,   vr10
++    vmulwod.h.bu.b vr8, vr6,   vr10
++    vhaddw.w.h   vr7,   vr7,   vr7
++    vhaddw.w.h   vr8,   vr8,   vr8
++    vpickev.h    vr9,   vr8,   vr7
++    vhaddw.w.h   vr9,   vr9,   vr9
++    vpickev.h    vr6,   vr0,   vr9
++    vadd.h       vr7,   vr6,   vr11
++    add.d        a0,    a0,    a1
++    fst.d        f7,    a2,    0
++    add.d        a2,    a2,    a3
++.loopS_4tap_4x\h:
++    fld.s        f0,    a0,    -1
++    fld.s        f1,    a0,    0
++    fld.s        f2,    a0,    1
++    fld.s        f3,    a0,    2
++    add.d        a0,    a0,    a1
++    vilvl.b      vr4,   vr2,   vr0
++    vilvl.b      vr5,   vr3,   vr1
++    fld.s        f16,   a0,    -1
++    fld.s        f17,   a0,    0
++    fld.s        f18,   a0,    1
++    fld.s        f19,   a0,    2
++    vilvl.b      vr6,   vr18,  vr16
++    vilvl.b      vr7,   vr19,  vr17
++    add.d        a0,    a0,    a1
++    vilvl.d      vr8,   vr5,   vr4
++    vilvl.d      vr9,   vr7,   vr6
++    VMULW4_H vr8, vr9, vr10, vr10, vr12, vr13, vr14, vr15
++.irp x, vr12, vr13, vr14, vr15
++    vhaddw.w.h  \x, \x, \x
++.endr
++    vpickev.h    vr16,  vr13,  vr12
++    vpickev.h    vr17,  vr15,  vr14
++    vhaddw.w.h   vr16,  vr16,  vr16
++    vhaddw.w.h   vr17,  vr17,  vr17
++    vpickev.h    vr18,  vr17,  vr16
++    vadd.h       vr19,  vr18,  vr11
++    addi.d       t0,    t0,    -1
++    vstelm.d     vr19,  a2,    0,    0
++    add.d        a2,    a2,    a3
++    vstelm.d     vr19,  a2,    0,    1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4tap_4x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_4xN  2
++FILTER_HORIZ_4TAP_PS_4xN  4
++FILTER_HORIZ_4TAP_PS_4xN  8
++FILTER_HORIZ_4TAP_PS_4xN  16
++FILTER_HORIZ_4TAP_PS_4xN  32
++
++.macro FILTER_HORIZ_4TAP_PS_6xN  h
++function x265_interp_4tap_horiz_ps_6x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    beqz         a5,    .loopS_4tap_6x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_6x\h:
++    fld.d        f0,    a0,    -1
++    fld.d        f1,    a0,    0
++    fld.d        f2,    a0,    1
++    fld.d        f3,    a0,    2
++    vilvl.b      vr4,   vr2,   vr0
++    vilvl.b      vr5,   vr3,   vr1
++    VMULW4_H vr4, vr5, vr10, vr10, vr0, vr1, vr2, vr3
++.irp x, vr0, vr1, vr2, vr3
++    vhaddw.w.h  \x, \x, \x
++.endr
++    vpickev.h    vr4,   vr1,   vr0
++    vpickev.h    vr5,   vr3,   vr2
++    vhaddw.w.h   vr4,   vr4,   vr4
++    vhaddw.w.h   vr5,   vr5,   vr5
++    vpackev.h    vr6,   vr5,   vr4
++    add.d        a0,    a0,    a1
++    vadd.h       vr7,   vr6,   vr11
++    addi.d       t0,    t0,    -1
++    vstelm.w     vr7,   a2,    0,   0
++    vstelm.w     vr7,   a2,    4,   2
++    vstelm.w     vr7,   a2,    8,   1
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4tap_6x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_6xN 8
++FILTER_HORIZ_4TAP_PS_6xN 16
++
++.macro FILTER_HORIZ_4TAP_PS_8xN  h
++function x265_interp_4tap_horiz_ps_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    beqz         a5,    .loopS_4tap_8x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_8x\h:
++    fld.d        f0,    a0,    -1
++    fld.d        f1,    a0,    0
++    fld.d        f2,    a0,    1
++    fld.d        f3,    a0,    2
++    vilvl.b      vr4,   vr2,   vr0
++    vilvl.b      vr5,   vr3,   vr1
++    VMULW4_H vr4, vr5, vr10, vr10, vr0, vr1, vr2, vr3
++.irp x, vr0, vr1, vr2, vr3
++    vhaddw.w.h  \x, \x, \x
++.endr
++    vpickev.h    vr4,   vr1,   vr0
++    vpickev.h    vr5,   vr3,   vr2
++    vhaddw.w.h   vr4,   vr4,   vr4
++    vhaddw.w.h   vr5,   vr5,   vr5
++    vpackev.h    vr6,   vr5,   vr4
++    add.d        a0,    a0,    a1
++    vadd.h       vr7,   vr6,   vr11
++    addi.d       t0,    t0,    -1
++    vshuf4i.w    vr8,   vr7,   0xD8
++    vst          vr8,   a2,    0
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4tap_8x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_8xN 2
++FILTER_HORIZ_4TAP_PS_8xN 4
++FILTER_HORIZ_4TAP_PS_8xN 6
++FILTER_HORIZ_4TAP_PS_8xN 8
++FILTER_HORIZ_4TAP_PS_8xN 12
++FILTER_HORIZ_4TAP_PS_8xN 16
++FILTER_HORIZ_4TAP_PS_8xN 32
++FILTER_HORIZ_4TAP_PS_8xN 64
++
++.macro FILTER_HORIZ_4TAP_PS_12xN  h
++function x265_interp_4tap_horiz_ps_12x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr11,  t5,    0
++    addi.d       t0,    zero,  \h
++    beqz         a5,    .loopS_4tap_12x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_12x\h:
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    vilvh.b      vr6,   vr2,   vr0
++    vilvh.b      vr7,   vr3,   vr1
++    vilvl.b      vr4,   vr2,   vr0
++    vilvl.b      vr5,   vr3,   vr1
++    vilvl.d      vr8,   vr7,   vr6  //8,10,9,11
++    VMULW4_H vr4, vr5, vr10, vr10, vr0, vr1, vr2, vr3
++    vmulwev.h.bu.b vr16, vr8,  vr10
++    vmulwod.h.bu.b vr17, vr8,  vr10
++
++.irp x, vr0, vr1, vr2, vr3, vr16, vr17
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h    vr4,   vr1,   vr0
++    vpickev.h    vr5,   vr3,   vr2
++    vpickev.h    vr15,  vr17,  vr16
++    vhaddw.w.h   vr4,   vr4,   vr4
++    vhaddw.w.h   vr5,   vr5,   vr5
++    vhaddw.w.h   vr15,  vr15,  vr15
++    vpackev.h    vr6,   vr5,   vr4
++    vpickev.h    vr9,   vr16,  vr15
++    add.d        a0,    a0,    a1
++    vadd.h       vr7,   vr6,   vr11
++    vadd.h       vr8,   vr9,   vr11
++    vshuf4i.w    vr7,   vr7,   0xD8
++    addi.d       t0,    t0,    -1
++    vst          vr7,   a2,    0
++    fst.d        f8,    a2,    16
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4tap_12x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_12xN  16
++FILTER_HORIZ_4TAP_PS_12xN  32
++
++.macro FILTER_HORIZ_4TAP_PS_24xN  h
++function x265_interp_4tap_horiz_ps_24x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    vldx         vr10,  t6,    t7
++    vld          vr21,  t5,    0
++    addi.d       t0,    zero,  \h
++    beqz         a5,    .loopS_4tap_24x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_24x\h:
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    fld.d        f4,    a0,    15
++    fld.d        f5,    a0,    16
++    fld.d        f6,    a0,    17
++    fld.d        f7,    a0,    18
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++    vilvl.b      vr13,  vr5,   vr4
++    vilvl.b      vr14,  vr7,   vr6
++
++    VMULW4_H vr8, vr9, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr11, vr12, vr10, vr10, vr4, vr5, vr6, vr7
++    VMULW4_H vr13, vr14, vr10, vr10, vr8, vr9, vr17, vr18
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, vr8, vr9, vr17, vr18
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h    vr11,  vr2,   vr0
++    vpickev.h    vr12,  vr3,   vr1
++    vpickev.h    vr13,  vr6,   vr4
++    vpickev.h    vr14,  vr7,   vr5
++    vpickev.h    vr15,  vr17,  vr8
++    vpickev.h    vr16,  vr18,  vr9
++
++.irp x, vr11, vr12, vr13, vr14, vr15, vr16
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpackev.h    vr2,   vr12,  vr11
++    vpackev.h    vr3,   vr14,  vr13
++    vpackev.h    vr4,   vr16,  vr15
++
++    add.d        a0,    a0,    a1
++    vadd.h       vr5,   vr2,   vr21
++    vadd.h       vr6,   vr3,   vr21
++    vadd.h       vr7,   vr4,   vr21
++    vshuf4i.w    vr0,   vr5,   0xD8
++    vshuf4i.w    vr1,   vr6,   0xD8
++    vshuf4i.w    vr2,   vr7,   0xD8
++    addi.d       t0,    t0,    -1
++    vst          vr0,   a2,    0
++    vst          vr1,   a2,    16
++    vst          vr2,   a2,    32
++    add.d        a2,    a2,    a3
++    blt          zero,  t0,    .loopS_4tap_24x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_24xN  32
++FILTER_HORIZ_4TAP_PS_24xN  64
++
++.macro FILTER_HORIZ_4TAP_PS_WxN  w, h, rep
++function x265_interp_4tap_horiz_ps_\w\()x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    addi.d       t0,    zero,  \h
++    vldx         vr10,  t6,    t7
++    vld          vr21,  t5,    0
++    beqz         a5,    .loopS_4tap_\w\()x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept  \rep
++    vld          vr0,   t1,    -1
++    vld          vr1,   t1,    0
++    vld          vr2,   t1,    1
++    vld          vr3,   t1,    2
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++
++    VMULW4_H vr8, vr9, vr10, vr10, vr0, vr1, vr2, vr3
++    VMULW4_H vr11, vr12, vr10, vr10, vr4, vr5, vr6, vr7
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h      vr11, vr2,  vr0
++    vpickev.h      vr12, vr3,  vr1
++    vpickev.h      vr13, vr6,  vr4
++    vpickev.h      vr14, vr7,  vr5
++
++.irp x, vr11, vr12, vr13, vr14
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpackev.h      vr2,  vr12, vr11
++    vpackev.h      vr3,  vr14, vr13
++
++    vadd.h         vr4,  vr2,  vr21
++    vadd.h         vr5,  vr3,  vr21
++    addi.d         t1,   t1,   16
++    vshuf4i.w      vr6,  vr4,  0xD8
++    vshuf4i.w      vr7,  vr5,  0xD8
++    vst            vr6,  t2,   0
++    vst            vr7,  t2,   16
++    addi.d         t2,   t2,   32
++.endr
++    addi.d         t0,   t0,   -1
++    add.d          a0,   a0,   a1
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopS_4tap_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_WxN 16, 4,  1
++FILTER_HORIZ_4TAP_PS_WxN 16, 8,  1
++FILTER_HORIZ_4TAP_PS_WxN 16, 12, 1
++FILTER_HORIZ_4TAP_PS_WxN 16, 16, 1
++FILTER_HORIZ_4TAP_PS_WxN 16, 24, 1
++FILTER_HORIZ_4TAP_PS_WxN 16, 32, 1
++FILTER_HORIZ_4TAP_PS_WxN 16, 64, 1
++
++FILTER_HORIZ_4TAP_PS_WxN 32, 8,  2
++FILTER_HORIZ_4TAP_PS_WxN 32, 16, 2
++FILTER_HORIZ_4TAP_PS_WxN 32, 24, 2
++FILTER_HORIZ_4TAP_PS_WxN 32, 32, 2
++FILTER_HORIZ_4TAP_PS_WxN 32, 48, 2
++FILTER_HORIZ_4TAP_PS_WxN 32, 64, 2
++
++FILTER_HORIZ_4TAP_PS_WxN 48, 64, 3
++
++FILTER_HORIZ_4TAP_PS_WxN 64, 16, 4
++FILTER_HORIZ_4TAP_PS_WxN 64, 32, 4
++FILTER_HORIZ_4TAP_PS_WxN 64, 48, 4
++FILTER_HORIZ_4TAP_PS_WxN 64, 64, 4
++
++.macro FILTER_HORIZ_4TAP_PS_16xN_LASX  h
++function x265_interp_4tap_horiz_ps_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    addi.d       t0,    zero,  \h/2
++    xvldx        xr10,  t6,    t7
++    xvld         xr23,  t5,    0
++    slli.d       t3,    a3,    1
++    beqz         a5,    .loopS_4tap_lasx_16x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    1
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++
++    xvpermi.q    xr11,  xr8,   0x20
++    xvpermi.q    xr12,  xr9,   0x20
++    XMULW4_H xr11, xr12, xr10, xr10, xr8, xr9, xr17, xr18
++
++.irp x, xr8, xr9, xr17, xr18
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h     xr15, xr17, xr8
++    xvpickev.h     xr16, xr18, xr9
++    xvhaddw.w.h    xr15, xr15, xr15
++    xvhaddw.w.h    xr16, xr16, xr16
++    xvpackev.h     xr4,  xr16, xr15
++    xvadd.h        xr6,  xr4,  xr23
++    xvshuf4i.w     xr8,  xr6,  0xD8
++    add.d          a0,   a0,   a1
++    xvst           xr8,  a2,   0
++    add.d          a2,   a2,   a3
++.loopS_4tap_lasx_16x\h:
++    add.d        t1,    a0,    a1
++    vld          vr0,   a0,    -1
++    vld          vr1,   a0,    0
++    vld          vr2,   a0,    1
++    vld          vr3,   a0,    2
++    vld          vr4,   t1,    -1
++    vld          vr5,   t1,    0
++    vld          vr6,   t1,    1
++    vld          vr7,   t1,    2
++
++    vilvl.b      vr8,   vr1,   vr0
++    vilvl.b      vr9,   vr3,   vr2
++    vilvh.b      vr11,  vr1,   vr0
++    vilvh.b      vr12,  vr3,   vr2
++
++    vilvl.b      vr13,  vr5,   vr4
++    vilvl.b      vr14,  vr7,   vr6
++    vilvh.b      vr15,  vr5,   vr4
++    vilvh.b      vr16,  vr7,   vr6
++
++    xvpermi.q    xr11,  xr8,   0x20
++    xvpermi.q    xr12,  xr9,   0x20
++    xvpermi.q    xr15,  xr13,  0x20
++    xvpermi.q    xr16,  xr14,  0x20
++    XMULW4_H xr11, xr12, xr10, xr10, xr8, xr9, xr17, xr18
++    XMULW4_H xr15, xr16, xr10, xr10, xr19, xr20, xr21, xr22
++
++.irp x, xr8, xr9, xr17, xr18, xr19, xr20, xr21, xr22
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h     xr15, xr17, xr8
++    xvpickev.h     xr16, xr18, xr9
++    xvpickev.h     xr0,  xr21, xr19
++    xvpickev.h     xr1,  xr22, xr20
++
++.irp x, xr15, xr16, xr0, xr1
++    xvhaddw.w.h   \x, \x, \x
++.endr
++
++    xvpackev.h     xr4,  xr16, xr15
++    xvpackev.h     xr5,  xr1,  xr0
++
++    xvadd.h        xr6,  xr4,  xr23
++    xvadd.h        xr7,  xr5,  xr23
++
++    xvshuf4i.w     xr8,  xr6,  0xD8
++    xvshuf4i.w     xr9,  xr7,  0xD8
++    addi.d         t0,   t0,    -1
++    add.d          a0,   t1,    a1
++    xvst           xr8,  a2,    0
++    xvstx          xr9,  a2,    a3
++    add.d          a2,   a2,    t3
++    blt            zero, t0,    .loopS_4tap_lasx_16x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_16xN_LASX 4
++FILTER_HORIZ_4TAP_PS_16xN_LASX 8
++FILTER_HORIZ_4TAP_PS_16xN_LASX 12
++FILTER_HORIZ_4TAP_PS_16xN_LASX 16
++FILTER_HORIZ_4TAP_PS_16xN_LASX 24
++FILTER_HORIZ_4TAP_PS_16xN_LASX 32
++FILTER_HORIZ_4TAP_PS_16xN_LASX 64
++
++.macro FILTER_HORIZ_4TAP_PS_24xN_LASX h
++function x265_interp_4tap_horiz_ps_24x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    addi.d       t0,    zero,  \h/2
++    xvldx        xr10,  t6,    t7
++    xvld         xr23,  t5,    0
++    beqz         a5,    .loopS_4tap_lasx_24x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    1
++    xvld         xr0,   a0,    -1
++    xvld         xr1,   a0,    0
++    xvld         xr2,   a0,    1
++    xvld         xr3,   a0,    2
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvh.b     xr8,   xr2,   xr0
++    xvilvh.b     xr9,   xr3,   xr1
++    xvpermi.q    xr9,   xr8,   0x20
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    xvmulwev.h.bu.b xr14, xr9, xr10
++    xvmulwod.h.bu.b xr15, xr9, xr10
++
++.irp x, xr0, xr1, xr2, xr3, xr14, xr15
++    xvhaddw.w.h  \x, \x, \x
++.endr
++    xvpickev.h      xr4, xr2,  xr0
++    xvpickev.h      xr6, xr15, xr14
++    xvpickev.h      xr5, xr3,  xr1
++
++    xvhaddw.w.h     xr4, xr4,  xr4
++    xvhaddw.w.h     xr6, xr6,  xr6
++    xvhaddw.w.h     xr5, xr5,  xr5
++
++    xvpermi.d       xr7, xr6,  0x4E
++    xvpackev.h      xr0, xr5,  xr4
++    xvpackev.h      xr1, xr7,  xr6
++    xvadd.h         xr0, xr0,  xr23
++    xvadd.h         xr1, xr1,  xr23
++    xvshuf4i.w      xr2, xr0,  0xD8
++    xvshuf4i.w      xr3, xr1,  0xD8
++    xvpermi.d       xr4, xr2,  0x4E
++    xvpermi.q       xr3, xr2,  0x20
++    add.d           a0,  a0,   a1
++    xvst            xr3, a2,   0
++    vst             vr4, a2,   32
++    add.d           a2,  a2,   a3
++.loopS_4tap_lasx_24x\h:
++    add.d        t1,    a0,    a1
++    xvld         xr0,   a0,    -1
++    xvld         xr1,   a0,    0
++    xvld         xr2,   a0,    1
++    xvld         xr3,   a0,    2
++    xvld         xr18,  t1,    -1
++    xvld         xr19,  t1,    0
++    xvld         xr20,  t1,    1
++    xvld         xr21,  t1,    2
++
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvl.b     xr6,   xr19,  xr18
++    xvilvl.b     xr7,   xr21,  xr20
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    xvilvh.b     xr12,  xr19,  xr18
++    xvilvh.b     xr13,  xr21,  xr20
++
++    xvpermi.q    xr12,  xr8,   0x20
++    xvpermi.q    xr13,  xr9,   0x20
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr6, xr7, xr10, xr10, xr14, xr15, xr16, xr17
++    XMULW4_H xr12, xr13, xr10, xr10, xr18, xr19, xr20, xr21
++
++.irp x, xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, xr18, xr19, xr20, xr21
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h      xr4, xr2,  xr0
++    xvpickev.h      xr5, xr3,  xr1
++    xvpickev.h      xr6, xr16, xr14
++    xvpickev.h      xr7, xr17, xr15
++    xvpickev.h      xr8, xr20, xr18
++    xvpickev.h      xr9, xr21, xr19
++
++.irp x, xr4, xr5, xr6, xr7, xr8, xr9
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpackev.h     xr0,  xr5,  xr4
++    xvpackev.h     xr1,  xr7,  xr6
++    xvpackev.h     xr2,  xr9,  xr8
++
++    xvadd.h        xr0,  xr0,  xr23
++    xvadd.h        xr1,  xr1,  xr23
++    xvadd.h        xr2,  xr2,  xr23
++    xvshuf4i.w     xr4,  xr0,  0xD8
++    xvshuf4i.w     xr5,  xr1,  0xD8
++    xvshuf4i.w     xr6,  xr2,  0xD8
++    xvpermi.d      xr7,  xr4,  0x4E
++    xvpermi.d      xr8,  xr5,  0x4E
++
++    xvpermi.q      xr4,  xr6,  0x02
++    xvpermi.q      xr5,  xr6,  0x12
++    xvst           xr4,  a2,   0
++    vst            vr7,  a2,   32
++    add.d          a2,   a2,   a3
++    add.d          a0,   t1,   a1
++    addi.d         t0,   t0,   -1
++    xvst           xr5,  a2,   0
++    vst            vr8,  a2,   32
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopS_4tap_lasx_24x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_24xN_LASX  32
++FILTER_HORIZ_4TAP_PS_24xN_LASX  64
++
++function x265_interp_4tap_horiz_ps_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    addi.d       t0,    zero,  64
++    xvldx        xr10,  t6,    t7
++    xvld         xr23,  t5,    0
++    beqz         a5,    .loopS_4tap_lasx_48x64
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_lasx_48x64:
++    xvld         xr0,   a0,    -1
++    xvld         xr1,   a0,    0
++    xvld         xr2,   a0,    1
++    xvld         xr3,   a0,    2
++    vld          vr18,  a0,    31
++    vld          vr19,  a0,    32
++    vld          vr20,  a0,    33
++    vld          vr21,  a0,    34
++
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    vilvl.b      vr6,   vr19,  vr18
++    vilvl.b      vr7,   vr21,  vr20
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++    vilvh.b      vr12,  vr19,  vr18
++    vilvh.b      vr13,  vr21,  vr20
++
++    xvpermi.q    xr12,  xr6,   0x20
++    xvpermi.q    xr13,  xr7,   0x20
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr8, xr9, xr10, xr10, xr14, xr15, xr16, xr17
++    XMULW4_H xr12, xr13, xr10, xr10, xr18, xr19, xr20, xr21
++
++.irp x, xr0, xr1, xr2, xr3, xr14, xr15, xr16, xr17, xr18, xr19, xr20, xr21
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpickev.h   xr4,  xr2,  xr0
++    xvpickev.h   xr5,  xr3,  xr1
++    xvpickev.h   xr6,  xr16, xr14
++    xvpickev.h   xr7,  xr17, xr15
++    xvpickev.h   xr8,  xr20, xr18
++    xvpickev.h   xr9,  xr21, xr19
++
++.irp x, xr4, xr5, xr6, xr7, xr8, xr9
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpackev.h     xr0,  xr5,  xr4
++    xvpackev.h     xr2,  xr9,  xr8
++    xvpackev.h     xr1,  xr7,  xr6
++
++    xvadd.h        xr0,  xr0,  xr23
++    xvadd.h        xr2,  xr2,  xr23
++    xvadd.h        xr1,  xr1,  xr23
++    xvshuf4i.w     xr3,  xr0,  0xD8
++    xvshuf4i.w     xr4,  xr1,  0xD8
++    xvshuf4i.w     xr5,  xr2,  0xD8
++    xvor.v         xr6,  xr3,  xr3
++    xvpermi.q      xr3,  xr4,  0x2
++    xvpermi.q      xr6,  xr4,  0x13
++
++    xvst           xr3,  a2,   0
++    xvst           xr6,  a2,   32
++    xvst           xr5,  a2,   64
++    addi.d         t0,   t0,   -1
++    add.d          a0,   a0,   a1
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopS_4tap_lasx_48x64
++endfunc
++
++.macro FILTER_HORIZ_4TAP_PS_WxN_LASX  w, h, rep
++function x265_interp_4tap_horiz_ps_\w\()x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t5,    h_psOffset
++    addi.d       t0,    zero,  \h
++    xvldx        xr10,  t6,    t7
++    xvld         xr23,  t5,    0
++    beqz         a5,    .loopS_4tap_lasx_\w\()x\h
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    t0,    3
++.loopS_4tap_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept  \rep
++    add.d        t5,    t1,    a1
++    xvld         xr0,   t1,    -1
++    xvld         xr1,   t1,    0
++    xvld         xr2,   t1,    1
++    xvld         xr3,   t1,    2
++
++    xvilvl.b     xr4,   xr1,   xr0
++    xvilvl.b     xr5,   xr3,   xr2
++    xvilvh.b     xr8,   xr1,   xr0
++    xvilvh.b     xr9,   xr3,   xr2
++
++    XMULW4_H xr4, xr5, xr10, xr10, xr0, xr1, xr2, xr3
++    XMULW4_H xr8, xr9, xr10, xr10, xr4, xr5, xr6, xr7
++
++.irp x, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7
++    xvhaddw.w.h  \x, \x, \x
++.endr
++    xvpickev.h   xr14,  xr2,  xr0
++    xvpickev.h   xr15,  xr3,  xr1
++    xvpickev.h   xr16,  xr6,  xr4
++    xvpickev.h   xr17,  xr7,  xr5
++
++.irp x, xr14, xr15, xr16, xr17
++    xvhaddw.w.h  \x, \x, \x
++.endr
++
++    xvpackev.h     xr0,  xr15, xr14
++    xvpackev.h     xr1,  xr17, xr16
++    xvadd.h        xr2,  xr0,  xr23
++    xvadd.h        xr3,  xr1,  xr23
++    xvshuf4i.w     xr4,  xr2,  0xD8
++    xvshuf4i.w     xr5,  xr3,  0xD8
++    xvor.v         xr6,  xr4,  xr4
++    xvpermi.q      xr4,  xr5,  0x2
++    xvpermi.q      xr6,  xr5,  0x13
++    addi.d         t1,   t1,   32
++    xvst           xr4,  t2,   0
++    xvst           xr6,  t2,   32
++    addi.d         t2,   t2,   64
++.endr
++    addi.d         t0,   t0,   -1
++    add.d          a0,   a0,   a1
++    add.d          a2,   a2,   a3
++    blt            zero, t0,   .loopS_4tap_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_HORIZ_4TAP_PS_WxN_LASX 32, 8,  1
++FILTER_HORIZ_4TAP_PS_WxN_LASX 32, 16, 1
++FILTER_HORIZ_4TAP_PS_WxN_LASX 32, 24, 1
++FILTER_HORIZ_4TAP_PS_WxN_LASX 32, 32, 1
++FILTER_HORIZ_4TAP_PS_WxN_LASX 32, 48, 1
++FILTER_HORIZ_4TAP_PS_WxN_LASX 32, 64, 1
++
++FILTER_HORIZ_4TAP_PS_WxN_LASX 64, 16, 2
++FILTER_HORIZ_4TAP_PS_WxN_LASX 64, 32, 2
++FILTER_HORIZ_4TAP_PS_WxN_LASX 64, 48, 2
++FILTER_HORIZ_4TAP_PS_WxN_LASX 64, 64, 2
++
++function x265_interp_4tap_vert_pp_2x4_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    sub.d        a0,    a0,    a1
++    vldx         vr16,  t6,    t7
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++
++    vilvl.h      vr8,   vr1,   vr0  //0, 1
++    vilvl.h      vr9,   vr3,   vr2  //2, 3
++    vilvl.h      vr10,  vr2,   vr1  //1, 2
++    vilvl.h      vr11,  vr4,   vr3  //3, 4
++    vilvl.h      vr12,  vr5,   vr4  //4, 5
++    vilvl.h      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.w      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.w      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.w      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.w      vr3,   vr14,  vr11 //3,4,5,6
++
++    vilvl.d      vr4,   vr1,   vr0  //0,1,2,3,1,2,3,4
++    vilvl.d      vr5,   vr3,   vr2  //2,3,4,5,3,4,5,6
++
++    VMULW4_H  vr4, vr5, vr16, vr16, vr6, vr7, vr8, vr9
++    vhaddw.w.h   vr0,   vr6,   vr6
++    vhaddw.w.h   vr1,   vr7,   vr7
++    vhaddw.w.h   vr2,   vr8,   vr8
++    vhaddw.w.h   vr3,   vr9,   vr9
++
++    vpickev.h    vr4,   vr2,   vr0
++    vpickev.h    vr5,   vr3,   vr1
++    vhaddw.w.h   vr6,   vr4,   vr4
++    vhaddw.w.h   vr7,   vr5,   vr5
++    vpackev.h    vr8,   vr7,   vr6
++
++    vssrarni.bu.h    vr10, vr8,  6
++
++    vstelm.h         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.h         vr10, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.h         vr10, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.h         vr10, a2,   0,   3
++endfunc
++
++.macro VERT_4TAP_PP_2xH  h
++function x265_interp_4tap_vert_pp_2x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    zero,  \h/8
++    vldx         vr16,  t6,    t7
++
++.loopV_4tap_2x\h:
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.h      vr8,   vr1,   vr0  //0, 1
++    vilvl.h      vr9,   vr3,   vr2  //2, 3
++    vilvl.h      vr10,  vr2,   vr1  //1, 2
++    vilvl.h      vr11,  vr4,   vr3  //3, 4
++    vilvl.h      vr12,  vr5,   vr4  //4, 5
++    vilvl.h      vr13,  vr7,   vr6  //6, 7
++    vilvl.h      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.w      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.w      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.w      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.w      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.w      vr4,   vr13,  vr12 //4,5,6,7
++
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.h      vr15,  vr8,   vr7  //7, 8
++    vilvl.h      vr11,  vr9,   vr8  //8, 9
++    vilvl.h      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.w      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.w      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.w      vr7,   vr12,  vr15 //7,8,9,10
++
++    vilvl.d      vr8,   vr1,   vr0
++    vilvl.d      vr9,   vr3,   vr2
++    vilvl.d      vr10,  vr5,   vr4
++    vilvl.d      vr11,  vr7,   vr6
++
++    VMULW4_H  vr8, vr9, vr16, vr16, vr0, vr1, vr2, vr3
++    VMULW4_H  vr10, vr11, vr16, vr16, vr4, vr5, vr6, vr7
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h    vr8,   vr2,   vr0
++    vpickev.h    vr9,   vr3,   vr1
++    vpickev.h    vr10,  vr6,   vr4
++    vpickev.h    vr11,  vr7,   vr5
++.irp x, vr8, vr9, vr10, vr11
++    vhaddw.w.h  \x, \x, \x
++.endr
++    vpackev.h    vr0,   vr9,   vr8
++    vpackev.h    vr1,   vr11,  vr10
++    vssrarni.bu.h    vr1,  vr0,  6
++    addi.d           t0,   t0,   -1
++    vstelm.h         vr1,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   3
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   4
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   5
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   6
++    add.d            a2,   a2,   a3
++    vstelm.h         vr1,  a2,   0,   7
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_2x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_2xH  8
++VERT_4TAP_PP_2xH  16
++
++function x265_interp_4tap_vert_pp_4x2_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    sub.d        a0,    a0,    a1
++    vldx         vr16,  t6,    t7
++
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++    fldx.s       f4,    a0,    t3   //4
++
++    vilvl.h      vr8,   vr1,   vr0  //0, 1
++    vilvl.h      vr9,   vr3,   vr2  //2, 3
++    vilvl.h      vr10,  vr2,   vr1  //1, 2
++    vilvl.h      vr11,  vr4,   vr3  //3, 4
++
++    vilvl.w      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.w      vr1,   vr11,  vr10 //1,2,3,4
++
++    VMULW4_H vr0, vr1, vr16, vr16, vr9, vr10, vr11, vr12
++
++    vhaddw.w.h   vr0,   vr9,   vr9
++    vhaddw.w.h   vr1,   vr10,  vr10
++    vhaddw.w.h   vr2,   vr11,  vr11
++    vhaddw.w.h   vr3,   vr12,  vr12
++
++    vpickev.h    vr4,   vr1,   vr0
++    vpickev.h    vr5,   vr3,   vr2
++    vhaddw.w.h   vr6,   vr4,   vr4
++    vhaddw.w.h   vr7,   vr5,   vr5
++    vpickev.h    vr8,   vr7,   vr6
++
++    vssrarni.bu.h    vr9,  vr8,  6
++    vshuf4i.b        vr10, vr9,  0xD8
++    vstelm.w         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   1
++endfunc
++
++function x265_interp_4tap_vert_pp_4x4_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        a0,    a0,    a1
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++
++    vmulwev.h.bu.b   vr9,  vr0,  vr16   //0, 2
++    vmulwod.h.bu.b   vr10, vr0,  vr16   //1, 3
++
++    VMADDW4_H vr1, vr2, vr17, vr18, vr9, vr10, vr9, vr10
++    vmaddwev.h.bu.b  vr9,  vr3,  vr19
++    vmaddwod.h.bu.b  vr10, vr3,  vr19
++    vssrarni.bu.h    vr10, vr9,  6
++    vstelm.w         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   3
++endfunc
++
++.macro VERT_4TAP_PP_4xH  h
++function x265_interp_4tap_vert_pp_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        a0,    a0,    a1
++    addi.d       t0,    zero,  \h/8
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++.loopV_4tap_4x\h:
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++    VMULW4_H  vr0, vr4, vr16, vr16, vr9, vr10, vr11, vr12
++    VMADDW4_H vr1, vr5, vr17, vr17, vr9, vr10, vr11, vr12
++    VMADDW4_H vr2, vr6, vr18, vr18, vr9, vr10, vr11, vr12
++    VMADDW4_H vr3, vr7, vr19, vr19, vr9, vr10, vr11, vr12
++
++    vssrarni.bu.h    vr10, vr9,  6
++    vssrarni.bu.h    vr12, vr11, 6
++    addi.d           t0,   t0,   -1
++    vstelm.w         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   3
++    add.d            a2,   a2,   a3
++    vstelm.w         vr12, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr12, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr12, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr12, a2,   0,   3
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_4x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_4xH  8
++VERT_4TAP_PP_4xH  16
++VERT_4TAP_PP_4xH  32
++
++.macro VERT_4TAP_PP_6xN  h
++function x265_interp_4tap_vert_pp_6x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        t6,    a0,    a1
++    addi.d       t0,    zero,  \h/4
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++.loopV_4tap_6x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    add.d        a0,    a0,    t3
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++    vilvl.b      vr4,   vr13,  vr12 //4,5
++    vilvl.b      vr5,   vr14,  vr13 //5,6
++
++    VMULW4_H  vr0, vr2, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr1, vr3, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr4, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr3, vr5, vr19, vr19, vr20, vr21, vr22, vr23
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr10, vr14, vr14
++
++    vssrarni.bu.h    vr21, vr20, 6
++    vssrarni.bu.h    vr23, vr22, 6
++    addi.d           t0,   t0,   -1
++    vstelm.w         vr21, a2,   0,   0
++    vstelm.h         vr21, a2,   4,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr21, a2,   0,   2
++    vstelm.h         vr21, a2,   4,   6
++    add.d            a2,   a2,   a3
++    vstelm.w         vr23, a2,   0,   0
++    vstelm.h         vr23, a2,   4,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr23, a2,   0,   2
++    vstelm.h         vr23, a2,   4,   6
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_6x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_6xN 8
++VERT_4TAP_PP_6xN 16
++
++.macro VERT_4TAP_PP_8x2N  h
++function x265_interp_4tap_vert_pp_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    add.d        t2,    t1,    a1
++    sub.d        t6,    a0,    a1
++    addi.d       t0,    zero,  \h/2
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1
++
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++.loopV_4tap_8x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    add.d        a0,    a0,    t1
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++
++    vmulwev.h.bu.b   vr20, vr0,  vr16
++    vmulwod.h.bu.b   vr21, vr0,  vr16
++    VMADDW4_H vr1, vr2, vr17, vr18, vr20, vr21, vr20, vr21
++    vmaddwev.h.bu.b  vr20, vr3,  vr19
++    vmaddwod.h.bu.b  vr21, vr3,  vr19
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr10, vr12, vr12
++    vssrarni.bu.h    vr21, vr20, 6
++    addi.d           t0,   t0,   -1
++    vstelm.d         vr21, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr21, a2,   0,   1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_8x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_8x2N 2
++VERT_4TAP_PP_8x2N 6
++
++.macro VERT_4TAP_PP_8xN  h
++function x265_interp_4tap_vert_pp_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        t6,    a0,    a1
++    addi.d       t0,    zero,  \h/4
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++.loopV_4tap_8x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    add.d        a0,    a0,    t3
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++    vilvl.b      vr4,   vr13,  vr12 //4,5
++    vilvl.b      vr5,   vr14,  vr13 //5,6
++
++    VMULW4_H  vr0, vr2, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr1, vr3, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr4, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr3, vr5, vr19, vr19, vr20, vr21, vr22, vr23
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr10, vr14, vr14
++
++    vssrarni.bu.h    vr21, vr20, 6
++    vssrarni.bu.h    vr23, vr22, 6
++    addi.d           t0,   t0,   -1
++    vstelm.d         vr21, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr21, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr23, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr23, a2,   0,   1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_8x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_8xN 4
++VERT_4TAP_PP_8xN 8
++VERT_4TAP_PP_8xN 12
++VERT_4TAP_PP_8xN 16
++VERT_4TAP_PP_8xN 32
++VERT_4TAP_PP_8xN 64
++
++.macro VERT_4TAP_PP_12xN  h
++function x265_interp_4tap_vert_pp_12x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_4tap_12x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++    VMULW4_H  vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++
++    vssrarni.bu.h    vr12, vr10, 6
++    vssrarni.bu.h    vr13, vr11, 6
++    addi.d           t0,   t0,   -1
++    vilvl.b          vr14, vr13, vr12
++    vilvh.b          vr15, vr13, vr12
++    vstelm.d         vr14, a2,   0,   0
++    vstelm.w         vr14, a2,   8,   2
++    add.d            a2,   a2,   a3
++    vstelm.d         vr15, a2,   0,   0
++    vstelm.w         vr15, a2,   8,   2
++    add.d            a0,   a0,   t1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_12x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_12xN  16
++VERT_4TAP_PP_12xN  32
++
++.macro VERT_4TAP_PP_16xN  h
++function x265_interp_4tap_vert_pp_16x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        a0,    t6,    t2
++    slli.d       t7,    a3,    1
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_4tap_16x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++    VMULW4_H  vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++
++    vssrarni.bu.h    vr12, vr10, 6
++    vssrarni.bu.h    vr13, vr11, 6
++    vilvl.b          vr14, vr13, vr12
++    vilvh.b          vr15, vr13, vr12
++    vst              vr14, a2,   0
++    vstx             vr15, a2,   a3
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .loopV_4tap_16x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_16xN 4
++VERT_4TAP_PP_16xN 8
++VERT_4TAP_PP_16xN 12
++VERT_4TAP_PP_16xN 16
++VERT_4TAP_PP_16xN 24
++VERT_4TAP_PP_16xN 32
++VERT_4TAP_PP_16xN 64
++
++.macro VERT_4TAP_PP_24xN h
++function x265_interp_4tap_vert_pp_24x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    add.d        t2,    t1,    a1
++    sub.d        a0,    a0,    a1
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    fld.d        f5,    t6,    0
++    fldx.d       f6,    t6,    a1
++    fldx.d       f7,    t6,    t1
++    vilvl.b      vr10,  vr6,   vr5  //0,1
++    vilvl.b      vr11,  vr7,   vr6  //1,2
++
++.loopV_4tap_24x\h:
++    addi.d       t6,    a0,    16
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++    fld.d        f8,    t6,    0
++    fldx.d       f9,    t6,    a1
++
++    vilvl.b      vr12,  vr8,   vr7  //2,3
++    vilvl.b      vr13,  vr9,   vr8  //3,4
++
++    VMULW4_H  vr0, vr1, vr16, vr16, vr20, vr21, vr22, vr23
++    vmulwev.h.bu.b vr14,  vr10, vr16
++    vmulwod.h.bu.b vr15,  vr10, vr16
++    VMADDW4_H vr1, vr2, vr17, vr17, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14, vr11, vr17
++    vmaddwod.h.bu.b vr15, vr11, vr17
++    VMADDW4_H vr2, vr3, vr18, vr18, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14, vr12, vr18
++    vmaddwod.h.bu.b vr15, vr12, vr18
++    VMADDW4_H vr3, vr4, vr19, vr19, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14, vr13, vr19
++    vmaddwod.h.bu.b vr15, vr13, vr19
++
++    vssrarni.bu.h    vr22, vr20, 6
++    vssrarni.bu.h    vr23, vr21, 6
++    vssrarni.bu.h    vr15, vr14, 6
++    vor.v            vr10, vr12, vr12
++    vor.v            vr11, vr13, vr13
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr7,  vr9,  vr9
++
++    vilvl.b          vr20, vr23, vr22
++    vilvh.b          vr21, vr23, vr22
++
++    vst              vr20, a2,   0
++    vstelm.d         vr15, a2,   16,   0
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    vst              vr21, a2,   0
++    vstelm.d         vr15, a2,   16,   1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_24x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_24xN 32
++VERT_4TAP_PP_24xN 64
++
++.macro VERT_4TAP_PP_32xN  h
++function x265_interp_4tap_vert_pp_32x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++
++.loopV_4tap_32x\h:
++    addi.d       t6,    a0,    16
++    vld          vr3,   a0,    0
++    vldx         vr4,   a0,    a1  //7
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++
++    VMULW4_H  vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMULW4_H  vr5, vr6, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr7, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr8, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr8, vr9, vr19, vr19, vr20, vr21, vr22, vr23
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++    vor.v            vr7,  vr9,  vr9
++
++    vssrarni.bu.h    vr12, vr10, 6
++    vssrarni.bu.h    vr13, vr11, 6
++    vssrarni.bu.h    vr22, vr20, 6
++    vssrarni.bu.h    vr23, vr21, 6
++
++    vilvl.b          vr10, vr13, vr12
++    vilvh.b          vr11, vr13, vr12
++    vilvl.b          vr20, vr23, vr22
++    vilvh.b          vr21, vr23, vr22
++
++    vst              vr10, a2,   0
++    vst              vr20, a2,   16
++    add.d            a0,   a0,   t1
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    vst              vr11, a2,   0
++    vst              vr21, a2,   16
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_32x\h
++endfunc
++.endm
++
++VERT_4TAP_PP_32xN 8
++VERT_4TAP_PP_32xN 16
++VERT_4TAP_PP_32xN 24
++VERT_4TAP_PP_32xN 32
++VERT_4TAP_PP_32xN 48
++VERT_4TAP_PP_32xN 64
++
++function x265_interp_4tap_vert_pp_48x64_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    a1
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        t6,    a0,    a1
++    vld          vr0,   a0,    0    //0
++    vld          vr1,   a0,    16   //0
++    vld          vr2,   a0,    32   //0
++
++    add.d        a0,    t6,    a1
++    vld          vr3,   t6,    0   //1
++    vld          vr4,   t6,    16  //1
++    vld          vr5,   t6,    32  //1
++
++    add.d        t6,    a0,    a1
++    vld          vr6,   a0,    0    //2
++    vld          vr7,   a0,    16   //2
++    vld          vr8,   a0,    32   //2
++.loopV_4tap_48x64:
++    vld          vr9,   t6,    0
++    vld          vr10,  t6,    16
++    vld          vr11,  t6,    32
++
++    VMULW4_H  vr0, vr1, vr16, vr16, vr12, vr13, vr14, vr15
++    vmulwev.h.bu.b  vr20, vr2,  vr16
++    vmulwod.h.bu.b  vr21, vr2,  vr16
++    VMADDW4_H vr3, vr4, vr17, vr17, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b vr20, vr5,  vr17
++    vmaddwod.h.bu.b vr21, vr5,  vr17
++    VMADDW4_H vr6, vr7, vr18, vr18, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b vr20, vr8,  vr18
++    vmaddwod.h.bu.b vr21, vr8,  vr18
++    VMADDW4_H vr9, vr10, vr19, vr19, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b vr20, vr11, vr19
++    vmaddwod.h.bu.b vr21, vr11, vr19
++
++    vssrarni.bu.h    vr14, vr12, 6
++    vssrarni.bu.h    vr15, vr13, 6
++    vssrarni.bu.h    vr22, vr20, 6
++    vssrarni.bu.h    vr23, vr21, 6
++
++    vor.v            vr0,  vr3,  vr3
++    vor.v            vr1,  vr4,  vr4
++    vor.v            vr2,  vr5,  vr5
++    vor.v            vr3,  vr6,  vr6
++    vor.v            vr4,  vr7,  vr7
++    vor.v            vr5,  vr8,  vr8
++    vor.v            vr6,  vr9,  vr9
++    vor.v            vr7,  vr10, vr10
++    vor.v            vr8,  vr11, vr11
++    vilvl.b          vr12, vr15, vr14
++    vilvh.b          vr13, vr15, vr14
++    vilvl.b          vr20, vr23, vr22
++
++    vst              vr12, a2,   0
++    vst              vr13, a2,   16
++    vst              vr20, a2,   32
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_48x64
++endfunc
++
++.macro VERT_4TAP_PP_64xN  h
++function x265_interp_4tap_vert_pp_64x\h\()_lsx
++    slli.d       t7,    a4,    5
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++    addi.d       sp,    sp,    -32
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        t6,    a0,    a1
++    vld          vr0,   a0,    0    //0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++
++    add.d        a0,    t6,    a1
++    vld          vr4,   t6,    0    //1
++    vld          vr5,   t6,    16
++    vld          vr6,   t6,    32
++    vld          vr7,   t6,    48
++
++    add.d        t6,    a0,    a1
++    vld          vr8,   a0,    0    //2
++    vld          vr9,   a0,    16
++    vld          vr10,  a0,    32
++    vld          vr11,  a0,    48
++.loopV_4tap_64x\h:
++    vld          vr12,  t6,    0    //3
++    vld          vr13,  t6,    16
++    vld          vr14,  t6,    32
++    vld          vr15,  t6,    48
++
++    VMULW4_H  vr0, vr1, vr16, vr16, vr20, vr21, vr22, vr23
++    VMULW4_H  vr2, vr3, vr16, vr16, vr24, vr25, vr26, vr27
++    VMADDW4_H vr4, vr5, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr6, vr7, vr17, vr17, vr24, vr25, vr26, vr27
++    VMADDW4_H vr8, vr9, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr10, vr11, vr18, vr18, vr24, vr25, vr26, vr27
++    VMADDW4_H vr12, vr13, vr19, vr19, vr20, vr21, vr22, vr23
++    VMADDW4_H vr14, vr15, vr19, vr19, vr24, vr25, vr26, vr27
++
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr2,  vr6,  vr6
++    vor.v            vr3,  vr7,  vr7
++
++    vssrarni.bu.h    vr22, vr20, 6
++    vssrarni.bu.h    vr23, vr21, 6
++    vssrarni.bu.h    vr26, vr24, 6
++    vssrarni.bu.h    vr27, vr25, 6
++
++    vor.v            vr4,  vr8,  vr8
++    vor.v            vr5,  vr9,  vr9
++    vor.v            vr6,  vr10, vr10
++    vor.v            vr7,  vr11, vr11
++
++    vilvl.b          vr20, vr23, vr22
++    vilvh.b          vr21, vr23, vr22
++    vilvl.b          vr24, vr27, vr26
++    vilvh.b          vr25, vr27, vr26
++
++    vor.v            vr8,  vr12, vr12
++    vor.v            vr9,  vr13, vr13
++    vor.v            vr10, vr14, vr14
++    vor.v            vr11, vr15, vr15
++
++    vst              vr20, a2,   0
++    vst              vr21, a2,   16
++    vst              vr24, a2,   32
++    vst              vr25, a2,   48
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_64x\h
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    addi.d       sp,    sp,    32
++endfunc
++.endm
++
++VERT_4TAP_PP_64xN 16
++VERT_4TAP_PP_64xN 32
++VERT_4TAP_PP_64xN 48
++VERT_4TAP_PP_64xN 64
++
++.macro LASX_VERT_4TAP_PP_16xN  h
++function x265_interp_4tap_vert_pp_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++    slli.d       t7,    a3,    1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++
++    add.d        t6,    a0,    t2
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++    xvpermi.q    xr0,   xr1,   0x2  //0,1
++    xvpermi.q    xr1,   xr2,   0x2  //1,2
++.lasx_loopV_4tap_16x\h:
++    xvld         xr3,   t6,    0   //3
++    xvldx        xr4,   t6,    a1  //4
++    xvpermi.q    xr2,   xr3,   0x2  //2,3
++    xvpermi.q    xr3,   xr4,   0x2  //3,4
++
++    xvmulwev.h.bu.b  xr10, xr0, xr16
++    xvmulwod.h.bu.b  xr11, xr0, xr16
++    XMADDW4_H xr1, xr2, xr17, xr18, xr10, xr11, xr10, xr11
++    xvmaddwev.h.bu.b xr10, xr3, xr19
++    xvmaddwod.h.bu.b xr11, xr3, xr19
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++
++    xvssrarni.bu.h   xr11, xr10, 6
++    xvpermi.d        xr12, xr11, 0xB1
++    add.d            t6,   t6,   t1
++    xvilvl.b         xr13, xr12, xr11
++    addi.d           t0,   t0,   -1
++    xvpermi.d        xr14, xr13, 0x4E
++    vst              vr13, a2,   0
++    vstx             vr14, a2,   a3
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .lasx_loopV_4tap_16x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PP_16xN 4
++LASX_VERT_4TAP_PP_16xN 8
++LASX_VERT_4TAP_PP_16xN 12
++LASX_VERT_4TAP_PP_16xN 16
++LASX_VERT_4TAP_PP_16xN 24
++LASX_VERT_4TAP_PP_16xN 32
++LASX_VERT_4TAP_PP_16xN 64
++
++.macro LASX_VERT_4TAP_PP_24xN  h
++function x265_interp_4tap_vert_pp_24x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++
++    add.d        t6,    a0,    t2
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++
++.lasx_loopV_4tap_24x\h:
++    xvld         xr3,   t6,    0   //3
++    xvldx        xr4,   t6,    a1  //4
++
++    XMULW4_H  xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++
++    xvssrarni.bu.h   xr12, xr10, 6
++    xvssrarni.bu.h   xr13, xr11, 6
++    add.d            t7,   a2,   a3
++    xvilvl.b         xr14, xr13, xr12
++    xvilvh.b         xr15, xr13, xr12
++
++    vst              vr14, a2,   0
++    xvstelm.d        xr14, a2,   16,  2
++    vst              vr15, t7,   0
++    xvstelm.d        xr15, t7,   16,  2
++    add.d            t6,   t6,   t1
++    add.d            a2,   a3,   t7
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .lasx_loopV_4tap_24x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PP_24xN 32
++LASX_VERT_4TAP_PP_24xN 64
++
++function x265_interp_4tap_vert_pp_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  32
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++    add.d        a0,    a0,    t2
++
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++
++    xvpermi.q    xr5,   xr6,   0x2
++    xvpermi.q    xr6,   xr7,   0x2
++.lasx_loopV_4tap_48x64:
++    addi.d       t6,    a0,    32
++    xvld         xr3,   a0,    0   //3
++    xvldx        xr4,   a0,    a1  //4
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++
++    xvpermi.q    xr7,   xr8,   0x2
++    xvpermi.q    xr8,   xr9,   0x2
++    XMULW4_H  xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    xvmulwev.h.bu.b  xr14, xr5,  xr16
++    xvmulwod.h.bu.b  xr15, xr5,  xr16
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    xvmaddwev.h.bu.b xr14, xr6,  xr17
++    xvmaddwod.h.bu.b xr15, xr6,  xr17
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    xvmaddwev.h.bu.b xr14, xr7,  xr18
++    xvmaddwod.h.bu.b xr15, xr7,  xr18
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    xvmaddwev.h.bu.b xr14, xr8,  xr19
++    xvmaddwod.h.bu.b xr15, xr8,  xr19
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++    xvor.v           xr7,  xr9,  xr9
++
++    xvssrarni.bu.h   xr15, xr14, 6
++    xvssrarni.bu.h   xr12, xr10, 6
++    xvssrarni.bu.h   xr13, xr11, 6
++    xvpermi.d        xr14, xr15, 0xB1
++    add.d            t7,   a2,   a3
++    xvilvl.b         xr20, xr13, xr12
++    xvilvh.b         xr21, xr13, xr12
++    xvilvl.b         xr22, xr14, xr15
++    xvst             xr20, a2,   0
++    vst              vr22, a2,   32
++    xvpermi.d        xr23, xr22, 0x4E
++    add.d            a0,   a0,   t1
++    xvst             xr21, t7,   0
++    vst              vr23, t7,   32
++    add.d            a2,   a3,   t7
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .lasx_loopV_4tap_48x64
++endfunc
++
++.macro LASX_VERT_4TAP_PP_32xN  h
++function x265_interp_4tap_vert_pp_32x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++    slli.d       t7,    a3,    1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++
++    add.d        t6,    a0,    t2
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++
++.lasx_loopV_4tap_32x\h:
++    xvld         xr3,   t6,    0   //3
++    xvldx        xr4,   t6,    a1  //4
++
++    XMULW4_H  xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++
++    xvssrarni.bu.h   xr12, xr10, 6
++    xvssrarni.bu.h   xr13, xr11, 6
++    xvilvl.b         xr14, xr13, xr12
++    xvilvh.b         xr15, xr13, xr12
++
++    xvst             xr14, a2,   0
++    xvstx            xr15, a2,   a3
++    add.d            t6,   t6,   t1
++    add.d            a2,   a2,   t7
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .lasx_loopV_4tap_32x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PP_32xN 8
++LASX_VERT_4TAP_PP_32xN 16
++LASX_VERT_4TAP_PP_32xN 24
++LASX_VERT_4TAP_PP_32xN 32
++LASX_VERT_4TAP_PP_32xN 48
++LASX_VERT_4TAP_PP_32xN 64
++
++.macro LASX_VERT_4TAP_PP_64xN  h
++function x265_interp_4tap_vert_pp_64x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    xvld         xr5,   t6,    0
++    xvldx        xr6,   t6,    a1
++    xvldx        xr7,   t6,    t1
++
++.lasx_loopV_4tap_64x\h:
++    addi.d       t6,    a0,    32
++    xvld         xr3,   a0,    0
++    xvldx        xr4,   a0,    a1  //7
++    xvld         xr8,   t6,    0
++    xvldx        xr9,   t6,    a1
++
++    XMULW4_H  xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMULW4_H  xr5, xr6, xr16, xr16, xr20, xr21, xr22, xr23
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr6, xr7, xr17, xr17, xr20, xr21, xr22, xr23
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7, xr8, xr18, xr18, xr20, xr21, xr22, xr23
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADDW4_H xr8, xr9, xr19, xr19, xr20, xr21, xr22, xr23
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++    xvor.v           xr7,  xr9,  xr9
++
++    xvssrarni.bu.h   xr12, xr10, 6
++    xvssrarni.bu.h   xr13, xr11, 6
++    xvssrarni.bu.h   xr22, xr20, 6
++    xvssrarni.bu.h   xr23, xr21, 6
++
++    xvilvl.b         xr10, xr13, xr12
++    xvilvh.b         xr11, xr13, xr12
++    xvilvl.b         xr20, xr23, xr22
++    xvilvh.b         xr21, xr23, xr22
++
++    xvst             xr10, a2,   0
++    xvst             xr20, a2,   32
++    add.d            a0,   a0,   t1
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    xvst             xr11, a2,   0
++    xvst             xr21, a2,   32
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_4tap_64x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PP_64xN 16
++LASX_VERT_4TAP_PP_64xN 32
++LASX_VERT_4TAP_PP_64xN 48
++LASX_VERT_4TAP_PP_64xN 64
++
++function x265_interp_4tap_vert_ps_2x4_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    sub.d        a0,    a0,    a1  //src -= srcStride
++    vldx         vr16,  t6,    t7
++    vld          vr17,  t4,    0
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++
++    vilvl.h      vr8,   vr1,   vr0  //0, 1
++    vilvl.h      vr9,   vr3,   vr2  //2, 3
++    vilvl.h      vr10,  vr2,   vr1  //1, 2
++    vilvl.h      vr11,  vr4,   vr3  //3, 4
++    vilvl.h      vr12,  vr5,   vr4  //4, 5
++    vilvl.h      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.w      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.w      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.w      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.w      vr3,   vr14,  vr11 //3,4,5,6
++
++    vilvl.d      vr4,   vr1,   vr0  //0,1,2,3,1,2,3,4
++    vilvl.d      vr5,   vr3,   vr2  //2,3,4,5,3,4,5,6
++
++    VMULW4_H  vr4, vr5, vr16, vr16, vr6, vr7, vr8, vr9
++    vhaddw.w.h   vr0,   vr6,   vr6
++    vhaddw.w.h   vr1,   vr7,   vr7
++    vhaddw.w.h   vr2,   vr8,   vr8
++    vhaddw.w.h   vr3,   vr9,   vr9
++
++    vpickev.h    vr4,   vr2,   vr0
++    vpickev.h    vr5,   vr3,   vr1
++    vhaddw.w.h   vr6,   vr4,   vr4
++    vhaddw.w.h   vr7,   vr5,   vr5
++    vpackev.h    vr8,   vr7,   vr6
++
++    vadd.h       vr10,  vr8,   vr17
++
++    vstelm.w         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr10, a2,   0,   3
++endfunc
++
++.macro VERT_4TAP_PS_2xH  h
++function x265_interp_4tap_vert_ps_2x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    sub.d        a0,    a0,    a1  //src -= srcStride
++    addi.d       t0,    zero,  \h/8
++    vldx         vr16,  t6,    t7
++    vld          vr17,  t4,    0
++
++.loopV_ps_4tap_2x\h:
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.h      vr8,   vr1,   vr0  //0, 1
++    vilvl.h      vr9,   vr3,   vr2  //2, 3
++    vilvl.h      vr10,  vr2,   vr1  //1, 2
++    vilvl.h      vr11,  vr4,   vr3  //3, 4
++    vilvl.h      vr12,  vr5,   vr4  //4, 5
++    vilvl.h      vr13,  vr7,   vr6  //6, 7
++    vilvl.h      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.w      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.w      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.w      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.w      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.w      vr4,   vr13,  vr12 //4,5,6,7
++
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.h      vr15,  vr8,   vr7  //7, 8
++    vilvl.h      vr11,  vr9,   vr8  //8, 9
++    vilvl.h      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.w      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.w      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.w      vr7,   vr12,  vr15 //7,8,9,10
++
++    vilvl.d      vr8,   vr1,   vr0
++    vilvl.d      vr9,   vr3,   vr2
++    vilvl.d      vr10,  vr5,   vr4
++    vilvl.d      vr11,  vr7,   vr6
++
++    VMULW4_H  vr8, vr9, vr16, vr16, vr0, vr1, vr2, vr3
++    VMULW4_H  vr10, vr11, vr16, vr16, vr4, vr5, vr6, vr7
++
++.irp x, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.w.h  \x, \x, \x
++.endr
++
++    vpickev.h    vr8,   vr2,   vr0
++    vpickev.h    vr9,   vr3,   vr1
++    vpickev.h    vr10,  vr6,   vr4
++    vpickev.h    vr11,  vr7,   vr5
++.irp x, vr8, vr9, vr10, vr11
++    vhaddw.w.h  \x, \x, \x
++.endr
++    vpackev.h    vr0,   vr9,   vr8
++    vpackev.h    vr1,   vr11,  vr10
++    vadd.h       vr0,   vr0,   vr17
++    vadd.h       vr1,   vr1,   vr17
++    addi.d           t0,   t0,   -1
++    vstelm.w         vr0,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr0,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr0,  a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr0,  a2,   0,   3
++    add.d            a2,   a2,   a3
++    vstelm.w         vr1,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr1,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr1,  a2,   0,   2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr1,  a2,   0,   3
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_2x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_2xH  8
++VERT_4TAP_PS_2xH  16
++
++function x265_interp_4tap_vert_ps_4x2_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    sub.d        a0,    a0,    a1  //src -= srcStride
++    vldx         vr16,  t6,    t7
++    vld          vr17,  t4,    0
++
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++    fldx.s       f4,    a0,    t3   //4
++
++    vilvl.h      vr8,   vr1,   vr0  //0, 1
++    vilvl.h      vr9,   vr3,   vr2  //2, 3
++    vilvl.h      vr10,  vr2,   vr1  //1, 2
++    vilvl.h      vr11,  vr4,   vr3  //3, 4
++
++    vilvl.w      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.w      vr1,   vr11,  vr10 //1,2,3,4
++
++    VMULW4_H vr0, vr1, vr16, vr16, vr9, vr10, vr11, vr12
++
++    vhaddw.w.h   vr0,   vr9,   vr9
++    vhaddw.w.h   vr1,   vr10,  vr10
++    vhaddw.w.h   vr2,   vr11,  vr11
++    vhaddw.w.h   vr3,   vr12,  vr12
++
++    vpickev.h    vr4,   vr1,   vr0
++    vpickev.h    vr5,   vr3,   vr2
++    vhaddw.w.h   vr6,   vr4,   vr4
++    vhaddw.w.h   vr7,   vr5,   vr5
++    vpickev.h    vr8,   vr7,   vr6
++    vadd.h       vr9,   vr8,   vr17
++
++    vshuf4i.h        vr10, vr9,  0xD8
++    vstelm.d         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr10, a2,   0,   1
++endfunc
++
++function x265_interp_4tap_vert_ps_4x4_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        a0,    a0,    a1  //src -= srcStride
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr20,  t4,    0
++
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++
++    vor.v        vr9,   vr20,  vr20
++
++    VMADDW4_H vr0, vr1, vr16, vr17, vr9, vr20, vr9, vr20
++    VMADDW4_H vr2, vr3, vr18, vr19, vr9, vr20, vr9, vr20
++    vstelm.d         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr20, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr20, a2,   0,   1
++endfunc
++
++.macro VERT_4TAP_PS_4xH  h
++function x265_interp_4tap_vert_ps_4x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        a0,    a0,    a1  //src -= srcStride
++    addi.d       t0,    zero,  \h/8
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr20,  t4,    0
++
++.loopV_ps_4tap_4x\h:
++    add.d        t6,    a0,    t3
++    fld.s        f0,    a0,    0    //0
++    fldx.s       f1,    a0,    a1   //1
++    fldx.s       f2,    a0,    t1   //2
++    fldx.s       f3,    a0,    t2   //3
++
++    fld.s        f4,    t6,    0    //4
++    fldx.s       f5,    t6,    a1   //5
++    fldx.s       f6,    t6,    t1   //6
++    fldx.s       f7,    t6,    t2   //7
++    add.d        a0,    t6,    t3
++
++    vilvl.b      vr8,   vr1,   vr0  //0, 1
++    vilvl.b      vr9,   vr3,   vr2  //2, 3
++    vilvl.b      vr10,  vr2,   vr1  //1, 2
++    vilvl.b      vr11,  vr4,   vr3  //3, 4
++    vilvl.b      vr12,  vr5,   vr4  //4, 5
++    vilvl.b      vr13,  vr7,   vr6  //6, 7
++    vilvl.b      vr14,  vr6,   vr5  //5, 6
++
++    vilvl.d      vr0,   vr9,   vr8  //0,1,2,3
++    vilvl.d      vr1,   vr11,  vr10 //1,2,3,4
++    vilvl.d      vr2,   vr12,  vr9  //2,3,4,5
++    vilvl.d      vr3,   vr14,  vr11 //3,4,5,6
++    vilvl.d      vr4,   vr13,  vr12 //4,5,6,7
++
++    fld.s        f8,    a0,    0    //8
++    fldx.s       f9,    a0,    a1   //9
++    fldx.s       f10,   a0,    t1   //10
++
++    vilvl.b      vr15,  vr8,   vr7  //7, 8
++    vilvl.b      vr11,  vr9,   vr8  //8, 9
++    vilvl.b      vr12,  vr10,  vr9  //9, 10
++
++    vilvl.d      vr5,   vr15,  vr14 //5,6,7,8
++    vilvl.d      vr6,   vr11,  vr13 //6,7,8,9
++    vilvl.d      vr7,   vr12,  vr15 //7,8,9,10
++
++.irp x, vr9, vr10, vr11, vr12
++    vor.v        \x,    vr20,  vr20
++.endr
++    VMADDW4_H vr0, vr4, vr16, vr16, vr9, vr10, vr11, vr12
++    VMADDW4_H vr1, vr5, vr17, vr17, vr9, vr10, vr11, vr12
++    VMADDW4_H vr2, vr6, vr18, vr18, vr9, vr10, vr11, vr12
++    VMADDW4_H vr3, vr7, vr19, vr19, vr9, vr10, vr11, vr12
++
++    addi.d           t0,   t0,   -1
++    vstelm.d         vr9,  a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr10, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr10, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr11, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr12, a2,   0,   0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr11, a2,   0,   1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr12, a2,   0,   1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_4x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_4xH  8
++VERT_4TAP_PS_4xH  16
++VERT_4TAP_PS_4xH  32
++
++.macro VERT_4TAP_PS_6xN  h
++function x265_interp_4tap_vert_ps_6x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        t6,    a0,    a1  //src -= srcStride
++    addi.d       t0,    zero,  \h/4
++    vld          vr15,  t4,    0
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++.loopV_ps_4tap_6x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    add.d        a0,    a0,    t3
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++    vilvl.b      vr4,   vr13,  vr12 //4,5
++    vilvl.b      vr5,   vr14,  vr13 //5,6
++
++.irp x, vr20, vr21, vr22, vr23
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADDW4_H vr0, vr2, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr1, vr3, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr4, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr3, vr5, vr19, vr19, vr20, vr21, vr22, vr23
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr10, vr14, vr14
++
++    addi.d           t0,   t0,   -1
++    vstelm.d         vr20, a2,   0,   0
++    vstelm.w         vr20, a2,   8,   2
++    add.d            a2,   a2,   a3
++    vstelm.d         vr21, a2,   0,   0
++    vstelm.w         vr21, a2,   8,   2
++    add.d            a2,   a2,   a3
++    vstelm.d         vr22, a2,   0,   0
++    vstelm.w         vr22, a2,   8,   2
++    add.d            a2,   a2,   a3
++    vstelm.d         vr23, a2,   0,   0
++    vstelm.w         vr23, a2,   8,   2
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_6x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_6xN 8
++VERT_4TAP_PS_6xN 16
++
++.macro VERT_4TAP_PS_8x2N  h
++function x265_interp_4tap_vert_ps_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    add.d        t2,    t1,    a1
++    sub.d        t6,    a0,    a1  //src -= srcStride
++    addi.d       t0,    zero,  \h/2
++    slli.d       t7,    a3,    1
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr20,  t4,    0
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1
++
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++.loopV_ps_4tap_8x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    add.d        a0,    a0,    t1
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++
++    vor.v        vr21,  vr20,  vr20
++    vor.v        vr22,  vr20,  vr20
++    VMADDW4_H vr0, vr1, vr16, vr17, vr21, vr22, vr21, vr22
++    VMADDW4_H vr2, vr3, vr18, vr19, vr21, vr22, vr21, vr22
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr10, vr12, vr12
++    addi.d           t0,   t0,   -1
++    vst              vr21, a2,   0
++    vstx             vr22, a2,   a3
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .loopV_ps_4tap_8x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_8x2N 2
++VERT_4TAP_PS_8x2N 6
++
++.macro VERT_4TAP_PS_8xN  h
++function x265_interp_4tap_vert_ps_8x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        t6,    a0,    a1  //src -= srcStride
++    addi.d       t0,    zero,  \h/4
++    vld          vr15,  t4,    0
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    slli.d       t4,    a3,    1  //dstStride * 2
++    slli.d       t7,    a3,    2  //dstStride * 4
++    add.d        t5,    t4,    a3
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++
++    vilvl.b      vr0,   vr9,   vr8  //0,1
++    vilvl.b      vr1,   vr10,  vr9  //1,2
++.loopV_ps_4tap_8x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    add.d        a0,    a0,    t3
++    vilvl.b      vr2,   vr11,  vr10 //2,3
++    vilvl.b      vr3,   vr12,  vr11 //3,4
++    vilvl.b      vr4,   vr13,  vr12 //4,5
++    vilvl.b      vr5,   vr14,  vr13 //5,6
++
++.irp x, vr20, vr21, vr22, vr23
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADDW4_H vr0, vr2, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr1, vr3, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr4, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr3, vr5, vr19, vr19, vr20, vr21, vr22, vr23
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr10, vr14, vr14
++
++    addi.d           t0,   t0,   -1
++    vst              vr20, a2,   0
++    vstx             vr21, a2,   a3
++    vstx             vr22, a2,   t4
++    vstx             vr23, a2,   t5
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .loopV_ps_4tap_8x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_8xN 4
++VERT_4TAP_PS_8xN 8
++VERT_4TAP_PS_8xN 12
++VERT_4TAP_PS_8xN 16
++VERT_4TAP_PS_8xN 32
++VERT_4TAP_PS_8xN 64
++
++.macro VERT_4TAP_PS_12xN  h
++function x265_interp_4tap_vert_ps_12x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr20,  t4,    0
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_ps_4tap_12x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr20,  vr20
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    vor.v        vr0,   vr2,   vr2
++    vor.v        vr1,   vr3,   vr3
++    vor.v        vr2,   vr4,   vr4
++
++    vilvl.h      vr5,   vr11,  vr10
++    vilvh.h      vr6,   vr11,  vr10
++    vilvl.h      vr7,   vr13,  vr12
++    vilvh.h      vr8,   vr13,  vr12
++
++    addi.d           t0,   t0,   -1
++    vst              vr5,  a2,   0
++    vstelm.d         vr6,  a2,   16,  0
++    add.d            a2,   a2,   a3
++    vst              vr7,  a2,   0
++    vstelm.d         vr8,  a2,   16,  0
++    add.d            a0,   a0,   t1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_12x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_12xN  16
++VERT_4TAP_PS_12xN  32
++
++.macro VERT_4TAP_PS_16xN  h
++function x265_interp_4tap_vert_ps_16x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7  //g_lumaFilter
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr20,  t4,    0
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_ps_4tap_16x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr20,  vr20
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    vor.v        vr0,   vr2,   vr2
++    vor.v        vr1,   vr3,   vr3
++    vor.v        vr2,   vr4,   vr4
++
++    vilvl.h      vr5,   vr11,  vr10
++    vilvh.h      vr6,   vr11,  vr10
++    vilvl.h      vr7,   vr13,  vr12
++    vilvh.h      vr8,   vr13,  vr12
++
++    vst              vr5,  a2,   0
++    vst              vr6,  a2,   16
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    vst              vr7,  a2,   0
++    vst              vr8,  a2,   16
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_16x\h
++endfunc
++.endm
++
++VERT_4TAP_PS_16xN 4
++VERT_4TAP_PS_16xN 8
++VERT_4TAP_PS_16xN 12
++VERT_4TAP_PS_16xN 16
++VERT_4TAP_PS_16xN 24
++VERT_4TAP_PS_16xN 32
++VERT_4TAP_PS_16xN 64
++
++.macro VERT_4TAP_PS_24xN h
++function x265_interp_4tap_vert_ps_24x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    addi.d       sp,    sp,    -8
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    fst.d        f24,   sp,    0
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    add.d        t2,    t1,    a1
++    sub.d        a0,    a0,    a1
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr24,  t4,    0
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    fld.d        f5,    t6,    0
++    fldx.d       f6,    t6,    a1
++    fldx.d       f7,    t6,    t1
++    vilvl.b      vr10,  vr6,   vr5  //0,1
++    vilvl.b      vr11,  vr7,   vr6  //1,2
++
++.loopV_ps_4tap_24x\h:
++    addi.d       t6,    a0,    16
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++    fld.d        f8,    t6,    0
++    fldx.d       f9,    t6,    a1
++
++    vilvl.b      vr12,  vr8,   vr7  //2,3
++    vilvl.b      vr13,  vr9,   vr8  //3,4
++
++.irp x, vr20, vr21, vr22, vr23, vr14, vr15
++    vor.v        \x,    vr24,  vr24
++.endr
++    VMADDW4_H  vr0, vr1, vr16, vr16, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14,  vr10, vr16
++    vmaddwod.h.bu.b vr15,  vr10, vr16
++    VMADDW4_H vr1, vr2, vr17, vr17, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14, vr11, vr17
++    vmaddwod.h.bu.b vr15, vr11, vr17
++    VMADDW4_H vr2, vr3, vr18, vr18, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14, vr12, vr18
++    vmaddwod.h.bu.b vr15, vr12, vr18
++    VMADDW4_H vr3, vr4, vr19, vr19, vr20, vr21, vr22, vr23
++    vmaddwev.h.bu.b vr14, vr13, vr19
++    vmaddwod.h.bu.b vr15, vr13, vr19
++
++    vor.v            vr10, vr12, vr12
++    vor.v            vr11, vr13, vr13
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr7,  vr9,  vr9
++
++    vilvl.h          vr5,  vr21, vr20
++    vilvh.h          vr6,  vr21, vr20
++    vilvl.h          vr8,  vr23, vr22
++    vilvh.h          vr9,  vr23, vr22
++
++    vst              vr5,  a2,   0
++    vst              vr6,  a2,   16
++    vst              vr14, a2,   32
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    vst              vr8,  a2,   0
++    vst              vr9,  a2,   16
++    vst              vr15, a2,   32
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_24x\h
++    fld.d            f24,  sp,   0
++    addi.d           sp,   sp,   8
++endfunc
++.endm
++
++VERT_4TAP_PS_24xN 32
++VERT_4TAP_PS_24xN 64
++
++.macro VERT_4TAP_PS_32xN  h
++function x265_interp_4tap_vert_ps_32x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    addi.d       sp,    sp,    -8
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++    fst.d        f24,   sp,    0
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr24,  t4,    0
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++
++.loopV_ps_4tap_32x\h:
++    addi.d       t6,    a0,    16
++    vld          vr3,   a0,    0
++    vldx         vr4,   a0,    a1  //7
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++
++.irp x, vr10, vr11, vr12, vr13, vr20, vr21, vr22, vr23
++    vor.v        \x,    vr24,  vr24
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADDW4_H vr5, vr6, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADDW4_H vr6, vr7, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADDW4_H vr7, vr8, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADDW4_H vr8, vr9, vr19, vr19, vr20, vr21, vr22, vr23
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++    vor.v            vr7,  vr9,  vr9
++
++    vilvl.h          vr3,  vr11, vr10
++    vilvh.h          vr4,  vr11, vr10
++    vilvl.h          vr8,  vr13, vr12
++    vilvh.h          vr9,  vr13, vr12
++
++    vilvl.h          vr10, vr21, vr20
++    vilvh.h          vr11, vr21, vr20
++    vilvl.h          vr12, vr23, vr22
++    vilvh.h          vr13, vr23, vr22
++
++    vst              vr3,  a2,   0
++    vst              vr4,  a2,   16
++    vst              vr10, a2,   32
++    vst              vr11, a2,   48
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    vst              vr8,  a2,   0
++    vst              vr9,  a2,   16
++    vst              vr12, a2,   32
++    vst              vr13, a2,   48
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_32x\h
++    fld.d            f24,  sp,   0
++    addi.d           sp,   sp,   8
++endfunc
++.endm
++
++VERT_4TAP_PS_32xN 8
++VERT_4TAP_PS_32xN 16
++VERT_4TAP_PS_32xN 24
++VERT_4TAP_PS_32xN 32
++VERT_4TAP_PS_32xN 48
++VERT_4TAP_PS_32xN 64
++
++function x265_interp_4tap_vert_ps_48x64_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    a1
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr23,  t4,    0
++
++    add.d        t6,    a0,    a1
++    vld          vr0,   a0,    0    //0
++    vld          vr1,   a0,    16   //0
++    vld          vr2,   a0,    32   //0
++
++    add.d        a0,    t6,    a1
++    vld          vr3,   t6,    0   //1
++    vld          vr4,   t6,    16  //1
++    vld          vr5,   t6,    32  //1
++
++    add.d        t6,    a0,    a1
++    vld          vr6,   a0,    0    //2
++    vld          vr7,   a0,    16   //2
++    vld          vr8,   a0,    32   //2
++.loopV_ps_4tap_48x64:
++    vld          vr9,   t6,    0
++    vld          vr10,  t6,    16
++    vld          vr11,  t6,    32
++
++.irp x, vr12, vr13, vr14, vr15, vr20, vr21
++    vor.v        \x,    vr23,  vr23
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b  vr20, vr2,  vr16
++    vmaddwod.h.bu.b  vr21, vr2,  vr16
++    VMADDW4_H vr3, vr4, vr17, vr17, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b vr20, vr5,  vr17
++    vmaddwod.h.bu.b vr21, vr5,  vr17
++    VMADDW4_H vr6, vr7, vr18, vr18, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b vr20, vr8,  vr18
++    vmaddwod.h.bu.b vr21, vr8,  vr18
++    VMADDW4_H vr9, vr10, vr19, vr19, vr12, vr13, vr14, vr15
++    vmaddwev.h.bu.b vr20, vr11, vr19
++    vmaddwod.h.bu.b vr21, vr11, vr19
++
++    vor.v            vr0,  vr3,  vr3
++    vor.v            vr1,  vr4,  vr4
++    vor.v            vr2,  vr5,  vr5
++    vor.v            vr3,  vr6,  vr6
++    vor.v            vr4,  vr7,  vr7
++    vor.v            vr5,  vr8,  vr8
++    vor.v            vr6,  vr9,  vr9
++    vor.v            vr7,  vr10, vr10
++    vor.v            vr8,  vr11, vr11
++
++    vilvl.h          vr9,  vr13, vr12
++    vilvh.h          vr10, vr13, vr12
++    vilvl.h          vr11, vr15, vr14
++    vilvh.h          vr22, vr15, vr14
++    vilvl.h          vr12, vr21, vr20
++    vilvh.h          vr13, vr21, vr20
++    vst              vr9,  a2,   0
++    vst              vr10, a2,   16
++    vst              vr11, a2,   32
++    vst              vr22, a2,   48
++    vst              vr12, a2,   64
++    vst              vr13, a2,   80
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_48x64
++endfunc
++
++.macro VERT_4TAP_PS_64xN  h
++function x265_interp_4tap_vert_ps_64x\h\()_lsx
++    slli.d       t7,    a4,    5
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++    addi.d       sp,    sp,    -40
++    fst.d        f24,   sp,    0
++    fst.d        f25,   sp,    8
++    fst.d        f26,   sp,    16
++    fst.d        f27,   sp,    24
++    fst.d        f28,   sp,    32
++
++    vldrepl.b    vr16,  t5,    0
++    vldrepl.b    vr17,  t5,    2
++    vldrepl.b    vr18,  t5,    4
++    vldrepl.b    vr19,  t5,    6
++    vld          vr28,  t4,    0
++
++    add.d        t6,    a0,    a1
++    vld          vr0,   a0,    0    //0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++
++    add.d        a0,    t6,    a1
++    vld          vr4,   t6,    0    //1
++    vld          vr5,   t6,    16
++    vld          vr6,   t6,    32
++    vld          vr7,   t6,    48
++
++    add.d        t6,    a0,    a1
++    vld          vr8,   a0,    0    //2
++    vld          vr9,   a0,    16
++    vld          vr10,  a0,    32
++    vld          vr11,  a0,    48
++.loopV_ps_4tap_64x\h:
++    vld          vr12,  t6,    0    //3
++    vld          vr13,  t6,    16
++    vld          vr14,  t6,    32
++    vld          vr15,  t6,    48
++
++.irp x, vr20, vr21, vr22, vr23, vr24, vr25, vr26, vr27
++    vor.v        \x,    vr28,  vr28
++.endr
++    VMADDW4_H vr0, vr1, vr16, vr16, vr20, vr21, vr22, vr23
++    VMADDW4_H vr2, vr3, vr16, vr16, vr24, vr25, vr26, vr27
++    VMADDW4_H vr4, vr5, vr17, vr17, vr20, vr21, vr22, vr23
++    VMADDW4_H vr6, vr7, vr17, vr17, vr24, vr25, vr26, vr27
++    VMADDW4_H vr8, vr9, vr18, vr18, vr20, vr21, vr22, vr23
++    VMADDW4_H vr10, vr11, vr18, vr18, vr24, vr25, vr26, vr27
++    VMADDW4_H vr12, vr13, vr19, vr19, vr20, vr21, vr22, vr23
++    VMADDW4_H vr14, vr15, vr19, vr19, vr24, vr25, vr26, vr27
++
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr2,  vr6,  vr6
++    vor.v            vr3,  vr7,  vr7
++    vor.v            vr4,  vr8,  vr8
++    vor.v            vr5,  vr9,  vr9
++    vor.v            vr6,  vr10, vr10
++    vor.v            vr7,  vr11, vr11
++    vor.v            vr8,  vr12, vr12
++    vor.v            vr9,  vr13, vr13
++    vor.v            vr10, vr14, vr14
++    vor.v            vr11, vr15, vr15
++
++    vilvl.h          vr12, vr21, vr20
++    vilvh.h          vr13, vr21, vr20
++    vilvl.h          vr14, vr23, vr22
++    vilvh.h          vr15, vr23, vr22
++    vilvl.h          vr20, vr25, vr24
++    vilvh.h          vr21, vr25, vr24
++    vilvl.h          vr22, vr27, vr26
++    vilvh.h          vr23, vr27, vr26
++
++    vst              vr12, a2,   0
++    vst              vr13, a2,   16
++    vst              vr14, a2,   32
++    vst              vr15, a2,   48
++    vst              vr20, a2,   64
++    vst              vr21, a2,   80
++    vst              vr22, a2,   96
++    vst              vr23, a2,   112
++    addi.d           t0,   t0,   -1
++    add.d            t6,   t6,   a1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_ps_4tap_64x\h
++    fld.d        f24,   sp,    0
++    fld.d        f25,   sp,    8
++    fld.d        f26,   sp,    16
++    fld.d        f27,   sp,    24
++    fld.d        f28,   sp,    32
++    addi.d       sp,    sp,    40
++endfunc
++.endm
++
++VERT_4TAP_PS_64xN 16
++VERT_4TAP_PS_64xN 32
++VERT_4TAP_PS_64xN 48
++VERT_4TAP_PS_64xN 64
++
++.macro LASX_VERT_4TAP_PS_16xN  h
++function x265_interp_4tap_vert_ps_16x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++    slli.d       t7,    a3,    1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvld         xr20,  t4,    0
++
++    add.d        t6,    a0,    t2
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    xvpermi.q    xr0,   xr1,   0x2
++    xvpermi.q    xr1,   xr2,   0x2
++.lasx_loopV_ps_4tap_16x\h:
++    xvld         xr3,   t6,    0   //3
++    xvldx        xr4,   t6,    a1  //4
++    xvor.v       xr10,  xr20,  xr20
++    xvor.v       xr11,  xr20,  xr20
++    xvpermi.q    xr2,   xr3,   0x2
++    xvpermi.q    xr3,   xr4,   0x2
++    XMADDW4_H xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++
++    xvilvl.h         xr12, xr11, xr10
++    xvilvh.h         xr13, xr11, xr10
++    xvor.v           xr9,  xr12, xr12
++    xvpermi.q        xr12, xr13, 0x02
++    xvpermi.q        xr9,  xr13, 0x13
++    add.d            t6,   t6,   t1
++    xvst             xr12, a2,   0
++    xvstx            xr9,  a2,   a3
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t7
++    blt              zero, t0,   .lasx_loopV_ps_4tap_16x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PS_16xN 4
++LASX_VERT_4TAP_PS_16xN 8
++LASX_VERT_4TAP_PS_16xN 12
++LASX_VERT_4TAP_PS_16xN 16
++LASX_VERT_4TAP_PS_16xN 24
++LASX_VERT_4TAP_PS_16xN 32
++LASX_VERT_4TAP_PS_16xN 64
++
++.macro LASX_VERT_4TAP_PS_24xN  h
++function x265_interp_4tap_vert_ps_24x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvld         xr20,  t4,    0
++
++    add.d        t6,    a0,    t2
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++
++.lasx_loopV_ps_4tap_24x\h:
++    xvld         xr3,   t6,    0   //3
++    xvldx        xr4,   t6,    a1  //4
++
++.irp x, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr20,  xr20
++.endr
++    XMADDW4_H xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++
++    xvpermi.d        xr10, xr10, 0xD8
++    xvpermi.d        xr11, xr11, 0xD8
++    xvpermi.d        xr12, xr12, 0xD8
++    xvpermi.d        xr13, xr13, 0xD8
++    xvilvl.h         xr9,  xr11, xr10
++    xvilvh.h         xr14, xr11, xr10
++    xvilvl.h         xr7,  xr13, xr12
++    xvilvh.h         xr8,  xr13, xr12
++
++    xvst             xr9,  a2,   0
++    vst              vr14, a2,   32
++    add.d            a2,   a2,   a3
++    add.d            t6,   t6,   t1
++    addi.d           t0,   t0,   -1
++    xvst             xr7,  a2,   0
++    vst              vr8,  a2,   32
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_4tap_24x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PS_24xN 32
++LASX_VERT_4TAP_PS_24xN 64
++
++function x265_interp_4tap_vert_ps_48x64_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  32
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvld         xr20,  t4,    0
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++    add.d        a0,    a0,    t2
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++    xvpermi.q    xr5,   xr6,   0x2
++    xvpermi.q    xr6,   xr7,   0x2
++.lasx_loopV_ps_4tap_48x64:
++    addi.d       t6,    a0,    32
++    xvld         xr3,   a0,    0   //3
++    xvldx        xr4,   a0,    a1  //4
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++
++.irp x, xr10, xr11, xr12, xr13, xr14, xr15
++    xvor.v       \x,    xr20,  xr20
++.endr
++    xvpermi.q    xr7,   xr8,   0x2
++    xvpermi.q    xr8,   xr9,   0x2
++
++    XMADDW4_H xr0,  xr1,  xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr5,  xr1,  xr16, xr17, xr14, xr15, xr10, xr11
++    XMADDW4_H xr2,  xr6,  xr17, xr17, xr12, xr13, xr14, xr15
++    XMADDW4_H xr2,  xr3,  xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7,  xr3,  xr18, xr19, xr14, xr15, xr10, xr11
++    XMADDW4_H xr4,  xr8,  xr19, xr19, xr12, xr13, xr14, xr15
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++    xvor.v           xr7,  xr9,  xr9
++    xvpermi.d        xr10, xr10, 0xD8
++    xvpermi.d        xr11, xr11, 0xD8
++    xvpermi.d        xr12, xr12, 0xD8
++    xvpermi.d        xr13, xr13, 0xD8
++
++    xvilvl.h         xr3,  xr11, xr10
++    xvilvh.h         xr4,  xr11, xr10
++    xvilvl.h         xr8,  xr13, xr12
++    xvilvh.h         xr9,  xr13, xr12
++    xvilvl.h         xr21, xr15, xr14
++    xvilvh.h         xr22, xr15, xr14
++    xvor.v           xr23, xr21, xr21
++    xvpermi.q        xr21, xr22, 0x2
++    xvpermi.q        xr23, xr22, 0x13
++
++    xvst             xr3,  a2,   0
++    xvst             xr4,  a2,   32
++    xvst             xr21, a2,   64
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    xvst             xr8,  a2,   0
++    xvst             xr9,  a2,   32
++    xvst             xr23, a2,   64
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_4tap_48x64
++endfunc
++
++.macro LASX_VERT_4TAP_PS_32xN  h
++function x265_interp_4tap_vert_ps_32x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++    xvld         xr20,  t4,    0
++
++    add.d        t6,    a0,    t2
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++
++.lasx_loopV_ps_4tap_32x\h:
++    xvld         xr3,   t6,    0   //3
++    xvldx        xr4,   t6,    a1  //4
++
++.irp x, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr20,  xr20
++.endr
++    XMADDW4_H xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++
++    xvilvl.h         xr5,  xr11, xr10
++    xvilvh.h         xr6,  xr11, xr10
++    xvilvl.h         xr7,  xr13, xr12
++    xvilvh.h         xr8,  xr13, xr12
++
++    xvor.v           xr14, xr6,  xr6
++    xvor.v           xr15, xr8,  xr8
++
++    xvpermi.q        xr6,  xr5,  0x20
++    xvpermi.q        xr14, xr5,  0x31
++    xvpermi.q        xr8,  xr7,  0x20
++    xvpermi.q        xr15, xr7,  0x31
++    xvst             xr6,  a2,   0
++    xvst             xr14, a2,   32
++    add.d            a2,   a2,   a3
++    add.d            t6,   t6,   t1
++    xvst             xr8,  a2,   0
++    xvst             xr15, a2,   32
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_4tap_32x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PS_32xN 8
++LASX_VERT_4TAP_PS_32xN 16
++LASX_VERT_4TAP_PS_32xN 24
++LASX_VERT_4TAP_PS_32xN 32
++LASX_VERT_4TAP_PS_32xN 48
++LASX_VERT_4TAP_PS_32xN 64
++
++.macro LASX_VERT_4TAP_PS_64xN  h
++function x265_interp_4tap_vert_ps_64x\h\()_lasx
++    slli.d       t7,    a4,    5
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       a3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    xvld         xr15,  t4,    0
++    xvldrepl.b   xr16,  t5,    0
++    xvldrepl.b   xr17,  t5,    2
++    xvldrepl.b   xr18,  t5,    4
++    xvldrepl.b   xr19,  t5,    6
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0    //0
++    xvldx        xr1,   a0,    a1   //1
++    xvldx        xr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    xvld         xr5,   t6,    0
++    xvldx        xr6,   t6,    a1
++    xvldx        xr7,   t6,    t1
++
++.lasx_loopV_ps_4tap_64x\h:
++    addi.d       t6,    a0,    32
++    xvld         xr3,   a0,    0
++    xvldx        xr4,   a0,    a1  //7
++    xvld         xr8,   t6,    0
++    xvldx        xr9,   t6,    a1
++
++.irp x, xr10, xr11, xr12, xr13, xr20, xr21, xr22, xr23
++    xvor.v       \x,    xr15,  xr15
++.endr
++    XMADDW4_H xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADDW4_H xr5, xr6, xr16, xr16, xr20, xr21, xr22, xr23
++    XMADDW4_H xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADDW4_H xr6, xr7, xr17, xr17, xr20, xr21, xr22, xr23
++    XMADDW4_H xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADDW4_H xr7, xr8, xr18, xr18, xr20, xr21, xr22, xr23
++    XMADDW4_H xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    XMADDW4_H xr8, xr9, xr19, xr19, xr20, xr21, xr22, xr23
++
++    xvor.v           xr0,  xr2,  xr2
++    xvor.v           xr1,  xr3,  xr3
++    xvor.v           xr2,  xr4,  xr4
++    xvor.v           xr5,  xr7,  xr7
++    xvor.v           xr6,  xr8,  xr8
++    xvor.v           xr7,  xr9,  xr9
++
++    xvilvl.h         xr3,  xr11, xr10
++    xvilvh.h         xr4,  xr11, xr10
++    xvilvl.h         xr8,  xr13, xr12
++    xvilvh.h         xr9,  xr13, xr12
++    xvilvl.h         xr10, xr21, xr20
++    xvilvh.h         xr11, xr21, xr20
++    xvilvl.h         xr12, xr23, xr22
++    xvilvh.h         xr13, xr23, xr22
++
++    xvor.v           xr20, xr4,  xr4
++    xvor.v           xr21, xr9,  xr9
++    xvor.v           xr22, xr11, xr11
++    xvor.v           xr23, xr13, xr13
++
++    xvpermi.q        xr4,  xr3,  0x20
++    xvpermi.q        xr20, xr3,  0x31
++    xvpermi.q        xr9,  xr8,  0x20
++    xvpermi.q        xr21, xr8,  0x31
++    xvpermi.q        xr11, xr10, 0x20
++    xvpermi.q        xr22, xr10, 0x31
++    xvpermi.q        xr13, xr12, 0x20
++    xvpermi.q        xr23, xr12, 0x31
++
++    xvst             xr4,  a2,   0
++    xvst             xr20, a2,   32
++    xvst             xr11, a2,   64
++    xvst             xr22, a2,   96
++    add.d            a0,   a0,   t1
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    xvst             xr9,  a2,   0
++    xvst             xr21, a2,   32
++    xvst             xr13, a2,   64
++    xvst             xr23, a2,   96
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .lasx_loopV_ps_4tap_64x\h
++endfunc
++.endm
++
++LASX_VERT_4TAP_PS_64xN 16
++LASX_VERT_4TAP_PS_64xN 32
++LASX_VERT_4TAP_PS_64xN 48
++LASX_VERT_4TAP_PS_64xN 64
++
++.macro FILTER_VERT_4TAP_SP_2xN  h
++function x265_interp_4tap_vert_sp_2x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/4
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr15,  t4,    32
++
++    add.d        a0,    t6,    t2
++    fld.s        f8,    t6,    0    //0
++    fldx.s       f9,    t6,    a1   //1
++    fldx.s       f10,   t6,    t1   //2
++
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++
++.loopV_4tap_sp_2x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vilvl.h      vr4,   vr13,  vr12 //4,5
++    vilvl.h      vr5,   vr14,  vr13 //5,6
++
++    vilvl.d      vr6,   vr2,   vr0  //0,1,2,3
++    vilvl.d      vr7,   vr3,   vr1  //1,2,3,4
++    vilvl.d      vr8,   vr4,   vr2  //2,3,4,5
++    vilvl.d      vr9,   vr5,   vr3  //3,4,5,6
++    vor.v        vr20,  vr15,  vr15
++    vor.v        vr21,  vr15,  vr15
++    VMADD4_W vr6, vr7, vr16, vr17, vr20, vr21, vr20, vr21
++    VMADD4_W vr8, vr9, vr18, vr19, vr20, vr21, vr20, vr21
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++
++    vssrani.h.w      vr21, vr20, 12
++    vor.v            vr10, vr14, vr14
++    vssrani.bu.h     vr9,  vr21, 0
++    vstelm.h         vr9,  a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.h         vr9,  a2,   0,  2
++    add.d            a2,   a2,   a3
++    vstelm.h         vr9,  a2,   0,  1
++    add.d            a2,   a2,   a3
++    vstelm.h         vr9,  a2,   0,  3
++    add.d            a0,   a0,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_4tap_sp_2x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_2xN  4
++FILTER_VERT_4TAP_SP_2xN  8
++FILTER_VERT_4TAP_SP_2xN  16
++
++function x265_interp_4tap_vert_sp_4x2_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr20,  t4,    32
++
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++    fldx.d       f11,   t6,    t2   //3
++    fldx.d       f12,   t6,    t3   //4
++
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vor.v        vr6,   vr20,  vr20
++    vor.v        vr7,   vr20,  vr20
++    VMADD4_W vr0, vr1, vr16, vr17, vr6, vr7, vr6, vr7
++    VMADD4_W vr2, vr3, vr18, vr19, vr6, vr7, vr6, vr7
++
++    vssrani.h.w      vr7,  vr6,  12
++    vssrani.bu.h     vr9,  vr7,  0
++    vstelm.w         vr9,  a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,  1
++endfunc
++
++.macro FILTER_VERT_4TAP_SP_4xN  h
++function x265_interp_4tap_vert_sp_4x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/4
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr20,  t4,    32
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++.loopV_4tap_sp_4x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vilvl.h      vr4,   vr13,  vr12 //4,5
++    vilvl.h      vr5,   vr14,  vr13 //5,6
++.irp x, vr6, vr7, vr8, vr9
++    vor.v        \x,    vr20,  vr20
++.endr
++    VMADD4_W vr0, vr2, vr16, vr16, vr6, vr7, vr8, vr9
++    VMADD4_W vr1, vr3, vr17, vr17, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr4, vr18, vr18, vr6, vr7, vr8, vr9
++    VMADD4_W vr3, vr5, vr19, vr19, vr6, vr7, vr8, vr9
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++
++    vssrani.h.w      vr7,  vr6,  12
++    vssrani.h.w      vr9,  vr8,  12
++    vor.v            vr10, vr14, vr14
++    vssrani.bu.h     vr9,  vr7,  0
++    vstelm.w         vr9,  a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,  1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,  2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr9,  a2,   0,  3
++    add.d            a0,   a0,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_4tap_sp_4x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_4xN 4
++FILTER_VERT_4TAP_SP_4xN 8
++FILTER_VERT_4TAP_SP_4xN 16
++FILTER_VERT_4TAP_SP_4xN 32
++
++.macro FILTER_VERT_4TAP_SP_6xN  h
++function x265_interp_4tap_vert_sp_6x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr15,  t4,    32
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_4tap_sp_6x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vssrani.h.w      vr12, vr10, 12
++    vssrani.h.w      vr13, vr11, 12
++    vssrani.bu.h     vr13, vr12, 0
++    vor.v            vr2,  vr4,  vr4
++    vbsrl.v          vr10, vr13, 8
++    vilvl.b          vr11, vr10, vr13
++
++    vstelm.w         vr11, a2,   0,  0
++    vstelm.h         vr11, a2,   4,  2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr11, a2,   0,  2
++    vstelm.h         vr11, a2,   4,  6
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_sp_6x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_6xN 8
++FILTER_VERT_4TAP_SP_6xN 16
++
++.macro FILTER_VERT_4TAP_SP_8xN  h
++function x265_interp_4tap_vert_sp_8x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr15,  t4,    32
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_4tap_sp_8x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++.irp x, vr10, vr11, vr12, vr13
++    vor.v        \x,    vr15,  vr15
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vssrani.h.w      vr12, vr10, 12
++    vssrani.h.w      vr13, vr11, 12
++    vssrani.bu.h     vr13, vr12, 0
++    vor.v            vr2,  vr4,  vr4
++    vbsrl.v          vr10, vr13, 8
++    vilvl.b          vr11, vr10, vr13
++
++    vstelm.d         vr11, a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr11, a2,   0,  1
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_sp_8x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_8xN 2
++FILTER_VERT_4TAP_SP_8xN 4
++FILTER_VERT_4TAP_SP_8xN 6
++FILTER_VERT_4TAP_SP_8xN 8
++FILTER_VERT_4TAP_SP_8xN 12
++FILTER_VERT_4TAP_SP_8xN 16
++FILTER_VERT_4TAP_SP_8xN 32
++FILTER_VERT_4TAP_SP_8xN 64
++
++.macro FILTER_VERT_4TAP_SP_12xN h
++function x265_interp_4tap_vert_sp_12x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr20,  t4,    32
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    fld.d        f5,    t6,    0
++    fldx.d       f6,    t6,    a1
++    fldx.d       f7,    t6,    t1
++    vilvl.h      vr5,   vr6,   vr5  //0,1
++
++.loopV_4tap_sp_12x\h:
++    add.d        t6,    a0,    a1
++    vld          vr3,   a0,    0   //3
++    fld.d        f8,    a0,    16  //3
++    vld          vr4,   t6,    0   //4
++    fld.d        f9,    t6,    16  //4
++    vilvl.h      vr6,   vr8,   vr7 //2, 3
++    vilvl.h      vr21,  vr20,  vr9 //4
++
++.irp x, vr10, vr11, vr12, vr13, vr14, vr15
++    vor.v        \x,    vr20,  vr20
++.endr
++
++    VMADD4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr5, vr16
++    vmaddwod.w.h  vr15, vr5, vr16
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    vmaddwod.w.h  vr14, vr5, vr17
++    vmaddwev.w.h  vr15, vr6, vr17
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr6, vr18
++    vmaddwod.w.h  vr15, vr6, vr18
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    vmaddwod.w.h  vr14, vr6, vr19
++    vmaddwev.w.h  vr15, vr21,vr19
++
++    vor.v         vr0,  vr2,  vr2
++    vor.v         vr1,  vr3,  vr3
++    vssrani.h.w   vr12, vr10, 12
++    vssrani.h.w   vr13, vr11, 12
++    vssrani.h.w   vr15, vr14, 12
++    vor.v         vr2,  vr4,  vr4
++    vor.v         vr5,  vr6,  vr6
++    vilvl.h       vr10, vr13, vr12
++    vilvh.h       vr11, vr13, vr12
++    vor.v         vr7,  vr9,  vr9
++    vssrani.bu.h  vr11, vr10, 0
++    vssrani.bu.h  vr12, vr15, 0
++
++    vstelm.d         vr11, a2,   0,  0
++    vstelm.w         vr12, a2,   8,  0
++    add.d            a2,   a2,   a3
++    add.d            a0,   t6,   a1
++    addi.d           t0,   t0,   -1
++    vstelm.d         vr11, a2,   0,  1
++    vstelm.w         vr12, a2,   8,  1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_sp_12x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_12xN 16
++FILTER_VERT_4TAP_SP_12xN 32
++
++.macro FILTER_VERT_4TAP_SP_16xN  h
++function x265_interp_4tap_vert_sp_16x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr20,  t4,    32
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++.loopV_4tap_sp_16x\h:
++    add.d        t6,    a0,    a1
++    vld          vr3,   a0,    0   //3
++    vld          vr8,   a0,    16
++    vld          vr4,   t6,    0   //4
++    vld          vr9,   t6,    16
++.irp x, vr10, vr11, vr12, vr13, vr14, vr15, vr21, vr22
++    vor.v        \x,    vr20,  vr20
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr5, vr6, vr16, vr16, vr14, vr15, vr21, vr22
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr6, vr7, vr17, vr17, vr14, vr15, vr21, vr22
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr7, vr8, vr18, vr18, vr14, vr15, vr21, vr22
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr8, vr9, vr19, vr19, vr14, vr15, vr21, vr22
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++
++    vssrani.h.w      vr12, vr10, 12
++    vssrani.h.w      vr13, vr11, 12
++    vssrani.h.w      vr21, vr14, 12
++    vssrani.h.w      vr22, vr15, 12
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++    vor.v            vr7,  vr9,  vr9
++    vilvl.h          vr10, vr13, vr12
++    vilvh.h          vr11, vr13, vr12
++    vilvl.h          vr14, vr22, vr21
++    vilvh.h          vr15, vr22, vr21
++    vssrani.bu.h     vr14, vr10, 0
++    vssrani.bu.h     vr15, vr11, 0
++
++    vst              vr14, a2,   0
++    vstx             vr15, a2,   a3
++    add.d            a0,   t6,   a1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t3
++    blt              zero, t0,   .loopV_4tap_sp_16x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_16xN 4
++FILTER_VERT_4TAP_SP_16xN 8
++FILTER_VERT_4TAP_SP_16xN 12
++FILTER_VERT_4TAP_SP_16xN 16
++FILTER_VERT_4TAP_SP_16xN 24
++FILTER_VERT_4TAP_SP_16xN 32
++FILTER_VERT_4TAP_SP_16xN 64
++
++.macro FILTER_VERT_4TAP_SP_24xN h
++function x265_interp_4tap_vert_sp_24x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr20,  t4,    32
++
++    addi.d       t6,    a0,    16
++    addi.d       t7,    a0,    32
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    vld          vr4,   t6,    0
++    vldx         vr5,   t6,    a1
++    vldx         vr6,   t6,    t1
++
++    vld          vr7,   t7,    0
++    vldx         vr8,   t7,    a1
++    vldx         vr9,   t7,    t1
++.loopV_4tap_sp_24x\h:
++    vld          vr3,   a0,    0
++    vld          vr21,  a0,    16
++    vld          vr22,  a0,    32
++
++.irp x, vr10, vr11, vr12, vr13, vr14, vr15
++    vor.v        \x,    vr20,  vr20
++.endr
++
++    VMADD4_W vr0, vr4, vr16, vr16, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr7, vr16
++    vmaddwod.w.h  vr15, vr7, vr16
++    VMADD4_W vr1, vr5, vr17, vr17, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr8, vr17
++    vmaddwod.w.h  vr15, vr8, vr17
++    VMADD4_W vr2, vr6, vr18, vr18, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr9, vr18
++    vmaddwod.w.h  vr15, vr9, vr18
++    VMADD4_W vr3, vr21, vr19, vr19, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr22, vr19
++    vmaddwod.w.h  vr15, vr22, vr19
++
++    vor.v         vr0,  vr1,  vr1
++    vor.v         vr1,  vr2,  vr2
++    vor.v         vr2,  vr3,  vr3
++    vssrani.h.w   vr12, vr10, 12
++    vssrani.h.w   vr13, vr11, 12
++    vssrani.h.w   vr15, vr14, 12
++    vor.v         vr4,  vr5,  vr5
++    vor.v         vr5,  vr6,  vr6
++    vor.v         vr6,  vr21, vr21
++    vilvl.h       vr10, vr13, vr12
++    vilvh.h       vr11, vr13, vr12
++    vssrani.bu.h  vr14, vr15, 0
++    vor.v         vr7,  vr8,  vr8
++    vor.v         vr8,  vr9,  vr9
++    vssrani.bu.h  vr11, vr10, 0
++    vbsrl.v       vr12, vr14, 4
++    vor.v         vr9,  vr22, vr22
++    vilvl.b       vr10, vr12, vr14
++
++    vst              vr11, a2,   0
++    vstelm.d         vr10, a2,   16,  0
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   a1
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_4tap_sp_24x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_24xN 32
++FILTER_VERT_4TAP_SP_24xN 64
++
++function x265_interp_4tap_vert_sp_48x64_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr7,   t4,    32
++
++.loopV_4tap_sp_48x64:
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++    vld          vr4,   a0,    64
++    vld          vr5,   a0,    80
++    add.d        t5,    a0,    a1
++.irp x, vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, vr20, vr21, vr22, vr23
++    vor.v        \x,    vr7,   vr7
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr16, vr16, vr20, vr21, vr22, vr23
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr17, vr17, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr17, vr17, vr20, vr21, vr22, vr23
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr18, vr18, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr18, vr18, vr20, vr21, vr22, vr23
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr19, vr19, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr19, vr19, vr20, vr21, vr22, vr23
++
++    vssrani.h.w  vr10, vr8,  12
++    vssrani.h.w  vr11, vr9,  12
++    vssrani.h.w  vr14, vr12, 12
++    vssrani.h.w  vr15, vr13, 12
++    vssrani.h.w  vr22, vr20, 12
++    vssrani.h.w  vr23, vr21, 12
++    vssrani.bu.h vr14, vr10, 0
++    vssrani.bu.h vr15, vr11, 0
++    vssrani.bu.h vr23, vr22, 0
++    vilvl.b      vr4,  vr15, vr14
++    vilvh.b      vr5,  vr15, vr14
++    vbsrl.v      vr22, vr23, 8
++    vilvl.b      vr6,  vr22, vr23
++    vst          vr4,  a2,   0
++    vst          vr5,  a2,   16
++    vst          vr6,  a2,   32
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_4tap_sp_48x64
++endfunc
++
++.macro FILTER_VERT_4TAP_SP_WxN  w, h, rep
++function x265_interp_4tap_vert_sp_\w\()x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++    vld          vr7,   t4,    32
++
++.loopV_4tap_sp_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    vld          vr0,   t1,    0
++    vld          vr1,   t1,    16
++    vld          vr2,   t1,    32
++    vld          vr3,   t1,    48
++    add.d        t5,    t1,    a1
++.irp x, vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15
++    vor.v        \x,    vr7,   vr7
++.endr
++    VMADD4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr18, vr18, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr19, vr19, vr12, vr13, vr14, vr15
++
++    vssrani.h.w  vr10, vr8,  12
++    vssrani.h.w  vr11, vr9,  12
++    vssrani.h.w  vr14, vr12, 12
++    vssrani.h.w  vr15, vr13, 12
++    vssrani.bu.h vr14, vr10, 0
++    vssrani.bu.h vr15, vr11, 0
++    addi.d       t1,   t1,   64
++    vilvl.b      vr4,  vr15, vr14
++    vilvh.b      vr5,  vr15, vr14
++    vst          vr4,  t2,   0
++    vst          vr5,  t2,   16
++    addi.d       t2,   t2,   32
++.endr
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_4tap_sp_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_WxN 32, 8,  1
++FILTER_VERT_4TAP_SP_WxN 32, 16, 1
++FILTER_VERT_4TAP_SP_WxN 32, 24, 1
++FILTER_VERT_4TAP_SP_WxN 32, 32, 1
++FILTER_VERT_4TAP_SP_WxN 32, 48, 1
++FILTER_VERT_4TAP_SP_WxN 32, 64, 1
++FILTER_VERT_4TAP_SP_WxN 64, 16, 2
++FILTER_VERT_4TAP_SP_WxN 64, 32, 2
++FILTER_VERT_4TAP_SP_WxN 64, 48, 2
++FILTER_VERT_4TAP_SP_WxN 64, 64, 2
++
++.macro FILTER_VERT_4TAP_SP_16xN_LASX h
++function x265_interp_4tap_vert_sp_16x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    add.d        t2,    t1,    a1
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++
++    slli.d       t7,    a3,    1
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++    xvld         xr20,  t4,    32
++    add.d        a0,    t6,    t2
++    xvld         xr0,   t6,    0
++    xvldx        xr1,   t6,    a1
++    xvldx        xr2,   t6,    t1
++.loopV_4tap_sp_lasx_16x\h:
++    xvld         xr3,   a0,    0
++    xvldx        xr4,   a0,    a1
++.irp x, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr20,  xr20
++.endr
++    XMADD4_W xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADD4_W xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADD4_W xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADD4_W xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    xvor.v        xr0,  xr2,  xr2
++    xvor.v        xr1,  xr3,  xr3
++    xvor.v        xr2,  xr4,  xr4
++    xvssrani.h.w  xr12, xr10, 12
++    xvssrani.h.w  xr13, xr11, 12
++    xvilvl.h      xr10, xr13, xr12
++    xvilvh.h      xr11, xr13, xr12
++    add.d         a0,   a0,   t1
++    xvssrani.bu.h xr11, xr10, 0
++    addi.d        t0,   t0,   -1
++    xvpermi.d     xr12, xr11, 0xD8
++    xvpermi.d     xr13, xr11, 0x8D
++    vst           vr12, a2,   0
++    vstx          vr13, a2,   a3
++    add.d         a2,   a2,   t7
++    blt           zero, t0,   .loopV_4tap_sp_lasx_16x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_16xN_LASX 4
++FILTER_VERT_4TAP_SP_16xN_LASX 8
++FILTER_VERT_4TAP_SP_16xN_LASX 12
++FILTER_VERT_4TAP_SP_16xN_LASX 16
++FILTER_VERT_4TAP_SP_16xN_LASX 24
++FILTER_VERT_4TAP_SP_16xN_LASX 32
++FILTER_VERT_4TAP_SP_16xN_LASX 64
++
++.macro FILTER_VERT_4TAP_SP_24xN_LASX h
++function x265_interp_4tap_vert_sp_24x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    add.d        t2,    t1,    a1
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++    xvld         xr20,  t4,    32
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0
++    xvldx        xr1,   a0,    a1
++    xvldx        xr2,   a0,    t1
++    add.d        a0,    a0,    t2
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++    xvpermi.q    xr5,   xr6,   0x2
++    xvpermi.q    xr6,   xr7,   0x2
++.loopV_4tap_sp_lasx_24x\h:
++    addi.d       t6,    a0,    32
++    xvld         xr3,   a0,    0
++    xvldx        xr4,   a0,    a1
++    xvld         xr8,   t6,    0
++    xvldx        xr9,   t6,    a1
++.irp x, xr10, xr11, xr12, xr13, xr14, xr15
++    xvor.v       \x,    xr20,  xr20
++.endr
++    xvpermi.q    xr7,   xr8,   0x2
++    xvpermi.q    xr8,   xr9,   0x2
++    XMADD4_W xr0,  xr1,  xr16, xr16, xr10, xr11, xr12, xr13
++    XMADD4_W xr5,  xr1,  xr16, xr17, xr14, xr15, xr10, xr11
++    XMADD4_W xr2,  xr6,  xr17, xr17, xr12, xr13, xr14, xr15
++    XMADD4_W xr2,  xr3,  xr18, xr18, xr10, xr11, xr12, xr13
++    XMADD4_W xr7,  xr3,  xr18, xr19, xr14, xr15, xr10, xr11
++    XMADD4_W xr4,  xr8,  xr19, xr19, xr12, xr13, xr14, xr15
++
++    xvor.v        xr0,  xr2,  xr2
++    xvor.v        xr1,  xr3,  xr3
++    xvor.v        xr2,  xr4,  xr4
++    xvor.v        xr5,  xr7,  xr7
++    xvor.v        xr6,  xr8,  xr8
++    xvor.v        xr7,  xr9,  xr9
++    xvssrani.h.w  xr15, xr14, 12
++    xvssrani.h.w  xr12, xr10, 12
++    xvssrani.h.w  xr13, xr11, 12
++    xvpermi.d     xr14, xr15, 0xB1
++    xvilvl.h      xr3,  xr13, xr12
++    xvilvh.h      xr4,  xr13, xr12
++    xvilvl.h      xr8,  xr14, xr15
++    addi.d        t0,   t0,   -1
++    xvssrani.bu.h xr4,  xr3,  0
++    xvssrani.bu.h xr9,  xr8,  0
++    xvpermi.d     xr21, xr4,  0xD8
++    xvpermi.d     xr22, xr4,  0x8D
++    vst           vr21, a2,   0
++    xvstelm.d     xr9,  a2,   16,  0
++    add.d         a2,   a2,   a3
++    add.d         a0,   a0,   t1
++    vst           vr22, a2,   0
++    xvstelm.d     xr9,  a2,   16,  2
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_sp_lasx_24x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_24xN_LASX 32
++FILTER_VERT_4TAP_SP_24xN_LASX 64
++
++function x265_interp_4tap_vert_sp_48x64_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++    xvld         xr20,  t4,    32
++
++.loopV_4tap_sp_lasx_48x64:
++    xvld         xr0,   a0,    0
++    xvld         xr1,   a0,    32
++    xvld         xr2,   a0,    64
++    add.d        t5,    a0,    a1
++.irp x, xr8, xr9, xr10, xr11, xr12, xr13
++    xvor.v       \x,    xr20,  xr20
++.endr
++    XMADD4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2, xr16
++    xvmaddwod.w.h xr13, xr2, xr16
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2, xr17
++    xvmaddwod.w.h xr13, xr2, xr17
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2, xr18
++    xvmaddwod.w.h xr13, xr2, xr18
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2, xr19
++    xvmaddwod.w.h xr13, xr2, xr19
++
++    xvssrani.h.w  xr13, xr12, 12
++    xvssrani.h.w  xr10, xr8,  12
++    xvssrani.h.w  xr11, xr9,  12
++    xvpermi.d     xr14, xr13, 0xB1
++    xvilvl.h      xr3,  xr11, xr10
++    xvilvh.h      xr4,  xr11, xr10
++    xvilvl.h      xr5,  xr14, xr13
++    xvssrani.bu.h xr4,  xr3,  0
++    xvssrani.bu.h xr6,  xr5,  0
++    xvpermi.d     xr0,  xr4,  0xD8
++    xvpermi.d     xr1,  xr6,  0xD8
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    xvst          xr0,  a2,   0
++    vst           vr1,  a2,   32
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_sp_lasx_48x64
++endfunc
++
++.macro FILTER_VERT_4TAP_SP_WxN_LASX  w, h, rep
++function x265_interp_4tap_vert_sp_\w\()x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       t7,    a4,    3
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++    xvld         xr7,   t4,    32
++
++.loopV_4tap_sp_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    xvld         xr0,   t1,    0
++    xvld         xr1,   t1,    32
++    add.d        t5,    t1,    a1
++    xvor.v       xr8,   xr7,   xr7
++    xvor.v       xr9,   xr7,   xr7
++    xvor.v       xr10,  xr7,   xr7
++    xvor.v       xr11,  xr7,   xr7
++    XMADD4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++
++    xvssrani.h.w  xr10, xr8,  12
++    xvssrani.h.w  xr11, xr9,  12
++    addi.d        t1,   t1,   64
++    xvilvl.h      xr12, xr11, xr10
++    xvilvh.h      xr13, xr11, xr10
++    xvssrani.bu.h xr13, xr12, 0
++    xvpermi.d     xr14, xr13, 0xD8
++    xvst          xr14, t2,   0
++    addi.d        t2,   t2,   32
++.endr
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_sp_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SP_WxN_LASX 32, 8,  1
++FILTER_VERT_4TAP_SP_WxN_LASX 32, 16, 1
++FILTER_VERT_4TAP_SP_WxN_LASX 32, 24, 1
++FILTER_VERT_4TAP_SP_WxN_LASX 32, 32, 1
++FILTER_VERT_4TAP_SP_WxN_LASX 32, 48, 1
++FILTER_VERT_4TAP_SP_WxN_LASX 32, 64, 1
++FILTER_VERT_4TAP_SP_WxN_LASX 64, 16, 2
++FILTER_VERT_4TAP_SP_WxN_LASX 64, 32, 2
++FILTER_VERT_4TAP_SP_WxN_LASX 64, 48, 2
++FILTER_VERT_4TAP_SP_WxN_LASX 64, 64, 2
++
++.macro FILTER_VERT_4TAP_SS_2xN  h
++function x265_interp_4tap_vert_ss_2x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/4
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    add.d        a0,    t6,    t2
++    fld.s        f8,    t6,    0    //0
++    fldx.s       f9,    t6,    a1   //1
++    fldx.s       f10,   t6,    t1   //2
++
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++
++.loopV_4tap_ss_2x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vilvl.h      vr4,   vr13,  vr12 //4,5
++    vilvl.h      vr5,   vr14,  vr13 //5,6
++
++    vilvl.d      vr6,   vr2,   vr0  //0,1,2,3
++    vilvl.d      vr7,   vr3,   vr1  //1,2,3,4
++    vilvl.d      vr8,   vr4,   vr2  //2,3,4,5
++    vilvl.d      vr9,   vr5,   vr3  //3,4,5,6
++    vmulwev.w.h  vr20,  vr6,   vr16
++    vmulwod.w.h  vr21,  vr6,   vr16
++    VMADD4_W vr7, vr8, vr17, vr18, vr20, vr21, vr20, vr21
++    vmaddwev.w.h vr20,  vr9,   vr19
++    vmaddwod.w.h vr21,  vr9,   vr19
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr10, vr14, vr14
++
++    vssrani.h.w      vr21, vr20, 6
++    vstelm.w         vr21, a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.w         vr21, a2,   0,  2
++    add.d            a2,   a2,   a3
++    vstelm.w         vr21, a2,   0,  1
++    add.d            a2,   a2,   a3
++    vstelm.w         vr21, a2,   0,  3
++    add.d            a0,   a0,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_4tap_ss_2x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_2xN  4
++FILTER_VERT_4TAP_SS_2xN  8
++FILTER_VERT_4TAP_SS_2xN  16
++
++function x265_interp_4tap_vert_ss_4x2_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++    fldx.d       f11,   t6,    t2   //3
++    fldx.d       f12,   t6,    t3   //4
++
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vmulwev.w.h  vr6,   vr0,   vr16
++    vmulwod.w.h  vr7,   vr0,   vr16
++    VMADD4_W vr1, vr2, vr17, vr18, vr6, vr7, vr6, vr7
++    vmaddwev.w.h vr6,   vr3,   vr19
++    vmaddwod.w.h vr7,   vr3,   vr19
++
++    vssrani.h.w  vr7,   vr6,   6
++    vstelm.d     vr7,   a2,    0,  0
++    add.d        a2,    a2,    a3
++    vstelm.d     vr7,   a2,    0,  1
++endfunc
++
++.macro FILTER_VERT_4TAP_SS_4xN  h
++function x265_interp_4tap_vert_ss_4x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a1,    2   //srcStride * 4
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/4
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    add.d        a0,    t6,    t2
++    fld.d        f8,    t6,    0    //0
++    fldx.d       f9,    t6,    a1   //1
++    fldx.d       f10,   t6,    t1   //2
++
++    vilvl.h      vr0,   vr9,   vr8  //0,1
++    vilvl.h      vr1,   vr10,  vr9  //1,2
++.loopV_4tap_ss_4x\h:
++    fld.d        f11,   a0,    0    //3
++    fldx.d       f12,   a0,    a1   //4
++    fldx.d       f13,   a0,    t1   //5
++    fldx.d       f14,   a0,    t2   //6
++    vilvl.h      vr2,   vr11,  vr10 //2,3
++    vilvl.h      vr3,   vr12,  vr11 //3,4
++    vilvl.h      vr4,   vr13,  vr12 //4,5
++    vilvl.h      vr5,   vr14,  vr13 //5,6
++    VMULW4_W vr0, vr2, vr16, vr16, vr6, vr7, vr8, vr9
++    VMADD4_W vr1, vr3, vr17, vr17, vr6, vr7, vr8, vr9
++    VMADD4_W vr2, vr4, vr18, vr18, vr6, vr7, vr8, vr9
++    VMADD4_W vr3, vr5, vr19, vr19, vr6, vr7, vr8, vr9
++    vor.v            vr0,  vr4,  vr4
++    vor.v            vr1,  vr5,  vr5
++    vor.v            vr10, vr14, vr14
++
++    vssrani.h.w      vr7,  vr6,  6
++    vssrani.h.w      vr9,  vr8,  6
++    vstelm.d         vr7,  a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr7,  a2,   0,  1
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,  0
++    add.d            a2,   a2,   a3
++    vstelm.d         vr9,  a2,   0,  1
++    add.d            a0,   a0,   t3
++    add.d            a2,   a2,   a3
++    addi.d           t0,   t0,   -1
++    blt              zero, t0,   .loopV_4tap_ss_4x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_4xN 4
++FILTER_VERT_4TAP_SS_4xN 8
++FILTER_VERT_4TAP_SS_4xN 16
++FILTER_VERT_4TAP_SS_4xN 32
++
++.macro FILTER_VERT_4TAP_SS_6xN  h
++function x265_interp_4tap_vert_ss_6x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_4tap_ss_6x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++    VMULW4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vssrani.h.w      vr12, vr10, 6
++    vssrani.h.w      vr13, vr11, 6
++    vor.v            vr2,  vr4,  vr4
++    vilvl.h          vr10, vr13, vr12
++    vilvh.h          vr11, vr13, vr12
++
++    vstelm.d         vr10, a2,   0,    0
++    vstelm.w         vr10, a2,   8,    2
++    add.d            a2,   a2,   a3
++    add.d            a0,   a0,   t1
++    vstelm.d         vr11, a2,   0,    0
++    vstelm.w         vr11, a2,   8,    2
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_ss_6x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_6xN 8
++FILTER_VERT_4TAP_SS_6xN 16
++
++.macro FILTER_VERT_4TAP_SS_8xN  h
++function x265_interp_4tap_vert_ss_8x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    slli.d       t3,    a3,    1
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        t6,    a0,    a1
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    add.d        a0,    t6,    t2
++    vld          vr0,   t6,    0    //0
++    vldx         vr1,   t6,    a1   //1
++    vldx         vr2,   t6,    t1   //2
++
++.loopV_4tap_ss_8x\h:
++    vld          vr3,   a0,    0   //3
++    vldx         vr4,   a0,    a1  //4
++    VMULW4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vssrani.h.w      vr12, vr10, 6
++    vssrani.h.w      vr13, vr11, 6
++    vor.v            vr2,  vr4,  vr4
++    vilvl.h          vr10, vr13, vr12
++    vilvh.h          vr11, vr13, vr12
++
++    vst              vr10, a2,   0
++    vstx             vr11, a2,   a3
++    add.d            a0,   a0,   t1
++    addi.d           t0,   t0,   -1
++    add.d            a2,   a2,   t3
++    blt              zero, t0,   .loopV_4tap_ss_8x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_8xN 2
++FILTER_VERT_4TAP_SS_8xN 4
++FILTER_VERT_4TAP_SS_8xN 6
++FILTER_VERT_4TAP_SS_8xN 8
++FILTER_VERT_4TAP_SS_8xN 12
++FILTER_VERT_4TAP_SS_8xN 16
++FILTER_VERT_4TAP_SS_8xN 32
++FILTER_VERT_4TAP_SS_8xN 64
++
++.macro FILTER_VERT_4TAP_SS_12xN h
++function x265_interp_4tap_vert_ss_12x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1  //srcStride * 3
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    fld.d        f5,    t6,    0
++    fldx.d       f6,    t6,    a1
++    fldx.d       f7,    t6,    t1
++    vilvl.h      vr5,   vr6,   vr5  //0,1
++
++.loopV_4tap_ss_12x\h:
++    add.d        t6,    a0,    a1
++    vld          vr3,   a0,    0   //3
++    fld.d        f8,    a0,    16  //3
++    vld          vr4,   t6,    0   //4
++    fld.d        f9,    t6,    16  //4
++    vilvl.h      vr6,   vr8,   vr7 //2, 3
++    vilvl.h      vr21,  vr20,  vr9 //4
++
++    VMULW4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    vmulwev.w.h  vr14, vr5, vr16
++    vmulwod.w.h  vr15, vr5, vr16
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    vmaddwod.w.h  vr14, vr5, vr17
++    vmaddwev.w.h  vr15, vr6, vr17
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr6, vr18
++    vmaddwod.w.h  vr15, vr6, vr18
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    vmaddwod.w.h  vr14, vr6, vr19
++    vmaddwev.w.h  vr15, vr21,vr19
++
++    vor.v         vr0,  vr2,  vr2
++    vor.v         vr1,  vr3,  vr3
++    vssrani.h.w   vr12, vr10, 6
++    vssrani.h.w   vr13, vr11, 6
++    vssrani.h.w   vr15, vr14, 6
++    vor.v         vr2,  vr4,  vr4
++    vor.v         vr5,  vr6,  vr6
++    vilvl.h       vr10, vr13, vr12
++    vilvh.h       vr11, vr13, vr12
++    vor.v         vr7,  vr9,  vr9
++
++    vst           vr10, a2,   0
++    vstelm.d      vr15, a2,   16,  0
++    add.d         a2,   a2,   a3
++    add.d         a0,   t6,   a1
++    addi.d        t0,   t0,   -1
++    vst           vr11, a2,   0
++    vstelm.d      vr15, a2,   16,  1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_ss_12x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_12xN 16
++FILTER_VERT_4TAP_SS_12xN 32
++
++.macro FILTER_VERT_4TAP_SS_16xN  h
++function x265_interp_4tap_vert_ss_16x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    addi.d       t6,    a0,    16
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++.loopV_4tap_ss_16x\h:
++    add.d        t6,    a0,    a1
++    vld          vr3,   a0,    0   //3
++    vld          vr8,   a0,    16
++    vld          vr4,   t6,    0   //4
++    vld          vr9,   t6,    16
++    VMULW4_W vr0, vr1, vr16, vr16, vr10, vr11, vr12, vr13
++    VMULW4_W vr5, vr6, vr16, vr16, vr14, vr15, vr21, vr22
++    VMADD4_W vr1, vr2, vr17, vr17, vr10, vr11, vr12, vr13
++    VMADD4_W vr6, vr7, vr17, vr17, vr14, vr15, vr21, vr22
++    VMADD4_W vr2, vr3, vr18, vr18, vr10, vr11, vr12, vr13
++    VMADD4_W vr7, vr8, vr18, vr18, vr14, vr15, vr21, vr22
++    VMADD4_W vr3, vr4, vr19, vr19, vr10, vr11, vr12, vr13
++    VMADD4_W vr8, vr9, vr19, vr19, vr14, vr15, vr21, vr22
++
++    vor.v            vr0,  vr2,  vr2
++    vor.v            vr1,  vr3,  vr3
++    vor.v            vr2,  vr4,  vr4
++
++    vssrani.h.w      vr12, vr10, 6
++    vssrani.h.w      vr13, vr11, 6
++    vssrani.h.w      vr21, vr14, 6
++    vssrani.h.w      vr22, vr15, 6
++    vor.v            vr5,  vr7,  vr7
++    vor.v            vr6,  vr8,  vr8
++    vor.v            vr7,  vr9,  vr9
++    vilvl.h          vr10, vr13, vr12
++    vilvh.h          vr11, vr13, vr12
++    vilvl.h          vr14, vr22, vr21
++    vilvh.h          vr15, vr22, vr21
++
++    vst              vr10, a2,   0
++    vst              vr14, a2,   16
++    add.d            a2,   a2,   a3
++    add.d            a0,   t6,   a1
++    addi.d           t0,   t0,   -1
++    vst              vr11, a2,   0
++    vst              vr15, a2,   16
++    add.d            a2,   a2,   a3
++    blt              zero, t0,   .loopV_4tap_ss_16x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_16xN 4
++FILTER_VERT_4TAP_SS_16xN 8
++FILTER_VERT_4TAP_SS_16xN 12
++FILTER_VERT_4TAP_SS_16xN 16
++FILTER_VERT_4TAP_SS_16xN 24
++FILTER_VERT_4TAP_SS_16xN 32
++FILTER_VERT_4TAP_SS_16xN 64
++
++.macro FILTER_VERT_4TAP_SS_24xN h
++function x265_interp_4tap_vert_ss_24x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1   //srcStride * 2
++    la.local     t6,    g_chromaFilter
++    add.d        t2,    t1,    a1
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++    addi.d       t6,    a0,    16
++    addi.d       t7,    a0,    32
++    vld          vr0,   a0,    0    //0
++    vldx         vr1,   a0,    a1   //1
++    vldx         vr2,   a0,    t1   //2
++
++    add.d        a0,    a0,    t2
++    vld          vr4,   t6,    0
++    vldx         vr5,   t6,    a1
++    vldx         vr6,   t6,    t1
++
++    vld          vr7,   t7,    0
++    vldx         vr8,   t7,    a1
++    vldx         vr9,   t7,    t1
++.loopV_4tap_ss_24x\h:
++    vld          vr3,   a0,    0
++    vld          vr21,  a0,    16
++    vld          vr22,  a0,    32
++
++    VMULW4_W vr0, vr4, vr16, vr16, vr10, vr11, vr12, vr13
++    vmulwev.w.h  vr14, vr7, vr16
++    vmulwod.w.h  vr15, vr7, vr16
++    VMADD4_W vr1, vr5, vr17, vr17, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr8, vr17
++    vmaddwod.w.h  vr15, vr8, vr17
++    VMADD4_W vr2, vr6, vr18, vr18, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr9, vr18
++    vmaddwod.w.h  vr15, vr9, vr18
++    VMADD4_W vr3, vr21, vr19, vr19, vr10, vr11, vr12, vr13
++    vmaddwev.w.h  vr14, vr22, vr19
++    vmaddwod.w.h  vr15, vr22, vr19
++
++    vor.v         vr0,  vr1,  vr1
++    vor.v         vr1,  vr2,  vr2
++    vor.v         vr2,  vr3,  vr3
++    vssrani.h.w   vr12, vr10, 6
++    vssrani.h.w   vr13, vr11, 6
++    vssrani.h.w   vr15, vr14, 6
++    vor.v         vr4,  vr5,  vr5
++    vor.v         vr5,  vr6,  vr6
++    vor.v         vr6,  vr21, vr21
++    vilvl.h       vr10, vr13, vr12
++    vilvh.h       vr11, vr13, vr12
++    vbsrl.v       vr14, vr15, 8
++    vor.v         vr7,  vr8,  vr8
++    vor.v         vr8,  vr9,  vr9
++    vor.v         vr9,  vr22, vr22
++    vilvl.h       vr12, vr14, vr15
++
++    vst           vr10, a2,   0
++    vst           vr11, a2,   16
++    vst           vr12, a2,   32
++    add.d         a2,   a2,   a3
++    add.d         a0,   a0,   a1
++    addi.d        t0,   t0,   -1
++    blt           zero, t0,   .loopV_4tap_ss_24x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_24xN 32
++FILTER_VERT_4TAP_SS_24xN 64
++
++function x265_interp_4tap_vert_ss_48x64_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1
++    la.local     t6,    g_chromaFilter
++    la.local     t4,    h_psOffset
++    add.d        t2,    t1,    a1
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++.loopV_4tap_ss_48x64:
++    vld          vr0,   a0,    0
++    vld          vr1,   a0,    16
++    vld          vr2,   a0,    32
++    vld          vr3,   a0,    48
++    vld          vr4,   a0,    64
++    vld          vr5,   a0,    80
++    add.d        t5,    a0,    a1
++    VMULW4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMULW4_W vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    VMULW4_W vr4, vr5, vr16, vr16, vr20, vr21, vr22, vr23
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr17, vr17, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr17, vr17, vr20, vr21, vr22, vr23
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr18, vr18, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr18, vr18, vr20, vr21, vr22, vr23
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    vld          vr4,   t5,    64
++    vld          vr5,   t5,    80
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr19, vr19, vr12, vr13, vr14, vr15
++    VMADD4_W vr4, vr5, vr19, vr19, vr20, vr21, vr22, vr23
++
++    vssrani.h.w  vr10, vr8,  6
++    vssrani.h.w  vr11, vr9,  6
++    vssrani.h.w  vr14, vr12, 6
++    vssrani.h.w  vr15, vr13, 6
++    vssrani.h.w  vr22, vr20, 6
++    vssrani.h.w  vr23, vr21, 6
++    vilvl.h      vr8,  vr11, vr10
++    vilvh.h      vr9,  vr11, vr10
++    vilvl.h      vr12, vr15, vr14
++    vilvh.h      vr13, vr15, vr14
++    vilvl.h      vr20, vr23, vr22
++    vilvh.h      vr21, vr23, vr22
++    vst          vr8,  a2,   0
++    vst          vr9,  a2,   16
++    vst          vr12, a2,   32
++    vst          vr13, a2,   48
++    vst          vr20, a2,   64
++    vst          vr21, a2,   80
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_4tap_ss_48x64
++endfunc
++
++.macro FILTER_VERT_4TAP_SS_WxN  w, h, rep
++function x265_interp_4tap_vert_ss_\w\()x\h\()_lsx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++
++    vldrepl.h    vr16,  t5,    0 + 256
++    vldrepl.h    vr17,  t5,    2 + 256
++    vldrepl.h    vr18,  t5,    4 + 256
++    vldrepl.h    vr19,  t5,    6 + 256
++
++.loopV_4tap_ss_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    vld          vr0,   t1,    0
++    vld          vr1,   t1,    16
++    vld          vr2,   t1,    32
++    vld          vr3,   t1,    48
++    add.d        t5,    t1,    a1
++    VMULW4_W vr0, vr1, vr16, vr16, vr8, vr9, vr10, vr11
++    VMULW4_W vr2, vr3, vr16, vr16, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr17, vr17, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr17, vr17, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr18, vr18, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr18, vr18, vr12, vr13, vr14, vr15
++    vld          vr0,   t5,    0
++    vld          vr1,   t5,    16
++    vld          vr2,   t5,    32
++    vld          vr3,   t5,    48
++    add.d        t5,    t5,    a1
++    VMADD4_W vr0, vr1, vr19, vr19, vr8, vr9, vr10, vr11
++    VMADD4_W vr2, vr3, vr19, vr19, vr12, vr13, vr14, vr15
++
++    vssrani.h.w  vr10, vr8,  6
++    vssrani.h.w  vr11, vr9,  6
++    vssrani.h.w  vr14, vr12, 6
++    vssrani.h.w  vr15, vr13, 6
++    addi.d       t1,   t1,   64
++    vilvl.h      vr8,  vr11, vr10
++    vilvh.h      vr9,  vr11, vr10
++    vilvl.h      vr12, vr15, vr14
++    vilvh.h      vr13, vr15, vr14
++    vst          vr8,  t2,   0
++    vst          vr9,  t2,   16
++    vst          vr12, t2,   32
++    vst          vr13, t2,   48
++    addi.d       t2,   t2,   64
++.endr
++    addi.d       t0,   t0,   -1
++    add.d        a0,   a0,   a1
++    add.d        a2,   a2,   a3
++    blt          zero, t0,   .loopV_4tap_ss_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_WxN 32, 8,  1
++FILTER_VERT_4TAP_SS_WxN 32, 16, 1
++FILTER_VERT_4TAP_SS_WxN 32, 24, 1
++FILTER_VERT_4TAP_SS_WxN 32, 32, 1
++FILTER_VERT_4TAP_SS_WxN 32, 48, 1
++FILTER_VERT_4TAP_SS_WxN 32, 64, 1
++FILTER_VERT_4TAP_SS_WxN 64, 16, 2
++FILTER_VERT_4TAP_SS_WxN 64, 32, 2
++FILTER_VERT_4TAP_SS_WxN 64, 48, 2
++FILTER_VERT_4TAP_SS_WxN 64, 64, 2
++
++.macro FILTER_VERT_4TAP_SS_16xN_LASX  h
++function x265_interp_4tap_vert_ss_16x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    add.d        t2,    t1,    a1
++    sub.d        t6,    a0,    a1
++
++    slli.d       t7,    a3,    1
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++
++    add.d        a0,    t6,    t2
++    xvld         xr0,   t6,    0
++    xvldx        xr1,   t6,    a1
++    xvldx        xr2,   t6,    t1
++.loopV_4tap_ss_lasx_16x\h:
++    xvld         xr3,   a0,    0
++    xvldx        xr4,   a0,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    XMADD4_W xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    XMADD4_W xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    XMADD4_W xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    xvor.v       xr0,   xr2,   xr2
++    xvor.v       xr1,   xr3,   xr3
++    xvor.v       xr2,   xr4,   xr4
++
++    xvssrani.h.w  xr12, xr10, 6
++    xvssrani.h.w  xr13, xr11, 6
++    xvilvl.h      xr14, xr13, xr12
++    xvilvh.h      xr15, xr13, xr12
++    addi.d        t0,   t0,   -1
++    xvst          xr14, a2,   0
++    xvstx         xr15, a2,   a3
++    add.d         a0,   a0,   t1
++    add.d         a2,   a2,   t7
++    blt           zero, t0,   .loopV_4tap_ss_lasx_16x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_16xN_LASX 4
++FILTER_VERT_4TAP_SS_16xN_LASX 8
++FILTER_VERT_4TAP_SS_16xN_LASX 12
++FILTER_VERT_4TAP_SS_16xN_LASX 16
++FILTER_VERT_4TAP_SS_16xN_LASX 24
++FILTER_VERT_4TAP_SS_16xN_LASX 32
++FILTER_VERT_4TAP_SS_16xN_LASX 64
++
++.macro FILTER_VERT_4TAP_SS_24xN_LASX  h
++function x265_interp_4tap_vert_ss_24x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    slli.d       t1,    a1,    1
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h/2
++    add.d        t2,    t1,    a1
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++
++    addi.d       t6,    a0,    32
++    xvld         xr0,   a0,    0
++    xvldx        xr1,   a0,    a1
++    xvldx        xr2,   a0,    t1
++    vld          vr5,   t6,    0
++    vldx         vr6,   t6,    a1
++    vldx         vr7,   t6,    t1
++    add.d        a0,    a0,    t2
++    xvpermi.q    xr5,   xr6,   0x2
++    xvpermi.q    xr6,   xr7,   0x2
++.loopV_4tap_ss_lasx_24x\h:
++    addi.d       t6,    a0,    32
++    xvld         xr3,   a0,    0
++    xvldx        xr4,   a0,    a1
++    vld          vr8,   t6,    0
++    vldx         vr9,   t6,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr10, xr11, xr12, xr13
++    xvmulwev.w.h  xr14, xr5,   xr16
++    xvmulwod.w.h  xr15, xr5,   xr16
++    xvpermi.q     xr7,  xr8,   0x2
++    xvpermi.q     xr8,  xr9,   0x2
++    XMADD4_W xr1, xr2, xr17, xr17, xr10, xr11, xr12, xr13
++    xvmaddwev.w.h xr14, xr6,   xr17
++    xvmaddwod.w.h xr15, xr6,   xr17
++    XMADD4_W xr2, xr3, xr18, xr18, xr10, xr11, xr12, xr13
++    xvmaddwev.w.h xr14, xr7,   xr18
++    xvmaddwod.w.h xr15, xr7,   xr18
++    XMADD4_W xr3, xr4, xr19, xr19, xr10, xr11, xr12, xr13
++    xvmaddwev.w.h xr14, xr8,   xr19
++    xvmaddwod.w.h xr15, xr8,   xr19
++    xvor.v       xr0,   xr2,   xr2
++    xvor.v       xr1,   xr3,   xr3
++    xvor.v       xr2,   xr4,   xr4
++    xvor.v       xr5,   xr7,   xr7
++    xvor.v       xr6,   xr8,   xr8
++    xvor.v       xr7,   xr9,   xr9
++
++    xvssrani.h.w  xr15, xr14, 6
++    xvssrani.h.w  xr12, xr10, 6
++    xvssrani.h.w  xr13, xr11, 6
++    xvpermi.d     xr14, xr15, 0xB1
++    xvilvl.h      xr3,  xr13, xr12
++    xvilvh.h      xr4,  xr13, xr12
++    xvilvl.h      xr8,  xr14, xr15
++    addi.d        t0,   t0,   -1
++    xvst          xr3,  a2,   0
++    vst           vr8,  a2,   32
++    add.d         a2,   a2,   a3
++    xvpermi.d     xr9,  xr8,  0x4E
++    add.d         a0,   a0,   t1
++    xvst          xr4,  a2,   0
++    vst           vr9,  a2,   32
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_ss_lasx_24x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_24xN_LASX 32
++FILTER_VERT_4TAP_SS_24xN_LASX 64
++
++function x265_interp_4tap_vert_ss_48x64_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  64
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++
++.loopV_4tap_ss_lasx_48x64:
++    xvld         xr0,   a0,    0
++    xvld         xr1,   a0,    32
++    xvld         xr2,   a0,    64
++    add.d        t5,    a0,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvmulwev.w.h  xr12, xr2,   xr16
++    xvmulwod.w.h  xr13, xr2,   xr16
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr17
++    xvmaddwod.w.h xr13, xr2,   xr17
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr18
++    xvmaddwod.w.h xr13, xr2,   xr18
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    xvld         xr2,   t5,    64
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++    xvmaddwev.w.h xr12, xr2,   xr19
++    xvmaddwod.w.h xr13, xr2,   xr19
++
++    xvssrani.h.w  xr13, xr12, 6
++    xvssrani.h.w  xr10, xr8,  6
++    xvssrani.h.w  xr11, xr9,  6
++    xvpermi.d     xr14, xr13, 0xB1
++    xvilvl.h      xr3,  xr11, xr10
++    xvilvh.h      xr4,  xr11, xr10
++    xvilvl.h      xr5,  xr14, xr13
++    xvst          xr3,  a2,   0
++    xvst          xr4,  a2,   32
++    xvst          xr5,  a2,   64
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_ss_lasx_48x64
++endfunc
++
++.macro FILTER_VERT_4TAP_SS_WxN_LASX  w, h, rep
++function x265_interp_4tap_vert_ss_\w\()x\h\()_lasx
++    slli.d       a1,    a1,    1
++    slli.d       a3,    a3,    1
++    slli.d       t7,    a4,    3
++    la.local     t6,    g_chromaFilter
++    add.d        t5,    t6,    t7
++    addi.d       t0,    zero,  \h
++    sub.d        a0,    a0,    a1
++
++    xvldrepl.h   xr16,  t5,    0 + 256
++    xvldrepl.h   xr17,  t5,    2 + 256
++    xvldrepl.h   xr18,  t5,    4 + 256
++    xvldrepl.h   xr19,  t5,    6 + 256
++
++.loopV_4tap_ss_lasx_\w\()x\h:
++    move         t1,    a0
++    move         t2,    a2
++.rept \rep
++    xvld         xr0,   t1,    0
++    xvld         xr1,   t1,    32
++    add.d        t5,    t1,    a1
++    XMULW4_W xr0, xr1, xr16, xr16, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr17, xr17, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    add.d        t5,    t5,    a1
++    XMADD4_W xr0, xr1, xr18, xr18, xr8, xr9, xr10, xr11
++    xvld         xr0,   t5,    0
++    xvld         xr1,   t5,    32
++    XMADD4_W xr0, xr1, xr19, xr19, xr8, xr9, xr10, xr11
++
++    xvssrani.h.w  xr10, xr8,  6
++    xvssrani.h.w  xr11, xr9,  6
++    addi.d        t1,   t1,   64
++    xvilvl.h      xr12, xr11, xr10
++    xvilvh.h      xr13, xr11, xr10
++    xvst          xr12, t2,   0
++    xvst          xr13, t2,   32
++    addi.d        t2,   t2,   64
++.endr
++    addi.d        t0,   t0,   -1
++    add.d         a0,   a0,   a1
++    add.d         a2,   a2,   a3
++    blt           zero, t0,   .loopV_4tap_ss_lasx_\w\()x\h
++endfunc
++.endm
++
++FILTER_VERT_4TAP_SS_WxN_LASX 32, 8,  1
++FILTER_VERT_4TAP_SS_WxN_LASX 32, 16, 1
++FILTER_VERT_4TAP_SS_WxN_LASX 32, 24, 1
++FILTER_VERT_4TAP_SS_WxN_LASX 32, 32, 1
++FILTER_VERT_4TAP_SS_WxN_LASX 32, 48, 1
++FILTER_VERT_4TAP_SS_WxN_LASX 32, 64, 1
++FILTER_VERT_4TAP_SS_WxN_LASX 64, 16, 2
++FILTER_VERT_4TAP_SS_WxN_LASX 64, 32, 2
++FILTER_VERT_4TAP_SS_WxN_LASX 64, 48, 2
++FILTER_VERT_4TAP_SS_WxN_LASX 64, 64, 2
+diff --git a/source/common/loongarch64/ipfilter8.h b/source/common/loongarch64/ipfilter8.h
+new file mode 100644
+index 000000000..0a65f02ce
+--- /dev/null
++++ b/source/common/loongarch64/ipfilter8.h
+@@ -0,0 +1,143 @@
++/*****************************************************************************
++ * Copyright (C) 2013-2024 MulticoreWare, Inc
++ *
++ * Authors: Hao Chen <chenhao@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_IPFILTER8_H
++#define X265_IPFILTER8_H
++
++#define FUNCDEF_PU(ret, name, cpu, ...) \
++    ret PFX(name ## _4x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x32_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x4_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x8_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x8_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _48x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x48_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x64_ ## cpu)(__VA_ARGS__); \
++
++#define FUNCDEF_PU_LASX(ret, name, ...) \
++    ret PFX(name ## _16x4_  ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _16x8_  ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _16x12_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _16x16_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _16x32_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _16x64_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _24x32_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _32x8_  ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _32x16_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _32x24_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _32x32_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _32x64_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _48x64_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _64x16_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _64x32_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _64x48_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _64x64_ ## lasx)(__VA_ARGS__); \
++
++#define FUNCDEF_CHROMA_PU(ret, name, cpu, ...) \
++    FUNCDEF_PU(ret, name, cpu, __VA_ARGS__); \
++    ret PFX(name ## _2x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x2_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x32_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _6x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _6x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x2_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x6_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x12_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x64_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x48_ ## cpu)(__VA_ARGS__); \
++
++#define FUNCDEF_CHROMA_PU_LASX(ret, name, ...) \
++    FUNCDEF_PU_LASX(ret, name, __VA_ARGS__); \
++    ret PFX(name ## _16x24_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _24x64_ ## lasx)(__VA_ARGS__); \
++    ret PFX(name ## _32x48_ ## lasx)(__VA_ARGS__); \
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++#define SETUP_FUNC_DEF(cpu) \
++    FUNCDEF_PU(void, interp_8tap_horiz_pp, cpu, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_PU(void, interp_8tap_horiz_ps, cpu, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx, int isRowExt); \
++    FUNCDEF_PU(void, interp_8tap_vert_pp, cpu, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_PU(void, interp_8tap_vert_ps, cpu, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_PU(void, interp_8tap_vert_sp, cpu, const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_PU(void, interp_8tap_vert_ss, cpu, const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_PU(void, interp_8tap_hv_pp, cpu, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int idxX, int idxY); \
++    FUNCDEF_CHROMA_PU(void, filterPixelToShort, cpu, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride); \
++    FUNCDEF_CHROMA_PU(void, interp_4tap_horiz_pp, cpu, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_CHROMA_PU(void, interp_4tap_horiz_ps, cpu, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx, int isRowExt); \
++    FUNCDEF_CHROMA_PU(void, interp_4tap_vert_pp, cpu, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_CHROMA_PU(void, interp_4tap_vert_ps, cpu, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_CHROMA_PU(void, interp_4tap_vert_sp, cpu, const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx); \
++    FUNCDEF_CHROMA_PU(void, interp_4tap_vert_ss, cpu, const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx); \
++
++SETUP_FUNC_DEF(lsx)
++
++FUNCDEF_PU_LASX(void, interp_8tap_horiz_pp, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_PU_LASX(void, interp_8tap_horiz_ps, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx, int isRowExt);
++FUNCDEF_PU_LASX(void, interp_8tap_vert_pp, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_PU_LASX(void, interp_8tap_vert_ps, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_PU_LASX(void, interp_8tap_vert_sp, const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_PU_LASX(void, interp_8tap_vert_ss, const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_PU_LASX(void, interp_8tap_hv_pp, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int idxX, int idxY);
++FUNCDEF_CHROMA_PU_LASX(void, interp_4tap_horiz_pp, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_CHROMA_PU_LASX(void, interp_4tap_horiz_ps, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx, int isRowExt);
++FUNCDEF_CHROMA_PU_LASX(void, filterPixelToShort, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride);
++FUNCDEF_CHROMA_PU_LASX(void, interp_4tap_vert_pp, const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_CHROMA_PU_LASX(void, interp_4tap_vert_ps, const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_CHROMA_PU_LASX(void, interp_4tap_vert_sp, const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx);
++FUNCDEF_CHROMA_PU_LASX(void, interp_4tap_vert_ss, const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx);
++
++#undef FUNCDEF_PU
++#undef FUNCDEF_PU_LASX
++#undef FUNCDEF_CHROMA_PU
++
++#ifdef __cplusplus
++}
++#endif /*__cplusplus*/
++
++#endif // ifndef X265_LOOPFILTER_H
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0006-FROMLIST-LoongArch64-Optimize-functions-in-dct.S-fil.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0006-FROMLIST-LoongArch64-Optimize-functions-in-dct.S-fil.patch
@@ -1,0 +1,5817 @@
+From 8624f07282ecb2d5f05134fa920178379e9c40e1 Mon Sep 17 00:00:00 2001
+From: zhoupeng <zhoupeng@loongson.cn>
+Date: Fri, 31 May 2024 15:56:10 +0800
+Subject: [PATCH 06/15] FROMLIST: LoongArch64: Optimize functions in dct.S file
+ - Patch 1
+
+The optimized functions are as follows:
+dct32_lsx/dct32_lasx
+dct16_lsx/dct16_lasx
+idct16_lsx/idct16_lasx
+idct32_lsx/idct32_lasx
+dct8/4_lsx
+idct8/4_lsx
+dst4/idst4_lsx
+scanPosLast_lsx
+costCoeffNxN_lsx
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |    4 +-
+ source/common/loongarch64/asm-primitives.cpp |   21 +
+ source/common/loongarch64/dct.S              | 5653 ++++++++++++++++++
+ source/common/loongarch64/dct.h              |   57 +
+ 4 files changed, 5733 insertions(+), 2 deletions(-)
+ create mode 100644 source/common/loongarch64/dct.S
+ create mode 100644 source/common/loongarch64/dct.h
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index a57a3675a..f5025f030 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -138,11 +138,11 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+         message(STATUS "Detected CXX compiler using -O3 optimization level")
+     endif()
+ 
+-    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h)
++    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S ipfilter8.S)
++    set(A_SRCS loopfilter.S ipfilter8.S dct.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 947568ae6..ff1e7b0a5 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -27,6 +27,7 @@
+ #include "cpu.h"
+ #include "loopfilter.h"
+ #include "ipfilter8.h"
++#include "dct.h"
+ 
+ namespace X265_NS {
+ // private x265 namespace
+@@ -200,6 +201,20 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         CHROMA_444(64, 32, lsx)
+         CHROMA_444(64, 48, lsx)
+         CHROMA_444(64, 64, lsx)
++
++        //dct
++        p.cu[BLOCK_32x32].dct  = PFX(dct32_lsx);
++        p.cu[BLOCK_16x16].dct  = PFX(dct16_lsx);
++        p.cu[BLOCK_8x8].dct    = PFX(dct8_lsx);
++        p.cu[BLOCK_4x4].dct    = PFX(dct4_lsx);
++        p.cu[BLOCK_4x4].idct   = PFX(idct4_lsx);
++        p.cu[BLOCK_8x8].idct   = PFX(idct8_lsx);
++        p.cu[BLOCK_16x16].idct = PFX(idct16_lsx);
++        p.cu[BLOCK_32x32].idct = PFX(idct32_lsx);
++        p.dst4x4               = PFX(dst4_lsx);
++        p.idst4x4              = PFX(idst4_lsx);
++        p.scanPosLast          = PFX(scanPosLast_lsx);
++        p.costCoeffNxN         = PFX(costCoeffNxN_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -267,6 +282,12 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         CHROMA_444(64, 32, lasx)
+         CHROMA_444(64, 48, lasx)
+         CHROMA_444(64, 64, lasx)
++
++        //dct
++        p.cu[BLOCK_16x16].dct  = PFX(dct16_lasx);
++        p.cu[BLOCK_32x32].dct  = PFX(dct32_lasx);
++        p.cu[BLOCK_16x16].idct = PFX(idct16_lasx);
++        p.cu[BLOCK_32x32].idct = PFX(idct32_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/dct.S b/source/common/loongarch64/dct.S
+new file mode 100644
+index 000000000..c9d25daf4
+--- /dev/null
++++ b/source/common/loongarch64/dct.S
+@@ -0,0 +1,5653 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Peng Zhou <zhoupeng@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "loongson_asm.S"
++
++const shuf_1
++.byte 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1
++.byte 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1
++endconst
++
++const shuf_2
++.byte 12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3
++endconst
++
++const shift_1
++.byte 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
++endconst
++
++const shift_2
++.byte 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
++endconst
++
++const shift_3
++.byte 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
++endconst
++
++const entropyStateBits
++.int 0x02007B23, 0x000085F9, 0x040074A0, 0x00008CBC, 0x06006EE4, 0x02009354, 0x080067F4, 0x04009C1B
++.int 0x0A0060B0, 0x0400A62A, 0x0C005A9C, 0x0800AF5B, 0x0E00548D, 0x0800B955, 0x10004F56, 0x0A00C2A9
++.int 0x12004A87, 0x0C00CBF7, 0x140045D6, 0x0E00D5C3, 0x16004144, 0x1000E01B, 0x18003D88, 0x1200E937
++.int 0x1A0039E0, 0x1200F2CD, 0x1C003663, 0x1600FC9E, 0x1E003347, 0x16010600, 0x20003050, 0x18010F95
++.int 0x22002D4D, 0x1A011A02, 0x24002AD3, 0x1A012333, 0x2600286E, 0x1E012CAD, 0x28002604, 0x1E0136DF
++.int 0x2A002425, 0x20013F48, 0x2C0021F4, 0x200149C4, 0x2E00203E, 0x2401527B, 0x30001E4D, 0x24015D00
++.int 0x32001C99, 0x260166DE, 0x34001B18, 0x26017017, 0x360019A5, 0x2A017988, 0x38001841, 0x2A018327
++.int 0x3A0016DF, 0x2C018D50, 0x3C0015D9, 0x2C019547, 0x3E00147C, 0x2E01A083, 0x4000138E, 0x3001A8A3
++.int 0x42001251, 0x3001B418, 0x44001166, 0x3201BD27, 0x46001068, 0x3401C77B, 0x48000F7F, 0x3401D18E
++.int 0x4A000EDA, 0x3601D91A, 0x4C000E19, 0x3601E254, 0x4E000D4F, 0x3801EC9A, 0x50000C90, 0x3A01F6E0
++.int 0x52000C01, 0x3A01FEF8, 0x54000B5F, 0x3C0208B1, 0x56000AB6, 0x3C021362, 0x58000A15, 0x3C021E46
++.int 0x5A000988, 0x3E02285D, 0x5C000934, 0x40022EA8, 0x5E0008A8, 0x400239B2, 0x6000081D, 0x42024577
++.int 0x620007C9, 0x42024CE6, 0x64000763, 0x42025663, 0x66000710, 0x44025E8F, 0x680006A0, 0x44026A26
++.int 0x6A000672, 0x46026F23, 0x6C0005E8, 0x46027EF8, 0x6E0005BA, 0x460284B5, 0x7000055E, 0x48029057
++.int 0x7200050C, 0x48029BAB, 0x740004C1, 0x4802A674, 0x760004A7, 0x4A02AA5E, 0x7800046F, 0x4A02B32F
++.int 0x7A00041F, 0x4A02C0AD, 0x7C0003E7, 0x4C02CA8D, 0x7C0003BA, 0x4C02D323, 0x7E00010C, 0x7E03BFBB
++endconst
++
++const table_dct16
++.int 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
++.int 90, 87, 80, 70, 57, 43, 25,  9, -9, -25, -43, -57, -70, -80, -87, -90
++.int 89, 75, 50, 18, -18, -50, -75, -89, -89, -75, -50, -18, 18, 50, 75, 89
++.int 87, 57,  9, -43, -80, -90, -70, -25, 25, 70, 90, 80, 43, -9, -57, -87
++.int 83, 36, -36, -83, -83, -36, 36, 83, 83, 36, -36, -83, -83, -36, 36, 83
++.int 80,  9, -70, -87, -25, 57, 90, 43, -43, -90, -57, 25, 87, 70, -9, -80
++.int 75, -18, -89, -50, 50, 89, 18, -75, -75, 18, 89, 50, -50, -89, -18, 75
++.int 70, -43, -87,  9, 90, 25, -80, -57, 57, 80, -25, -90, -9, 87, 43, -70
++.int 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64
++.int 57, -80, -25, 90, -9, -87, 43, 70, -70, -43, 87,  9, -90, 25, 80, -57
++.int 50, -89, 18, 75, -75, -18, 89, -50, -50, 89, -18, -75, 75, 18, -89, 50
++.int 43, -90, 57, 25, -87, 70,  9, -80, 80, -9, -70, 87, -25, -57, 90, -43
++.int 36, -83, 83, -36, -36, 83, -83, 36, 36, -83, 83, -36, -36, 83, -83, 36
++.int 25, -70, 90, -80, 43,  9, -57, 87, -87, 57, -9, -43, 80, -90, 70, -25
++.int 18, -50, 75, -89, 89, -75, 50, -18, -18, 50, -75, 89, -89, 75, -50, 18
++.int  9, -25, 43, -57, 70, -80, 87, -90, 90, -87, 80, -70, 57, -43, 25, -9
++endconst
++
++const table_dct32
++.int 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
++.int 90, 90, 88, 85, 82, 78, 73, 67, 61, 54, 46, 38, 31, 22, 13,  4, -4, -13, -22, -31, -38, -46, -54, -61, -67, -73, -78, -82, -85, -88, -90, -90
++.int 90, 87, 80, 70, 57, 43, 25,  9, -9, -25, -43, -57, -70, -80, -87, -90, -90, -87, -80, -70, -57, -43, -25, -9,  9, 25, 43, 57, 70, 80, 87, 90
++.int 90, 82, 67, 46, 22, -4, -31, -54, -73, -85, -90, -88, -78, -61, -38, -13, 13, 38, 61, 78, 88, 90, 85, 73, 54, 31,  4, -22, -46, -67, -82, -90
++.int 89, 75, 50, 18, -18, -50, -75, -89, -89, -75, -50, -18, 18, 50, 75, 89, 89, 75, 50, 18, -18, -50, -75, -89, -89, -75, -50, -18, 18, 50, 75, 89
++.int 88, 67, 31, -13, -54, -82, -90, -78, -46, -4, 38, 73, 90, 85, 61, 22, -22, -61, -85, -90, -73, -38,  4, 46, 78, 90, 82, 54, 13, -31, -67, -88
++.int 87, 57,  9, -43, -80, -90, -70, -25, 25, 70, 90, 80, 43, -9, -57, -87, -87, -57, -9, 43, 80, 90, 70, 25, -25, -70, -90, -80, -43,  9, 57, 87
++.int 85, 46, -13, -67, -90, -73, -22, 38, 82, 88, 54, -4, -61, -90, -78, -31, 31, 78, 90, 61,  4, -54, -88, -82, -38, 22, 73, 90, 67, 13, -46, -85
++.int 83, 36, -36, -83, -83, -36, 36, 83, 83, 36, -36, -83, -83, -36, 36, 83, 83, 36, -36, -83, -83, -36, 36, 83, 83, 36, -36, -83, -83, -36, 36, 83
++.int 82, 22, -54, -90, -61, 13, 78, 85, 31, -46, -90, -67,  4, 73, 88, 38, -38, -88, -73, -4, 67, 90, 46, -31, -85, -78, -13, 61, 90, 54, -22, -82
++.int 80,  9, -70, -87, -25, 57, 90, 43, -43, -90, -57, 25, 87, 70, -9, -80, -80, -9, 70, 87, 25, -57, -90, -43, 43, 90, 57, -25, -87, -70,  9, 80
++.int 78, -4, -82, -73, 13, 85, 67, -22, -88, -61, 31, 90, 54, -38, -90, -46, 46, 90, 38, -54, -90, -31, 61, 88, 22, -67, -85, -13, 73, 82,  4, -78
++.int 75, -18, -89, -50, 50, 89, 18, -75, -75, 18, 89, 50, -50, -89, -18, 75, 75, -18, -89, -50, 50, 89, 18, -75, -75, 18, 89, 50, -50, -89, -18, 75
++.int 73, -31, -90, -22, 78, 67, -38, -90, -13, 82, 61, -46, -88, -4, 85, 54, -54, -85,  4, 88, 46, -61, -82, 13, 90, 38, -67, -78, 22, 90, 31, -73
++.int 70, -43, -87,  9, 90, 25, -80, -57, 57, 80, -25, -90, -9, 87, 43, -70, -70, 43, 87, -9, -90, -25, 80, 57, -57, -80, 25, 90,  9, -87, -43, 70
++.int 67, -54, -78, 38, 85, -22, -90,  4, 90, 13, -88, -31, 82, 46, -73, -61, 61, 73, -46, -82, 31, 88, -13, -90, -4, 90, 22, -85, -38, 78, 54, -67
++.int 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64, 64, -64, -64, 64
++.int 61, -73, -46, 82, 31, -88, -13, 90, -4, -90, 22, 85, -38, -78, 54, 67, -67, -54, 78, 38, -85, -22, 90,  4, -90, 13, 88, -31, -82, 46, 73, -61
++.int 57, -80, -25, 90, -9, -87, 43, 70, -70, -43, 87,  9, -90, 25, 80, -57, -57, 80, 25, -90,  9, 87, -43, -70, 70, 43, -87, -9, 90, -25, -80, 57
++.int 54, -85, -4, 88, -46, -61, 82, 13, -90, 38, 67, -78, -22, 90, -31, -73, 73, 31, -90, 22, 78, -67, -38, 90, -13, -82, 61, 46, -88,  4, 85, -54
++.int 50, -89, 18, 75, -75, -18, 89, -50, -50, 89, -18, -75, 75, 18, -89, 50, 50, -89, 18, 75, -75, -18, 89, -50, -50, 89, -18, -75, 75, 18, -89, 50
++.int 46, -90, 38, 54, -90, 31, 61, -88, 22, 67, -85, 13, 73, -82,  4, 78, -78, -4, 82, -73, -13, 85, -67, -22, 88, -61, -31, 90, -54, -38, 90, -46
++.int 43, -90, 57, 25, -87, 70,  9, -80, 80, -9, -70, 87, -25, -57, 90, -43, -43, 90, -57, -25, 87, -70, -9, 80, -80,  9, 70, -87, 25, 57, -90, 43
++.int 38, -88, 73, -4, -67, 90, -46, -31, 85, -78, 13, 61, -90, 54, 22, -82, 82, -22, -54, 90, -61, -13, 78, -85, 31, 46, -90, 67,  4, -73, 88, -38
++.int 36, -83, 83, -36, -36, 83, -83, 36, 36, -83, 83, -36, -36, 83, -83, 36, 36, -83, 83, -36, -36, 83, -83, 36, 36, -83, 83, -36, -36, 83, -83, 36
++.int 31, -78, 90, -61,  4, 54, -88, 82, -38, -22, 73, -90, 67, -13, -46, 85, -85, 46, 13, -67, 90, -73, 22, 38, -82, 88, -54, -4, 61, -90, 78, -31
++.int 25, -70, 90, -80, 43,  9, -57, 87, -87, 57, -9, -43, 80, -90, 70, -25, -25, 70, -90, 80, -43, -9, 57, -87, 87, -57,  9, 43, -80, 90, -70, 25
++.int 22, -61, 85, -90, 73, -38, -4, 46, -78, 90, -82, 54, -13, -31, 67, -88, 88, -67, 31, 13, -54, 82, -90, 78, -46,  4, 38, -73, 90, -85, 61, -22
++.int 18, -50, 75, -89, 89, -75, 50, -18, -18, 50, -75, 89, -89, 75, -50, 18, 18, -50, 75, -89, 89, -75, 50, -18, -18, 50, -75, 89, -89, 75, -50, 18
++.int 13, -38, 61, -78, 88, -90, 85, -73, 54, -31,  4, 22, -46, 67, -82, 90, -90, 82, -67, 46, -22, -4, 31, -54, 73, -85, 90, -88, 78, -61, 38, -13
++.int  9, -25, 43, -57, 70, -80, 87, -90, 90, -87, 80, -70, 57, -43, 25, -9, -9, 25, -43, 57, -70, 80, -87, 90, -90, 87, -80, 70, -57, 43, -25,  9
++.int  4, -13, 22, -31, 38, -46, 54, -61, 67, -73, 78, -82, 85, -88, 90, -90, 90, -90, 88, -85, 82, -78, 73, -67, 61, -54, 46, -38, 31, -22, 13, -4
++endconst
++
++/*
++ * Description : Transpose 4x4 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     :
++ * Example     :
++ *               1, 2, 3, 4            1, 5, 9,13
++ *               5, 6, 7, 8    to      2, 6,10,14
++ *               9,10,11,12  =====>    3, 7,11,15
++ *              13,14,15,16            4, 8,12,16
++ */
++.macro LSX_TRANSPOSE4x4_W_EXTRA in0, in1, in2, in3, out0, out1, out2, out3
++
++    vilvl.w    \out0,   \in1,    \in0
++    vilvl.w    \out2,   \in3,    \in2
++    vilvh.d    \out1,   \out2,   \out0
++    vilvl.d    \out0,   \out2,   \out0
++
++    vilvh.w    \in1,    \in1,    \in0
++    vilvh.w    \in3,    \in3,    \in2
++    vilvl.d    \out2,   \in3,    \in1
++    vilvh.d    \out3,   \in3,    \in1
++.endm
++
++/*
++ * Description : Transpose 8x8 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6,
++ *               _out7
++ * Tip         : (in0, in1, in2, in3) these four input registers will be modified.
++ * Example     :
++ *         in0 : 1,2,3,4,5,6,7,8
++ *         in1 : 2,2,3,4,5,6,7,8
++ *         in2 : 3,2,3,4,5,6,7,8
++ *         in3 : 4,2,3,4,5,6,7,8
++ *         in4 : 5,2,3,4,5,6,7,8
++ *         in5 : 6,2,3,4,5,6,7,8
++ *         in6 : 7,2,3,4,5,6,7,8
++ *         in7 : 8,2,3,4,5,6,7,8
++ *
++ *        out0 : 1,2,3,4,5,6,7,8
++ *        out1 : 2,2,2,2,2,2,2,2
++ *        out2 : 3,3,3,3,3,3,3,3
++ *        out3 : 4,4,4,4,4,4,4,4
++ *        out4 : 5,5,5,5,5,5,5,5
++ *        out5 : 6,6,6,6,6,6,6,6
++ *        out6 : 7,7,7,7,7,7,7,7
++ *        out7 : 8,8,8,8,8,8,8,8
++ */
++.macro LASX_TRANSPOSE8x8_W_EXTRA in0, in1, in2, in3, in4, in5, in6, in7,\
++                                 out0, out1, out2, out3, out4, out5, out6, out7
++    xvilvl.w    \out4,   \in2,    \in0
++    xvilvl.w    \out5,   \in3,    \in1
++    xvilvh.w    \out6,   \in2,    \in0
++    xvilvh.w    \out7,   \in3,    \in1
++    xvilvl.w    \out0,   \out5,   \out4
++    xvilvh.w    \out1,   \out5,   \out4
++    xvilvl.w    \out2,   \out7,   \out6
++    xvilvh.w    \out3,   \out7,   \out6
++
++    xvilvl.w    \in0,    \in6,    \in4
++    xvilvl.w    \in1,    \in7,    \in5
++    xvilvh.w    \in2,    \in6,    \in4
++    xvilvh.w    \in3,    \in7,    \in5
++    xvilvl.w    \out4,   \in1,    \in0
++    xvilvh.w    \out5,   \in1,    \in0
++    xvilvl.w    \out6,   \in3,    \in2
++    xvilvh.w    \out7,   \in3,    \in2
++
++    xmov        \in0,    \out0
++    xmov        \in1,    \out1
++    xmov        \in2,    \out2
++    xmov        \in3,    \out3
++    xvpermi.q   \out0,   \out4,   0x02
++    xvpermi.q   \out1,   \out5,   0x02
++    xvpermi.q   \out2,   \out6,   0x02
++    xvpermi.q   \out3,   \out7,   0x02
++    xvpermi.q   \out4,   \in0,    0x31
++    xvpermi.q   \out5,   \in1,    0x31
++    xvpermi.q   \out6,   \in2,    0x31
++    xvpermi.q   \out7,   \in3,    0x31
++.endm
++
++/*
++ *  _out0 ... _out3: E[0...15]
++ *  _out4 ... _out7: O[0...15]
++ *  temp reg: vr20, vr21, vr22, vr23
++ */
++.macro LOAD_DCT32 _out0, _out1, _out2, _out3, _out4, _out5, _out6, _out7, _in
++    vld          vr20,  \_in,    0    //src[0...7]
++    vld          vr21,  \_in,    16   //src[8...15]
++    vld          vr22,  \_in,    32   //src[16...23]
++    vld          vr23,  \_in,    48   //src[24...31]
++
++    vshuf.b      vr22, vr22, vr22, vr31
++    vshuf.b      vr23, vr23, vr23, vr31
++
++    vaddwev.w.h   \_out4,  vr20,    vr23
++    vaddwod.w.h   \_out5,  vr20,    vr23
++    vilvl.w       \_out0,  \_out5,  \_out4  //E[0...3]
++    vilvh.w       \_out1,  \_out5,  \_out4  //E[4...7]
++    vaddwev.w.h   \_out4,  vr21,    vr22
++    vaddwod.w.h   \_out5,  vr21,    vr22
++    vilvl.w       \_out2,  \_out5,  \_out4  //E[8...11]
++    vilvh.w       \_out3,  \_out5,  \_out4  //E[12...15]
++
++    vsubwev.w.h   \_out6,  vr20,    vr23
++    vsubwod.w.h   \_out7,  vr20,    vr23
++    vilvl.w       \_out4,  \_out7,  \_out6  //O[0...3]
++    vilvh.w       \_out5,  \_out7,  \_out6  //O[4...7]
++    vsubwev.w.h   vr20,    vr21,    vr22
++    vsubwod.w.h   vr23,    vr21,    vr22
++    vilvl.w       \_out6,  vr23,    vr20    //O[8...11]
++    vilvh.w       \_out7,  vr23,    vr20    //O[12...15]
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(calculate 2 outputs)
++ * temp reg: vr8~vr11
++ */
++.macro LSX_CAL_DCT_4_ELE_2 _rin, _in0, _in1, _in2, _in3, \
++                           _out0, _out1, _si0, _si1, _si2, _si3
++    vldrepl.w    vr8,     \_rin,    \_si0
++    vldrepl.w    vr9,     \_rin,    \_si1
++    vldrepl.w    vr10,    \_rin,    \_si2
++    vldrepl.w    vr11,    \_rin,    \_si3
++    vmul.w       \_out0,  \_in0,    vr8
++    vmadd.w      \_out0,  \_in1,    vr9
++    vmadd.w      \_out0,  \_in2,    vr10
++    vmadd.w      \_out0,  \_in3,    vr11
++    vmul.w       \_out1,  \_in0,    vr11
++    vmsub.w      \_out1,  \_in1,    vr10
++    vmadd.w      \_out1,  \_in2,    vr9
++    vmsub.w      \_out1,  \_in3,    vr8
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: vr8~vr11
++ */
++.macro LSX_CAL_DCT_4_ELE_2X _rin, _in0, _in1, _in2, _in3, \
++                            _out0, _out1, _si0, _si1, _si2, _si3
++    vldrepl.w    vr8,     \_rin,    \_si0
++    vldrepl.w    vr9,     \_rin,    \_si1
++    vldrepl.w    vr10,    \_rin,    \_si2
++    vldrepl.w    vr11,    \_rin,    \_si3
++    vmul.w       \_out0,  \_in0,    vr8
++    vmadd.w      \_out0,  \_in1,    vr9
++    vmadd.w      \_out0,  \_in2,    vr10
++    vmadd.w      \_out0,  \_in3,    vr11
++    vmul.w       \_out1,  \_in3,    vr8
++    vmsub.w      \_out1,  \_in2,    vr9
++    vmadd.w      \_out1,  \_in1,    vr10
++    vmsub.w      \_out1,  \_in0,    vr11
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: \_tmp0~\_tmp7
++ */
++.macro LSX_CAL_DCT_8_ELE_2 _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                           _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                           _out0, _out1, _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    vldrepl.w    \_tmp0,  \_rin,    \_si0
++    vldrepl.w    \_tmp1,  \_rin,    \_si1
++    vldrepl.w    \_tmp2,  \_rin,    \_si2
++    vldrepl.w    \_tmp3,  \_rin,    \_si3
++    vldrepl.w    \_tmp4,  \_rin,    \_si4
++    vldrepl.w    \_tmp5,  \_rin,    \_si5
++    vldrepl.w    \_tmp6,  \_rin,    \_si6
++    vldrepl.w    \_tmp7,  \_rin,    \_si7
++    vmul.w       \_out0,  \_in0,    \_tmp0
++    vmul.w       \_out1,  \_in0,    \_tmp7
++    vmadd.w      \_out0,  \_in1,    \_tmp1
++    vmsub.w      \_out1,  \_in1,    \_tmp6
++    vmadd.w      \_out0,  \_in2,    \_tmp2
++    vmadd.w      \_out1,  \_in2,    \_tmp5
++    vmadd.w      \_out0,  \_in3,    \_tmp3
++    vmsub.w      \_out1,  \_in3,    \_tmp4
++    vmadd.w      \_out0,  \_in4,    \_tmp4
++    vmadd.w      \_out1,  \_in4,    \_tmp3
++    vmadd.w      \_out0,  \_in5,    \_tmp5
++    vmsub.w      \_out1,  \_in5,    \_tmp2
++    vmadd.w      \_out0,  \_in6,    \_tmp6
++    vmadd.w      \_out1,  \_in6,    \_tmp1
++    vmadd.w      \_out0,  \_in7,    \_tmp7
++    vmsub.w      \_out1,  \_in7,    \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _tmp0~_tmp7
++ */
++.macro LSX_CAL_DCT_8_ELE_2X _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                            _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                            _out0, _out1, _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    vldrepl.w    \_tmp0,  \_rin,    \_si0
++    vldrepl.w    \_tmp1,  \_rin,    \_si1
++    vldrepl.w    \_tmp2,  \_rin,    \_si2
++    vldrepl.w    \_tmp3,  \_rin,    \_si3
++    vldrepl.w    \_tmp4,  \_rin,    \_si4
++    vldrepl.w    \_tmp5,  \_rin,    \_si5
++    vldrepl.w    \_tmp6,  \_rin,    \_si6
++    vldrepl.w    \_tmp7,  \_rin,    \_si7
++    vmul.w       \_out0,  \_in0,    \_tmp0
++    vmul.w       \_out1,  \_in7,    \_tmp0
++    vmadd.w      \_out0,  \_in1,    \_tmp1
++    vmsub.w      \_out1,  \_in6,    \_tmp1
++    vmadd.w      \_out0,  \_in2,    \_tmp2
++    vmadd.w      \_out1,  \_in5,    \_tmp2
++    vmadd.w      \_out0,  \_in3,    \_tmp3
++    vmsub.w      \_out1,  \_in4,    \_tmp3
++    vmadd.w      \_out0,  \_in4,    \_tmp4
++    vmadd.w      \_out1,  \_in3,    \_tmp4
++    vmadd.w      \_out0,  \_in5,    \_tmp5
++    vmsub.w      \_out1,  \_in2,    \_tmp5
++    vmadd.w      \_out0,  \_in6,    \_tmp6
++    vmadd.w      \_out1,  \_in1,    \_tmp6
++    vmadd.w      \_out0,  \_in7,    \_tmp7
++    vmsub.w      \_out1,  \_in0,    \_tmp7
++.endm
++
++/*
++ * Description : Transpose 4x4x2 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Example     :
++ *               1, 2, 3, 4, 1, 2, 3, 4           1, 5, 9,13, 1, 5, 9,13
++ *               5, 6, 7, 8, 5, 6, 7, 8   to      2, 6,10,14, 2, 6,10,14
++ *               9,10,11,12, 9,10,11,12  =====>   3, 7,11,15, 3, 7,11,15
++ *              13,14,15,16,13,14,15,16           4, 8,12,16, 4, 8,12,16
++ */
++.macro LSX_TRANSPOSE4x4x2_H in0, in1, in2, in3, out0, out1, out2, out3, \
++                             tmp0, tmp1
++    vpackev.h   \tmp0,  \in1,   \in0
++    vpackev.h   \tmp1,  \in3,   \in2
++    vpackev.w   \out0,  \tmp1,  \tmp0
++    vpackod.w   \out2,  \tmp1,  \tmp0
++    vpackod.h   \tmp0,  \in1,   \in0
++    vpackod.h   \tmp1,  \in3,   \in2
++    vpackev.w   \out1,  \tmp1,  \tmp0
++    vpackod.w   \out3,  \tmp1,  \tmp0
++.endm
++
++.macro LSX_DCT16_4_LINE _shift, _rout
++    LSX_TRANSPOSE4x4x2_H vr0, vr1, vr2, vr3, vr12, vr13, vr14, vr15, vr20, vr21
++    LSX_TRANSPOSE4x4x2_H vr4, vr5, vr6, vr7, vr16, vr17, vr18, vr19, vr20, vr21
++
++    /* src[0...8] */
++    vsllwil.w.h   vr0,     vr12,    0
++    vexth.w.h     vr4,     vr12
++    vsllwil.w.h   vr1,     vr13,    0
++    vexth.w.h     vr5,     vr13
++    vsllwil.w.h   vr2,     vr14,    0
++    vexth.w.h     vr6,     vr14
++    vsllwil.w.h   vr3,     vr15,    0
++    vexth.w.h     vr7,     vr15
++
++    /* src[9...15] */
++    vsllwil.w.h   vr8,     vr16,    0
++    vexth.w.h     vr12,    vr16
++    vsllwil.w.h   vr9,     vr17,    0
++    vexth.w.h     vr13,    vr17
++    vsllwil.w.h   vr10,    vr18,    0
++    vexth.w.h     vr14,    vr18
++    vsllwil.w.h   vr11,    vr19,    0
++    vexth.w.h     vr15,    vr19
++
++    /* O[0...7] */
++    vsub.w        vr16,    vr0,     vr15
++    vsub.w        vr17,    vr1,     vr14
++    vsub.w        vr18,    vr2,     vr13
++    vsub.w        vr19,    vr3,     vr12
++    vsub.w        vr20,    vr4,     vr11
++    vsub.w        vr21,    vr5,     vr10
++    vsub.w        vr22,    vr6,     vr9
++    vsub.w        vr23,    vr7,     vr8
++
++    /* E[0...7] */
++    vadd.w        vr15,    vr0,     vr15
++    vadd.w        vr14,    vr1,     vr14
++    vadd.w        vr13,    vr2,     vr13
++    vadd.w        vr12,    vr3,     vr12
++    vadd.w        vr11,    vr4,     vr11
++    vadd.w        vr10,    vr5,     vr10
++    vadd.w        vr9,     vr6,     vr9
++    vadd.w        vr8,     vr7,     vr8
++
++    /* EE[0...3] */
++    vadd.w        vr0,     vr15,    vr8
++    vadd.w        vr1,     vr14,    vr9
++    vadd.w        vr2,     vr13,    vr10
++    vadd.w        vr3,     vr12,    vr11
++
++    /* EO[0...3] */
++    vsub.w        vr4,     vr15,    vr8
++    vsub.w        vr5,     vr14,    vr9
++    vsub.w        vr6,     vr13,    vr10
++    vsub.w        vr7,     vr12,    vr11
++    vadd.w        vr8,     vr0,     vr3  // EEE[0]
++    vadd.w        vr9,     vr1,     vr2  // EEE[1]
++    vsub.w        vr10,    vr0,     vr3  // EEO[0]
++    vsub.w        vr11,    vr1,     vr2  // EEO[1]
++
++    /* CAL0-8-4-12*/
++    vldrepl.w     vr12,    t1,      0
++    vldrepl.w     vr13,    t1,      64 * 4
++    vldrepl.w     vr14,    t1,      64 * 4 + 4
++    vmul.w        vr0,     vr8,     vr12
++    vmadd.w       vr0,     vr9,     vr12  //dst[0]
++    vmul.w        vr1,     vr10,    vr13
++    vmadd.w       vr1,     vr11,    vr14  //dst[4]
++    vmul.w        vr2,     vr8,     vr12
++    vmsub.w       vr2,     vr9,     vr12  //dst[8]
++    vmul.w        vr3,     vr10,    vr14
++    vmsub.w       vr3,     vr11,    vr13  //dst[12]
++
++    /* CAL2-6-10-14*/
++    LSX_CAL_DCT_4_ELE_2 t1, vr4, vr5, vr6, vr7, vr12, vr15, \
++                        64 * 2, 64 * 2 + 4, 64 * 2 + 8, 64 * 2 + 12
++    LSX_CAL_DCT_4_ELE_2X t1, vr4, vr5, vr6, vr7, vr13, vr14, \
++                         64 * 6, 64 * 6 + 4, 64 * 6 + 8, 64 * 6 + 12
++
++    vssrarni.h.w    vr12,   vr0,    \_shift
++    vssrarni.h.w    vr13,   vr1,    \_shift
++    vssrarni.h.w    vr14,   vr2,    \_shift
++    vssrarni.h.w    vr15,   vr3,    \_shift
++
++    vstelm.d        vr12,   \_rout, 0,            0
++    vstelm.d        vr12,   \_rout, 32 * 2,       1
++    vstelm.d        vr13,   \_rout, 32 * 4,       0
++    vstelm.d        vr13,   \_rout, 32 * 6,       1
++    vstelm.d        vr14,   \_rout, 32 * 8,       0
++    vstelm.d        vr14,   \_rout, 32 * 10,      1
++    vstelm.d        vr15,   \_rout, 32 * 12,      0
++    vstelm.d        vr15,   \_rout, 32 * 14,      1
++
++    /* CAL1-3-5-7...*/
++    LSX_CAL_DCT_8_ELE_2 t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                        vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                        vr0, vr7, 64 * 1, 64 * 1 + 4, 64 * 1 + 8, 64 * 1 + 12, \
++                        64 * 1 + 16, 64 * 1 + 20, 64 * 1 + 24, 64 * 1 + 28
++    LSX_CAL_DCT_8_ELE_2X t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                         vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                         vr1, vr6, 64 * 3, 64 * 3 + 4, 64 * 3 + 8, 64 * 3 + 12, \
++                         64 * 3 + 16, 64 * 3 + 20, 64 * 3 + 24, 64 * 3 + 28
++    LSX_CAL_DCT_8_ELE_2 t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                        vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                        vr2, vr5, 64 * 5, 64 * 5 + 4, 64 * 5 + 8, 64 * 5 + 12, \
++                        64 * 5 + 16, 64 * 5 + 20, 64 * 5 + 24, 64 * 5 + 28
++    LSX_CAL_DCT_8_ELE_2X t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                         vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                         vr3, vr4, 64 * 7, 64 * 7 + 4, 64 * 7 + 8, 64 * 7 + 12, \
++                         64 * 7 + 16, 64 * 7 + 20, 64 * 7 + 24, 64 * 7 + 28
++
++    vssrarni.h.w    vr1,    vr0,    \_shift
++    vssrarni.h.w    vr3,    vr2,    \_shift
++    vssrarni.h.w    vr5,    vr4,    \_shift
++    vssrarni.h.w    vr7,    vr6,    \_shift
++
++    vstelm.d        vr1,    \_rout, 32 * 1,       0
++    vstelm.d        vr1,    \_rout, 32 * 3,       1
++    vstelm.d        vr3,    \_rout, 32 * 5,       0
++    vstelm.d        vr3,    \_rout, 32 * 7,       1
++    vstelm.d        vr5,    \_rout, 32 * 9,       0
++    vstelm.d        vr5,    \_rout, 32 * 11,      1
++    vstelm.d        vr7,    \_rout, 32 * 13,      0
++    vstelm.d        vr7,    \_rout, 32 * 15,      1
++.endm
++
++/* void x265_dct16_lsx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dct16_lsx
++    addi.d        sp,      sp,      -512 //-(16*16*2) si12 Immediate overflow
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,      1  //stride
++    slli.d        a4,      a2,      2  //stride2
++    slli.d        a6,      a2,      3  //stride4
++    add.d         a5,      a4,      a3 //stride3
++
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr0,     a0,      0    //line0_l
++    vldx          vr1,     a0,      a3   //line1_l
++    vldx          vr2,     a0,      a4   //line2_l
++    vldx          vr3,     a0,      a5   //line3_l
++    addi.d        t3,      a0,      16
++    vld           vr4,     t3,      0    //line0_h
++    vldx          vr5,     t3,      a3   //line1_h
++    vldx          vr6,     t3,      a4   //line2_h
++    vldx          vr7,     t3,      a5   //line3_h
++    LSX_DCT16_4_LINE 3, sp
++    addi.d        t2,      sp,      8
++
++    add.d         a0,      a0,      a6
++    vld           vr0,     a0,      0    //line4_l
++    vldx          vr1,     a0,      a3   //line5_l
++    vldx          vr2,     a0,      a4   //line6_l
++    vldx          vr3,     a0,      a5   //line7_l
++    addi.d        t3,      a0,      16
++    vld           vr4,     t3,      0    //line4_h
++    vldx          vr5,     t3,      a3   //line5_h
++    vldx          vr6,     t3,      a4   //line6_h
++    vldx          vr7,     t3,      a5   //line7_h
++    LSX_DCT16_4_LINE 3, t2
++    addi.d        t2,      t2,      8
++
++    add.d         a0,      a0,      a6
++    vld           vr0,     a0,      0    //line8_l
++    vldx          vr1,     a0,      a3   //line9_l
++    vldx          vr2,     a0,      a4   //line10_l
++    vldx          vr3,     a0,      a5   //line11_l
++    addi.d        t3,      a0,      16
++    vld           vr4,     t3,      0    //line8_h
++    vldx          vr5,     t3,      a3   //line9_h
++    vldx          vr6,     t3,      a4   //line10_h
++    vldx          vr7,     t3,      a5   //line11_h
++    LSX_DCT16_4_LINE 3, t2
++    addi.d        t2,      t2,      8
++
++    add.d         a0,      a0,      a6
++    vld           vr0,     a0,      0    //line12_l
++    vldx          vr1,     a0,      a3   //line13_l
++    vldx          vr2,     a0,      a4   //line14_l
++    vldx          vr3,     a0,      a5   //line15_l
++    addi.d        t3,      a0,      16
++    vld           vr4,     t3,      0    //line12_h
++    vldx          vr5,     t3,      a3   //line13_h
++    vldx          vr6,     t3,      a4   //line14_h
++    vldx          vr7,     t3,      a5   //line15_h
++    LSX_DCT16_4_LINE 3, t2
++
++    /*
++     * The second butterfly operation.
++     */
++    vld           vr0,     sp,      0    //line0_l
++    vld           vr1,     sp,      32   //line1_l
++    vld           vr2,     sp,      64   //line2_l
++    vld           vr3,     sp,      96   //line3_l
++    vld           vr4,     sp,      16   //line0_h
++    vld           vr5,     sp,      48   //line1_h
++    vld           vr6,     sp,      80   //line2_h
++    vld           vr7,     sp,      112  //line3_h
++    LSX_DCT16_4_LINE 10, a1
++    addi.d        t2,      a1,      8
++
++    vld           vr0,     sp,      128  //line4_l
++    vld           vr1,     sp,      160  //line5_l
++    vld           vr2,     sp,      192  //line6_l
++    vld           vr3,     sp,      224  //line7_l
++    vld           vr4,     sp,      144  //line4_h
++    vld           vr5,     sp,      176  //line5_h
++    vld           vr6,     sp,      208  //line6_h
++    vld           vr7,     sp,      240  //line7_h
++    LSX_DCT16_4_LINE 10, t2
++    addi.d        t2,      t2,      8
++
++    vld           vr0,     sp,      256  //line8_l
++    vld           vr1,     sp,      288  //line9_l
++    vld           vr2,     sp,      320  //line10_l
++    vld           vr3,     sp,      352  //line11_l
++    vld           vr4,     sp,      272  //line8_h
++    vld           vr5,     sp,      304  //line9_h
++    vld           vr6,     sp,      336  //line10_h
++    vld           vr7,     sp,      368  //line11_h
++    LSX_DCT16_4_LINE 10, t2
++    addi.d        t2,      t2,      8
++
++    vld           vr0,     sp,      384  //line12_l
++    vld           vr1,     sp,      416  //line13_l
++    vld           vr2,     sp,      448  //line14_l
++    vld           vr3,     sp,      480  //line15_l
++    vld           vr4,     sp,      400  //line12_h
++    vld           vr5,     sp,      432  //line13_h
++    vld           vr6,     sp,      464  //line14_h
++    vld           vr7,     sp,      496  //line15_h
++    LSX_DCT16_4_LINE 10, t2
++
++    addi.d        sp,      sp,   512
++endfunc
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * IN reg      :
++ * vr20, vr21, vr22, vr23
++ * vr4,  vr8,  vr12, vr16
++ * vr5,  vr9,  vr13, vr17
++ * vr6,  vr10, vr14, vr18
++ *
++ * Temp reg    : vr7,vr11, vr15, vr19
++ */
++.macro LSX_CAL_DCT_16_ELE_2 _rin, _out0, _out1, \
++                            _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                            _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    vldrepl.w     vr7,     \_rin,    \_si0
++    vldrepl.w     vr11,    \_rin,    \_si1
++    vldrepl.w     vr15,    \_rin,    \_si2
++    vldrepl.w     vr19,    \_rin,    \_si3
++    vmul.w        \_out0,  vr20,     vr7
++    vmul.w        \_out1,  vr6,      vr19
++    vmadd.w       \_out0,  vr21,     vr11
++    vmsub.w       \_out1,  vr10,     vr15
++    vmadd.w       \_out0,  vr22,     vr15
++    vmadd.w       \_out1,  vr14,     vr11
++    vmadd.w       \_out0,  vr23,     vr19
++    vmsub.w       \_out1,  vr18,     vr7
++
++    vldrepl.w     vr7,     \_rin,    \_si4
++    vldrepl.w     vr11,    \_rin,    \_si5
++    vldrepl.w     vr15,    \_rin,    \_si6
++    vldrepl.w     vr19,    \_rin,    \_si7
++    vmadd.w       \_out0,  vr4,      vr7
++    vmadd.w       \_out1,  vr5,      vr19
++    vmadd.w       \_out0,  vr8,      vr11
++    vmsub.w       \_out1,  vr9,      vr15
++    vmadd.w       \_out0,  vr12,     vr15
++    vmadd.w       \_out1,  vr13,     vr11
++    vmadd.w       \_out0,  vr16,     vr19
++    vmsub.w       \_out1,  vr17,     vr7
++
++    vldrepl.w     vr7,     \_rin,    \_si8
++    vldrepl.w     vr11,    \_rin,    \_si9
++    vldrepl.w     vr15,    \_rin,    \_si10
++    vldrepl.w     vr19,    \_rin,    \_si11
++    vmadd.w       \_out0,  vr5,      vr7
++    vmadd.w       \_out1,  vr4,      vr19
++    vmadd.w       \_out0,  vr9,      vr11
++    vmsub.w       \_out1,  vr8,      vr15
++    vmadd.w       \_out0,  vr13,     vr15
++    vmadd.w       \_out1,  vr12,     vr11
++    vmadd.w       \_out0,  vr17,     vr19
++    vmsub.w       \_out1,  vr16,     vr7
++
++    vldrepl.w     vr7,     \_rin,    \_si12
++    vldrepl.w     vr11,    \_rin,    \_si13
++    vldrepl.w     vr15,    \_rin,    \_si14
++    vldrepl.w     vr19,    \_rin,    \_si15
++    vmadd.w       \_out0,  vr6,      vr7
++    vmadd.w       \_out1,  vr20,     vr19
++    vmadd.w       \_out0,  vr10,     vr11
++    vmsub.w       \_out1,  vr21,     vr15
++    vmadd.w       \_out0,  vr14,     vr15
++    vmadd.w       \_out1,  vr22,     vr11
++    vmadd.w       \_out0,  vr18,     vr19
++    vmsub.w       \_out1,  vr23,     vr7
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * IN reg      :
++ * vr20, vr21, vr22, vr23
++ * vr4,  vr8,  vr12, vr16
++ * vr5,  vr9,  vr13, vr17
++ * vr6,  vr10, vr14, vr18
++ *
++ * Temp reg    : vr7,vr11, vr15, vr19
++ */
++.macro LSX_CAL_DCT_16_ELE_2X _rin, _out0, _out1, \
++                             _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                             _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    vldrepl.w     vr7,     \_rin,    \_si0
++    vldrepl.w     vr11,    \_rin,    \_si1
++    vldrepl.w     vr15,    \_rin,    \_si2
++    vldrepl.w     vr19,    \_rin,    \_si3
++    vmul.w        \_out0,  vr20,     vr7
++    vmul.w        \_out1,  vr18,     vr7
++    vmadd.w       \_out0,  vr21,     vr11
++    vmsub.w       \_out1,  vr14,     vr11
++    vmadd.w       \_out0,  vr22,     vr15
++    vmadd.w       \_out1,  vr10,     vr15
++    vmadd.w       \_out0,  vr23,     vr19
++    vmsub.w       \_out1,  vr6,      vr19
++
++    vldrepl.w     vr7,     \_rin,    \_si4
++    vldrepl.w     vr11,    \_rin,    \_si5
++    vldrepl.w     vr15,    \_rin,    \_si6
++    vldrepl.w     vr19,    \_rin,    \_si7
++    vmadd.w       \_out0,  vr4,      vr7
++    vmadd.w       \_out1,  vr17,     vr7
++    vmadd.w       \_out0,  vr8,      vr11
++    vmsub.w       \_out1,  vr13,     vr11
++    vmadd.w       \_out0,  vr12,     vr15
++    vmadd.w       \_out1,  vr9,      vr15
++    vmadd.w       \_out0,  vr16,     vr19
++    vmsub.w       \_out1,  vr5,      vr19
++
++    vldrepl.w     vr7,     \_rin,    \_si8
++    vldrepl.w     vr11,    \_rin,    \_si9
++    vldrepl.w     vr15,    \_rin,    \_si10
++    vldrepl.w     vr19,    \_rin,    \_si11
++    vmadd.w       \_out0,  vr5,      vr7
++    vmadd.w       \_out1,  vr16,     vr7
++    vmadd.w       \_out0,  vr9,      vr11
++    vmsub.w       \_out1,  vr12,     vr11
++    vmadd.w       \_out0,  vr13,     vr15
++    vmadd.w       \_out1,  vr8,      vr15
++    vmadd.w       \_out0,  vr17,     vr19
++    vmsub.w       \_out1,  vr4,      vr19
++
++    vldrepl.w     vr7,     \_rin,    \_si12
++    vldrepl.w     vr11,    \_rin,    \_si13
++    vldrepl.w     vr15,    \_rin,    \_si14
++    vldrepl.w     vr19,    \_rin,    \_si15
++    vmadd.w       \_out0,  vr6,      vr7
++    vmadd.w       \_out1,  vr23,     vr7
++    vmadd.w       \_out0,  vr10,     vr11
++    vmsub.w       \_out1,  vr22,     vr11
++    vmadd.w       \_out0,  vr14,     vr15
++    vmadd.w       \_out1,  vr21,     vr15
++    vmadd.w       \_out0,  vr18,     vr19
++    vmsub.w       \_out1,  vr20,     vr19
++.endm
++
++.macro CLA_DCT32_O_ALL _shift
++    LSX_TRANSPOSE4x4_W_EXTRA vr0, vr4, vr24, vr28, vr20, vr21, vr22, vr23
++    LSX_TRANSPOSE4x4_W_EXTRA vr1, vr5, vr25, vr29, vr4,  vr8,  vr12, vr16
++    LSX_TRANSPOSE4x4_W_EXTRA vr2, vr6, vr26, vr30, vr5,  vr9,  vr13, vr17
++    LSX_TRANSPOSE4x4_W_EXTRA vr3, vr7, vr27, vr31, vr6,  vr10, vr14, vr18
++
++    addi.d        t3,      t2,      64 * 14
++    addi.d        t5,      t3,      64 * 14
++
++    LSX_CAL_DCT_16_ELE_2 t1, vr25, vr3, 128 * 1, 128 * 1 + 4, 128 * 1 + 8, 128 * 1 + 12, \
++                         128 * 1 + 16, 128 * 1 + 20, 128 * 1 + 24, 128 * 1 + 28, \
++                         128 * 1 + 32, 128 * 1 + 36, 128 * 1 + 40, 128 * 1 + 44, \
++                         128 * 1 + 48, 128 * 1 + 52, 128 * 1 + 56, 128 * 1 + 60
++    LSX_CAL_DCT_16_ELE_2X t1, vr26, vr2, \
++                          128 * 3, 128 * 3 + 4, 128 * 3 + 8, 128 * 3 + 12, \
++                          128 * 3 + 16, 128 * 3 + 20, 128 * 3 + 24, 128 * 3 + 28, \
++                          128 * 3 + 32, 128 * 3 + 36, 128 * 3 + 40, 128 * 3 + 44, \
++                          128 * 3 + 48, 128 * 3 + 52, 128 * 3 + 56, 128 * 3 + 60
++    vssrarni.h.w  vr26,    vr25,    \_shift
++    vssrarni.h.w  vr3,     vr2,     \_shift
++
++    LSX_CAL_DCT_16_ELE_2 t1, vr25, vr1, 128 * 5, 128 * 5 + 4, 128 * 5 + 8, 128 * 5 + 12, \
++                         128 * 5 + 16, 128 * 5 + 20, 128 * 5 + 24, 128 * 5 + 28, \
++                         128 * 5 + 32, 128 * 5 + 36, 128 * 5 + 40, 128 * 5 + 44, \
++                         128 * 5 + 48, 128 * 5 + 52, 128 * 5 + 56, 128 * 5 + 60
++    LSX_CAL_DCT_16_ELE_2X t1, vr27, vr2, \
++                          128 * 7, 128 * 7 + 4, 128 * 7 + 8, 128 * 7 + 12, \
++                          128 * 7 + 16, 128 * 7 + 20, 128 * 7 + 24, 128 * 7 + 28, \
++                          128 * 7 + 32, 128 * 7 + 36, 128 * 7 + 40, 128 * 7 + 44, \
++                          128 * 7 + 48, 128 * 7 + 52, 128 * 7 + 56, 128 * 7 + 60
++    vssrarni.h.w  vr27,    vr25,    \_shift
++    vssrarni.h.w  vr1,     vr2,     \_shift
++
++    LSX_CAL_DCT_16_ELE_2 t1, vr25, vr0, 128 * 9, 128 * 9 + 4, 128 * 9 + 8, 128 * 9 + 12, \
++                         128 * 9 + 16, 128 * 9 + 20, 128 * 9 + 24, 128 * 9 + 28, \
++                         128 * 9 + 32, 128 * 9 + 36, 128 * 9 + 40, 128 * 9 + 44, \
++                         128 * 9 + 48, 128 * 9 + 52, 128 * 9 + 56, 128 * 9 + 60
++    LSX_CAL_DCT_16_ELE_2X t1, vr28, vr2, \
++                          128 * 11, 128 * 11 + 4, 128 * 11 + 8, 128 * 11 + 12, \
++                          128 * 11 + 16, 128 * 11 + 20, 128 * 11 + 24, 128 * 11 + 28, \
++                          128 * 11 + 32, 128 * 11 + 36, 128 * 11 + 40, 128 * 11 + 44, \
++                          128 * 11 + 48, 128 * 11 + 52, 128 * 11 + 56, 128 * 11 + 60
++    vssrarni.h.w  vr28,    vr25,    \_shift
++    vssrarni.h.w  vr0,     vr2,     \_shift
++
++    LSX_CAL_DCT_16_ELE_2 t1, vr25, vr31, \
++                         128 * 13, 128 * 13 + 4, 128 * 13 + 8, 128 * 13 + 12, \
++                         128 * 13 + 16, 128 * 13 + 20, 128 * 13 + 24, 128 * 13 + 28, \
++                         128 * 13 + 32, 128 * 13 + 36, 128 * 13 + 40, 128 * 13 + 44, \
++                         128 * 13 + 48, 128 * 13 + 52, 128 * 13 + 56, 128 * 13 + 60
++    LSX_CAL_DCT_16_ELE_2X t1, vr29, vr2, \
++                          128 * 15, 128 * 15 + 4, 128 * 15 + 8, 128 * 15 + 12, \
++                          128 * 15 + 16, 128 * 15 + 20, 128 * 15 + 24, 128 * 15 + 28, \
++                          128 * 15 + 32, 128 * 15 + 36, 128 * 15 + 40, 128 * 15 + 44, \
++                          128 * 15 + 48, 128 * 15 + 52, 128 * 15 + 56, 128 * 15 + 60
++    vssrarni.h.w  vr29,    vr25,    \_shift
++    vssrarni.h.w  vr31,    vr2,     \_shift
++
++    vstelm.d      vr26,    t2,      64 * 1,  0  // k = 1
++    vstelm.d      vr26,    t2,      64 * 3,  1  // k = 3
++    vstelm.d      vr27,    t2,      64 * 5,  0  // k = 5
++    vstelm.d      vr27,    t2,      64 * 7,  1  // k = 7
++    vstelm.d      vr28,    t2,      64 * 9,  0  // k = 9
++    vstelm.d      vr28,    t2,      64 * 11, 1  // k = 11
++    vstelm.d      vr29,    t2,      64 * 13, 0  // k = 13
++    vstelm.d      vr29,    t3,      64 * 1,  1  // k = 15
++    vstelm.d      vr31,    t3,      64 * 3,  0  // k = 17
++    vstelm.d      vr31,    t3,      64 * 5,  1  // k = 19
++    vstelm.d      vr0,     t3,      64 * 7,  0  // k = 21
++    vstelm.d      vr0,     t3,      64 * 9,  1  // k = 23
++    vstelm.d      vr1,     t3,      64 * 11, 0  // k = 25
++    vstelm.d      vr1,     t3,      64 * 13, 1  // k = 27
++    vstelm.d      vr3,     t5,      64 * 1,  0  // k = 29
++    vstelm.d      vr3,     t5,      64 * 3,  1  // k = 31
++.endm
++
++.macro CLA_DCT32_E_ALL _shift
++    LSX_TRANSPOSE4x4_W_EXTRA vr4,  vr5,  vr6,  vr7,  vr0,  vr1,  vr2,  vr3
++    LSX_TRANSPOSE4x4_W_EXTRA vr8,  vr9,  vr10, vr11, vr4,  vr5,  vr6,  vr7
++    LSX_TRANSPOSE4x4_W_EXTRA vr12, vr13, vr14, vr15, vr8,  vr9,  vr10, vr11
++    LSX_TRANSPOSE4x4_W_EXTRA vr16, vr17, vr18, vr19, vr12, vr13, vr14, vr15
++
++    /* EO[0...7] */
++    vsub.w        vr16,    vr0,     vr15
++    vsub.w        vr17,    vr1,     vr14
++    vsub.w        vr18,    vr2,     vr13
++    vsub.w        vr19,    vr3,     vr12
++    vsub.w        vr20,    vr4,     vr11
++    vsub.w        vr21,    vr5,     vr10
++    vsub.w        vr22,    vr6,     vr9
++    vsub.w        vr23,    vr7,     vr8
++
++    /* EE[0...7] */
++    vadd.w        vr15,    vr0,     vr15
++    vadd.w        vr14,    vr1,     vr14
++    vadd.w        vr13,    vr2,     vr13
++    vadd.w        vr12,    vr3,     vr12
++    vadd.w        vr11,    vr4,     vr11
++    vadd.w        vr10,    vr5,     vr10
++    vadd.w        vr9,     vr6,     vr9
++    vadd.w        vr8,     vr7,     vr8
++
++    /* EEE[0...3] */
++    vadd.w        vr0,     vr15,    vr8
++    vadd.w        vr1,     vr14,    vr9
++    vadd.w        vr2,     vr13,    vr10
++    vadd.w        vr3,     vr12,    vr11
++
++    /* EEO[0...3] */
++    vsub.w        vr4,     vr15,    vr8
++    vsub.w        vr5,     vr14,    vr9
++    vsub.w        vr6,     vr13,    vr10
++    vsub.w        vr7,     vr12,    vr11
++    vadd.w        vr8,     vr0,     vr3  // EEEE[0]
++    vadd.w        vr9,     vr1,     vr2  // EEEE[1]
++    vsub.w        vr10,    vr0,     vr3  // EEEO[0]
++    vsub.w        vr11,    vr1,     vr2  // EEEO[1]
++
++    addi.d        t3,      t2,      64 * 16
++    addi.d        t5,      t1,      128 * 15
++
++    /* CAL0-16-8-24*/
++    vldrepl.w     vr12,    t1,      0
++    vldrepl.w     vr13,    t1,      128 * 8
++    vldrepl.w     vr14,    t1,      128 * 8 + 4
++    vmul.w        vr0,     vr8,     vr12
++    vmadd.w       vr0,     vr9,     vr12  //dst[0]
++    vmul.w        vr1,     vr10,    vr13
++    vmadd.w       vr1,     vr11,    vr14  //dst[8]
++    vmul.w        vr2,     vr8,     vr12
++    vmsub.w       vr2,     vr9,     vr12  //dst[16]
++    vmul.w        vr3,     vr10,    vr14
++    vmsub.w       vr3,     vr11,    vr13  //dst[24]
++
++    /* CAL4-12-20-28*/
++    LSX_CAL_DCT_4_ELE_2 t1, vr4, vr5, vr6, vr7, vr12, vr15, \
++                        128 * 4, 128 * 4 + 4, 128 * 4 + 8, 128 * 4 + 12
++    LSX_CAL_DCT_4_ELE_2X t1, vr4, vr5, vr6, vr7, vr13, vr14, \
++                         128 * 12, 128 * 12 + 4, 128 * 12 + 8, 128 * 12 + 12
++
++    vssrarni.h.w    vr12,   vr0,    \_shift
++    vssrarni.h.w    vr13,   vr1,    \_shift
++    vssrarni.h.w    vr14,   vr2,    \_shift
++    vssrarni.h.w    vr15,   vr3,    \_shift
++
++    vstelm.d        vr12,   t2,     0,            0
++    vstelm.d        vr12,   t2,     64 * 4,       1
++    vstelm.d        vr13,   t2,     64 * 8,       0
++    vstelm.d        vr13,   t2,     64 * 12,      1
++    vstelm.d        vr14,   t3,     0,            0
++    vstelm.d        vr14,   t3,     64 * 4,       1
++    vstelm.d        vr15,   t3,     64 * 8,       0
++    vstelm.d        vr15,   t3,     64 * 12,      1
++
++    /* CAL2-6-10-14...*/
++    LSX_CAL_DCT_8_ELE_2 t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                        vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                        vr0, vr7, 128 * 2, 128 * 2 + 4, 128 * 2 + 8, 128 * 2 + 12, \
++                        128 * 2 + 16, 128 * 2 + 20, 128 * 2 + 24, 128 * 2 + 28
++    LSX_CAL_DCT_8_ELE_2X t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                         vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                         vr1, vr6, 128 * 6, 128 * 6 + 4, 128 * 6 + 8, 128 * 6 + 12, \
++                         128 * 6 + 16, 128 * 6 + 20, 128 * 6 + 24, 128 * 6 + 28
++    LSX_CAL_DCT_8_ELE_2 t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                        vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                        vr2, vr5, 128 * 10, 128 * 10 + 4, 128 * 10 + 8, 128 * 10 + 12, \
++                        128 * 10 + 16, 128 * 10 + 20, 128 * 10 + 24, 128 * 10 + 28
++    LSX_CAL_DCT_8_ELE_2X t1, vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                         vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                         vr3, vr4,128 * 14, 128 * 14 + 4, 128 * 14 + 8, 128 * 14 + 12, \
++                         128 * 14 + 16, 128 * 14 + 20, 128 * 14 + 24, 128 * 14 + 28
++
++    vssrarni.h.w    vr1,    vr0,    \_shift
++    vssrarni.h.w    vr3,    vr2,    \_shift
++    vssrarni.h.w    vr5,    vr4,    \_shift
++    vssrarni.h.w    vr7,    vr6,    \_shift
++
++    vstelm.d        vr1,    t2,     64 * 2,       0
++    vstelm.d        vr1,    t2,     64 * 6,       1
++    vstelm.d        vr3,    t2,     64 * 10,      0
++    vstelm.d        vr3,    t2,     64 * 14,      1
++    vstelm.d        vr5,    t3,     64 * 2,       0
++    vstelm.d        vr5,    t3,     64 * 6,       1
++    vstelm.d        vr7,    t3,     64 * 10,      0
++    vstelm.d        vr7,    t3,     64 * 14,      1
++.endm
++
++.macro DCT32_4_LINE_1
++    vld           vr31,    t0,      0
++
++    LOAD_DCT32    vr4, vr8, vr12, vr16, vr0, vr1, vr2, vr3, a0
++    add.d         a0,      a0,      a2
++    vst           vr0,     t4,      0
++    vst           vr1,     t4,      16
++    vst           vr2,     t4,      16 * 2
++    vst           vr3,     t4,      16 * 3
++    LOAD_DCT32    vr5, vr9, vr13, vr17, vr0, vr1, vr2, vr3, a0
++    add.d         a0,      a0,      a2
++    vst           vr0,     t4,      16 * 4
++    vst           vr1,     t4,      16 * 5
++    vst           vr2,     t4,      16 * 6
++    vst           vr3,     t4,      16 * 7
++    LOAD_DCT32    vr6, vr10, vr14, vr18, vr24, vr25, vr26, vr27, a0
++    add.d         a0,      a0,      a2
++    LOAD_DCT32    vr7, vr11, vr15, vr19, vr28, vr29, vr30, vr31, a0
++    add.d         a0,      a0,      a2
++
++    CLA_DCT32_E_ALL 4
++
++    vld           vr0,     t4,      0
++    vld           vr1,     t4,      16
++    vld           vr2,     t4,      16 * 2
++    vld           vr3,     t4,      16 * 3
++    vld           vr4,     t4,      16 * 4
++    vld           vr5,     t4,      16 * 5
++    vld           vr6,     t4,      16 * 6
++    vld           vr7,     t4,      16 * 7
++    CLA_DCT32_O_ALL 4
++
++    addi.d        t2,      t2,      8
++.endm
++
++.macro DCT32_4_LINE_2
++    vld           vr31,    t0,      0
++
++    LOAD_DCT32    vr4, vr8, vr12, vr16, vr0, vr1, vr2, vr3, a3
++    addi.d        a3,      a3,      64
++    vst           vr0,     t4,      0
++    vst           vr1,     t4,      16
++    vst           vr2,     t4,      16 * 2
++    vst           vr3,     t4,      16 * 3
++    LOAD_DCT32    vr5, vr9, vr13, vr17, vr0, vr1, vr2, vr3, a3
++    addi.d        a3,      a3,      64
++    vst           vr0,     t4,      16 * 4
++    vst           vr1,     t4,      16 * 5
++    vst           vr2,     t4,      16 * 6
++    vst           vr3,     t4,      16 * 7
++    LOAD_DCT32    vr6, vr10, vr14, vr18, vr24, vr25, vr26, vr27, a3
++    addi.d        a3,      a3,      64
++    LOAD_DCT32    vr7, vr11, vr15, vr19, vr28, vr29, vr30, vr31, a3
++    addi.d        a3,      a3,      64
++
++    CLA_DCT32_E_ALL 11
++
++    vld           vr0,     t4,      0
++    vld           vr1,     t4,      16
++    vld           vr2,     t4,      16 * 2
++    vld           vr3,     t4,      16 * 3
++    vld           vr4,     t4,      16 * 4
++    vld           vr5,     t4,      16 * 5
++    vld           vr6,     t4,      16 * 6
++    vld           vr7,     t4,      16 * 7
++    CLA_DCT32_O_ALL 11
++
++    addi.d        t2,      t2,      8
++.endm
++
++/* void x265_dct32_lsx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dct32_lsx
++    addi.d        sp,      sp,      -1120 //-(64 + 8*16 + 32*32*2) si12 Immediate overflow
++    addi.d        sp,      sp,      -1120
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t0,      shuf_1
++    la.local      t1,      table_dct32
++    slli.d        a2,      a2,      1  //stride
++
++    /*
++     * The first butterfly operation.
++     */
++    addi.d        t2,      sp,      64 + 8 * 16
++    addi.d        t4,      sp,      64
++
++    /* line 0 ~ 3  */
++    DCT32_4_LINE_1
++    /* line 4 ~ 7  */
++    DCT32_4_LINE_1
++    /* line 8 ~ 11  */
++    DCT32_4_LINE_1
++    /* line 12 ~ 15  */
++    DCT32_4_LINE_1
++    /* line 16 ~ 19  */
++    DCT32_4_LINE_1
++    /* line 20 ~ 23  */
++    DCT32_4_LINE_1
++    /* line 24 ~ 27  */
++    DCT32_4_LINE_1
++    /* line 28 ~ 31  */
++    DCT32_4_LINE_1
++
++    /*
++     * The second butterfly operation.
++     */
++    addi.d        t2,      a1,      0
++    addi.d        a3,      sp,      64 + 8 * 16
++
++    /* line 0 ~ 3  */
++    DCT32_4_LINE_2
++    /* line 4 ~ 7  */
++    DCT32_4_LINE_2
++    /* line 8 ~ 11  */
++    DCT32_4_LINE_2
++    /* line 12 ~ 15  */
++    DCT32_4_LINE_2
++    /* line 16 ~ 19  */
++    DCT32_4_LINE_2
++    /* line 20 ~ 23  */
++    DCT32_4_LINE_2
++    /* line 24 ~ 27  */
++    DCT32_4_LINE_2
++    /* line 28 ~ 31  */
++    DCT32_4_LINE_2
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f28,   sp,   32
++    fld.d         f29,   sp,   40
++    fld.d         f30,   sp,   48
++    fld.d         f31,   sp,   56
++    addi.d        sp,    sp,   1120
++    addi.d        sp,    sp,   1120
++endfunc
++
++.macro DCT8_BUFFER_FLY _shift
++    LSX_TRANSPOSE8x8_H vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                       vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                       vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23
++
++    /* O[0...3] */
++    vsubwev.w.h   vr24,   vr8,     vr15
++    vsubwod.w.h   vr25,   vr8,     vr15
++    vilvl.w       vr16,   vr25,    vr24  //[0...3]
++    vilvh.w       vr17,   vr25,    vr24  //[4...7]
++    vsubwev.w.h   vr24,   vr9,     vr14
++    vsubwod.w.h   vr25,   vr9,     vr14
++    vilvl.w       vr18,   vr25,    vr24  //[0...3]
++    vilvh.w       vr19,   vr25,    vr24  //[4...7]
++    vsubwev.w.h   vr24,   vr10,    vr13
++    vsubwod.w.h   vr25,   vr10,    vr13
++    vilvl.w       vr20,   vr25,    vr24  //[0...3]
++    vilvh.w       vr21,   vr25,    vr24  //[4...7]
++    vsubwev.w.h   vr24,   vr11,    vr12
++    vsubwod.w.h   vr25,   vr11,    vr12
++    vilvl.w       vr22,   vr25,    vr24  //[0...3]
++    vilvh.w       vr23,   vr25,    vr24  //[4...7]
++
++    vldrepl.w     vr24,   t1,      128 * 1
++    vldrepl.w     vr25,   t1,      128 * 1 + 4
++    vldrepl.w     vr26,   t1,      128 * 1 + 8
++    vldrepl.w     vr27,   t1,      128 * 1 + 12
++    vldrepl.w     vr29,   t1,      128 * 3 + 4
++    vldrepl.w     vr30,   t1,      128 * 3 + 8
++    vldrepl.w     vr31,   t1,      128 * 3 + 12
++    vmul.w        vr28,   vr16,    vr24
++    vmul.w        vr1,    vr17,    vr24
++    vmadd.w       vr28,   vr18,    vr25
++    vmadd.w       vr1,    vr19,    vr25
++    vmadd.w       vr28,   vr20,    vr26
++    vmadd.w       vr1,    vr21,    vr26
++    vmadd.w       vr28,   vr22,    vr27
++    vmadd.w       vr1,    vr23,    vr27
++    vssrarni.h.w  vr1,    vr28,    \_shift
++
++    vmul.w        vr28,   vr16,    vr25
++    vmul.w        vr3,    vr17,    vr25
++    vmadd.w       vr28,   vr18,    vr29
++    vmadd.w       vr3,    vr19,    vr29
++    vmadd.w       vr28,   vr20,    vr30
++    vmadd.w       vr3,    vr21,    vr30
++    vmadd.w       vr28,   vr22,    vr31
++    vmadd.w       vr3,    vr23,    vr31
++    vssrarni.h.w  vr3,    vr28,    \_shift
++
++    vmul.w        vr28,   vr16,    vr26
++    vmul.w        vr5,    vr17,    vr26
++    vmadd.w       vr28,   vr18,    vr30
++    vmadd.w       vr5,    vr19,    vr30
++    vmadd.w       vr28,   vr20,    vr27
++    vmadd.w       vr5,    vr21,    vr27
++    vmadd.w       vr28,   vr22,    vr25
++    vmadd.w       vr5,    vr23,    vr25
++    vssrarni.h.w  vr5,    vr28,    \_shift
++
++    vmul.w        vr28,   vr16,    vr27
++    vmul.w        vr7,    vr17,    vr27
++    vmadd.w       vr28,   vr18,    vr31
++    vmadd.w       vr7,    vr19,    vr31
++    vmadd.w       vr28,   vr20,    vr25
++    vmadd.w       vr7,    vr21,    vr25
++    vmadd.w       vr28,   vr22,    vr30
++    vmadd.w       vr7,    vr23,    vr30
++    vssrarni.h.w  vr7,    vr28,    \_shift
++
++    /* E[0...3] */
++    vaddwev.w.h   vr24,   vr8,     vr15
++    vaddwod.w.h   vr25,   vr8,     vr15
++    vilvl.w       vr16,   vr25,    vr24  //[0...3]
++    vilvh.w       vr17,   vr25,    vr24  //[4...7]
++    vaddwev.w.h   vr24,   vr9,     vr14
++    vaddwod.w.h   vr25,   vr9,     vr14
++    vilvl.w       vr18,   vr25,    vr24  //[0...3]
++    vilvh.w       vr19,   vr25,    vr24  //[4...7]
++    vaddwev.w.h   vr24,   vr10,    vr13
++    vaddwod.w.h   vr25,   vr10,    vr13
++    vilvl.w       vr20,   vr25,    vr24  //[0...3]
++    vilvh.w       vr21,   vr25,    vr24  //[4...7]
++    vaddwev.w.h   vr24,   vr11,    vr12
++    vaddwod.w.h   vr25,   vr11,    vr12
++    vilvl.w       vr22,   vr25,    vr24  //[0...3]
++    vilvh.w       vr23,   vr25,    vr24  //[4...7]
++
++    vadd.w        vr8,    vr16,    vr22
++    vadd.w        vr9,    vr17,    vr23  //EE[0]
++    vadd.w        vr10,   vr18,    vr20
++    vadd.w        vr11,   vr19,    vr21  //EE[1]
++    vsub.w        vr12,   vr16,    vr22
++    vsub.w        vr13,   vr17,    vr23  //EO[0]
++    vsub.w        vr14,   vr18,    vr20
++    vsub.w        vr15,   vr19,    vr21  //EO[1]
++
++    vldrepl.w     vr24,   t1,      0
++    vldrepl.w     vr25,   t1,      128 * 2
++    vldrepl.w     vr26,   t1,      128 * 2 + 4
++    vldrepl.w     vr27,   t1,      128 * 4 + 4
++    vldrepl.w     vr29,   t1,      128 * 6 + 4
++    vmul.w        vr28,   vr8,     vr24
++    vmul.w        vr0,    vr9,     vr24
++    vmadd.w       vr28,   vr10,    vr24
++    vmadd.w       vr0,    vr11,    vr24
++    vssrarni.h.w  vr0,    vr28,    \_shift
++
++    vmul.w        vr28,   vr12,    vr25
++    vmul.w        vr2,    vr13,    vr25
++    vmadd.w       vr28,   vr14,    vr26
++    vmadd.w       vr2,    vr15,    vr26
++    vssrarni.h.w  vr2,    vr28,    \_shift
++
++    vmul.w        vr28,   vr8,     vr24
++    vmul.w        vr4,    vr9,     vr24
++    vmadd.w       vr28,   vr10,    vr27
++    vmadd.w       vr4,    vr11,    vr27
++    vssrarni.h.w  vr4,    vr28,    \_shift
++
++    vmul.w        vr28,   vr12,    vr26
++    vmul.w        vr6,    vr13,    vr26
++    vmadd.w       vr28,   vr14,    vr29
++    vmadd.w       vr6,    vr15,    vr29
++    vssrarni.h.w  vr6,    vr28,    \_shift
++.endm
++
++/* void x265_dct8_lsx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dct8_lsx
++    addi.d        sp,      sp,      -64
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,      1  //stride
++    slli.d        a4,      a2,      2  //stride2
++    slli.d        a6,      a2,      3  //stride4
++    add.d         a5,      a4,      a3 //stride3
++    add.d         a7,      a6,      a3 //stride5
++    add.d         t7,      a6,      a4 //stride6
++    add.d         t8,      a6,      a5 //stride7
++
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr0,     a0,      0    //line0
++    vldx          vr1,     a0,      a3   //line1
++    vldx          vr2,     a0,      a4   //line2
++    vldx          vr3,     a0,      a5   //line3
++    vldx          vr4,     a0,      a6   //line4
++    vldx          vr5,     a0,      a7   //line5
++    vldx          vr6,     a0,      t7   //line6
++    vldx          vr7,     a0,      t8   //line7
++
++    DCT8_BUFFER_FLY 2
++
++    /*
++     * The second butterfly operation.
++     */
++    DCT8_BUFFER_FLY 9
++    vst           vr0,     a1,     0
++    vst           vr1,     a1,     16
++    vst           vr2,     a1,     32
++    vst           vr3,     a1,     48
++    vst           vr4,     a1,     64
++    vst           vr5,     a1,     80
++    vst           vr6,     a1,     96
++    vst           vr7,     a1,     112
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f28,   sp,   32
++    fld.d         f29,   sp,   40
++    fld.d         f30,   sp,   48
++    fld.d         f31,   sp,   56
++    addi.d        sp,    sp,   64
++endfunc
++
++.macro DCT4_BUFFER_FLY
++    LSX_TRANSPOSE4x4_W_EXTRA vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++
++    vadd.w        vr8,     vr4,     vr7 // E[0]
++    vadd.w        vr9,     vr5,     vr6 // E[1]
++    vsub.w        vr10,    vr4,     vr7 // O[0]
++    vsub.w        vr11,    vr5,     vr6 // O[1]
++
++    vmul.w        vr0,     vr8,     vr12
++    vmul.w        vr2,     vr8,     vr12
++    vmul.w        vr1,     vr10,    vr13
++    vmul.w        vr3,     vr10,    vr14
++    vmadd.w       vr0,     vr9,     vr12
++    vmadd.w       vr2,     vr9,     vr15
++    vmadd.w       vr1,     vr11,    vr14
++    vmadd.w       vr3,     vr11,    vr16
++.endm
++
++/* void x265_dct4_lsx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dct4_lsx
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,      1  //stride
++    slli.d        a4,      a2,      2  //stride2
++    add.d         a5,      a4,      a3 //stride3
++
++    vldi          vr12,    0x840       // 64 g_t4[0][0] g_t4[0][1] g_t4[2][0]
++    vldi          vr13,    0x853       // 83 g_t4[1][0]
++    vldi          vr14,    0x824       // 36 g_t4[1][1] g_t4[3][0]
++    vldrepl.w     vr15,    t1,      256 * 2 + 4 // -64 g_t4[2][1]
++    vldrepl.w     vr16,    t1,      256 * 3 + 4
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr0,     a0,      0    //line0
++    vldx          vr1,     a0,      a3   //line1
++    vldx          vr2,     a0,      a4   //line2
++    vldx          vr3,     a0,      a5   //line3
++
++    vsllwil.w.h   vr0,     vr0,     0
++    vsllwil.w.h   vr1,     vr1,     0
++    vsllwil.w.h   vr2,     vr2,     0
++    vsllwil.w.h   vr3,     vr3,     0
++
++    DCT4_BUFFER_FLY
++
++    vsrari.w      vr0,     vr0,     1
++    vsrari.w      vr1,     vr1,     1
++    vsrari.w      vr2,     vr2,     1
++    vsrari.w      vr3,     vr3,     1
++
++    /*
++     * The second butterfly operation.
++     */
++    DCT4_BUFFER_FLY
++
++    vssrarni.h.w  vr1,     vr0,    8
++    vssrarni.h.w  vr3,     vr2,    8
++
++    vst           vr1,     a1,     0
++    vst           vr3,     a1,     16
++endfunc
++
++.macro DST4_4_LINE
++    LSX_TRANSPOSE4x4_W_EXTRA vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++
++    vadd.w        vr8,     vr4,     vr7  // c[0]
++    vadd.w        vr9,     vr5,     vr7  // c[1]
++    vsub.w        vr10,    vr4,     vr5  // c[2]
++    vmul.w        vr11,    vr6,     vr12 // c[3]
++
++    vmul.w        vr0,     vr8,     vr13
++    vmul.w        vr2,     vr10,    vr13
++    vadd.w        vr1,     vr4,     vr5
++    vsub.w        vr1,     vr1,     vr7
++    vmadd.w       vr2,     vr8,     vr14
++    vmadd.w       vr0,     vr9,     vr14
++    vmul.w        vr1,     vr1,     vr12
++    vadd.w        vr0,     vr0,     vr11
++    vsub.w        vr2,     vr2,     vr11
++    vmadd.w       vr11,    vr10,    vr14
++    vmul.w        vr3,     vr9,     vr13
++    vsub.w        vr3,     vr11,    vr3
++.endm
++
++/* void x265_dst4_lsx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dst4_lsx
++    slli.d        a3,      a2,      1  //stride
++    vldi          vr12,    0x84A       // 74
++    vldi          vr13,    0x81D       // 29
++    vldi          vr14,    0x837       // 55
++
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr0,     a0,      0    //line0
++    vldx          vr1,     a0,      a3   //line1
++    alsl.d        a0,      a3,      a0,  1
++    vld           vr2,     a0,      0    //line0
++    vldx          vr3,     a0,      a3   //line1
++
++    vsllwil.w.h   vr0,     vr0,     0
++    vsllwil.w.h   vr1,     vr1,     0
++    vsllwil.w.h   vr2,     vr2,     0
++    vsllwil.w.h   vr3,     vr3,     0
++
++    DST4_4_LINE
++
++    vsrari.w      vr0,     vr0,     1
++    vsrari.w      vr1,     vr1,     1
++    vsrari.w      vr2,     vr2,     1
++    vsrari.w      vr3,     vr3,     1
++
++    /*
++     * The second butterfly operation.
++     */
++    DST4_4_LINE
++
++    vssrarni.h.w  vr1,     vr0,    8
++    vssrarni.h.w  vr3,     vr2,    8
++
++    vst           vr1,     a1,     0
++    vst           vr3,     a1,     16
++endfunc
++
++.macro IDST4_4_LINE
++    vadd.w        vr4,     vr0,     vr2  //c[0]
++    vadd.w        vr5,     vr2,     vr3  //c[1]
++    vsub.w        vr6,     vr0,     vr3  //c[2]
++    vmul.w        vr7,     vr1,     vr12 //c[3]
++
++
++    vmul.w        vr8,     vr4,     vr13
++    vsub.w        vr10,    vr0,     vr2
++    vmul.w        vr9,     vr6,     vr14
++    vadd.w        vr10,    vr10,    vr3
++    vmul.w        vr11,    vr4,     vr14
++    vmadd.w       vr8,     vr5,     vr14
++    vadd.w        vr8,     vr8,     vr7
++    vmsub.w       vr9,     vr5,     vr13
++    vmadd.w       vr11,    vr6,     vr13
++    vadd.w        vr9,     vr9,     vr7
++    vmul.w        vr10,    vr10,    vr12
++    vsub.w        vr11,    vr11,    vr7
++
++    LSX_TRANSPOSE4x4_W_EXTRA vr8, vr9, vr10, vr11, vr0, vr1, vr2, vr3
++.endm
++
++/* void x265_idst4_c(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idst4_lsx
++    slli.d        a3,      a2,     1  //stride
++    vldi          vr12,    0x84A       // 74
++    vldi          vr13,    0x81D       // 29
++    vldi          vr14,    0x837       // 55
++
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr4,     a0,     0    //line01
++    vld           vr5,     a0,     16   //line23
++
++    vsllwil.w.h   vr0,     vr4,    0
++    vexth.w.h     vr1,     vr4
++    vsllwil.w.h   vr2,     vr5,    0
++    vexth.w.h     vr3,     vr5
++
++    IDST4_4_LINE
++
++    vsrari.w      vr0,     vr0,    7
++    vsrari.w      vr1,     vr1,    7
++    vsrari.w      vr2,     vr2,    7
++    vsrari.w      vr3,     vr3,    7
++
++    /*
++     * The second butterfly operation.
++     */
++    IDST4_4_LINE
++
++    vssrarni.h.w  vr1,     vr0,    12
++    vssrarni.h.w  vr3,     vr2,    12
++
++    vstelm.d      vr1,     a1,     0,   0
++    add.d         a1,      a1,     a3
++    vstelm.d      vr1,     a1,     0,   1
++    add.d         a1,      a1,     a3
++    vstelm.d      vr3,     a1,     0,   0
++    add.d         a1,      a1,     a3
++    vstelm.d      vr3,     a1,     0,   1
++endfunc
++
++/*
++ * Description : Half word signed extension to words.
++ * Arguments   : Inputs  - in
++ *               Outputs - out0, out1
++ * Details     :
++ * Example     :
++ *               in :1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
++ *               =====>
++ *               out0: 1, 2, 3, 4, 5, 6, 7, 8,
++ *               out1: 9, 10, 11, 12, 13, 14, 15,
++ */
++.macro LASX_EXT_W_H _in, _out0, _out1
++    xvpermi.d     \_out1,  \_in,    0xd8
++    xvsllwil.w.h  \_out0,  \_out1,  0
++    xvexth.w.h    \_out1,  \_out1
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: xr8~xr11
++ */
++.macro LASX_CAL_DCT_4_ELE_2 _rin, _in0, _in1, _in2, _in3, \
++                            _out0, _out1, _si0, _si1, _si2, _si3
++    xvldrepl.w    xr8,     \_rin,    \_si0
++    xvldrepl.w    xr9,     \_rin,    \_si1
++    xvldrepl.w    xr10,    \_rin,    \_si2
++    xvldrepl.w    xr11,    \_rin,    \_si3
++    xvmul.w       \_out0,  \_in0,    xr8
++    xvmadd.w      \_out0,  \_in1,    xr9
++    xvmadd.w      \_out0,  \_in2,    xr10
++    xvmadd.w      \_out0,  \_in3,    xr11
++    xvmul.w       \_out1,  \_in0,    xr11
++    xvmsub.w      \_out1,  \_in1,    xr10
++    xvmadd.w      \_out1,  \_in2,    xr9
++    xvmsub.w      \_out1,  \_in3,    xr8
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: xr8~xr11
++ */
++.macro LASX_CAL_DCT_4_ELE_2X _rin, _in0, _in1, _in2, _in3, \
++                             _out0, _out1, _si0, _si1, _si2, _si3
++    xvldrepl.w    xr8,     \_rin,    \_si0
++    xvldrepl.w    xr9,     \_rin,    \_si1
++    xvldrepl.w    xr10,    \_rin,    \_si2
++    xvldrepl.w    xr11,    \_rin,    \_si3
++    xvmul.w       \_out0,  \_in0,    xr8
++    xvmadd.w      \_out0,  \_in1,    xr9
++    xvmadd.w      \_out0,  \_in2,    xr10
++    xvmadd.w      \_out0,  \_in3,    xr11
++    xvmul.w       \_out1,  \_in3,    xr8
++    xvmsub.w      \_out1,  \_in2,    xr9
++    xvmadd.w      \_out1,  \_in1,    xr10
++    xvmsub.w      \_out1,  \_in0,    xr11
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: xr8~xr15
++ */
++.macro LASX_CAL_DCT_8_ELE_2 _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                            _out0, _out1, _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    xvldrepl.w    xr8,     \_rin,    \_si0
++    xvldrepl.w    xr9,     \_rin,    \_si1
++    xvldrepl.w    xr10,    \_rin,    \_si2
++    xvldrepl.w    xr11,    \_rin,    \_si3
++    xvldrepl.w    xr12,    \_rin,    \_si4
++    xvldrepl.w    xr13,    \_rin,    \_si5
++    xvldrepl.w    xr14,    \_rin,    \_si6
++    xvldrepl.w    xr15,    \_rin,    \_si7
++    xvmul.w       \_out0,  \_in0,    xr8
++    xvmul.w       \_out1,  \_in0,    xr15
++    xvmadd.w      \_out0,  \_in1,    xr9
++    xvmsub.w      \_out1,  \_in1,    xr14
++    xvmadd.w      \_out0,  \_in2,    xr10
++    xvmadd.w      \_out1,  \_in2,    xr13
++    xvmadd.w      \_out0,  \_in3,    xr11
++    xvmsub.w      \_out1,  \_in3,    xr12
++    xvmadd.w      \_out0,  \_in4,    xr12
++    xvmadd.w      \_out1,  \_in4,    xr11
++    xvmadd.w      \_out0,  \_in5,    xr13
++    xvmsub.w      \_out1,  \_in5,    xr10
++    xvmadd.w      \_out0,  \_in6,    xr14
++    xvmadd.w      \_out1,  \_in6,    xr9
++    xvmadd.w      \_out0,  \_in7,    xr15
++    xvmsub.w      \_out1,  \_in7,    xr8
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: xr8~xr15
++ */
++.macro LASX_CAL_DCT_8_ELE_2X _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                             _out0, _out1, _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    xvldrepl.w    xr8,     \_rin,    \_si0
++    xvldrepl.w    xr9,     \_rin,    \_si1
++    xvldrepl.w    xr10,    \_rin,    \_si2
++    xvldrepl.w    xr11,    \_rin,    \_si3
++    xvldrepl.w    xr12,    \_rin,    \_si4
++    xvldrepl.w    xr13,    \_rin,    \_si5
++    xvldrepl.w    xr14,    \_rin,    \_si6
++    xvldrepl.w    xr15,    \_rin,    \_si7
++    xvmul.w       \_out0,  \_in0,    xr8
++    xvmul.w       \_out1,  \_in7,    xr8
++    xvmadd.w      \_out0,  \_in1,    xr9
++    xvmsub.w      \_out1,  \_in6,    xr9
++    xvmadd.w      \_out0,  \_in2,    xr10
++    xvmadd.w      \_out1,  \_in5,    xr10
++    xvmadd.w      \_out0,  \_in3,    xr11
++    xvmsub.w      \_out1,  \_in4,    xr11
++    xvmadd.w      \_out0,  \_in4,    xr12
++    xvmadd.w      \_out1,  \_in3,    xr12
++    xvmadd.w      \_out0,  \_in5,    xr13
++    xvmsub.w      \_out1,  \_in2,    xr13
++    xvmadd.w      \_out0,  \_in6,    xr14
++    xvmadd.w      \_out1,  \_in1,    xr14
++    xvmadd.w      \_out0,  \_in7,    xr15
++    xvmsub.w      \_out1,  \_in0,    xr15
++.endm
++
++.macro DCT16_8_LINE _shift, _rout
++    LASX_TRANSPOSE8x8_H xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7,\
++                        xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                        xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15
++
++    LASX_EXT_W_H xr16, xr0, xr8
++    LASX_EXT_W_H xr17, xr1, xr9
++    LASX_EXT_W_H xr18, xr2, xr10
++    LASX_EXT_W_H xr19, xr3, xr11
++    LASX_EXT_W_H xr20, xr4, xr12
++    LASX_EXT_W_H xr21, xr5, xr13
++    LASX_EXT_W_H xr22, xr6, xr14
++    LASX_EXT_W_H xr23, xr7, xr15
++
++    /* O[0...7] */
++    xvsub.w       xr16,    xr0,     xr15
++    xvsub.w       xr17,    xr1,     xr14
++    xvsub.w       xr18,    xr2,     xr13
++    xvsub.w       xr19,    xr3,     xr12
++    xvsub.w       xr20,    xr4,     xr11
++    xvsub.w       xr21,    xr5,     xr10
++    xvsub.w       xr22,    xr6,     xr9
++    xvsub.w       xr23,    xr7,     xr8
++
++    /* E[0...7] */
++    xvadd.w       xr15,    xr0,     xr15
++    xvadd.w       xr14,    xr1,     xr14
++    xvadd.w       xr13,    xr2,     xr13
++    xvadd.w       xr12,    xr3,     xr12
++    xvadd.w       xr11,    xr4,     xr11
++    xvadd.w       xr10,    xr5,     xr10
++    xvadd.w       xr9,     xr6,     xr9
++    xvadd.w       xr8,     xr7,     xr8
++
++    /* EE[0...3] */
++    xvadd.w       xr0,     xr15,    xr8
++    xvadd.w       xr1,     xr14,    xr9
++    xvadd.w       xr2,     xr13,    xr10
++    xvadd.w       xr3,     xr12,    xr11
++
++    /* EO[0...3] */
++    xvsub.w       xr4,     xr15,    xr8
++    xvsub.w       xr5,     xr14,    xr9
++    xvsub.w       xr6,     xr13,    xr10
++    xvsub.w       xr7,     xr12,    xr11
++
++    xvadd.w       xr8,     xr0,     xr3  // EEE[0]
++    xvadd.w       xr9,     xr1,     xr2  // EEE[1]
++    xvsub.w       xr10,    xr0,     xr3  // EEO[0]
++    xvsub.w       xr11,    xr1,     xr2  // EEO[1]
++
++    /* CAL0-8-4-12*/
++    xvldrepl.w    xr12,    t1,      0
++    xvmul.w       xr0,     xr8,     xr12
++    xvmul.w       xr2,     xr8,     xr12
++    xvmadd.w      xr0,     xr9,     xr12  //dst[0]
++    xvmsub.w      xr2,     xr9,     xr12  //dst[8]
++
++    xvldrepl.w    xr12,    t1,      64 * 4
++    xvldrepl.w    xr13,    t1,      64 * 4 + 4
++    xvmul.w       xr1,     xr10,    xr12
++    xvmul.w       xr3,     xr10,    xr13
++    xvmadd.w      xr1,     xr11,    xr13  //dst[4]
++    xvmsub.w      xr3,     xr11,    xr12  //dst[12]
++
++    /* CAL2-6-10-14*/
++    LASX_CAL_DCT_4_ELE_2 t1, xr4, xr5, xr6, xr7, xr12, xr15, \
++                         64 * 2, 64 * 2 + 4, 64 * 2 + 8, 64 * 2 + 12
++    LASX_CAL_DCT_4_ELE_2X t1, xr4, xr5, xr6, xr7, xr13, xr14, \
++                          64 * 6, 64 * 6 + 4, 64 * 6 + 8, 64 * 6 + 12
++
++    xvssrarni.h.w   xr12,   xr0,    \_shift
++    xvssrarni.h.w   xr13,   xr1,    \_shift
++    xvssrarni.h.w   xr14,   xr2,    \_shift
++    xvssrarni.h.w   xr15,   xr3,    \_shift
++
++    xvstelm.d       xr12,   \_rout, 0,            0
++    xvstelm.d       xr12,   \_rout, 8,            2  // k = 0
++    xvstelm.d       xr12,   \_rout, 32 * 2,       1
++    xvstelm.d       xr12,   \_rout, 32 * 2 + 8,   3  // k = 2
++    xvstelm.d       xr13,   \_rout, 32 * 4,       0
++    xvstelm.d       xr13,   \_rout, 32 * 4 + 8,   2  // k = 4
++    xvstelm.d       xr13,   \_rout, 32 * 6,       1
++    xvstelm.d       xr13,   \_rout, 32 * 6 + 8,   3  // k = 6
++    xvstelm.d       xr14,   \_rout, 32 * 8,       0
++    xvstelm.d       xr14,   \_rout, 32 * 8 + 8,   2  // k = 8
++    xvstelm.d       xr14,   \_rout, 32 * 10,      1
++    xvstelm.d       xr14,   \_rout, 32 * 10 + 8,  3  // k = 10
++    xvstelm.d       xr15,   \_rout, 32 * 12,      0
++    xvstelm.d       xr15,   \_rout, 32 * 12 + 8,  2  // k = 12
++    xvstelm.d       xr15,   \_rout, 32 * 14,      1
++    xvstelm.d       xr15,   \_rout, 32 * 14 + 8,  3  // k = 14
++
++    /* CAL1-3-5-7...*/
++    LASX_CAL_DCT_8_ELE_2 t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                         xr0, xr7, 64 * 1, 64 * 1 + 4, 64 * 1 + 8, 64 * 1 + 12, \
++                         64 * 1 + 16, 64 * 1 + 20, 64 * 1 + 24, 64 * 1 + 28
++    LASX_CAL_DCT_8_ELE_2X t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                          xr1, xr6, 64 * 3, 64 * 3 + 4, 64 * 3 + 8, 64 * 3 + 12, \
++                          64 * 3 + 16, 64 * 3 + 20, 64 * 3 + 24, 64 * 3 + 28
++    LASX_CAL_DCT_8_ELE_2 t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                         xr2, xr5, 64 * 5, 64 * 5 + 4, 64 * 5 + 8, 64 * 5 + 12, \
++                         64 * 5 + 16, 64 * 5 + 20, 64 * 5 + 24, 64 * 5 + 28
++    LASX_CAL_DCT_8_ELE_2X t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                          xr3, xr4, 64 * 7, 64 * 7 + 4, 64 * 7 + 8, 64 * 7 + 12, \
++                          64 * 7 + 16, 64 * 7 + 20, 64 * 7 + 24, 64 * 7 + 28
++
++    xvssrarni.h.w   xr1,    xr0,    \_shift
++    xvssrarni.h.w   xr3,    xr2,    \_shift
++    xvssrarni.h.w   xr5,    xr4,    \_shift
++    xvssrarni.h.w   xr7,    xr6,    \_shift
++
++    xvstelm.d       xr1,    \_rout, 32 * 1,       0
++    xvstelm.d       xr1,    \_rout, 32 * 1 + 8,   2  // k = 1
++    xvstelm.d       xr1,    \_rout, 32 * 3,       1
++    xvstelm.d       xr1,    \_rout, 32 * 3 + 8,   3  // k = 3
++    xvstelm.d       xr3,    \_rout, 32 * 5,       0
++    xvstelm.d       xr3,    \_rout, 32 * 5 + 8,   2  // k = 5
++    xvstelm.d       xr3,    \_rout, 32 * 7,       1
++    xvstelm.d       xr3,    \_rout, 32 * 7 + 8,   3  // k = 7
++    xvstelm.d       xr5,    \_rout, 32 * 9,       0
++    xvstelm.d       xr5,    \_rout, 32 * 9 + 8,   2  // k = 9
++    xvstelm.d       xr5,    \_rout, 32 * 11,      1
++    xvstelm.d       xr5,    \_rout, 32 * 11 + 8,  3  // k = 11
++    xvstelm.d       xr7,    \_rout, 32 * 13,      0
++    xvstelm.d       xr7,    \_rout, 32 * 13 + 8,  2  // k = 13
++    xvstelm.d       xr7,    \_rout, 32 * 15,      1
++    xvstelm.d       xr7,    \_rout, 32 * 15 + 8,  3  // k = 15
++.endm
++
++/* void x265_dct16_lasx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dct16_lasx
++    addi.d        sp,      sp,      -512 //-(16*16*2) si12 Immediate overflow
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,      1  //stride
++    slli.d        a4,      a2,      2  //stride2
++    slli.d        a6,      a2,      3  //stride4
++    slli.d        t6,      a2,      4  //stride8
++    add.d         a5,      a4,      a3 //stride3
++    add.d         a7,      a6,      a3 //stride5
++    add.d         t7,      a6,      a4 //stride6
++    add.d         t8,      a6,      a5 //stride7
++
++    /*
++     * The first butterfly operation.
++     */
++    xvld          xr0,     a0,      0    //line0
++    xvldx         xr1,     a0,      a3   //line1
++    xvldx         xr2,     a0,      a4   //line2
++    xvldx         xr3,     a0,      a5   //line3
++    xvldx         xr4,     a0,      a6   //line4
++    xvldx         xr5,     a0,      a7   //line5
++    xvldx         xr6,     a0,      t7   //line6
++    xvldx         xr7,     a0,      t8   //line7
++    DCT16_8_LINE 3, sp
++    addi.d        t2,      sp,      16
++
++    add.d         a0,      a0,      t6
++    xvld          xr0,     a0,      0    //line8
++    xvldx         xr1,     a0,      a3   //line9
++    xvldx         xr2,     a0,      a4   //line10
++    xvldx         xr3,     a0,      a5   //line11
++    xvldx         xr4,     a0,      a6   //line12
++    xvldx         xr5,     a0,      a7   //line13
++    xvldx         xr6,     a0,      t7   //line14
++    xvldx         xr7,     a0,      t8   //line15
++    DCT16_8_LINE 3, t2
++
++    /*
++     * The second butterfly operation.
++     */
++    xvld          xr0,     sp,      0    //line0
++    xvld          xr1,     sp,      32   //line1
++    xvld          xr2,     sp,      64   //line2
++    xvld          xr3,     sp,      96   //line3
++    xvld          xr4,     sp,      128  //line4
++    xvld          xr5,     sp,      160  //line5
++    xvld          xr6,     sp,      192  //line6
++    xvld          xr7,     sp,      224  //line7
++    DCT16_8_LINE 10, a1
++
++    addi.d        t2,      a1,      16
++    xvld          xr0,     sp,      256  //line8
++    xvld          xr1,     sp,      288  //line9
++    xvld          xr2,     sp,      320  //line10
++    xvld          xr3,     sp,      352  //line11
++    xvld          xr4,     sp,      384  //line12
++    xvld          xr5,     sp,      416  //line13
++    xvld          xr6,     sp,      448  //line14
++    xvld          xr7,     sp,      480  //line15
++    DCT16_8_LINE 10, t2
++
++    addi.d        sp,      sp,   512
++endfunc
++
++/*
++ *  _out0, _out1: E[0...15]
++ *  _out2, _out3: O[0...15]
++ *  temp reg: xr28, xr29, xr30
++ */
++.macro LASX_LOAD_DCT32 _out0, _out1, _out2, _out3, _in
++    xvld          xr28,  \_in,    0    //src[0...15]
++    xvld          xr29,  \_in,    32   //src[16...31]
++
++    xvshuf.b      xr29,   xr29,   xr29, xr31
++    xvpermi.q     xr29,   xr29,   0x1
++
++    xvaddwev.w.h  \_out2,  xr28,    xr29
++    xvaddwod.w.h  \_out3,  xr28,    xr29
++    xvilvl.w      \_out0,  \_out3,  \_out2
++    xvilvh.w      \_out1,  \_out3,  \_out2
++    xmov          xr30,    \_out0
++    xvpermi.q     \_out0,  \_out1,  0x2   //E[0...7]
++    xvpermi.q     \_out1,  xr30,    0x31  //E[8...15]1
++
++    xvsubwev.w.h  xr30,    xr28,    xr29
++    xvsubwod.w.h  xr28,    xr28,    xr29
++    xvilvl.w      \_out2,  xr28,    xr30
++    xvilvh.w      \_out3,  xr28,    xr30
++    xmov          xr30,    \_out2
++    xvpermi.q     \_out2,  \_out3,  0x2   //O[0...7]
++    xvpermi.q     \_out3,  xr30,    0x31  //O[8...15]1
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * in reg: xr8 ~ xr15, xr0, xr2, xr4, xr6, xr20, xr21, xr22, xr23
++ * temp reg: xr16 ~ xr19
++ */
++.macro LASX_CAL_DCT_16_ELE_2 _rin, _out0,  _out1, \
++                             _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                             _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    xvldrepl.w     xr16,    \_rin,    \_si0
++    xvldrepl.w     xr17,    \_rin,    \_si1
++    xvldrepl.w     xr18,    \_rin,    \_si2
++    xvldrepl.w     xr19,    \_rin,    \_si3
++    xvmul.w        \_out0,  xr8,      xr16
++    xvmul.w        \_out1,  xr20,     xr19
++    xvmadd.w       \_out0,  xr9,      xr17
++    xvmsub.w       \_out1,  xr21,     xr18
++    xvmadd.w       \_out0,  xr10,     xr18
++    xvmadd.w       \_out1,  xr22,     xr17
++    xvmadd.w       \_out0,  xr11,     xr19
++    xvmsub.w       \_out1,  xr23,     xr16
++
++    xvldrepl.w     xr16,    \_rin,    \_si4
++    xvldrepl.w     xr17,    \_rin,    \_si5
++    xvldrepl.w     xr18,    \_rin,    \_si6
++    xvldrepl.w     xr19,    \_rin,    \_si7
++    xvmadd.w       \_out0,  xr12,     xr16
++    xvmadd.w       \_out1,  xr0,      xr19
++    xvmadd.w       \_out0,  xr13,     xr17
++    xvmsub.w       \_out1,  xr2,      xr18
++    xvmadd.w       \_out0,  xr14,     xr18
++    xvmadd.w       \_out1,  xr4,      xr17
++    xvmadd.w       \_out0,  xr15,     xr19
++    xvmsub.w       \_out1,  xr6,      xr16
++
++    xvldrepl.w     xr16,    \_rin,    \_si8
++    xvldrepl.w     xr17,    \_rin,    \_si9
++    xvldrepl.w     xr18,    \_rin,    \_si10
++    xvldrepl.w     xr19,    \_rin,    \_si11
++    xvmadd.w       \_out0,  xr0,      xr16
++    xvmadd.w       \_out1,  xr12,     xr19
++    xvmadd.w       \_out0,  xr2,      xr17
++    xvmsub.w       \_out1,  xr13,     xr18
++    xvmadd.w       \_out0,  xr4,      xr18
++    xvmadd.w       \_out1,  xr14,     xr17
++    xvmadd.w       \_out0,  xr6,      xr19
++    xvmsub.w       \_out1,  xr15,     xr16
++
++    xvldrepl.w     xr16,    \_rin,    \_si12
++    xvldrepl.w     xr17,    \_rin,    \_si13
++    xvldrepl.w     xr18,    \_rin,    \_si14
++    xvldrepl.w     xr19,    \_rin,    \_si15
++    xvmadd.w       \_out0,  xr20,     xr16
++    xvmadd.w       \_out1,  xr8,      xr19
++    xvmadd.w       \_out0,  xr21,     xr17
++    xvmsub.w       \_out1,  xr9,      xr18
++    xvmadd.w       \_out0,  xr22,     xr18
++    xvmadd.w       \_out1,  xr10,     xr17
++    xvmadd.w       \_out0,  xr23,     xr19
++    xvmsub.w       \_out1,  xr11,     xr16
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * in reg: xr8 ~ xr15, xr0, xr2, xr4, xr6, xr20, xr21, xr22, xr23
++ * temp reg: xr16 ~ xr19
++ */
++.macro LASX_CAL_DCT_16_ELE_2X _rin, _out0,  _out1, \
++                              _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                              _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    xvldrepl.w     xr16,    \_rin,    \_si0
++    xvldrepl.w     xr17,    \_rin,    \_si1
++    xvldrepl.w     xr18,    \_rin,    \_si2
++    xvldrepl.w     xr19,    \_rin,    \_si3
++    xvmul.w        \_out0,  xr8,      xr16
++    xvmul.w        \_out1,  xr23,     xr16
++    xvmadd.w       \_out0,  xr9,      xr17
++    xvmsub.w       \_out1,  xr22,     xr17
++    xvmadd.w       \_out0,  xr10,     xr18
++    xvmadd.w       \_out1,  xr21,     xr18
++    xvmadd.w       \_out0,  xr11,     xr19
++    xvmsub.w       \_out1,  xr20,     xr19
++
++    xvldrepl.w     xr16,    \_rin,    \_si4
++    xvldrepl.w     xr17,    \_rin,    \_si5
++    xvldrepl.w     xr18,    \_rin,    \_si6
++    xvldrepl.w     xr19,    \_rin,    \_si7
++    xvmadd.w       \_out0,  xr12,     xr16
++    xvmadd.w       \_out1,  xr6,      xr16
++    xvmadd.w       \_out0,  xr13,     xr17
++    xvmsub.w       \_out1,  xr4,      xr17
++    xvmadd.w       \_out0,  xr14,     xr18
++    xvmadd.w       \_out1,  xr2,      xr18
++    xvmadd.w       \_out0,  xr15,     xr19
++    xvmsub.w       \_out1,  xr0,      xr19
++
++    xvldrepl.w     xr16,    \_rin,    \_si8
++    xvldrepl.w     xr17,    \_rin,    \_si9
++    xvldrepl.w     xr18,    \_rin,    \_si10
++    xvldrepl.w     xr19,    \_rin,    \_si11
++    xvmadd.w       \_out0,  xr0,      xr16
++    xvmadd.w       \_out1,  xr15,     xr16
++    xvmadd.w       \_out0,  xr2,      xr17
++    xvmsub.w       \_out1,  xr14,     xr17
++    xvmadd.w       \_out0,  xr4,      xr18
++    xvmadd.w       \_out1,  xr13,     xr18
++    xvmadd.w       \_out0,  xr6,      xr19
++    xvmsub.w       \_out1,  xr12,     xr19
++
++    xvldrepl.w     xr16,    \_rin,    \_si12
++    xvldrepl.w     xr17,    \_rin,    \_si13
++    xvldrepl.w     xr18,    \_rin,    \_si14
++    xvldrepl.w     xr19,    \_rin,    \_si15
++    xvmadd.w       \_out0,  xr20,     xr16
++    xvmadd.w       \_out1,  xr11,     xr16
++    xvmadd.w       \_out0,  xr21,     xr17
++    xvmsub.w       \_out1,  xr10,     xr17
++    xvmadd.w       \_out0,  xr22,     xr18
++    xvmadd.w       \_out1,  xr9,      xr18
++    xvmadd.w       \_out0,  xr23,     xr19
++    xvmsub.w       \_out1,  xr8,      xr19
++.endm
++
++.macro LASX_CLA_DCT32_O _shift
++    LASX_TRANSPOSE8x8_W xr0, xr2, xr4, xr6, xr24, xr26, xr16, xr18, \
++                        xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                        xr28, xr29, xr30, xr31
++    LASX_TRANSPOSE8x8_W xr1, xr3, xr5, xr7, xr25, xr27, xr17, xr19, \
++                        xr0, xr2, xr4, xr6, xr20, xr21, xr22, xr23,\
++                        xr28, xr29, xr30, xr31
++
++    addi.d        t3,      t2,      64 * 14
++    addi.d        t6,      t3,      64 * 14
++    LASX_CAL_DCT_16_ELE_2 t1, xr25, xr28, \
++                          128 * 1, 128 * 1 + 4, 128 * 1 + 8, 128 * 1 + 12, \
++                          128 * 1 + 16, 128 * 1 + 20, 128 * 1 + 24, 128 * 1 + 28, \
++                          128 * 1 + 32, 128 * 1 + 36, 128 * 1 + 40, 128 * 1 + 44, \
++                          128 * 1 + 48, 128 * 1 + 52, 128 * 1 + 56, 128 * 1 + 60
++    LASX_CAL_DCT_16_ELE_2X t1, xr26, xr27, \
++                           128 * 3, 128 * 3 + 4, 128 * 3 + 8, 128 * 3 + 12, \
++                           128 * 3 + 16, 128 * 3 + 20, 128 * 3 + 24, 128 * 3 + 28, \
++                           128 * 3 + 32, 128 * 3 + 36, 128 * 3 + 40, 128 * 3 + 44, \
++                           128 * 3 + 48, 128 * 3 + 52, 128 * 3 + 56, 128 * 3 + 60
++    xvssrarni.h.w  xr26,    xr25,    \_shift
++    xvssrarni.h.w  xr28,    xr27,    \_shift
++
++    LASX_CAL_DCT_16_ELE_2 t1, xr25, xr3, \
++                          128 * 5, 128 * 5 + 4, 128 * 5 + 8, 128 * 5 + 12, \
++                          128 * 5 + 16, 128 * 5 + 20, 128 * 5 + 24, 128 * 5 + 28, \
++                          128 * 5 + 32, 128 * 5 + 36, 128 * 5 + 40, 128 * 5 + 44, \
++                          128 * 5 + 48, 128 * 5 + 52, 128 * 5 + 56, 128 * 5 + 60
++    LASX_CAL_DCT_16_ELE_2X t1, xr1, xr27, \
++                           128 * 7, 128 * 7 + 4, 128 * 7 + 8, 128 * 7 + 12, \
++                           128 * 7 + 16, 128 * 7 + 20, 128 * 7 + 24, 128 * 7 + 28, \
++                           128 * 7 + 32, 128 * 7 + 36, 128 * 7 + 40, 128 * 7 + 44, \
++                           128 * 7 + 48, 128 * 7 + 52, 128 * 7 + 56, 128 * 7 + 60
++    xvssrarni.h.w  xr1,    xr25,     \_shift
++    xvssrarni.h.w  xr3,    xr27,     \_shift
++
++    LASX_CAL_DCT_16_ELE_2 t1, xr25, xr7, \
++                          128 * 9, 128 * 9 + 4, 128 * 9 + 8, 128 * 9 + 12, \
++                          128 * 9 + 16, 128 * 9 + 20, 128 * 9 + 24, 128 * 9 + 28, \
++                          128 * 9 + 32, 128 * 9 + 36, 128 * 9 + 40, 128 * 9 + 44, \
++                          128 * 9 + 48, 128 * 9 + 52, 128 * 9 + 56, 128 * 9 + 60
++    LASX_CAL_DCT_16_ELE_2X t1, xr5, xr27, \
++                           128 * 11, 128 * 11 + 4, 128 * 11 + 8, 128 * 11 + 12, \
++                           128 * 11 + 16, 128 * 11 + 20, 128 * 11 + 24, 128 * 11 + 28, \
++                           128 * 11 + 32, 128 * 11 + 36, 128 * 11 + 40, 128 * 11 + 44, \
++                           128 * 11 + 48, 128 * 11 + 52, 128 * 11 + 56, 128 * 11 + 60
++    xvssrarni.h.w  xr5,     xr25,    \_shift
++    xvssrarni.h.w  xr7,     xr27,    \_shift
++
++    LASX_CAL_DCT_16_ELE_2 t1, xr25, xr30, \
++                          128 * 13, 128 * 13 + 4, 128 * 13 + 8, 128 * 13 + 12, \
++                          128 * 13 + 16, 128 * 13 + 20, 128 * 13 + 24, 128 * 13 + 28, \
++                          128 * 13 + 32, 128 * 13 + 36, 128 * 13 + 40, 128 * 13 + 44, \
++                          128 * 13 + 48, 128 * 13 + 52, 128 * 13 + 56, 128 * 13 + 60
++    LASX_CAL_DCT_16_ELE_2X t1, xr29, xr27, \
++                           128 * 15, 128 * 15 + 4, 128 * 15 + 8, 128 * 15 + 12, \
++                           128 * 15 + 16, 128 * 15 + 20, 128 * 15 + 24, 128 * 15 + 28, \
++                           128 * 15 + 32, 128 * 15 + 36, 128 * 15 + 40, 128 * 15 + 44, \
++                           128 * 15 + 48, 128 * 15 + 52, 128 * 15 + 56, 128 * 15 + 60
++    xvssrarni.h.w  xr29,    xr25,    \_shift
++    xvssrarni.h.w  xr30,    xr27,    \_shift
++
++    xvstelm.d      xr26,    t2,      64 * 1,       0
++    xvstelm.d      xr26,    t2,      64 * 1 + 8,   2  // k = 1
++    xvstelm.d      xr26,    t2,      64 * 3,       1
++    xvstelm.d      xr26,    t2,      64 * 3 + 8,   3  // k = 3
++    xvstelm.d      xr1,     t2,      64 * 5,       0
++    xvstelm.d      xr1,     t2,      64 * 5 + 8,   2  // k = 5
++    xvstelm.d      xr1,     t2,      64 * 7,       1
++    xvstelm.d      xr1,     t2,      64 * 7 + 8,   3  // k = 7
++    xvstelm.d      xr5,     t2,      64 * 9,       0
++    xvstelm.d      xr5,     t2,      64 * 9 + 8,   2  // k = 9
++    xvstelm.d      xr5,     t2,      64 * 11,      1
++    xvstelm.d      xr5,     t2,      64 * 11 + 8,  3  // k = 11
++    xvstelm.d      xr29,    t2,      64 * 13,      0
++    xvstelm.d      xr29,    t2,      64 * 13 + 8,  2  // k = 13
++    xvstelm.d      xr29,    t3,      64 * 1,       1
++    xvstelm.d      xr29,    t3,      64 * 1 + 8,   3  // k = 15
++    xvstelm.d      xr30,    t3,      64 * 3,       0
++    xvstelm.d      xr30,    t3,      64 * 3 + 8,   2  // k = 17
++    xvstelm.d      xr30,    t3,      64 * 5,       1
++    xvstelm.d      xr30,    t3,      64 * 5 + 8,   3  // k = 19
++    xvstelm.d      xr7,     t3,      64 * 7,       0
++    xvstelm.d      xr7,     t3,      64 * 7 + 8,   2  // k = 21
++    xvstelm.d      xr7,     t3,      64 * 9,       1
++    xvstelm.d      xr7,     t3,      64 * 9 + 8,   3  // k = 23
++    xvstelm.d      xr3,     t3,      64 * 11,      0
++    xvstelm.d      xr3,     t3,      64 * 11 + 8,  2  // k = 25
++    xvstelm.d      xr3,     t3,      64 * 13,      1
++    xvstelm.d      xr3,     t3,      64 * 13 + 8,  3  // k = 27
++    xvstelm.d      xr28,    t6,      64 * 1,       0
++    xvstelm.d      xr28,    t6,      64 * 1 + 8,   2  // k = 29
++    xvstelm.d      xr28,    t6,      64 * 3,       1
++    xvstelm.d      xr28,    t6,      64 * 3 + 8,   3  // k = 31
++.endm
++
++.macro LASX_CLA_DCT32_E _shift
++    LASX_TRANSPOSE8x8_W xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                        xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7,\
++                        xr28, xr29, xr30, xr31
++    LASX_TRANSPOSE8x8_W xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                        xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                        xr28, xr29, xr30, xr31
++
++    /* EO[0...7] */
++    xvsub.w       xr16,    xr0,     xr15
++    xvsub.w       xr17,    xr1,     xr14
++    xvsub.w       xr18,    xr2,     xr13
++    xvsub.w       xr19,    xr3,     xr12
++    xvsub.w       xr20,    xr4,     xr11
++    xvsub.w       xr21,    xr5,     xr10
++    xvsub.w       xr22,    xr6,     xr9
++    xvsub.w       xr23,    xr7,     xr8
++
++    /* EE[0...7] */
++    xvadd.w       xr15,    xr0,     xr15
++    xvadd.w       xr14,    xr1,     xr14
++    xvadd.w       xr13,    xr2,     xr13
++    xvadd.w       xr12,    xr3,     xr12
++    xvadd.w       xr11,    xr4,     xr11
++    xvadd.w       xr10,    xr5,     xr10
++    xvadd.w       xr9,     xr6,     xr9
++    xvadd.w       xr8,     xr7,     xr8
++
++    /* EEE[0...3] */
++    xvadd.w       xr0,     xr15,    xr8
++    xvadd.w       xr1,     xr14,    xr9
++    xvadd.w       xr2,     xr13,    xr10
++    xvadd.w       xr3,     xr12,    xr11
++
++    /* EEO[0...3] */
++    xvsub.w       xr4,     xr15,    xr8
++    xvsub.w       xr5,     xr14,    xr9
++    xvsub.w       xr6,     xr13,    xr10
++    xvsub.w       xr7,     xr12,    xr11
++
++    xvadd.w       xr8,     xr0,     xr3  // EEEE[0]
++    xvadd.w       xr9,     xr1,     xr2  // EEEE[1]
++    xvsub.w       xr10,    xr0,     xr3  // EEEO[0]
++    xvsub.w       xr11,    xr1,     xr2  // EEEO[1]
++
++    addi.d        t3,      t2,      64 * 16
++
++    /* CAL0-8-16-24*/
++    xvldrepl.w    xr12,    t1,      0
++    xvmul.w       xr0,     xr8,     xr12
++    xvmul.w       xr2,     xr8,     xr12
++    xvmadd.w      xr0,     xr9,     xr12  //dst[0]
++    xvmsub.w      xr2,     xr9,     xr12  //dst[16]
++
++    xvldrepl.w    xr13,    t1,      128 * 8
++    xvldrepl.w    xr14,    t1,      128 * 8 + 4
++    xvmul.w       xr1,     xr10,    xr13
++    xvmul.w       xr3,     xr10,    xr14
++    xvmadd.w      xr1,     xr11,    xr14  //dst[8]
++    xvmsub.w      xr3,     xr11,    xr13  //dst[24]
++
++    /* CAL2-6-10-14*/
++    LASX_CAL_DCT_4_ELE_2 t1, xr4, xr5, xr6, xr7, xr12, xr15, \
++                         128 * 4, 128 * 4 + 4, 128 * 4 + 8, 128 * 4 + 12
++    LASX_CAL_DCT_4_ELE_2X t1, xr4, xr5, xr6, xr7, xr13, xr14, \
++                          128 * 12, 128 * 12 + 4, 128 * 12 + 8, 128 * 12 + 12
++
++    xvssrarni.h.w   xr12,   xr0,    \_shift
++    xvssrarni.h.w   xr13,   xr1,    \_shift
++    xvssrarni.h.w   xr14,   xr2,    \_shift
++    xvssrarni.h.w   xr15,   xr3,    \_shift
++
++    xvstelm.d       xr12,   t2,     0,            0
++    xvstelm.d       xr12,   t2,     8,            2  // k = 0
++    xvstelm.d       xr12,   t2,     64 * 4,       1
++    xvstelm.d       xr12,   t2,     64 * 4+ 8,    3  // k = 4
++    xvstelm.d       xr13,   t2,     64 * 8,       0
++    xvstelm.d       xr13,   t2,     64 * 8 + 8,   2  // k = 8
++    xvstelm.d       xr13,   t2,     64 * 12,      1
++    xvstelm.d       xr13,   t2,     64 * 12 + 8,  3  // k = 12
++    xvstelm.d       xr14,   t3,     0,            0
++    xvstelm.d       xr14,   t3,     8,            2  // k = 16
++    xvstelm.d       xr14,   t3,     64 * 4,       1
++    xvstelm.d       xr14,   t3,     64 * 4 + 8,   3  // k = 20
++    xvstelm.d       xr15,   t3,     64 * 8,       0
++    xvstelm.d       xr15,   t3,     64 * 8 + 8,   2  // k = 24
++    xvstelm.d       xr15,   t3,     64 * 12,      1
++    xvstelm.d       xr15,   t3,     64 * 12 + 8,  3  // k = 28
++
++    /* CAL2-6-10-14...*/
++    LASX_CAL_DCT_8_ELE_2 t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                         xr0, xr7, 128 * 2, 128 * 2 + 4, 128 * 2 + 8, 128 * 2 + 12, \
++                         128 * 2 + 16, 128 * 2 + 20, 128 * 2 + 24, 128 * 2 + 28
++    LASX_CAL_DCT_8_ELE_2X t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                          xr1, xr6, 128 * 6, 128 * 6 + 4, 128 * 6 + 8, 128 * 6 + 12, \
++                          128 * 6 + 16, 128 * 6 + 20, 128 * 6 + 24, 128 * 6 + 28
++    LASX_CAL_DCT_8_ELE_2 t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                         xr2, xr5, 128 * 10, 128 * 10 + 4, 128 * 10 + 8, 128 * 10 + 12, \
++                         128 * 10 + 16, 128 * 10 + 20, 128 * 10 + 24, 128 * 10 + 28
++    LASX_CAL_DCT_8_ELE_2X t1, xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                          xr3, xr4, 128 * 14, 128 * 14 + 4, 128 * 14 + 8, 128 * 14 + 12, \
++                          128 * 14 + 16, 128 * 14 + 20, 128 * 14 + 24, 128 * 14 + 28
++
++    xvssrarni.h.w   xr1,    xr0,    \_shift
++    xvssrarni.h.w   xr3,    xr2,    \_shift
++    xvssrarni.h.w   xr5,    xr4,    \_shift
++    xvssrarni.h.w   xr7,    xr6,    \_shift
++
++    xvstelm.d       xr1,    t2,     64 * 2,       0
++    xvstelm.d       xr1,    t2,     64 * 2 + 8,   2  // k = 2
++    xvstelm.d       xr1,    t2,     64 * 6,       1
++    xvstelm.d       xr1,    t2,     64 * 6 + 8,   3  // k = 6
++    xvstelm.d       xr3,    t2,     64 * 10,      0
++    xvstelm.d       xr3,    t2,     64 * 10 + 8,  2  // k = 10
++    xvstelm.d       xr3,    t2,     64 * 14,      1
++    xvstelm.d       xr3,    t2,     64 * 14 + 8,  3  // k = 14
++    xvstelm.d       xr5,    t3,     64 * 2,       0
++    xvstelm.d       xr5,    t3,     64 * 2 + 8,   2  // k = 18
++    xvstelm.d       xr5,    t3,     64 * 6,       1
++    xvstelm.d       xr5,    t3,     64 * 6 + 8,   3  // k = 22
++    xvstelm.d       xr7,    t3,     64 * 10,      0
++    xvstelm.d       xr7,    t3,     64 * 10 + 8,  2  // k = 26
++    xvstelm.d       xr7,    t3,     64 * 14,      1
++    xvstelm.d       xr7,    t3,     64 * 14 + 8,  3  // k = 30
++.endm
++
++.macro DCT32_8_LINE_1
++    xvld          xr31,    t0,      0
++
++    LASX_LOAD_DCT32   xr8, xr16, xr0, xr1, a0
++    add.d         a0,      a0,      a2
++    LASX_LOAD_DCT32   xr9, xr17, xr2, xr3, a0
++    add.d         a0,      a0,      a2
++    LASX_LOAD_DCT32   xr10, xr18, xr4, xr5, a0
++    add.d         a0,      a0,      a2
++    LASX_LOAD_DCT32   xr11, xr19, xr6, xr7, a0
++    add.d         a0,      a0,      a2
++    LASX_LOAD_DCT32   xr12, xr20, xr24, xr25, a0
++    add.d         a0,      a0,      a2
++    LASX_LOAD_DCT32   xr13, xr21, xr26, xr27, a0
++    add.d         a0,      a0,      a2
++
++    xvst          xr0,     t4,      0
++    xvst          xr1,     t4,      32
++    xvst          xr2,     t4,      32 * 2
++    xvst          xr3,     t4,      32 * 3
++    xvst          xr4,     t4,      32 * 4
++    xvst          xr5,     t4,      32 * 5
++    xvst          xr6,     t4,      32 * 6
++    xvst          xr7,     t4,      32 * 7
++
++    LASX_LOAD_DCT32   xr14, xr22, xr0, xr1, a0
++    add.d         a0,      a0,      a2
++    LASX_LOAD_DCT32   xr15, xr23, xr2, xr3, a0
++    add.d         a0,      a0,      a2
++    xvst          xr0,     t4,      32 * 8
++    xvst          xr1,     t4,      32 * 9
++    xvst          xr2,     t4,      32 * 10
++    xvst          xr3,     t4,      32 * 11
++
++    LASX_CLA_DCT32_E 4
++
++    xvld          xr0,     t4,      0
++    xvld          xr1,     t4,      32
++    xvld          xr2,     t4,      32 * 2
++    xvld          xr3,     t4,      32 * 3
++    xvld          xr4,     t4,      32 * 4
++    xvld          xr5,     t4,      32 * 5
++    xvld          xr6,     t4,      32 * 6
++    xvld          xr7,     t4,      32 * 7
++    xvld          xr16,    t4,      32 * 8
++    xvld          xr17,    t4,      32 * 9
++    xvld          xr18,    t4,      32 * 10
++    xvld          xr19,    t4,      32 * 11
++    LASX_CLA_DCT32_O 4
++
++    addi.d        t2,      t2,      16
++.endm
++
++.macro DCT32_8_LINE_2
++    xvld          xr31,    t0,      0
++
++    LASX_LOAD_DCT32   xr8, xr16, xr0, xr1, a3
++    addi.d        a3,      a3,      64
++    LASX_LOAD_DCT32   xr9, xr17, xr2, xr3, a3
++    addi.d        a3,      a3,      64
++    LASX_LOAD_DCT32   xr10, xr18, xr4, xr5, a3
++    addi.d        a3,      a3,      64
++    LASX_LOAD_DCT32   xr11, xr19, xr6, xr7, a3
++    addi.d        a3,      a3,      64
++    LASX_LOAD_DCT32   xr12, xr20, xr24, xr25, a3
++    addi.d        a3,      a3,      64
++    LASX_LOAD_DCT32   xr13, xr21, xr26, xr27, a3
++    addi.d        a3,      a3,      64
++
++    xvst          xr0,     t4,      0
++    xvst          xr1,     t4,      32
++    xvst          xr2,     t4,      32 * 2
++    xvst          xr3,     t4,      32 * 3
++    xvst          xr4,     t4,      32 * 4
++    xvst          xr5,     t4,      32 * 5
++    xvst          xr6,     t4,      32 * 6
++    xvst          xr7,     t4,      32 * 7
++
++    LASX_LOAD_DCT32   xr14, xr22, xr0, xr1, a3
++    addi.d        a3,      a3,      64
++    LASX_LOAD_DCT32   xr15, xr23, xr2, xr3, a3
++    addi.d        a3,      a3,      64
++    xvst          xr0,     t4,      32 * 8
++    xvst          xr1,     t4,      32 * 9
++    xvst          xr2,     t4,      32 * 10
++    xvst          xr3,     t4,      32 * 11
++
++    LASX_CLA_DCT32_E 11
++
++    xvld          xr0,     t4,      0
++    xvld          xr1,     t4,      32
++    xvld          xr2,     t4,      32 * 2
++    xvld          xr3,     t4,      32 * 3
++    xvld          xr4,     t4,      32 * 4
++    xvld          xr5,     t4,      32 * 5
++    xvld          xr6,     t4,      32 * 6
++    xvld          xr7,     t4,      32 * 7
++    xvld          xr16,    t4,      32 * 8
++    xvld          xr17,    t4,      32 * 9
++    xvld          xr18,    t4,      32 * 10
++    xvld          xr19,    t4,      32 * 11
++    LASX_CLA_DCT32_O 11
++
++    addi.d        t2,      t2,      16
++.endm
++
++/* void x265_dct32_lasx(const int16_t* src, int16_t* dst, intptr_t srcStride) */
++function x265_dct32_lasx
++    addi.d        sp,      sp,      -1248 //-(64 + 12*32 + 32*32*2) si12 Immediate overflow
++    addi.d        sp,      sp,      -1248
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t0,      shuf_1
++    la.local      t1,      table_dct32
++    slli.d        a2,      a2,      1  //stride
++
++    /*
++     * The first butterfly operation.
++     */
++    addi.d        t2,      sp,      64 + 12 * 32
++    addi.d        t4,      sp,      64
++
++   /* line 0 ~ 7  */
++    DCT32_8_LINE_1
++    /* line 8 ~ 15  */
++    DCT32_8_LINE_1
++    /* line 16 ~ 23  */
++    DCT32_8_LINE_1
++    /* line 24 ~ 31  */
++    DCT32_8_LINE_1
++
++    /*
++     * The second butterfly operation.
++     */
++    addi.d        t2,      a1,      0
++    addi.d        a3,      sp,      64 + 12 * 32
++
++    /* line 0 ~ 7  */
++    DCT32_8_LINE_2
++    /* line 8 ~ 15  */
++    DCT32_8_LINE_2
++    /* line 16 ~ 23  */
++    DCT32_8_LINE_2
++    /* line 24 ~ 31  */
++    DCT32_8_LINE_2
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f28,   sp,   32
++    fld.d         f29,   sp,   40
++    fld.d         f30,   sp,   48
++    fld.d         f31,   sp,   56
++    addi.d        sp,    sp,   1248
++    addi.d        sp,    sp,   1248
++endfunc
++
++.macro IDCT4_4_LINE
++    vmul.w        vr4,     vr1,     vr9
++    vmul.w        vr6,     vr0,     vr8
++    vmul.w        vr5,     vr1,     vr10
++    vmul.w        vr7,     vr0,     vr8
++    vmadd.w       vr4,     vr3,     vr10
++    vmadd.w       vr6,     vr2,     vr8
++    vadd.w        vr16,    vr6,     vr4
++    vsub.w        vr19,    vr6,     vr4
++
++    vmadd.w       vr5,     vr3,     vr12
++    vmadd.w       vr7,     vr2,     vr11
++    vadd.w        vr17,    vr7,     vr5
++    vsub.w        vr18,    vr7,     vr5
++    LSX_TRANSPOSE4x4_W_EXTRA vr16, vr17, vr18, vr19, vr0, vr1, vr2, vr3
++.endm
++
++/* void x265_idct4_lsx(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idct4_lsx
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,     1  //stride
++    vldi          vr8,     0x840               // 64 g_t4[0][0] g_t4[0][1] g_t4[2][0]
++    vldi          vr9,     0x853               // 83 g_t4[1][0]
++    vldi          vr10,    0x824               // 36 g_t4[1][1] g_t4[3][0]
++    vldrepl.w     vr11,    t1,     256 * 2 + 4 // -64 g_t4[2][1]
++    vldrepl.w     vr12,    t1,     256 * 3 + 4
++
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr4,     a0,     0    //line01
++    vld           vr5,     a0,     16   //line23
++
++    vsllwil.w.h   vr0,     vr4,    0
++    vexth.w.h     vr1,     vr4
++    vsllwil.w.h   vr2,     vr5,    0
++    vexth.w.h     vr3,     vr5
++
++    IDCT4_4_LINE
++
++    vsrari.w      vr0,     vr0,    7
++    vsrari.w      vr1,     vr1,    7
++    vsrari.w      vr2,     vr2,    7
++    vsrari.w      vr3,     vr3,    7
++
++    /*
++     * The second butterfly operation.
++     */
++    IDCT4_4_LINE
++
++    vssrarni.h.w  vr1,     vr0,    12
++    vssrarni.h.w  vr3,     vr2,    12
++
++    vstelm.d      vr1,     a1,     0,   0
++    add.d         a1,      a1,     a3
++    vstelm.d      vr1,     a1,     0,   1
++    add.d         a1,      a1,     a3
++    vstelm.d      vr3,     a1,     0,   0
++    add.d         a1,      a1,     a3
++    vstelm.d      vr3,     a1,     0,   1
++endfunc
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LSX_CAL_IDCT_4_ELE_4 _rin, _in0, _in1, _in2, _in3, \
++                            _in4, _in5, _in6, _in7, _out0, _out1, _out2, _out3, \
++                            _temp0, _temp1, _temp2, _temp3, \
++                            _si0, _si1, _si2, _si3
++    vldrepl.w     \_temp0, \_rin,    \_si0
++    vldrepl.w     \_temp1, \_rin,    \_si1
++    vldrepl.w     \_temp2, \_rin,    \_si2
++    vldrepl.w     \_temp3, \_rin,    \_si3
++    vmul.w        \_out0,  \_in0,    \_temp0
++    vmul.w        \_out1,  \_in4,    \_temp0
++    vmadd.w       \_out0,  \_in1,    \_temp1
++    vmadd.w       \_out1,  \_in5,    \_temp1
++    vmadd.w       \_out0,  \_in2,    \_temp2
++    vmadd.w       \_out1,  \_in6,    \_temp2
++    vmadd.w       \_out0,  \_in3,    \_temp3
++    vmadd.w       \_out1,  \_in7,    \_temp3
++
++    vmul.w        \_out2,  \_in0,    \_temp3
++    vmul.w        \_out3,  \_in4,    \_temp3
++    vmsub.w       \_out2,  \_in1,    \_temp2
++    vmsub.w       \_out3,  \_in5,    \_temp2
++    vmadd.w       \_out2,  \_in2,    \_temp1
++    vmadd.w       \_out3,  \_in6,    \_temp1
++    vmsub.w       \_out2,  \_in3,    \_temp0
++    vmsub.w       \_out3,  \_in7,    \_temp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LSX_CAL_IDCT_4_ELE_4X _rin, _in0, _in1, _in2, _in3, \
++                             _in4, _in5, _in6, _in7, _out0, _out1, _out2, _out3, \
++                             _temp0, _temp1, _temp2, _temp3, \
++                             _si0, _si1, _si2, _si3
++    vldrepl.w     \_temp0, \_rin,    \_si0
++    vldrepl.w     \_temp1, \_rin,    \_si1
++    vldrepl.w     \_temp2, \_rin,    \_si2
++    vldrepl.w     \_temp3, \_rin,    \_si3
++    vmul.w        \_out0,  \_in0,    \_temp0
++    vmul.w        \_out1,  \_in4,    \_temp0
++    vmadd.w       \_out0,  \_in1,    \_temp1
++    vmadd.w       \_out1,  \_in5,    \_temp1
++    vmadd.w       \_out0,  \_in2,    \_temp2
++    vmadd.w       \_out1,  \_in6,    \_temp2
++    vmadd.w       \_out0,  \_in3,    \_temp3
++    vmadd.w       \_out1,  \_in7,    \_temp3
++
++    vmul.w        \_out2,  \_in3,    \_temp0
++    vmul.w        \_out3,  \_in7,    \_temp0
++    vmsub.w       \_out2,  \_in2,    \_temp1
++    vmsub.w       \_out3,  \_in6,    \_temp1
++    vmadd.w       \_out2,  \_in1,    \_temp2
++    vmadd.w       \_out3,  \_in5,    \_temp2
++    vmsub.w       \_out2,  \_in0,    \_temp3
++    vmsub.w       \_out3,  \_in4,    \_temp3
++.endm
++
++.macro IDCT8_8_LINE
++    /* O[0...3] */
++    vldrepl.w     vr24,    t1,      128 * 1
++    vldrepl.w     vr25,    t1,      128 * 1 + 4
++    vldrepl.w     vr26,    t1,      128 * 1 + 8
++    vldrepl.w     vr27,    t1,      128 * 1 + 12
++    vldrepl.w     vr29,    t1,      128 * 3 + 4
++    vldrepl.w     vr30,    t1,      128 * 3 + 8
++    vldrepl.w     vr31,    t1,      128 * 3 + 12
++
++    vmul.w        vr16,    vr1,     vr24
++    vmul.w        vr17,    vr9,     vr24
++    vmul.w        vr18,    vr1,     vr25
++    vmul.w        vr19,    vr9,     vr25
++    vmul.w        vr20,    vr1,     vr26
++    vmul.w        vr21,    vr9,     vr26
++    vmul.w        vr22,    vr1,     vr27
++    vmul.w        vr23,    vr9,     vr27
++
++    vmadd.w       vr16,    vr3,     vr25
++    vmadd.w       vr17,    vr11,    vr25
++    vmadd.w       vr18,    vr3,     vr29
++    vmadd.w       vr19,    vr11,    vr29
++    vmadd.w       vr20,    vr3,     vr30
++    vmadd.w       vr21,    vr11,    vr30
++    vmadd.w       vr22,    vr3,     vr31
++    vmadd.w       vr23,    vr11,    vr31
++
++    vmadd.w       vr16,    vr5,     vr26
++    vmadd.w       vr17,    vr13,    vr26
++    vmadd.w       vr18,    vr5,     vr30
++    vmadd.w       vr19,    vr13,    vr30
++    vmadd.w       vr20,    vr5,     vr27
++    vmadd.w       vr21,    vr13,    vr27
++    vmadd.w       vr22,    vr5,     vr25
++    vmadd.w       vr23,    vr13,    vr25
++
++    vmadd.w       vr16,    vr7,     vr27
++    vmadd.w       vr17,    vr15,    vr27
++    vmadd.w       vr18,    vr7,     vr31
++    vmadd.w       vr19,    vr15,    vr31
++    vmadd.w       vr20,    vr7,     vr25
++    vmadd.w       vr21,    vr15,    vr25
++    vmadd.w       vr22,    vr7,     vr30
++    vmadd.w       vr23,    vr15,    vr30
++
++    /* EE */
++    vldrepl.w     vr24,   t1,      0
++    vldrepl.w     vr25,   t1,      128 * 2
++    vldrepl.w     vr26,   t1,      128 * 2 + 4
++    vldrepl.w     vr27,   t1,      128 * 4 + 4
++    vldrepl.w     vr29,   t1,      128 * 6 + 4
++    vmul.w        vr1,     vr0,    vr24
++    vmul.w        vr3,     vr8,    vr24
++    vmul.w        vr5,     vr0,    vr24
++    vmul.w        vr7,     vr8,    vr24
++    vmadd.w       vr1,     vr4,    vr24
++    vmadd.w       vr3,     vr12,   vr24  // EE[0]
++    vmadd.w       vr5,     vr4,    vr27
++    vmadd.w       vr7,     vr12,   vr27  // EE[1]
++
++    /* EO */
++    vmul.w        vr9,     vr2,    vr25
++    vmadd.w       vr9,     vr6,    vr26
++    vmul.w        vr11,    vr10,   vr25
++    vmadd.w       vr11,    vr14,   vr26  // EO[0]
++    vmul.w        vr13,    vr2,    vr26
++    vmadd.w       vr13,    vr6,    vr29
++    vmul.w        vr15,    vr10,   vr26
++    vmadd.w       vr15,    vr14,   vr29  // EO[1]
++
++    /* E */
++    vadd.w        vr0,     vr1,     vr9
++    vadd.w        vr2,     vr3,     vr11  //E[0]
++    vsub.w        vr4,     vr1,     vr9
++    vsub.w        vr6,     vr3,     vr11  //E[3]
++    vadd.w        vr8,     vr5,     vr13
++    vadd.w        vr10,    vr7,     vr15  //E[1]
++    vsub.w        vr12,    vr5,     vr13
++    vsub.w        vr14,    vr7,     vr15  //E[2]
++
++    /* dst */
++    vadd.w        vr9,     vr0,     vr16
++    vadd.w        vr25,    vr2,     vr17  //dst[0]
++    vsub.w        vr26,    vr0,     vr16
++    vsub.w        vr27,    vr2,     vr17  //dst[7]
++    vadd.w        vr11,    vr8,     vr18
++    vadd.w        vr16,    vr10,    vr19  //dst[1]
++    vsub.w        vr24,    vr8,     vr18
++    vsub.w        vr17,    vr10,    vr19  //dst[6]
++    vadd.w        vr8,     vr12,    vr20
++    vadd.w        vr18,    vr14,    vr21  //dst[2]
++    vsub.w        vr20,    vr12,    vr20
++    vsub.w        vr19,    vr14,    vr21  //dst[5]
++    vadd.w        vr10,    vr4,     vr22
++    vadd.w        vr21,    vr6,     vr23  //dst[3]
++    vsub.w        vr22,    vr4,     vr22
++    vsub.w        vr23,    vr6,     vr23  //dst[4]
++.endm
++
++/* void x265_idct8_lsx(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idct8_lsx
++    addi.d        sp,      sp,      -56
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f29,     sp,      32
++    fst.d         f30,     sp,      40
++    fst.d         f31,     sp,      48
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,      1  //stride
++
++    /*
++     * The first butterfly operation.
++     */
++    vld           vr8,     a0,     0    //line0
++    vld           vr9,     a0,     16   //line1
++    vld           vr10,    a0,     32   //line2
++    vld           vr11,    a0,     48   //line3
++    vld           vr12,    a0,     64   //line4
++    vld           vr13,    a0,     80   //line5
++    vld           vr14,    a0,     96   //line6
++    vld           vr15,    a0,     112  //line7
++    vsllwil.w.h   vr0,     vr8,    0
++    vsllwil.w.h   vr1,     vr9,    0
++    vsllwil.w.h   vr2,     vr10,   0
++    vsllwil.w.h   vr3,     vr11,   0
++    vsllwil.w.h   vr4,     vr12,   0
++    vsllwil.w.h   vr5,     vr13,   0
++    vsllwil.w.h   vr6,     vr14,   0
++    vsllwil.w.h   vr7,     vr15,   0
++    vexth.w.h     vr8,     vr8
++    vexth.w.h     vr9,     vr9
++    vexth.w.h     vr10,    vr10
++    vexth.w.h     vr11,    vr11
++    vexth.w.h     vr12,    vr12
++    vexth.w.h     vr13,    vr13
++    vexth.w.h     vr14,    vr14
++    vexth.w.h     vr15,    vr15
++
++    IDCT8_8_LINE
++
++    vsrari.w      vr9,     vr9,    7
++    vsrari.w      vr25,    vr25,   7
++    vsrari.w      vr26,    vr26,   7
++    vsrari.w      vr27,    vr27,   7
++    vsrari.w      vr11,    vr11,   7
++    vsrari.w      vr16,    vr16,   7
++    vsrari.w      vr24,    vr24,   7
++    vsrari.w      vr17,    vr17,   7
++    vsrari.w      vr8,     vr8,    7
++    vsrari.w      vr18,    vr18,   7
++    vsrari.w      vr20,    vr20,   7
++    vsrari.w      vr19,    vr19,   7
++    vsrari.w      vr10,    vr10,   7
++    vsrari.w      vr21,    vr21,   7
++    vsrari.w      vr22,    vr22,   7
++    vsrari.w      vr23,    vr23,   7
++    LSX_TRANSPOSE4x4_W_EXTRA vr9, vr11, vr8, vr10, vr0, vr1, vr2, vr3
++    LSX_TRANSPOSE4x4_W_EXTRA vr22, vr20, vr24, vr26, vr8, vr9, vr10, vr11
++    LSX_TRANSPOSE4x4_W_EXTRA vr25, vr16, vr18, vr21, vr4, vr5, vr6, vr7
++    LSX_TRANSPOSE4x4_W_EXTRA vr23, vr19, vr17, vr27, vr12, vr13, vr14, vr15
++
++    /*
++     * The second butterfly operation.
++     */
++    IDCT8_8_LINE
++
++    vssrarni.h.w  vr25,    vr9,    12
++    vssrarni.h.w  vr27,    vr26,   12
++    vssrarni.h.w  vr16,    vr11,   12
++    vssrarni.h.w  vr17,    vr24,   12
++    vssrarni.h.w  vr18,    vr8,    12
++    vssrarni.h.w  vr19,    vr20,   12
++    vssrarni.h.w  vr21,    vr10,   12
++    vssrarni.h.w  vr23,    vr22,   12
++
++    LSX_TRANSPOSE8x8_H vr25, vr16, vr18, vr21, vr23, vr19, vr17, vr27, \
++                       vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                       vr9, vr26, vr11, vr24, vr8, vr20, vr10, vr22
++
++    vst           vr0,     a1,     0
++    vstx          vr1,     a1,     a3
++    alsl.d        a1,      a3,     a1,  1
++    vst           vr2,     a1,     0
++    vstx          vr3,     a1,     a3
++    alsl.d        a1,      a3,     a1,  1
++    vst           vr4,     a1,     0
++    vstx          vr5,     a1,     a3
++    alsl.d        a1,      a3,     a1,  1
++    vst           vr6,     a1,     0
++    vstx          vr7,     a1,     a3
++    alsl.d        a1,      a3,     a1,  1
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f29,   sp,   32
++    fld.d         f30,   sp,   40
++    fld.d         f31,   sp,   48
++    addi.d        sp,    sp,   56
++endfunc
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LSX_CAL_IDCT_8_ELE_4 _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                            _in8, _in9, _in10, _in11, _in12, _in13, _in14, _in15, \
++                            _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                            _out0, _out1, _out2, _out3, \
++                            _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    vldrepl.w     \_tmp0,  \_rin,    \_si0
++    vldrepl.w     \_tmp1,  \_rin,    \_si1
++    vldrepl.w     \_tmp2,  \_rin,    \_si2
++    vldrepl.w     \_tmp3,  \_rin,    \_si3
++    vldrepl.w     \_tmp4,  \_rin,    \_si4
++    vldrepl.w     \_tmp5,  \_rin,    \_si5
++    vldrepl.w     \_tmp6,  \_rin,    \_si6
++    vldrepl.w     \_tmp7,  \_rin,    \_si7
++    vmul.w        \_out0,  \_in0,    \_tmp0
++    vmul.w        \_out1,  \_in8,    \_tmp0
++    vmul.w        \_out2,  \_in0,    \_tmp7
++    vmul.w        \_out3,  \_in8,    \_tmp7
++    vmadd.w       \_out0,  \_in1,    \_tmp1
++    vmadd.w       \_out1,  \_in9,    \_tmp1
++    vmsub.w       \_out2,  \_in1,    \_tmp6
++    vmsub.w       \_out3,  \_in9,    \_tmp6
++    vmadd.w       \_out0,  \_in2,    \_tmp2
++    vmadd.w       \_out1,  \_in10,   \_tmp2
++    vmadd.w       \_out2,  \_in2,    \_tmp5
++    vmadd.w       \_out3,  \_in10,   \_tmp5
++    vmadd.w       \_out0,  \_in3,    \_tmp3
++    vmadd.w       \_out1,  \_in11,   \_tmp3
++    vmsub.w       \_out2,  \_in3,    \_tmp4
++    vmsub.w       \_out3,  \_in11,   \_tmp4
++    vmadd.w       \_out0,  \_in4,    \_tmp4
++    vmadd.w       \_out1,  \_in12,   \_tmp4
++    vmadd.w       \_out2,  \_in4,    \_tmp3
++    vmadd.w       \_out3,  \_in12,   \_tmp3
++    vmadd.w       \_out0,  \_in5,    \_tmp5
++    vmadd.w       \_out1,  \_in13,   \_tmp5
++    vmsub.w       \_out2,  \_in5,    \_tmp2
++    vmsub.w       \_out3,  \_in13,   \_tmp2
++    vmadd.w       \_out0,  \_in6,    \_tmp6
++    vmadd.w       \_out1,  \_in14,   \_tmp6
++    vmadd.w       \_out2,  \_in6,    \_tmp1
++    vmadd.w       \_out3,  \_in14,   \_tmp1
++    vmadd.w       \_out0,  \_in7,    \_tmp7
++    vmadd.w       \_out1,  \_in15,   \_tmp7
++    vmsub.w       \_out2,  \_in7,    \_tmp0
++    vmsub.w       \_out3,  \_in15,   \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LSX_CAL_IDCT_8_ELE_4X _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                             _in8, _in9, _in10, _in11, _in12, _in13, _in14, _in15, \
++                             _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                             _out0, _out1, _out2, _out3, \
++                             _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    vldrepl.w     \_tmp0,  \_rin,    \_si0
++    vldrepl.w     \_tmp1,  \_rin,    \_si1
++    vldrepl.w     \_tmp2,  \_rin,    \_si2
++    vldrepl.w     \_tmp3,  \_rin,    \_si3
++    vldrepl.w     \_tmp4,  \_rin,    \_si4
++    vldrepl.w     \_tmp5,  \_rin,    \_si5
++    vldrepl.w     \_tmp6,  \_rin,    \_si6
++    vldrepl.w     \_tmp7,  \_rin,    \_si7
++    vmul.w        \_out0,  \_in0,    \_tmp0
++    vmul.w        \_out1,  \_in8,    \_tmp0
++    vmadd.w       \_out0,  \_in1,    \_tmp1
++    vmadd.w       \_out1,  \_in9,    \_tmp1
++    vmadd.w       \_out0,  \_in2,    \_tmp2
++    vmadd.w       \_out1,  \_in10,   \_tmp2
++    vmadd.w       \_out0,  \_in3,    \_tmp3
++    vmadd.w       \_out1,  \_in11,   \_tmp3
++    vmadd.w       \_out0,  \_in4,    \_tmp4
++    vmadd.w       \_out1,  \_in12,   \_tmp4
++    vmadd.w       \_out0,  \_in5,    \_tmp5
++    vmadd.w       \_out1,  \_in13,   \_tmp5
++    vmadd.w       \_out0,  \_in6,    \_tmp6
++    vmadd.w       \_out1,  \_in14,   \_tmp6
++    vmadd.w       \_out0,  \_in7,    \_tmp7
++    vmadd.w       \_out1,  \_in15,   \_tmp7
++
++    vmul.w        \_out2,  \_in7,    \_tmp0
++    vmul.w        \_out3,  \_in15,   \_tmp0
++    vmsub.w       \_out2,  \_in6,    \_tmp1
++    vmsub.w       \_out3,  \_in14,   \_tmp1
++    vmadd.w       \_out2,  \_in5,    \_tmp2
++    vmadd.w       \_out3,  \_in13,   \_tmp2
++    vmsub.w       \_out2,  \_in4,    \_tmp3
++    vmsub.w       \_out3,  \_in12,   \_tmp3
++    vmadd.w       \_out2,  \_in3,    \_tmp4
++    vmadd.w       \_out3,  \_in11,   \_tmp4
++    vmsub.w       \_out2,  \_in2,    \_tmp5
++    vmsub.w       \_out3,  \_in10,   \_tmp5
++    vmadd.w       \_out2,  \_in1,    \_tmp6
++    vmadd.w       \_out3,  \_in9,    \_tmp6
++    vmsub.w       \_out2,  \_in0,    \_tmp7
++    vmsub.w       \_out3,  \_in8,    \_tmp7
++.endm
++
++.macro CLA_IDCT16_O
++    LSX_CAL_IDCT_8_ELE_4 t1, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                         vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                         vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                         vr24, vr25, vr26, vr27, \
++                         64 * 1, 64 * 3, 64 * 5, 64 * 7, \
++                         64 * 9, 64 * 11, 64 * 13, 64 * 15
++    LSX_CAL_IDCT_8_ELE_4X t1, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                          vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                          vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                          vr28, vr29, vr30, vr31, \
++                          64 * 1 + 4, 64 * 3 + 4, 64 * 5 + 4, 64 * 7 + 4, \
++                          64 * 9 + 4, 64 * 11 + 4, 64 * 13 + 4, 64 * 15 + 4
++
++    vst           vr24,     t4,      0
++    vst           vr25,     t4,      16
++    vst           vr28,     t4,      16 * 2
++    vst           vr29,     t4,      16 * 3
++    vst           vr30,     t4,      16 * 12
++    vst           vr31,     t4,      16 * 13
++    vst           vr26,     t4,      16 * 14
++    vst           vr27,     t4,      16 * 15
++
++    LSX_CAL_IDCT_8_ELE_4 t1, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                         vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                         vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                         vr24, vr25, vr26, vr27, \
++                         64 * 1 + 8, 64 * 3 + 8, 64 * 5 + 8, 64 * 7 + 8, \
++                         64 * 9 + 8, 64 * 11 + 8, 64 * 13 + 8, 64 * 15 + 8
++    LSX_CAL_IDCT_8_ELE_4X t1, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                          vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15, \
++                          vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, \
++                          vr28, vr29, vr30, vr31, \
++                          64 * 1 + 12, 64 * 3 + 12, 64 * 5 + 12, 64 * 7 + 12, \
++                          64 * 9 + 12, 64 * 11 + 12, 64 * 13 + 12, 64 * 15 + 12
++
++    vst           vr24,     t4,      16 * 4
++    vst           vr25,     t4,      16 * 5
++    vst           vr28,     t4,      16 * 6
++    vst           vr29,     t4,      16 * 7
++    vst           vr30,     t4,      16 * 8
++    vst           vr31,     t4,      16 * 9
++    vst           vr26,     t4,      16 * 10
++    vst           vr27,     t4,      16 * 11
++.endm
++
++.macro CLA_IDCT16_E
++    /* EO[0...3] */
++    LSX_CAL_IDCT_4_ELE_4 t1, vr1, vr3, vr5, vr7, vr9, vr11, vr13, vr15, \
++                         vr16, vr17, vr22, vr23, vr24, vr25, vr26, vr27, \
++                         64 * 2, 64 * 6, 64 * 10, 64 * 14
++    LSX_CAL_IDCT_4_ELE_4X t1, vr1, vr3, vr5, vr7, vr9, vr11, vr13, vr15, \
++                          vr18, vr19, vr20, vr21, vr24, vr25, vr26, vr27, \
++                          64 * 2 + 4, 64 * 6 + 4, 64 * 10 + 4, 64 * 14 + 4
++
++    /* EEE */
++    vldrepl.w     vr24,    t1,     0
++    vldrepl.w     vr25,    t1,     4
++    vldrepl.w     vr26,    t1,     64 * 8
++    vldrepl.w     vr27,    t1,     64 * 8 + 4
++    vmul.w        vr1,     vr0,    vr24
++    vmadd.w       vr1,     vr4,    vr26
++    vmul.w        vr3,     vr8,    vr24
++    vmadd.w       vr3,     vr12,   vr26  // EEE[0]
++    vmul.w        vr5,     vr0,    vr25
++    vmadd.w       vr5,     vr4,    vr27
++    vmul.w        vr7,     vr8,    vr25
++    vmadd.w       vr7,     vr12,   vr27  // EEE[1]
++
++    /* EEO */
++    vldrepl.w     vr24,    t1,     64 * 4
++    vldrepl.w     vr25,    t1,     64 * 4 + 4
++    vldrepl.w     vr26,    t1,     64 * 12
++    vldrepl.w     vr27,    t1,     64 * 12 + 4
++    vmul.w        vr9,     vr2,    vr24
++    vmadd.w       vr9,     vr6,    vr26
++    vmul.w        vr11,    vr10,   vr24
++    vmadd.w       vr11,    vr14,   vr26  // EEO[0]
++    vmul.w        vr13,    vr2,    vr25
++    vmadd.w       vr13,    vr6,    vr27
++    vmul.w        vr15,    vr10,   vr25
++    vmadd.w       vr15,    vr14,   vr27  // EEO[1]
++
++    /* EE */
++    vadd.w        vr0,     vr1,     vr9
++    vadd.w        vr2,     vr3,     vr11  //EE[0]
++    vsub.w        vr4,     vr1,     vr9
++    vsub.w        vr6,     vr3,     vr11  //EE[3]
++    vadd.w        vr8,     vr5,     vr13
++    vadd.w        vr10,    vr7,     vr15  //EE[1]
++    vsub.w        vr12,    vr5,     vr13
++    vsub.w        vr14,    vr7,     vr15  //EE[2]
++
++    /* E */
++    vadd.w        vr24,    vr0,     vr16
++    vadd.w        vr25,    vr2,     vr17  //E[0]
++    vsub.w        vr26,    vr0,     vr16
++    vsub.w        vr27,    vr2,     vr17  //E[7]
++    vadd.w        vr28,    vr8,     vr18
++    vadd.w        vr29,    vr10,    vr19  //E[1]
++    vsub.w        vr30,    vr8,     vr18
++    vsub.w        vr31,    vr10,    vr19  //E[6]
++    vadd.w        vr16,    vr12,    vr20
++    vadd.w        vr17,    vr14,    vr21  //E[2]
++    vsub.w        vr18,    vr12,    vr20
++    vsub.w        vr19,    vr14,    vr21  //E[5]
++    vadd.w        vr20,    vr4,     vr22
++    vadd.w        vr21,    vr6,     vr23  //E[3]
++    vsub.w        vr22,    vr4,     vr22
++    vsub.w        vr23,    vr6,     vr23  //E[4]
++.endm
++
++.macro LSX_IDCT16_8_ROW _rin
++    vld           vr8,     \_rin,  32   //line1
++    vld           vr9,     \_rin,  96   //line3
++    vld           vr10,    \_rin,  160  //line5
++    vld           vr11,    \_rin,  224  //line7
++    vld           vr12,    \_rin,  288  //line9
++    vld           vr13,    \_rin,  352  //line11
++    vld           vr14,    \_rin,  416  //line13
++    vld           vr15,    \_rin,  480  //line15
++    vsllwil.w.h   vr0,     vr8,    0
++    vsllwil.w.h   vr1,     vr9,    0
++    vsllwil.w.h   vr2,     vr10,   0
++    vsllwil.w.h   vr3,     vr11,   0
++    vsllwil.w.h   vr4,     vr12,   0
++    vsllwil.w.h   vr5,     vr13,   0
++    vsllwil.w.h   vr6,     vr14,   0
++    vsllwil.w.h   vr7,     vr15,   0
++    vexth.w.h     vr8,     vr8
++    vexth.w.h     vr9,     vr9
++    vexth.w.h     vr10,    vr10
++    vexth.w.h     vr11,    vr11
++    vexth.w.h     vr12,    vr12
++    vexth.w.h     vr13,    vr13
++    vexth.w.h     vr14,    vr14
++    vexth.w.h     vr15,    vr15
++
++    CLA_IDCT16_O
++
++    vld           vr8,     \_rin,  0    //line0
++    vld           vr9,     \_rin,  64   //line2
++    vld           vr10,    \_rin,  128  //line4
++    vld           vr11,    \_rin,  192  //line6
++    vld           vr12,    \_rin,  256  //line8
++    vld           vr13,    \_rin,  320  //line10
++    vld           vr14,    \_rin,  384  //line12
++    vld           vr15,    \_rin,  448  //line14
++    vsllwil.w.h   vr0,     vr8,    0
++    vsllwil.w.h   vr1,     vr9,    0
++    vsllwil.w.h   vr2,     vr10,   0
++    vsllwil.w.h   vr3,     vr11,   0
++    vsllwil.w.h   vr4,     vr12,   0
++    vsllwil.w.h   vr5,     vr13,   0
++    vsllwil.w.h   vr6,     vr14,   0
++    vsllwil.w.h   vr7,     vr15,   0
++    vexth.w.h     vr8,     vr8
++    vexth.w.h     vr9,     vr9
++    vexth.w.h     vr10,    vr10
++    vexth.w.h     vr11,    vr11
++    vexth.w.h     vr12,    vr12
++    vexth.w.h     vr13,    vr13
++    vexth.w.h     vr14,    vr14
++    vexth.w.h     vr15,    vr15
++
++    CLA_IDCT16_E
++.endm
++
++.macro LSX_ST_IDCT16_1 _shift
++    /* dst[0...3] dst[12...15] */
++    vld           vr4,     t4,     0
++    vld           vr5,     t4,     16 * 2
++    vld           vr6,     t4,     16 * 4
++    vld           vr7,     t4,     16 * 6
++    vadd.w        vr8,     vr24,   vr4
++    vadd.w        vr9,     vr28,   vr5
++    vadd.w        vr10,    vr16,   vr6
++    vadd.w        vr11,    vr20,   vr7
++    LSX_TRANSPOSE4x4_W_EXTRA vr8, vr9, vr10, vr11, vr0, vr1, vr2, vr3
++    vsub.w        vr8,     vr24,   vr4  //dst[15]
++    vsub.w        vr9,     vr28,   vr5  //dst[14]
++    vsub.w        vr10,    vr16,   vr6  //dst[13]
++    vsub.w        vr11,    vr20,   vr7  //dst[12]
++    LSX_TRANSPOSE4x4_W_EXTRA vr11, vr10, vr9, vr8, vr12, vr13, vr14, vr15
++
++    /* dst[4...11] */
++    vld           vr24,    t4,     16 * 8
++    vld           vr28,    t4,     16 * 10
++    vld           vr16,    t4,     16 * 12
++    vld           vr20,    t4,     16 * 14
++    vadd.w        vr8,     vr22,   vr24  //dst[4]
++    vadd.w        vr9,     vr18,   vr28  //dst[5]
++    vadd.w        vr10,    vr30,   vr16  //dst[6]
++    vadd.w        vr11,    vr26,   vr20  //dst[7]
++    LSX_TRANSPOSE4x4_W_EXTRA vr8, vr9, vr10, vr11, vr4, vr5, vr6, vr7
++    vsub.w        vr8,     vr22,   vr24  //dst[11]
++    vsub.w        vr9,     vr18,   vr28  //dst[10]
++    vsub.w        vr10,    vr30,   vr16  //dst[9]
++    vsub.w        vr11,    vr26,   vr20  //dst[8]
++    LSX_TRANSPOSE4x4_W_EXTRA vr11, vr10, vr9, vr8, vr24, vr28, vr16, vr20
++
++    vssrarni.h.w  vr4,     vr0,    \_shift
++    vssrarni.h.w  vr5,     vr1,    \_shift
++    vssrarni.h.w  vr6,     vr2,    \_shift
++    vssrarni.h.w  vr7,     vr3,    \_shift
++    vssrarni.h.w  vr12,    vr24,   \_shift
++    vssrarni.h.w  vr13,    vr28,   \_shift
++    vssrarni.h.w  vr14,    vr16,   \_shift
++    vssrarni.h.w  vr15,    vr20,   \_shift
++.endm
++
++.macro LSX_ST_IDCT16_2 _shift
++    /* dst[0...3] dst[12...15] */
++    vld           vr22,    t4,     16
++    vld           vr18,    t4,     16 * 3
++    vld           vr30,    t4,     16 * 5
++    vld           vr26,    t4,     16 * 7
++    vadd.w        vr24,    vr25,   vr22
++    vadd.w        vr28,    vr29,   vr18
++    vadd.w        vr16,    vr17,   vr30
++    vadd.w        vr20,    vr21,   vr26
++    LSX_TRANSPOSE4x4_W_EXTRA vr24, vr28, vr16, vr20, vr0, vr1, vr2, vr3
++    vsub.w        vr24,    vr25,   vr22  //dst[15]
++    vsub.w        vr28,    vr29,   vr18  //dst[14]
++    vsub.w        vr16,    vr17,   vr30  //dst[13]
++    vsub.w        vr20,    vr21,   vr26  //dst[12]
++    LSX_TRANSPOSE4x4_W_EXTRA vr20, vr16, vr28, vr24, vr12, vr13, vr14, vr15
++
++    /* dst[4...11] */
++    vld           vr22,    t4,     16 * 9
++    vld           vr18,    t4,     16 * 11
++    vld           vr30,    t4,     16 * 13
++    vld           vr26,    t4,     16 * 15
++    vadd.w        vr24,    vr23,   vr22
++    vadd.w        vr28,    vr19,   vr18
++    vadd.w        vr16,    vr31,   vr30
++    vadd.w        vr20,    vr27,   vr26
++    LSX_TRANSPOSE4x4_W_EXTRA vr24, vr28, vr16, vr20, vr4, vr5, vr6, vr7
++    vsub.w        vr24,    vr23,   vr22 //dst[11]
++    vsub.w        vr28,    vr19,   vr18 //dst[10]
++    vsub.w        vr16,    vr31,   vr30 //dst[9]
++    vsub.w        vr20,    vr27,   vr26 //dst[8]
++    LSX_TRANSPOSE4x4_W_EXTRA vr20, vr16, vr28, vr24, vr22, vr18, vr30, vr26
++
++    vssrarni.h.w  vr4,     vr0,    \_shift
++    vssrarni.h.w  vr5,     vr1,    \_shift
++    vssrarni.h.w  vr6,     vr2,    \_shift
++    vssrarni.h.w  vr7,     vr3,    \_shift
++    vssrarni.h.w  vr12,    vr22,   \_shift
++    vssrarni.h.w  vr13,    vr18,   \_shift
++    vssrarni.h.w  vr14,    vr30,   \_shift
++    vssrarni.h.w  vr15,    vr26,   \_shift
++.endm
++
++/* void x265_idct16_lsx(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idct16_lsx
++    addi.d        sp,      sp,      -832 //-(64 + 16*16 + 16 *16*2) si12 Immediate overflow
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t1,      table_dct16
++    slli.d        a3,      a2,      1  //stride
++
++    /*
++     * The first butterfly operation.
++     */
++    addi.d        t4,      sp,      64
++    addi.d        t2,      t4,      256
++
++    LSX_IDCT16_8_ROW a0
++    LSX_ST_IDCT16_1  7
++    vst           vr4,     t2,     0
++    vst           vr12,    t2,     16
++    vst           vr5,     t2,     32
++    vst           vr13,    t2,     48
++    vst           vr6,     t2,     64
++    vst           vr14,    t2,     80
++    vst           vr7,     t2,     96
++    vst           vr15,    t2,     112
++    LSX_ST_IDCT16_2  7
++    vst           vr4,     t2,     128
++    vst           vr12,    t2,     144
++    vst           vr5,     t2,     160
++    vst           vr13,    t2,     176
++    vst           vr6,     t2,     192
++    vst           vr14,    t2,     208
++    vst           vr7,     t2,     224
++    vst           vr15,    t2,     240
++
++    addi.d        a0,      a0,     16
++    LSX_IDCT16_8_ROW a0
++    LSX_ST_IDCT16_1  7
++    vst           vr4,     t2,     256
++    vst           vr12,    t2,     272
++    vst           vr5,     t2,     288
++    vst           vr13,    t2,     304
++    vst           vr6,     t2,     320
++    vst           vr14,    t2,     336
++    vst           vr7,     t2,     352
++    vst           vr15,    t2,     368
++    LSX_ST_IDCT16_2  7
++    vst           vr4,     t2,     384
++    vst           vr12,    t2,     400
++    vst           vr5,     t2,     416
++    vst           vr13,    t2,     432
++    vst           vr6,     t2,     448
++    vst           vr14,    t2,     464
++    vst           vr7,     t2,     480
++    vst           vr15,    t2,     496
++
++    /*
++     * The second butterfly operation.
++     */
++    LSX_IDCT16_8_ROW t2
++    LSX_ST_IDCT16_1  12
++    vst           vr4,     a1,     0
++    vst           vr12,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr5,     a1,     0
++    vst           vr13,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr6,     a1,     0
++    vst           vr14,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr7,     a1,     0
++    vst           vr15,    a1,     16
++    add.d         a1,      a1,     a3
++    LSX_ST_IDCT16_2  12
++    vst           vr4,     a1,     0
++    vst           vr12,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr5,     a1,     0
++    vst           vr13,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr6,     a1,     0
++    vst           vr14,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr7,     a1,     0
++    vst           vr15,    a1,     16
++    add.d         a1,      a1,     a3
++
++    addi.d        t2,      t2,     16
++    LSX_IDCT16_8_ROW t2
++    LSX_ST_IDCT16_1  12
++    vst           vr4,     a1,     0
++    vst           vr12,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr5,     a1,     0
++    vst           vr13,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr6,     a1,     0
++    vst           vr14,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr7,     a1,     0
++    vst           vr15,    a1,     16
++    add.d         a1,      a1,     a3
++    LSX_ST_IDCT16_2  12
++    vst           vr4,     a1,     0
++    vst           vr12,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr5,     a1,     0
++    vst           vr13,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr6,     a1,     0
++    vst           vr14,    a1,     16
++    add.d         a1,      a1,     a3
++    vst           vr7,     a1,     0
++    vst           vr15,    a1,     16
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f28,   sp,   32
++    fld.d         f29,   sp,   40
++    fld.d         f30,   sp,   48
++    fld.d         f31,   sp,   56
++    addi.d        sp,    sp,   832
++endfunc
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LSX_CAL_IDCT_8_ELE_2 _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                            _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                            _out0, _out1, _si0, _si1, _si2, _si3, \
++                            _si4, _si5, _si6, _si7
++    vldrepl.w     \_tmp0,  t1,       \_si0
++    vldrepl.w     \_tmp1,  t1,       \_si1
++    vldrepl.w     \_tmp2,  t1,       \_si2
++    vldrepl.w     \_tmp3,  t1,       \_si3
++    vldrepl.w     \_tmp4,  t5,       \_si4
++    vldrepl.w     \_tmp5,  t5,       \_si5
++    vldrepl.w     \_tmp6,  t5,       \_si6
++    vldrepl.w     \_tmp7,  t6,       \_si7
++
++    vmul.w        \_out0,  \_in0,    \_tmp0
++    vmul.w        \_out1,  \_in0,    \_tmp7
++    vmadd.w       \_out0,  \_in1,    \_tmp1
++    vmsub.w       \_out1,  \_in1,    \_tmp6
++    vmadd.w       \_out0,  \_in2,    \_tmp2
++    vmadd.w       \_out1,  \_in2,    \_tmp5
++    vmadd.w       \_out0,  \_in3,    \_tmp3
++    vmsub.w       \_out1,  \_in3,    \_tmp4
++    vmadd.w       \_out0,  \_in4,    \_tmp4
++    vmadd.w       \_out1,  \_in4,    \_tmp3
++    vmadd.w       \_out0,  \_in5,    \_tmp5
++    vmsub.w       \_out1,  \_in5,    \_tmp2
++    vmadd.w       \_out0,  \_in6,    \_tmp6
++    vmadd.w       \_out1,  \_in6,    \_tmp1
++    vmadd.w       \_out0,  \_in7,    \_tmp7
++    vmsub.w       \_out1,  \_in7,    \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LSX_CAL_IDCT_8_ELE_2X _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                             _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                             _out0, _out1, _si0, _si1, _si2, _si3, \
++                             _si4, _si5, _si6, _si7
++    vldrepl.w     \_tmp0,  t1,       \_si0
++    vldrepl.w     \_tmp1,  t1,       \_si1
++    vldrepl.w     \_tmp2,  t1,       \_si2
++    vldrepl.w     \_tmp3,  t1,       \_si3
++    vldrepl.w     \_tmp4,  t5,       \_si4
++    vldrepl.w     \_tmp5,  t5,       \_si5
++    vldrepl.w     \_tmp6,  t5,       \_si6
++    vldrepl.w     \_tmp7,  t6,       \_si7
++
++    vmul.w       \_out0,  \_in0,     \_tmp0
++    vmul.w       \_out1,  \_in7,     \_tmp0
++    vmadd.w      \_out0,  \_in1,     \_tmp1
++    vmsub.w      \_out1,  \_in6,     \_tmp1
++    vmadd.w      \_out0,  \_in2,     \_tmp2
++    vmadd.w      \_out1,  \_in5,     \_tmp2
++    vmadd.w      \_out0,  \_in3,     \_tmp3
++    vmsub.w      \_out1,  \_in4,     \_tmp3
++    vmadd.w      \_out0,  \_in4,     \_tmp4
++    vmadd.w      \_out1,  \_in3,     \_tmp4
++    vmadd.w      \_out0,  \_in5,     \_tmp5
++    vmsub.w      \_out1,  \_in2,     \_tmp5
++    vmadd.w      \_out0,  \_in6,     \_tmp6
++    vmadd.w      \_out1,  \_in1,     \_tmp6
++    vmadd.w      \_out0,  \_in7,     \_tmp7
++    vmsub.w      \_out1,  \_in0,     \_tmp7
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LSX_CAL_IDCT_4_ELE_2 _in0, _in1, _in2, _in3, \
++                            _tmp0, _tmp1, _tmp2, _tmp3, _out0, _out1\
++                            _si0, _si1, _si2, _si3
++    vldrepl.w    \_tmp0,  t1,        \_si0
++    vldrepl.w    \_tmp1,  t1,        \_si1
++    vldrepl.w    \_tmp2,  t5,        \_si2
++    vldrepl.w    \_tmp3,  t5,        \_si3
++
++    vmul.w       \_out0,  \_in0,     \_tmp0
++    vmul.w       \_out1,  \_in0,     \_tmp3
++    vmadd.w      \_out0,  \_in1,     \_tmp1
++    vmsub.w      \_out1,  \_in1,     \_tmp2
++    vmadd.w      \_out0,  \_in2,     \_tmp2
++    vmadd.w      \_out1,  \_in2,     \_tmp1
++    vmadd.w      \_out0,  \_in3,     \_tmp3
++    vmsub.w      \_out1,  \_in3,     \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LSX_CAL_IDCT_4_ELE_2X _in0, _in1, _in2, _in3, \
++                             _tmp0, _tmp1, _tmp2, _tmp3, _out0, _out1\
++                             _si0, _si1, _si2, _si3
++    vldrepl.w    \_tmp0,  t1,       \_si0
++    vldrepl.w    \_tmp1,  t1,       \_si1
++    vldrepl.w    \_tmp2,  t5,       \_si2
++    vldrepl.w    \_tmp3,  t5,       \_si3
++    vmul.w       \_out0,  \_in0,     \_tmp0
++    vmul.w       \_out1,  \_in3,     \_tmp0
++    vmadd.w      \_out0,  \_in1,     \_tmp1
++    vmsub.w      \_out1,  \_in2,     \_tmp1
++    vmadd.w      \_out0,  \_in2,     \_tmp2
++    vmadd.w      \_out1,  \_in1,     \_tmp2
++    vmadd.w      \_out0,  \_in3,     \_tmp3
++    vmsub.w      \_out1,  \_in0,     \_tmp3
++.endm
++
++.macro CLA_IDCT32_EO
++    LSX_CAL_IDCT_8_ELE_2 vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                         vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, vr8, vr15, \
++                         128 * 2, 128 * 6, 128 * 10, 128 * 14, \
++                         128 * 3, 128 * 7, 128 * 11, 0
++    LSX_CAL_IDCT_8_ELE_2X vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                          vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, vr9, vr14, \
++                          128 * 2 + 4, 128 * 6 + 4, 128 * 10 + 4, 128 * 14 + 4, \
++                          128 * 3 + 4, 128 * 7 + 4, 128 * 11 + 4, 4
++    LSX_CAL_IDCT_8_ELE_2 vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                         vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, vr10, vr13, \
++                         128 * 2 + 8, 128 * 6 + 8, 128 * 10 + 8, 128 * 14 + 8, \
++                         128 * 3 + 8, 128 * 7 + 8, 128 * 11 + 8, 8
++    LSX_CAL_IDCT_8_ELE_2X vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++                          vr16, vr17, vr18, vr19, vr20, vr21, vr22, vr23, vr11, vr12, \
++                          128 * 2 + 12, 128 * 6 + 12, 128 * 10 + 12, 128 * 14 + 12, \
++                          128 * 3 + 12, 128 * 7 + 12, 128 * 11 + 12, 12
++.endm
++
++.macro CLA_IDCT32_EE
++    /* EEO[0...3] */
++    LSX_CAL_IDCT_4_ELE_2 vr1, vr3, vr5, vr7, vr20, vr21, vr22, vr23, vr16, vr19, \
++                         128 * 4, 128 * 12, 128 * 5, 128 * 13
++    LSX_CAL_IDCT_4_ELE_2X vr1, vr3, vr5, vr7, vr20, vr21, vr22, vr23, vr17, vr18, \
++                          128 * 4 + 4, 128 * 12 + 4, 128 * 5 + 4, 128 * 13 + 4
++
++    /* EEEE */
++    vldrepl.w     vr1,    t1,     0
++    vmul.w        vr20,   vr0,    vr1
++    vmadd.w       vr20,   vr4,    vr1  // EEEE[0]
++    vmul.w        vr21,   vr0,    vr1
++    vmsub.w       vr21,   vr4,    vr1  // EEEE[1]
++
++    /* EEEO */
++    vldrepl.w     vr1,    t1,     128 * 8
++    vldrepl.w     vr5,    t1,     128 * 8 + 4
++    vmul.w        vr22,    vr2,    vr1
++    vmadd.w       vr22,    vr6,    vr5  // EEEO[0]
++    vmul.w        vr23,    vr2,    vr5
++    vmsub.w       vr23,    vr6,    vr1  // EEEO[1]
++
++    /* EEE */
++    vadd.w        vr4,     vr20,     vr22 // EEE[0]
++    vsub.w        vr7,     vr20,     vr22 // EEE[3]
++    vadd.w        vr5,     vr21,     vr23 // EEE[1]
++    vsub.w        vr6,     vr21,     vr23 // EEE[2]
++
++    /* EE*/
++    vadd.w        vr0,     vr4,      vr16 //EE[0]
++    vsub.w        vr23,    vr4,      vr16 //EE[7]
++    vadd.w        vr1,     vr5,      vr17 //EE[1]
++    vsub.w        vr22,    vr5,      vr17 //EE[6]
++    vadd.w        vr2,     vr6,      vr18 //EE[2]
++    vsub.w        vr21,    vr6,      vr18 //EE[5]
++    vadd.w        vr3,     vr7,      vr19 //EE[3]
++    vsub.w        vr20,    vr7,      vr19 //EE[4]
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * in reg: vr0 ~ vr15
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LSX_CAL_IDCT_16_ELE_2 _out0, _out1, _temp0, _temp1, _temp2, _temp3, \
++                             _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                             _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    vldrepl.w     \_temp0, t1,       \_si0
++    vldrepl.w     \_temp1, t1,       \_si1
++    vldrepl.w     \_temp2, t1,       \_si2
++    vldrepl.w     \_temp3, t1,       \_si3
++    vmul.w        \_out0,  vr0,      \_temp0
++    vmul.w        \_out1,  vr12,     \_temp3
++    vmadd.w       \_out0,  vr1,      \_temp1
++    vmsub.w       \_out1,  vr13,     \_temp2
++    vmadd.w       \_out0,  vr2,      \_temp2
++    vmadd.w       \_out1,  vr14,     \_temp1
++    vmadd.w       \_out0,  vr3,      \_temp3
++    vmsub.w       \_out1,  vr15,     \_temp0
++
++    vldrepl.w     \_temp0, t1,       \_si4
++    vldrepl.w     \_temp1, t1,       \_si5
++    vldrepl.w     \_temp2, t1,       \_si6
++    vldrepl.w     \_temp3, t5,       \_si7
++    vmadd.w       \_out0,  vr4,      \_temp0
++    vmadd.w       \_out1,  vr8,      \_temp3
++    vmadd.w       \_out0,  vr5,      \_temp1
++    vmsub.w       \_out1,  vr9,      \_temp2
++    vmadd.w       \_out0,  vr6,      \_temp2
++    vmadd.w       \_out1,  vr10,     \_temp1
++    vmadd.w       \_out0,  vr7,      \_temp3
++    vmsub.w       \_out1,  vr11,     \_temp0
++
++    vldrepl.w     \_temp0, t5,       \_si8
++    vldrepl.w     \_temp1, t5,       \_si9
++    vldrepl.w     \_temp2, t5,       \_si10
++    vldrepl.w     \_temp3, t5,       \_si11
++    vmadd.w       \_out0,  vr8,      \_temp0
++    vmadd.w       \_out1,  vr4,      \_temp3
++    vmadd.w       \_out0,  vr9,      \_temp1
++    vmsub.w       \_out1,  vr5,      \_temp2
++    vmadd.w       \_out0,  vr10,     \_temp2
++    vmadd.w       \_out1,  vr6,      \_temp1
++    vmadd.w       \_out0,  vr11,     \_temp3
++    vmsub.w       \_out1,  vr7,      \_temp0
++
++    vldrepl.w     \_temp0, t5,       \_si12
++    vldrepl.w     \_temp1, t5,       \_si13
++    vldrepl.w     \_temp2, t5,       \_si14
++    vldrepl.w     \_temp3, t6,       \_si15
++    vmadd.w       \_out0,  vr12,     \_temp0
++    vmadd.w       \_out1,  vr0,      \_temp3
++    vmadd.w       \_out0,  vr13,     \_temp1
++    vmsub.w       \_out1,  vr1,      \_temp2
++    vmadd.w       \_out0,  vr14,     \_temp2
++    vmadd.w       \_out1,  vr2,      \_temp1
++    vmadd.w       \_out0,  vr15,     \_temp3
++    vmsub.w       \_out1,  vr3,      \_temp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * in reg: vr0 ~ vr15
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LSX_CAL_IDCT_16_ELE_2X _out0, _out1, _temp0, _temp1, _temp2, _temp3, \
++                              _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                              _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    vldrepl.w     \_temp0, t1,       \_si0
++    vldrepl.w     \_temp1, t1,       \_si1
++    vldrepl.w     \_temp2, t1,       \_si2
++    vldrepl.w     \_temp3, t1,       \_si3
++    vmul.w        \_out0,  vr0,      \_temp0
++    vmul.w        \_out1,  vr15,     \_temp0
++    vmadd.w       \_out0,  vr1,      \_temp1
++    vmsub.w       \_out1,  vr14,     \_temp1
++    vmadd.w       \_out0,  vr2,      \_temp2
++    vmadd.w       \_out1,  vr13,     \_temp2
++    vmadd.w       \_out0,  vr3,      \_temp3
++    vmsub.w       \_out1,  vr12,     \_temp3
++
++    vldrepl.w     \_temp0, t1,       \_si4
++    vldrepl.w     \_temp1, t1,       \_si5
++    vldrepl.w     \_temp2, t1,       \_si6
++    vldrepl.w     \_temp3, t5,       \_si7
++    vmadd.w       \_out0,  vr4,      \_temp0
++    vmadd.w       \_out1,  vr11,     \_temp0
++    vmadd.w       \_out0,  vr5,      \_temp1
++    vmsub.w       \_out1,  vr10,     \_temp1
++    vmadd.w       \_out0,  vr6,      \_temp2
++    vmadd.w       \_out1,  vr9,      \_temp2
++    vmadd.w       \_out0,  vr7,      \_temp3
++    vmsub.w       \_out1,  vr8,      \_temp3
++
++    vldrepl.w     \_temp0, t5,       \_si8
++    vldrepl.w     \_temp1, t5,       \_si9
++    vldrepl.w     \_temp2, t5,       \_si10
++    vldrepl.w     \_temp3, t5,       \_si11
++    vmadd.w       \_out0,  vr8,      \_temp0
++    vmadd.w       \_out1,  vr7,      \_temp0
++    vmadd.w       \_out0,  vr9,      \_temp1
++    vmsub.w       \_out1,  vr6,      \_temp1
++    vmadd.w       \_out0,  vr10,     \_temp2
++    vmadd.w       \_out1,  vr5,      \_temp2
++    vmadd.w       \_out0,  vr11,     \_temp3
++    vmsub.w       \_out1,  vr4,      \_temp3
++
++    vldrepl.w     \_temp0, t5,       \_si12
++    vldrepl.w     \_temp1, t5,       \_si13
++    vldrepl.w     \_temp2, t5,       \_si14
++    vldrepl.w     \_temp3, t6,       \_si15
++    vmadd.w       \_out0,  vr12,     \_temp0
++    vmadd.w       \_out1,  vr3,      \_temp0
++    vmadd.w       \_out0,  vr13,     \_temp1
++    vmsub.w       \_out1,  vr2,      \_temp1
++    vmadd.w       \_out0,  vr14,     \_temp2
++    vmadd.w       \_out1,  vr1,      \_temp2
++    vmadd.w       \_out0,  vr15,     \_temp3
++    vmsub.w       \_out1,  vr0,      \_temp3
++.endm
++
++.macro CLA_IDCT32_O
++    LSX_CAL_IDCT_16_ELE_2 vr24, vr23, vr16, vr17, vr18, vr19, \
++                          128 * 1, 128 * 3, 128 * 5, 128 * 7, \
++                          128 * 9, 128 * 11, 128 * 13, 0, \
++                          128 * 2, 128 * 4, 128 * 6, 128 * 8, \
++                          128 * 10, 128 * 12, 128 * 14, 128 * 1
++    LSX_CAL_IDCT_16_ELE_2X vr25, vr22, vr16, vr17, vr18, vr19, \
++                           128 * 1 + 4, 128 * 3 + 4, 128 * 5 + 4, 128 * 7 + 4, \
++                           128 * 9 + 4, 128 * 11 + 4, 128 * 13 + 4, 4, \
++                           128 * 2 + 4, 128 * 4 + 4, 128 * 6 + 4, 128 * 8 + 4, \
++                           128 * 10 + 4, 128 * 12 + 4, 128 * 14 + 4, 128 * 1 + 4
++    LSX_CAL_IDCT_16_ELE_2 vr26, vr21, vr16, vr17, vr18, vr19, \
++                          128 * 1 + 8, 128 * 3 + 8, 128 * 5 + 8, 128 * 7 + 8, \
++                          128 * 9 + 8, 128 * 11 + 8, 128 * 13 + 8, 8, \
++                          128 * 2 + 8, 128 * 4 + 8, 128 * 6 + 8, 128 * 8 + 8, \
++                          128 * 10 + 8, 128 * 12 + 8, 128 * 14 + 8, 128 * 1 + 8
++    LSX_CAL_IDCT_16_ELE_2X vr27, vr20, vr16, vr17, vr18, vr19, \
++                           128 * 1 + 12, 128 * 3 + 12, 128 * 5 + 12, 128 * 7 + 12, \
++                           128 * 9 + 12, 128 * 11 + 12, 128 * 13 + 12, 12, \
++                           128 * 2 + 12, 128 * 4 + 12, 128 * 6 + 12, 128 * 8 + 12, \
++                           128 * 10 + 12, 128 * 12 + 12, 128 * 14 + 12, 128 * 1 + 12
++    vst           vr20,     t4,      16 * 4
++    vst           vr21,     t4,      16 * 5
++    vst           vr22,     t4,      16 * 6
++    vst           vr23,     t4,      16 * 7
++
++    LSX_CAL_IDCT_16_ELE_2 vr28, vr23, vr16, vr17, vr18, vr19, \
++                       128 * 1 + 16, 128 * 3 + 16, 128 * 5 + 16, 128 * 7 + 16, \
++                       128 * 9 + 16, 128 * 11 + 16, 128 * 13 + 16, 16, \
++                       128 * 2 + 16, 128 * 4 + 16, 128 * 6 + 16, 128 * 8 + 16, \
++                       128 * 10 + 16, 128 * 12 + 16, 128 * 14 + 16, 128 * 1 + 16
++    LSX_CAL_IDCT_16_ELE_2X vr29, vr22, vr16, vr17, vr18, vr19, \
++                       128 * 1 + 20, 128 * 3 + 20, 128 * 5 + 20, 128 * 7 + 20, \
++                       128 * 9 + 20, 128 * 11 + 20, 128 * 13 + 20, 20, \
++                       128 * 2 + 20, 128 * 4 + 20, 128 * 6 + 20, 128 * 8 + 20, \
++                       128 * 10 + 20, 128 * 12 + 20, 128 * 14 + 20, 128 * 1 + 20
++    LSX_CAL_IDCT_16_ELE_2 vr30, vr21, vr16, vr17, vr18, vr19, \
++                       128 * 1 + 24, 128 * 3 + 24, 128 * 5 + 24, 128 * 7 + 24, \
++                       128 * 9 + 24, 128 * 11 + 24, 128 * 13 + 24, 24, \
++                       128 * 2 + 24, 128 * 4 + 24, 128 * 6 + 24, 128 * 8 + 24, \
++                       128 * 10 + 24, 128 * 12 + 24, 128 * 14 + 24, 128 * 1 + 24
++    LSX_CAL_IDCT_16_ELE_2X vr31, vr20, vr16, vr17, vr18, vr19, \
++                       128 * 1 + 28, 128 * 3 + 28, 128 * 5 + 28, 128 * 7 + 28, \
++                       128 * 9 + 28, 128 * 11 + 28, 128 * 13 + 28, 28, \
++                       128 * 2 + 28, 128 * 4 + 28, 128 * 6 + 28, 128 * 8 + 28, \
++                       128 * 10 + 28, 128 * 12 + 28, 128 * 14 + 28, 128 * 1 + 28
++    vst           vr20,     t4,      0
++    vst           vr21,     t4,      16
++    vst           vr22,     t4,      16 * 2
++    vst           vr23,     t4,      16 * 3
++.endm
++
++.macro LSX_IDCT32_4_ROW _rin, _shift
++    /* O */
++    vld           vr0,     \_rin,  64    //line1
++    vld           vr1,     \_rin,  192   //line3
++    vld           vr2,     \_rin,  320   //line5
++    vld           vr3,     \_rin,  448   //line7
++    vld           vr4,     \_rin,  576   //line9
++    vld           vr5,     \_rin,  704   //line11
++    vld           vr6,     \_rin,  832   //line13
++    vld           vr7,     \_rin,  960   //line15
++    vld           vr8,     \_rin,  1088  //line17
++    vld           vr9,     \_rin,  1216  //line19
++    vld           vr10,    \_rin,  1344  //line21
++    vld           vr11,    \_rin,  1472  //line23
++    vld           vr12,    \_rin,  1600  //line25
++    vld           vr13,    \_rin,  1728  //line27
++    vld           vr14,    \_rin,  1856  //line29
++    vld           vr15,    \_rin,  1984  //line31
++    .irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, vr8, vr9, \
++            vr10, vr11, vr12, vr13, vr14, vr15
++    vsllwil.w.h   \i,      \i,     0
++    .endr
++
++    CLA_IDCT32_O
++
++    vld           vr0,     \_rin,  128   //line2
++    vld           vr1,     \_rin,  384   //line6
++    vld           vr2,     \_rin,  640   //line10
++    vld           vr3,     \_rin,  896   //line14
++    vld           vr4,     \_rin,  1152  //line18
++    vld           vr5,     \_rin,  1408  //line22
++    vld           vr6,     \_rin,  1664  //line26
++    vld           vr7,     \_rin,  1920  //line30
++    .irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vsllwil.w.h   \i,      \i,     0
++    .endr
++    CLA_IDCT32_EO
++    vld           vr0,     \_rin,  0     //line0
++    vld           vr1,     \_rin,  256   //line4
++    vld           vr2,     \_rin,  512   //line8
++    vld           vr3,     \_rin,  768   //line12
++    vld           vr4,     \_rin,  1024  //line16
++    vld           vr5,     \_rin,  1280  //line20
++    vld           vr6,     \_rin,  1536  //line24
++    vld           vr7,     \_rin,  1792  //line38
++    .irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vsllwil.w.h   \i,      \i,     0
++    .endr
++    CLA_IDCT32_EE
++
++    /* E */
++    vadd.w        vr4,     vr0,      vr8  //E[0]
++    vsub.w        vr19,    vr0,      vr8  //E[15]
++    vadd.w        vr5,     vr1,      vr9  //E[1]
++    vsub.w        vr18,    vr1,      vr9  //E[14]
++    vadd.w        vr6,     vr2,      vr10 //E[2]
++    vsub.w        vr17,    vr2,      vr10 //E[13]
++    vadd.w        vr7,     vr3,      vr11 //E[3]
++    vsub.w        vr16,    vr3,      vr11 //E[12]
++    vadd.w        vr8,     vr20,     vr12 //E[4]
++    vsub.w        vr3,     vr20,     vr12 //E[11]
++    vadd.w        vr9,     vr21,     vr13 //E[5]
++    vsub.w        vr2,     vr21,     vr13 //E[10]
++    vadd.w        vr10,    vr22,     vr14 //E[6]
++    vsub.w        vr1,     vr22,     vr14 //E[9]
++    vadd.w        vr11,    vr23,     vr15 //E[7]
++    vsub.w        vr0,     vr23,     vr15 //E[8]
++
++    /* dst */
++    vadd.w        vr12,    vr4,      vr24 //[0]
++    vsub.w        vr23,    vr4,      vr24 //[31]
++    vadd.w        vr13,    vr5,      vr25 //[1]
++    vsub.w        vr22,    vr5,      vr25 //[30]
++    vadd.w        vr14,    vr6,      vr26 //[2]
++    vsub.w        vr21,    vr6,      vr26 //[29]
++    vadd.w        vr15,    vr7,      vr27 //[3]
++    vsub.w        vr20,    vr7,      vr27 //[28]
++
++    vadd.w        vr4,     vr8,      vr28 //[4]
++    vsub.w        vr27,    vr8,      vr28 //[27]
++    vadd.w        vr5,     vr9,      vr29 //[5]
++    vsub.w        vr26,    vr9,      vr29 //[26]
++    vadd.w        vr6,     vr10,     vr30 //[6]
++    vsub.w        vr25,    vr10,     vr30 //[25]
++    vadd.w        vr7,     vr11,     vr31 //[7]
++    vsub.w        vr24,    vr11,     vr31 //[24]
++
++    LSX_TRANSPOSE4x4_W_EXTRA vr12, vr13, vr14, vr15, vr8, vr9, vr10, vr11
++    LSX_TRANSPOSE4x4_W_EXTRA vr4, vr5, vr6, vr7, vr12, vr13, vr14, vr15
++    LSX_TRANSPOSE4x4_W_EXTRA vr24, vr25, vr26, vr27, vr4, vr5, vr6, vr7
++    LSX_TRANSPOSE4x4_W_EXTRA vr20, vr21, vr22, vr23, vr24, vr25, vr26, vr27
++
++    vssrarni.h.w  vr12,    vr8,    \_shift
++    vssrarni.h.w  vr13,    vr9,    \_shift
++    vssrarni.h.w  vr14,    vr10,   \_shift
++    vssrarni.h.w  vr15,    vr11,   \_shift  //[0...7]
++    vssrarni.h.w  vr24,    vr4,    \_shift
++    vssrarni.h.w  vr25,    vr5,    \_shift
++    vssrarni.h.w  vr26,    vr6,    \_shift
++    vssrarni.h.w  vr27,    vr7,    \_shift  //[24...31]
++
++    vld           vr4,     t4,      0
++    vld           vr5,     t4,      16
++    vld           vr6,     t4,      16 * 2
++    vld           vr7,     t4,      16 * 3
++    vld           vr8,     t4,      16 * 4
++    vld           vr9,     t4,      16 * 5
++    vld           vr10,    t4,      16 * 6
++    vld           vr11,    t4,      16 * 7
++
++    vadd.w        vr20,    vr0,      vr4 //[8]
++    vsub.w        vr31,    vr0,      vr4 //[23]
++    vadd.w        vr21,    vr1,      vr5 //[9]
++    vsub.w        vr30,    vr1,      vr5 //[22]
++    vadd.w        vr22,    vr2,      vr6 //[10]
++    vsub.w        vr29,    vr2,      vr6 //[21]
++    vadd.w        vr23,    vr3,      vr7 //[11]
++    vsub.w        vr28,    vr3,      vr7 //[20]
++
++    vadd.w        vr4,     vr16,     vr8  //[12]
++    vsub.w        vr3,     vr16,     vr8  //[19]
++    vadd.w        vr5,     vr17,     vr9  //[13]
++    vsub.w        vr2,     vr17,     vr9  //[18]
++    vadd.w        vr6,     vr18,     vr10 //[14]
++    vsub.w        vr1,     vr18,     vr10 //[17]
++    vadd.w        vr7,     vr19,     vr11 //[15]
++    vsub.w        vr0,     vr19,     vr11 //[16]
++
++    LSX_TRANSPOSE4x4_W_EXTRA vr20, vr21, vr22, vr23, vr8, vr9, vr10, vr11
++    LSX_TRANSPOSE4x4_W_EXTRA vr4, vr5, vr6, vr7, vr20, vr21, vr22, vr23
++    LSX_TRANSPOSE4x4_W_EXTRA vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    LSX_TRANSPOSE4x4_W_EXTRA vr28, vr29, vr30, vr31, vr0, vr1, vr2, vr3
++
++    vssrarni.h.w  vr20,    vr8,    \_shift
++    vssrarni.h.w  vr21,    vr9,    \_shift
++    vssrarni.h.w  vr22,    vr10,   \_shift
++    vssrarni.h.w  vr23,    vr11,   \_shift  //[8...15]
++    vssrarni.h.w  vr0,     vr4,    \_shift
++    vssrarni.h.w  vr1,     vr5,    \_shift
++    vssrarni.h.w  vr2,     vr6,    \_shift
++    vssrarni.h.w  vr3,     vr7,    \_shift  //[16...23]
++.endm
++
++/* void x265_idct32_lsx(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idct32_lsx
++    addi.d        sp,      sp,      -1120 //-(64 + 8*16 + 32*32*2) si12 Immediate overflow
++    addi.d        sp,      sp,      -1120
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t1,      table_dct32
++    slli.d        a2,      a2,      1  //stride
++    addi.d        t5,      t1,      128 * 15
++    addi.d        t6,      t5,      128 * 15
++
++    /*
++     * The first butterfly operation.
++     */
++    addi.d        t4,      sp,      64
++    addi.d        t2,      t4,      8 * 16
++
++    /* row 0 ~ 3  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     0
++    vst           vr20,    t2,     16
++    vst           vr0,     t2,     32
++    vst           vr24,    t2,     48
++    vst           vr13,    t2,     64
++    vst           vr21,    t2,     80
++    vst           vr1,     t2,     96
++    vst           vr25,    t2,     112
++    vst           vr14,    t2,     128
++    vst           vr22,    t2,     144
++    vst           vr2,     t2,     160
++    vst           vr26,    t2,     176
++    vst           vr15,    t2,     192
++    vst           vr23,    t2,     208
++    vst           vr3,     t2,     224
++    vst           vr27,    t2,     240
++
++    /* row 4 ~ 7  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     256
++    vst           vr20,    t2,     272
++    vst           vr0,     t2,     288
++    vst           vr24,    t2,     304
++    vst           vr13,    t2,     320
++    vst           vr21,    t2,     336
++    vst           vr1,     t2,     352
++    vst           vr25,    t2,     368
++    vst           vr14,    t2,     384
++    vst           vr22,    t2,     400
++    vst           vr2,     t2,     416
++    vst           vr26,    t2,     432
++    vst           vr15,    t2,     448
++    vst           vr23,    t2,     464
++    vst           vr3,     t2,     480
++    vst           vr27,    t2,     496
++
++    /* row 8 ~ 11  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     512
++    vst           vr20,    t2,     528
++    vst           vr0,     t2,     544
++    vst           vr24,    t2,     560
++    vst           vr13,    t2,     576
++    vst           vr21,    t2,     592
++    vst           vr1,     t2,     608
++    vst           vr25,    t2,     624
++    vst           vr14,    t2,     640
++    vst           vr22,    t2,     656
++    vst           vr2,     t2,     672
++    vst           vr26,    t2,     688
++    vst           vr15,    t2,     704
++    vst           vr23,    t2,     720
++    vst           vr3,     t2,     736
++    vst           vr27,    t2,     752
++
++    /* row 12 ~ 15  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     768
++    vst           vr20,    t2,     784
++    vst           vr0,     t2,     800
++    vst           vr24,    t2,     816
++    vst           vr13,    t2,     832
++    vst           vr21,    t2,     848
++    vst           vr1,     t2,     864
++    vst           vr25,    t2,     880
++    vst           vr14,    t2,     896
++    vst           vr22,    t2,     912
++    vst           vr2,     t2,     928
++    vst           vr26,    t2,     944
++    vst           vr15,    t2,     960
++    vst           vr23,    t2,     976
++    vst           vr3,     t2,     992
++    vst           vr27,    t2,     1008
++
++    /* row 16 ~ 19  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     1024
++    vst           vr20,    t2,     1040
++    vst           vr0,     t2,     1056
++    vst           vr24,    t2,     1072
++    vst           vr13,    t2,     1088
++    vst           vr21,    t2,     1104
++    vst           vr1,     t2,     1120
++    vst           vr25,    t2,     1136
++    vst           vr14,    t2,     1152
++    vst           vr22,    t2,     1168
++    vst           vr2,     t2,     1184
++    vst           vr26,    t2,     1200
++    vst           vr15,    t2,     1216
++    vst           vr23,    t2,     1232
++    vst           vr3,     t2,     1248
++    vst           vr27,    t2,     1264
++
++    /* row 20 ~ 23  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     1280
++    vst           vr20,    t2,     1296
++    vst           vr0,     t2,     1312
++    vst           vr24,    t2,     1328
++    vst           vr13,    t2,     1344
++    vst           vr21,    t2,     1360
++    vst           vr1,     t2,     1376
++    vst           vr25,    t2,     1392
++    vst           vr14,    t2,     1408
++    vst           vr22,    t2,     1424
++    vst           vr2,     t2,     1440
++    vst           vr26,    t2,     1456
++    vst           vr15,    t2,     1472
++    vst           vr23,    t2,     1488
++    vst           vr3,     t2,     1504
++    vst           vr27,    t2,     1520
++
++    /* row 24 ~ 27  */
++    LSX_IDCT32_4_ROW a0, 7
++    addi.d        a0,      a0,     8
++    vst           vr12,    t2,     1536
++    vst           vr20,    t2,     1552
++    vst           vr0,     t2,     1568
++    vst           vr24,    t2,     1584
++    vst           vr13,    t2,     1600
++    vst           vr21,    t2,     1616
++    vst           vr1,     t2,     1632
++    vst           vr25,    t2,     1648
++    vst           vr14,    t2,     1664
++    vst           vr22,    t2,     1680
++    vst           vr2,     t2,     1696
++    vst           vr26,    t2,     1712
++    vst           vr15,    t2,     1728
++    vst           vr23,    t2,     1744
++    vst           vr3,     t2,     1760
++    vst           vr27,    t2,     1776
++
++    /* row 28 ~ 31  */
++    LSX_IDCT32_4_ROW a0, 7
++    vst           vr12,    t2,     1792
++    vst           vr20,    t2,     1808
++    vst           vr0,     t2,     1824
++    vst           vr24,    t2,     1840
++    vst           vr13,    t2,     1856
++    vst           vr21,    t2,     1872
++    vst           vr1,     t2,     1888
++    vst           vr25,    t2,     1904
++    vst           vr14,    t2,     1920
++    vst           vr22,    t2,     1936
++    vst           vr2,     t2,     1952
++    vst           vr26,    t2,     1968
++    vst           vr15,    t2,     1984
++    vst           vr23,    t2,     2000
++    vst           vr3,     t2,     2016
++    vst           vr27,    t2,     2032
++
++    /*
++     * The second butterfly operation.
++     */
++
++    /* row 0 ~ 3  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 4 ~ 7  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 8 ~ 11  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 12 ~ 15  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 16 ~ 19  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 20 ~ 23  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 24 ~ 27  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++    add.d         a1,      a1,     a2
++
++    /* row 28 ~ 31  */
++    LSX_IDCT32_4_ROW t2, 12
++    addi.d        t2,      t2,     8
++    vst           vr12,    a1,     0
++    vst           vr20,    a1,     16
++    vst           vr0,     a1,     32
++    vst           vr24,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr13,    a1,     0
++    vst           vr21,    a1,     16
++    vst           vr1,     a1,     32
++    vst           vr25,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr14,    a1,     0
++    vst           vr22,    a1,     16
++    vst           vr2,     a1,     32
++    vst           vr26,    a1,     48
++    add.d         a1,      a1,     a2
++    vst           vr15,    a1,     0
++    vst           vr23,    a1,     16
++    vst           vr3,     a1,     32
++    vst           vr27,    a1,     48
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f28,   sp,   32
++    fld.d         f29,   sp,   40
++    fld.d         f30,   sp,   48
++    fld.d         f31,   sp,   56
++    addi.d        sp,    sp,   1120
++    addi.d        sp,    sp,   1120
++endfunc
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LASX_CAL_IDCT_8_ELE_4 _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                             _in8, _in9, _in10, _in11, _in12, _in13, _in14, _in15, \
++                             _tmp0, _tmp1, _tmp2, _tmp3, \
++                             _out0, _out1, _out2, _out3, \
++                             _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    xvldrepl.w     \_tmp0,  \_rin,    \_si0
++    xvldrepl.w     \_tmp1,  \_rin,    \_si1
++    xvldrepl.w     \_tmp2,  \_rin,    \_si2
++    xvldrepl.w     \_tmp3,  \_rin,    \_si3
++    xvmul.w        \_out0,  \_in0,    \_tmp0
++    xvmul.w        \_out1,  \_in8,    \_tmp0
++    xvmadd.w       \_out0,  \_in1,    \_tmp1
++    xvmadd.w       \_out1,  \_in9,    \_tmp1
++    xvmadd.w       \_out0,  \_in2,    \_tmp2
++    xvmadd.w       \_out1,  \_in10,   \_tmp2
++    xvmadd.w       \_out0,  \_in3,    \_tmp3
++    xvmadd.w       \_out1,  \_in11,   \_tmp3
++
++    xvmul.w        \_out2,  \_in4,    \_tmp3
++    xvmul.w        \_out3,  \_in12,   \_tmp3
++    xvmsub.w       \_out2,  \_in5,    \_tmp2
++    xvmsub.w       \_out3,  \_in13,   \_tmp2
++    xvmadd.w       \_out2,  \_in6,    \_tmp1
++    xvmadd.w       \_out3,  \_in14,   \_tmp1
++    xvmsub.w       \_out2,  \_in7,    \_tmp0
++    xvmsub.w       \_out3,  \_in15,   \_tmp0
++
++    xvldrepl.w     \_tmp0,  \_rin,    \_si4
++    xvldrepl.w     \_tmp1,  \_rin,    \_si5
++    xvldrepl.w     \_tmp2,  \_rin,    \_si6
++    xvldrepl.w     \_tmp3,  \_rin,    \_si7
++    xvmadd.w       \_out0,  \_in4,    \_tmp0
++    xvmadd.w       \_out1,  \_in12,   \_tmp0
++    xvmadd.w       \_out0,  \_in5,    \_tmp1
++    xvmadd.w       \_out1,  \_in13,   \_tmp1
++    xvmadd.w       \_out0,  \_in6,    \_tmp2
++    xvmadd.w       \_out1,  \_in14,   \_tmp2
++    xvmadd.w       \_out0,  \_in7,    \_tmp3
++    xvmadd.w       \_out1,  \_in15,   \_tmp3
++
++    xvmadd.w       \_out2,  \_in0,    \_tmp3
++    xvmadd.w       \_out3,  \_in8,    \_tmp3
++    xvmsub.w       \_out2,  \_in1,    \_tmp2
++    xvmsub.w       \_out3,  \_in9,    \_tmp2
++    xvmadd.w       \_out2,  \_in2,    \_tmp1
++    xvmadd.w       \_out3,  \_in10,   \_tmp1
++    xvmsub.w       \_out2,  \_in3,    \_tmp0
++    xvmsub.w       \_out3,  \_in11,   \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LASX_CAL_IDCT_8_ELE_4X _rin, _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                              _in8, _in9, _in10, _in11, _in12, _in13, _in14, _in15, \
++                              _tmp0, _tmp1, _tmp2, _tmp3, \
++                              _out0, _out1, _out2, _out3, \
++                              _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7
++    xvldrepl.w     \_tmp0,  \_rin,    \_si0
++    xvldrepl.w     \_tmp1,  \_rin,    \_si1
++    xvldrepl.w     \_tmp2,  \_rin,    \_si2
++    xvldrepl.w     \_tmp3,  \_rin,    \_si3
++    xvmul.w        \_out0,  \_in0,    \_tmp0
++    xvmul.w        \_out1,  \_in8,    \_tmp0
++    xvmadd.w       \_out0,  \_in1,    \_tmp1
++    xvmadd.w       \_out1,  \_in9,    \_tmp1
++    xvmadd.w       \_out0,  \_in2,    \_tmp2
++    xvmadd.w       \_out1,  \_in10,   \_tmp2
++    xvmadd.w       \_out0,  \_in3,    \_tmp3
++    xvmadd.w       \_out1,  \_in11,   \_tmp3
++
++    xvmul.w        \_out2,  \_in7,    \_tmp0
++    xvmul.w        \_out3,  \_in15,   \_tmp0
++    xvmsub.w       \_out2,  \_in6,    \_tmp1
++    xvmsub.w       \_out3,  \_in14,   \_tmp1
++    xvmadd.w       \_out2,  \_in5,    \_tmp2
++    xvmadd.w       \_out3,  \_in13,   \_tmp2
++    xvmsub.w       \_out2,  \_in4,    \_tmp3
++    xvmsub.w       \_out3,  \_in12,   \_tmp3
++
++    xvldrepl.w     \_tmp0,  \_rin,    \_si4
++    xvldrepl.w     \_tmp1,  \_rin,    \_si5
++    xvldrepl.w     \_tmp2,  \_rin,    \_si6
++    xvldrepl.w     \_tmp3,  \_rin,    \_si7
++    xvmadd.w       \_out0,  \_in4,    \_tmp0
++    xvmadd.w       \_out1,  \_in12,   \_tmp0
++    xvmadd.w       \_out0,  \_in5,    \_tmp1
++    xvmadd.w       \_out1,  \_in13,   \_tmp1
++    xvmadd.w       \_out0,  \_in6,    \_tmp2
++    xvmadd.w       \_out1,  \_in14,   \_tmp2
++    xvmadd.w       \_out0,  \_in7,    \_tmp3
++    xvmadd.w       \_out1,  \_in15,   \_tmp3
++
++    xvmadd.w       \_out2,  \_in3,    \_tmp0
++    xvmadd.w       \_out3,  \_in11,   \_tmp0
++    xvmsub.w       \_out2,  \_in2,    \_tmp1
++    xvmsub.w       \_out3,  \_in10,   \_tmp1
++    xvmadd.w       \_out2,  \_in1,    \_tmp2
++    xvmadd.w       \_out3,  \_in9,    \_tmp2
++    xvmsub.w       \_out2,  \_in0,    \_tmp3
++    xvmsub.w       \_out3,  \_in8,    \_tmp3
++.endm
++
++.macro LASX_CLA_IDCT16_O _rin
++    xvld           xr8,     \_rin,  32   //line1
++    xvld           xr9,     \_rin,  96   //line3
++    xvld           xr10,    \_rin,  160  //line5
++    xvld           xr11,    \_rin,  224  //line7
++    xvld           xr12,    \_rin,  288  //line9
++    xvld           xr13,    \_rin,  352  //line11
++    xvld           xr14,    \_rin,  416  //line13
++    xvld           xr15,    \_rin,  480  //line15
++    LASX_EXT_W_H   xr8,     xr0,    xr8
++    LASX_EXT_W_H   xr9,     xr1,    xr9
++    LASX_EXT_W_H   xr10,    xr2,    xr10
++    LASX_EXT_W_H   xr11,    xr3,    xr11
++    LASX_EXT_W_H   xr12,    xr4,    xr12
++    LASX_EXT_W_H   xr13,    xr5,    xr13
++    LASX_EXT_W_H   xr14,    xr6,    xr14
++    LASX_EXT_W_H   xr15,    xr7,    xr15
++
++    LASX_CAL_IDCT_8_ELE_4 t1, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                          xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                          xr16, xr17, xr18, xr19, xr24, xr20, xr31, xr23, \
++                          64 * 1, 64 * 3, 64 * 5, 64 * 7, \
++                          64 * 9, 64 * 11, 64 * 13, 64 * 15
++    LASX_CAL_IDCT_8_ELE_4X t1, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                           xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                           xr16, xr17, xr18, xr19, xr25, xr21, xr30, xr22, \
++                           64 * 1 + 4, 64 * 3 + 4, 64 * 5 + 4, 64 * 7 + 4, \
++                           64 * 9 + 4, 64 * 11 + 4, 64 * 13 + 4, 64 * 15 + 4
++    xvst           xr20,     t4,      0
++    xvst           xr21,     t4,      32
++    xvst           xr22,     t4,      32 * 6
++    xvst           xr23,     t4,      32 * 7
++
++    LASX_CAL_IDCT_8_ELE_4 t1, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                          xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                          xr16, xr17, xr18, xr19, xr26, xr20, xr29, xr23, \
++                          64 * 1 + 8, 64 * 3 + 8, 64 * 5 + 8, 64 * 7 + 8, \
++                          64 * 9 + 8, 64 * 11 + 8, 64 * 13 + 8, 64 * 15 + 8
++    LASX_CAL_IDCT_8_ELE_4X t1, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                           xr8, xr9, xr10, xr11, xr12, xr13, xr14, xr15, \
++                           xr16, xr17, xr18, xr19, xr27, xr21, xr28, xr22, \
++                           64 * 1 + 12, 64 * 3 + 12, 64 * 5 + 12, 64 * 7 + 12, \
++                           64 * 9 + 12, 64 * 11 + 12, 64 * 13 + 12, 64 * 15 + 12
++    xvst           xr20,     t4,      32 * 2
++    xvst           xr21,     t4,      32 * 3
++    xvst           xr22,     t4,      32 * 4
++    xvst           xr23,     t4,      32 * 5
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LASX_CAL_IDCT_4_ELE_4 _rin, _in0, _in1, _in2, _in3, \
++                             _in4, _in5, _in6, _in7, _out0, _out1, _out2, _out3, \
++                             _temp0, _temp1, _temp2, _temp3, \
++                             _si0, _si1, _si2, _si3
++    xvldrepl.w     \_temp0, \_rin,    \_si0
++    xvldrepl.w     \_temp1, \_rin,    \_si1
++    xvldrepl.w     \_temp2, \_rin,    \_si2
++    xvldrepl.w     \_temp3, \_rin,    \_si3
++    xvmul.w        \_out0,  \_in0,    \_temp0
++    xvmul.w        \_out1,  \_in4,    \_temp0
++    xvmadd.w       \_out0,  \_in1,    \_temp1
++    xvmadd.w       \_out1,  \_in5,    \_temp1
++    xvmadd.w       \_out0,  \_in2,    \_temp2
++    xvmadd.w       \_out1,  \_in6,    \_temp2
++    xvmadd.w       \_out0,  \_in3,    \_temp3
++    xvmadd.w       \_out1,  \_in7,    \_temp3
++
++    xvmul.w        \_out2,  \_in0,    \_temp3
++    xvmul.w        \_out3,  \_in4,    \_temp3
++    xvmsub.w       \_out2,  \_in1,    \_temp2
++    xvmsub.w       \_out3,  \_in5,    \_temp2
++    xvmadd.w       \_out2,  \_in2,    \_temp1
++    xvmadd.w       \_out3,  \_in6,    \_temp1
++    xvmsub.w       \_out2,  \_in3,    \_temp0
++    xvmsub.w       \_out3,  \_in7,    \_temp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 4 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LASX_CAL_IDCT_4_ELE_4X _rin, _in0, _in1, _in2, _in3, \
++                              _in4, _in5, _in6, _in7, _out0, _out1, _out2, _out3, \
++                              _temp0, _temp1, _temp2, _temp3, \
++                              _si0, _si1, _si2, _si3
++    xvldrepl.w     \_temp0, \_rin,    \_si0
++    xvldrepl.w     \_temp1, \_rin,    \_si1
++    xvldrepl.w     \_temp2, \_rin,    \_si2
++    xvldrepl.w     \_temp3, \_rin,    \_si3
++    xvmul.w        \_out0,  \_in0,    \_temp0
++    xvmul.w        \_out1,  \_in4,    \_temp0
++    xvmadd.w       \_out0,  \_in1,    \_temp1
++    xvmadd.w       \_out1,  \_in5,    \_temp1
++    xvmadd.w       \_out0,  \_in2,    \_temp2
++    xvmadd.w       \_out1,  \_in6,    \_temp2
++    xvmadd.w       \_out0,  \_in3,    \_temp3
++    xvmadd.w       \_out1,  \_in7,    \_temp3
++
++    xvmul.w        \_out2,  \_in3,    \_temp0
++    xvmul.w        \_out3,  \_in7,    \_temp0
++    xvmsub.w       \_out2,  \_in2,    \_temp1
++    xvmsub.w       \_out3,  \_in6,    \_temp1
++    xvmadd.w       \_out2,  \_in1,    \_temp2
++    xvmadd.w       \_out3,  \_in5,    \_temp2
++    xvmsub.w       \_out2,  \_in0,    \_temp3
++    xvmsub.w       \_out3,  \_in4,    \_temp3
++.endm
++
++.macro LASX_CLA_IDCT16_E  _rin
++    xvld           xr8,     \_rin,  0    //line0
++    xvld           xr9,     \_rin,  64   //line2
++    xvld           xr10,    \_rin,  128  //line4
++    xvld           xr11,    \_rin,  192  //line6
++    xvld           xr12,    \_rin,  256  //line8
++    xvld           xr13,    \_rin,  320  //line10
++    xvld           xr14,    \_rin,  384  //line12
++    xvld           xr15,    \_rin,  448  //line14
++    LASX_EXT_W_H   xr9,     xr1,    xr9
++    LASX_EXT_W_H   xr11,    xr3,    xr11
++    LASX_EXT_W_H   xr13,    xr5,    xr13
++    LASX_EXT_W_H   xr15,    xr7,    xr15
++
++    /* EO[0...3] */
++    LASX_CAL_IDCT_4_ELE_4 t1, xr1, xr3, xr5, xr7, xr9, xr11, xr13, xr15, \
++                          xr16, xr17, xr22, xr23, xr0, xr2, xr4, xr6, \
++                          64 * 2, 64 * 6, 64 * 10, 64 * 14
++    LASX_CAL_IDCT_4_ELE_4X t1, xr1, xr3, xr5, xr7, xr9, xr11, xr13, xr15, \
++                           xr18, xr19, xr20, xr21, xr0, xr2, xr4, xr6, \
++                           64 * 2 + 4, 64 * 6 + 4, 64 * 10 + 4, 64 * 14 + 4
++
++    LASX_EXT_W_H   xr8,     xr0,    xr8
++    LASX_EXT_W_H   xr10,    xr2,    xr10
++    LASX_EXT_W_H   xr12,    xr4,    xr12
++    LASX_EXT_W_H   xr14,    xr6,    xr14
++
++    /* EEE */
++    xvldrepl.w     xr9,     t1,     0
++    xvmul.w        xr1,     xr0,    xr9
++    xvmul.w        xr3,     xr8,    xr9
++    xvmadd.w       xr1,     xr4,    xr9
++    xvmadd.w       xr3,     xr12,   xr9  // EEE[0]
++    xvmul.w        xr5,     xr0,    xr9
++    xvmul.w        xr7,     xr8,    xr9
++    xvmsub.w       xr5,     xr4,    xr9
++    xvmsub.w       xr7,     xr12,   xr9  // EEE[1]
++
++    /* EEO */
++    xvldrepl.w     xr0,     t1,     64 * 4
++    xvldrepl.w     xr4,     t1,     64 * 4 + 4
++    xvmul.w        xr9,     xr2,    xr0
++    xvmul.w        xr11,    xr10,   xr0
++    xvmadd.w       xr9,     xr6,    xr4
++    xvmadd.w       xr11,    xr14,   xr4   // EEO[0]
++    xvmul.w        xr13,    xr2,    xr4
++    xvmul.w        xr15,    xr10,   xr4
++    xvmsub.w       xr13,    xr6,    xr0
++    xvmsub.w       xr15,    xr14,   xr0   // EEO[1]
++
++    /* EE */
++    xvadd.w        xr0,     xr1,     xr9
++    xvadd.w        xr2,     xr3,     xr11  //EE[0]
++    xvsub.w        xr4,     xr1,     xr9
++    xvsub.w        xr6,     xr3,     xr11  //EE[3]
++    xvadd.w        xr8,     xr5,     xr13
++    xvadd.w        xr10,    xr7,     xr15  //EE[1]
++    xvsub.w        xr12,    xr5,     xr13
++    xvsub.w        xr14,    xr7,     xr15  //EE[2]
++
++    /* E */
++    xvadd.w        xr1,     xr2,     xr17  //E[0]
++    xvsub.w        xr15,    xr2,     xr17  //E[7]
++    xvadd.w        xr3,     xr10,    xr19  //E[1]
++    xvsub.w        xr13,    xr10,    xr19  //E[6]
++    xvadd.w        xr5,     xr14,    xr21  //E[2]
++    xvsub.w        xr11,    xr14,    xr21  //E[5]
++    xvadd.w        xr7,     xr6,     xr23  //E[3]
++    xvsub.w        xr9,     xr6,     xr23  //E[4]
++
++    xvst           xr1,     t4,      32 * 8
++    xvst           xr15,    t4,      32 * 9
++    xvst           xr3,     t4,      32 * 10
++    xvst           xr13,    t4,      32 * 11
++    xvst           xr5,     t4,      32 * 12
++    xvst           xr11,    t4,      32 * 13
++    xvst           xr7,     t4,      32 * 14
++    xvst           xr9,     t4,      32 * 15
++
++    xvadd.w        xr1,     xr0,     xr16
++    xvsub.w        xr15,    xr0,     xr16
++    xvadd.w        xr3,     xr8,     xr18
++    xvsub.w        xr13,    xr8,     xr18
++    xvadd.w        xr5,     xr12,    xr20
++    xvsub.w        xr11,    xr12,    xr20
++    xvadd.w        xr7,     xr4,     xr22
++    xvsub.w        xr9,     xr4,     xr22
++.endm
++
++.macro LASX_IDCT16_16_ROW_1 _rin, _rout, _shift
++
++    LASX_CLA_IDCT16_O \_rin  /* xr24 ~ xr31 */
++
++    LASX_CLA_IDCT16_E \_rin  /* xr:1\3\5\7\9\11\13\15 */
++
++    /* row0~7 dst */
++    xvadd.w         xr0,     xr1,     xr24  //dst[0]
++    xvsub.w         xr23,    xr1,     xr24  //dst[15]
++    xvadd.w         xr2,     xr3,     xr25  //dst[1]
++    xvsub.w         xr22,    xr3,     xr25  //dst[14]
++    xvadd.w         xr4,     xr5,     xr26  //dst[2]
++    xvsub.w         xr21,    xr5,     xr26  //dst[13]
++    xvadd.w         xr6,     xr7,     xr27  //dst[3]
++    xvsub.w         xr20,    xr7,     xr27  //dst[12]
++    xvadd.w         xr8,     xr9,     xr28  //dst[4]
++    xvsub.w         xr19,    xr9,     xr28  //dst[11]
++    xvadd.w         xr10,    xr11,    xr29  //dst[5]
++    xvsub.w         xr18,    xr11,    xr29  //dst[10]
++    xvadd.w         xr12,    xr13,    xr30  //dst[6]
++    xvsub.w         xr17,    xr13,    xr30  //dst[9]
++    xvadd.w         xr14,    xr15,    xr31  //dst[7]
++    xvsub.w         xr16,    xr15,    xr31  //dst[8]
++
++    LASX_TRANSPOSE8x8_W xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr1, xr3, xr5, xr7, xr9, xr11, xr13, xr15, \
++                        xr24, xr25, xr26, xr27
++    LASX_TRANSPOSE8x8_W xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                        xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr24, xr25, xr26, xr27
++
++    xvssrarni.h.w   xr0,    xr1,     \_shift
++    xvssrarni.h.w   xr2,    xr3,     \_shift
++    xvssrarni.h.w   xr4,    xr5,     \_shift
++    xvssrarni.h.w   xr6,    xr7,     \_shift
++    xvssrarni.h.w   xr8,    xr9,     \_shift
++    xvssrarni.h.w   xr10,   xr11,    \_shift
++    xvssrarni.h.w   xr12,   xr13,    \_shift
++    xvssrarni.h.w   xr14,   xr15,    \_shift
++
++    xvstelm.d       xr0,    \_rout,  0,         0
++    xvstelm.d       xr0,    \_rout,  8,         2
++    xvstelm.d       xr0,    \_rout,  16,        1
++    xvstelm.d       xr0,    \_rout,  24,        3  // k = 0
++    xvstelm.d       xr2,    \_rout,  32,        0
++    xvstelm.d       xr2,    \_rout,  40,        2
++    xvstelm.d       xr2,    \_rout,  48,        1
++    xvstelm.d       xr2,    \_rout,  56,        3  // k = 1
++    xvstelm.d       xr4,    \_rout,  64,        0
++    xvstelm.d       xr4,    \_rout,  72,        2
++    xvstelm.d       xr4,    \_rout,  80,        1
++    xvstelm.d       xr4,    \_rout,  88,        3  // k = 2
++    xvstelm.d       xr6,    \_rout,  96,        0
++    xvstelm.d       xr6,    \_rout,  104,       2
++    xvstelm.d       xr6,    \_rout,  112,       1
++    xvstelm.d       xr6,    \_rout,  120,       3  // k = 3
++    xvstelm.d       xr8,    \_rout,  128,       0
++    xvstelm.d       xr8,    \_rout,  136,       2
++    xvstelm.d       xr8,    \_rout,  144,       1
++    xvstelm.d       xr8,    \_rout,  152,       3  // k = 4
++    xvstelm.d       xr10,   \_rout,  160,       0
++    xvstelm.d       xr10,   \_rout,  168,       2
++    xvstelm.d       xr10,   \_rout,  176,       1
++    xvstelm.d       xr10,   \_rout,  184,       3  // k = 5
++    xvstelm.d       xr12,   \_rout,  192,       0
++    xvstelm.d       xr12,   \_rout,  200,       2
++    xvstelm.d       xr12,   \_rout,  208,       1
++    xvstelm.d       xr12,   \_rout,  216,       3  // k = 6
++    xvstelm.d       xr14,   \_rout,  224,       0
++    xvstelm.d       xr14,   \_rout,  232,       2
++    xvstelm.d       xr14,   \_rout,  240,       1
++    xvstelm.d       xr14,   \_rout,  248,       3  // k = 7
++
++    xvld            xr24,    t4,      0
++    xvld            xr25,    t4,      32
++    xvld            xr26,    t4,      32 * 2
++    xvld            xr27,    t4,      32 * 3
++    xvld            xr28,    t4,      32 * 4
++    xvld            xr29,    t4,      32 * 5
++    xvld            xr30,    t4,      32 * 6
++    xvld            xr31,    t4,      32 * 7
++
++    xvld            xr1,     t4,      32 * 8
++    xvld            xr15,    t4,      32 * 9
++    xvld            xr3,     t4,      32 * 10
++    xvld            xr13,    t4,      32 * 11
++    xvld            xr5,     t4,      32 * 12
++    xvld            xr11,    t4,      32 * 13
++    xvld            xr7,     t4,      32 * 14
++    xvld            xr9,     t4,      32 * 15
++    /* row8~15 dst */
++    xvadd.w         xr0,     xr1,     xr24  //dst[0]
++    xvsub.w         xr23,    xr1,     xr24  //dst[15]
++    xvadd.w         xr2,     xr3,     xr25  //dst[1]
++    xvsub.w         xr22,    xr3,     xr25  //dst[14]
++    xvadd.w         xr4,     xr5,     xr26  //dst[2]
++    xvsub.w         xr21,    xr5,     xr26  //dst[13]
++    xvadd.w         xr6,     xr7,     xr27  //dst[3]
++    xvsub.w         xr20,    xr7,     xr27  //dst[12]
++    xvadd.w         xr8,     xr9,     xr28  //dst[4]
++    xvsub.w         xr19,    xr9,     xr28  //dst[11]
++    xvadd.w         xr10,    xr11,    xr29  //dst[5]
++    xvsub.w         xr18,    xr11,    xr29  //dst[10]
++    xvadd.w         xr12,    xr13,    xr30  //dst[6]
++    xvsub.w         xr17,    xr13,    xr30  //dst[9]
++    xvadd.w         xr14,    xr15,    xr31  //dst[7]
++    xvsub.w         xr16,    xr15,    xr31  //dst[8]
++
++    LASX_TRANSPOSE8x8_W xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr1, xr3, xr5, xr7, xr9, xr11, xr13, xr15, \
++                        xr24, xr25, xr26, xr27
++    LASX_TRANSPOSE8x8_W xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                        xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr24, xr25, xr26, xr27
++
++    xvssrarni.h.w   xr0,    xr1,     \_shift
++    xvssrarni.h.w   xr2,    xr3,     \_shift
++    xvssrarni.h.w   xr4,    xr5,     \_shift
++    xvssrarni.h.w   xr6,    xr7,     \_shift
++    xvssrarni.h.w   xr8,    xr9,     \_shift
++    xvssrarni.h.w   xr10,   xr11,    \_shift
++    xvssrarni.h.w   xr12,   xr13,    \_shift
++    xvssrarni.h.w   xr14,   xr15,    \_shift
++
++    xvstelm.d       xr0,    \_rout,  256,       0
++    xvstelm.d       xr0,    \_rout,  264,       2
++    xvstelm.d       xr0,    \_rout,  272,       1
++    xvstelm.d       xr0,    \_rout,  280,       3  // k = 8
++    xvstelm.d       xr2,    \_rout,  288,       0
++    xvstelm.d       xr2,    \_rout,  296,       2
++    xvstelm.d       xr2,    \_rout,  304,       1
++    xvstelm.d       xr2,    \_rout,  312,       3  // k = 9
++    xvstelm.d       xr4,    \_rout,  320,       0
++    xvstelm.d       xr4,    \_rout,  328,       2
++    xvstelm.d       xr4,    \_rout,  336,       1
++    xvstelm.d       xr4,    \_rout,  344,       3  // k = 10
++    xvstelm.d       xr6,    \_rout,  352,       0
++    xvstelm.d       xr6,    \_rout,  360,       2
++    xvstelm.d       xr6,    \_rout,  368,       1
++    xvstelm.d       xr6,    \_rout,  376,       3  // k = 11
++    xvstelm.d       xr8,    \_rout,  384,       0
++    xvstelm.d       xr8,    \_rout,  392,       2
++    xvstelm.d       xr8,    \_rout,  400,       1
++    xvstelm.d       xr8,    \_rout,  408,       3  // k = 12
++    xvstelm.d       xr10,   \_rout,  416,       0
++    xvstelm.d       xr10,   \_rout,  424,       2
++    xvstelm.d       xr10,   \_rout,  432,       1
++    xvstelm.d       xr10,   \_rout,  440,       3  // k = 13
++    xvstelm.d       xr12,   \_rout,  448,       0
++    xvstelm.d       xr12,   \_rout,  456,       2
++    xvstelm.d       xr12,   \_rout,  464,       1
++    xvstelm.d       xr12,   \_rout,  472,       3  // k = 14
++    xvstelm.d       xr14,   \_rout,  480,       0
++    xvstelm.d       xr14,   \_rout,  488,       2
++    xvstelm.d       xr14,   \_rout,  496,       1
++    xvstelm.d       xr14,   \_rout,  504,       3  // k = 15
++.endm
++
++.macro LASX_IDCT16_16_ROW_2 _rin, _shift
++
++    LASX_CLA_IDCT16_O \_rin  /* xr24 ~ xr31 */
++
++    LASX_CLA_IDCT16_E \_rin  /* xr:1\3\5\7\9\11\13\15 */
++
++    /* row0~7 dst */
++    xvadd.w         xr0,     xr1,     xr24  //dst[0]
++    xvsub.w         xr23,    xr1,     xr24  //dst[15]
++    xvadd.w         xr2,     xr3,     xr25  //dst[1]
++    xvsub.w         xr22,    xr3,     xr25  //dst[14]
++    xvadd.w         xr4,     xr5,     xr26  //dst[2]
++    xvsub.w         xr21,    xr5,     xr26  //dst[13]
++    xvadd.w         xr6,     xr7,     xr27  //dst[3]
++    xvsub.w         xr20,    xr7,     xr27  //dst[12]
++    xvadd.w         xr8,     xr9,     xr28  //dst[4]
++    xvsub.w         xr19,    xr9,     xr28  //dst[11]
++    xvadd.w         xr10,    xr11,    xr29  //dst[5]
++    xvsub.w         xr18,    xr11,    xr29  //dst[10]
++    xvadd.w         xr12,    xr13,    xr30  //dst[6]
++    xvsub.w         xr17,    xr13,    xr30  //dst[9]
++    xvadd.w         xr14,    xr15,    xr31  //dst[7]
++    xvsub.w         xr16,    xr15,    xr31  //dst[8]
++
++    LASX_TRANSPOSE8x8_W xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr1, xr3, xr5, xr7, xr9, xr11, xr13, xr15, \
++                        xr24, xr25, xr26, xr27
++    LASX_TRANSPOSE8x8_W xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                        xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr24, xr25, xr26, xr27
++
++    xvssrarni.h.w   xr0,    xr1,     \_shift
++    xvssrarni.h.w   xr2,    xr3,     \_shift
++    xvssrarni.h.w   xr4,    xr5,     \_shift
++    xvssrarni.h.w   xr6,    xr7,     \_shift
++    xvssrarni.h.w   xr8,    xr9,     \_shift
++    xvssrarni.h.w   xr10,   xr11,    \_shift
++    xvssrarni.h.w   xr12,   xr13,    \_shift
++    xvssrarni.h.w   xr14,   xr15,    \_shift
++
++    xvstelm.d       xr0,    a1,      0,         0
++    xvstelm.d       xr0,    a1,      8,         2
++    xvstelm.d       xr0,    a1,      16,        1
++    xvstelm.d       xr0,    a1,      24,        3  // k = 0
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr2,    a1,      0,         0
++    xvstelm.d       xr2,    a1,      8,         2
++    xvstelm.d       xr2,    a1,      16,        1
++    xvstelm.d       xr2,    a1,      24,        3  // k = 1
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr4,    a1,      0,         0
++    xvstelm.d       xr4,    a1,      8,         2
++    xvstelm.d       xr4,    a1,      16,        1
++    xvstelm.d       xr4,    a1,      24,        3  // k = 2
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr6,    a1,      0,         0
++    xvstelm.d       xr6,    a1,      8,         2
++    xvstelm.d       xr6,    a1,      16,        1
++    xvstelm.d       xr6,    a1,      24,        3  // k = 3
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr8,    a1,      0,         0
++    xvstelm.d       xr8,    a1,      8,         2
++    xvstelm.d       xr8,    a1,      16,        1
++    xvstelm.d       xr8,    a1,      24,        3  // k = 4
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr10,   a1,      0,         0
++    xvstelm.d       xr10,   a1,      8,         2
++    xvstelm.d       xr10,   a1,      16,        1
++    xvstelm.d       xr10,   a1,      24,        3  // k = 5
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr12,   a1,      0,         0
++    xvstelm.d       xr12,   a1,      8,         2
++    xvstelm.d       xr12,   a1,      16,        1
++    xvstelm.d       xr12,   a1,      24,        3  // k = 6
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr14,   a1,      0,         0
++    xvstelm.d       xr14,   a1,      8,         2
++    xvstelm.d       xr14,   a1,      16,        1
++    xvstelm.d       xr14,   a1,      24,        3  // k = 7
++    add.d           a1,     a1,      a2
++
++    xvld            xr24,    t4,      0
++    xvld            xr25,    t4,      32
++    xvld            xr26,    t4,      32 * 2
++    xvld            xr27,    t4,      32 * 3
++    xvld            xr28,    t4,      32 * 4
++    xvld            xr29,    t4,      32 * 5
++    xvld            xr30,    t4,      32 * 6
++    xvld            xr31,    t4,      32 * 7
++
++    xvld            xr1,     t4,      32 * 8
++    xvld            xr15,    t4,      32 * 9
++    xvld            xr3,     t4,      32 * 10
++    xvld            xr13,    t4,      32 * 11
++    xvld            xr5,     t4,      32 * 12
++    xvld            xr11,    t4,      32 * 13
++    xvld            xr7,     t4,      32 * 14
++    xvld            xr9,     t4,      32 * 15
++    /* row8~15 dst */
++    xvadd.w         xr0,     xr1,     xr24  //dst[0]
++    xvsub.w         xr23,    xr1,     xr24  //dst[15]
++    xvadd.w         xr2,     xr3,     xr25  //dst[1]
++    xvsub.w         xr22,    xr3,     xr25  //dst[14]
++    xvadd.w         xr4,     xr5,     xr26  //dst[2]
++    xvsub.w         xr21,    xr5,     xr26  //dst[13]
++    xvadd.w         xr6,     xr7,     xr27  //dst[3]
++    xvsub.w         xr20,    xr7,     xr27  //dst[12]
++    xvadd.w         xr8,     xr9,     xr28  //dst[4]
++    xvsub.w         xr19,    xr9,     xr28  //dst[11]
++    xvadd.w         xr10,    xr11,    xr29  //dst[5]
++    xvsub.w         xr18,    xr11,    xr29  //dst[10]
++    xvadd.w         xr12,    xr13,    xr30  //dst[6]
++    xvsub.w         xr17,    xr13,    xr30  //dst[9]
++    xvadd.w         xr14,    xr15,    xr31  //dst[7]
++    xvsub.w         xr16,    xr15,    xr31  //dst[8]
++
++    LASX_TRANSPOSE8x8_W xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr1, xr3, xr5, xr7, xr9, xr11, xr13, xr15, \
++                        xr24, xr25, xr26, xr27
++    LASX_TRANSPOSE8x8_W xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, \
++                        xr0, xr2, xr4, xr6, xr8, xr10, xr12, xr14, \
++                        xr24, xr25, xr26, xr27
++
++    xvssrarni.h.w   xr0,    xr1,     \_shift
++    xvssrarni.h.w   xr2,    xr3,     \_shift
++    xvssrarni.h.w   xr4,    xr5,     \_shift
++    xvssrarni.h.w   xr6,    xr7,     \_shift
++    xvssrarni.h.w   xr8,    xr9,     \_shift
++    xvssrarni.h.w   xr10,   xr11,    \_shift
++    xvssrarni.h.w   xr12,   xr13,    \_shift
++    xvssrarni.h.w   xr14,   xr15,    \_shift
++
++    xvstelm.d       xr0,    a1,      0,         0
++    xvstelm.d       xr0,    a1,      8,         2
++    xvstelm.d       xr0,    a1,      16,        1
++    xvstelm.d       xr0,    a1,      24,        3  // k = 8
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr2,    a1,      0,         0
++    xvstelm.d       xr2,    a1,      8,         2
++    xvstelm.d       xr2,    a1,      16,        1
++    xvstelm.d       xr2,    a1,      24,        3  // k = 9
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr4,    a1,      0,         0
++    xvstelm.d       xr4,    a1,      8,         2
++    xvstelm.d       xr4,    a1,      16,        1
++    xvstelm.d       xr4,    a1,      24,        3  // k = 10
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr6,    a1,      0,         0
++    xvstelm.d       xr6,    a1,      8,         2
++    xvstelm.d       xr6,    a1,      16,        1
++    xvstelm.d       xr6,    a1,      24,        3  // k = 11
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr8,    a1,      0,         0
++    xvstelm.d       xr8,    a1,      8,         2
++    xvstelm.d       xr8,    a1,      16,        1
++    xvstelm.d       xr8,    a1,      24,        3  // k = 12
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr10,   a1,      0,         0
++    xvstelm.d       xr10,   a1,      8,         2
++    xvstelm.d       xr10,   a1,      16,        1
++    xvstelm.d       xr10,   a1,      24,        3  // k = 13
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr12,   a1,      0,         0
++    xvstelm.d       xr12,   a1,      8,         2
++    xvstelm.d       xr12,   a1,      16,        1
++    xvstelm.d       xr12,   a1,      24,        3  // k = 14
++    add.d           a1,     a1,      a2
++    xvstelm.d       xr14,   a1,      0,         0
++    xvstelm.d       xr14,   a1,      8,         2
++    xvstelm.d       xr14,   a1,      16,        1
++    xvstelm.d       xr14,   a1,      24,        3  // k = 15
++.endm
++
++/* void x265_idct16_lasx(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idct16_lasx
++    addi.d        sp,      sp,      -1088 //-(64 + 32*16 + 16 *16*2)
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t1,      table_dct16
++    slli.d        a2,      a2,      1  //stride
++    addi.d        t4,      sp,      64
++    addi.d        t2,      t4,      32 * 16
++
++    /*
++     * The first butterfly operation.
++     */
++    LASX_IDCT16_16_ROW_1 a0, t2, 7
++
++    /*
++     * The second butterfly operation.
++     */
++    LASX_IDCT16_16_ROW_2 t2, 12
++
++    fld.d         f24,      sp,     0
++    fld.d         f25,      sp,     8
++    fld.d         f26,      sp,     16
++    fld.d         f27,      sp,     24
++    fld.d         f28,      sp,     32
++    fld.d         f29,      sp,     40
++    fld.d         f30,      sp,     48
++    fld.d         f31,      sp,     56
++    addi.d        sp,       sp,     1088
++endfunc
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * in reg: xr0 ~ xr15
++ * temp reg: _temp0 ~ _temp1
++ */
++.macro LASX_CAL_IDCT_16_ELE_2 _out0,  _out1, _temp0, _temp1, _temp2, _temp3, \
++                              _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                              _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    xvldrepl.w     \_temp0, t1,       \_si0
++    xvldrepl.w     \_temp1, t1,       \_si1
++    xvldrepl.w     \_temp2, t1,       \_si2
++    xvldrepl.w     \_temp3, t1,       \_si3
++    xvmul.w        \_out0,  xr0,      \_temp0
++    xvmul.w        \_out1,  xr12,     \_temp3
++    xvmadd.w       \_out0,  xr1,      \_temp1
++    xvmsub.w       \_out1,  xr13,     \_temp2
++    xvmadd.w       \_out0,  xr2,      \_temp2
++    xvmadd.w       \_out1,  xr14,     \_temp1
++    xvmadd.w       \_out0,  xr3,      \_temp3
++    xvmsub.w       \_out1,  xr15,     \_temp0
++
++    xvldrepl.w     \_temp0, t1,       \_si4
++    xvldrepl.w     \_temp1, t1,       \_si5
++    xvldrepl.w     \_temp2, t1,       \_si6
++    xvldrepl.w     \_temp3, t5,       \_si7
++    xvmadd.w       \_out0,  xr4,      \_temp0
++    xvmadd.w       \_out1,  xr8,      \_temp3
++    xvmadd.w       \_out0,  xr5,      \_temp1
++    xvmsub.w       \_out1,  xr9,      \_temp2
++    xvmadd.w       \_out0,  xr6,      \_temp2
++    xvmadd.w       \_out1,  xr10,     \_temp1
++    xvmadd.w       \_out0,  xr7,      \_temp3
++    xvmsub.w       \_out1,  xr11,     \_temp0
++
++    xvldrepl.w     \_temp0, t5,       \_si8
++    xvldrepl.w     \_temp1, t5,       \_si9
++    xvldrepl.w     \_temp2, t5,       \_si10
++    xvldrepl.w     \_temp3, t5,       \_si11
++    xvmadd.w       \_out0,  xr8,      \_temp0
++    xvmadd.w       \_out1,  xr4,      \_temp3
++    xvmadd.w       \_out0,  xr9,      \_temp1
++    xvmsub.w       \_out1,  xr5,      \_temp2
++    xvmadd.w       \_out0,  xr10,     \_temp2
++    xvmadd.w       \_out1,  xr6,      \_temp1
++    xvmadd.w       \_out0,  xr11,     \_temp3
++    xvmsub.w       \_out1,  xr7,      \_temp0
++
++    xvldrepl.w     \_temp0, t5,       \_si12
++    xvldrepl.w     \_temp1, t5,       \_si13
++    xvldrepl.w     \_temp2, t5,       \_si14
++    xvldrepl.w     \_temp3, t6,       \_si15
++    xvmadd.w       \_out0,  xr12,     \_temp0
++    xvmadd.w       \_out1,  xr0,      \_temp3
++    xvmadd.w       \_out0,  xr13,     \_temp1
++    xvmsub.w       \_out1,  xr1,      \_temp2
++    xvmadd.w       \_out0,  xr14,     \_temp2
++    xvmadd.w       \_out1,  xr2,      \_temp1
++    xvmadd.w       \_out0,  xr15,     \_temp3
++    xvmsub.w       \_out1,  xr3,      \_temp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 16 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * in reg: xr0 ~ xr15
++ * temp reg: _temp0 ~ _temp1
++ */
++.macro LASX_CAL_IDCT_16_ELE_2X _out0, _out1, _temp0, _temp1, _temp2, _temp3, \
++                               _si0, _si1, _si2, _si3, _si4, _si5, _si6, _si7, \
++                               _si8, _si9, _si10, _si11, _si12, _si13, _si14, _si15
++    xvldrepl.w     \_temp0, t1,       \_si0
++    xvldrepl.w     \_temp1, t1,       \_si1
++    xvldrepl.w     \_temp2, t1,       \_si2
++    xvldrepl.w     \_temp3, t1,       \_si3
++    xvmul.w        \_out0,  xr0,      \_temp0
++    xvmul.w        \_out1,  xr15,     \_temp0
++    xvmadd.w       \_out0,  xr1,      \_temp1
++    xvmsub.w       \_out1,  xr14,     \_temp1
++    xvmadd.w       \_out0,  xr2,      \_temp2
++    xvmadd.w       \_out1,  xr13,     \_temp2
++    xvmadd.w       \_out0,  xr3,      \_temp3
++    xvmsub.w       \_out1,  xr12,     \_temp3
++
++    xvldrepl.w     \_temp0, t1,       \_si4
++    xvldrepl.w     \_temp1, t1,       \_si5
++    xvldrepl.w     \_temp2, t1,       \_si6
++    xvldrepl.w     \_temp3, t5,       \_si7
++    xvmadd.w       \_out0,  xr4,      \_temp0
++    xvmadd.w       \_out1,  xr11,     \_temp0
++    xvmadd.w       \_out0,  xr5,      \_temp1
++    xvmsub.w       \_out1,  xr10,     \_temp1
++    xvmadd.w       \_out0,  xr6,      \_temp2
++    xvmadd.w       \_out1,  xr9,      \_temp2
++    xvmadd.w       \_out0,  xr7,      \_temp3
++    xvmsub.w       \_out1,  xr8,      \_temp3
++
++    xvldrepl.w     \_temp0, t5,       \_si8
++    xvldrepl.w     \_temp1, t5,       \_si9
++    xvldrepl.w     \_temp2, t5,       \_si10
++    xvldrepl.w     \_temp3, t5,       \_si11
++    xvmadd.w       \_out0,  xr8,      \_temp0
++    xvmadd.w       \_out1,  xr7,      \_temp0
++    xvmadd.w       \_out0,  xr9,      \_temp1
++    xvmsub.w       \_out1,  xr6,      \_temp1
++    xvmadd.w       \_out0,  xr10,     \_temp2
++    xvmadd.w       \_out1,  xr5,      \_temp2
++    xvmadd.w       \_out0,  xr11,     \_temp3
++    xvmsub.w       \_out1,  xr4,      \_temp3
++
++    xvldrepl.w     \_temp0, t5,       \_si12
++    xvldrepl.w     \_temp1, t5,       \_si13
++    xvldrepl.w     \_temp2, t5,       \_si14
++    xvldrepl.w     \_temp3, t6,       \_si15
++    xvmadd.w       \_out0,  xr12,     \_temp0
++    xvmadd.w       \_out1,  xr3,      \_temp0
++    xvmadd.w       \_out0,  xr13,     \_temp1
++    xvmsub.w       \_out1,  xr2,      \_temp1
++    xvmadd.w       \_out0,  xr14,     \_temp2
++    xvmadd.w       \_out1,  xr1,      \_temp2
++    xvmadd.w       \_out0,  xr15,     \_temp3
++    xvmsub.w       \_out1,  xr0,      \_temp3
++.endm
++
++.macro LASX_CLA_IDCT32_O
++    LASX_CAL_IDCT_16_ELE_2 xr24, xr23, xr16, xr17, xr18, xr19, \
++                           128 * 1, 128 * 3, 128 * 5, 128 * 7, \
++                           128 * 9, 128 * 11, 128 * 13, 0, \
++                           128 * 2, 128 * 4, 128 * 6, 128 * 8, \
++                           128 * 10, 128 * 12, 128 * 14, 128 * 1
++    LASX_CAL_IDCT_16_ELE_2X xr25, xr22, xr16, xr17, xr18, xr19, \
++                           128 * 1 + 4, 128 * 3 + 4, 128 * 5 + 4, 128 * 7 + 4, \
++                           128 * 9 + 4, 128 * 11 + 4, 128 * 13 + 4, 4, \
++                           128 * 2 + 4, 128 * 4 + 4, 128 * 6 + 4, 128 * 8 + 4, \
++                           128 * 10 + 4, 128 * 12 + 4, 128 * 14 + 4, 128 * 1 + 4
++    LASX_CAL_IDCT_16_ELE_2 xr26, xr21, xr16, xr17, xr18, xr19, \
++                           128 * 1 + 8, 128 * 3 + 8, 128 * 5 + 8, 128 * 7 + 8, \
++                           128 * 9 + 8, 128 * 11 + 8, 128 * 13 + 8, 8, \
++                           128 * 2 + 8, 128 * 4 + 8, 128 * 6 + 8, 128 * 8 + 8, \
++                           128 * 10 + 8, 128 * 12 + 8, 128 * 14 + 8, 128 * 1 + 8
++    LASX_CAL_IDCT_16_ELE_2X xr27, xr20, xr16, xr17, xr18, xr19, \
++                           128 * 1 + 12, 128 * 3 + 12, 128 * 5 + 12, 128 * 7 + 12, \
++                           128 * 9 + 12, 128 * 11 + 12, 128 * 13 + 12, 12, \
++                           128 * 2 + 12, 128 * 4 + 12, 128 * 6 + 12, 128 * 8 + 12, \
++                           128 * 10 + 12, 128 * 12 + 12, 128 * 14 + 12, 128 * 1 + 12
++    xvst           xr20,     t4,      32 * 4
++    xvst           xr21,     t4,      32 * 5
++    xvst           xr22,     t4,      32 * 6
++    xvst           xr23,     t4,      32 * 7
++
++    LASX_CAL_IDCT_16_ELE_2 xr28, xr23, xr16, xr17, xr18, xr19, \
++                           128 * 1 + 16, 128 * 3 + 16, 128 * 5 + 16, 128 * 7 + 16, \
++                           128 * 9 + 16, 128 * 11 + 16, 128 * 13 + 16, 16, \
++                           128 * 2 + 16, 128 * 4 + 16, 128 * 6 + 16, 128 * 8 + 16, \
++                           128 * 10 + 16, 128 * 12 + 16, 128 * 14 + 16, 128 * 1 + 16
++    LASX_CAL_IDCT_16_ELE_2X xr29, xr22, xr16, xr17, xr18, xr19, \
++                           128 * 1 + 20, 128 * 3 + 20, 128 * 5 + 20, 128 * 7 + 20, \
++                           128 * 9 + 20, 128 * 11 + 20, 128 * 13 + 20, 20, \
++                           128 * 2 + 20, 128 * 4 + 20, 128 * 6 + 20, 128 * 8 + 20, \
++                           128 * 10 + 20, 128 * 12 + 20, 128 * 14 + 20, 128 * 1 + 20
++    LASX_CAL_IDCT_16_ELE_2 xr30, xr21, xr16, xr17, xr18, xr19, \
++                           128 * 1 + 24, 128 * 3 + 24, 128 * 5 + 24, 128 * 7 + 24, \
++                           128 * 9 + 24, 128 * 11 + 24, 128 * 13 + 24, 24, \
++                           128 * 2 + 24, 128 * 4 + 24, 128 * 6 + 24, 128 * 8 + 24, \
++                           128 * 10 + 24, 128 * 12 + 24, 128 * 14 + 24, 128 * 1 + 24
++    LASX_CAL_IDCT_16_ELE_2X xr31, xr20, xr16, xr17, xr18, xr19, \
++                            128 * 1 + 28, 128 * 3 + 28, 128 * 5 + 28, 128 * 7 + 28, \
++                            128 * 9 + 28, 128 * 11 + 28, 128 * 13 + 28, 28, \
++                            128 * 2 + 28, 128 * 4 + 28, 128 * 6 + 28, 128 * 8 + 28, \
++                            128 * 10 + 28, 128 * 12 + 28, 128 * 14 + 28, 128 * 1 + 28
++    xvst           xr20,     t4,      0
++    xvst           xr21,     t4,      32
++    xvst           xr22,     t4,      32 * 2
++    xvst           xr23,     t4,      32 * 3
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LASX_CAL_IDCT_8_ELE_2 _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                             _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                             _out0, _out1, _si0, _si1, _si2, _si3, \
++                             _si4, _si5, _si6, _si7
++    xvldrepl.w     \_tmp0,  t1,       \_si0
++    xvldrepl.w     \_tmp1,  t1,       \_si1
++    xvldrepl.w     \_tmp2,  t1,       \_si2
++    xvldrepl.w     \_tmp3,  t1,       \_si3
++    xvldrepl.w     \_tmp4,  t5,       \_si4
++    xvldrepl.w     \_tmp5,  t5,       \_si5
++    xvldrepl.w     \_tmp6,  t5,       \_si6
++    xvldrepl.w     \_tmp7,  t6,       \_si7
++
++    xvmul.w        \_out0,  \_in0,    \_tmp0
++    xvmul.w        \_out1,  \_in0,    \_tmp7
++    xvmadd.w       \_out0,  \_in1,    \_tmp1
++    xvmsub.w       \_out1,  \_in1,    \_tmp6
++    xvmadd.w       \_out0,  \_in2,    \_tmp2
++    xvmadd.w       \_out1,  \_in2,    \_tmp5
++    xvmadd.w       \_out0,  \_in3,    \_tmp3
++    xvmsub.w       \_out1,  \_in3,    \_tmp4
++    xvmadd.w       \_out0,  \_in4,    \_tmp4
++    xvmadd.w       \_out1,  \_in4,    \_tmp3
++    xvmadd.w       \_out0,  \_in5,    \_tmp5
++    xvmsub.w       \_out1,  \_in5,    \_tmp2
++    xvmadd.w       \_out0,  \_in6,    \_tmp6
++    xvmadd.w       \_out1,  \_in6,    \_tmp1
++    xvmadd.w       \_out0,  \_in7,    \_tmp7
++    xvmsub.w       \_out1,  \_in7,    \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 8 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _tmp0 ~ _tmp7
++ */
++.macro LASX_CAL_IDCT_8_ELE_2X _in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7, \
++                              _tmp0, _tmp1, _tmp2, _tmp3, _tmp4, _tmp5, _tmp6, _tmp7, \
++                              _out0, _out1, _si0, _si1, _si2, _si3, \
++                              _si4, _si5, _si6, _si7
++    xvldrepl.w     \_tmp0,  t1,       \_si0
++    xvldrepl.w     \_tmp1,  t1,       \_si1
++    xvldrepl.w     \_tmp2,  t1,       \_si2
++    xvldrepl.w     \_tmp3,  t1,       \_si3
++    xvldrepl.w     \_tmp4,  t5,       \_si4
++    xvldrepl.w     \_tmp5,  t5,       \_si5
++    xvldrepl.w     \_tmp6,  t5,       \_si6
++    xvldrepl.w     \_tmp7,  t6,       \_si7
++
++    xvmul.w       \_out0,  \_in0,     \_tmp0
++    xvmul.w       \_out1,  \_in7,     \_tmp0
++    xvmadd.w      \_out0,  \_in1,     \_tmp1
++    xvmsub.w      \_out1,  \_in6,     \_tmp1
++    xvmadd.w      \_out0,  \_in2,     \_tmp2
++    xvmadd.w      \_out1,  \_in5,     \_tmp2
++    xvmadd.w      \_out0,  \_in3,     \_tmp3
++    xvmsub.w      \_out1,  \_in4,     \_tmp3
++    xvmadd.w      \_out0,  \_in4,     \_tmp4
++    xvmadd.w      \_out1,  \_in3,     \_tmp4
++    xvmadd.w      \_out0,  \_in5,     \_tmp5
++    xvmsub.w      \_out1,  \_in2,     \_tmp5
++    xvmadd.w      \_out0,  \_in6,     \_tmp6
++    xvmadd.w      \_out1,  \_in1,     \_tmp6
++    xvmadd.w      \_out0,  \_in7,     \_tmp7
++    xvmsub.w      \_out1,  \_in0,     \_tmp7
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LASX_CAL_IDCT_4_ELE_2 _in0, _in1, _in2, _in3, \
++                             _tmp0, _tmp1, _tmp2, _tmp3, _out0, _out1\
++                             _si0, _si1, _si2, _si3
++    xvldrepl.w     \_tmp0,  t1,       \_si0
++    xvldrepl.w     \_tmp1,  t1,       \_si1
++    xvldrepl.w     \_tmp2,  t5,       \_si2
++    xvldrepl.w     \_tmp3,  t5,       \_si3
++
++    xvmul.w       \_out0,  \_in0,     \_tmp0
++    xvmul.w       \_out1,  \_in0,     \_tmp3
++    xvmadd.w      \_out0,  \_in1,     \_tmp1
++    xvmsub.w      \_out1,  \_in1,     \_tmp2
++    xvmadd.w      \_out0,  \_in2,     \_tmp2
++    xvmadd.w      \_out1,  \_in2,     \_tmp1
++    xvmadd.w      \_out0,  \_in3,     \_tmp3
++    xvmsub.w      \_out1,  \_in3,     \_tmp0
++.endm
++
++/*
++ * Description : Multiplication and addition calculation of 4 input elements
++ *               and DCT coefficients.(Calculate 2 outputs)
++ * Note        : DCT coefficient symmetry is different from above.
++ * temp reg: _temp0 ~ _temp3
++ */
++.macro LASX_CAL_IDCT_4_ELE_2X _in0, _in1, _in2, _in3, \
++                              _tmp0, _tmp1, _tmp2, _tmp3, _out0, _out1\
++                              _si0, _si1, _si2, _si3
++    xvldrepl.w     \_tmp0,  t1,       \_si0
++    xvldrepl.w     \_tmp1,  t1,       \_si1
++    xvldrepl.w     \_tmp2,  t5,       \_si2
++    xvldrepl.w     \_tmp3,  t5,       \_si3
++    xvmul.w       \_out0,  \_in0,     \_tmp0
++    xvmul.w       \_out1,  \_in3,     \_tmp0
++    xvmadd.w      \_out0,  \_in1,     \_tmp1
++    xvmsub.w      \_out1,  \_in2,     \_tmp1
++    xvmadd.w      \_out0,  \_in2,     \_tmp2
++    xvmadd.w      \_out1,  \_in1,     \_tmp2
++    xvmadd.w      \_out0,  \_in3,     \_tmp3
++    xvmsub.w      \_out1,  \_in0,     \_tmp3
++.endm
++
++.macro LASX_CLA_IDCT32_EO
++    LASX_CAL_IDCT_8_ELE_2 xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                          xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, xr8, xr15, \
++                          128 * 2, 128 * 6, 128 * 10, 128 * 14, \
++                          128 * 3, 128 * 7, 128 * 11, 0
++    LASX_CAL_IDCT_8_ELE_2X xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                           xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, xr9, xr14, \
++                           128 * 2 + 4, 128 * 6 + 4, 128 * 10 + 4, 128 * 14 + 4, \
++                           128 * 3 + 4, 128 * 7 + 4, 128 * 11 + 4, 4
++    LASX_CAL_IDCT_8_ELE_2 xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                          xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, xr10, xr13, \
++                          128 * 2 + 8, 128 * 6 + 8, 128 * 10 + 8, 128 * 14 + 8, \
++                          128 * 3 + 8, 128 * 7 + 8, 128 * 11 + 8, 8
++    LASX_CAL_IDCT_8_ELE_2X xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, \
++                           xr16, xr17, xr18, xr19, xr20, xr21, xr22, xr23, xr11, xr12, \
++                           128 * 2 + 12, 128 * 6 + 12, 128 * 10 + 12, 128 * 14 + 12, \
++                           128 * 3 + 12, 128 * 7 + 12, 128 * 11 + 12, 12
++.endm
++
++.macro LASX_IDCT32_OUT_SORT _in0, _in1, _tmp
++    xvpermi.d     \_in0,   \_in0,  0xd8
++    xvpermi.d     \_in1,   \_in1,  0xd8
++    xmov          \_tmp,   \_in0
++    xvpermi.q     \_in0,   \_in1,  0x02
++    xvpermi.q     \_in1,   \_tmp,  0x13
++.endm
++
++.macro LASX_CLA_IDCT32_EE
++    /* EEO[0...3] */
++    LASX_CAL_IDCT_4_ELE_2 xr1, xr3, xr5, xr7, xr20, xr21, xr22, xr23, xr16, xr19, \
++                          128 * 4, 128 * 12, 128 * 5, 128 * 13
++    LASX_CAL_IDCT_4_ELE_2X xr1, xr3, xr5, xr7, xr20, xr21, xr22, xr23, xr17, xr18, \
++                           128 * 4 + 4, 128 * 12 + 4, 128 * 5 + 4, 128 * 13 + 4
++
++    /* EEEE */
++    xvldrepl.w     xr1,    t1,     0
++    xvmul.w        xr20,   xr0,    xr1
++    xvmadd.w       xr20,   xr4,    xr1  // EEEE[0]
++    xvmul.w        xr21,   xr0,    xr1
++    xvmsub.w       xr21,   xr4,    xr1  // EEEE[1]
++
++    /* EEEO */
++    xvldrepl.w     xr1,    t1,     128 * 8
++    xvldrepl.w     xr5,    t1,     128 * 8 + 4
++    xvmul.w        xr22,    xr2,    xr1
++    xvmadd.w       xr22,    xr6,    xr5  // EEEO[0]
++    xvmul.w        xr23,    xr2,    xr5
++    xvmsub.w       xr23,    xr6,    xr1  // EEEO[1]
++
++    /* EEE */
++    xvadd.w        xr4,     xr20,     xr22 // EEE[0]
++    xvsub.w        xr7,     xr20,     xr22 // EEE[3]
++    xvadd.w        xr5,     xr21,     xr23 // EEE[1]
++    xvsub.w        xr6,     xr21,     xr23 // EEE[2]
++
++    /* EE*/
++    xvadd.w        xr0,     xr4,      xr16 //EE[0]
++    xvsub.w        xr23,    xr4,      xr16 //EE[7]
++    xvadd.w        xr1,     xr5,      xr17 //EE[1]
++    xvsub.w        xr22,    xr5,      xr17 //EE[6]
++    xvadd.w        xr2,     xr6,      xr18 //EE[2]
++    xvsub.w        xr21,    xr6,      xr18 //EE[5]
++    xvadd.w        xr3,     xr7,      xr19 //EE[3]
++    xvsub.w        xr20,    xr7,      xr19 //EE[4]
++.endm
++
++.macro LASX_IDCT32_8_ROW _rin, _shift
++    /* O */
++    xvld          xr0,     \_rin,  64    //line1
++    xvld          xr1,     \_rin,  192   //line3
++    xvld          xr2,     \_rin,  320   //line5
++    xvld          xr3,     \_rin,  448   //line7
++    xvld          xr4,     \_rin,  576   //line9
++    xvld          xr5,     \_rin,  704   //line11
++    xvld          xr6,     \_rin,  832   //line13
++    xvld          xr7,     \_rin,  960   //line15
++    xvld          xr8,     \_rin,  1088  //line17
++    xvld          xr9,     \_rin,  1216  //line19
++    xvld          xr10,    \_rin,  1344  //line21
++    xvld          xr11,    \_rin,  1472  //line23
++    xvld          xr12,    \_rin,  1600  //line25
++    xvld          xr13,    \_rin,  1728  //line27
++    xvld          xr14,    \_rin,  1856  //line29
++    xvld          xr15,    \_rin,  1984  //line31
++
++    .irp i, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7, xr8, xr9, \
++            xr10, xr11, xr12, xr13, xr14, xr15
++    xvpermi.d     \i,      \i,     0xd8
++    xvsllwil.w.h  \i,      \i,     0
++    .endr
++    LASX_CLA_IDCT32_O
++
++    xvld          xr0,     \_rin,  128   //line2
++    xvld          xr1,     \_rin,  384   //line6
++    xvld          xr2,     \_rin,  640   //line10
++    xvld          xr3,     \_rin,  896   //line14
++    xvld          xr4,     \_rin,  1152  //line18
++    xvld          xr5,     \_rin,  1408  //line22
++    xvld          xr6,     \_rin,  1664  //line26
++    xvld          xr7,     \_rin,  1920  //line30
++    .irp i, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7
++    xvpermi.d     \i,      \i,     0xd8
++    xvsllwil.w.h  \i,      \i,     0
++    .endr
++    LASX_CLA_IDCT32_EO
++
++    xvld          xr0,     \_rin,  0     //line0
++    xvld          xr1,     \_rin,  256   //line4
++    xvld          xr2,     \_rin,  512   //line8
++    xvld          xr3,     \_rin,  768   //line12
++    xvld          xr4,     \_rin,  1024  //line16
++    xvld          xr5,     \_rin,  1280  //line20
++    xvld          xr6,     \_rin,  1536  //line24
++    xvld          xr7,     \_rin,  1792  //line38
++    .irp i, xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7
++    xvpermi.d     \i,      \i,     0xd8
++    xvsllwil.w.h  \i,      \i,     0
++    .endr
++    LASX_CLA_IDCT32_EE
++
++    /* E */
++    xvadd.w        xr4,     xr0,      xr8  //E[0]
++    xvsub.w        xr19,    xr0,      xr8  //E[15]
++    xvadd.w        xr5,     xr1,      xr9  //E[1]
++    xvsub.w        xr18,    xr1,      xr9  //E[14]
++    xvadd.w        xr6,     xr2,      xr10 //E[2]
++    xvsub.w        xr17,    xr2,      xr10 //E[13]
++    xvadd.w        xr7,     xr3,      xr11 //E[3]
++    xvsub.w        xr16,    xr3,      xr11 //E[12]
++    xvadd.w        xr8,     xr20,     xr12 //E[4]
++    xvsub.w        xr3,     xr20,     xr12 //E[11]
++    xvadd.w        xr9,     xr21,     xr13 //E[5]
++    xvsub.w        xr2,     xr21,     xr13 //E[10]
++    xvadd.w        xr10,    xr22,     xr14 //E[6]
++    xvsub.w        xr1,     xr22,     xr14 //E[9]
++    xvadd.w        xr11,    xr23,     xr15 //E[7]
++    xvsub.w        xr0,     xr23,     xr15 //E[8]
++
++    /* dst */
++    xvadd.w        xr12,    xr4,      xr24 //[0]
++    xvsub.w        xr23,    xr4,      xr24 //[31]
++    xvadd.w        xr13,    xr5,      xr25 //[1]
++    xvsub.w        xr22,    xr5,      xr25 //[30]
++    xvadd.w        xr14,    xr6,      xr26 //[2]
++    xvsub.w        xr21,    xr6,      xr26 //[29]
++    xvadd.w        xr15,    xr7,      xr27 //[3]
++    xvsub.w        xr20,    xr7,      xr27 //[28]
++
++    xvadd.w        xr4,     xr8,      xr28 //[4]
++    xvsub.w        xr27,    xr8,      xr28 //[27]
++    xvadd.w        xr5,     xr9,      xr29 //[5]
++    xvsub.w        xr26,    xr9,      xr29 //[26]
++    xvadd.w        xr6,     xr10,     xr30 //[6]
++    xvsub.w        xr25,    xr10,     xr30 //[25]
++    xvadd.w        xr7,     xr11,     xr31 //[7]
++    xvsub.w        xr24,    xr11,     xr31 //[24]
++
++    LASX_TRANSPOSE8x8_W_EXTRA xr12, xr13, xr14, xr15, xr4, xr5, xr6, xr7, \
++                              xr8, xr9, xr10, xr11, xr28, xr29, xr30, xr31
++    LASX_TRANSPOSE8x8_W_EXTRA xr24, xr25, xr26, xr27, xr20, xr21, xr22, xr23, \
++                              xr12, xr13, xr14, xr15, xr4, xr5, xr6, xr7
++
++    xvssrarni.h.w  xr12,    xr8,     \_shift
++    xvssrarni.h.w  xr13,    xr9,     \_shift
++    xvssrarni.h.w  xr14,    xr10,    \_shift
++    xvssrarni.h.w  xr15,    xr11,    \_shift
++    xvssrarni.h.w  xr4,     xr28,    \_shift
++    xvssrarni.h.w  xr5,     xr29,    \_shift
++    xvssrarni.h.w  xr6,     xr30,    \_shift
++    xvssrarni.h.w  xr7,     xr31,    \_shift
++
++    xvld           xr24,    t4,      0
++    xvld           xr25,    t4,      32
++    xvld           xr26,    t4,      32 * 2
++    xvld           xr27,    t4,      32 * 3
++    xvld           xr8,     t4,      32 * 4
++    xvld           xr9,     t4,      32 * 5
++    xvld           xr10,    t4,      32 * 6
++    xvld           xr11,    t4,      32 * 7
++
++    xvadd.w        xr20,    xr0,      xr24 //[8]
++    xvsub.w        xr31,    xr0,      xr24 //[23]
++    xvadd.w        xr21,    xr1,      xr25 //[9]
++    xvsub.w        xr30,    xr1,      xr25 //[22]
++    xvadd.w        xr22,    xr2,      xr26 //[10]
++    xvsub.w        xr29,    xr2,      xr26 //[21]
++    xvadd.w        xr23,    xr3,      xr27 //[11]
++    xvsub.w        xr28,    xr3,      xr27 //[20]
++
++    xvadd.w        xr24,    xr16,     xr8  //[12]
++    xvsub.w        xr3,     xr16,     xr8  //[19]
++    xvadd.w        xr25,    xr17,     xr9  //[13]
++    xvsub.w        xr2,     xr17,     xr9  //[18]
++    xvadd.w        xr26,    xr18,     xr10 //[14]
++    xvsub.w        xr1,     xr18,     xr10 //[17]
++    xvadd.w        xr27,    xr19,     xr11 //[15]
++    xvsub.w        xr0,     xr19,     xr11 //[16]
++
++    LASX_TRANSPOSE8x8_W_EXTRA xr20, xr21, xr22, xr23, xr24, xr25, xr26, xr27, \
++                              xr8, xr9, xr10, xr11, xr16, xr17, xr18, xr19
++    LASX_TRANSPOSE8x8_W_EXTRA xr0, xr1, xr2, xr3, xr28, xr29, xr30, xr31, \
++                              xr20, xr21, xr22, xr23, xr24, xr25, xr26, xr27
++
++    xvssrarni.h.w  xr20,    xr8,    \_shift
++    xvssrarni.h.w  xr21,    xr9,    \_shift
++    xvssrarni.h.w  xr22,    xr10,   \_shift
++    xvssrarni.h.w  xr23,    xr11,   \_shift
++    xvssrarni.h.w  xr24,    xr16,   \_shift
++    xvssrarni.h.w  xr25,    xr17,   \_shift
++    xvssrarni.h.w  xr26,    xr18,   \_shift
++    xvssrarni.h.w  xr27,    xr19,   \_shift
++
++    /* Output sorting */
++    LASX_IDCT32_OUT_SORT  xr12, xr20, xr0
++    LASX_IDCT32_OUT_SORT  xr13, xr21, xr0
++    LASX_IDCT32_OUT_SORT  xr14, xr22, xr0
++    LASX_IDCT32_OUT_SORT  xr15, xr23, xr0
++    LASX_IDCT32_OUT_SORT  xr4,  xr24, xr0
++    LASX_IDCT32_OUT_SORT  xr5,  xr25, xr0
++    LASX_IDCT32_OUT_SORT  xr6,  xr26, xr0
++    LASX_IDCT32_OUT_SORT  xr7,  xr27, xr0
++.endm
++
++/* void x265_idct32_lasx(const int16_t* src, int16_t* dst, intptr_t dstStride) */
++function x265_idct32_lasx
++    addi.d        sp,      sp,      -1184 //-(64 + 8*32 + 32*32*2) si12 Immediate overflow
++    addi.d        sp,      sp,      -1184
++    fst.d         f24,     sp,      0
++    fst.d         f25,     sp,      8
++    fst.d         f26,     sp,      16
++    fst.d         f27,     sp,      24
++    fst.d         f28,     sp,      32
++    fst.d         f29,     sp,      40
++    fst.d         f30,     sp,      48
++    fst.d         f31,     sp,      56
++    la.local      t1,      table_dct32
++    slli.d        a2,      a2,      1  //stride
++    addi.d        t5,      t1,      128 * 15
++    addi.d        t6,      t5,      128 * 15
++
++    /*
++     * The first butterfly operation.
++     */
++    addi.d        t4,      sp,      64
++    addi.d        t2,      t4,      8 * 32
++
++    /* row 0 ~ 7  */
++    LASX_IDCT32_8_ROW a0, 7
++    addi.d        a0,       a0,     16
++    xvst          xr12,     t2,     0
++    xvst          xr20,     t2,     32
++    xvst          xr13,     t2,     64
++    xvst          xr21,     t2,     96
++    xvst          xr14,     t2,     128
++    xvst          xr22,     t2,     160
++    xvst          xr15,     t2,     192
++    xvst          xr23,     t2,     224
++    xvst          xr4,      t2,     256
++    xvst          xr24,     t2,     288
++    xvst          xr5,      t2,     320
++    xvst          xr25,     t2,     352
++    xvst          xr6,      t2,     384
++    xvst          xr26,     t2,     416
++    xvst          xr7,      t2,     448
++    xvst          xr27,     t2,     480
++
++    /* row 8 ~ 15  */
++    LASX_IDCT32_8_ROW a0, 7
++    addi.d        a0,       a0,     16
++    xvst          xr12,     t2,     512
++    xvst          xr20,     t2,     544
++    xvst          xr13,     t2,     576
++    xvst          xr21,     t2,     608
++    xvst          xr14,     t2,     640
++    xvst          xr22,     t2,     672
++    xvst          xr15,     t2,     704
++    xvst          xr23,     t2,     736
++    xvst          xr4,      t2,     768
++    xvst          xr24,     t2,     800
++    xvst          xr5,      t2,     832
++    xvst          xr25,     t2,     864
++    xvst          xr6,      t2,     896
++    xvst          xr26,     t2,     928
++    xvst          xr7,      t2,     960
++    xvst          xr27,     t2,     992
++
++    /* row 16 ~ 23  */
++    LASX_IDCT32_8_ROW a0, 7
++    addi.d        a0,       a0,     16
++    xvst          xr12,     t2,     1024
++    xvst          xr20,     t2,     1056
++    xvst          xr13,     t2,     1088
++    xvst          xr21,     t2,     1120
++    xvst          xr14,     t2,     1152
++    xvst          xr22,     t2,     1184
++    xvst          xr15,     t2,     1216
++    xvst          xr23,     t2,     1248
++    xvst          xr4,      t2,     1280
++    xvst          xr24,     t2,     1312
++    xvst          xr5,      t2,     1344
++    xvst          xr25,     t2,     1376
++    xvst          xr6,      t2,     1408
++    xvst          xr26,     t2,     1440
++    xvst          xr7,      t2,     1472
++    xvst          xr27,     t2,     1504
++
++    /* row 24 ~ 31  */
++    LASX_IDCT32_8_ROW a0, 7
++    xvst          xr12,     t2,     1536
++    xvst          xr20,     t2,     1568
++    xvst          xr13,     t2,     1600
++    xvst          xr21,     t2,     1632
++    xvst          xr14,     t2,     1664
++    xvst          xr22,     t2,     1696
++    xvst          xr15,     t2,     1728
++    xvst          xr23,     t2,     1760
++    xvst          xr4,      t2,     1792
++    xvst          xr24,     t2,     1824
++    xvst          xr5,      t2,     1856
++    xvst          xr25,     t2,     1888
++    xvst          xr6,      t2,     1920
++    xvst          xr26,     t2,     1952
++    xvst          xr7,      t2,     1984
++    xvst          xr27,     t2,     2016
++
++    /*
++     * The second butterfly operation.
++     */
++
++    /* row 0 ~ 7  */
++    LASX_IDCT32_8_ROW t2, 12
++    addi.d        t2,       t2,     16
++    xvst          xr12,     a1,     0
++    xvst          xr20,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr13,     a1,     0
++    xvst          xr21,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr14,     a1,     0
++    xvst          xr22,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr15,     a1,     0
++    xvst          xr23,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr4,      a1,     0
++    xvst          xr24,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr5,      a1,     0
++    xvst          xr25,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr6,      a1,     0
++    xvst          xr26,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr7,      a1,     0
++    xvst          xr27,     a1,     32
++    add.d         a1,       a1,     a2
++
++    /* row 8 ~ 15  */
++    LASX_IDCT32_8_ROW t2, 12
++    addi.d        t2,       t2,     16
++    xvst          xr12,     a1,     0
++    xvst          xr20,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr13,     a1,     0
++    xvst          xr21,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr14,     a1,     0
++    xvst          xr22,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr15,     a1,     0
++    xvst          xr23,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr4,      a1,     0
++    xvst          xr24,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr5,      a1,     0
++    xvst          xr25,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr6,      a1,     0
++    xvst          xr26,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr7,      a1,     0
++    xvst          xr27,     a1,     32
++    add.d         a1,       a1,     a2
++
++    /* row 16 ~ 23  */
++    LASX_IDCT32_8_ROW t2, 12
++    addi.d        t2,       t2,     16
++    xvst          xr12,     a1,     0
++    xvst          xr20,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr13,     a1,     0
++    xvst          xr21,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr14,     a1,     0
++    xvst          xr22,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr15,     a1,     0
++    xvst          xr23,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr4,      a1,     0
++    xvst          xr24,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr5,      a1,     0
++    xvst          xr25,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr6,      a1,     0
++    xvst          xr26,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr7,      a1,     0
++    xvst          xr27,     a1,     32
++    add.d         a1,       a1,     a2
++
++    /* row 24 ~ 31  */
++    LASX_IDCT32_8_ROW t2, 12
++    xvst          xr12,     a1,     0
++    xvst          xr20,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr13,     a1,     0
++    xvst          xr21,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr14,     a1,     0
++    xvst          xr22,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr15,     a1,     0
++    xvst          xr23,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr4,      a1,     0
++    xvst          xr24,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr5,      a1,     0
++    xvst          xr25,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr6,      a1,     0
++    xvst          xr26,     a1,     32
++    add.d         a1,       a1,     a2
++    xvst          xr7,      a1,     0
++    xvst          xr27,     a1,     32
++
++    fld.d         f24,   sp,   0
++    fld.d         f25,   sp,   8
++    fld.d         f26,   sp,   16
++    fld.d         f27,   sp,   24
++    fld.d         f28,   sp,   32
++    fld.d         f29,   sp,   40
++    fld.d         f30,   sp,   48
++    fld.d         f31,   sp,   56
++    addi.d        sp,    sp,   1184
++    addi.d        sp,    sp,   1184
++endfunc
++
++/*
++ * scanPosLast_lsx(const uint16_t *scan, const coeff_t *coeff, uint16_t *coeffSign,
++ *                 uint16_t *coeffFlag, uint8_t *coeffNum, int numSig,
++ *                 const uint16_t* /*scanCG4x4*, const int /*trSize*)
++ */
++function x265_scanPosLast_lsx
++    /* loading scan table and convert to Byte */
++    vld           vr0,   a6,   0
++    vld           vr20,  a6,   16
++    vssrarni.b.h  vr20,  vr0,  0      // Zigzag scan table
++    vxori.b       vr21,  vr20, 15
++
++    /* convert unit of Stride(trSize) to int16_t */
++    slli.d        a7,    a7,   1
++    slli.d        t1,    a7,   1
++    add.d         t2,    t1,   a7
++
++    /* clear CG count */
++    xor           t7,    t7,   t7
++    li.d          t0,    0xffffffff00000000
++    li.d          a6,    0xffffffff
++1:
++    /* position of current CG */
++    ld.h          t8,    a0,   0
++    slli.d        t8,    t8,   1
++    add.d         t8,    a1,   t8
++    addi.d        a0,    a0,   16 * 2
++
++    /* loading current CG */
++    vld           vr0,   t8,   0
++    vldx          vr1,   t8,   a7
++    vldx          vr2,   t8,   t1
++    vldx          vr3,   t8,   t2
++    vilvl.d       vr1,   vr1,  vr0
++    vilvl.d       vr3,   vr3,  vr2
++    vssrarni.b.h  vr3,   vr1,  0
++
++    /* Zigzag */
++    vshuf.b       vr4,   vr3,  vr3,  vr20
++    vshuf.b       vr8,   vr3,  vr3,  vr21
++
++    /* get sign */
++    vmskltz.b     vr5,   vr4
++    vpickve2gr.hu t4,    vr5,  0
++    vmsknz.b      vr6,   vr4
++    vpickve2gr.hu t5,    vr6,  0
++
++    /* pext */
++    addi.d        t3,    zero, 64
++    beqz          t5,    3f
++2:
++    cto.w         t8,    t5
++    rotr.d        t4,    t4,   t8
++    and           t6,    t4,   t0
++    srl.d         t5,    t5,   t8
++    sub.d         t3,    t3,   t8
++
++    ctz.w         t8,    t5
++    srl.d         t4,    t4,   t8
++    and           t4,    t4,   a6
++    or            t4,    t4,   t6
++    srl.d         t5,    t5,   t8
++    bnez          t5,    2b
++3:
++    srl.d         t4,    t4,   t3
++
++    /* get non-zero flag */
++    vmsknz.b      vr6,   vr8
++    vpickve2gr.hu t5,    vr6,  0    //coeffFlag
++    vpcnt.h       vr7,   vr6
++    vpickve2gr.hu t8,    vr7,  0    //coeffNum
++
++    slli.d        t6,    t7,   1
++    sub.d         a5,    a5,   t8
++    stx.b         t8,    a4,   t7
++    stx.h         t5,    a3,   t6
++    stx.h         t4,    a2,   t6
++    addi.d        t7,    t7,   1
++    blt           zero,  a5,   1b
++
++    /* fixup last CG non-zero flag */
++    ctz.w         t8,    t5
++    srl.d         t0,    t5,   t8
++    stx.h         t0,    a3,   t6
++
++    /* get last pos */
++    addi.d        t7,    t7,   -1
++    slli.w        t7,    t7,   4
++    xori          t8,    t8,   15
++    add.d         a0,    t7,   t8
++endfunc
++
++/* costCoeffNxN_lsx(const uint16_t *scan, const coeff_t *coeff, intptr_t trSize,
++ *                  uint16_t *absCoeff, const uint8_t *tabSigCtx, uint32_t scanFlagMask,
++ *                  uint8_t *baseCtx, int offset, int scanPosSigOff, int subPosBase)
++ */
++function x265_costCoeffNxN_lsx
++    /* abs(coeff) */
++    slli.d        a2,    a2,   1
++    slli.d        t1,    a2,   1
++    add.d         t0,    t1,   a2
++    vldi          vr20,   0
++    vld           vr0,   a1,   0
++    vldx          vr1,   a1,   a2
++    vldx          vr2,   a1,   t1
++    vldx          vr3,   a1,   t0
++    vilvl.d       vr0,   vr1,  vr0
++    vilvl.d       vr1,   vr3,  vr2
++    vabsd.h       vr4,   vr0,  vr20
++    vabsd.h       vr5,   vr1,  vr20  //coeff
++
++    /* loading scan table */
++    ld.d          a2,    sp,   0
++    addi.d        a1,    a2,   -15   //scanPosSigOff-16
++    slli.d        a1,    a1,   1
++    vldx          vr0,   a0,   a1
++    addi.d        a0,    a0,   16
++    vldx          vr1,   a0,   a1    //scan
++    vmov          vr3,   vr1
++    vssrarni.b.h  vr3,   vr0,  0
++
++    /* scanPosSigOff < (SCAN_SET_SIZE - 1) ? 1 : 0 */
++    addi.d        t5,    zero, 1
++    addi.d        t6,    a2,   1
++    srli.d        t6,    t6,   4
++    masknez       t6,    t5,   t6
++
++    /* reorder coeff */
++    vshuf.h       vr0,   vr5,  vr4
++    vshuf.h       vr1,   vr5,  vr4
++
++    /* loading tabSigCtx (+offset) */
++    vld           vr2,   a4,   0
++    vreplgr2vr.b  vr8,   a7
++    vshuf.b       vr9,   vr2,  vr2,  vr3
++    vadd.b        vr2,   vr9,  vr8  //sigCtx
++
++    // free {a0, a1, a2, a4, a7, sp + 0}
++    la.local      a0,    entropyStateBits
++    la.local      a4,    shift_1
++    vld           vr20,  a4,   0
++    la.local      a4,    shift_2
++    vld           vr21,  a4,   0
++    la.local      a4,    shift_3
++    vld           vr22,  a4,   0
++    li.d          t7,    0xffffff
++    xor           a4,    a4,   a4  // numNonZero
++    xor           t8,    t8,   t8  // sum
++    beqz          a2,    3f        // scanPosSigOff
++1:
++    vstelm.h      vr1,   a3,   0,   7      // absCoeff[numNonZero] = tmpCoeff[blkPos]
++    vpickve2gr.bu a7,    vr2,  15
++    ldx.b         a1,    a6,   a7          // mstate = baseCtx[ctxSig]
++    vshuf.b       vr1,   vr1,  vr0,  vr21  // update tmpCoeff
++    vshuf.b       vr0,   vr0,  vr0,  vr20
++    vshuf.b       vr2,   vr2,  vr2,  vr22  // ctxSig
++
++    andi          t0,    a5,   1           // t0 = sig
++    srli.d        a5,    a5,   1
++    add.d         a4,    a4,   t0          // numNonZero += sig
++    alsl.d        a3,    t0,   a3,  1      // absCoeff
++    andi          t3,    a1,   1           // mps = mstate & 1
++    xor           t4,    a1,   t0          // t4 = mstate ^ sig
++    slli.d        t1,    t4,   2
++    ldx.w         t2,    a0,   t1          // stateBits t2
++    add.d         t8,    t8,   t2          // sum += stateBits
++
++    addi.d        t4,    t4,   -1
++    bnez          t4,    2f
++    stx.b         t0,    a6,   a7
++    addi.d        a2,    a2,   -1
++    blt           zero,  a2,   1b
++    b             3f
++2:
++    srli.d        t2,    t2,   24
++    add.d         t3,    t3,   t2          // nextState = (stateBits >> 24) + mps
++    stx.b         t3,    a6,   a7
++    addi.d        a2,    a2,   -1
++    blt           zero,  a2,   1b
++3:
++    ld.w          t4,    sp,   8           // subPosBase
++    vstelm.h      vr1,   a3,   0,   7      // absCoeff[numNonZero] = tmpCoeff[blkPos]
++    add.d         a4,    a4,   t6
++    masknez       t4,    t5,   t4
++    add.d         a4,    a4,   t4
++    beqz          a4,    5f
++
++    addi.d        t4,    t4,   -1
++    vpickve2gr.bu a7,    vr2,  15
++    and           a7,    a7,   t4          // ctxSig
++    ldx.b         a1,    a6,   a7          // mstate = baseCtx[ctxSig]
++    andi          t3,    a1,   1           // mps = mstate & 1
++    xor           a1,    a1,   a5          // a1 = mstate ^ sig
++    slli.d        t1,    a1,   2
++    ldx.w         t2,    a0,   t1          // stateBits t2
++    add.d         t8,    t8,   t2          // sum += stateBits
++    srli.d        t2,    t2,   24
++    add.d         t3,    t3,   t2          // nextState = (stateBits >> 24) + mps
++
++    addi.d        a1,    a1,   -1
++    bnez          a1,    4f
++    slli.d        t3,    a5,   0
++4:
++    stx.b         t3,    a6,   a7
++5:
++    and           a0,    t8,   t7
++endfunc
+diff --git a/source/common/loongarch64/dct.h b/source/common/loongarch64/dct.h
+new file mode 100644
+index 000000000..4ea8d5f20
+--- /dev/null
++++ b/source/common/loongarch64/dct.h
+@@ -0,0 +1,57 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Peng Zhou <zhoupeng@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_LOONGARCH_DCT_H
++#define X265_LOONGARCH_DCT_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++void PFX(dct32_lsx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(dct16_lsx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(dct4_lsx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(dct8_lsx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(idct4_lsx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++void PFX(idct8_lsx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++void PFX(idct16_lsx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++void PFX(idct32_lsx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++void PFX(dst4_lsx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(idst4_lsx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++int PFX(scanPosLast_lsx)(const uint16_t *scan, const coeff_t *coeff,
++                         uint16_t *coeffSign, uint16_t *coeffFlag, uint8_t *coeffNum,
++                         int numSig, const uint16_t* scanCG4x4, const int trSize);
++uint32_t PFX(costCoeffNxN_lsx)(const uint16_t *scan, const coeff_t *coeff, intptr_t trSize,
++                               uint16_t *absCoeff, const uint8_t *tabSigCtx, uint32_t scanFlagMask,
++                               uint8_t *baseCtx, int offset, int scanPosSigOff, int subPosBase);
++
++void PFX(dct16_lasx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(dct32_lasx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
++void PFX(idct16_lasx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++void PFX(idct32_lasx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++
++#ifdef __cplusplus
++}
++#endif /*__cplusplus*/
++
++#endif // ifndef X265_LOONGARCH_DCT_H
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0007-FROMLIST-LoongArch64-Optimize-functions-in-dct.S-fil.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0007-FROMLIST-LoongArch64-Optimize-functions-in-dct.S-fil.patch
@@ -1,0 +1,561 @@
+From bc2d58b852664d9aae648ea78b923c4659b05258 Mon Sep 17 00:00:00 2001
+From: Hao Chen <chenhao@loongson.cn>
+Date: Tue, 11 Jun 2024 11:18:14 +0800
+Subject: [PATCH 07/15] FROMLIST: LoongArch64: Optimize functions in dct.S file
+ - Patch 2
+
+The optimized functions are as follows:
+quant_lsx/quant_lasx
+dequant_normal_lsx/dequant_normal_lasx
+dequant_scaling_lsx/dequant_scaling_lasx
+nquant_lsx/nquant_lasx
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/loongarch64/asm-primitives.cpp |   8 +
+ source/common/loongarch64/dct.S              | 480 +++++++++++++++++++
+ source/common/loongarch64/dct.h              |   8 +
+ 3 files changed, 496 insertions(+)
+
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index ff1e7b0a5..b79297367 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -215,6 +215,10 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.idst4x4              = PFX(idst4_lsx);
+         p.scanPosLast          = PFX(scanPosLast_lsx);
+         p.costCoeffNxN         = PFX(costCoeffNxN_lsx);
++        p.quant                = PFX(quant_lsx);
++        p.dequant_normal       = PFX(dequant_normal_lsx);
++        p.dequant_scaling      = PFX(dequant_scaling_lsx);
++        p.nquant               = PFX(nquant_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -288,6 +292,10 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.cu[BLOCK_32x32].dct  = PFX(dct32_lasx);
+         p.cu[BLOCK_16x16].idct = PFX(idct16_lasx);
+         p.cu[BLOCK_32x32].idct = PFX(idct32_lasx);
++        p.quant                = PFX(quant_lasx);
++        p.dequant_normal       = PFX(dequant_normal_lasx);
++        p.dequant_scaling      = PFX(dequant_scaling_lasx);
++        p.nquant               = PFX(nquant_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/dct.S b/source/common/loongarch64/dct.S
+index c9d25daf4..7f9b05b42 100644
+--- a/source/common/loongarch64/dct.S
++++ b/source/common/loongarch64/dct.S
+@@ -5651,3 +5651,483 @@ function x265_costCoeffNxN_lsx
+ 5:
+     and           a0,    t8,   t7
+ endfunc
++
++/* uint32_t quant_c(const int16_t* coef, const int32_t* quantCoeff,
++   int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff)
++*/
++function x265_quant_lsx
++    srli.d        t0,    a6,   4     //numCoeff / 16
++    vreplgr2vr.w  vr20,  a4         //qBits
++    vreplgr2vr.w  vr22,  a5         //add
++    vldi          vr23,  0          //numsig
++    vldi          vr10,  0
++    vldi          vr11,  0x401
++    vsubi.wu      vr21,  vr20, 8    //qBits8
++1:
++    vld           vr0,   a0,   0     //level
++    vld           vr1,   a0,   16
++    vld           vr2,   a1,   0     //quantCoeff
++    vld           vr3,   a1,   16
++    vld           vr4,   a1,   32
++    vld           vr5,   a1,   48
++    vsigncov.h    vr6,   vr0,  vr11
++    vsigncov.h    vr7,   vr1,  vr11
++    vadda.h       vr8,   vr0,  vr10  //abs(level)
++    vadda.h       vr9,   vr1,  vr10
++    vor.v         vr6,   vr6,  vr11  //sign
++    vor.v         vr7,   vr7,  vr11
++    vilvl.h       vr12,  vr10, vr8
++    vilvh.h       vr13,  vr10, vr8
++    vilvl.h       vr14,  vr10, vr9
++    vilvh.h       vr15,  vr10, vr9
++    vmul.w        vr12,  vr12, vr2  //tmplevel
++    vmul.w        vr13,  vr13, vr3
++    vmul.w        vr14,  vr14, vr4
++    vmul.w        vr15,  vr15, vr5
++    vadd.w        vr2,   vr12, vr22   //templevel + add
++    vadd.w        vr3,   vr13, vr22
++    vadd.w        vr4,   vr14, vr22
++    vadd.w        vr5,   vr15, vr22
++    vsra.w        vr2,   vr2,  vr20   //level
++    vsra.w        vr3,   vr3,  vr20
++    vsra.w        vr4,   vr4,  vr20
++    vsra.w        vr5,   vr5,  vr20
++    vsll.w        vr16,  vr2,  vr20   //level << qBits
++    vsll.w        vr17,  vr3,  vr20
++    vsll.w        vr18,  vr4,  vr20
++    vsll.w        vr19,  vr5,  vr20
++    vsub.w        vr12,  vr12, vr16
++    vsub.w        vr13,  vr13, vr17
++    vsub.w        vr14,  vr14, vr18
++    vsub.w        vr15,  vr15, vr19
++    vsra.w        vr12,  vr12, vr21
++    vsra.w        vr13,  vr13, vr21
++    vsra.w        vr14,  vr14, vr21
++    vsra.w        vr15,  vr15, vr21
++    vst           vr12,  a2,   0
++    vst           vr13,  a2,   16
++    vst           vr14,  a2,   32
++    vst           vr15,  a2,   48
++    vseq.w        vr16,  vr2,  vr10
++    vseq.w        vr17,  vr3,  vr10
++    vseq.w        vr18,  vr4,  vr10
++    vseq.w        vr19,  vr5,  vr10
++    vpickev.h     vr8,   vr17, vr16
++    vpickev.h     vr9,   vr19, vr18
++    vilvl.h       vr16,  vr6,  vr6
++    vilvl.h       vr18,  vr7,  vr7
++    vandn.v       vr12,  vr8,  vr11
++    vandn.v       vr13,  vr9,  vr11
++    vilvh.h       vr17,  vr6,  vr6
++    vilvh.h       vr19,  vr7,  vr7
++    vsigncov.w    vr0,   vr16, vr2
++    vsigncov.w    vr8,   vr18, vr4
++    vsigncov.w    vr1,   vr17, vr3
++    vsigncov.w    vr9,   vr19, vr5
++    vadd.h        vr23,  vr23, vr12
++    vssrani.h.w   vr1,   vr0,  0
++    vssrani.h.w   vr9,   vr8,  0
++    vadd.h        vr23,  vr23, vr13
++    vst           vr1,   a3,   0
++    vst           vr9,   a3,   16
++    addi.d        t0,    t0,   -1
++    addi.d        a0,    a0,   32
++    addi.d        a1,    a1,   64
++    addi.d        a2,    a2,   64
++    addi.d        a3,    a3,   32
++    blt           zero,  t0,   1b
++    vhaddw.wu.hu  vr0,   vr23, vr23
++    vhaddw.du.wu  vr1,   vr0,  vr0
++    vhaddw.qu.du  vr2,   vr1,  vr1
++    vpickve2gr.w  a0,    vr2,  0
++endfunc
++
++function x265_quant_lasx
++    srli.d         t0,    a6,   4     //numCoeff / 16
++    xvreplgr2vr.w  xr20,  a4         //qBits
++    xvreplgr2vr.w  xr22,  a5         //add
++    xvldi          xr23,  0          //numsig
++    xvldi          xr10,  0
++    xvldi          xr11,  0x401
++    xvsubi.wu      xr21,  xr20, 8    //qBits8
++2:
++    xvld           xr0,   a0,   0     //level
++    xvld           xr1,   a1,   0     //quantCoeff
++    xvld           xr2,   a1,   32
++    xvpermi.d      xr0,   xr0,  0xD8
++    xvsigncov.h    xr6,   xr0,  xr11
++    xvadda.h       xr8,   xr0,  xr10  //abs(level)
++    xvor.v         xr6,   xr6,  xr11  //sign
++    xvilvl.h       xr12,  xr10, xr8
++    xvilvh.h       xr13,  xr10, xr8
++    xvmul.w        xr12,  xr12, xr1  //tmplevel
++    xvmul.w        xr13,  xr13, xr2
++    xvadd.w        xr2,   xr12, xr22   //templevel + add
++    xvadd.w        xr3,   xr13, xr22
++    xvsra.w        xr2,   xr2,  xr20   //level
++    xvsra.w        xr3,   xr3,  xr20
++    xvsll.w        xr16,  xr2,  xr20   //level << qBits
++    xvsll.w        xr17,  xr3,  xr20
++    xvsub.w        xr12,  xr12, xr16
++    xvsub.w        xr13,  xr13, xr17
++    xvsra.w        xr12,  xr12, xr21
++    xvsra.w        xr13,  xr13, xr21
++    xvseq.w        xr16,  xr2,  xr10
++    xvseq.w        xr17,  xr3,  xr10
++    xvst           xr12,  a2,   0
++    xvst           xr13,  a2,   32
++    xvpickev.h     xr8,   xr17, xr16
++    xvilvl.h       xr16,  xr6,  xr6
++    xvilvh.h       xr17,  xr6,  xr6
++    xvandn.v       xr12,  xr8,  xr11
++    xvsigncov.w    xr0,   xr16, xr2
++    xvsigncov.w    xr1,   xr17, xr3
++    xvadd.h        xr23,  xr23, xr12
++    xvssrani.h.w   xr1,   xr0,  0
++    addi.d         t0,    t0,   -1
++    addi.d         a0,    a0,   32
++    xvpermi.d      xr2,   xr1,  0xD8
++    addi.d         a1,    a1,   64
++    addi.d         a2,    a2,   64
++    xvst           xr2,   a3,   0
++    addi.d         a3,    a3,   32
++    blt            zero,  t0,   2b
++    xvhaddw.wu.hu  xr0,   xr23, xr23
++    xvhaddw.du.wu  xr1,   xr0,  xr0
++    xvhaddw.qu.du  xr2,   xr1,  xr1
++    xvpickve2gr.w  t0,    xr2,  0
++    xvpickve2gr.w  t1,    xr2,  4
++    add.d          a0,    t0,   t1
++endfunc
++
++/* void dequant_normal(const int16_t* quantCoef, int16_t* coef, int num,
++   int scale, int shift)
++*/
++function x265_dequant_normal_lsx
++    srli.d        t0,    a2,   4     //num / 16
++    andi          t1,    a2,   15
++    vreplgr2vr.w  vr20,  a3         //scale
++    vreplgr2vr.w  vr21,  a4
++1:
++    beqz          t0,    2f
++    vld           vr0,   a0,   0     //quantCoef
++    vld           vr1,   a0,   16
++    addi.d        a0,    a0,   32
++    vsllwil.w.h   vr2,   vr0,  0
++    vsllwil.w.h   vr4,   vr1,  0
++    vexth.w.h     vr3,   vr0
++    vexth.w.h     vr5,   vr1
++    vmul.w        vr6,   vr2,  vr20
++    vmul.w        vr7,   vr3,  vr20
++    vmul.w        vr8,   vr4,  vr20
++    vmul.w        vr9,   vr5,  vr20
++    vssrarn.h.w   vr0,   vr6,  vr21
++    vssrarn.h.w   vr1,   vr7,  vr21
++    vssrarn.h.w   vr2,   vr8,  vr21
++    vssrarn.h.w   vr3,   vr9,  vr21
++    vilvl.d       vr7,   vr1,  vr0
++    vilvl.d       vr9,   vr3,  vr2
++    addi.d        t0,    t0,   -1
++    vst           vr7,   a1,   0
++    vst           vr9,   a1,   16
++    addi.d        a1,    a1,   32
++    b             1b
++2:
++    beqz          t1,    3f
++    vld           vr0,   a0,   0
++    vsllwil.w.h   vr1,   vr0,  0
++    vexth.w.h     vr2,   vr0
++    vmul.w        vr3,   vr1,  vr20
++    vmul.w        vr4,   vr2,  vr20
++    vssrarn.h.w   vr5,   vr3,  vr21
++    vssrarn.h.w   vr6,   vr4,  vr21
++    vilvl.d       vr7,   vr6,  vr5
++    vst           vr7,   a1,   0
++3:
++endfunc
++
++function x265_dequant_normal_lasx
++    srli.d         t0,    a2,   4     //num / 16
++    andi           t1,    a2,   15
++    xvreplgr2vr.w  xr20,  a3         //scale
++    xvreplgr2vr.w  xr21,  a4
++1:
++    beqz           t0,    2f
++    xvld           xr0,   a0,   0     //quantCoef
++    addi.d         a0,    a0,   32
++    xvsllwil.w.h   xr1,   xr0,  0
++    xvexth.w.h     xr2,   xr0
++    xvmul.w        xr3,   xr1,  xr20
++    xvmul.w        xr4,   xr2,  xr20
++    addi.d         t0,    t0,   -1
++    xvssrarn.h.w   xr5,   xr3,  xr21
++    xvssrarn.h.w   xr6,   xr4,  xr21
++    xvilvl.d       xr7,   xr6,  xr5
++    xvst           xr7,   a1,   0
++    addi.d         a1,    a1,   32
++    blt            zero,  t0,   1b
++2:
++    beqz           t1,    3f
++    vld            vr0,   a0,   0
++    vext2xv.w.h    xr1,   xr0
++    xvmul.w        xr2,   xr1,  xr20
++    xvssrarn.h.w   xr3,   xr2,  xr21
++    xvpermi.d      xr4,   xr3,  0xD8
++    vst            vr4,   a1,   0
++3:
++endfunc
++
++/* void dequant_scaling(const int16_t* quantCoef, const int32_t* deQuantCoef,
++   int16_t* coef, int num, int per, int shift)
++*/
++function x265_dequant_scaling_lsx
++    addi.d         a5,    a5,   4
++    srli.d         t0,    a3,   4
++    bge            a4,    a5,   1f
++    sub.d          t3,    a5,   a4
++    vreplgr2vr.w   vr20,  t3
++2:
++    beqz           t0,    3f
++    vld            vr0,   a0,   0
++    vld            vr1,   a0,   16
++    vld            vr2,   a1,   0
++    vld            vr3,   a1,   16
++    vld            vr4,   a1,   32
++    vld            vr5,   a1,   48
++    vsllwil.w.h    vr6,   vr0,  0
++    vsllwil.w.h    vr8,   vr1,  0
++    vexth.w.h      vr7,   vr0
++    vexth.w.h      vr9,   vr1
++    vmul.w         vr10,  vr6,  vr2
++    vmul.w         vr11,  vr7,  vr3
++    vmul.w         vr12,  vr8,  vr4
++    vmul.w         vr13,  vr9,  vr5
++    vssrarn.h.w    vr0,   vr10, vr20
++    vssrarn.h.w    vr1,   vr11, vr20
++    vssrarn.h.w    vr2,   vr12, vr20
++    vssrarn.h.w    vr3,   vr13, vr20
++    addi.d         t0,    t0,   -1
++    vilvl.d        vr4,   vr1,  vr0
++    vilvl.d        vr5,   vr3,  vr2
++    addi.d         a0,    a0,   32
++    addi.d         a1,    a1,   64
++    vst            vr4,   a2,   0
++    vst            vr5,   a2,   16
++    addi.d         a2,    a2,   32
++    b              2b
++1:
++    sub.d          t3,    a4,   a5
++    vreplgr2vr.w   vr20,  t3
++4:
++    beqz           t0,    3f
++    vld            vr0,   a0,   0
++    vld            vr1,   a0,   16
++    vld            vr2,   a1,   0
++    vld            vr3,   a1,   16
++    vld            vr4,   a1,   32
++    vld            vr5,   a1,   48
++    vsllwil.w.h    vr6,   vr0,  0
++    vsllwil.w.h    vr8,   vr1,  0
++    vexth.w.h      vr7,   vr0
++    vexth.w.h      vr9,   vr1
++    vmul.w         vr10,  vr6,  vr2
++    vmul.w         vr11,  vr7,  vr3
++    vmul.w         vr12,  vr8,  vr4
++    vmul.w         vr13,  vr9,  vr5
++    vsat.w         vr0,   vr10, 31
++    vsat.w         vr1,   vr11, 31
++    vsat.w         vr2,   vr12, 31
++    vsat.w         vr3,   vr13, 31
++    vsll.w         vr4,   vr0,  vr20
++    vsll.w         vr5,   vr1,  vr20
++    vsll.w         vr6,   vr2,  vr20
++    vsll.w         vr7,   vr3,  vr20
++    addi.d         a0,    a0,   32
++    vssrani.h.w    vr5,   vr4,  0
++    vssrani.h.w    vr7,   vr6,  0
++    addi.d         a1,    a1,   64
++    addi.d         t0,    t0,   -1
++    vst            vr5,   a2,   0
++    vst            vr7,   a2,   16
++    addi.d         a2,    a2,   32
++    b              4b
++3:
++endfunc
++
++function x265_dequant_scaling_lasx
++    addi.d         a5,    a5,   4
++    srli.d         t0,    a3,   4
++    bge            a4,    a5,   1f
++    sub.d          t3,    a5,   a4
++    xvreplgr2vr.w  xr20,  t3
++2:
++    beqz           t0,    4f
++    xvld           xr0,   a0,   0
++    xvld           xr2,   a1,   0
++    xvld           xr3,   a1,   32
++    xvpermi.d      xr1,   xr0,  0xD8
++    xvsllwil.w.h   xr6,   xr1,  0
++    xvexth.w.h     xr7,   xr1
++    xvmul.w        xr10,  xr6,  xr2
++    xvmul.w        xr11,  xr7,  xr3
++    xvssrarn.h.w   xr0,   xr10, xr20
++    xvssrarn.h.w   xr1,   xr11, xr20
++    addi.d         t0,    t0,   -1
++    xvilvl.d       xr4,   xr1,  xr0
++    addi.d         a0,    a0,   32
++    xvpermi.d      xr5,   xr4,  0xD8
++    addi.d         a1,    a1,   64
++    xvst           xr5,   a2,   0
++    addi.d         a2,    a2,   32
++    b              2b
++1:
++    sub.d          t3,    a4,   a5
++    xvreplgr2vr.w  xr20,  t3
++3:
++    beqz           t0,    4f
++    xvld           xr0,   a0,   0
++    xvld           xr2,   a1,   0
++    xvld           xr3,   a1,   32
++    xvpermi.d      xr1,   xr0,  0xD8
++    xvsllwil.w.h   xr6,   xr1,  0
++    xvexth.w.h     xr7,   xr1
++    xvmul.w        xr10,  xr6,  xr2
++    xvmul.w        xr11,  xr7,  xr3
++    xvsat.w        xr0,   xr10, 31
++    xvsat.w        xr1,   xr11, 31
++    xvsll.w        xr4,   xr0,  xr20
++    xvsll.w        xr5,   xr1,  xr20
++    addi.d         a0,    a0,   32
++    xvssrani.h.w   xr5,   xr4,  0
++    addi.d         a1,    a1,   64
++    xvpermi.d      xr6,   xr5,  0xD8
++    addi.d         t0,    t0,   -1
++    xvst           xr6,   a2,   0
++    addi.d         a2,    a2,   32
++    b              3b
++4:
++endfunc
++
++/* uint32_t nquant_c(const int16_t* coef, const int32_t* quantCoeff,
++   int16_t* qCoef, int qBits, int add, int numCoeff)
++*/
++function x265_nquant_lsx
++    srli.d        t0,    a5,   4     //numCoeff / 16
++    vreplgr2vr.w  vr20,  a3         //qBits
++    vreplgr2vr.w  vr22,  a4         //add
++    vldi          vr23,  0          //numsig
++    vldi          vr10,  0
++    vldi          vr11,  0x401
++1:
++    vld           vr0,   a0,   0     //level
++    vld           vr1,   a0,   16
++    vld           vr2,   a1,   0     //quantCoeff
++    vld           vr3,   a1,   16
++    vld           vr4,   a1,   32
++    vld           vr5,   a1,   48
++    vsigncov.h    vr6,   vr0,  vr11
++    vsigncov.h    vr7,   vr1,  vr11
++    vadda.h       vr8,   vr0,  vr10  //abs(level)
++    vadda.h       vr9,   vr1,  vr10
++    vor.v         vr6,   vr6,  vr11  //sign
++    vor.v         vr7,   vr7,  vr11
++    vilvl.h       vr12,  vr10, vr8
++    vilvh.h       vr13,  vr10, vr8
++    vilvl.h       vr14,  vr10, vr9
++    vilvh.h       vr15,  vr10, vr9
++    vmul.w        vr12,  vr12, vr2  //tmplevel
++    vmul.w        vr13,  vr13, vr3
++    vmul.w        vr14,  vr14, vr4
++    vmul.w        vr15,  vr15, vr5
++    vadd.w        vr2,   vr12, vr22   //templevel + add
++    vadd.w        vr3,   vr13, vr22
++    vadd.w        vr4,   vr14, vr22
++    vadd.w        vr5,   vr15, vr22
++    vsra.w        vr2,   vr2,  vr20   //level
++    vsra.w        vr3,   vr3,  vr20
++    vsra.w        vr4,   vr4,  vr20
++    vsra.w        vr5,   vr5,  vr20
++
++    vseq.w        vr16,  vr2,  vr10
++    vseq.w        vr17,  vr3,  vr10
++    vseq.w        vr18,  vr4,  vr10
++    vseq.w        vr19,  vr5,  vr10
++    vpickev.h     vr8,   vr17, vr16
++    vpickev.h     vr9,   vr19, vr18
++    vilvl.h       vr16,  vr6,  vr6
++    vilvl.h       vr18,  vr7,  vr7
++    vandn.v       vr12,  vr8,  vr11
++    vandn.v       vr13,  vr9,  vr11
++    vilvh.h       vr17,  vr6,  vr6
++    vilvh.h       vr19,  vr7,  vr7
++    vsigncov.w    vr0,   vr16, vr2
++    vsigncov.w    vr8,   vr18, vr4
++    vsigncov.w    vr1,   vr17, vr3
++    vsigncov.w    vr9,   vr19, vr5
++    vadd.h        vr23,  vr23, vr12
++    vssrani.h.w   vr1,   vr0,  0
++    vssrani.h.w   vr9,   vr8,  0
++    vadd.h        vr23,  vr23, vr13
++    vadda.h       vr1,   vr1,  vr10
++    vadda.h       vr9,   vr9,  vr10
++    vst           vr1,   a2,   0
++    vst           vr9,   a2,   16
++    addi.d        t0,    t0,   -1
++    addi.d        a0,    a0,   32
++    addi.d        a1,    a1,   64
++    addi.d        a2,    a2,   32
++    blt           zero,  t0,   1b
++    vhaddw.wu.hu  vr0,   vr23, vr23
++    vhaddw.du.wu  vr1,   vr0,  vr0
++    vhaddw.qu.du  vr2,   vr1,  vr1
++    vpickve2gr.w  a0,    vr2,  0
++endfunc
++
++function x265_nquant_lasx
++    srli.d         t0,    a5,   4     //numCoeff / 16
++    xvreplgr2vr.w  xr20,  a3         //qBits
++    xvreplgr2vr.w  xr22,  a4         //add
++    xvldi          xr23,  0          //numsig
++    xvldi          xr10,  0
++    xvldi          xr11,  0x401
++1:
++    xvld           xr0,   a0,   0     //level
++    xvld           xr1,   a1,   0     //quantCoeff
++    xvld           xr2,   a1,   32
++    xvpermi.d      xr0,   xr0,  0xD8
++    xvsigncov.h    xr6,   xr0,  xr11
++    xvadda.h       xr8,   xr0,  xr10  //abs(level)
++    xvor.v         xr6,   xr6,  xr11  //sign
++    xvilvl.h       xr12,  xr10, xr8
++    xvilvh.h       xr13,  xr10, xr8
++    xvmul.w        xr12,  xr12, xr1  //tmplevel
++    xvmul.w        xr13,  xr13, xr2
++    xvadd.w        xr2,   xr12, xr22   //templevel + add
++    xvadd.w        xr3,   xr13, xr22
++    xvsra.w        xr2,   xr2,  xr20   //level
++    xvsra.w        xr3,   xr3,  xr20
++    xvseq.w        xr16,  xr2,  xr10
++    xvseq.w        xr17,  xr3,  xr10
++    xvpickev.h     xr8,   xr17, xr16
++    xvilvl.h       xr16,  xr6,  xr6
++    xvilvh.h       xr17,  xr6,  xr6
++    xvandn.v       xr12,  xr8,  xr11
++    xvsigncov.w    xr0,   xr16, xr2
++    xvsigncov.w    xr1,   xr17, xr3
++    xvadd.h        xr23,  xr23, xr12
++    xvssrani.h.w   xr1,   xr0,  0
++    addi.d         t0,    t0,   -1
++    addi.d         a0,    a0,   32
++    xvpermi.d      xr2,   xr1,  0xD8
++    addi.d         a1,    a1,   64
++    xvadda.h       xr2,   xr2,  xr10
++    xvst           xr2,   a2,   0
++    addi.d         a2,    a2,   32
++    blt            zero,  t0,   1b
++    xvhaddw.wu.hu  xr0,   xr23, xr23
++    xvhaddw.du.wu  xr1,   xr0,  xr0
++    xvhaddw.qu.du  xr2,   xr1,  xr1
++    xvpickve2gr.w  t0,    xr2,  0
++    xvpickve2gr.w  t1,    xr2,  4
++    add.d          a0,    t0,   t1
++endfunc
+diff --git a/source/common/loongarch64/dct.h b/source/common/loongarch64/dct.h
+index 4ea8d5f20..f78422e61 100644
+--- a/source/common/loongarch64/dct.h
++++ b/source/common/loongarch64/dct.h
+@@ -44,11 +44,19 @@ int PFX(scanPosLast_lsx)(const uint16_t *scan, const coeff_t *coeff,
+ uint32_t PFX(costCoeffNxN_lsx)(const uint16_t *scan, const coeff_t *coeff, intptr_t trSize,
+                                uint16_t *absCoeff, const uint8_t *tabSigCtx, uint32_t scanFlagMask,
+                                uint8_t *baseCtx, int offset, int scanPosSigOff, int subPosBase);
++uint32_t PFX(quant_lsx)(const int16_t* coef, const int32_t* quantCoeff, int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff);
++void PFX(dequant_normal_lsx)(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
++void PFX(dequant_scaling_lsx)(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
++uint32_t PFX(nquant_lsx)(const int16_t* coef, const int32_t* quantCoeff, int16_t* qCoef, int qBits, int add, int numCoeff);
+ 
+ void PFX(dct16_lasx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
+ void PFX(dct32_lasx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
+ void PFX(idct16_lasx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
+ void PFX(idct32_lasx)(const int16_t* src, int16_t* dst, intptr_t dstStride);
++uint32_t PFX(quant_lasx)(const int16_t* coef, const int32_t* quantCoeff, int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff);
++void PFX(dequant_normal_lasx)(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
++void PFX(dequant_scaling_lasx)(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
++uint32_t PFX(nquant_lasx)(const int16_t* coef, const int32_t* quantCoeff, int16_t* qCoef, int qBits, int add, int numCoeff);
+ 
+ #ifdef __cplusplus
+ }
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0008-FROMLIST-LoongArch64-Optimize-functions-in-dct.S-fil.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0008-FROMLIST-LoongArch64-Optimize-functions-in-dct.S-fil.patch
@@ -1,0 +1,974 @@
+From e272af58b70438e744b9e10865e05c5c25ffe508 Mon Sep 17 00:00:00 2001
+From: pengxu <pengxu@loongson.cn>
+Date: Tue, 11 Jun 2024 15:58:19 +0800
+Subject: [PATCH 08/15] FROMLIST: LoongArch64: Optimize functions in dct.S file
+ - Patch 3
+
+The optimized functions are as follows:
+count_nonzero_32_lsx/count_nonzero_32_lasx
+count_nonzero_16_lsx/count_nonzero_16_lasx
+count_nonzero_8_lsx/count_nonzero_8_lasx
+count_nonzero_4_lsx/count_nonzero_4_lasx
+costC1C2Flag_lsx
+costCoeffRemain_lsx
+findPosFirstLast_lsx/findPosFirstLast_lasx
+denoiseDct_lsx/denoiseDct_lasx
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/loongarch64/asm-primitives.cpp |  14 +
+ source/common/loongarch64/dct.S              | 868 +++++++++++++++++++
+ source/common/loongarch64/dct.h              |  14 +
+ 3 files changed, 896 insertions(+)
+
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index b79297367..ef17528f3 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -219,6 +219,14 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.dequant_normal       = PFX(dequant_normal_lsx);
+         p.dequant_scaling      = PFX(dequant_scaling_lsx);
+         p.nquant               = PFX(nquant_lsx);
++        p.cu[BLOCK_32x32].count_nonzero = PFX(count_nonzero_32_lsx);
++        p.cu[BLOCK_16x16].count_nonzero = PFX(count_nonzero_16_lsx);
++        p.cu[BLOCK_8x8].count_nonzero   = PFX(count_nonzero_8_lsx);
++        p.cu[BLOCK_4x4].count_nonzero   = PFX(count_nonzero_4_lsx);
++        p.costC1C2Flag         = PFX(costC1C2Flag_lsx);
++        p.costCoeffRemain      = PFX(costCoeffRemain_lsx);
++        p.findPosFirstLast     = PFX(findPosFirstLast_lsx);
++        p.denoiseDct           = PFX(denoiseDct_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -296,6 +304,12 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.dequant_normal       = PFX(dequant_normal_lasx);
+         p.dequant_scaling      = PFX(dequant_scaling_lasx);
+         p.nquant               = PFX(nquant_lasx);
++        p.cu[BLOCK_32x32].count_nonzero = PFX(count_nonzero_32_lasx);
++        p.cu[BLOCK_16x16].count_nonzero = PFX(count_nonzero_16_lasx);
++        p.cu[BLOCK_8x8].count_nonzero   = PFX(count_nonzero_8_lasx);
++        p.cu[BLOCK_4x4].count_nonzero   = PFX(count_nonzero_4_lasx);
++        p.findPosFirstLast     = PFX(findPosFirstLast_lasx);
++        p.denoiseDct           = PFX(denoiseDct_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/dct.S b/source/common/loongarch64/dct.S
+index 7f9b05b42..0973d2f09 100644
+--- a/source/common/loongarch64/dct.S
++++ b/source/common/loongarch64/dct.S
+@@ -117,6 +117,36 @@ const table_dct32
+ .int  4, -13, 22, -31, 38, -46, 54, -61, 67, -73, 78, -82, 85, -88, 90, -90, 90, -90, 88, -85, 82, -78, 73, -67, 61, -54, 46, -38, 31, -22, 13, -4
+ endconst
+ 
++const gt_entropyBits
++.int 31523,34297,29856,36028,28388,37716,26612,39963,24752,42538,23196,44891,21645,47445,20310,49833
++.int 19079,52215,17878,54723,16708,57371,15752,59703,14816,62157,13923,64670,13127,67072,12368,69525
++.int 11597,72194,10963,74547,10350,76973,9732,79583,9253,81736,8692,84420,8254,86651,7757,89344
++.int 7321,91870,6936,94231,6565,96648,6209,99111,5855,101712,5593,103751,5244,106627,5006,108707
++.int 4689,111640,4454,113959,4200,116603,3967,119182,3802,121114,3609,123476,3407,126106,3216,128736
++.int 3073,130808,2911,133297,2742,136034,2581,138822,2440,141405,2356,143016,2216,145842,2077,148855
++.int 1993,150758,1891,153187,1808,155279,1696,158246,1650,159523,1512,163576,1466,165045,1374,168023
++.int 1292,170923,1217,173684,1191,174686,1135,176943,1055,180397,999,182925,954,185123,268,245691
++endconst
++
++const gt_nextState
++.byte 2, 1, 0, 3, 4, 0, 1, 5, 6, 2, 3, 7, 8, 4, 5, 9
++.byte 10, 4, 5, 11, 12, 8, 9, 13, 14, 8, 9, 15, 16, 10, 11, 17
++.byte 18, 12, 13, 19, 20, 14, 15, 21, 22, 16, 17, 23, 24, 18, 19, 25
++.byte 26, 18, 19, 27, 28, 22, 23, 29, 30, 22, 23, 31, 32, 24, 25, 33
++.byte 34, 26, 27, 35, 36, 26, 27, 37, 38, 30, 31, 39, 40, 30, 31, 41
++.byte 42, 32, 33, 43, 44, 32, 33, 45, 46, 36, 37, 47, 48, 36, 37, 49
++.byte 50, 38, 39, 51, 52, 38, 39, 53, 54, 42, 43, 55, 56, 42, 43, 57
++.byte 58, 44, 45, 59, 60, 44, 45, 61, 62, 46, 47, 63, 64, 48, 49, 65
++.byte 66, 48, 49, 67, 68, 50, 51, 69, 70, 52, 53, 71, 72, 52, 53, 73
++.byte 74, 54, 55, 75, 76, 54, 55, 77, 78, 56, 57, 79, 80, 58, 59, 81
++.byte 82, 58, 59, 83, 84, 60, 61, 85, 86, 60, 61, 87, 88, 60, 61, 89
++.byte 90, 62, 63, 91, 92, 64, 65, 93, 94, 64, 65, 95, 96, 66, 67, 97
++.byte 98, 66, 67, 99, 100, 66, 67, 101, 102, 68, 69, 103, 104, 68, 69, 105
++.byte 106, 70, 71, 107, 108, 70, 71, 109, 110, 70, 71, 111, 112, 72, 73, 113
++.byte 114, 72, 73, 115, 116, 72, 73, 117, 118, 74, 75, 119, 120, 74, 75, 121
++.byte 122, 74, 75, 123, 124, 76, 77, 125, 124, 76, 77, 125, 126, 126, 127, 127
++endconst
++
+ /*
+  * Description : Transpose 4x4 block with word elements in vectors
+  * Arguments   : Inputs  - in0, in1, in2, in3
+@@ -6131,3 +6161,841 @@ function x265_nquant_lasx
+     xvpickve2gr.w  t1,    xr2,  4
+     add.d          a0,    t0,   t1
+ endfunc
++
++function x265_count_nonzero_32_lsx
++    or             t0,    zero, zero //count
++    or             t5,    zero, zero //index
++    ori            t2,    zero, 128  //loop max
++
++.CN32L01: //8
++    vldx           vr0,   a0,   t5
++    vseqi.h        vr1,   vr0,  0
++    vaddi.hu       vr1,   vr1,  1
++    vhaddw.wu.hu   vr2,   vr1,  vr1
++    vhaddw.du.wu   vr3,   vr2,  vr2
++    vhaddw.qu.du   vr3,   vr3,  vr3
++    vpickve2gr.hu  t6,    vr3,  0
++    add.d          t0,    t0,   t6
++
++    addi.d         t5,    t5,   16
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN32L01
++
++.CN32L02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_16_lsx
++    or             t0,    zero, zero //count
++    or             t5,    zero, zero //index
++    ori            t2,    zero, 32  //loop max
++
++.CN16L01: //8
++    vldx           vr0,   a0,   t5
++    vseqi.h        vr1,   vr0,  0
++    vaddi.hu       vr1,   vr1,  1
++    vhaddw.wu.hu   vr2,   vr1,  vr1
++    vhaddw.du.wu   vr3,   vr2,  vr2
++    vhaddw.qu.du   vr3,   vr3,  vr3
++    vpickve2gr.hu  t6,    vr3,  0
++    add.d          t0,    t0,   t6
++
++    addi.d         t5,    t5,   16
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN16L01
++
++.CN16L02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_8_lsx
++    or             t0,    zero, zero //count
++    or             t5,    zero, zero //index
++    ori            t2,    zero, 8  //loop max
++
++.CN8L01: //8
++    vldx           vr0,   a0,   t5
++    vseqi.h        vr1,   vr0,  0
++    vaddi.hu       vr1,   vr1,  1
++    vhaddw.wu.hu   vr2,   vr1,  vr1
++    vhaddw.du.wu   vr3,   vr2,  vr2
++    vhaddw.qu.du   vr3,   vr3,  vr3
++    vpickve2gr.hu  t6,    vr3,  0
++    add.d          t0,    t0,   t6
++
++    addi.d         t5,    t5,   16
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN8L01
++
++.CN8L02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_4_lsx
++    or             t0,    zero, zero //count
++    or             t5,    zero, zero //index
++    ori            t2,    zero, 2  //loop max
++
++.CN4L01: //8
++    vldx           vr0,   a0,   t5
++    vseqi.h        vr1,   vr0,  0
++    vaddi.hu       vr1,   vr1,  1
++    vhaddw.wu.hu   vr2,   vr1,  vr1
++    vhaddw.du.wu   vr3,   vr2,  vr2
++    vhaddw.qu.du   vr3,   vr3,  vr3
++    vpickve2gr.hu  t6,    vr3,  0
++    add.d          t0,    t0,   t6
++
++    addi.d         t5,    t5,   16
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN4L01
++
++.CN4L02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_32_lasx
++    or             t0,    zero, zero //count
++    or             t3,    zero, zero //index
++    ori            t2,    zero, 64  //loop max
++
++.CN32LA01: //16
++    xvldx          xr0,   a0,   t3
++    xvseqi.h       xr1,   xr0,  0
++    xvaddi.hu      xr1,   xr1,  1
++    xvhaddw.wu.hu  xr1,   xr1,  xr1
++    xvhaddw.du.wu  xr1,   xr1,  xr1
++    xvhaddw.qu.du  xr1,   xr1,  xr1
++    xvpermi.q      xr0,   xr1,  0x01
++    vadd.d         vr1,   vr1,  vr0
++    vpickve2gr.hu  t4,    vr1,  0
++    add.d          t0,    t0,   t4
++
++    addi.d         t3,    t3,   32
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN32LA01
++
++.CN32LA02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_16_lasx
++    or             t0,    zero, zero //count
++    or             t3,    zero, zero //index
++    ori            t2,    zero, 16  //loop max
++
++.CN16LA01: //16
++    xvldx          xr0,   a0,   t3
++    xvseqi.h       xr1,   xr0,  0
++    xvaddi.hu      xr1,   xr1,  1
++    xvhaddw.wu.hu  xr1,   xr1,  xr1
++    xvhaddw.du.wu  xr1,   xr1,  xr1
++    xvhaddw.qu.du  xr1,   xr1,  xr1
++    xvpermi.q      xr0,   xr1,  0x01
++    vadd.d         vr1,   vr1,  vr0
++    vpickve2gr.hu  t4,    vr1,  0
++    add.d          t0,    t0,   t4
++
++    addi.d         t3,    t3,   32
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN16LA01
++
++.CN16LA02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_8_lasx
++    or             t0,    zero, zero //count
++    or             t3,    zero, zero //index
++    ori            t2,    zero, 4  //loop max
++
++.CN8LA01: //16
++    xvldx          xr0,   a0,   t3
++    xvseqi.h       xr1,   xr0,  0
++    xvaddi.hu      xr1,   xr1,  1
++    xvhaddw.wu.hu  xr1,   xr1,  xr1
++    xvhaddw.du.wu  xr1,   xr1,  xr1
++    xvhaddw.qu.du  xr1,   xr1,  xr1
++    xvpermi.q      xr0,   xr1,  0x01
++    vadd.d         vr1,   vr1,  vr0
++    vpickve2gr.hu  t4,    vr1,  0
++    add.d          t0,    t0,   t4
++
++    addi.d         t3,    t3,   32
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN8LA01
++
++.CN8LA02:
++    move           a0,    t0
++endfunc
++
++function x265_count_nonzero_4_lasx
++    or             t0,    zero, zero //count
++    or             t3,    zero, zero //index
++    ori            t2,    zero, 1  //loop max
++
++.CN4LA01: //16
++    xvldx          xr0,   a0,   t3
++    xvseqi.h       xr1,   xr0,  0
++    xvaddi.hu      xr1,   xr1,  1
++    xvhaddw.wu.hu  xr1,   xr1,  xr1
++    xvhaddw.du.wu  xr1,   xr1,  xr1
++    xvhaddw.qu.du  xr1,   xr1,  xr1
++    xvpermi.q      xr0,   xr1,  0x01
++    vadd.d         vr1,   vr1,  vr0
++    vpickve2gr.hu  t4,    vr1,  0
++    add.d          t0,    t0,   t4
++
++    addi.d         t3,    t3,   32
++    addi.d         t2,    t2,   -1
++    bnez           t2,   .CN4LA01
++
++.CN4LA02:
++    move           a0,    t0
++endfunc
++
++.macro COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM in0, in1, in2, in3, in4, out0, tmp0, tmp1
++    ldx.bu         \tmp0, \in2, \in0
++    add.d          \tmp1, \tmp0,\tmp0
++    add.d          \tmp1, \tmp1,\in1
++    ldx.bu         \tmp1, \in3, \tmp1  //baseCtxMod
++    stx.b          \tmp1, \in2, \in0
++    slli.d         \tmp0, \tmp0,2
++    slli.d         \tmp1, \in1, 2
++    xor            \tmp1, \tmp0,\tmp1
++    ldx.wu         \tmp1, \in4, \tmp1
++    add.d          \out0, \out0,\tmp1  //sum
++.endm
++
++//param: absCoeff:a0, numC1Flag:a1, baseCtxMod:a2, ctxOffset:a3
++function x265_costC1C2Flag_lsx
++    or             a4,    zero, zero //sum
++    addi.d         a5,    zero, 8    //firstC2Idx
++    addi.d         a6,    zero, 2    //firstC2Flag
++    li.d           a7,    0xfffffffe //c1Next
++    addi.d         t0,    zero, 1    //c1
++    or             t1,    zero, zero //idx
++    vandi.b        vr0,   vr0,  0
++    vaddi.hu       vr1,   vr0,  1
++    vaddi.hu       vr2,   vr0,  2
++
++    la.local       t5,    gt_nextState
++    la.local       t6,    gt_entropyBits
++
++    beqz           a1,    .CC1C2FL030
++
++    srai.d         t2,    a1,   2   //loop param
++    beqz           t2,   .CC1C2FL02
++
++.CC1C2FL01: //4
++    fldx.d         f0,    a0,   t1
++    vslt.hu        vr3,   vr1,  vr0
++    vslt.hu        vr4,   vr2,  vr0
++    vneg.h         vr3,   vr3  //symbol1
++    vneg.h         vr4,   vr4  //symbol2
++    srai.d         t8,    t1,   1
++
++    vpickve2gr.hu  t3,    vr3,  0
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0101
++    vpickve2gr.hu  a6,    vr4,  0
++.CC1C2FL0101:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0102
++    or             a5,    t8,   t8
++.CC1C2FL0102:
++    beqz           t3,    .CC1C2FL0103
++    or             a7,    zero, zero
++    or             t0,    zero, zero
++    b              .CC1C2FL01040
++.CC1C2FL0103:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++.CC1C2FL01040:
++    vpickve2gr.hu  t3,    vr3,  1
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0104
++    vpickve2gr.hu  a6,    vr4,  1
++.CC1C2FL0104:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0105
++    addi.d         a5,    t8,   1
++.CC1C2FL0105:
++    beqz           t3,    .CC1C2FL0106
++    or             a7,    zero, zero
++    or             t0,    zero, zero
++    b              .CC1C2FL01070
++.CC1C2FL0106:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++.CC1C2FL01070:
++    vpickve2gr.hu  t3,    vr3,  2
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0107
++    vpickve2gr.hu  a6,    vr4,  2
++.CC1C2FL0107:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0108
++    addi.d         a5,    t8,   2
++.CC1C2FL0108:
++    beqz           t3,    .CC1C2FL0109
++    or             a7,    zero, zero
++    or             t0,    zero, zero
++    b              .CC1C2FL01100
++.CC1C2FL0109:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++.CC1C2FL01100:
++    vpickve2gr.hu  t3,    vr3,  3
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0110
++    vpickve2gr.hu  a6,    vr4,  3
++.CC1C2FL0110:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0111
++    addi.d         a5,    t8,   3
++.CC1C2FL0111:
++    beqz           t3,    .CC1C2FL0112
++    or             a7,    zero, zero
++    or             t0,    zero, zero
++    b              .CC1C2FL0113
++.CC1C2FL0112:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++.CC1C2FL0113:
++    addi.d         t1,    t1,   8
++    addi.d         t2,    t2,   -1
++    bnez           t2,    .CC1C2FL01
++
++.CC1C2FL02: //2
++    andi           t7,    a1,   2
++    beqz           t7,    .CC1C2FL03
++
++    fldx.d         f0,    a0,   t1
++    vslt.hu        vr3,   vr1,  vr0
++    vslt.hu        vr4,   vr2,  vr0
++    vneg.h         vr3,   vr3  //symbol1
++    vneg.h         vr4,   vr4  //symbol2
++    srai.d         t8,    t1,   1
++
++    vpickve2gr.hu  t3,    vr3,  0
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0201
++    vpickve2gr.hu  a6,    vr4,  0
++.CC1C2FL0201:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0202
++    or             a5,    t8,   t8
++.CC1C2FL0202:
++    beqz           t3,    .CC1C2FL0203
++    or             a7,    zero, zero
++.CC1C2FL0203:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++    vpickve2gr.hu  t3,    vr3,  1
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0204
++    vpickve2gr.hu  a6,    vr4,  1
++.CC1C2FL0204:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0205
++    addi.d         a5,    t8,   1
++.CC1C2FL0205:
++    beqz           t3,    .CC1C2FL0206
++    or             a7,    zero, zero
++.CC1C2FL0206:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++    addi.d         t1,    t1,   4
++
++.CC1C2FL03: //1
++    andi           t7,    a1,   1
++    beqz           t7,    .CC1C2FL04
++
++.CC1C2FL030:
++    fldx.d         f0,    a0,   t1
++    vslt.hu        vr3,   vr1,  vr0
++    vslt.hu        vr4,   vr2,  vr0
++    vneg.h         vr3,   vr3  //symbol1
++    vneg.h         vr4,   vr4  //symbol2
++    srai.d         t8,    t1,   1
++
++    vpickve2gr.hu  t3,    vr3,  0
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, t3, a2, t5, t6, a4, t4, t7
++    ori            t4,    zero, 3
++    add.d          t7,    t3,   a6
++    bne            t7,    t4,   .CC1C2FL0301
++    vpickve2gr.hu  a6,    vr4,  0
++.CC1C2FL0301:
++    ori            t4,    zero, 9
++    add.d          t7,    t3,   a5
++    bne            t7,    t4,   .CC1C2FL0302
++    or             a5,    t8,   t8
++.CC1C2FL0302:
++    beqz           t3,    .CC1C2FL0303
++    or             a7,    zero, zero
++.CC1C2FL0303:
++    andi           t0,    a7,   3
++    srai.d         a7,    a7,   2
++
++    addi.d         t1,    t1,   4
++
++.CC1C2FL04: //!c1
++    bnez           t0,    .CC1C2FL05
++    add.d          a2,    a2,   a3
++    COSTC1C2FLAG_CALC_BASECTXMOD_AND_SUM t0, a6, a2, t5, t6, a4, t4, t7
++
++.CC1C2FL05: //return
++    li.d           t1,    0x00FFFFFF
++    and            t2,    a4,   t1
++    slli.d         t3,    t0,   26
++    slli.d         t4,    a5,   28
++    add.d          a0,    t2,   t3
++    add.d          a0,    a0,   t4
++endfunc
++
++.macro CCRL_CALC_SUM in0, in1, h, out0
++    sra.d          \in0,  \in0, \in1
++    addi.d         \in0,  \in0, -3
++    blt            \in0,  zero, 1f
++    addi.d         t3,    \in0, 1
++    clz.w          t3,    t3
++    xori           t3,    t3,   31
++    add.d          \in0,  t3,   t3
++1:
++    addi.d         \out0, \out0,4
++    add.d          \out0, \out0,\in1
++    add.d          \out0, \out0,\in0
++
++    add.d          t7,    a0,   a6
++    ld.h           t2,    t7,   \h
++    sll.d          t3,    t5,   \in1
++    beq            t2,    t3,   2f
++    blt            t2,    t3,   2f
++    addi.d         t2,    \in1, 1
++    srai.d         t3,    \in1, 2
++    sub.d          \in1,  t2,   t3
++2:
++.endm
++
++//uint32_t costCoeffRemain_lsx(uint16_t *absCoeff, int numNonZero, int idx)
++//param: absCoeff:a0, numNonZero:a1, idx:a2
++function x265_costCoeffRemain_lsx
++    or             a3,    zero, zero //goRiceParam
++    or             a4,    zero, zero //sum
++    ori            t0,    zero, 3    //baseLevel0
++    slli.d         a6,    a2,   1    //data indx
++    ori            t4,    zero, 8    //C1FLAG_NUMBER
++    ori            t5,    zero, 3    //COEF_REMAIN_BIN_REDUCTION
++
++    sub.d          a7,    a1,   a2
++    bge            zero,  a7,   .CCRL030
++    srai.d         a7,    a7,   2
++    add.d          a7,    a7,   a2  //loop max
++    beq            a2,    a7,   .CCRL02
++
++.CCRL01: //4
++    ori            t1,    zero, 2
++    ori            t2,    zero, 2
++    ori            t3,    zero, 2
++
++    srai.d         t6,    a6,   1
++    blt            t6,    t4,   .CCRL0101
++    ori            t0,    zero, 1
++.CCRL0101:
++    addi.d         t7,    t6,   1
++    blt            t7,    t4,   .CCRL0102
++    ori            t1,    zero, 1
++.CCRL0102:
++    addi.d         t7,    t6,   2
++    blt            t7,    t4,   .CCRL0103
++    ori            t2,    zero, 1
++.CCRL0103:
++    addi.d         t7,    t6,   3
++    blt            t7,    t4,   .CCRL0104
++    ori            t3,    zero, 1
++.CCRL0104:
++    vinsgr2vr.h    vr1,   t0,   0
++    vinsgr2vr.h    vr1,   t1,   1
++    vinsgr2vr.h    vr1,   t2,   2
++    vinsgr2vr.h    vr1,   t3,   3
++
++    fldx.d         f0,    a0,   a6
++    vsub.h         vr0,   vr0,  vr1
++
++    ori            t0,    zero, 2
++
++    vpickve2gr.h   t1,    vr0,  0  //codeNumber0
++    blt            t1,    zero, .CCRL0105
++    CCRL_CALC_SUM  t1,    a3,   0,   a4
++
++.CCRL0105:
++    vpickve2gr.h   t1,    vr0,  1  //codeNumber1
++    blt            t1,    zero, .CCRL0106
++    CCRL_CALC_SUM  t1,    a3,   2,   a4
++
++.CCRL0106:
++    vpickve2gr.h   t1,    vr0,  2  //codeNumber2
++    blt            t1,    zero, .CCRL0107
++    CCRL_CALC_SUM  t1,    a3,   4,   a4
++
++.CCRL0107:
++    vpickve2gr.h   t1,    vr0,  3  //codeNumber3
++    blt            t1,    zero, .CCRL0108
++    CCRL_CALC_SUM  t1,    a3,   6,   a4
++
++.CCRL0108:
++    addi.d         a6,    a6,   8
++    addi.d         a7,    a7,   -1
++    blt            a2,    a7,   .CCRL01
++
++.CCRL02: //2
++    sub.d          t2,    a1,   a2
++    bge            zero,  t2,   .CCRL03
++    andi           t2,    t2,   2
++    beqz           t2,    .CCRL03
++
++    ori            t1,    zero, 2
++
++    srai.d         t6,    a6,   1
++    blt            t6,    t4,   .CCRL0201
++    ori            t0,    zero, 1
++.CCRL0201:
++    addi.d         t6,    t6,   1
++    blt            t6,    t4,   .CCRL0202
++    ori            t1,    zero, 1
++.CCRL0202:
++    vinsgr2vr.h    vr1,   t0,   0
++    vinsgr2vr.h    vr1,   t1,   1
++
++    fldx.s         f0,    a0,   a6
++    vsub.h         vr0,   vr0,  vr1
++
++    ori            t0,    zero, 2
++
++    vpickve2gr.h   t1,    vr0,  0  //codeNumber0
++    blt            t1,    zero, .CCRL0205
++    CCRL_CALC_SUM  t1,    a3,   0,   a4
++
++.CCRL0205:
++    vpickve2gr.h   t1,    vr0,  1  //codeNumber1
++    blt            t1,    zero, .CCRL0206
++    CCRL_CALC_SUM  t1,    a3,   2,   a4
++
++.CCRL0206:
++    addi.d         a6,    a6,   4
++
++.CCRL03:  //1
++    sub.d          t2,    a1,   a2
++    bge            zero,  t2,   .CCRL04
++    andi           t2,    t2,   1
++    beqz           t2,    .CCRL04
++.CCRL030:
++    srai.d         t6,    a6,   1
++    blt            t6,    t4,   .CCRL0301
++    ori            t0,    zero, 1
++.CCRL0301:
++    ldx.h          t2,    a0,   a6
++    sub.w          t1,    t2,   t0
++
++    ori            t0,    zero, 2
++
++    blt            t1,    zero, .CCRL0305
++    CCRL_CALC_SUM  t1,    a3,   0,   a4
++
++.CCRL0305:
++    addi.d         a6,    a6,   2
++
++.CCRL04:
++    or             a0,    a4,   a4
++endfunc
++
++//uint32_t findPosFirstLast_c(const int16_t *dstCoeff, const intptr_t trSize, const uint16_t scanTbl[16]);
++//param: dstCoeff: a0, trSize: a1, scanTbl[16]: a2
++function x265_findPosFirstLast_lasx
++    slli.d         a1,    a1,   1   //trSize
++    add.d          a3,    a1,   a1  //trSize * 2
++    add.d          a4,    a3,   a1  //trSize * 3
++    fld.d          f1,    a0,   0
++    fldx.d         f2,    a0,   a1
++    fldx.d         f3,    a0,   a3
++    fldx.d         f4,    a0,   a4
++
++    vpermi.w       vr2,   vr1,  0x44
++    vpermi.w       vr4,   vr3,  0x44
++    xvpermi.d      xr2,   xr2,  0x44
++    xvpermi.d      xr4,   xr4,  0x44
++
++    xvld           xr5,   a2,   0
++    xvshuf.h       xr5,   xr4,  xr2
++
++    xvhaddw.w.h    xr6,   xr5,  xr5
++    xvhaddw.d.w    xr6,   xr6,  xr6
++    xvhaddw.q.d    xr6,   xr6,  xr6
++    xvpermi.q      xr7,   xr6,  0x01
++
++    vadd.q         vr6,   vr6,  vr7
++    vpickve2gr.d   a3,    vr6,  0  //absSumSign
++
++    // calc lastNZPosInCG firstNZPosInCG
++    xvxor.v        xr1,   xr1,  xr1
++    xvabsd.h       xr2,   xr5,  xr1
++    xvneg.h        xr2,   xr2
++    xvmskltz.h     xr2,   xr2
++    vpickve2gr.h   a4,    vr2,  0
++    xvpermi.q      xr2,   xr2,  0x01
++    vpickve2gr.h   a7,    vr2,  0
++
++    ctz.w          t0,    a4   //firstNZPosInCG 1
++    or             t1,    zero, zero
++    addi.w         t2,    t0,   -32
++    bnez           t2,    1f
++    li.d           t0,    8
++    ctz.w          t1,    a7   //firstNZPosInCG 2
++    addi.w         t2,    t1,   -32
++    bnez           t2,    1f
++    li.d           t1,    8
++1:
++    add.w          a6,    t0,   t1
++
++    clz.w          t0,    a7   //lastNZPosInCG 2
++    addi.w         t0,    t0,   -24
++    or             t1,    zero, zero
++    li.d           t2,    8
++    bne            t2,    t0,   2f
++    clz.w          t1,    a4   //lastNZPosInCG 1
++    addi.w         t1,    t1,   -24
++2:
++    add.w          a5,    t0,   t1
++    li.d           a7,    15
++    sub.w          a5,    a7,  a5
++
++    bge            a5,    zero, 3f
++    li.d           a5,    0xffffffff
++3:
++    andi           t0,    a3,   1
++    beqz           t0,    4f
++    li.w           t0,    0x80000000
++4:
++    li.d           t1,    0xffffff
++    and            a5,    a5,   t1
++    slli.d         t2,    a5,   8
++    or             a7,    t0,   t2
++    or             a0,    a7,   a6
++endfunc
++
++function x265_findPosFirstLast_lsx
++    slli.d         a1,    a1,   1   //trSize
++    add.d          a3,    a1,   a1  //trSize * 2
++    add.d          a4,    a3,   a1  //trSize * 3
++    fld.d          f1,    a0,   0
++    fldx.d         f2,    a0,   a1
++    fldx.d         f3,    a0,   a3
++    fldx.d         f4,    a0,   a4
++
++    vpermi.w       vr2,   vr1,  0x44
++    vpermi.w       vr4,   vr3,  0x44
++
++    vld            vr5,   a2,   0
++    vld            vr3,   a2,   16
++
++    vshuf.h        vr5,   vr4,  vr2
++    vshuf.h        vr3,   vr4,  vr2
++
++    vhaddw.w.h     vr6,   vr5,  vr5
++    vhaddw.d.w     vr6,   vr6,  vr6
++    vhaddw.q.d     vr6,   vr6,  vr6
++
++    vhaddw.w.h     vr7,   vr3,  vr3
++    vhaddw.d.w     vr7,   vr7,  vr7
++    vhaddw.q.d     vr7,   vr7,  vr7
++
++    vadd.q         vr6,   vr6,  vr7
++    vpickve2gr.d   a3,    vr6,  0  //absSumSign
++
++    // calc lastNZPosInCG firstNZPosInCG
++    vxor.v         vr1,   vr1,  vr1
++    vabsd.h        vr2,   vr5,  vr1
++    vneg.h         vr2,   vr2
++    vmskltz.h      vr2,   vr2
++    vpickve2gr.h   a4,    vr2,  0
++    vabsd.h        vr2,   vr3,  vr1
++    vneg.h         vr2,   vr2
++    vmskltz.h      vr2,   vr2
++    vpickve2gr.h   a7,    vr2,  0
++
++    ctz.w          t0,    a4   //firstNZPosInCG 1
++    or             t1,    zero, zero
++    addi.w         t2,    t0,   -32
++    bnez           t2,    1f
++    li.d           t0,    8
++    ctz.w          t1,    a7   //firstNZPosInCG 2
++    addi.w         t2,    t1,   -32
++    bnez           t2,    1f
++    li.d           t1,    8
++1:
++    add.w          a6,    t0,   t1
++
++    clz.w          t0,    a7   //lastNZPosInCG 2
++    addi.w         t0,    t0,   -24
++    or             t1,    zero, zero
++    li.d           t2,    8
++    bne            t2,    t0,   2f
++    clz.w          t1,    a4   //lastNZPosInCG 1
++    addi.w         t1,    t1,   -24
++2:
++    add.w          a5,    t0,   t1
++    li.d           a7,    15
++    sub.w          a5,    a7,  a5
++
++    bge            a5,    zero, 3f
++    li.d           a5,    0xffffffff
++3:
++    andi           t0,    a3,   1
++    beqz           t0,    4f
++    li.w           t0,    0x80000000
++4:
++    li.d           t1,    0xffffff
++    and            a5,    a5,   t1
++    slli.d         t2,    a5,   8
++    or             a7,    t0,   t2
++    or             a0,    a7,   a6
++endfunc
++
++//void x265_denoiseDct_lsx(int16_t* dctCoef, uint32_t* resSum, const uint16_t* offset, int numCoeff)
++function x265_denoiseDct_lsx
++    vxor.v         vr4,   vr4,  vr4
++    or             a4,    zero, zero  //data index
++    srai.d         a5,    a3,   2     //loop param
++
++    beqz           a5,    2f
++
++1: // /4
++    slli.d         a6,    a4,   1
++    fldx.d         f0,    a0,   a4  //level
++    vsllwil.w.h    vr7,   vr0,  0
++
++    vsrai.w        vr1,   vr7,  31 //sign
++    vadd.w         vr7,   vr7,  vr1
++    vxor.v         vr7,   vr7,  vr1
++
++    vldx           vr2,   a1,   a6  //resSum
++    vadd.w         vr2,   vr2,  vr7
++    vstx           vr2,   a1,   a6
++
++    vldx           vr9,   a2,   a4  //offset
++    vsllwil.wu.hu  vr3,   vr9,  0
++    vsub.w         vr7,   vr7,  vr3
++
++    vxor.v         vr8,   vr7,  vr1  //level l
++    vsub.w         vr8,   vr8,  vr1
++
++    vsle.w         vr0,   vr7,  vr4
++    vbitsel.v      vr0,   vr8,  vr4,  vr0
++    vsrlni.h.w     vr2,   vr0,  0
++
++    fstx.d         f2,    a0,   a4
++
++    addi.d         a4,    a4,   8
++    addi.d         a5,    a5,   -1
++    blt            zero,  a5,   1b
++
++2:
++endfunc
++
++function x265_denoiseDct_lasx
++    xvxor.v        xr4,   xr4,  xr4
++    or             a4,    zero, zero  //data index
++    srai.d         a5,    a3,   3     //loop param
++
++    beqz           a5,    2f
++
++1: // /8
++    slli.d         a6,    a4,   1
++    vldx           vr0,   a0,   a4  //level
++    xvpermi.d      xr0,   xr0,  0x10
++    xvsllwil.w.h   xr7,   xr0,  0
++
++    xvsrai.w       xr1,   xr7,  31 //sign
++    xvadd.w        xr7,   xr7,  xr1
++    xvxor.v        xr7,   xr7,  xr1
++
++    xvldx          xr2,   a1,   a6  //resSum
++    xvadd.w        xr2,   xr2,  xr7
++    xvstx          xr2,   a1,   a6
++
++    vldx           vr9,   a2,   a4  //offset
++    xvpermi.d      xr9,   xr9,  0x10
++    xvsllwil.wu.hu xr3,   xr9,  0
++    xvsub.w        xr7,   xr7,  xr3
++
++    xvxor.v        xr8,   xr7,  xr1  //level l
++    xvsub.w        xr8,   xr8,  xr1
++
++    xvsle.w        xr0,   xr7,  xr4
++    xvbitsel.v     xr0,   xr8,  xr4,  xr0
++    xvsran.h.w     xr2,   xr0,  xr4
++    xvpermi.d      xr2,   xr2,  0x08
++
++    vstx           vr2,   a0,   a4
++
++    addi.d         a4,    a4,   16
++    addi.d         a5,    a5,   -1
++    blt            zero,  a5,   1b
++
++2:
++    andi           a5,    a3,   4
++    beqz           a5,    3f
++
++    slli.d         a6,    a4,   1
++    fldx.d         f0,    a0,   a4  //level
++    vsllwil.w.h    vr7,   vr0,  0
++
++    vsra.w         vr1,   vr7,  vr6 //sign
++    vadd.w         vr7,   vr7,  vr1
++    vxor.v         vr7,   vr7,  vr1
++
++    vldx           vr2,   a1,   a6  //resSum
++    vadd.w         vr2,   vr2,  vr7
++    vstx           vr2,   a1,   a6
++
++    vldx           vr9,   a2,   a4  //offset
++    vsllwil.wu.hu  vr3,   vr9,  0
++    vsub.w         vr7,   vr7,  vr3
++
++    vxor.v         vr8,   vr7,  vr1  //level l
++    vsub.w         vr8,   vr8,  vr1
++
++    vsle.w         vr0,   vr7,  vr4
++    vbitsel.v      vr0,   vr8,  vr4,  vr0
++    vsrlni.h.w     vr2,   vr0,  0
++
++    fstx.d         f2,    a0,   a4
++
++    addi.d         a4,    a4,   8
++3:
++endfunc
+diff --git a/source/common/loongarch64/dct.h b/source/common/loongarch64/dct.h
+index f78422e61..e1ace326f 100644
+--- a/source/common/loongarch64/dct.h
++++ b/source/common/loongarch64/dct.h
+@@ -48,6 +48,14 @@ uint32_t PFX(quant_lsx)(const int16_t* coef, const int32_t* quantCoeff, int32_t*
+ void PFX(dequant_normal_lsx)(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
+ void PFX(dequant_scaling_lsx)(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
+ uint32_t PFX(nquant_lsx)(const int16_t* coef, const int32_t* quantCoeff, int16_t* qCoef, int qBits, int add, int numCoeff);
++int PFX(count_nonzero_32_lsx)(const int16_t* quantCoeff);
++int PFX(count_nonzero_16_lsx)(const int16_t* quantCoeff);
++int PFX(count_nonzero_8_lsx)(const int16_t* quantCoeff);
++int PFX(count_nonzero_4_lsx)(const int16_t* quantCoeff);
++uint32_t PFX(costC1C2Flag_lsx)(uint16_t *absCoeff, intptr_t numNonZero, uint8_t *baseCtxMod, intptr_t ctxOffset);
++uint32_t PFX(costCoeffRemain_lsx)(uint16_t *absCoeff, int numNonZero, int idx);
++uint32_t PFX(findPosFirstLast_lsx)(const int16_t *dstCoeff, const intptr_t trSize, const uint16_t scanTbl[16]);
++void PFX(denoiseDct_lsx)(int16_t* dctCoef, uint32_t* resSum, const uint16_t* offset, int numCoeff);
+ 
+ void PFX(dct16_lasx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
+ void PFX(dct32_lasx)(const int16_t* src, int16_t* dst, intptr_t srcStride);
+@@ -57,6 +65,12 @@ uint32_t PFX(quant_lasx)(const int16_t* coef, const int32_t* quantCoeff, int32_t
+ void PFX(dequant_normal_lasx)(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
+ void PFX(dequant_scaling_lasx)(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
+ uint32_t PFX(nquant_lasx)(const int16_t* coef, const int32_t* quantCoeff, int16_t* qCoef, int qBits, int add, int numCoeff);
++int PFX(count_nonzero_32_lasx)(const int16_t* quantCoeff);
++int PFX(count_nonzero_16_lasx)(const int16_t* quantCoeff);
++int PFX(count_nonzero_8_lasx)(const int16_t* quantCoeff);
++int PFX(count_nonzero_4_lasx)(const int16_t* quantCoeff);
++uint32_t PFX(findPosFirstLast_lasx)(const int16_t *dstCoeff, const intptr_t trSize, const uint16_t scanTbl[16]);
++void PFX(denoiseDct_lasx)(int16_t* dctCoef, uint32_t* resSum, const uint16_t* offset, int numCoeff);
+ 
+ #ifdef __cplusplus
+ }
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0009-FROMLIST-LoongArch64-Optimize-functions-in-mc-a.S-fi.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0009-FROMLIST-LoongArch64-Optimize-functions-in-mc-a.S-fi.patch
@@ -1,0 +1,1292 @@
+From 441ab462fd013cacfc41496a5caa947cd0255eed Mon Sep 17 00:00:00 2001
+From: jinbo <jinbo@loongson.cn>
+Date: Wed, 12 Jun 2024 11:50:55 +0800
+Subject: [PATCH 09/15] FROMLIST: LoongArch64: Optimize functions in mc-a.S
+ file
+
+Optimize functions in mc-a.S file with lsx and lasx.
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |   4 +-
+ source/common/loongarch64/asm-primitives.cpp | 157 ++++
+ source/common/loongarch64/mc-a.S             | 921 +++++++++++++++++++
+ source/common/loongarch64/pixel.h            | 130 +++
+ 4 files changed, 1210 insertions(+), 2 deletions(-)
+ create mode 100644 source/common/loongarch64/mc-a.S
+ create mode 100644 source/common/loongarch64/pixel.h
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index f5025f030..bfa08b9b7 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -138,11 +138,11 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+         message(STATUS "Detected CXX compiler using -O3 optimization level")
+     endif()
+ 
+-    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h)
++    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h pixel.h)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S ipfilter8.S dct.S)
++    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index ef17528f3..2ce6ab686 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -28,6 +28,11 @@
+ #include "loopfilter.h"
+ #include "ipfilter8.h"
+ #include "dct.h"
++#include "pixel.h"
++
++#define ASSIGN2(func, fname) \
++    func[ALIGNED] = PFX(fname); \
++    func[NONALIGNED] = PFX(fname)
+ 
+ namespace X265_NS {
+ // private x265 namespace
+@@ -73,6 +78,18 @@ namespace X265_NS {
+     p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].p2s[NONALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].p2s[ALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU);
+ 
++#define LUMA_PU(W, H, CPU) \
++    p.pu[LUMA_ ## W ## x ## H].addAvg[NONALIGNED] = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
++    p.pu[LUMA_ ## W ## x ## H].addAvg[ALIGNED] = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
++
++#define CHROMA_PU_420(W, H, CPU) \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].addAvg[NONALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].addAvg[ALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
++
++#define CHROMA_PU_422(W, H, CPU) \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].addAvg[NONALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].addAvg[ALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
++
+ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ {
+ #if HAVE_LSX
+@@ -227,6 +244,111 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.costCoeffRemain      = PFX(costCoeffRemain_lsx);
+         p.findPosFirstLast     = PFX(findPosFirstLast_lsx);
+         p.denoiseDct           = PFX(denoiseDct_lsx);
++
++        //pixelAvg_pp
++        ASSIGN2(p.pu[LUMA_64x64].pixelavg_pp, pixel_avg_64x64_lsx);
++        ASSIGN2(p.pu[LUMA_64x48].pixelavg_pp, pixel_avg_64x48_lsx);
++        ASSIGN2(p.pu[LUMA_64x32].pixelavg_pp, pixel_avg_64x32_lsx);
++        ASSIGN2(p.pu[LUMA_64x16].pixelavg_pp, pixel_avg_64x16_lsx);
++        ASSIGN2(p.pu[LUMA_48x64].pixelavg_pp, pixel_avg_48x64_lsx);
++        ASSIGN2(p.pu[LUMA_32x64].pixelavg_pp, pixel_avg_32x64_lsx);
++        ASSIGN2(p.pu[LUMA_32x32].pixelavg_pp, pixel_avg_32x32_lsx);
++        ASSIGN2(p.pu[LUMA_32x24].pixelavg_pp, pixel_avg_32x24_lsx);
++        ASSIGN2(p.pu[LUMA_32x16].pixelavg_pp, pixel_avg_32x16_lsx);
++        ASSIGN2(p.pu[LUMA_32x8].pixelavg_pp, pixel_avg_32x8_lsx);
++        ASSIGN2(p.pu[LUMA_24x32].pixelavg_pp, pixel_avg_24x32_lsx);
++        ASSIGN2(p.pu[LUMA_16x64].pixelavg_pp, pixel_avg_16x64_lsx);
++        ASSIGN2(p.pu[LUMA_16x32].pixelavg_pp, pixel_avg_16x32_lsx);
++        ASSIGN2(p.pu[LUMA_16x16].pixelavg_pp, pixel_avg_16x16_lsx);
++        ASSIGN2(p.pu[LUMA_16x12].pixelavg_pp, pixel_avg_16x12_lsx);
++        ASSIGN2(p.pu[LUMA_16x8].pixelavg_pp, pixel_avg_16x8_lsx);
++        ASSIGN2(p.pu[LUMA_16x4].pixelavg_pp, pixel_avg_16x4_lsx);
++        ASSIGN2(p.pu[LUMA_12x16].pixelavg_pp, pixel_avg_12x16_lsx);
++        ASSIGN2(p.pu[LUMA_8x32].pixelavg_pp, pixel_avg_8x32_lsx);
++        ASSIGN2(p.pu[LUMA_8x16].pixelavg_pp, pixel_avg_8x16_lsx);
++        ASSIGN2(p.pu[LUMA_8x8].pixelavg_pp, pixel_avg_8x8_lsx);
++        ASSIGN2(p.pu[LUMA_8x4].pixelavg_pp, pixel_avg_8x4_lsx);
++        ASSIGN2(p.pu[LUMA_4x16].pixelavg_pp, pixel_avg_4x16_lsx);
++        ASSIGN2(p.pu[LUMA_4x8].pixelavg_pp, pixel_avg_4x8_lsx);
++        ASSIGN2(p.pu[LUMA_4x4].pixelavg_pp, pixel_avg_4x4_lsx);
++
++        LUMA_PU(4,   4, lsx);
++        LUMA_PU(8,   8, lsx);
++        LUMA_PU(16, 16, lsx);
++        LUMA_PU(32, 32, lsx);
++        LUMA_PU(64, 64, lsx);
++        LUMA_PU(4,   8, lsx);
++        LUMA_PU(8,   4, lsx);
++        LUMA_PU(16,  8, lsx);
++        LUMA_PU(8,  16, lsx);
++        LUMA_PU(16, 12, lsx);
++        LUMA_PU(12, 16, lsx);
++        LUMA_PU(16,  4, lsx);
++        LUMA_PU(4,  16, lsx);
++        LUMA_PU(32, 16, lsx);
++        LUMA_PU(16, 32, lsx);
++        LUMA_PU(32, 24, lsx);
++        LUMA_PU(24, 32, lsx);
++        LUMA_PU(32,  8, lsx);
++        LUMA_PU(8,  32, lsx);
++        LUMA_PU(64, 32, lsx);
++        LUMA_PU(32, 64, lsx);
++        LUMA_PU(64, 48, lsx);
++        LUMA_PU(48, 64, lsx);
++        LUMA_PU(64, 16, lsx);
++        LUMA_PU(16, 64, lsx);
++
++        CHROMA_PU_420(2,   2, lsx);
++        CHROMA_PU_420(2,   4, lsx);
++        CHROMA_PU_420(4,   4, lsx);
++        CHROMA_PU_420(8,   8, lsx);
++        CHROMA_PU_420(16, 16, lsx);
++        CHROMA_PU_420(32, 32, lsx);
++        CHROMA_PU_420(4,   2, lsx);
++        CHROMA_PU_420(8,   4, lsx);
++        CHROMA_PU_420(4,   8, lsx);
++        CHROMA_PU_420(8,   6, lsx);
++        CHROMA_PU_420(6,   8, lsx);
++        CHROMA_PU_420(8,   2, lsx);
++        CHROMA_PU_420(2,   8, lsx);
++        CHROMA_PU_420(16,  8, lsx);
++        CHROMA_PU_420(8,  16, lsx);
++        CHROMA_PU_420(16, 12, lsx);
++        CHROMA_PU_420(12, 16, lsx);
++        CHROMA_PU_420(16,  4, lsx);
++        CHROMA_PU_420(4,  16, lsx);
++        CHROMA_PU_420(32, 16, lsx);
++        CHROMA_PU_420(16, 32, lsx);
++        CHROMA_PU_420(32, 24, lsx);
++        CHROMA_PU_420(24, 32, lsx);
++        CHROMA_PU_420(32,  8, lsx);
++        CHROMA_PU_420(8,  32, lsx);
++
++        CHROMA_PU_422(2,   4, lsx);
++        CHROMA_PU_422(4,   8, lsx);
++        CHROMA_PU_422(8,  16, lsx);
++        CHROMA_PU_422(16, 32, lsx);
++        CHROMA_PU_422(32, 64, lsx);
++        CHROMA_PU_422(4,   4, lsx);
++        CHROMA_PU_422(2,   8, lsx);
++        CHROMA_PU_422(8,   8, lsx);
++        CHROMA_PU_422(4,  16, lsx);
++        CHROMA_PU_422(8,  12, lsx);
++        CHROMA_PU_422(6,  16, lsx);
++        CHROMA_PU_422(8,   4, lsx);
++        CHROMA_PU_422(2,  16, lsx);
++        CHROMA_PU_422(16, 16, lsx);
++        CHROMA_PU_422(8,  32, lsx);
++        CHROMA_PU_422(16, 24, lsx);
++        CHROMA_PU_422(12, 32, lsx);
++        CHROMA_PU_422(16,  8, lsx);
++        CHROMA_PU_422(4,  32, lsx);
++        CHROMA_PU_422(32, 32, lsx);
++        CHROMA_PU_422(16, 64, lsx);
++        CHROMA_PU_422(32, 48, lsx);
++        CHROMA_PU_422(24, 64, lsx);
++        CHROMA_PU_422(32, 16, lsx);
++        CHROMA_PU_422(8,  64, lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -310,6 +432,41 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.cu[BLOCK_4x4].count_nonzero   = PFX(count_nonzero_4_lasx);
+         p.findPosFirstLast     = PFX(findPosFirstLast_lasx);
+         p.denoiseDct           = PFX(denoiseDct_lasx);
++
++        //pixelAvg_pp
++        ASSIGN2(p.pu[LUMA_64x64].pixelavg_pp, pixel_avg_64x64_lasx);
++        ASSIGN2(p.pu[LUMA_64x48].pixelavg_pp, pixel_avg_64x48_lasx);
++        ASSIGN2(p.pu[LUMA_64x32].pixelavg_pp, pixel_avg_64x32_lasx);
++        ASSIGN2(p.pu[LUMA_64x16].pixelavg_pp, pixel_avg_64x16_lasx);
++        ASSIGN2(p.pu[LUMA_48x64].pixelavg_pp, pixel_avg_48x64_lasx);
++        ASSIGN2(p.pu[LUMA_32x64].pixelavg_pp, pixel_avg_32x64_lasx);
++        ASSIGN2(p.pu[LUMA_32x32].pixelavg_pp, pixel_avg_32x32_lasx);
++        ASSIGN2(p.pu[LUMA_32x24].pixelavg_pp, pixel_avg_32x24_lasx);
++        ASSIGN2(p.pu[LUMA_32x16].pixelavg_pp, pixel_avg_32x16_lasx);
++        ASSIGN2(p.pu[LUMA_32x8].pixelavg_pp, pixel_avg_32x8_lasx);
++
++        //addAvg_pp
++        ASSIGN2(p.pu[LUMA_24x32].addAvg, addAvg_24x32_lasx);
++        ASSIGN2(p.pu[LUMA_32x8].addAvg, addAvg_32x8_lasx);
++        ASSIGN2(p.pu[LUMA_32x16].addAvg, addAvg_32x16_lasx);
++        ASSIGN2(p.pu[LUMA_32x24].addAvg, addAvg_32x24_lasx);
++        ASSIGN2(p.pu[LUMA_32x32].addAvg, addAvg_32x32_lasx);
++        ASSIGN2(p.pu[LUMA_32x64].addAvg, addAvg_32x64_lasx);
++        ASSIGN2(p.pu[LUMA_48x64].addAvg, addAvg_48x64_lasx);
++        ASSIGN2(p.pu[LUMA_64x16].addAvg, addAvg_64x16_lasx);
++        ASSIGN2(p.pu[LUMA_64x32].addAvg, addAvg_64x32_lasx);
++        ASSIGN2(p.pu[LUMA_64x48].addAvg, addAvg_64x48_lasx);
++        ASSIGN2(p.pu[LUMA_64x64].addAvg, addAvg_64x64_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I420].pu[CHROMA_420_24x32].addAvg, addAvg_24x32_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I420].pu[CHROMA_420_32x8].addAvg, addAvg_32x8_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I420].pu[CHROMA_420_32x16].addAvg, addAvg_32x16_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I420].pu[CHROMA_420_32x24].addAvg, addAvg_32x24_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I420].pu[CHROMA_420_32x32].addAvg, addAvg_32x32_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_24x64].addAvg, addAvg_24x64_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x16].addAvg, addAvg_32x16_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x32].addAvg, addAvg_32x32_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x48].addAvg, addAvg_32x48_lasx);
++        ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x64].addAvg, addAvg_32x64_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/mc-a.S b/source/common/loongarch64/mc-a.S
+new file mode 100644
+index 000000000..310dc16a8
+--- /dev/null
++++ b/source/common/loongarch64/mc-a.S
+@@ -0,0 +1,921 @@
++/*****************************************************************************
++ * mc-a.S: loongarch motion compensation
++ *****************************************************************************
++ * Copyright (C) 2023-2024 MulticoreWare, Inc
++ *
++ * Authors: jinbo <jinbo@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++/*----------------------------------------------------------------------------
++void pixelavg_pp(pixel dst, intptr_t dstride, const pixel src0,
++                 intptr_t sstride0, const pixel* src1, intptr_t sstride1, int)
++------------------------------------------------------------------------------*/
++
++#include "loongson_asm.S"
++
++.macro AVG_W4 w, h
++function x265_pixel_avg_\w\()x\h\()_lsx
++.rept \h/2
++    fld.s       f0,     a2,     0
++    fld.s       f1,     a4,     0
++    fldx.s      f2,     a2,     a3
++    fldx.s      f3,     a4,     a5
++    vavgr.bu    vr0,    vr1,    vr0
++    vavgr.bu    vr1,    vr3,    vr2
++    fst.s       f0,     a0,     0
++    fstx.s      f1,     a0,     a1
++    alsl.d      a2,     a3,     a2,   1
++    alsl.d      a4,     a5,     a4,   1
++    alsl.d      a0,     a1,     a0,   1
++.endr
++endfunc
++.endm
++
++AVG_W4 4, 16
++AVG_W4 4, 8
++AVG_W4 4, 4
++
++.macro AVG_W8 w, h
++function x265_pixel_avg_\w\()x\h\()_lsx
++.rept \h/2
++    fld.d       f0,     a2,     0
++    fld.d       f1,     a4,     0
++    fldx.d      f2,     a2,     a3
++    fldx.d      f3,     a4,     a5
++    vavgr.bu    vr0,    vr1,    vr0
++    vavgr.bu    vr1,    vr3,    vr2
++    fst.d       f0,     a0,     0
++    fstx.d      f1,     a0,     a1
++    alsl.d      a2,     a3,     a2,   1
++    alsl.d      a4,     a5,     a4,   1
++    alsl.d      a0,     a1,     a0,   1
++.endr
++endfunc
++.endm
++
++AVG_W8 8, 32
++AVG_W8 8, 16
++AVG_W8 8, 8
++AVG_W8 8, 4
++
++.macro AVG_W16 w, h
++function x265_pixel_avg_\w\()x\h\()_lsx
++.rept \h
++    vld         vr0,    a2,     0
++    vld         vr1,    a4,     0
++    vavgr.bu    vr0,    vr1,    vr0
++.if \w == 12
++    vstelm.d    vr0,    a0,     0,    0
++    vstelm.w    vr0,    a0,     8,    2
++.else
++    vst         vr0,    a0,     0
++.endif
++    add.d       a2,     a2,     a3
++    add.d       a4,     a4,     a5
++    add.d       a0,     a0,     a1
++.endr
++endfunc
++.endm
++
++AVG_W16 12, 16
++AVG_W16 16, 64
++AVG_W16 16, 32
++AVG_W16 16, 16
++AVG_W16 16, 12
++AVG_W16 16, 8
++AVG_W16 16, 4
++
++.macro AVG_W32 w, h
++function x265_pixel_avg_\w\()x\h\()_lsx
++.rept \h
++    vld         vr0,    a2,     0
++    vld         vr4,    a4,     0
++    vld         vr1,    a2,     16
++    vld         vr5,    a4,     16
++    vavgr.bu    vr0,    vr4,    vr0
++    vavgr.bu    vr1,    vr5,    vr1
++    vst         vr0,    a0,     0
++.if \w == 24
++    vstelm.d    vr1,    a0,     16,   0
++.else
++    vst         vr1,    a0,     16
++.endif
++    add.d       a2,     a2,     a3
++    add.d       a4,     a4,     a5
++    add.d       a0,     a0,     a1
++.endr
++endfunc
++.endm
++
++AVG_W32 24, 32
++AVG_W32 32, 64
++AVG_W32 32, 32
++AVG_W32 32, 24
++AVG_W32 32, 16
++AVG_W32 32, 8
++
++.macro LASX_AVG_W32 w, h
++function x265_pixel_avg_\w\()x\h\()_lasx
++.rept \h/2 - 1
++    xvld        xr0,    a2,     0
++    xvld        xr1,    a4,     0
++    xvldx       xr2,    a2,     a3
++    xvldx       xr3,    a4,     a5
++    xvavgr.bu   xr0,    xr1,    xr0
++    xvavgr.bu   xr2,    xr3,    xr2
++    xvst        xr0,    a0,     0
++    xvstx       xr2,    a0,     a1
++    alsl.d      a2,     a3,     a2,   1
++    alsl.d      a4,     a5,     a4,   1
++    alsl.d      a0,     a1,     a0,   1
++.endr
++    xvld        xr0,    a2,     0
++    xvld        xr1,    a4,     0
++    xvldx       xr2,    a2,     a3
++    xvldx       xr3,    a4,     a5
++    xvavgr.bu   xr0,    xr1,    xr0
++    xvavgr.bu   xr2,    xr3,    xr2
++    xvst        xr0,    a0,     0
++    xvstx       xr2,    a0,     a1
++endfunc
++.endm
++
++LASX_AVG_W32 32, 64
++LASX_AVG_W32 32, 32
++LASX_AVG_W32 32, 24
++LASX_AVG_W32 32, 16
++LASX_AVG_W32 32, 8
++
++.macro AVG_W64 w, h
++function x265_pixel_avg_\w\()x\h\()_lsx
++    li.w        t0,     \h
++1:  //h loop
++    vld         vr0,    a2,     0
++    vld         vr4,    a4,     0
++    vld         vr1,    a2,     16
++    vld         vr5,    a4,     16
++    vld         vr2,    a2,     32
++    vld         vr6,    a4,     32
++.if \w > 48
++    vld         vr3,    a2,     48
++    vld         vr7,    a4,     48
++.endif
++    vavgr.bu    vr0,    vr4,    vr0
++    vavgr.bu    vr1,    vr5,    vr1
++    vavgr.bu    vr2,    vr6,    vr2
++.if \w > 48
++    vavgr.bu    vr3,    vr7,    vr3
++.endif
++    vst         vr0,    a0,     0
++    vst         vr1,    a0,     16
++    vst         vr2,    a0,     32
++.if \w > 48
++    vst         vr3,    a0,     48
++.endif
++    add.d       a2,     a2,     a3
++    add.d       a4,     a4,     a5
++    add.d       a0,     a0,     a1
++    addi.w      t0,     t0,     -1
++    bnez        t0,     1b
++endfunc
++.endm
++
++AVG_W64 48, 64
++AVG_W64 64, 64
++AVG_W64 64, 48
++AVG_W64 64, 32
++AVG_W64 64, 16
++
++.macro LASX_AVG_W64 w, h
++function x265_pixel_avg_\w\()x\h\()_lasx
++    li.w        t0,     \h
++1:  //h loop
++    xvld        xr0,    a2,     0
++    xvld        xr1,    a2,     32
++    xvld        xr2,    a4,     0
++    xvld        xr3,    a4,     32
++    xvavgr.bu   xr0,    xr2,    xr0
++    xvavgr.bu   xr1,    xr3,    xr1
++    xvst        xr0,    a0,     0
++.if \w == 48
++    vst         vr1,    a0,     32
++.else
++    xvst        xr1,    a0,     32
++.endif
++    add.d       a2,     a2,     a3
++    add.d       a4,     a4,     a5
++    add.d       a0,     a0,     a1
++    addi.w      t0,     t0,     -1
++    bnez        t0,     1b
++endfunc
++.endm
++
++LASX_AVG_W64 48, 64
++LASX_AVG_W64 64, 64
++LASX_AVG_W64 64, 48
++LASX_AVG_W64 64, 32
++LASX_AVG_W64 64, 16
++
++/*
++ * void addAvg(const int16_t* src0, const int16_t* src1, pixel* dst,
++ *             intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++ */
++.macro ADDAVG_START
++    li.w             t0,     16448
++    slli.w           t1,     a3,     1
++    slli.w           t2,     a4,     1
++    vreplgr2vr.w     vr4,    t0
++.endm
++
++.macro ADDAVG_2xN  out0, idx
++    fld.s            f0,     a0,     0
++    fld.s            f1,     a1,     0
++    fldx.s           f2,     a0,     t1
++    fldx.s           f3,     a1,     t2
++    vilvl.w          vr0,    vr2,    vr0
++    vilvl.w          vr1,    vr3,    vr1
++    vilvl.h          vr0,    vr1,    vr0
++    vhaddw.w.h       \out0,  vr0,    vr0
++    vadd.w           \out0,  \out0,  vr4
++.if \idx == 0
++    alsl.d           a0,     a3,     a0,    2
++    alsl.d           a1,     a4,     a1,    2
++.endif
++.endm
++
++function x265_addAvg_2x2_lsx
++    ADDAVG_START
++    ADDAVG_2xN       vr0,    1
++    vssrani.h.w      vr0,    vr0,    7
++    vssrani.bu.h     vr0,    vr0,    0
++    vstelm.h         vr0,    a2,     0,     0
++    add.d            a2,     a2,     a5
++    vstelm.h         vr0,    a2,     0,     1
++endfunc
++
++function x265_addAvg_2x4_lsx
++    ADDAVG_START
++    ADDAVG_2xN       vr5,    0
++    ADDAVG_2xN       vr6,    1
++    vssrani.h.w      vr6,    vr5,    7
++    vssrani.bu.h     vr0,    vr6,    0
++    .irp i, 0, 1, 2
++    vstelm.h         vr0,    a2,     0,     \i
++    add.d            a2,     a2,     a5
++    .endr
++    vstelm.h         vr0,    a2,     0,     3
++endfunc
++
++function x265_addAvg_2x8_lsx
++    ADDAVG_START
++    ADDAVG_2xN       vr5,    0
++    ADDAVG_2xN       vr6,    0
++    ADDAVG_2xN       vr7,    0
++    ADDAVG_2xN       vr8,    1
++    vssrani.h.w      vr6,    vr5,    7
++    vssrani.h.w      vr8,    vr7,    7
++    vssrani.bu.h     vr8,    vr6,    0
++    .irp i, 0, 1, 2, 3, 4, 5 ,6
++    vstelm.h         vr8,    a2,     0,     \i
++    add.d            a2,     a2,     a5
++    .endr
++    vstelm.h         vr8,    a2,     0,     7
++endfunc
++
++function x265_addAvg_2x16_lsx
++    ADDAVG_START
++    ADDAVG_2xN       vr5,    0
++    ADDAVG_2xN       vr6,    0
++    ADDAVG_2xN       vr7,    0
++    ADDAVG_2xN       vr8,    0
++    ADDAVG_2xN       vr9,    0
++    ADDAVG_2xN       vr10,   0
++    ADDAVG_2xN       vr11,   0
++    ADDAVG_2xN       vr12,   1
++    vssrani.h.w      vr6,    vr5,    7
++    vssrani.h.w      vr8,    vr7,    7
++    vssrani.bu.h     vr8,    vr6,    0
++    vssrani.h.w      vr10,   vr9,    7
++    vssrani.h.w      vr12,   vr11,   7
++    vssrani.bu.h     vr12,   vr10,   0
++    .irp i, 0, 1, 2, 3, 4, 5 ,6, 7
++    vstelm.h         vr8,    a2,     0,     \i
++    add.d            a2,     a2,     a5
++    .endr
++    .irp i, 0, 1, 2, 3, 4, 5 ,6
++    vstelm.h         vr12,   a2,     0,     \i
++    add.d            a2,     a2,     a5
++    .endr
++    vstelm.h         vr12,   a2,     0,     7
++endfunc
++
++function x265_addAvg_4x2_lsx
++    ADDAVG_START
++    fld.d            f0,     a0,     0
++    fld.d            f1,     a1,     0
++    fldx.d           f2,     a0,     t1
++    fldx.d           f3,     a1,     t2
++    vilvl.h          vr0,    vr1,    vr0
++    vilvl.h          vr2,    vr3,    vr2
++    vhaddw.w.h       vr0,    vr0,    vr0
++    vhaddw.w.h       vr2,    vr2,    vr2
++    vadd.w           vr0,    vr0,    vr4
++    vadd.w           vr2,    vr2,    vr4
++    vssrani.h.w      vr2,    vr0,    7
++    vssrani.bu.h     vr2,    vr2,    0
++    vstelm.w         vr2,    a2,     0,     0
++    add.d            a2,     a2,     a5
++    vstelm.w         vr2,    a2,     0,     1
++endfunc
++
++.macro ADDAVG_W4_H2 h
++function x265_addAvg_4x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/4
++1:
++    //h0h1
++    fld.d            f0,     a0,     0
++    fld.d            f1,     a1,     0
++    fldx.d           f2,     a0,     t1
++    fldx.d           f3,     a1,     t2
++    alsl.d           a0,     a3,     a0,    2
++    alsl.d           a1,     a4,     a1,    2
++    vilvl.h          vr0,    vr1,    vr0
++    vilvl.h          vr1,    vr3,    vr2
++    vhaddw.w.h       vr0,    vr0,    vr0
++    vhaddw.w.h       vr1,    vr1,    vr1
++    vadd.w           vr0,    vr0,    vr4
++    vadd.w           vr1,    vr1,    vr4
++    vssrani.h.w      vr1,    vr0,    7
++    //h2h3
++    fld.d            f2,     a0,     0
++    fld.d            f3,     a1,     0
++    fldx.d           f5,     a0,     t1
++    fldx.d           f6,     a1,     t2
++    alsl.d           a0,     a3,     a0,    2
++    alsl.d           a1,     a4,     a1,    2
++    vilvl.h          vr2,    vr3,    vr2
++    vilvl.h          vr3,    vr6,    vr5
++    vhaddw.w.h       vr2,    vr2,    vr2
++    vhaddw.w.h       vr3,    vr3,    vr3
++    vadd.w           vr2,    vr2,    vr4
++    vadd.w           vr3,    vr3,    vr4
++    vssrani.h.w      vr3,    vr2,    7
++    //pack h0h1h2h3 and store
++    vssrani.bu.h     vr3,    vr1,    0
++    .irp i, 0, 1, 2, 3
++    vstelm.w         vr3,    a2,     0,     \i
++    add.d            a2,     a2,     a5
++    .endr
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W4_H2 4
++ADDAVG_W4_H2 8
++ADDAVG_W4_H2 16
++ADDAVG_W4_H2 32
++
++.macro ADDAVG_W6_H2 h
++function x265_addAvg_6x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/2
++1:
++    //h0
++    vld              vr0,    a0,     0
++    vld              vr1,    a1,     0
++    vilvh.h          vr2,    vr1,    vr0
++    vilvl.h          vr1,    vr1,    vr0
++    vhaddw.w.h       vr0,    vr1,    vr1
++    vhaddw.w.h       vr1,    vr2,    vr2
++    vadd.w           vr0,    vr0,    vr4
++    vadd.w           vr1,    vr1,    vr4
++    //h1
++    vldx             vr5,    a0,     t1
++    vldx             vr6,    a1,     t2
++    alsl.d           a0,     a3,     a0,    2
++    alsl.d           a1,     a4,     a1,    2
++    vilvh.h          vr7,    vr6,    vr5
++    vilvl.h          vr6,    vr6,    vr5
++    vhaddw.w.h       vr5,    vr6,    vr6
++    vhaddw.w.h       vr6,    vr7,    vr7
++    vadd.w           vr5,    vr5,    vr4
++    vadd.w           vr6,    vr6,    vr4
++    //pacck and store
++    vssrani.h.w      vr5,    vr0,    7 //02
++    vssrani.h.w      vr6,    vr1,    7 //13
++    vssrani.bu.h     vr6,    vr5,    0 //0213
++    vstelm.w         vr6,    a2,     0,     0
++    vstelm.h         vr6,    a2,     4,     4
++    add.d            a2,     a2,     a5
++    vstelm.w         vr6,    a2,     0,     1
++    vstelm.h         vr6,    a2,     4,     6
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W6_H2 8
++ADDAVG_W6_H2 16
++
++.macro ADDAVG_W8_H2 h
++function x265_addAvg_8x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/2
++1:
++    vld              vr0,    a0,     0
++    vld              vr1,    a1,     0
++    vldx             vr2,    a0,     t1
++    vldx             vr3,    a1,     t2
++    alsl.d           a0,     a3,     a0,    2
++    alsl.d           a1,     a4,     a1,    2
++    vilvh.h          vr5,    vr1,    vr0
++    vilvl.h          vr0,    vr1,    vr0
++    vilvh.h          vr6,    vr3,    vr2
++    vilvl.h          vr3,    vr3,    vr2
++    .irp i, vr5, vr0, vr6, vr3
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    vssrani.h.w      vr5,    vr0,    7
++    vssrani.h.w      vr6,    vr3,    7
++    vssrani.bu.h     vr6,    vr5,    0
++    vstelm.d         vr6,    a2,     0,     0
++    add.d            a2,     a2,     a5
++    vstelm.d         vr6,    a2,     0,     1
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W8_H2 2
++ADDAVG_W8_H2 4
++ADDAVG_W8_H2 6
++ADDAVG_W8_H2 8
++ADDAVG_W8_H2 12
++ADDAVG_W8_H2 16
++ADDAVG_W8_H2 32
++ADDAVG_W8_H2 64
++
++.macro ADDAVG_W12_H2 h
++function x265_addAvg_12x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/2
++1:
++    //h0
++    vld              vr0,    a0,     0
++    vld              vr1,    a0,     16
++    vld              vr2,    a1,     0
++    vld              vr3,    a1,     16
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    //h1
++    vld              vr5,    a0,     0
++    vld              vr6,    a0,     16
++    vld              vr7,    a1,     0
++    vld              vr8,    a1,     16
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    vilvh.h          vr9,    vr2,    vr0
++    vilvl.h          vr0,    vr2,    vr0
++    vilvl.h          vr2,    vr3,    vr1
++    vilvh.h          vr10,   vr7,    vr5
++    vilvl.h          vr5,    vr7,    vr5
++    vilvl.h          vr3,    vr8,    vr6
++    .irp i, vr9, vr0, vr2, vr10, vr5, vr3
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    //pack and store
++    vssrani.h.w      vr9,    vr0,    7
++    vssrani.h.w      vr10,   vr5,    7
++    vssrani.h.w      vr3,    vr2,    7
++    vssrani.bu.h     vr10,   vr9,    0
++    vssrani.bu.h     vr3,    vr3,    0
++    vstelm.d         vr10,   a2,     0,     0
++    vstelm.w         vr3,    a2,     8,     0
++    add.d            a2,     a2,     a5
++    vstelm.d         vr10,   a2,     0,     1
++    vstelm.w         vr3,    a2,     8,     1
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W12_H2 16
++ADDAVG_W12_H2 32
++
++.macro ADDAVG_W16_H2 h
++function x265_addAvg_16x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/2
++1:
++    //h0
++    vld              vr0,    a0,     0
++    vld              vr1,    a0,     16
++    vld              vr2,    a1,     0
++    vld              vr3,    a1,     16
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    //h1
++    vld              vr6,    a0,     0
++    vld              vr7,    a0,     16
++    vld              vr8,    a1,     0
++    vld              vr9,    a1,     16
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    vilvh.h          vr11,   vr2,    vr0
++    vilvl.h          vr10,   vr2,    vr0
++    vilvh.h          vr13,   vr3,    vr1
++    vilvl.h          vr12,   vr3,    vr1
++    vilvh.h          vr15,   vr8,    vr6
++    vilvl.h          vr14,   vr8,    vr6
++    vilvh.h          vr17,   vr9,    vr7
++    vilvl.h          vr16,   vr9,    vr7
++    .irp i, vr10, vr11, vr12, vr13, vr14, vr15, vr16, vr17
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    //pack and store
++    vssrani.h.w      vr11,   vr10,   7
++    vssrani.h.w      vr13,   vr12,   7
++    vssrani.h.w      vr15,   vr14,   7
++    vssrani.h.w      vr17,   vr16,   7
++    vssrani.bu.h     vr13,   vr11,   0
++    vssrani.bu.h     vr17,   vr15,   0
++    vst              vr13,   a2,     0
++    add.d            a2,     a2,     a5
++    vst              vr17,   a2,     0
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W16_H2 4
++ADDAVG_W16_H2 8
++ADDAVG_W16_H2 12
++ADDAVG_W16_H2 16
++ADDAVG_W16_H2 24
++ADDAVG_W16_H2 32
++ADDAVG_W16_H2 64
++
++.macro ADDAVG_W24_H2 h
++function x265_addAvg_24x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/2
++    1:
++    //h0
++    vld              vr0,    a0,     0
++    vld              vr1,    a0,     16
++    vld              vr2,    a0,     32
++    vld              vr3,    a1,     0
++    vld              vr5,    a1,     16
++    vld              vr6,    a1,     32
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    //h1
++    vld              vr7,    a0,     0
++    vld              vr8,    a0,     16
++    vld              vr9,    a0,     32
++    vld              vr10,   a1,     0
++    vld              vr11,   a1,     16
++    vld              vr12,   a1,     32
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    vilvh.h          vr14,   vr3,    vr0
++    vilvl.h          vr13,   vr3,    vr0
++    vilvh.h          vr16,   vr5,    vr1
++    vilvl.h          vr15,   vr5,    vr1
++    vilvh.h          vr18,   vr6,    vr2
++    vilvl.h          vr17,   vr6,    vr2
++    .irp i, vr13, vr14, vr15, vr16, vr17, vr18
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    vssrani.h.w      vr14,   vr13,   7
++    vssrani.h.w      vr16,   vr15,   7
++    vssrani.h.w      vr18,   vr17,   7
++    vssrani.bu.h     vr16,   vr14,   0
++    vilvh.h          vr14,   vr10,   vr7
++    vilvl.h          vr13,   vr10,   vr7
++    vilvh.h          vr17,   vr11,   vr8
++    vilvl.h          vr15,   vr11,   vr8
++    vilvh.h          vr20,   vr12,   vr9
++    vilvl.h          vr19,   vr12,   vr9
++    .irp i, vr13, vr14, vr15, vr17, vr19, vr20
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    vssrani.h.w      vr14,   vr13,   7
++    vssrani.h.w      vr17,   vr15,   7
++    vssrani.h.w      vr20,   vr19,   7
++    vssrani.bu.h     vr17,   vr14,   0
++    vssrani.bu.h     vr20,   vr18,   0
++    vst              vr16,   a2,     0
++    vstelm.d         vr20,   a2,     16,   0
++    add.d            a2,     a2,     a5
++    vst              vr17,   a2,     0
++    vstelm.d         vr20,   a2,     16,   1
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W24_H2 32
++ADDAVG_W24_H2 64
++
++.macro ADDAVG_W32_H1
++    vld              vr0,    a0,     0
++    vld              vr1,    a0,     16
++    vld              vr2,    a0,     32
++    vld              vr3,    a0,     48
++    vld              vr5,    a1,     0
++    vld              vr6,    a1,     16
++    vld              vr7,    a1,     32
++    vld              vr8,    a1,     48
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    vilvh.h          vr10,   vr5,    vr0
++    vilvl.h          vr9,    vr5,    vr0
++    vilvh.h          vr12,   vr6,    vr1
++    vilvl.h          vr11,   vr6,    vr1
++    vilvh.h          vr14,   vr7,    vr2
++    vilvl.h          vr13,   vr7,    vr2
++    vilvh.h          vr16,   vr8,    vr3
++    vilvl.h          vr15,   vr8,    vr3
++    .irp i, vr10, vr9, vr12, vr11, vr14, vr13, vr16, vr15
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    vssrani.h.w      vr10,   vr9,    7
++    vssrani.h.w      vr12,   vr11,   7
++    vssrani.h.w      vr14,   vr13,   7
++    vssrani.h.w      vr16,   vr15,   7
++    vssrani.bu.h     vr12,   vr10,   0
++    vssrani.bu.h     vr16,   vr14,   0
++    vst              vr12,   a2,     0
++    vst              vr16,   a2,     16
++    add.d            a2,     a2,     a5
++.endm
++
++.macro ADDAVG_W32_H4 h
++function x265_addAvg_32x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h/4
++1:
++    ADDAVG_W32_H1
++    ADDAVG_W32_H1
++    ADDAVG_W32_H1
++    ADDAVG_W32_H1
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W32_H4 8
++ADDAVG_W32_H4 16
++ADDAVG_W32_H4 24
++ADDAVG_W32_H4 32
++ADDAVG_W32_H4 48
++ADDAVG_W32_H4 64
++
++.macro LASX_ADDAVG_W32_H1 w
++    xvld             xr0,    a0,     0
++    xvld             xr1,    a0,     32
++    xvld             xr2,    a1,     0
++    xvld             xr3,    a1,     32
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    xvilvh.h         xr5,    xr2,    xr0
++    xvilvl.h         xr4,    xr2,    xr0
++    xvilvh.h         xr7,    xr3,    xr1
++    xvilvl.h         xr6,    xr3,    xr1
++    .irp i, xr4, xr5, xr6, xr7
++    xvhaddw.w.h      \i,     \i,     \i
++    xvadd.w          \i,     \i,     xr8
++    .endr
++    xvssrani.h.w     xr5,    xr4,    7
++    xvssrani.h.w     xr7,    xr6,    7
++    xvssrani.bu.h    xr7,    xr5,    0
++    xvpermi.d        xr7,    xr7,    0xd8
++.if \w == 24
++    vst              vr7,    a2,     0
++    xvpermi.q        xr7,    xr7,    0x01
++    fst.d            f7,     a2,     16
++.else
++    xvst             xr7,    a2,     0
++.endif
++    add.d            a2,     a2,     a5
++.endm
++
++.macro LASX_ADDAVG_W32_H4 w, h
++function x265_addAvg_\w\()x\h\()_lasx
++    li.w             t0,     16448
++    slli.w           t1,     a3,     1
++    slli.w           t2,     a4,     1
++    xvreplgr2vr.w    xr8,    t0
++    li.w             t7,     \h/4
++1:
++    LASX_ADDAVG_W32_H1 \w
++    LASX_ADDAVG_W32_H1 \w
++    LASX_ADDAVG_W32_H1 \w
++    LASX_ADDAVG_W32_H1 \w
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++LASX_ADDAVG_W32_H4 32 8
++LASX_ADDAVG_W32_H4 32 16
++LASX_ADDAVG_W32_H4 32 24
++LASX_ADDAVG_W32_H4 32 32
++LASX_ADDAVG_W32_H4 32 48
++LASX_ADDAVG_W32_H4 32 64
++
++LASX_ADDAVG_W32_H4 24 32
++LASX_ADDAVG_W32_H4 24 64
++
++function x265_addAvg_48x64_lsx
++    ADDAVG_START
++    li.w             t7,     64
++1:
++    vld              vr0,    a0,     0
++    vld              vr1,    a0,     16
++    vld              vr2,    a0,     32
++    vld              vr3,    a0,     48
++    vld              vr5,    a0,     64
++    vld              vr6,    a0,     80
++    vld              vr7,    a1,     0
++    vld              vr8,    a1,     16
++    vld              vr9,    a1,     32
++    vld              vr10,   a1,     48
++    vld              vr11,   a1,     64
++    vld              vr12,   a1,     80
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    vilvh.h          vr14,   vr7,    vr0
++    vilvl.h          vr13,   vr7,    vr0
++    vilvh.h          vr16,   vr8,    vr1
++    vilvl.h          vr15,   vr8,    vr1
++    vilvh.h          vr18,   vr9,    vr2
++    vilvl.h          vr17,   vr9,    vr2
++    vilvh.h          vr20,   vr10,   vr3
++    vilvl.h          vr19,   vr10,   vr3
++    vilvh.h          vr22,   vr11,   vr5
++    vilvl.h          vr21,   vr11,   vr5
++    vilvh.h          vr23,   vr12,   vr6
++    vilvl.h          vr0,    vr12,   vr6
++    .irp i, vr14, vr13, vr16, vr15, vr18, vr17, \
++            vr20, vr19, vr22, vr21, vr23, vr0
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    vssrani.h.w      vr14,   vr13,   7
++    vssrani.h.w      vr16,   vr15,   7
++    vssrani.h.w      vr18,   vr17,   7
++    vssrani.h.w      vr20,   vr19,   7
++    vssrani.h.w      vr22,   vr21,   7
++    vssrani.h.w      vr23,   vr0,    7
++    vssrani.bu.h     vr16,   vr14,   0
++    vssrani.bu.h     vr20,   vr18,   0
++    vssrani.bu.h     vr23,   vr22,   0
++    vst              vr16,   a2,     0
++    vst              vr20,   a2,     16
++    vst              vr23,   a2,     32
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++
++.macro ADDAVG_W64_H0 in0, in1, in2, in3, out0
++    vilvh.h          vr18,   \in0,   \in1
++    vilvl.h          vr17,   \in0,   \in1
++    vilvh.h          \out0,  \in2,   \in3
++    vilvl.h          vr19,   \in2,   \in3
++    .irp i, vr18, vr17, \out0, vr19
++    vhaddw.w.h       \i,     \i,     \i
++    vadd.w           \i,     \i,     vr4
++    .endr
++    vssrani.h.w      vr18,   vr17,   7
++    vssrani.h.w      \out0,  vr19,   7
++    vssrani.bu.h     \out0,  vr18,   0
++.endm
++
++.macro ADDAVG_W64_H1 h
++function x265_addAvg_64x\h\()_lsx
++    ADDAVG_START
++    li.w             t7,     \h
++1:
++    vld              vr0,    a0,     0
++    vld              vr1,    a0,     16
++    vld              vr2,    a0,     32
++    vld              vr3,    a0,     48
++    vld              vr5,    a0,     64
++    vld              vr6,    a0,     80
++    vld              vr7,    a0,     96
++    vld              vr8,    a0,     112
++    vld              vr9,    a1,     0
++    vld              vr10,   a1,     16
++    vld              vr11,   a1,     32
++    vld              vr12,   a1,     48
++    vld              vr13,   a1,     64
++    vld              vr14,   a1,     80
++    vld              vr15,   a1,     96
++    vld              vr16,   a1,     112
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    ADDAVG_W64_H0 vr9, vr0, vr10, vr1, vr20
++    ADDAVG_W64_H0 vr11, vr2, vr12, vr3, vr21
++    ADDAVG_W64_H0 vr13, vr5, vr14, vr6, vr22
++    ADDAVG_W64_H0 vr15, vr7, vr16, vr8, vr23
++    vst              vr20,   a2,     0
++    vst              vr21,   a2,     16
++    vst              vr22,   a2,     32
++    vst              vr23,   a2,     48
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++ADDAVG_W64_H1 16
++ADDAVG_W64_H1 32
++ADDAVG_W64_H1 48
++ADDAVG_W64_H1 64
++
++.macro LASX_ADDAVG_W64_H0 in0, in1, in2, in3, out0
++    xvilvh.h         xr18,   \in0,   \in1
++    xvilvl.h         xr17,   \in0,   \in1
++    xvilvh.h         \out0,  \in2,   \in3
++    xvilvl.h         xr19,   \in2,   \in3
++    .irp i, xr18, xr17, \out0, xr19
++    xvhaddw.w.h      \i,     \i,     \i
++    xvadd.w          \i,     \i,     xr8
++    .endr
++    xvssrani.h.w     xr18,   xr17,   7
++    xvssrani.h.w     \out0,  xr19,   7
++    xvssrani.bu.h    \out0,  xr18,   0
++    xvpermi.d        \out0,  \out0,  0xd8
++.endm
++
++.macro LASX_ADDAVG_W64_H1 w, h
++function x265_addAvg_\w\()x\h\()_lasx
++    li.w             t0,     16448
++    slli.w           t1,     a3,     1
++    slli.w           t2,     a4,     1
++    xvreplgr2vr.w    xr8,    t0
++    li.w             t7,     \h
++1:
++    xvld             xr0,    a0,     0
++    xvld             xr1,    a0,     32
++    xvld             xr2,    a0,     64
++    xvld             xr3,    a0,     96
++    xvld             xr4,    a1,     0
++    xvld             xr5,    a1,     32
++    xvld             xr6,    a1,     64
++    xvld             xr7,    a1,     96
++    add.d            a0,     a0,     t1
++    add.d            a1,     a1,     t2
++    LASX_ADDAVG_W64_H0 xr4, xr0, xr5, xr1, xr20
++    LASX_ADDAVG_W64_H0 xr6, xr2, xr7, xr3, xr21
++    xvst             xr20,   a2,     0
++.if \w == 48
++    vst              vr21,   a2,     32
++.else
++    xvst             xr21,   a2,     32
++.endif
++    add.d            a2,     a2,     a5
++    addi.w           t7,     t7,     -1
++    bnez             t7,     1b
++endfunc
++.endm
++
++LASX_ADDAVG_W64_H1 64 16
++LASX_ADDAVG_W64_H1 64 32
++LASX_ADDAVG_W64_H1 64 48
++LASX_ADDAVG_W64_H1 64 64
++
++LASX_ADDAVG_W64_H1 48 64
+diff --git a/source/common/loongarch64/pixel.h b/source/common/loongarch64/pixel.h
+new file mode 100644
+index 000000000..ed1cb75c8
+--- /dev/null
++++ b/source/common/loongarch64/pixel.h
+@@ -0,0 +1,130 @@
++/*****************************************************************************
++ * pixel.h: loongarch pixel metrics
++ *****************************************************************************
++ * Copyright (C) 2013-2024 MulticoreWare, Inc
++ *
++ * Authors: jinbo <jinbo@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_LOONGARCH_PIXEL_H
++#define X265_LOONGARCH_PIXEL_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++#define FUNCDEF_PU(ret, name, cpu, ...) \
++    ret PFX(name ## _4x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x8_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x4_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x8_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x32_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x48_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _48x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x64_ ## cpu)(__VA_ARGS__)
++
++#define FUNCDEF_CHROMA_PU(ret, name, cpu, ...) \
++    FUNCDEF_PU(ret, name, cpu, __VA_ARGS__); \
++    ret PFX(name ## _2x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x4_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x6_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _6x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _6x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x6_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x4_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x4_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x48_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _48x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x64_ ## cpu)(__VA_ARGS__);
++
++#define DECL_PIXELS(cpu) \
++    FUNCDEF_PU(void, pixel_avg, cpu, pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int); \
++    FUNCDEF_CHROMA_PU(void, addAvg, cpu, const int16_t*, const int16_t*, pixel*, intptr_t, intptr_t, intptr_t); \
++    FUNCDEF_CHROMA_PU(void, addAvg_aligned, cpu, const int16_t*, const int16_t*, pixel*, intptr_t, intptr_t, intptr_t);
++
++DECL_PIXELS(lsx);
++
++void x265_pixel_avg_32x8_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_32x16_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_32x24_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_32x32_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_32x64_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_48x64_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_64x16_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_64x32_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_64x48_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++void x265_pixel_avg_64x64_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
++
++void x265_addAvg_24x32_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_24x64_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_32x8_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_32x16_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_32x24_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_32x32_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_32x48_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_32x64_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_48x64_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_64x16_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_64x32_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_64x48_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++void x265_addAvg_64x64_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
++
++#undef FUNCDEF_PU
++#undef DECL_PIXELS
++#undef FUNCDEF_CHROMA_PU
++
++#ifdef __cplusplus
++}
++#endif /*__cplusplus*/
++
++#endif // ifndef X265_LOONGARCH_PIXEL_H
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0010-FROMLIST-LoongArch64-Optimize-functions-in-intrapred.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0010-FROMLIST-LoongArch64-Optimize-functions-in-intrapred.patch
@@ -1,0 +1,11256 @@
+From c5401ca9a5df07925eb794acf9ff31bd5a6f87e8 Mon Sep 17 00:00:00 2001
+From: jinbo <jinbo@loongson.cn>
+Date: Wed, 12 Jun 2024 17:46:24 +0800
+Subject: [PATCH 10/15] FROMLIST: LoongArch64: Optimize functions in
+ intrapred8.S file - Patch 1
+
+The optimized functions are as follows:
+intra_pred_ang4_*_lsx
+intra_pred_ang8_*_lsx/intra_pred_ang8_*_lasx
+intra_pred_ang16_*_lsx/intra_pred_ang16_*_lasx
+intra_pred_ang32_*_lsx
+intra_pred_dc4_lsx
+intra_pred_dc8_lsx
+intra_pred_dc16_lsx
+intra_pred_dc32_lsx
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |     4 +-
+ source/common/loongarch64/asm-primitives.cpp |   188 +
+ source/common/loongarch64/intrapred.h        |   205 +
+ source/common/loongarch64/intrapred8.S       | 10778 +++++++++++++++++
+ 4 files changed, 11173 insertions(+), 2 deletions(-)
+ create mode 100644 source/common/loongarch64/intrapred.h
+ create mode 100644 source/common/loongarch64/intrapred8.S
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index bfa08b9b7..d9d16d6ff 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -138,11 +138,11 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+         message(STATUS "Detected CXX compiler using -O3 optimization level")
+     endif()
+ 
+-    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h pixel.h)
++    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h pixel.h intrapred.h)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S)
++    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 2ce6ab686..883c63b60 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -29,6 +29,7 @@
+ #include "ipfilter8.h"
+ #include "dct.h"
+ #include "pixel.h"
++#include "intrapred.h"
+ 
+ #define ASSIGN2(func, fname) \
+     func[ALIGNED] = PFX(fname); \
+@@ -349,6 +350,149 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         CHROMA_PU_422(24, 64, lsx);
+         CHROMA_PU_422(32, 16, lsx);
+         CHROMA_PU_422(8,  64, lsx);
++
++        // intra_pred
++        p.cu[BLOCK_4x4].intra_pred[2] = PFX(intra_pred_ang4_2_lsx);
++        p.cu[BLOCK_4x4].intra_pred[3] = PFX(intra_pred_ang4_3_lsx);
++        p.cu[BLOCK_4x4].intra_pred[4] = PFX(intra_pred_ang4_4_lsx);
++        p.cu[BLOCK_4x4].intra_pred[5] = PFX(intra_pred_ang4_5_lsx);
++        p.cu[BLOCK_4x4].intra_pred[6] = PFX(intra_pred_ang4_6_lsx);
++        p.cu[BLOCK_4x4].intra_pred[7] = PFX(intra_pred_ang4_7_lsx);
++        p.cu[BLOCK_4x4].intra_pred[8] = PFX(intra_pred_ang4_8_lsx);
++        p.cu[BLOCK_4x4].intra_pred[9] = PFX(intra_pred_ang4_9_lsx);
++        p.cu[BLOCK_4x4].intra_pred[10] = PFX(intra_pred_ang4_10_lsx);
++        p.cu[BLOCK_4x4].intra_pred[11] = PFX(intra_pred_ang4_11_lsx);
++        p.cu[BLOCK_4x4].intra_pred[12] = PFX(intra_pred_ang4_12_lsx);
++        p.cu[BLOCK_4x4].intra_pred[13] = PFX(intra_pred_ang4_13_lsx);
++        p.cu[BLOCK_4x4].intra_pred[14] = PFX(intra_pred_ang4_14_lsx);
++        p.cu[BLOCK_4x4].intra_pred[15] = PFX(intra_pred_ang4_15_lsx);
++        p.cu[BLOCK_4x4].intra_pred[16] = PFX(intra_pred_ang4_16_lsx);
++        p.cu[BLOCK_4x4].intra_pred[17] = PFX(intra_pred_ang4_17_lsx);
++        p.cu[BLOCK_4x4].intra_pred[18] = PFX(intra_pred_ang4_18_lsx);
++        p.cu[BLOCK_4x4].intra_pred[19] = PFX(intra_pred_ang4_19_lsx);
++        p.cu[BLOCK_4x4].intra_pred[20] = PFX(intra_pred_ang4_20_lsx);
++        p.cu[BLOCK_4x4].intra_pred[21] = PFX(intra_pred_ang4_21_lsx);
++        p.cu[BLOCK_4x4].intra_pred[22] = PFX(intra_pred_ang4_22_lsx);
++        p.cu[BLOCK_4x4].intra_pred[23] = PFX(intra_pred_ang4_23_lsx);
++        p.cu[BLOCK_4x4].intra_pred[24] = PFX(intra_pred_ang4_24_lsx);
++        p.cu[BLOCK_4x4].intra_pred[25] = PFX(intra_pred_ang4_25_lsx);
++        p.cu[BLOCK_4x4].intra_pred[26] = PFX(intra_pred_ang4_26_lsx);
++        p.cu[BLOCK_4x4].intra_pred[27] = PFX(intra_pred_ang4_27_lsx);
++        p.cu[BLOCK_4x4].intra_pred[28] = PFX(intra_pred_ang4_28_lsx);
++        p.cu[BLOCK_4x4].intra_pred[29] = PFX(intra_pred_ang4_29_lsx);
++        p.cu[BLOCK_4x4].intra_pred[30] = PFX(intra_pred_ang4_30_lsx);
++        p.cu[BLOCK_4x4].intra_pred[31] = PFX(intra_pred_ang4_31_lsx);
++        p.cu[BLOCK_4x4].intra_pred[32] = PFX(intra_pred_ang4_32_lsx);
++        p.cu[BLOCK_4x4].intra_pred[33] = PFX(intra_pred_ang4_33_lsx);
++        p.cu[BLOCK_4x4].intra_pred[34] = PFX(intra_pred_ang4_34_lsx);
++
++        p.cu[BLOCK_8x8].intra_pred[2] = PFX(intra_pred_ang8_2_lsx);
++        p.cu[BLOCK_8x8].intra_pred[3] = PFX(intra_pred_ang8_3_lsx);
++        p.cu[BLOCK_8x8].intra_pred[4] = PFX(intra_pred_ang8_4_lsx);
++        p.cu[BLOCK_8x8].intra_pred[5] = PFX(intra_pred_ang8_5_lsx);
++        p.cu[BLOCK_8x8].intra_pred[6] = PFX(intra_pred_ang8_6_lsx);
++        p.cu[BLOCK_8x8].intra_pred[7] = PFX(intra_pred_ang8_7_lsx);
++        p.cu[BLOCK_8x8].intra_pred[8] = PFX(intra_pred_ang8_8_lsx);
++        p.cu[BLOCK_8x8].intra_pred[9] = PFX(intra_pred_ang8_9_lsx);
++        p.cu[BLOCK_8x8].intra_pred[10] = PFX(intra_pred_ang8_10_lsx);
++        p.cu[BLOCK_8x8].intra_pred[11] = PFX(intra_pred_ang8_11_lsx);
++        p.cu[BLOCK_8x8].intra_pred[12] = PFX(intra_pred_ang8_12_lsx);
++        p.cu[BLOCK_8x8].intra_pred[13] = PFX(intra_pred_ang8_13_lsx);
++        p.cu[BLOCK_8x8].intra_pred[14] = PFX(intra_pred_ang8_14_lsx);
++        p.cu[BLOCK_8x8].intra_pred[15] = PFX(intra_pred_ang8_15_lsx);
++        p.cu[BLOCK_8x8].intra_pred[16] = PFX(intra_pred_ang8_16_lsx);
++        p.cu[BLOCK_8x8].intra_pred[17] = PFX(intra_pred_ang8_17_lsx);
++        p.cu[BLOCK_8x8].intra_pred[18] = PFX(intra_pred_ang8_18_lsx);
++        p.cu[BLOCK_8x8].intra_pred[19] = PFX(intra_pred_ang8_17_lsx);
++        p.cu[BLOCK_8x8].intra_pred[20] = PFX(intra_pred_ang8_16_lsx);
++        p.cu[BLOCK_8x8].intra_pred[21] = PFX(intra_pred_ang8_15_lsx);
++        p.cu[BLOCK_8x8].intra_pred[22] = PFX(intra_pred_ang8_14_lsx);
++        p.cu[BLOCK_8x8].intra_pred[23] = PFX(intra_pred_ang8_13_lsx);
++        p.cu[BLOCK_8x8].intra_pred[24] = PFX(intra_pred_ang8_12_lsx);
++        p.cu[BLOCK_8x8].intra_pred[25] = PFX(intra_pred_ang8_11_lsx);
++        p.cu[BLOCK_8x8].intra_pred[26] = PFX(intra_pred_ang8_26_lsx);
++        p.cu[BLOCK_8x8].intra_pred[27] = PFX(intra_pred_ang8_9_lsx);
++        p.cu[BLOCK_8x8].intra_pred[28] = PFX(intra_pred_ang8_8_lsx);
++        p.cu[BLOCK_8x8].intra_pred[29] = PFX(intra_pred_ang8_7_lsx);
++        p.cu[BLOCK_8x8].intra_pred[30] = PFX(intra_pred_ang8_6_lsx);
++        p.cu[BLOCK_8x8].intra_pred[31] = PFX(intra_pred_ang8_5_lsx);
++        p.cu[BLOCK_8x8].intra_pred[32] = PFX(intra_pred_ang8_4_lsx);
++        p.cu[BLOCK_8x8].intra_pred[33] = PFX(intra_pred_ang8_3_lsx);
++        p.cu[BLOCK_8x8].intra_pred[34] = PFX(intra_pred_ang8_34_lsx);
++
++        p.cu[BLOCK_16x16].intra_pred[2] = PFX(intra_pred_ang16_2_lsx);
++        p.cu[BLOCK_16x16].intra_pred[3] = PFX(intra_pred_ang16_3_lsx);
++        p.cu[BLOCK_16x16].intra_pred[4] = PFX(intra_pred_ang16_4_lsx);
++        p.cu[BLOCK_16x16].intra_pred[5] = PFX(intra_pred_ang16_5_lsx);
++        p.cu[BLOCK_16x16].intra_pred[6] = PFX(intra_pred_ang16_6_lsx);
++        p.cu[BLOCK_16x16].intra_pred[7] = PFX(intra_pred_ang16_7_lsx);
++        p.cu[BLOCK_16x16].intra_pred[8] = PFX(intra_pred_ang16_8_lsx);
++        p.cu[BLOCK_16x16].intra_pred[9] = PFX(intra_pred_ang16_9_lsx);
++        p.cu[BLOCK_16x16].intra_pred[10] = PFX(intra_pred_ang16_10_lsx);
++        p.cu[BLOCK_16x16].intra_pred[11] = PFX(intra_pred_ang16_11_lsx);
++        p.cu[BLOCK_16x16].intra_pred[12] = PFX(intra_pred_ang16_12_lsx);
++        p.cu[BLOCK_16x16].intra_pred[13] = PFX(intra_pred_ang16_13_lsx);
++        p.cu[BLOCK_16x16].intra_pred[14] = PFX(intra_pred_ang16_14_lsx);
++        p.cu[BLOCK_16x16].intra_pred[15] = PFX(intra_pred_ang16_15_lsx);
++        p.cu[BLOCK_16x16].intra_pred[16] = PFX(intra_pred_ang16_16_lsx);
++        p.cu[BLOCK_16x16].intra_pred[17] = PFX(intra_pred_ang16_17_lsx);
++        p.cu[BLOCK_16x16].intra_pred[18] = PFX(intra_pred_ang16_18_lsx);
++        p.cu[BLOCK_16x16].intra_pred[19] = PFX(intra_pred_ang16_19_lsx);
++        p.cu[BLOCK_16x16].intra_pred[20] = PFX(intra_pred_ang16_20_lsx);
++        p.cu[BLOCK_16x16].intra_pred[21] = PFX(intra_pred_ang16_21_lsx);
++        p.cu[BLOCK_16x16].intra_pred[22] = PFX(intra_pred_ang16_22_lsx);
++        p.cu[BLOCK_16x16].intra_pred[23] = PFX(intra_pred_ang16_23_lsx);
++        p.cu[BLOCK_16x16].intra_pred[24] = PFX(intra_pred_ang16_24_lsx);
++        p.cu[BLOCK_16x16].intra_pred[25] = PFX(intra_pred_ang16_25_lsx);
++        p.cu[BLOCK_16x16].intra_pred[26] = PFX(intra_pred_ang16_26_lsx);
++        p.cu[BLOCK_16x16].intra_pred[27] = PFX(intra_pred_ang16_27_lsx);
++        p.cu[BLOCK_16x16].intra_pred[28] = PFX(intra_pred_ang16_28_lsx);
++        p.cu[BLOCK_16x16].intra_pred[29] = PFX(intra_pred_ang16_29_lsx);
++        p.cu[BLOCK_16x16].intra_pred[30] = PFX(intra_pred_ang16_30_lsx);
++        p.cu[BLOCK_16x16].intra_pred[31] = PFX(intra_pred_ang16_31_lsx);
++        p.cu[BLOCK_16x16].intra_pred[32] = PFX(intra_pred_ang16_32_lsx);
++        p.cu[BLOCK_16x16].intra_pred[33] = PFX(intra_pred_ang16_33_lsx);
++        p.cu[BLOCK_16x16].intra_pred[34] = PFX(intra_pred_ang16_2_lsx);
++
++        p.cu[BLOCK_32x32].intra_pred[2] = PFX(intra_pred_ang32_2_lsx);
++        p.cu[BLOCK_32x32].intra_pred[3] = PFX(intra_pred_ang32_3_lsx);
++        p.cu[BLOCK_32x32].intra_pred[4] = PFX(intra_pred_ang32_4_lsx);
++        p.cu[BLOCK_32x32].intra_pred[5] = PFX(intra_pred_ang32_5_lsx);
++        p.cu[BLOCK_32x32].intra_pred[6] = PFX(intra_pred_ang32_6_lsx);
++        p.cu[BLOCK_32x32].intra_pred[7] = PFX(intra_pred_ang32_7_lsx);
++        p.cu[BLOCK_32x32].intra_pred[8] = PFX(intra_pred_ang32_8_lsx);
++        p.cu[BLOCK_32x32].intra_pred[9] = PFX(intra_pred_ang32_9_lsx);
++        p.cu[BLOCK_32x32].intra_pred[10] = PFX(intra_pred_ang32_10_lsx);
++        p.cu[BLOCK_32x32].intra_pred[11] = PFX(intra_pred_ang32_11_lsx);
++        p.cu[BLOCK_32x32].intra_pred[12] = PFX(intra_pred_ang32_12_lsx);
++        p.cu[BLOCK_32x32].intra_pred[13] = PFX(intra_pred_ang32_13_lsx);
++        p.cu[BLOCK_32x32].intra_pred[14] = PFX(intra_pred_ang32_14_lsx);
++        p.cu[BLOCK_32x32].intra_pred[15] = PFX(intra_pred_ang32_15_lsx);
++        p.cu[BLOCK_32x32].intra_pred[16] = PFX(intra_pred_ang32_16_lsx);
++        p.cu[BLOCK_32x32].intra_pred[17] = PFX(intra_pred_ang32_17_lsx);
++        p.cu[BLOCK_32x32].intra_pred[18] = PFX(intra_pred_ang32_18_lsx);
++        p.cu[BLOCK_32x32].intra_pred[19] = PFX(intra_pred_ang32_19_lsx);
++        p.cu[BLOCK_32x32].intra_pred[20] = PFX(intra_pred_ang32_20_lsx);
++        p.cu[BLOCK_32x32].intra_pred[21] = PFX(intra_pred_ang32_21_lsx);
++        p.cu[BLOCK_32x32].intra_pred[22] = PFX(intra_pred_ang32_22_lsx);
++        p.cu[BLOCK_32x32].intra_pred[23] = PFX(intra_pred_ang32_23_lsx);
++        p.cu[BLOCK_32x32].intra_pred[24] = PFX(intra_pred_ang32_24_lsx);
++        p.cu[BLOCK_32x32].intra_pred[25] = PFX(intra_pred_ang32_25_lsx);
++        p.cu[BLOCK_32x32].intra_pred[26] = PFX(intra_pred_ang32_26_lsx);
++        p.cu[BLOCK_32x32].intra_pred[27] = PFX(intra_pred_ang32_27_lsx);
++        p.cu[BLOCK_32x32].intra_pred[28] = PFX(intra_pred_ang32_28_lsx);
++        p.cu[BLOCK_32x32].intra_pred[29] = PFX(intra_pred_ang32_29_lsx);
++        p.cu[BLOCK_32x32].intra_pred[30] = PFX(intra_pred_ang32_30_lsx);
++        p.cu[BLOCK_32x32].intra_pred[31] = PFX(intra_pred_ang32_31_lsx);
++        p.cu[BLOCK_32x32].intra_pred[32] = PFX(intra_pred_ang32_32_lsx);
++        p.cu[BLOCK_32x32].intra_pred[33] = PFX(intra_pred_ang32_33_lsx);
++        p.cu[BLOCK_32x32].intra_pred[34] = PFX(intra_pred_ang32_34_lsx);
++
++        //intra_pred_dc
++        p.cu[BLOCK_4x4].intra_pred[DC_IDX] = PFX(intra_pred_dc4_lsx);
++        p.cu[BLOCK_8x8].intra_pred[DC_IDX] = PFX(intra_pred_dc8_lsx);
++        p.cu[BLOCK_16x16].intra_pred[DC_IDX] = PFX(intra_pred_dc16_lsx);
++        p.cu[BLOCK_32x32].intra_pred[DC_IDX] = PFX(intra_pred_dc32_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -467,6 +611,50 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x32].addAvg, addAvg_32x32_lasx);
+         ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x48].addAvg, addAvg_32x48_lasx);
+         ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x64].addAvg, addAvg_32x64_lasx);
++
++        //intra_pred
++        p.cu[BLOCK_8x8].intra_pred[3] = PFX(intra_pred_ang8_3_lasx);
++        p.cu[BLOCK_8x8].intra_pred[4] = PFX(intra_pred_ang8_4_lasx);
++        p.cu[BLOCK_8x8].intra_pred[5] = PFX(intra_pred_ang8_5_lasx);
++        p.cu[BLOCK_8x8].intra_pred[6] = PFX(intra_pred_ang8_6_lasx);
++        p.cu[BLOCK_8x8].intra_pred[7] = PFX(intra_pred_ang8_7_lasx);
++        p.cu[BLOCK_8x8].intra_pred[8] = PFX(intra_pred_ang8_8_lasx);
++        p.cu[BLOCK_8x8].intra_pred[9] = PFX(intra_pred_ang8_9_lasx);
++        p.cu[BLOCK_8x8].intra_pred[11] = PFX(intra_pred_ang8_11_lasx);
++        p.cu[BLOCK_8x8].intra_pred[12] = PFX(intra_pred_ang8_12_lasx);
++        p.cu[BLOCK_8x8].intra_pred[13] = PFX(intra_pred_ang8_13_lasx);
++        p.cu[BLOCK_8x8].intra_pred[14] = PFX(intra_pred_ang8_14_lasx);
++        p.cu[BLOCK_8x8].intra_pred[15] = PFX(intra_pred_ang8_15_lasx);
++        p.cu[BLOCK_8x8].intra_pred[16] = PFX(intra_pred_ang8_16_lasx);
++        p.cu[BLOCK_8x8].intra_pred[17] = PFX(intra_pred_ang8_17_lasx);
++        p.cu[BLOCK_8x8].intra_pred[19] = PFX(intra_pred_ang8_19_lasx);
++        p.cu[BLOCK_8x8].intra_pred[20] = PFX(intra_pred_ang8_20_lasx);
++        p.cu[BLOCK_8x8].intra_pred[21] = PFX(intra_pred_ang8_21_lasx);
++        p.cu[BLOCK_8x8].intra_pred[22] = PFX(intra_pred_ang8_22_lasx);
++        p.cu[BLOCK_8x8].intra_pred[23] = PFX(intra_pred_ang8_23_lasx);
++        p.cu[BLOCK_8x8].intra_pred[24] = PFX(intra_pred_ang8_24_lasx);
++        p.cu[BLOCK_8x8].intra_pred[25] = PFX(intra_pred_ang8_25_lasx);
++        p.cu[BLOCK_8x8].intra_pred[27] = PFX(intra_pred_ang8_27_lasx);
++        p.cu[BLOCK_8x8].intra_pred[28] = PFX(intra_pred_ang8_28_lasx);
++        p.cu[BLOCK_8x8].intra_pred[29] = PFX(intra_pred_ang8_29_lasx);
++        p.cu[BLOCK_8x8].intra_pred[30] = PFX(intra_pred_ang8_30_lasx);
++        p.cu[BLOCK_8x8].intra_pred[31] = PFX(intra_pred_ang8_31_lasx);
++        p.cu[BLOCK_8x8].intra_pred[32] = PFX(intra_pred_ang8_32_lasx);
++        p.cu[BLOCK_8x8].intra_pred[33] = PFX(intra_pred_ang8_33_lasx);
++        p.cu[BLOCK_16x16].intra_pred[3] = PFX(intra_pred_ang16_3_lasx);
++        p.cu[BLOCK_16x16].intra_pred[4] = PFX(intra_pred_ang16_4_lasx);
++        p.cu[BLOCK_16x16].intra_pred[5] = PFX(intra_pred_ang16_5_lasx);
++        p.cu[BLOCK_16x16].intra_pred[6] = PFX(intra_pred_ang16_6_lasx);
++        p.cu[BLOCK_16x16].intra_pred[7] = PFX(intra_pred_ang16_7_lasx);
++        p.cu[BLOCK_16x16].intra_pred[8] = PFX(intra_pred_ang16_8_lasx);
++        p.cu[BLOCK_16x16].intra_pred[9] = PFX(intra_pred_ang16_9_lasx);
++        p.cu[BLOCK_16x16].intra_pred[11] = PFX(intra_pred_ang16_11_lasx);
++        p.cu[BLOCK_16x16].intra_pred[12] = PFX(intra_pred_ang16_12_lasx);
++        p.cu[BLOCK_16x16].intra_pred[13] = PFX(intra_pred_ang16_13_lasx);
++        p.cu[BLOCK_16x16].intra_pred[14] = PFX(intra_pred_ang16_14_lasx);
++        p.cu[BLOCK_16x16].intra_pred[15] = PFX(intra_pred_ang16_15_lasx);
++        p.cu[BLOCK_16x16].intra_pred[16] = PFX(intra_pred_ang16_16_lasx);
++        p.cu[BLOCK_16x16].intra_pred[17] = PFX(intra_pred_ang16_17_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/intrapred.h b/source/common/loongarch64/intrapred.h
+new file mode 100644
+index 000000000..5220e2166
+--- /dev/null
++++ b/source/common/loongarch64/intrapred.h
+@@ -0,0 +1,205 @@
++/*****************************************************************************
++ * intrapred.h: Intra Prediction metrics
++ *****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: jinbo <jinbo@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_LOONGARCH_INTRAPRED_H
++#define X265_LOONGARCH_INTRAPRED_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++void x265_intra_pred_ang8_2_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_3_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_5_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_6_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_7_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_8_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_9_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_10_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_11_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_12_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_13_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_14_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_15_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_16_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_17_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_18_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_26_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_34_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_2_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_3_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_5_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_6_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_7_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_8_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_9_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_10_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_11_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_12_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_13_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_14_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_15_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_16_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_17_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_18_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_19_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_20_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_21_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_22_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_23_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_24_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_25_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_26_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_27_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_28_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_29_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_30_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_31_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_32_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_33_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_2_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_3_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_5_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_6_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_6_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_6_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_7_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_8_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_9_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_10_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_11_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_12_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_13_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_14_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_15_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_16_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_17_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_18_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_19_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_20_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_21_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_22_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_23_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_24_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_25_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_26_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_27_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_28_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_29_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_30_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_31_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_32_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_33_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang32_34_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_2_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_3_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_5_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_6_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_7_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_8_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_9_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_10_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_11_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_12_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_13_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_14_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_15_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_16_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_17_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_18_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_19_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_20_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_21_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_22_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_23_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_24_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_25_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_26_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_27_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_28_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_29_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_30_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_31_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_32_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_33_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang4_34_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++
++void x265_intra_pred_ang8_3_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_4_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_5_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_6_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_7_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_8_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_9_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_11_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_12_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_13_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_14_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_15_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_16_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_17_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_19_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_20_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_21_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_22_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_23_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_24_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_25_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_27_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_28_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_29_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_30_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_31_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_32_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang8_33_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_3_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_4_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_5_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_6_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_7_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_8_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_9_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_11_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_12_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_13_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_14_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_15_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_16_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_ang16_17_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++
++void x265_intra_pred_dc4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_dc8_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_dc16_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_dc32_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++void x265_intra_pred_dc32_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++#ifdef __cplusplus
++}
++#endif /* __cplusplus */
++
++#endif // ifndef X265_LOONGARCH_INTRAPRED_H
+diff --git a/source/common/loongarch64/intrapred8.S b/source/common/loongarch64/intrapred8.S
+new file mode 100644
+index 000000000..19969ca8a
+--- /dev/null
++++ b/source/common/loongarch64/intrapred8.S
+@@ -0,0 +1,10778 @@
++/*****************************************************************************
++* Copyright (C) 2024 MulticoreWare, Inc
++*
++* Authors: jinbo <jinbo@loongson.cn>
++*
++* This program is free software; you can redistribute it and/or modify
++* it under the terms of the GNU General Public License as published by
++* the Free Software Foundation; either version 2 of the License, or
++* (at your option) any later version.
++*
++* This program is distributed in the hope that it will be useful,
++* but WITHOUT ANY WARRANTY; without even the implied warranty of
++* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++* GNU General Public License for more details.
++*
++* You should have received a copy of the GNU General Public License
++* along with this program; if not, write to the Free Software
++* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++*
++* This program is also available under a commercial proprietary license.
++* For more information, contact us at license @ x265.com.
++******************************************************************************/
++
++#include "loongson_asm.S"
++
++/*
++void intra_pred_ang8_c(pixel* dst, intptr_t dstStride, const pixel *srcPix0,
++                      int dirMode, int bFilter)
++*/
++function x265_intra_pred_ang8_2_lsx
++    addi.d    t0,    a2,    18
++    vld       vr0,   t0,    0 //load srcPix0
++
++    vbsrl.v   vr1,   vr0,   1
++    fst.d     f0,    a0,    0
++    fstx.d    f1,    a0,    a1
++    alsl.d    a0,    a1,    a0,   1
++    vbsrl.v   vr1,   vr0,   2
++    vbsrl.v   vr2,   vr0,   3
++    fst.d     f1,    a0,    0
++    fstx.d    f2,    a0,    a1
++    alsl.d    a0,    a1,    a0,   1
++    vbsrl.v   vr1,   vr0,   4
++    vbsrl.v   vr2,   vr0,   5
++    fst.d     f1,    a0,    0
++    fstx.d    f2,    a0,    a1
++    alsl.d    a0,    a1,    a0,   1
++    vbsrl.v   vr1,   vr0,   6
++    vbsrl.v   vr2,   vr0,   7
++    fst.d     f1,    a0,    0
++    fstx.d    f2,    a0,    a1
++endfunc
++
++function x265_intra_pred_ang8_34_lsx
++    addi.d    t0,    a2,    2
++    vld       vr0,   t0,    0 //load srcPix0
++
++    vbsrl.v   vr1,   vr0,   1
++    fst.d     f0,    a0,    0
++    fstx.d    f1,    a0,    a1
++    alsl.d    a0,    a1,    a0,   1
++    vbsrl.v   vr1,   vr0,   2
++    vbsrl.v   vr2,   vr0,   3
++    fst.d     f1,    a0,    0
++    fstx.d    f2,    a0,    a1
++    alsl.d    a0,    a1,    a0,   1
++    vbsrl.v   vr1,   vr0,   4
++    vbsrl.v   vr2,   vr0,   5
++    fst.d     f1,    a0,    0
++    fstx.d    f2,    a0,    a1
++    alsl.d    a0,    a1,    a0,   1
++    vbsrl.v   vr1,   vr0,   6
++    vbsrl.v   vr2,   vr0,   7
++    fst.d     f1,    a0,    0
++    fstx.d    f2,    a0,    a1
++endfunc
++
++.macro TRANSPOSE4x16_B src0, src1, src2, src3, \
++                       dst0, dst1, dst2, dst3
++    vilvl.b    \dst0,   \src1,   \src0 // 0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 (0 1)
++    vilvh.b    \dst1,   \src1,   \src0 // 0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 (4 5)
++    vilvl.b    \dst2,   \src3,   \src2 // 0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 (2 3)
++    vilvh.b    \dst3,   \src3,   \src2 // 0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 (6 7)
++
++    vilvl.h    \src0,   \dst2,   \dst0 // 0 0 0 0 1 1 1 1 2 2 2 2 3 3 3 3 (0 1 2 3)
++    vilvh.h    \src1,   \dst2,   \dst0 // 4 4 4 4 5 5 5 5 6 6 6 6 7 7 7 7 (0 1 2 3)
++    vilvl.h    \src2,   \dst3,   \dst1 // 0 0 0 0 1 1 1 1 2 2 2 2 3 3 3 3 (4 5 6 7)
++    vilvh.h    \src3,   \dst3,   \dst1 // 4 4 4 4 5 5 5 5 6 6 6 6 7 7 7 7 (4 5 6 7)
++
++    vilvl.w    \dst0,   \src2,   \src0 // 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1
++    vilvh.w    \dst1,   \src2,   \src0 // 2 2 2 2 2 2 2 2 3 3 3 3 3 3 3 3
++    vilvl.w    \dst2,   \src3,   \src1 // 4 4 4 4 4 4 4 4 5 5 5 5 5 5 5 5
++    vilvh.w    \dst3,   \src3,   \src1 // 6 6 6 6 6 6 6 6 7 7 7 7 7 7 7 7
++.endm
++
++const ang8_mode3, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-26, 26, 32-20, 20, 32-14, 14, 32-8, 8, 32-2, 2, 32-28, 28, 32-22, 22, 32-16, 16
++endconst
++function x265_intra_pred_ang8_3_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     33
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=3
++    la.local            t0,     ang8_mode3
++    vld                 vr1,    t0,     16  //fraction
++    vld                 vr20,   t0,     0   //shuf
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++.macro ANG8_STORE8x8_B
++    xvstelm.d    xr7,    a0,    0,    0
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr7,    a0,    0,    2
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr7,    a0,    0,    1
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr7,    a0,    0,    3
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr13,   a0,    0,    0
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr13,   a0,    0,    2
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr13,   a0,    0,    1
++    add.d        a0,     a0,    a1
++    xvstelm.d    xr13,   a0,    0,    3
++.endm
++
++const lasx_ang8_mode3, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 4, 5, 5, 6, 6, 7, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 5, 6, 6, 7, 7, 8
++.byte 32-26, 26, 32-20, 20, 32-14, 14, 32-8, 8, 32-2, 2, 32-28, 28, 32-22, 22, 32-16, 16
++endconst
++function x265_intra_pred_ang8_3_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode3
++    xvld                xr1,    t0,     32 //fraction
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvld                xr2,    t0,     0  //shuf
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode33, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-26, 26, 32-14, 14, 32-2, 2, 32-22, 22, 0,0,0,0,0,0,0,0, 32-20, 20, 32-8, 8, 32-28, 28, 32-16, 16, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_33_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode33
++    xvld                xr1,    t0,     32  //fraction
++    xvld                xr20,   t0,     0   //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 1
++
++    xvaddi.bu           xr20,   xr20,   2 //offset = 2 3
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr20,   xr20,   2 //offset = 4 4
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr20
++    xvpermi.q           xr9,    xr9,    0x00
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 5 6
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode4, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-21, 21, 32-10, 10, 32-31, 31, 32-20, 20, 32-9, 9, 32-30, 30, 32-19, 19, 32-8, 8
++endconst
++function x265_intra_pred_ang8_4_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     32
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=4
++    la.local            t0,     ang8_mode4
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++const lasx_ang8_mode4, align=5
++.byte 0, 1, 1, 2, 1, 2, 2, 3, 3, 4, 3, 4, 4, 5, 5, 6, 1, 2, 2, 3, 2, 3, 3, 4, 4, 5, 4, 5, 5, 6, 6, 7
++.byte 32-21, 21, 32-10, 10, 32-31, 31, 32-20, 20, 32-9, 9, 32-30, 30, 32-19, 19, 32-8, 8
++endconst
++function x265_intra_pred_ang8_4_lasx
++    xvld                xr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode4
++    xvld                xr1,    t0,     32 //fraction
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvld                xr2,    t0,     0  //shuf
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode32, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-21, 21, 32-31, 31, 32-9, 9, 32-19, 19, 0,0,0,0,0,0,0,0, 32-10, 10, 32-20, 20, 32-30, 30, 32-8, 8, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_32_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode32
++    xvld                xr1,    t0,     32  //fraction
++    xvld                xr20,   t0,     0   //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 1
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 1 2
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr20,   xr20,   2 //offset = 3 3
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr20
++    xvpermi.q           xr9,    xr9,    0x00
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 4 5
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode5, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-17, 17, 32-2, 2, 32-19, 19, 32-4, 4, 32-21, 21, 32-6, 6, 32-23, 23, 32-8, 8
++endconst
++function x265_intra_pred_ang8_5_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     31
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=5
++    la.local            t0,     ang8_mode5
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++const lasx_ang8_mode5, align=5
++.byte 0, 1, 1, 2, 1, 2, 2, 3, 2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2, 3, 3, 4, 3, 4, 4, 5, 4, 5, 5, 6
++.byte 32-17, 17, 32-2, 2, 32-19, 19, 32-4, 4, 32-21, 21, 32-6, 6, 32-23, 23, 32-8, 8
++endconst
++function x265_intra_pred_ang8_5_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode5
++    xvld                xr1,    t0,     32 //fraction
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvld                xr2,    t0,     0  //shuf
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode31, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-17, 17, 32-19, 19, 32-21, 21, 32-23, 23, 0,0,0,0,0,0,0,0, 32-2, 2, 32-4, 4, 32-6, 6, 32-8, 8, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_31_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode31
++    xvld                xr1,    t0,     32  //fraction
++    xvld                xr20,   t0,     0   //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 1
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 1 2
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 2 3
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 3 4
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode6, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-13, 13, 32-26, 26, 32-7, 7, 32-20, 20, 32-1, 1, 32-14, 14, 32-27, 27, 32-8, 8
++endconst
++function x265_intra_pred_ang8_6_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     30
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=6
++    la.local            t0,     ang8_mode6
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++const lasx_ang8_mode6, align=5
++.byte 0, 1, 0, 1, 1, 2, 1, 2, 2, 3, 2, 3, 2, 3, 3, 4, 1, 2, 1, 2, 2, 3, 2, 3, 3, 4, 3, 4, 3, 4, 4, 5
++.byte 32-13, 13, 32-26, 26, 32-7, 7, 32-20, 20, 32-1, 1, 32-14, 14, 32-27, 27, 32-8, 8
++endconst
++function x265_intra_pred_ang8_6_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode6
++    xvld                xr1,    t0,     32 //fraction
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvld                xr2,    t0,     0  //shuf
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode30, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-13, 13, 32-7, 7, 32-1, 1, 32-27, 27, 0,0,0,0,0,0,0,0, 32-26, 26, 32-20, 20, 32-14, 14, 32-8, 8, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_30_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode30
++    xvld                xr1,    t0,     32  //fraction
++    xvld                xr20,   t0,     0   //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvpermi.q           xr6,    xr3,    0x11 //offset = 1 1
++    xvpermi.q           xr3,    xr3,    0x00
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2  //offset = 0 0
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr20,   xr20,   2 //offset = 2 3
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvpermi.q           xr9,    xr12,   0x00 //offset = 2 2
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode7, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-9, 9, 32-18, 18, 32-27, 27, 32-4, 4, 32-13, 13, 32-22, 22, 32-31, 31, 32-8, 8
++endconst
++function x265_intra_pred_ang8_7_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     29
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=7
++    la.local            t0,     ang8_mode7
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++const lasx_ang8_mode7, align=5
++.byte 0, 1, 0, 1, 0, 1, 1, 2, 1, 2, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2, 1, 2, 2, 3, 2, 3, 2, 3, 2, 3, 3, 4
++.byte 32-9, 9, 32-18, 18, 32-27, 27, 32-4, 4, 32-13, 13, 32-22, 22, 32-31, 31, 32-8, 8
++endconst
++function x265_intra_pred_ang8_7_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode7
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode29, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-9, 9, 32-27, 27, 32-13, 13, 32-31, 31, 0,0,0,0,0,0,0,0, 32-18, 18, 32-4, 4, 32-22, 22, 32-8, 8, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_29_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode29
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvpermi.q           xr3,    xr6,    0x00
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 0
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5 //offset = 0 1
++
++    xvaddi.bu           xr20,   xr20,   1 //offset = 1 2
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvpermi.q           xr9,    xr12,   0x00 //offset = 1 1
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode8, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-5, 5, 32-10, 10, 32-15, 15, 32-20, 20, 32-25, 25, 32-30, 30, 32-3, 3, 32-8, 8
++endconst
++function x265_intra_pred_ang8_8_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     28
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=8
++    la.local            t0,     ang8_mode8
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++const lasx_ang8_mode8, align=5
++.byte 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 2, 3, 2, 3
++.byte 32-5, 5, 32-10, 10, 32-15, 15, 32-20, 20, 32-25, 25, 32-30, 30, 32-3, 3, 32-8, 8
++endconst
++function x265_intra_pred_ang8_8_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode8
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode28, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-5, 5, 32-15, 15, 32-25, 25, 32-3, 3, 0,0,0,0,0,0,0,0, 32-10, 10, 32-20, 20, 32-30, 30, 32-8, 8, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_28_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode28
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvpermi.q           xr12,   xr6,    0x11
++    xvpermi.q           xr3,    xr6,    0x00
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 0
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr3,    xr5
++
++    xvaddi.bu           xr20,   xr20,   1
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr3,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr3,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr3,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode9, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-2, 2, 32-4, 4, 32-6, 6, 32-8, 8, 32-10, 10, 32-12, 12, 32-14, 14, 32-16, 16
++endconst
++function x265_intra_pred_ang8_9_lsx
++    addi.d              t0,     a2,     1
++    li.w                t1,     27
++    beq                 t1,     a3,     1f
++    addi.d              t0,     a2,     17
++1:
++    vld                 vr0,    t0,     0   //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=9
++    la.local            t0,     ang8_mode9
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beq                 t1,     a3,     2f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   3f
++2:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++3:
++endfunc
++
++const lasx_ang8_mode9, align=5
++.byte 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2
++.byte 32-2, 2, 32-4, 4, 32-6, 6, 32-8, 8, 32-10, 10, 32-12, 12, 32-14, 14, 32-16, 16
++endconst
++function x265_intra_pred_ang8_9_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    la.local            t0,     lasx_ang8_mode9
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode27, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9
++.byte 32-2, 2, 32-6, 6, 32-10, 10, 32-14, 14, 0,0,0,0,0,0,0,0, 32-4, 4, 32-8, 8, 32-12, 12, 32-16, 16, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_27_lasx
++    vld                 vr0,    a2,     1
++    la.local            t0,     lasx_ang8_mode27
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvpermi.q           xr3,    xr6,    0x00
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 0
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr3,    xr5
++
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr3,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr3,    xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr3,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr3,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr3,    xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++function x265_intra_pred_ang8_10_lsx
++    addi.d              t0,     a2,     17
++    vld                 vr0,    t0,     0 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 dirMode=10
++    vreplvei.b          vr2,    vr0,    0
++    vreplvei.b          vr3,    vr0,    1
++    vreplvei.b          vr4,    vr0,    2
++    vreplvei.b          vr5,    vr0,    3
++    vreplvei.b          vr6,    vr0,    4
++    vreplvei.b          vr7,    vr0,    5
++    vreplvei.b          vr8,    vr0,    6
++    vreplvei.b          vr9,    vr0,    7
++
++    beqz                a4,     1f
++
++    //bFilter
++    vld                 vr10,   a2,     0
++    vbsrl.v             vr11,   vr10,   1
++    vsllwil.hu.bu       vr11,   vr11,   0 //srcPix[width2 + 1 + y]
++    vsllwil.hu.bu       vr10,   vr10,   0
++    vreplvei.h          vr13,   vr10,   0 //topLeft
++    vsllwil.hu.bu       vr14,   vr2,    0
++    vreplvei.h          vr14,   vr14,   0 //top
++    vsub.h              vr11,   vr11,   vr13
++    vsrai.h             vr11,   vr11,   1
++    vadd.h              vr11,   vr11,   vr14
++    vssrani.bu.h        vr2,    vr11,   0
++1:
++    fst.d               f2,     a0,     0
++    fstx.d              f3,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f4,     a0,     0
++    fstx.d              f5,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f6,     a0,     0
++    fstx.d              f7,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f8,     a0,     0
++    fstx.d              f9,     a0,     a1
++endfunc
++
++function x265_intra_pred_ang8_26_lsx
++    addi.d              t0,     a2,     1
++    vld                 vr0,    t0,     0 //1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 dirMode=26
++
++    beqz                a4,     1f
++
++    //bFilter
++    addi.d              t0,     a2,     17
++    vld                 vr1,    t0,     0
++    vsllwil.hu.bu       vr2,    vr1,    0 //srcPix[width2 + 1 + y]
++    vldrepl.b           vr3,    a2,     0
++    vsllwil.hu.bu       vr3,    vr3,    0 //topLeft
++    vsllwil.hu.bu       vr4,    vr0,    0
++    vreplvei.h          vr4,    vr4,    0
++    vsub.h              vr2,    vr2,    vr3
++    vsrai.h             vr2,    vr2,    1
++    vadd.h              vr2,    vr2,    vr4
++    vssrani.bu.h        vr2,    vr2,    0
++
++    vextrins.b          vr0,    vr2,    0x00
++    fst.d               f0,     a0,     0
++    vextrins.b          vr0,    vr2,    0x01
++    fstx.d              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vextrins.b          vr0,    vr2,    0x02
++    fst.d               f0,     a0,     0
++    vextrins.b          vr0,    vr2,    0x03
++    fstx.d              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vextrins.b          vr0,    vr2,    0x04
++    fst.d               f0,     a0,     0
++    vextrins.b          vr0,    vr2,    0x05
++    fstx.d              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vextrins.b          vr0,    vr2,    0x06
++    fst.d               f0,     a0,     0
++    vextrins.b          vr0,    vr2,    0x07
++    fstx.d              f0,     a0,     a1
++    b                   2f
++1:
++    fst.d               f0,     a0,     0
++    fstx.d              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f0,     a0,     0
++    fstx.d              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f0,     a0,     0
++    fstx.d              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f0,     a0,     0
++    fstx.d              f0,     a0,     a1
++2:
++endfunc
++
++const ang8_mode11, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-30, 30, 32-28, 28, 32-26, 26, 32-24, 24, 32-22, 22, 32-20, 20, 32-18, 18, 32-16, 16
++endconst
++function x265_intra_pred_ang8_11_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -25
++    maskeqz             t0,     t2,     t1 // dirMode=25
++    add.d               t0,     t0,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vldrepl.b           vr20,   a2,     0
++    vextrins.b          vr0,    vr20,   0x00 //insert to ref_pix[-1]
++
++    la.local            t0,     ang8_mode11
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode11, align=5
++.byte 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2
++.byte 32-30, 30, 32-28, 28, 32-26, 26, 32-24, 24, 32-22, 22, 32-20, 20, 32-18, 18, 32-16, 16
++endconst
++function x265_intra_pred_ang8_11_lasx
++    vld                 vr0,    a2,     16 //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    vldrepl.b           vr1,    a2,     0
++    vextrins.b          vr0,    vr1,    0x00
++    la.local            t0,     lasx_ang8_mode11
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode25, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-30, 30, 32-26, 26, 32-22, 22, 32-18, 18, 0,0,0,0,0,0,0,0, 32-28, 28, 32-24, 24, 32-20, 20, 32-16, 16, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_25_lasx
++    vld                 vr0,    a2,     0
++    la.local            t0,     lasx_ang8_mode25
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2 //offset = 0 0
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr3,    xr5
++
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr3,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr3,    xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr3,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr3,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr3,    xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode12, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-27, 27, 32-22, 22, 32-17, 17, 32-12, 12, 32-7, 7, 32-2, 2, 32-29, 29, 32-24, 24
++endconst
++function x265_intra_pred_ang8_12_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -24
++    maskeqz             t0,     t2,     t1 //dirMode=24
++    masknez             t3,     t2,     t1 //dirMode=12
++    add.d               t0,     t0,     a2
++    add.d               t2,     t3,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vbsll.v             vr0,    vr0,    1   //x 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
++    vld                 vr20,   a2,     0
++    vld                 vr21,   t2,     0
++    vextrins.b          vr0,    vr21,   0x06 //insert to ref_pix[-2]
++    vextrins.b          vr0,    vr20,   0x10 //insert to ref_pix[-1]
++
++    la.local            t0,     ang8_mode12
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vbsrl.v             vr21,   vr0,    1   //ref_pix[-1]
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20 //ref_pix[-2]
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode12, align=5
++.byte 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 0, 1, 0, 1, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 1, 2, 1, 2
++.byte 32-27, 27, 32-22, 22, 32-17, 17, 32-12, 12, 32-7, 7, 32-2, 2, 32-29, 29, 32-24, 24
++endconst
++function x265_intra_pred_ang8_12_lasx
++    vld                 vr0,    a2,     15 //15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    vld                 vr1,    a2,     0
++    vextrins.b          vr0,    vr1,    0x06
++    vextrins.b          vr0,    vr1,    0x10
++    la.local            t0,     lasx_ang8_mode12
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode24, align=5
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-27, 27, 32-17, 17, 32-7, 7, 32-29, 29, 0,0,0,0,0,0,0,0, 32-22, 22, 32-12, 12, 32-2, 2, 32-24, 24, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_24_lasx
++    vld                 vr0,    a2,     0
++    vbsll.v             vr0,    vr0,    1
++    vldrepl.b           vr1,    a2,     16+6
++    vextrins.b          vr0,    vr1,    0x00
++    la.local            t0,     lasx_ang8_mode24
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvaddi.bu           xr14,   xr20,   1
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr14 //offset = -1 -1
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr3,    xr5
++
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr3,    xr8
++
++    xvshuf.b            xr6,    xr0,    xr0,    xr20
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr6,    xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr3,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr3,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr6,    xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode13, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-23, 23, 32-14, 14, 32-5, 5, 32-28, 28, 32-19, 19, 32-10, 10, 32-1, 1, 32-24, 24
++endconst
++function x265_intra_pred_ang8_13_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -23
++    maskeqz             t0,     t2,     t1 //dirMode=23
++    masknez             t3,     t2,     t1 //dirMode=13
++    add.d               t0,     t0,     a2
++    add.d               t2,     t3,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vbsll.v             vr0,    vr0,    2   //x 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
++    vld                 vr20,   a2,     0
++    vld                 vr21,   t2,     0
++    vextrins.b          vr0,    vr21,   0x07 //insert to ref_pix[-3]
++    vextrins.b          vr0,    vr21,   0x14 //insert to ref_pix[-2]
++    vextrins.b          vr0,    vr20,   0x20 //insert to ref_pix[-1]
++
++    la.local            t0,     ang8_mode13
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vbsrl.v             vr21,   vr0,    2   //ref_pix[-1]
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr21,   vr0,    1  //ref_pix[-2]
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr21,   vr21,     vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20 //ref_pix[-3]
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode13, align=5
++.byte 2, 3, 2, 3, 2, 3, 1, 2, 1, 2, 1, 2, 1, 2, 0, 1, 3, 4, 3, 4, 3, 4, 2, 3, 2, 3, 2, 3, 2, 3, 1, 2
++.byte 32-23, 23, 32-14, 14, 32-5, 5, 32-28, 28, 32-19, 19, 32-10, 10, 32-1, 1, 32-24, 24
++endconst
++function x265_intra_pred_ang8_13_lasx
++    vld                 vr0,    a2,     14 //14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    vld                 vr1,    a2,     0
++    vextrins.b          vr0,    vr1,    0x07
++    vextrins.b          vr0,    vr1,    0x14
++    vextrins.b          vr0,    vr1,    0x20
++    la.local            t0,     lasx_ang8_mode13
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode23, align=5
++.byte 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-23, 23, 32-5, 5, 32-19, 19, 32-1, 1, 0,0,0,0,0,0,0,0, 32-14, 14, 32-28, 28, 32-10, 10, 32-24, 24, 0,0,0,0,0,0,0,0
++endconst
++function x265_intra_pred_ang8_23_lasx
++    vld                 vr0,    a2,     0
++    vbsll.v             vr0,    vr0,    2
++    vld                 vr1,    a2,     16
++    vextrins.b          vr0,    vr1,    0x07
++    vextrins.b          vr0,    vr1,    0x14
++    la.local            t0,     lasx_ang8_mode23
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvaddi.bu           xr14,   xr20,   1 //offset = -1 -2
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr6,    xr0,    xr0,    xr14
++    xvpermi.q           xr3,    xr6,    0x00 //-1-1
++    xvpermi.q           xr9,    xr6,    0x11 //-2-2
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode14, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-19, 19, 32-6, 6, 32-25, 25, 32-12, 12, 32-31, 31, 32-18, 18, 32-5, 5, 32-24, 24
++endconst
++function x265_intra_pred_ang8_14_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -22
++    maskeqz             t0,     t2,     t1 //dirMode=22
++    masknez             t3,     t2,     t1 //dirMode=14
++    add.d               t0,     t0,     a2
++    add.d               t2,     t3,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vldrepl.b           vr20,   a2,     0
++    vld                 vr21,   t2,     0
++    vbsll.v             vr0,    vr0,    3   //x x x 16 17 18 19 20 21 22 23 24 25 26 27 28 29
++    vextrins.b          vr0,    vr21,   0x07 //insert to ref_pix[-4]
++    vextrins.b          vr0,    vr21,   0x15 //insert to ref_pix[-3]
++    vextrins.b          vr0,    vr21,   0x22 //insert to ref_pix[-2]
++    vextrins.b          vr0,    vr20,   0x30 //insert to ref_pix[-1]
++
++    la.local            t0,     ang8_mode14
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vbsrl.v             vr21,   vr0,    3   //ref_pix[-1]
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr6,    vr0,    2  //ref_pix[-2]
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr6,    vr6,     vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr3,    vr0,    1  //ref_pix[-3]
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr12,   vr3,    vr3,     vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,     vr20 //ref_pix[-4]
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode14, align=5
++.byte 3, 4, 3, 4, 2, 3, 2, 3, 1, 2, 1, 2, 1, 2, 0, 1, 4, 5, 4, 5, 3, 4, 3, 4, 2, 3, 2, 3, 2, 3, 1, 2
++.byte 32-19, 19, 32-6, 6, 32-25, 25, 32-12, 12, 32-31, 31, 32-18, 18, 32-5, 5, 32-24, 24
++.byte 7, 5, 2, 0, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
++endconst
++function x265_intra_pred_ang8_14_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29
++    vld                 vr1,    a2,     0
++    la.local            t0,     lasx_ang8_mode14
++    vld                 vr2,    t0,     48
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode22, align=5
++.byte 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-19, 19, 32-25, 25, 32-31, 31, 32-5, 5, 0,0,0,0,0,0,0,0, 32-6, 6, 32-12, 12, 32-18, 18, 32-24, 24, 0,0,0,0,0,0,0,0
++.byte 7, 5, 2, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
++endconst
++function x265_intra_pred_ang8_22_lasx
++    vld                 vr0,    a2,     0
++    vld                 vr1,    a2,     16
++    la.local            t0,     lasx_ang8_mode22
++    vld                 vr2,    t0,     64
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvaddi.bu           xr14,   xr20,   2 //offset = -1-2
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr6,    xr0,    xr0,    xr14
++    xvpermi.q           xr3,    xr6,    0x00 //-1-1
++    xvpermi.q           xr6,    xr6,    0x11 //-2-2
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2
++
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvshuf.b            xr12,   xr0,    xr0,    xr20 //offset = -3-4
++    xvpermi.q           xr9,    xr12,   0x00
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode15, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-15, 15, 32-30, 30, 32-13, 13, 32-28, 28, 32-11, 11, 32-26, 26, 32-9, 9, 32-24, 24
++endconst
++function x265_intra_pred_ang8_15_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -21
++    maskeqz             t0,     t2,     t1 //dirMode=21
++    masknez             t3,     t2,     t1 //dirMode=15
++    add.d               t0,     t0,     a2
++    add.d               t2,     t3,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vldrepl.b           vr20,   a2,     0
++    vld                 vr21,   t2,     0
++    vbsll.v             vr0,    vr0,    4   //x x x x 16 17 18 19 20 21 22 23 24 25 26 27 28 29
++    vextrins.b          vr0,    vr21,   0x08
++    vextrins.b          vr0,    vr21,   0x16
++    vextrins.b          vr0,    vr21,   0x24
++    vextrins.b          vr0,    vr21,   0x32
++    vextrins.b          vr0,    vr20,   0x40 //insert to ref_pix[-1]
++
++    la.local            t0,     ang8_mode15
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vbsrl.v             vr21,   vr0,    4   //ref_pix[-1]
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr21,   vr0,    3   //ref_pix[-2]
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr21,   vr0,    2   //ref_pix[-3]
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr21,   vr0,    1   //ref_pix[-4]
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr18,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr9,    vr18,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr18,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,     vr20 //ref_pix[-5]
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr18,   vr6
++    vmaddwod.h.bu.b     vr14,   vr18,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode15, align=5
++.byte 4, 5, 3, 4, 3, 4, 2, 3, 2, 3, 1, 2, 1, 2, 0, 1, 5, 6, 4, 5, 4, 5, 3, 4, 3, 4, 2, 3, 2, 3, 1, 2
++.byte 32-15, 15, 32-30, 30, 32-13, 13, 32-28, 28, 32-11, 11, 32-26, 26, 32-9, 9, 32-24, 24
++.byte 8, 6, 4, 2, 0, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26
++endconst
++function x265_intra_pred_ang8_15_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29
++    vld                 vr1,    a2,     0
++    la.local            t0,     lasx_ang8_mode15
++    vld                 vr2,    t0,     48
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode21, align=5
++.byte 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-15, 15, 32-13, 13, 32-11, 11, 32-9, 9, 0,0,0,0,0,0,0,0, 32-30, 30, 32-28, 28, 32-26, 26, 32-24, 24, 0,0,0,0,0,0,0,0
++.byte 8, 6, 4, 2, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
++endconst
++function x265_intra_pred_ang8_21_lasx
++    vld                 vr0,    a2,     0
++    vld                 vr1,    a2,     16
++    la.local            t0,     lasx_ang8_mode21
++    vld                 vr2,    t0,     64
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvaddi.bu           xr14,   xr20,   3 //offset = -1-2
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr14
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2
++
++    xvaddi.bu           xr14,   xr20,   2 //offset = -2-3
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvshuf.b            xr6,    xr0,    xr0,    xr14
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr14,   xr20,   1 //offset = -3-4
++    xvshuf.b            xr9,    xr0,    xr0,    xr14
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode16, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-11, 11, 32-22, 22, 32-1, 1, 32-12, 12, 32-23, 23, 32-2, 2, 32-13, 13, 32-24, 24
++endconst
++function x265_intra_pred_ang8_16_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -20
++    maskeqz             t0,     t2,     t1 //dirMode=20
++    masknez             t3,     t2,     t1 //dirMode=16
++    add.d               t0,     t0,     a2
++    add.d               t2,     t3,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vldrepl.b           vr20,   a2,     0
++    vld                 vr21,   t2,     0
++    vbsll.v             vr0,    vr0,    5   //x x x x x 16 17 18 19 20 21 22 23 24 25 26 27 28 29
++    vextrins.b          vr0,    vr21,   0x08
++    vextrins.b          vr0,    vr21,   0x16
++    vextrins.b          vr0,    vr21,   0x25
++    vextrins.b          vr0,    vr21,   0x33
++    vextrins.b          vr0,    vr21,   0x42
++    vextrins.b          vr0,    vr20,   0x50 //insert to ref_pix[-1]
++
++    la.local            t0,     ang8_mode16
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vbsrl.v             vr21,   vr0,    5   //ref_pix[-1]
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr21,   vr0,    4   //ref_pix[-2]
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr21,   vr0,    3   //ref_pix[-3]
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr21,   vr0,    2   //ref_pix[-4]
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr12,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr21,   vr0,    1   //ref_pix[-5]
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr18,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr14,   vr18,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,     vr20 //ref_pix[-6]
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr18,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode16, align=5
++.byte 5, 6, 4, 5, 4, 5, 3, 4, 2, 3, 2, 3, 1, 2, 0, 1, 6, 7, 5, 6, 5, 6, 4, 5, 3, 4, 3, 4, 2, 3, 1, 2
++.byte 32-11, 11, 32-22, 22, 32-1, 1, 32-12, 12, 32-23, 23, 32-2, 2, 32-13, 13, 32-24, 24
++.byte 8, 6, 5, 3, 2, 0, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
++endconst
++function x265_intra_pred_ang8_16_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29
++    vld                 vr1,    a2,     0
++    la.local            t0,     lasx_ang8_mode16
++    vld                 vr2,    t0,     48
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode20, align=5
++.byte 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-11, 11, 32-1, 1, 32-23, 23, 32-13, 13, 0,0,0,0,0,0,0,0, 32-22, 22, 32-12, 12, 32-2, 2, 32-24, 24, 0,0,0,0,0,0,0,0
++.byte 8, 6, 5, 3, 2, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26
++endconst
++function x265_intra_pred_ang8_20_lasx
++    vld                 vr0,    a2,     0
++    vld                 vr1,    a2,     16
++    la.local            t0,     lasx_ang8_mode20
++    vld                 vr2,    t0,     64
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvaddi.bu           xr14,   xr20,   4 //offset = -1-2
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr14
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2
++
++    xvaddi.bu           xr14,   xr20,   3 //offset = -2-3
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvshuf.b            xr6,    xr0,    xr0,    xr14
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr14,   xr20,   2 //offset = -3-4
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr14
++    xvpermi.q           xr9,    xr9,    0x11
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const ang8_mode17, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-6, 6, 32-12, 12, 32-18, 18, 32-24, 24, 32-30, 30, 32-4, 4, 32-10, 10, 32-16, 16
++endconst
++function x265_intra_pred_ang8_17_lsx
++    li.w                t2,     16
++    addi.w              t1,     a3,     -19
++    maskeqz             t0,     t2,     t1 //dirMode=19
++    masknez             t3,     t2,     t1 //dirMode=17
++    add.d               t0,     t0,     a2
++    add.d               t2,     t3,     a2
++
++    vld                 vr0,    t0,     0   //16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
++    vldrepl.b           vr20,   a2,     0
++    vld                 vr21,   t2,     0
++    vbsll.v             vr0,    vr0,    6   //x x x x x x x 16 17 18 19 20 21 22 23 24 25 26 27 28 29
++    vextrins.b          vr0,    vr21,   0x42
++    vextrins.b          vr0,    vr21,   0x51
++    vextrins.b          vr0,    vr20,   0x60 //insert to ref_pix[-1]
++    vshuf4i.b           vr21,   vr21,   0x1b //0001 1011 reverse 4567 to 7654
++    vextrins.w          vr0,    vr21,   0x01 //insert 7 6 5 4
++
++    la.local            t0,     ang8_mode17
++    vld                 vr20,   t0,     0   //shuf
++    vld                 vr1,    t0,     16  //fraction
++
++    vbsrl.v             vr21,   vr0,    6   //ref_pix[-1]
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr21,   vr0,    5   //ref_pix[-2]
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr21,   vr0,    4   //ref_pix[-3]
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr12,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr21,   vr0,    3   //ref_pix[-4]
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr14,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr13,   vr14,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr14,   vr11
++
++    vbsrl.v             vr21,   vr0,    2   //ref_pix[-5]
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr12,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr21,   vr0,    1   //ref_pix[-6]
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr18,   vr21,   vr21,    vr20
++    vmulwev.h.bu.b      vr14,   vr18,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,     vr20 //ref_pix[-6]
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr18,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++    beqz                t1,     1f
++
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr4, vr7, vr10, vr13
++
++    vstelm.d            vr4,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr4,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr7,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr10,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr13,   a0,     0,    1
++    b                   2f
++1:
++    vstelm.d            vr5,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    0
++    add.d               a0,     a0,     a1
++    vstelm.d            vr5,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr9,    a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr14,   a0,     0,    1
++    add.d               a0,     a0,     a1
++    vstelm.d            vr17,   a0,     0,    1
++2:
++endfunc
++
++const lasx_ang8_mode17, align=5
++.byte 6, 7, 5, 6, 4, 5, 3, 4, 2, 3, 2, 3, 1, 2, 0, 1, 7, 8, 6, 7, 5, 6, 4, 5, 3, 4, 3, 4, 2, 3, 1, 2
++.byte 32-6, 6, 32-12, 12, 32-18, 18, 32-24, 24, 32-30, 30, 32-4, 4, 32-10, 10, 32-16, 16
++.byte 7, 6, 5, 4, 2, 1, 0, 16, 17, 18, 19, 20, 21, 22, 23, 24
++endconst
++function x265_intra_pred_ang8_17_lasx
++    vld                 vr0,    a2,     17 //17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
++    vld                 vr1,    a2,     0
++    la.local            t0,     lasx_ang8_mode17
++    vld                 vr2,    t0,     48
++    vshuf.b             vr0,    vr0,    vr1,   vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr2,    t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++    xvpermi.q           xr1,    xr1,    0x00
++
++    xvshuf.b            xr3,    xr0,    xr0,    xr2 //row 0-1
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr5,    xr0,    xr0,    xr2 //row 2-3
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr6,    xr0,    xr0,    xr2 //row 4-5
++    xvaddi.bu           xr2,    xr2,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr2 //row 6-7
++
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvmulwev.h.bu.b     xr7,    xr5,    xr1
++    xvmulwev.h.bu.b     xr10,   xr6,    xr1
++    xvmulwev.h.bu.b     xr13,   xr9,    xr1
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr7,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr6,    xr1
++    xvmaddwod.h.bu.b    xr13,   xr9,    xr1
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++const lasx_ang8_mode19, align=5
++.byte 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-6, 6, 32-18, 18, 32-30, 30, 32-10, 10, 0,0,0,0,0,0,0,0, 32-12, 12, 32-24, 24, 32-4, 4, 32-16, 16, 0,0,0,0,0,0,0,0
++.byte 7, 6, 5, 4, 2, 1, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
++endconst
++function x265_intra_pred_ang8_19_lasx
++    vld                 vr0,    a2,     0
++    vld                 vr1,    a2,     16
++    la.local            t0,     lasx_ang8_mode19
++    vld                 vr2,    t0,     64
++    vshuf.b             vr0,    vr0,    vr1,    vr2
++    xvld                xr1,    t0,     32 //fraction
++    xvld                xr20,   t0,     0  //shuf
++    xvpermi.q           xr0,    xr0,    0x00
++
++    xvaddi.bu           xr14,   xr20,   5 //offset = -1-2
++    xvrepl128vei.h      xr2,    xr1,    0
++    xvshuf.b            xr3,    xr0,    xr0,    xr14
++    xvmulwev.h.bu.b     xr4,    xr3,    xr2
++
++    xvaddi.bu           xr14,   xr20,   3 //offset = -3-4
++    xvrepl128vei.h      xr5,    xr1,    1
++    xvshuf.b            xr6,    xr0,    xr0,    xr14
++    xvmulwev.h.bu.b     xr7,    xr6,    xr5
++
++    xvaddi.bu           xr14,   xr20,   2 //offset = -4-5
++    xvrepl128vei.h      xr8,    xr1,    2
++    xvshuf.b            xr9,    xr0,    xr0,    xr14
++    xvpermi.q           xr9,    xr9,    0x11
++    xvmulwev.h.bu.b     xr10,   xr9,    xr8
++
++    xvrepl128vei.h      xr11,   xr1,    3
++    xvshuf.b            xr12,   xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr13,   xr12,   xr11
++
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr2 //fraction * ref[offset + x + 1]
++    xvmaddwod.h.bu.b    xr7,    xr6,    xr5
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr8
++    xvmaddwod.h.bu.b    xr13,   xr12,   xr11
++
++    xvssrarni.bu.h      xr7,    xr4,    5 //+ 16) >> 5)
++    xvssrarni.bu.h      xr13,   xr10,   5
++    ANG8_STORE8x8_B
++endfunc
++
++function x265_intra_pred_ang8_18_lsx
++    vld                 vr0,    a2,     0   //0-15
++    vld                 vr21,   a2,     16
++    vextrins.b          vr21,   vr0,    0x00 //insert ref_pix[-1]
++    vshuf4i.b           vr21,   vr21,   0x1b //0001 1011 reverse 4567 to 7654
++    vbsll.v             vr0,    vr0,    7
++    vextrins.w          vr0,    vr21,   0x01 //insert 7 6 5 4
++    vextrins.w          vr0,    vr21,   0x10 //insert 0 1 2 3
++
++    vbsrl.v             vr1,    vr0,    7   //ref_pix[-1]
++    vbsrl.v             vr2,    vr0,    6   //ref_pix[-2]
++    vbsrl.v             vr3,    vr0,    5   //ref_pix[-3]
++    vbsrl.v             vr4,    vr0,    4   //ref_pix[-4]
++    vbsrl.v             vr5,    vr0,    3   //ref_pix[-5]
++    vbsrl.v             vr6,    vr0,    2   //ref_pix[-6]
++    vbsrl.v             vr7,    vr0,    1   //ref_pix[-7]
++
++    fst.d               f1,     a0,     0
++    fstx.d              f2,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f3,     a0,     0
++    fstx.d              f4,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f5,     a0,     0
++    fstx.d              f6,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.d               f7,     a0,     0
++    fstx.d              f0,     a0,     a1
++endfunc
++
++function x265_intra_pred_ang16_2_lsx
++    li.w                t0,     32
++    addi.w              t1,     a3,     -34
++    maskeqz             t2,     t0,     t1
++    add.d               t0,     t2,     a2
++    addi.d              t0,     t0,     2
++
++    vld                 vr0,    t0,     0
++    vld                 vr1,    t0,     16
++
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf1
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf2
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf3
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf4
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf5
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf6
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf7
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf8
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf9
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xfa
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xfb
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xfc
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xfd
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xfe
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++endfunc
++
++.macro STORE8x8_B
++    vstelm.d            vr5,    t3,     0,     0
++    vstelmx.d           vr9,    t3,     a1,    0
++    add.d               t3,     t3,     a1
++    vstelm.d            vr14,   t3,     0,     0
++    vstelmx.d           vr17,   t3,     a1,    0
++    add.d               t3,     t3,     a1
++    vstelm.d            vr5,    t3,     0,     1
++    vstelmx.d           vr9,    t3,     a1,    1
++    add.d               t3,     t3,     a1
++    vstelm.d            vr14,   t3,     0,     1
++    vstelmx.d           vr17,   t3,     a1,    1
++.endm
++
++.macro STORE8x16_B_TRANSPOSE
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr10, vr11, vr12, vr13
++
++    vpackev.d           vr3,    vr10,   vr18
++    vpackev.d           vr4,    vr11,   vr19
++    vpackev.d           vr5,    vr12,   vr21
++    vpackev.d           vr6,    vr13,   vr22
++    vpackod.d           vr7,    vr10,   vr18
++    vpackod.d           vr8,    vr11,   vr19
++    vpackod.d           vr9,    vr12,   vr21
++    vpackod.d           vr10,   vr13,   vr22
++
++    vst                 vr3,    a0,     0
++    vstx                vr7,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr4,    a0,     0
++    vstx                vr8,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr5,    a0,     0
++    vstx                vr9,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr6,    a0,     0
++    vstx                vr10,   a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++.endm
++
++const ang16_mode3, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-26, 26, 32-20, 20, 32-14, 14, 32-8, 8, 32-2, 2, 32-28, 28, 32-22, 22, 32-16, 16
++.byte 32-10, 10, 32-4, 4, 32-30, 30, 32-24, 24, 32-18, 18, 32-12, 12, 32-6, 6, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG16_3 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 3
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode3
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 4
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 5
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 6
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 3
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vld                 vr0,    t0,     7  //offset = 7
++
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 8
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 9
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 10
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 11
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 12
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 13
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++.if \mode == 3
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_3 3
++INTRA_PRED_ANG16_3 33
++
++.macro ANG16_MODE3_PROCESS_4x16_B idx0, idx1, idx2
++    vld                 vr0,    a2,     \idx0
++    xvpermi.q           xr0,    xr0,    0x00
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvshuf.b            xr5,    xr0,    xr0,    xr21
++    xvmulwev.h.bu.b     xr6,    xr5,    xr1
++    vld                 vr0,    a2,     \idx1
++    xvpermi.q           xr0,    xr0,    0x00
++    xvshuf.b            xr7,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr8,    xr7,    xr1
++    xvshuf.b            xr9,    xr0,    xr0,    xr21
++    xvmulwev.h.bu.b     xr10,   xr9,    xr1
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr6,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr8,    xr7,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr1
++    xvssrarni.bu.h      xr6,    xr4,    5
++    xvssrarni.bu.h      xr10,   xr8,    5
++    xvpermi.d           xr4,    xr6,    0xd8
++    xvpermi.d           xr8,    xr10,   0xd8
++    xvpermi.q           xr6,    xr4,    0x11
++    xvpermi.q           xr10,   xr8,    0x11
++    vst                 vr4,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr8,    a0,     0
++    vstx                vr10,   a0,     a1
++.if \idx2 == 1
++    alsl.d              a0,     a1,     a0,    1
++.endif
++.endm
++const lasx_ang16_mode3, align=5
++.byte 0,1,1,2,2,3,3,4,4,5,4,5,5,6,6,7,7,8,8,9,8,9,9,10,10,11,11,12,12,13,13,14
++.byte 32-26, 26, 32-20, 20, 32-14, 14, 32-8, 8, 32-2, 2, 32-28, 28, 32-22, 22, 32-16, 16
++.byte 32-10, 10, 32-4, 4, 32-30, 30, 32-24, 24, 32-18, 18, 32-12, 12, 32-6, 6, 32-0, 0
++endconst
++function x265_intra_pred_ang16_3_lasx
++    la.local            t1,     lasx_ang16_mode3
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1
++    ANG16_MODE3_PROCESS_4x16_B  33+0,   33+2,  1
++    ANG16_MODE3_PROCESS_4x16_B  33+4,   33+6,  1
++    ANG16_MODE3_PROCESS_4x16_B  33+8,   33+10, 1
++    ANG16_MODE3_PROCESS_4x16_B  33+12,  33+14, 0
++endfunc
++
++const ang16_mode4, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-21, 21, 32-10, 10, 32-31, 31, 32-20, 20, 32-9, 9, 32-30, 30, 32-19, 19, 32-8, 8
++.byte 32-29, 29, 32-18, 18, 32-7, 7, 32-28, 28, 32-17, 17, 32-6, 6, 32-27, 27, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_4 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 4
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode4
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 4
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 5
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 4
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 6
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 7
++    vreplvei.h          vr8,    vr23,   2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vld                 vr0,    t0,     8 //offset = 8
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 9
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 10
++    vreplvei.h          vr15,   vr23,   7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 4
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_4 4
++INTRA_PRED_ANG16_4 32
++
++.macro ANG16_MODE4_PROCESS_4x16_B idx0, idx1
++    vld                 vr0,    a2,     \idx0
++    xvpermi.q           xr0,    xr0,    0x00
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvshuf.b            xr5,    xr0,    xr0,    xr21
++    xvmulwev.h.bu.b     xr6,    xr5,    xr1
++    xvshuf.b            xr7,    xr0,    xr0,    xr22
++    xvmulwev.h.bu.b     xr8,    xr7,    xr1
++    xvshuf.b            xr9,    xr0,    xr0,    xr23
++    xvmulwev.h.bu.b     xr10,   xr9,    xr1
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr6,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr8,    xr7,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr1
++    xvssrarni.bu.h      xr6,    xr4,    5
++    xvssrarni.bu.h      xr10,   xr8,    5
++    xvpermi.d           xr4,    xr6,    0xd8
++    xvpermi.d           xr8,    xr10,   0xd8
++    xvpermi.q           xr6,    xr4,    0x11
++    xvpermi.q           xr10,   xr8,    0x11
++    vst                 vr4,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr8,    a0,     0
++    vstx                vr10,   a0,     a1
++.if \idx1 == 1
++    alsl.d              a0,     a1,     a0,    1
++.endif
++.endm
++const lasx_ang16_mode4, align=5
++.byte 0,1,1,2,1,2,2,3,3,4,3,4,4,5,5,6,5,6,6,7,7,8,7,8,8,9,9,10,9,10,10,11
++.byte 32-21, 21, 32-10, 10, 32-31, 31, 32-20, 20, 32-9, 9, 32-30, 30, 32-19, 19, 32-8, 8
++.byte 32-29, 29, 32-18, 18, 32-7, 7, 32-28, 28, 32-17, 17, 32-6, 6, 32-27, 27, 32-16, 16
++endconst
++function x265_intra_pred_ang16_4_lasx
++    la.local            t1,     lasx_ang16_mode4
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    ANG16_MODE4_PROCESS_4x16_B  33+0,   1
++    ANG16_MODE4_PROCESS_4x16_B  33+4,   1
++    ANG16_MODE4_PROCESS_4x16_B  33+8,   1
++    ANG16_MODE4_PROCESS_4x16_B  33+12,  0
++endfunc
++
++const ang16_mode5, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-17, 17, 32-2, 2, 32-19, 19, 32-4, 4, 32-21, 21, 32-6, 6, 32-23, 23, 32-8, 8
++.byte 32-25, 25, 32-10, 10, 32-27, 27, 32-12, 12, 32-29, 29, 32-14, 14, 32-31, 31, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_5 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 5
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode5
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 4
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 5
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 5
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 6
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 7
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vld                 vr0,    t0,     8  //offset = 8
++    vreplvei.h          vr15,   vr23,   7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 5
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_5 5
++INTRA_PRED_ANG16_5 31
++
++const lasx_ang16_mode5, align=5
++.byte 0,1,1,2,1,2,2,3,2,3,3,4,3,4,4,5,4,5,5,6,5,6,6,7,6,7,7,8,7,8,8,9
++.byte 32-17, 17, 32-2, 2, 32-19, 19, 32-4, 4, 32-21, 21, 32-6, 6, 32-23, 23, 32-8, 8
++.byte 32-25, 25, 32-10, 10, 32-27, 27, 32-12, 12, 32-29, 29, 32-14, 14, 32-31, 31, 32-16, 16
++endconst
++function x265_intra_pred_ang16_5_lasx
++    la.local            t1,     lasx_ang16_mode5
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    ANG16_MODE4_PROCESS_4x16_B  33+0,   1
++    ANG16_MODE4_PROCESS_4x16_B  33+4,   1
++    ANG16_MODE4_PROCESS_4x16_B  33+8,   1
++    ANG16_MODE4_PROCESS_4x16_B  33+12,  0
++endfunc
++
++const ang16_mode6, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-13, 13, 32-26, 26, 32-7, 7, 32-20, 20, 32-1, 1, 32-14, 14, 32-27, 27, 32-8, 8
++.byte 32-21, 21, 32-2, 2, 32-15, 15, 32-28, 28, 32-9, 9, 32-22, 22, 32-3, 3, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_6 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 6
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode6
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 1
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr6,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr6,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 6
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 4
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr6,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr6,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 5
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 6
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 6
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_6 6
++INTRA_PRED_ANG16_6 30
++
++.macro ANG16_MODE6_PROCESS_4x16_B idx0, idx1
++.if \idx0 > 0
++    vld                 vr0,    a2,     \idx0
++.else
++    vbsrl.v             vr0,    vr0,    4
++.endif
++    xvpermi.q           xr0,    xr0,    0x00
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvshuf.b            xr5,    xr0,    xr0,    xr21
++    xvmulwev.h.bu.b     xr6,    xr5,    xr1
++    xvshuf.b            xr7,    xr0,    xr0,    xr22
++    xvmulwev.h.bu.b     xr8,    xr7,    xr1
++    xvshuf.b            xr9,    xr0,    xr0,    xr23
++    xvmulwev.h.bu.b     xr10,   xr9,    xr1
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr6,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr8,    xr7,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr1
++    xvssrarni.bu.h      xr6,    xr4,    5
++    xvssrarni.bu.h      xr10,   xr8,    5
++    xvpermi.d           xr4,    xr6,    0xd8
++    xvpermi.d           xr8,    xr10,   0xd8
++    xvpermi.q           xr6,    xr4,    0x11
++    xvpermi.q           xr10,   xr8,    0x11
++    vst                 vr4,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr8,    a0,     0
++    vstx                vr10,   a0,     a1
++.if \idx1 == 1
++    alsl.d              a0,     a1,     a0,    1
++.endif
++.endm
++const lasx_ang16_mode6, align=5
++.byte 0,1,0,1,1,2,1,2,2,3,2,3,2,3,3,4,3,4,4,5,4,5,4,5,5,6,5,6,6,7,6,7
++.byte 32-13, 13, 32-26, 26, 32-7, 7, 32-20, 20, 32-1, 1, 32-14, 14, 32-27, 27, 32-8, 8
++.byte 32-21, 21, 32-2, 2, 32-15, 15, 32-28, 28, 32-9, 9, 32-22, 22, 32-3, 3, 32-16, 16
++endconst
++function x265_intra_pred_ang16_6_lasx
++    la.local            t1,     lasx_ang16_mode6
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    ANG16_MODE6_PROCESS_4x16_B  33+0,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   1
++    ANG16_MODE6_PROCESS_4x16_B  33+8,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   0
++endfunc
++
++const ang16_mode7, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-9, 9, 32-18, 18, 32-27, 27, 32-4, 4, 32-13, 13, 32-22, 22, 32-31, 31, 32-8, 8
++.byte 32-17, 17, 32-26, 26, 32-3, 3, 32-12, 12, 32-21, 21, 32-30, 30, 32-7, 7, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_7 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 7
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode7
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 1
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 7
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr8,    vr23,   2
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 4
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 7
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_7 7
++INTRA_PRED_ANG16_7 29
++
++const lasx_ang16_mode7, align=5
++.byte 0,1,0,1,0,1,1,2,1,2,1,2,1,2,2,3,2,3,2,3,3,4,3,4,3,4,3,4,4,5,4,5
++.byte 32-9, 9, 32-18, 18, 32-27, 27, 32-4, 4, 32-13, 13, 32-22, 22, 32-31, 31, 32-8, 8
++.byte 32-17, 17, 32-26, 26, 32-3, 3, 32-12, 12, 32-21, 21, 32-30, 30, 32-7, 7, 32-16, 16
++endconst
++function x265_intra_pred_ang16_7_lasx
++    la.local            t1,     lasx_ang16_mode7
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    ANG16_MODE6_PROCESS_4x16_B  33+0,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   1
++    ANG16_MODE6_PROCESS_4x16_B  33+8,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   0
++endfunc
++
++const ang16_mode8, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-5, 5, 32-10, 10, 32-15, 15, 32-20, 20, 32-25, 25, 32-30, 30, 32-3, 3, 32-8, 8
++.byte 32-13, 13, 32-18, 18, 32-23, 23, 32-28, 28, 32-1, 1, 32-6, 6, 32-11, 11, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_8 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 8
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode8
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 1
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr8,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr8,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 8
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr8,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr3,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr3
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr8,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr8,    vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr3
++    vmaddwod.h.bu.b     vr13,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 2
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 8
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_8 8
++INTRA_PRED_ANG16_8 28
++
++const lasx_ang16_mode8, align=5
++.byte 0,1,0,1,0,1,0,1,0,1,0,1,1,2,1,2,1,2,1,2,1,2,1,2,2,3,2,3,2,3,2,3
++.byte 32-5, 5, 32-10, 10, 32-15, 15, 32-20, 20, 32-25, 25, 32-30, 30, 32-3, 3, 32-8, 8
++.byte 32-13, 13, 32-18, 18, 32-23, 23, 32-28, 28, 32-1, 1, 32-6, 6, 32-11, 11, 32-16, 16
++endconst
++function x265_intra_pred_ang16_8_lasx
++    la.local            t1,     lasx_ang16_mode8
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    ANG16_MODE6_PROCESS_4x16_B  33+0,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   1
++    ANG16_MODE6_PROCESS_4x16_B  33+8,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   0
++endfunc
++
++const ang16_mode9, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-2, 2, 32-4, 4, 32-6, 6, 32-8, 8, 32-10, 10, 32-12, 12, 32-14, 14, 32-16, 16
++.byte 32-18, 18, 32-20, 20, 32-22, 22, 32-24, 24, 32-26, 26, 32-28, 28, 32-30, 30, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG16_9 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 9
++    addi.d              t0,     a2,     33
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang16_mode9
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 9
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr6
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 9
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_9 9
++INTRA_PRED_ANG16_9 27
++
++const lasx_ang16_mode9, align=5
++.byte 0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,1,2
++.byte 32-2, 2, 32-4, 4, 32-6, 6, 32-8, 8, 32-10, 10, 32-12, 12, 32-14, 14, 32-16, 16
++.byte 32-18, 18, 32-20, 20, 32-22, 22, 32-24, 24, 32-26, 26, 32-28, 28, 32-30, 30, 32-0, 0
++endconst
++function x265_intra_pred_ang16_9_lasx
++    la.local            t1,     lasx_ang16_mode9
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    ANG16_MODE6_PROCESS_4x16_B  33+0,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   1
++    ANG16_MODE6_PROCESS_4x16_B  33+8,   1
++    ANG16_MODE6_PROCESS_4x16_B  0   ,   0
++endfunc
++
++function x265_intra_pred_ang16_10_lsx
++    vld                 vr0,    a2,     33
++    //transpose
++    vreplvei.b          vr1,    vr0,    0
++    vreplvei.b          vr2,    vr0,    1
++    vreplvei.b          vr3,    vr0,    2
++    vreplvei.b          vr4,    vr0,    3
++    vreplvei.b          vr5,    vr0,    4
++    vreplvei.b          vr6,    vr0,    5
++    vreplvei.b          vr7,    vr0,    6
++    vreplvei.b          vr8,    vr0,    7
++    vreplvei.b          vr9,    vr0,    8
++    vreplvei.b          vr10,   vr0,    9
++    vreplvei.b          vr11,   vr0,    10
++    vreplvei.b          vr12,   vr0,    11
++    vreplvei.b          vr13,   vr0,    12
++    vreplvei.b          vr14,   vr0,    13
++    vreplvei.b          vr15,   vr0,    14
++    vreplvei.b          vr16,   vr0,    15
++
++    beqz                a4,     1f
++
++    //bFilter != 0
++    vldrepl.b           vr18,   a2,     0
++    vsllwil.hu.bu       vr17,   vr1,    0 //top
++    vsllwil.hu.bu       vr18,   vr18,   0 //topLeft
++    vld                 vr19,   a2,     1 //srcPixel[width2 + 1 + y]
++    vexth.hu.bu         vr20,   vr19
++    vsllwil.hu.bu       vr19,   vr19,   0
++    vsub.h              vr19,   vr19,   vr18
++    vsub.h              vr20,   vr20,   vr18
++    vsrai.h             vr19,   vr19,   1
++    vsrai.h             vr20,   vr20,   1
++    vadd.h              vr19,   vr19,   vr17
++    vadd.h              vr20,   vr20,   vr17
++    vssrani.bu.h        vr20,   vr19,   0
++    vmov                vr1,    vr20
++1:
++    vst                 vr1,    a0,     0
++    vstx                vr2,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr3,    a0,     0
++    vstx                vr4,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr5,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr7,    a0,     0
++    vstx                vr8,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr9,    a0,     0
++    vstx                vr10,   a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr11,   a0,     0
++    vstx                vr12,   a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr13,   a0,     0
++    vstx                vr14,   a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr15,   a0,     0
++    vstx                vr16,   a0,     a1
++endfunc
++
++.macro STORE_2x16 idx0, idx1
++    vextrins.b          vr0,    vr20,   \idx0
++    vst                 vr0,    a0,     0
++    vextrins.b          vr0,    vr20,   \idx1
++    vstx                vr0,    a0,     a1
++.if \idx1 < 0x0f
++    alsl.d              a0,     a1,     a0,   1
++.endif
++.endm
++
++function x265_intra_pred_ang16_26_lsx
++    vld                 vr0,    a2,     1
++
++    beqz                a4,     1f
++
++    //bFilter != 0
++    vldrepl.h           vr18,   a2,     0
++    vsllwil.hu.bu       vr18,   vr18,   0
++    vreplvei.h          vr17,   vr18,   1 //top
++    vreplvei.h          vr18,   vr18,   0 //topLeft
++    vld                 vr19,   a2,     33//srcPixel[width2 + 1 + y]
++    vexth.hu.bu         vr20,   vr19
++    vsllwil.hu.bu       vr19,   vr19,   0
++    vsub.h              vr19,   vr19,   vr18
++    vsub.h              vr20,   vr20,   vr18
++    vsrai.h             vr19,   vr19,   1
++    vsrai.h             vr20,   vr20,   1
++    vadd.h              vr19,   vr19,   vr17
++    vadd.h              vr20,   vr20,   vr17
++    vssrani.bu.h        vr20,   vr19,   0
++
++    STORE_2x16          0x00,   0x01
++    STORE_2x16          0x02,   0x03
++    STORE_2x16          0x04,   0x05
++    STORE_2x16          0x06,   0x07
++    STORE_2x16          0x08,   0x09
++    STORE_2x16          0x0a,   0x0b
++    STORE_2x16          0x0c,   0x0d
++    STORE_2x16          0x0e,   0x0f
++    b                   2f
++1:
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++2:
++endfunc
++
++const ang16_mode11, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-30, 30, 32-28, 28, 32-26, 26, 32-24, 24, 32-22, 22, 32-20, 20, 32-18, 18, 32-16, 16
++.byte 32-14, 14, 32-12, 12, 32-10, 10, 32-8, 8, 32-6, 6, 32-4, 4, 32-2, 2, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG16_11 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 11
++    addi.d              t0,     a2,     32
++.else
++    addi.d              t0,     a2,     0
++.endif
++    la.local            t1,     ang16_mode11
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    li.w                t4,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0  //offset = -1
++
++    blt                 t2,     t4,     2f //second loop dont need insert
++    vldrepl.b           vr2,    a2,     0
++    vextrins.b          vr0,    vr2,    0x00 //insert ref_pix[-1]
++2:
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 11
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr6
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13 //fraction=0
++
++.if \mode == 11
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     8
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_11 11
++INTRA_PRED_ANG16_11 25
++
++.macro ANG16_MODE11_PROCESS_4x16_B idx0
++    xvpermi.q           xr0,    xr0,    0x00
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvshuf.b            xr5,    xr0,    xr0,    xr21
++    xvmulwev.h.bu.b     xr6,    xr5,    xr1
++    xvshuf.b            xr7,    xr0,    xr0,    xr22
++    xvmulwev.h.bu.b     xr8,    xr7,    xr1
++    xvshuf.b            xr9,    xr0,    xr0,    xr23
++    xvmulwev.h.bu.b     xr10,   xr9,    xr1
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr6,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr8,    xr7,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr1
++    xvssrarni.bu.h      xr6,    xr4,    5
++    xvssrarni.bu.h      xr10,   xr8,    5
++    xvpermi.d           xr4,    xr6,    0xd8
++    xvpermi.d           xr8,    xr10,   0xd8
++    xvpermi.q           xr6,    xr4,    0x11
++    xvpermi.q           xr10,   xr8,    0x11
++    vst                 vr4,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr8,    a0,     0
++    vstx                vr10,   a0,     a1
++.if \idx0 == 1
++    alsl.d              a0,     a1,     a0,    1
++.endif
++.endm
++const lasx_ang16_mode11, align=5
++.byte 0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1
++.byte 32-30, 30, 32-28, 28, 32-26, 26, 32-24, 24, 32-22, 22, 32-20, 20, 32-18, 18, 32-16, 16
++.byte 32-14, 14, 32-12, 12, 32-10, 10, 32-8, 8, 32-6, 6, 32-4, 4, 32-2, 2, 32-0, 0
++endconst
++function x265_intra_pred_ang16_11_lasx
++    la.local            t1,     lasx_ang16_mode11
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    vld                 vr0,    a2,     32
++    vldrepl.b           vr11,   a2,     0
++    vextrins.b          vr0,    vr11,   0x00
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vld                 vr0,    a2,     32+8
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 0
++endfunc
++
++const ang16_mode12, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-27, 27, 32-22, 22, 32-17, 17, 32-12, 12, 32-7, 7, 32-2, 2, 32-29, 29, 32-24, 24
++.byte 32-19, 19, 32-14, 14, 32-9, 9, 32-4, 4, 32-31, 31, 32-26, 26, 32-21, 21, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_12 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 12
++    addi.d              t0,     a2,     32
++.else
++    addi.d              t0,     a2,     0
++.endif
++    la.local            t1,     ang16_mode12
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    li.w                t4,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0
++
++    blt                 t2,     t4,     2f //second loop dont need insert
++.if \mode == 12
++    vld                 vr2,    a2,     0
++.else
++    vld                 vr2,    a2,     32
++.endif
++    vldrepl.b           vr3,    a2,     0
++    vbsll.v             vr0,    vr0,    2
++    vextrins.b          vr0,    vr2,    0x0d //insert ref_pix[-3]
++    vextrins.b          vr0,    vr2,    0x16 //insert ref_pix[-2]
++    vextrins.b          vr0,    vr3,    0x20 //insert ref_pix[-1]
++2:
++    vbsrl.v             vr12,   vr0,    2  //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -2
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr8,    vr12,   vr12,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr8,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr8,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 12
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr8,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr8,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr8,    vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr8,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr12,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 12
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     6  //src offset for next loop
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_12 12
++INTRA_PRED_ANG16_12 24
++
++const lasx_ang16_mode12, align=5
++.byte 2,3,2,3,2,3,2,3,2,3,2,3,1,2,1,2,1,2,1,2,1,2,1,2,0,1,0,1,0,1,0,1
++.byte 32-27, 27, 32-22, 22, 32-17, 17, 32-12, 12, 32-7, 7, 32-2, 2, 32-29, 29, 32-24, 24
++.byte 32-19, 19, 32-14, 14, 32-9, 9, 32-4, 4, 32-31, 31, 32-26, 26, 32-21, 21, 32-16, 16
++.byte 13, 6, 0, 17, 18, 19, 20, 21, 22, 23, 24
++endconst
++function x265_intra_pred_ang16_12_lasx
++    la.local            t1,     lasx_ang16_mode12
++    vld                 vr12,   t1,     64
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    vld                 vr0,    a2,     32
++    vld                 vr11,   a2,     0
++    vshuf.b             vr0,    vr0,    vr11,   vr12 //Get the reference pixels
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vld                 vr0,    a2,     32+6
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 0
++endfunc
++
++const ang16_mode13, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-23, 23, 32-14, 14, 32-5, 5, 32-28, 28, 32-19, 19, 32-10, 10, 32-1, 1, 32-24, 24
++.byte 32-15, 15, 32-6, 6, 32-29, 29, 32-20, 20, 32-11, 11, 32-2, 2, 32-25, 25, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_13 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 13
++    addi.d              t0,     a2,     32
++.else
++    addi.d              t0,     a2,     0
++.endif
++    la.local            t1,     ang16_mode13
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    li.w                t4,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0
++
++    blt                 t2,     t4,     2f //second loop dont need insert
++.if \mode == 13
++    vld                 vr2,    a2,     0
++.else
++    vld                 vr2,    a2,     32
++.endif
++    vldrepl.b           vr3,    a2,     0
++    vbsll.v             vr0,    vr0,    4
++    vextrins.b          vr0,    vr2,    0x0e //insert ref_pix[-5]
++    vextrins.b          vr0,    vr2,    0x1b //insert ref_pix[-4]
++    vextrins.b          vr0,    vr2,    0x27 //insert ref_pix[-3]
++    vextrins.b          vr0,    vr2,    0x34 //insert ref_pix[-2]
++    vextrins.b          vr0,    vr3,    0x40 //insert ref_pix[-1]
++2:
++    vbsrl.v             vr12,   vr0,    4  //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr12,   vr0,    3  //offset = -2
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr12,   vr12,    vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -3
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 13
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -4
++    vreplvei.h          vr6,    vr23,   2
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr8,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr8,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr8,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -5
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr12,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr8,    vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 13
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     4  //src offset for next loop
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_13 13
++INTRA_PRED_ANG16_13 23
++
++const lasx_ang16_mode13, align=5
++.byte 4,5,4,5,4,5,3,4,3,4,3,4,3,4,2,3,2,3,2,3,1,2,1,2,1,2,1,2,0,1,0,1
++.byte 32-23, 23, 32-14, 14, 32-5, 5, 32-28, 28, 32-19, 19, 32-10, 10, 32-1, 1, 32-24, 24
++.byte 32-15, 15, 32-6, 6, 32-29, 29, 32-20, 20, 32-11, 11, 32-2, 2, 32-25, 25, 32-16, 16
++.byte 14, 11, 7, 4, 0, 17, 18, 19, 20, 21, 22, 23, 24
++endconst
++function x265_intra_pred_ang16_13_lasx
++    la.local            t1,     lasx_ang16_mode13
++    vld                 vr12,   t1,     64
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    vld                 vr0,    a2,     32
++    vld                 vr11,   a2,     0
++    vshuf.b             vr0,    vr0,    vr11,   vr12 //Get the reference pixels
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vld                 vr0,    a2,     32+4
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 0
++endfunc
++
++const ang16_mode14, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-19, 19, 32-6, 6, 32-25, 25, 32-12, 12, 32-31, 31, 32-18, 18, 32-5, 5, 32-24, 24
++.byte 32-11, 11, 32-30, 30, 32-17, 17, 32-4, 4, 32-23, 23, 32-10, 10, 32-29, 29, 32-16, 16
++endconst
++.macro INTRA_PRED_ANG16_14 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 14
++    addi.d              t0,     a2,     32
++.else
++    addi.d              t0,     a2,     0
++.endif
++    la.local            t1,     ang16_mode14
++    vld                 vr20,   t1,     0  //shuf
++    li.w                t2,     2
++    li.w                t4,     2
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++1:
++    vld                 vr0,    t0,     0
++
++    blt                 t2,     t4,     2f //second loop dont need insert
++.if \mode == 14
++    vld                 vr2,    a2,     0
++.else
++    vld                 vr2,    a2,     32
++.endif
++    vldrepl.b           vr3,    a2,     0
++    vbsll.v             vr0,    vr0,    6
++    vextrins.b          vr0,    vr2,    0x0f //insert ref_pix[-7]
++    vextrins.b          vr0,    vr2,    0x1c //insert ref_pix[-6]
++    vextrins.b          vr0,    vr2,    0x2a //insert ref_pix[-5]
++    vextrins.b          vr0,    vr2,    0x37 //insert ref_pix[-4]
++    vextrins.b          vr0,    vr2,    0x45 //insert ref_pix[-3]
++    vextrins.b          vr0,    vr2,    0x52 //insert ref_pix[-2]
++    vextrins.b          vr0,    vr3,    0x60 //insert ref_pix[-1]
++2:
++    vbsrl.v             vr12,   vr0,    6  //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr12,   vr0,    5  //offset = -2
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr6,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr6,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr6,    vr11
++
++    vbsrl.v             vr3,    vr0,    4  //offset = -3
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr16,   vr3,    vr3,    vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vbsrl.v             vr12,   vr0,    3  //offset = -4
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 14
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -5
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr8,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr8,    vr11
++
++    vbsrl.v             vr16,   vr0,    1  //offset = -6
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr8,    vr16,   vr16,   vr20
++    vmulwev.h.bu.b      vr5,    vr8,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -5
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr12,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr8,    vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 14
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t2,     t2,     -1
++    addi.d              t0,     t0,     2  //src offset for next loop
++    bnez                t2,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG16_14 14
++INTRA_PRED_ANG16_14 22
++
++const lasx_ang16_mode14, align=5
++.byte 6,7,6,7,5,6,5,6,4,5,4,5,4,5,3,4,3,4,2,3,2,3,2,3,1,2,1,2,0,1,0,1
++.byte 32-19, 19, 32-6, 6, 32-25, 25, 32-12, 12, 32-31, 31, 32-18, 18, 32-5, 5, 32-24, 24
++.byte 32-11, 11, 32-30, 30, 32-17, 17, 32-4, 4, 32-23, 23, 32-10, 10, 32-29, 29, 32-16, 16
++.byte 15, 12, 10, 7, 5, 2, 0, 17, 18, 19, 20, 21, 22, 23, 24
++endconst
++function x265_intra_pred_ang16_14_lasx
++    la.local            t1,     lasx_ang16_mode14
++    vld                 vr12,   t1,     64
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    vld                 vr0,    a2,     32
++    vld                 vr11,   a2,     0
++    vshuf.b             vr0,    vr0,    vr11,   vr12 //Get the reference pixels
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vld                 vr0,    a2,     32+2
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    ANG16_MODE11_PROCESS_4x16_B 0
++endfunc
++
++const ang16_mode15, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-15, 15, 32-30, 30, 32-13, 13, 32-28, 28, 32-11, 11, 32-26, 26, 32-9, 9, 32-24, 24
++.byte 32-7, 7, 32-22, 22, 32-5, 5, 32-20, 20, 32-3, 3, 32-18, 18, 32-1, 1, 32-16, 16
++.byte 15, 13, 11, 9, 8, 6, 4, 2, 16, 17, 18, 19, 20, 21, 22, 23
++endconst
++.macro INTRA_PRED_ANG16_15 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 15
++    vld                 vr0,    a2,     32
++    vld                 vr2,    a2,     0
++.else
++    vld                 vr0,    a2,     0
++    vld                 vr2,    a2,     32
++.endif
++
++    la.local            t1,     ang16_mode15
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++
++    //col 0-7
++    vld                 vr4,    t1,     48
++    vshuf.b             vr5,    vr0,    vr2,    vr4 //15 13 11 9 8 6 4 2 * 33 34 35 36 37 38 39
++.if \mode == 15
++    vextrins.b          vr5,    vr2,    0x80 // *==>0
++.endif
++    vbsrl.v             vr12,   vr5,    8    //offset = -1
++    vextrins.b          vr12,   vr0,    0x88 //0 33 34 35 36 37 38 39 40 0 ...
++    vmov                vr0,    vr5
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    7  //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr12,   vr0,    6  //offset = -3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    5  //offset = -4
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr12,   vr0,    4  //offset = -5
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 15
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    3  //offset = -6
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -7
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -8
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr12,   vr23,   7
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -9
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 15
++    STORE8x16_B_TRANSPOSE
++
++    //col 8-15
++    vld                 vr2,    a2,     33 //32
++    vldrepl.b           vr3,    a2,     0
++    vbsll.v             vr0,    vr2,    1
++    vextrins.b          vr0,    vr3,    0x00 //ref_pix[-1]
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++
++    //col 8-15
++    vld                 vr0,    a2,     0
++    vldrepl.b           vr2,    a2,     16
++.endif
++    vbsrl.v             vr12,   vr0,    8  //offset = -1
++    vextrins.b          vr12,   vr2,    0x8f
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    7  //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr12,   vr0,    6  //offset = -3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    5  //offset = -4
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr12,   vr0,    4  //offset = -5
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 15
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    3  //offset = -6
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -7
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -8
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr12,   vr23,   7
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -9
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 15
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG16_15 15
++INTRA_PRED_ANG16_15 21
++
++const lasx_ang16_mode15, align=5
++.byte 8,9,7,8,7,8,6,7,6,7,5,6,5,6,4,5,4,5,3,4,3,4,2,3,2,3,1,2,1,2,0,1
++.byte 32-15, 15, 32-30, 30, 32-13, 13, 32-28, 28, 32-11, 11, 32-26, 26, 32-9, 9, 32-24, 24
++.byte 32-7, 7, 32-22, 22, 32-5, 5, 32-20, 20, 32-3, 3, 32-18, 18, 32-1, 1, 32-16, 16
++.byte 15, 13, 11, 9, 8, 6, 4, 2, 0, 17, 18, 19, 20, 21, 22, 23
++endconst
++function x265_intra_pred_ang16_15_lasx
++    la.local            t1,     lasx_ang16_mode15
++    vld                 vr12,   t1,     64
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    vld                 vr0,    a2,     32
++    vld                 vr11,   a2,     0
++    vmov                vr13,   vr0
++    vshuf.b             vr0,    vr0,    vr11,   vr12 //Get the reference pixels
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    vextrins.b          vr0,    vr13,   0xc8
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vmov                vr0,    vr13
++    vextrins.b          vr0,    vr11,   0x00
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vld                 vr0,    a2,     32+4
++    ANG16_MODE11_PROCESS_4x16_B 0
++endfunc
++
++const ang16_mode16, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-11, 11, 32-22, 22, 32-1, 1, 32-12, 12, 32-23, 23, 32-2, 2, 32-13, 13, 32-24, 24
++.byte 32-3, 3, 32-14, 14, 32-25, 25, 32-4, 4, 32-15, 15, 32-26, 26, 32-5, 5, 32-16, 16
++.byte 15, 14, 12, 11, 9, 8, 6, 5, 3, 2, 16, 17, 18, 19, 20, 21
++endconst
++.macro INTRA_PRED_ANG16_16 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 16
++    vld                 vr0,    a2,     32
++    vld                 vr2,    a2,     0
++.else
++    vld                 vr0,    a2,     0
++    vld                 vr2,    a2,     32
++.endif
++
++    la.local            t1,     ang16_mode16
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++
++    //col 0-7
++    vmov                vr12,   vr0
++.if \mode == 16
++    vextrins.b          vr12,   vr2,    0x00 //offset = -1
++.endif
++
++    vreplvei.h          vr3,    vr1,    0
++    vshuf.b             vr6,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr6,    vr3
++
++    vbsll.v             vr12,   vr12,   1  //offset = -2
++    vextrins.b          vr12,   vr2,    0x02
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr9,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr9,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsll.v             vr12,   vr12,   1  //offset = -3
++    vextrins.b          vr12,   vr2,    0x03
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr3
++    vmaddwod.h.bu.b     vr7,    vr9,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vld                 vr5,    t1,     48
++    vshuf.b             vr0,    vr0,    vr2,    vr5
++.if \mode == 16
++    vextrins.b          vr0,    vr2,    0xa0
++.endif
++    vbsrl.v             vr12,   vr0,    7 //offset = -4
++
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr12,   vr0,    6 //offset = -5
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr12,   vr0,    5  //offset = -6
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 16
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    4  //offset = -7
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vbsrl.v             vr12,   vr0,    3  //offset = -8
++    vreplvei.h          vr6,    vr23,   2
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr10,   vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr6
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -9
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -10
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr12,   vr23,   7
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -11
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 16
++    STORE8x16_B_TRANSPOSE
++
++    //col 8-15
++    vld                 vr0,    a2,     33 //32
++    vbsrl.v             vr12,   vr0,    7  //offset = -1
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++
++    //col 8-15
++    vld                 vr0,    a2,     1
++    vbsrl.v             vr12,   vr0,    7 //offset = -1
++.endif
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    6  //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr9,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr9,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr12,   vr0,    5  //offset = -3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr9,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr12,   vr0,    4 //offset = -4
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr12,   vr0,    3 //offset = -5
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -6
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 16
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -7
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vshuf.b             vr3,    vr0,    vr0,   vr20 //offset = -8
++    vmulwev.h.bu.b      vr10,   vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr6
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vld                 vr1,    a2,     0
++    vbsll.v             vr12,   vr0,    1  //offset = -9
++    vextrins.b          vr12,   vr1,    0x00
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++.if \mode == 20
++    vld                 vr1,    a2,     32
++.endif
++    vbsll.v             vr12,   vr12,   1  //offset = -10
++    vextrins.b          vr12,   vr1,    0x02
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsll.v             vr0,    vr12,   1
++    vextrins.b          vr0,    vr1,    0x03
++    vreplvei.h          vr12,   vr23,   7
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -11
++    vmulwev.h.bu.b      vr17,   vr3,    vr12
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr12
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 16
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG16_16 16
++INTRA_PRED_ANG16_16 20
++
++const lasx_ang16_mode16, align=5
++.byte 10,11,9,10,9,10,8,9,7,8,7,8,6,7,5,6,5,6,4,5,3,4,3,4,2,3,1,2,1,2,0,1
++.byte 32-11, 11, 32-22, 22, 32-1, 1, 32-12, 12, 32-23, 23, 32-2, 2, 32-13, 13, 32-24, 24
++.byte 32-3, 3, 32-14, 14, 32-25, 25, 32-4, 4, 32-15, 15, 32-26, 26, 32-5, 5, 32-16, 16
++.byte 15, 14, 12, 11, 9, 8, 6, 5, 3, 2, 0, 17, 18, 19, 20, 21
++.byte 0, 1, 2, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
++endconst
++function x265_intra_pred_ang16_16_lasx
++    la.local            t1,     lasx_ang16_mode16
++    vld                 vr12,   t1,     64
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    xvaddi.bu           xr22,   xr20,   2  //shuf
++    xvaddi.bu           xr23,   xr20,   3  //shuf
++    vld                 vr0,    a2,     32
++    vld                 vr11,   a2,     0
++    vmov                vr13,   vr0
++    vshuf.b             vr0,    vr0,    vr11,   vr12 //Get the reference pixels
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    vextrins.h          vr0,    vr13,   0x63
++    vextrins.b          vr0,    vr13,   0xe8
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr0,    4
++    vld                 vr12,   t1,     80
++    vshuf.b             vr0,    vr13,   vr0,    vr12
++    ANG16_MODE11_PROCESS_4x16_B 1
++    vld                 vr0,    a2,     32+2
++    ANG16_MODE11_PROCESS_4x16_B 0
++endfunc
++
++const ang16_mode17, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-6, 6, 32-12, 12, 32-18, 18, 32-24, 24, 32-30, 30, 32-4, 4, 32-10, 10, 32-16, 16
++.byte 32-22, 22, 32-28, 28, 32-2, 2, 32-8, 8, 32-14, 14, 32-20, 20, 32-26, 26, 32-0, 0
++.byte 15, 14, 12, 11, 10, 9, 7, 6, 5, 4, 2, 1, 16, 17, 18, 19
++endconst
++.macro INTRA_PRED_ANG16_17 mode
++function x265_intra_pred_ang16_\mode\()_lsx
++.if \mode == 17
++    vld                 vr0,    a2,     32
++    vld                 vr2,    a2,     0
++.else
++    vld                 vr0,    a2,     0
++    vld                 vr2,    a2,     32
++.endif
++
++    la.local            t1,     ang16_mode17
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++
++    //col 0-7
++    vmov                vr12,   vr0
++.if \mode == 17
++    vextrins.b          vr12,   vr2,    0x00 //offset = -1
++.endif
++
++    vreplvei.h          vr3,    vr1,    0
++    vshuf.b             vr6,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr6,    vr3
++
++    vbsll.v             vr12,   vr12,   1  //offset = -2
++    vextrins.b          vr12,   vr2,    0x01
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr9,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr9,    vr5
++
++    vbsll.v             vr12,   vr12,   1  //offset = -3
++    vextrins.b          vr12,   vr2,    0x02
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vbsll.v             vr12,   vr12,   1  //offset = -4
++    vextrins.b          vr12,   vr2,    0x04
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr15,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr15,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr3
++    vmaddwod.h.bu.b     vr7,    vr9,    vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr15,   vr11
++
++    vbsll.v             vr12,   vr12,   1 //offset = -5
++    vextrins.b          vr12,   vr2,    0x05
++    vreplvei.h          vr18,   vr1,    4
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr18
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vld                 vr8,    t1,     48
++    vshuf.b             vr0,    vr0,    vr2,    vr8
++.if \mode == 17
++    vextrins.b          vr0,    vr2,    0xc0
++.endif
++
++    vbsrl.v             vr12,   vr0,    7 //offset = -6
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr12,   vr0,    6  //offset = -7
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr18
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 17
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vbsrl.v             vr12,   vr0,    5  //offset = -8
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    4  //offset = -9
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vbsrl.v             vr12,   vr0,    3  //offset = -10
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vbsrl.v             vr12,   vr0,    2  //offset = -11
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -12
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -13
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13 //fraction is 0
++.if \mode == 17
++    STORE8x16_B_TRANSPOSE
++
++    //col 8-15
++    vld                 vr0,    a2,     33 //32
++    vbsrl.v             vr12,   vr0,    7  //offset = -1
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++    addi.d              a0,     a0,     8
++
++    //col 8-15
++    vld                 vr0,    a2,     1
++    vbsrl.v             vr12,   vr0,    7 //offset = -1
++.endif
++
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr12,   vr0,    6  //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr9,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr9,    vr5
++
++    vbsrl.v             vr12,   vr0,    5  //offset = -3
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr15,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr10,   vr15,   vr8
++
++    vbsrl.v             vr12,   vr0,    4  //offset = -4
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr9,    vr5
++    vmaddwod.h.bu.b     vr10,   vr15,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr12,   vr0,    3 //offset = -5
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr12,   vr0,    2 //offset = -6
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr12,   vr0,    1  //offset = -7
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++.if \mode == 17
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    addi.d              t3,     a0,     0
++    STORE8x8_B
++.endif
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr16,   vr0,    vr0,    vr20 //offset = -8
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vld                 vr1,    a2,     0
++    vbsll.v             vr12,   vr0,    1  //offset = -9
++    vextrins.b          vr12,   vr1,    0x00
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr7,    vr8,    vr5
++
++.if \mode == 19
++     vld                vr1,    a2,     32
++.endif
++    vreplvei.h          vr6,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr8,    vr6
++
++    vbsll.v             vr12,   vr12,   1  //offset = -10
++    vextrins.b          vr12,   vr1,    0x01
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr8,    vr5
++    vmaddwod.h.bu.b     vr10,   vr8,    vr6
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vbsll.v             vr12,   vr12,   1  //offset = -11
++    vextrins.b          vr12,   vr1,    0x02
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsll.v             vr12,   vr12,   1  //offset = -12
++    vextrins.b          vr12,   vr1,    0x04
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vbsll.v             vr0,    vr12,   1
++    vextrins.b          vr0,    vr1,    0x05
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -13
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13 //fraction is 0
++.if \mode == 17
++    STORE8x16_B_TRANSPOSE
++.else
++    add.d               t3,     t3,     a1
++    STORE8x8_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG16_17 17
++INTRA_PRED_ANG16_17 19
++
++.macro ANG16_MODE17_PROCESS_4x16_B idx0
++    xvpermi.q           xr0,    xr0,    0x00
++    xvshuf.b            xr3,    xr0,    xr0,    xr20
++    xvmulwev.h.bu.b     xr4,    xr3,    xr1
++    xvshuf.b            xr5,    xr0,    xr0,    xr21
++    xvmulwev.h.bu.b     xr6,    xr5,    xr1
++    xvpermi.q           xr2,    xr2,    0x00
++    xvshuf.b            xr7,    xr2,    xr2,    xr20
++    xvmulwev.h.bu.b     xr8,    xr7,    xr1
++    xvshuf.b            xr9,    xr2,    xr2,    xr21
++    xvmulwev.h.bu.b     xr10,   xr9,    xr1
++    xvmaddwod.h.bu.b    xr4,    xr3,    xr1
++    xvmaddwod.h.bu.b    xr6,    xr5,    xr1
++    xvmaddwod.h.bu.b    xr8,    xr7,    xr1
++    xvmaddwod.h.bu.b    xr10,   xr9,    xr1
++    xvssrarni.bu.h      xr6,    xr4,    5
++    xvssrarni.bu.h      xr10,   xr8,    5
++    xvpermi.d           xr4,    xr6,    0xd8
++    xvpermi.d           xr8,    xr10,   0xd8
++    xvpermi.q           xr6,    xr4,    0x11
++    xvpermi.q           xr10,   xr8,    0x11
++    vst                 vr4,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    vst                 vr8,    a0,     0
++    vstx                vr10,   a0,     a1
++.if \idx0 == 1
++    alsl.d              a0,     a1,     a0,    1
++.endif
++.endm
++
++const lasx_ang16_mode17, align=5
++.byte 12,13,11,12,10,11,9,10,8,9,8,9,7,8,6,7,5,6,4,5,4,5,3,4,2,3,1,2,0,1,0,1
++.byte 32-6, 6, 32-12, 12, 32-18, 18, 32-24, 24, 32-30, 30, 32-4, 4, 32-10, 10, 32-16, 16
++.byte 32-22, 22, 32-28, 28, 32-2, 2, 32-8, 8, 32-14, 14, 32-20, 20, 32-26, 26, 32-0, 0
++.byte 15, 14, 12, 11, 10, 9, 7, 6, 5, 4, 2, 1, 0, 17, 18, 19
++endconst
++function x265_intra_pred_ang16_17_lasx
++    la.local            t1,     lasx_ang16_mode17
++    vld                 vr12,   t1,     64
++    xvld                xr20,   t1,     0  //shuf
++    xvld                xr1,    t1,     32 //fraction
++    xvaddi.bu           xr21,   xr20,   1  //shuf
++    vld                 vr0,    a2,     32
++    vld                 vr11,   a2,     0
++    vmov                vr13,   vr0
++    vshuf.b             vr0,    vr0,    vr11,   vr12 //Get the reference pixels
++    vbsrl.v             vr2,    vr0,    2
++    vextrins.h          vr2,    vr13,   0x72
++    ANG16_MODE17_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr2,    2
++    vextrins.h          vr0,    vr13,   0x73
++    vbsrl.v             vr2,    vr0,    2
++    vextrins.h          vr2,    vr13,   0x74
++    ANG16_MODE17_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr2,    2
++    vextrins.h          vr0,    vr13,   0x75
++    vbsrl.v             vr2,    vr0,    2
++    vextrins.h          vr2,    vr13,   0x76
++    ANG16_MODE17_PROCESS_4x16_B 1
++    vbsrl.v             vr0,    vr2,    2
++    vextrins.h          vr0,    vr13,   0x77
++    vld                 vr2,    a2,     32+2
++    ANG16_MODE17_PROCESS_4x16_B 1
++endfunc
++
++function x265_intra_pred_ang16_18_lsx
++    vld                 vr0,    a2,     0  //0  1  2  ...
++    vld                 vr1,    a2,     33 //33 34 35 ...
++
++    vst                 vr0,    a0,     0
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x00
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x01
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x02
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x03
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x04
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x05
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x06
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x07
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x08
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x09
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x0a
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x0b
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x0c
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x0d
++    vst                 vr0,    a0,     0
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0x0e
++    vstx                vr0,    a0,     a1
++endfunc
++
++.macro INTRA_PRED_ANG32_2_CORE in0, in1
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    \in0
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    \in1
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++.endm
++
++.macro INTRA_PRED_ANG32_2 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              t0,     a0,     0
++    addi.d              t1,     a2,     0
++.rept 2
++.rept 2
++.if \mode == 2
++    vld                 vr0,    a2,     66 //66 67 ...
++    vld                 vr1,    a2,     66+16
++.else
++    vld                 vr0,    a2,     2 //2 3 ...
++    vld                 vr1,    a2,     2+16
++.endif
++    vst                 vr0,    a0,     0
++    vbsrl.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr1,    0xf0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    INTRA_PRED_ANG32_2_CORE     0xf1,   0xf2
++    INTRA_PRED_ANG32_2_CORE     0xf3,   0xf4
++    INTRA_PRED_ANG32_2_CORE     0xf5,   0xf6
++    INTRA_PRED_ANG32_2_CORE     0xf7,   0xf8
++    INTRA_PRED_ANG32_2_CORE     0xf9,   0xfa
++    INTRA_PRED_ANG32_2_CORE     0xfb,   0xfc
++    INTRA_PRED_ANG32_2_CORE     0xfd,   0xfe
++    addi.d              a2,     a2,     16
++.endr
++    addi.d              a0,     t0,     16
++    addi.d              a2,     t1,     16
++.endr
++endfunc
++.endm
++
++INTRA_PRED_ANG32_2 2
++INTRA_PRED_ANG32_2 34
++
++const ang32_mode3, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-26, 26, 32-20, 20, 32-14, 14, 32-8, 8, 32-2, 2, 32-28, 28, 32-22, 22, 32-16, 16
++.byte 32-10, 10, 32-4, 4, 32-30, 30, 32-24, 24, 32-18, 18, 32-12, 12, 32-6, 6, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_3 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++.if \mode == 3
++    addi.d              t0,     a2,     65
++    addi.d              t2,     a0,     0
++.else
++    addi.d              t0,     a2,     1
++    addi.d              t3,     a0,     0
++.endif
++    la.local            t1,     ang32_mode3
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16 //fraction
++    vld                 vr23,   t1,     32 //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 4
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 5
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 6
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 3
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vld                 vr0,    t0,     7  //offset = 7
++
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 8
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 9
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 10
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 11
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 12
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 13
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 3
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t2,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vld                 vr0,    t0,     14 //offset = 14
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 15
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 16
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 17
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 18
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 19
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 3
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vld                 vr0,    t0,     20
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = 20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 21
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 22
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 23
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 24
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 25
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 26
++    //vreplvei.h          vr15,   vr23,   7
++    //vshuf.b             vr16,   vr0,    vr0,    vr20
++    //vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    //vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++.if \mode == 3
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t2,   3
++    addi.d              t2,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG32_3 3
++INTRA_PRED_ANG32_3 33
++
++const ang32_mode4, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-21, 21, 32-10, 10, 32-31, 31, 32-20, 20, 32-9, 9, 32-30, 30, 32-19, 19, 32-8, 8
++.byte 32-29, 29, 32-18, 18, 32-7, 7, 32-28, 28, 32-17, 17, 32-6, 6, 32-27, 27, 32-16, 16
++.byte 32-5, 5, 32-26, 26, 32-15, 15, 32-4, 4, 32-25, 25, 32-14, 14, 32-3, 3, 32-24, 24
++.byte 32-13, 13, 32-2, 2, 32-23, 23, 32-12, 12, 32-1, 1, 32-22, 22, 32-11, 11, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_4 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 4
++    addi.d              t0,     a2,     65
++    addi.d              t2,     a0,     0
++.else
++    addi.d              t0,     a2,     1
++    addi.d              t3,     a0,     0
++.endif
++    la.local            t1,     ang32_mode4
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 3
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 4
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 5
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 4
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 6
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vld                 vr0,    t0,     7 //offset = 7
++    vreplvei.h          vr8,    vr23,   2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 8
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 9
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 10
++    vreplvei.h          vr15,   vr23,   7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 4
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t2,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vbsrl.v             vr0,    vr0,    1 //offset = 11
++    vreplvei.h          vr2,    vr24,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr24,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 12
++    vreplvei.h          vr8,    vr24,   2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 13
++    vreplvei.h          vr11,   vr24,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 14
++    vreplvei.h          vr6,    vr24,   5
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vld                 vr0,    t0,     15 //offset = 15
++    vreplvei.h          vr11,   vr24,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr8,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr8,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 4
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vbsrl.v             vr0,    vr0,    1 //offset = 16
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = 20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 17
++    vreplvei.h          vr5,    vr25,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 18
++    vreplvei.h          vr11,   vr25,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 19
++    vreplvei.h          vr2,    vr25,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 20
++    vreplvei.h          vr11,   vr25,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 21
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 4
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t2,   3
++    addi.d              t2,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_4 4
++INTRA_PRED_ANG32_4 32
++
++const ang32_mode5, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-17, 17, 32-2, 2, 32-19, 19, 32-4, 4, 32-21, 21, 32-6, 6, 32-23, 23, 32-8, 8
++.byte 32-25, 25, 32-10, 10, 32-27, 27, 32-12, 12, 32-29, 29, 32-14, 14, 32-31, 31, 32-16, 16
++.byte 32-1, 1, 32-18, 18, 32-3, 3, 32-20, 20, 32-5, 5, 32-22, 22, 32-7, 7, 32-24, 24
++.byte 32-9, 9, 32-26, 26, 32-11, 11, 32-28, 28, 32-13, 13, 32-30, 30, 32-15, 15, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_5 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 5
++    addi.d              t0,     a2,     65
++    addi.d              t2,     a0,     0
++.else
++    addi.d              t0,     a2,     1
++    addi.d              t3,     a0,     0
++.endif
++    la.local            t1,     ang32_mode5
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 2
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 3
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 4
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 5
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 5
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 6
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 7
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vld                 vr0,    t0,     8 //offset = 8
++    vreplvei.h          vr15,   vr23,   7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 5
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t2,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vbsrl.v             vr0,    vr0,    1 //offset = 9
++    vreplvei.h          vr2,    vr24,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr24,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 10
++    vreplvei.h          vr8,    vr24,   2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr24,   3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 11
++    vreplvei.h          vr2,    vr24,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr24,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 12
++    vreplvei.h          vr11,   vr24,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr8,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr8,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 5
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vbsrl.v             vr0,    vr0,    1 //offset = 13
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 14
++    vreplvei.h          vr8,    vr25,   2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr25,   3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 15
++    vreplvei.h          vr2,    vr25,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vld                 vr0,    t0,     16  //offset = 16
++    vreplvei.h          vr11,   vr25,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1  //offset = 17
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 5
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t2,   3
++    addi.d              t2,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_5 5
++INTRA_PRED_ANG32_5 31
++
++const ang32_mode6, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-13, 13, 32-26, 26, 32-7, 7, 32-20, 20, 32-1, 1, 32-14, 14, 32-27, 27, 32-8, 8
++.byte 32-21, 21, 32-2, 2, 32-15, 15, 32-28, 28, 32-9, 9, 32-22, 22, 32-3, 3, 32-16, 16
++.byte 32-29, 29, 32-10, 10, 32-23, 23, 32-4, 4, 32-17, 17, 32-30, 30, 32-11, 11, 32-24, 24
++.byte 32-5, 5, 32-18, 18, 32-31, 31, 32-12, 12, 32-25, 25, 32-6, 6, 32-19, 19, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_6 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 6
++    addi.d              t0,     a2,     65
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang32_mode6
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0 //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 2
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 3
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 6
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 4
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr6,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr6,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 5
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 6
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 6
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr24,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 7
++    vreplvei.h          vr5,    vr24,   1
++    vshuf.b             vr6,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr24,   2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vld                 vr0,    t0,     8 //offset = 8
++    vreplvei.h          vr11,   vr24,   3
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr24,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 9
++    vreplvei.h          vr11,   vr24,   6
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr8,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr8,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 6
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vbsrl.v             vr0,    vr0,    1 //offset = 10
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 11
++    vreplvei.h          vr11,   vr25,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr25,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 12
++    vreplvei.h          vr6,    vr25,   5
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 13
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 6
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_6 6
++INTRA_PRED_ANG32_6 30
++
++const ang32_mode7, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-9, 9, 32-18, 18, 32-27, 27, 32-4, 4, 32-13, 13, 32-22, 22, 32-31, 31, 32-8, 8
++.byte 32-17, 17, 32-26, 26, 32-3, 3, 32-12, 12, 32-21, 21, 32-30, 30, 32-7, 7, 32-16, 16
++.byte 32-25, 25, 32-2, 2, 32-11, 11, 32-20, 20, 32-29, 29, 32-6, 6, 32-15, 15, 32-24, 24
++.byte 32-1, 1, 32-10, 10, 32-19, 19, 32-28, 28, 32-5, 5, 32-14, 14, 32-23, 23, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_7 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 7
++    addi.d              t0,     a2,     65
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang32_mode7
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0 //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 2
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 7
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 3
++    vreplvei.h          vr8,    vr23,   2
++    vshuf.b             vr12,   vr0,    vr0,   vr20
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 4
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 7
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr24,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 5
++    vreplvei.h          vr5,    vr24,   1
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr24,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr24,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 6
++    vreplvei.h          vr6,    vr24,   5
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr8,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++    vmaddwod.h.bu.b     vr17,   vr8,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 7
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vbsrl.v             vr0,    vr0,    1 //offset = 7
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr25,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vld                 vr0,    t0,     8 //offset = 8
++    vreplvei.h          vr2,    vr25,   4
++    vshuf.b             vr8,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr8,    vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr8,    vr6
++
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr8,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 13
++
++    vmaddwod.h.bu.b     vr5,    vr8,    vr2
++    vmaddwod.h.bu.b     vr9,    vr8,    vr6
++    vmaddwod.h.bu.b     vr14,   vr8,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 7
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_7 7
++INTRA_PRED_ANG32_7 29
++
++const ang32_mode8, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-5, 5, 32-10, 10, 32-15, 15, 32-20, 20, 32-25, 25, 32-30, 30, 32-3, 3, 32-8, 8
++.byte 32-13, 13, 32-18, 18, 32-23, 23, 32-28, 28, 32-1, 1, 32-6, 6, 32-11, 11, 32-16, 16
++.byte 32-21, 21, 32-26, 26, 32-31, 31, 32-4, 4, 32-9, 9, 32-14, 14, 32-19, 19, 32-24, 24
++.byte 32-29, 29, 32-2, 2, 32-7, 7, 32-12, 12, 32-17, 17, 32-22, 22, 32-27, 27, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_8 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 8
++    addi.d              t0,     a2,     65
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang32_mode8
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0 //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 8
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 2
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 8
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr24,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr24,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr24,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 3
++    vreplvei.h          vr11,   vr24,   3
++    vshuf.b             vr12,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr24,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 8
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vreplvei.h          vr2,    vr25,   0
++    vmulwev.h.bu.b      vr4,    vr12,   vr2
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 4
++    vreplvei.h          vr5,    vr25,   1
++    vshuf.b             vr3,    vr0,    vr0,   vr20
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr25,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr12,   vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr25,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 5
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 8
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_8 8
++INTRA_PRED_ANG32_8 28
++
++const ang32_mode9, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-2, 2, 32-4, 4, 32-6, 6, 32-8, 8, 32-10, 10, 32-12, 12, 32-14, 14, 32-16, 16
++.byte 32-18, 18, 32-20, 20, 32-22, 22, 32-24, 24, 32-26, 26, 32-28, 28, 32-30, 30, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_9 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++.if \mode == 9
++    addi.d              t0,     a2,     65
++.else
++    addi.d              t0,     a2,     1
++.endif
++    la.local            t1,     ang32_mode9
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0 //offset = 0
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 9
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 1
++    vreplvei.h          vr15,   vr23,   7
++    vshuf.b             vr16,   vr0,    vr0,   vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 9
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr1,    0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 9
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vbsrl.v             vr0,    vr0,    1 //offset = 2
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 9
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.w              t7,     t7,     -1
++    addi.d              t0,     t0,     8
++    bnez                t7,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG32_9 9
++INTRA_PRED_ANG32_9 27
++
++function x265_intra_pred_ang32_10_lsx
++    addi.d              t0,     a0,     0
++    addi.d              t1,     a2,     0
++    addi.d              t3,     a0,     0
++    vldrepl.b           vr17,   a2,     65
++    vldrepl.b           vr18,   a2,     0
++    vsllwil.hu.bu       vr17,   vr17,   0 //top
++    vsllwil.hu.bu       vr18,   vr18,   0 //topLeft
++.rept 2
++    vld                 vr0,    a2,     65
++    //transpose
++    vreplvei.b          vr1,    vr0,    0
++    vreplvei.b          vr2,    vr0,    1
++    vreplvei.b          vr3,    vr0,    2
++    vreplvei.b          vr4,    vr0,    3
++    vreplvei.b          vr5,    vr0,    4
++    vreplvei.b          vr6,    vr0,    5
++    vreplvei.b          vr7,    vr0,    6
++    vreplvei.b          vr8,    vr0,    7
++    vreplvei.b          vr9,    vr0,    8
++    vreplvei.b          vr10,   vr0,    9
++    vreplvei.b          vr11,   vr0,    10
++    vreplvei.b          vr12,   vr0,    11
++    vreplvei.b          vr13,   vr0,    12
++    vreplvei.b          vr14,   vr0,    13
++    vreplvei.b          vr15,   vr0,    14
++    vreplvei.b          vr16,   vr0,    15
++.rept 2
++    vst                 vr1,    a0,     0
++    vstx                vr2,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr3,    a0,     0
++    vstx                vr4,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr5,    a0,     0
++    vstx                vr6,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr7,    a0,     0
++    vstx                vr8,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr9,    a0,     0
++    vstx                vr10,   a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr11,   a0,     0
++    vstx                vr12,   a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr13,   a0,     0
++    vstx                vr14,   a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++    vst                 vr15,   a0,     0
++    vstx                vr16,   a0,     a1
++    addi.d              a0,     t0,     16
++.endr
++    beqz                a4,     1f
++    //bFilter != 0
++    vld                 vr19,   a2,     1 //srcPixel[width2 + 1 + y]
++    vexth.hu.bu         vr20,   vr19
++    vsllwil.hu.bu       vr19,   vr19,   0
++    vsub.h              vr19,   vr19,   vr18
++    vsub.h              vr20,   vr20,   vr18
++    vsrai.h             vr19,   vr19,   1
++    vsrai.h             vr20,   vr20,   1
++    vadd.h              vr19,   vr19,   vr17
++    vadd.h              vr20,   vr20,   vr17
++    vssrani.bu.h        vr20,   vr19,   0
++    vst                 vr20,   t3,     0 //update Row 0
++    addi.d              t3,     t3,     16
++1:
++    alsl.d              a0,     a1,     t0,   4
++    addi.d              t0,     a0,     0
++    addi.d              a2,     t1,     16
++.endr
++endfunc
++
++function x265_intra_pred_ang32_26_lsx
++    addi.d              t0,     a0,     0
++    addi.d              t1,     a2,     0
++    addi.d              t2,     a0,     0
++    vldrepl.h           vr18,   a2,     0
++    vsllwil.hu.bu       vr18,   vr18,   0
++    vreplvei.h          vr17,   vr18,   1 //top
++    vreplvei.h          vr18,   vr18,   0 //topLeft
++.rept 2
++    vld                 vr0,    a2,     1
++    //store no transpose
++.rept 15
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    alsl.d              a0,     a1,     a0,   1
++.endr
++    vst                 vr0,    a0,     0
++    vstx                vr0,    a0,     a1
++    beqz                a4,     1f
++    //bFilter != 0
++    vld                 vr19,   a2,     65//srcPixel[width2 + 1 + y]
++    vexth.hu.bu         vr20,   vr19
++    vsllwil.hu.bu       vr19,   vr19,   0
++    vsub.h              vr19,   vr19,   vr18
++    vsub.h              vr20,   vr20,   vr18
++    vsrai.h             vr19,   vr19,   1
++    vsrai.h             vr20,   vr20,   1
++    vadd.h              vr19,   vr19,   vr17
++    vadd.h              vr20,   vr20,   vr17
++    vssrani.bu.h        vr20,   vr19,   0
++    //update Col 0
++    .irp i, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
++    vstelm.b            vr20,   t2,     0,   \i
++    add.d               t2,     t2,     a1
++    .endr
++1:
++    addi.d              a0,     t0,     16
++    addi.d              a2,     t1,     16
++.endr
++endfunc
++
++const ang32_mode11, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-30, 30, 32-28, 28, 32-26, 26, 32-24, 24, 32-22, 22, 32-20, 20, 32-18, 18, 32-16, 16
++.byte 32-14, 14, 32-12, 12, 32-10, 10, 32-8, 8, 32-6, 6, 32-4, 4, 32-2, 2, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_11 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++.if \mode == 11
++    addi.d              t0,     a2,     64-1
++    vldrepl.b           vr2,    a2,     0
++    vldrepl.b           vr3,    a2,     16
++.else
++    addi.d              t0,     a2,     0-1
++    vldrepl.b           vr3,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode11
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    li.w                t6,     4
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0
++    blt                 t7,     t6,     2f //only insert in the beginning
++    vextrins.b          vr0,    vr3,    0x00 //ref_pix[-2]
++.if \mode == 11
++    vextrins.b          vr0,    vr2,    0x10 //ref_pix[-1]
++.endif
++2:
++    vbsrl.v             vr12,   vr0,    1 //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr12,   vr12,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 11
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr12,   vr13
++
++.if \mode == 11
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vshuf.b             vr16,   vr0,    vr0,   vr20 //offset = -2
++    vreplvei.h          vr2,    vr1,    0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 11
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 11
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++endfunc
++.endm
++
++INTRA_PRED_ANG32_11 11
++INTRA_PRED_ANG32_11 25
++
++const ang32_mode12, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-27, 27, 32-22, 22, 32-17, 17, 32-12, 12, 32-7, 7, 32-2, 2, 32-29, 29, 32-24, 24
++.byte 32-19, 19, 32-14, 14, 32-9, 9, 32-4, 4, 32-31, 31, 32-26, 26, 32-21, 21, 32-16, 16
++.byte 32-11, 11, 32-6, 6, 32-1, 1, 32-28, 28, 32-23, 23, 32-18, 18, 32-13, 13, 32-8, 8
++.byte 32-3, 3, 32-30, 30, 32-25, 25, 32-20, 20, 32-15, 15, 32-10, 10, 32-5, 5, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_12 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 12
++    addi.d              t0,     a2,     64-4
++    vld                 vr2,    a2,     0  // 6 13
++    vld                 vr3,    a2,     16 // 19 26
++.else
++    addi.d              t0,     a2,     0-4
++    vld                 vr2,    a2,     64
++    vld                 vr3,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode12
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t6,     4
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0
++
++    blt                 t7,     t6,     2f //only insert in the beginning
++    vextrins.b          vr0,    vr3,    0x0a //ref_pix[-5]
++    vextrins.b          vr0,    vr3,    0x13 //ref_pix[-4]
++    vextrins.b          vr0,    vr2,    0x2d //ref_pix[-3]
++    vextrins.b          vr0,    vr2,    0x36 //ref_pix[-2]
++.if \mode == 12
++    vextrins.b          vr0,    vr2,    0x40 //ref_pix[-1]
++.endif
++2:
++    vbsrl.v             vr22,   vr0,    4 //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr22,   vr0,    3 //offst = -2
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 12
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr12,   vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr12,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr17,   vr0,    2 //offset = -3
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 12
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr24,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr24,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr24,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vbsrl.v             vr22,   vr0,    1 // offset = -4
++    vreplvei.h          vr11,   vr24,   3
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr24,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 12
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vreplvei.h          vr2,    vr25,   0
++    vmulwev.h.bu.b      vr4,    vr12,   vr2
++
++    vshuf.b             vr16,   vr0,    vr0,   vr20 //offset = -5
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr25,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr12,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr25,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 12
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_12 12
++INTRA_PRED_ANG32_12 24
++
++const ang32_mode13, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-23, 23, 32-14, 14, 32-5, 5, 32-28, 28, 32-19, 19, 32-10, 10, 32-1, 1, 32-24, 24
++.byte 32-15, 15, 32-6, 6, 32-29, 29, 32-20, 20, 32-11, 11, 32-2, 2, 32-25, 25, 32-16, 16
++.byte 32-7, 7, 32-30, 30, 32-21, 21, 32-12, 12, 32-3, 3, 32-26, 26, 32-17, 17, 32-8, 8
++.byte 32-31, 31, 32-22, 22, 32-13, 13, 32-4, 4, 32-27, 27, 32-18, 18, 32-9, 9, 32-0, 0
++endconst
++.macro INTRA_PRED_ANG32_13 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++.if \mode == 13
++    addi.d              t0,     a2,     64-8
++    vld                 vr2,    a2,     0  // 4 7 11 14
++    vld                 vr3,    a2,     16 // 18 21 25 28
++.else
++    addi.d              t0,     a2,     0-8
++    vld                 vr2,    a2,     64
++    vld                 vr3,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode13
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    li.w                t5,     3
++    li.w                t6,     4
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     0
++
++    blt                 t7,     t6,     2f //Only insert in the 1st loop
++    vextrins.b          vr0,    vr3,    0x0c //ref_pix[-9]
++    vextrins.b          vr0,    vr3,    0x19 //ref_pix[-8]
++    vextrins.b          vr0,    vr3,    0x25 //ref_pix[-7]
++    vextrins.b          vr0,    vr3,    0x32 //ref_pix[-6]
++    vextrins.b          vr0,    vr2,    0x4e //ref_pix[-5]
++    vextrins.b          vr0,    vr2,    0x5b //ref_pix[-4]
++    vextrins.b          vr0,    vr2,    0x67 //ref_pix[-3]
++    vextrins.b          vr0,    vr2,    0x74 //ref_pix[-2]
++.if \mode == 13
++    vextrins.b          vr0,    vr2,    0x80 //ref_pix[-1]
++.endif
++2:
++.if \mode == 13
++    bne                 t7,     t5,     3f //Need to adjust ref_pix[-1]'s value
++    vldrepl.b           vr2,    a2,     0  //in the 2nd loop
++    vextrins.b          vr0,    vr2,    0x00
++.endif
++3:
++    vldrepl.b           vr2,    t0,     16
++    vbsrl.v             vr22,   vr0,    8 //offset = -1
++    vextrins.b          vr22,   vr2,    0x80
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr3,    vr8
++
++    vbsrl.v             vr22,   vr0,    7 //offset = -2
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr3,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vbsrl.v             vr22,   vr0,    6 //offset = -3
++    vreplvei.h          vr15,   vr1,    7
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 13
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr23,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vbsrl.v             vr17,   vr0,    5 //offset = -4
++    vreplvei.h          vr8,    vr23,   2
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vbsrl.v             vr17,   vr0,    4 //offset = -5
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 13
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr24,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr22,   vr0,    3 //offset = -6
++    vreplvei.h          vr5,    vr24,   1
++    vshuf.b             vr12,   vr22,   vr22,    vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr24,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr24,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -7
++    vreplvei.h          vr6,    vr24,   5
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr3,   vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr3,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr3,   vr6
++    vmaddwod.h.bu.b     vr14,   vr3,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 13
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vbsrl.v             vr17,   vr0,    1 //offset = -8
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr16,   vr17,   vr17,  vr20
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr25,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vshuf.b             vr16,   vr0,    vr0,   vr20
++    vreplvei.h          vr2,    vr25,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 13
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,    3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16
++endfunc
++.endm
++
++INTRA_PRED_ANG32_13 13
++INTRA_PRED_ANG32_13 23
++
++const ang32_mode14, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-19, 19, 32-6, 6, 32-25, 25, 32-12, 12, 32-31, 31, 32-18, 18, 32-5, 5, 32-24, 24
++.byte 32-11, 11, 32-30, 30, 32-17, 17, 32-4, 4, 32-23, 23, 32-10, 10, 32-29, 29, 32-16, 16
++.byte 32-3, 3, 32-22, 22, 32-9, 9, 32-28, 28, 32-15, 15, 32-2, 2, 32-21, 21, 32-8, 8
++.byte 32-27, 27, 32-14, 14, 32-1, 1, 32-20, 20, 32-7, 7, 32-26, 26, 32-13, 13, 32-0, 0
++.byte 30, 27, 25, 22, 20, 17, 15, 12, 10, 7, 5, 2, 0, 0, 0, 0
++endconst
++.macro INTRA_PRED_ANG32_14 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16-48
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++    addi.d              t4,     sp,     16
++.if \mode == 14
++    addi.d              t0,     a2,     64
++    vld                 vr4,    a2,     0
++    vld                 vr5,    a2,     16
++.else
++    addi.d              t0,     a2,     0
++    vld                 vr4,    a2,     64
++    vld                 vr5,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode14
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    //sort src in stack in ascending order
++    vld                 vr2,    t1,     16*5
++    vshuf.b             vr3,    vr5,    vr4,    vr2
++    vst                 vr3,    t4,     0
++.if \mode == 22
++    vldrepl.b           vr2,    a2,     0
++    vstelm.b            vr2,    t4,     12,     0
++.endif
++    vld                 vr3,    t0,     1
++    vst                 vr3,    t4,     13
++    vld                 vr2,    t0,     1+16
++    vst                 vr2,    t4,     13+16
++    addi.d              t0,     t4,     13
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     -4
++    vbsrl.v             vr22,   vr0,    3 //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr3,    vr5
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -2
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr3,    vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -3
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr1,    7 //offset = -4
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 14
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vld                 vr0,    t0,     -7
++    vbsrl.v             vr17,   vr0,    2 //offset = -5
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr17,   vr0,    1 //offset = -6
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr23,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vshuf.b             vr16,   vr0,    vr0,    vr20 //offset = -7
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 14
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vreplvei.h          vr2,    vr24,   0
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vld                 vr0,    t0,     -10
++    vbsrl.v             vr22,   vr0,    2 //offset = -8
++    vreplvei.h          vr5,    vr24,   1
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr24,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -9
++    vreplvei.h          vr11,   vr24,   3
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr24,   5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vshuf.b             vr12,   vr0,    vr0,    vr20 //offset = -10
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 14
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vld                 vr0,    t0,     -13
++    vbsrl.v             vr17,   vr0,    2 //offset = -11
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr16,   vr17,   vr17,  vr20
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vbsrl.v             vr17,   vr0,    1 //offset = -12
++    vreplvei.h          vr11,   vr25,   3
++    vshuf.b             vr12,   vr17,   vr17,  vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vreplvei.h          vr2,    vr25,   4
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vshuf.b             vr16,   vr0,    vr0,   vr20 //offset = -13
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 14
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16+48
++endfunc
++.endm
++
++INTRA_PRED_ANG32_14 14
++INTRA_PRED_ANG32_14 22
++
++const ang32_mode15, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-15, 15, 32-30, 30, 32-13, 13, 32-28, 28, 32-11, 11, 32-26, 26, 32-9, 9, 32-24, 24
++.byte 32-7, 7, 32-22, 22, 32-5, 5, 32-20, 20, 32-3, 3, 32-18, 18, 32-1, 1, 32-16, 16
++.byte 32-31, 31, 32-14, 14, 32-29, 29, 32-12, 12, 32-27, 27, 32-10, 10, 32-25, 25, 32-8, 8
++.byte 32-23, 23, 32-6, 6, 32-21, 21, 32-4, 4, 32-19, 19, 32-2, 2, 32-17, 17, 32-0, 0
++.byte 30, 28, 26, 24, 23, 21, 19, 17, 15, 13, 11, 9, 8, 6, 4, 2
++endconst
++.macro INTRA_PRED_ANG32_15 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16-56
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++    addi.d              t4,     sp,     16
++.if \mode == 15
++    addi.d              t0,     a2,     64
++    vld                 vr4,    a2,     0
++    vld                 vr5,    a2,     16
++.else
++    addi.d              t0,     a2,     0
++    vld                 vr4,    a2,     64
++    vld                 vr5,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode15
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    //sort src in stack in ascending order
++    vld                 vr2,    t1,     16*5
++    vshuf.b             vr3,    vr5,    vr4,    vr2
++    vst                 vr3,    t4,     0
++    vldrepl.b           vr2,    a2,     0
++    vstelm.b            vr2,    t4,     16,     0 //[-1]
++    vld                 vr3,    t0,     1
++    vst                 vr3,    t4,     17
++    vld                 vr2,    t0,     1+16
++    vst                 vr2,    t4,     17+16
++    addi.d              t0,     t4,     17
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     -5
++    vbsrl.v             vr22,   vr0,    4 //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr22,   vr0,    3 //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr1,    4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -4
++    vreplvei.h          vr6,    vr1,    5
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -5
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 15
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vld                 vr0,    t0,     -9
++    vbsrl.v             vr17,   vr0,    3 //offset = -6
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr17,   vr0,    2 //0ffset = -7
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vreplvei.h          vr2,    vr23,   4
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr17,   vr0,    1 //offst = -8
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -9
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 15
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vld                 vr0,    t0,     -13
++    vbsrl.v             vr22,   vr0,    3 //offset = -10
++    vreplvei.h          vr2,    vr24,   0
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr12,   vr2
++
++    vreplvei.h          vr5,    vr24,   1
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -11
++    vreplvei.h          vr8,    vr24,   2
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr24,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr12,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -12
++    vreplvei.h          vr2,    vr24,   4
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr24,   5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -13
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 15
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vld                 vr0,    t0,     -17
++    vbsrl.v             vr17,   vr0,    3 //offset = -14
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr16,   vr17,   vr17,  vr20
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vreplvei.h          vr5,    vr25,   1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vbsrl.v             vr17,   vr0,    2 //offset = -15
++    vreplvei.h          vr8,    vr25,   2
++    vshuf.b             vr12,   vr17,   vr17,  vr20
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr25,   3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr17,   vr0,    1 //offset = -16
++    vreplvei.h          vr2,    vr25,   4
++    vshuf.b             vr12,   vr17,   vr17,  vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vshuf.b             vr16,   vr0,    vr0,   vr20
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 15
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16+56
++endfunc
++.endm
++
++INTRA_PRED_ANG32_15 15
++INTRA_PRED_ANG32_15 21
++
++const ang32_mode16, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-11, 11, 32-22, 22, 32-1, 1, 32-12, 12, 32-23, 23, 32-2, 2, 32-13, 13, 32-24, 24
++.byte 32-3, 3, 32-14, 14, 32-25, 25, 32-4, 4, 32-15, 15, 32-26, 26, 32-5, 5, 32-16, 16
++.byte 32-27, 27, 32-6, 6, 32-17, 17, 32-28, 28, 32-7, 7, 32-18, 18, 32-29, 29, 32-8, 8
++.byte 32-19, 19, 32-30, 30, 32-9, 9, 32-20, 20, 32-31, 31, 32-10, 10, 32-21, 21, 32-0, 0
++.byte 30, 29, 27, 26, 24, 23, 21, 20, 18, 17, 15, 14, 12, 11, 9, 8
++endconst
++.macro INTRA_PRED_ANG32_16 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -16-56
++    fst.d               f24,    sp,     0
++    fst.d               f25,    sp,     8
++    addi.d              t4,     sp,     16
++.if \mode == 16
++    addi.d              t0,     a2,     64
++    vld                 vr4,    a2,     0
++    vld                 vr5,    a2,     16
++.else
++    addi.d              t0,     a2,     0
++    vld                 vr4,    a2,     64
++    vld                 vr5,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode16
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    vld                 vr24,   t1,     16*3  //fraction
++    vld                 vr25,   t1,     16*4  //fraction
++    //sort src in stack in ascending order
++    vld                 vr2,    t1,     16*5
++    vshuf.b             vr3,    vr5,    vr4,    vr2
++    vst                 vr3,    t4,     0
++    vstelm.b            vr4,    t4,     16,     6
++    vstelm.b            vr4,    t4,     17,     5
++    vstelm.b            vr4,    t4,     18,     3
++    vstelm.b            vr4,    t4,     19,     2
++    vldrepl.b           vr3,    a2,     0
++    vstelm.b            vr3,    t4,     20,     0 //[-1]
++    vld                 vr2,    t0,     1
++    vst                 vr2,    t4,     21
++    vld                 vr3,    t0,     1+16
++    vst                 vr3,    t4,     21+16
++    addi.d              t0,     t4,     21
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     -6
++    vbsrl.v             vr22,   vr0,    5 //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr22,   vr0,    4 //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr22,   vr0,    3 //offset = -3
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -4
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -5
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -6
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 16
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vreplvei.h          vr2,    vr23,   0
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vld                 vr0,    t0,     -11
++    vbsrl.v             vr17,   vr0,    4 //offset = -7
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vbsrl.v             vr17,   vr0,    3 //0ffset = -8
++    vreplvei.h          vr8,    vr23,   2
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vreplvei.h          vr11,   vr23,   3
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr17,   vr0,    2 //offst = -9
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr17,   vr0,    1 //offst = -10
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -11
++    vreplvei.h          vr15,   vr23,   7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 16
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vld                 vr0,    t0,     -16
++    vbsrl.v             vr22,   vr0,    4 //offset = -12
++    vreplvei.h          vr2,    vr24,   0
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr12,   vr2
++
++    vreplvei.h          vr5,    vr24,   1
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vbsrl.v             vr22,   vr0,    3 //offset = -13
++    vreplvei.h          vr8,    vr24,   2
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -14
++    vreplvei.h          vr11,   vr24,   3
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr12,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vreplvei.h          vr2,    vr24,   4
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -15
++    vreplvei.h          vr6,    vr24,   5
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vshuf.b             vr12,   vr0,    vr0,    vr20 //offset = -16
++    vreplvei.h          vr11,   vr24,   6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vreplvei.h          vr15,   vr24,   7
++    vmulwev.h.bu.b      vr17,   vr12,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr12,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 16
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vld                 vr0,    t0,     -21
++    vbsrl.v             vr17,   vr0,    4 //offset = -17
++    vreplvei.h          vr2,    vr25,   0
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr4,    vr16,   vr2
++
++    vbsrl.v             vr17,   vr0,    3 //offset = -18
++    vreplvei.h          vr5,    vr25,   1
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr25,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr17,   vr0,    2 //offset = -19
++    vreplvei.h          vr11,   vr25,   3
++    vshuf.b             vr3,    vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr16,   vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vbsrl.v             vr17,   vr0,    1 //offset = -20
++    vreplvei.h          vr2,    vr25,   4
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr5,    vr12,   vr2
++
++    vreplvei.h          vr6,    vr25,   5
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vshuf.b             vr16,   vr0,    vr0,    vr20 //offset = -21
++    vreplvei.h          vr11,   vr25,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr12,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 16
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++    fld.d               f24,    sp,     0
++    fld.d               f25,    sp,     8
++    addi.d              sp,     sp,     16+56
++endfunc
++.endm
++
++INTRA_PRED_ANG32_16 16
++INTRA_PRED_ANG32_16 20
++
++const ang32_mode17, align=4
++.byte 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8
++.byte 32-6, 6, 32-12, 12, 32-18, 18, 32-24, 24, 32-30, 30, 32-4, 4, 32-10, 10, 32-16, 16
++.byte 32-22, 22, 32-28, 28, 32-2, 2, 32-8, 8, 32-14, 14, 32-20, 20, 32-26, 26, 32-0, 0
++.byte 31, 30, 28, 27, 26, 25, 23, 22, 21, 20, 18, 17, 16, 15, 14, 12, 11
++.byte 10, 9, 7, 6, 5, 4, 2, 1, 0
++endconst
++.macro INTRA_PRED_ANG32_17 mode
++function x265_intra_pred_ang32_\mode\()_lsx
++    addi.d              sp,     sp,     -64
++.if \mode == 17
++    addi.d              t0,     a2,     64
++    vld                 vr4,    a2,     0
++    vld                 vr5,    a2,     16
++.else
++    addi.d              t0,     a2,     0
++    vld                 vr4,    a2,     64
++    vld                 vr5,    a2,     64+16
++.endif
++    la.local            t1,     ang32_mode17
++    addi.d              t3,     a0,     0
++    vld                 vr20,   t1,     0  //shuf
++    vld                 vr1,    t1,     16*1  //fraction
++    vld                 vr23,   t1,     16*2  //fraction
++    //sort src in stack in ascending order
++    vld                 vr2,    t1,     16*3
++    vshuf.b             vr3,    vr5,    vr4,    vr2
++    vst                 vr3,    sp,     0
++    vld                 vr2,    t1,     16*4
++    vshuf.b             vr3,    vr4,    vr4,    vr2
++    vst                 vr3,    sp,     16
++    vldrepl.b           vr2,    a2,     0
++    vstelm.b            vr2,    sp,     25,     0 //ref_pix[-1]
++    vld                 vr3,    t0,     1
++    vst                 vr3,    sp,     26
++    vld                 vr2,    t0,     1+16
++    vst                 vr2,    sp,     26+16
++    addi.d              t0,     sp,     26
++    li.w                t7,     4
++1:
++    //Row 0 - 7
++    vld                 vr0,    t0,     -7
++    vbsrl.v             vr22,   vr0,    6 //offset = -1
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr22,   vr0,    5 //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vbsrl.v             vr22,   vr0,    4 //offset = -3
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr10,   vr16,   vr8
++
++    vbsrl.v             vr22,   vr0,    3 //offset = -4
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr9,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr9,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr9,    vr11
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -5
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr16,   vr6
++
++    vbsrl.v             vr22,   vr0,    1 //offset = -6
++    vreplvei.h          vr11,   vr1,    6
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -7
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr3,    vr15
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr16,   vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr3,    vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 17
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 8 - 15
++    vld                 vr0,    t0,     -13
++    vbsrl.v             vr17,   vr0,    5 //offset = -8
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr3,    vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr17,   vr0,    4 //offset = -9
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr7,    vr12,   vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vbsrl.v             vr17,   vr0,    3 //offset = -10
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr13,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr12,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr16,   vr11
++
++    vbsrl.v             vr17,   vr0,    2 //offst = -11
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr16,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr5,    vr16,   vr2
++
++    vbsrl.v             vr17,   vr0,    1 //offst = -12
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vshuf.b             vr3,    vr0,    vr0,    vr20 //offset = -13
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr5,    vr16,   vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr3,    vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 17
++    STORE8x16_B_TRANSPOSE
++    addi.d              a0,     t3,     16
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 16 - 23
++    vld                 vr0,    t0,     -20
++    vbsrl.v             vr22,   vr0,    6 //offset = -14
++    vreplvei.h          vr2,    vr1,    0
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr4,    vr12,   vr2
++
++    vbsrl.v             vr22,   vr0,    5 //offset = -15
++    vreplvei.h          vr5,    vr1,    1
++    vshuf.b             vr16,   vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vbsrl.v             vr22,   vr0,    4 //offset = -16
++    vreplvei.h          vr8,    vr1,    2
++    vshuf.b             vr9,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr22,   vr0,    3 //offset = -17
++    vreplvei.h          vr11,   vr1,    3
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr13,   vr3,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr12,   vr2
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr3,    vr11
++
++    vbsrl.v             vr22,   vr0,    2 //offset = -18
++    vreplvei.h          vr2,    vr1,    4
++    vshuf.b             vr3,    vr22,   vr22,   vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vreplvei.h          vr6,    vr1,    5
++    vmulwev.h.bu.b      vr9,    vr3,    vr6
++
++    vbsrl.v             vr22,   vr0,    1 //offst = -19
++    vshuf.b             vr12,   vr22,   vr22,   vr20
++    vreplvei.h          vr11,   vr1,    6
++    vmulwev.h.bu.b      vr14,   vr12,   vr11
++
++    vshuf.b             vr16,   vr0,    vr0,    vr20 //offset = -20
++    vreplvei.h          vr15,   vr1,    7
++    vmulwev.h.bu.b      vr17,   vr16,   vr15
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr3,    vr6
++    vmaddwod.h.bu.b     vr14,   vr12,   vr11
++    vmaddwod.h.bu.b     vr17,   vr16,   vr15
++
++    vssrarni.bu.h       vr5,    vr4,    5
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr17,   vr13,   5
++
++.if \mode == 17
++    TRANSPOSE4x16_B     vr5, vr9, vr14, vr17, \
++                        vr18, vr19, vr21, vr22
++.else
++    STORE8x8_B
++    add.d               t3,     t3,     a1
++.endif
++
++    //Row 24 - 31
++    vld                 vr0,    t0,     -26
++    vbsrl.v             vr17,   vr0,    5 //offset = -21
++    vreplvei.h          vr2,    vr23,   0
++    vshuf.b             vr3,    vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr4,    vr3,    vr2
++
++    vbsrl.v             vr17,   vr0,    4 //offset = -22
++    vreplvei.h          vr5,    vr23,   1
++    vshuf.b             vr9,    vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr7,    vr9,    vr5
++
++    vreplvei.h          vr8,    vr23,   2
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr17,   vr0,    3 //offset = -23
++    vreplvei.h          vr11,   vr23,   3
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr3,    vr2
++    vmaddwod.h.bu.b     vr7,    vr9,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vbsrl.v             vr17,   vr0,    2 //offset = -24
++    vreplvei.h          vr2,    vr23,   4
++    vshuf.b             vr3,    vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr5,    vr3,    vr2
++
++    vbsrl.v             vr17,   vr0,    1 //offset = -25
++    vreplvei.h          vr6,    vr23,   5
++    vshuf.b             vr12,   vr17,   vr17,   vr20
++    vmulwev.h.bu.b      vr9,    vr12,   vr6
++
++    vshuf.b             vr16,   vr0,    vr0,    vr20
++    vreplvei.h          vr11,   vr23,   6
++    vmulwev.h.bu.b      vr14,   vr16,   vr11
++
++    vmaddwod.h.bu.b     vr5,    vr3,    vr2
++    vmaddwod.h.bu.b     vr9,    vr12,   vr6
++    vmaddwod.h.bu.b     vr14,   vr16,   vr11
++
++    vssrarni.bu.h       vr5,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr9,    vr7,    5
++    vssrarni.bu.h       vr14,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++    vilvl.d             vr17,   vr0,    vr13
++
++.if \mode == 17
++    STORE8x16_B_TRANSPOSE
++    alsl.d              a0,     a1,     t3,   3
++    addi.d              t3,     a0,     0
++.else
++    STORE8x8_B
++    addi.d              t3,     a0,     8
++    addi.d              a0,     a0,     8
++.endif
++    addi.d              t0,     t0,     8
++    addi.w              t7,     t7,     -1
++    bnez                t7,     1b
++    addi.d              sp,     sp,     64
++endfunc
++.endm
++
++INTRA_PRED_ANG32_17 17
++INTRA_PRED_ANG32_17 19
++
++function x265_intra_pred_ang32_18_lsx
++    vld                 vr0,    a2,     0  //0  1  2 .. 15
++    vld                 vr1,    a2,     16 // 16 17 .. 31
++
++    vld                 vr2,    a2,     64+1 //1 2 ... 16
++    vld                 vr3,    a2,     64+1+16 // 17 18 .. 32
++    //Row 0
++    vst                 vr0,    a0,     0
++    vst                 vr1,    a0,     16
++    add.d               a0,     a0,     a1
++
++    //Row 1-16
++.irp i, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,\
++        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
++    vbsll.v             vr1,    vr1,    1
++    vextrins.b          vr1,    vr0,    0x0f
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr2,    \i
++    vst                 vr0,    a0,     0
++    vst                 vr1,    a0,     16
++    add.d               a0,     a0,     a1
++.endr
++    //Row 17-31
++.irp i, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,\
++        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e
++    vbsll.v             vr1,    vr1,    1
++    vextrins.b          vr1,    vr0,    0x0f
++    vbsll.v             vr0,    vr0,    1
++    vextrins.b          vr0,    vr3,    \i
++    vst                 vr0,    a0,     0
++    vst                 vr1,    a0,     16
++    add.d               a0,     a0,     a1
++.endr
++endfunc
++
++function x265_intra_pred_ang4_2_lsx
++    vld                 vr0,    a2,     8+2
++    vbsrl.v             vr1,    vr0,    1
++    vbsrl.v             vr2,    vr0,    2
++    vbsrl.v             vr3,    vr0,    3
++    fst.s               f0,     a0,     0
++    fstx.s              f1,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.s               f2,     a0,     0
++    fstx.s              f3,     a0,     a1
++endfunc
++
++function x265_intra_pred_ang4_34_lsx
++    vld                 vr0,    a2,     0+2
++    vbsrl.v             vr1,    vr0,    1
++    vbsrl.v             vr2,    vr0,    2
++    vbsrl.v             vr3,    vr0,    3
++    fst.s               f0,     a0,     0
++    fstx.s              f1,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.s               f2,     a0,     0
++    fstx.s              f3,     a0,     a1
++endfunc
++
++.macro TRANSPOSE4x4_B_STORE
++    vilvl.b    vr4,    vr7,    vr4
++    vilvl.b    vr10,   vr13,   vr10
++    vilvl.h    vr4,    vr10,   vr4
++    vstelm.w   vr4,    a0,     0,    0
++    add.d      a0,     a0,     a1
++    vstelm.w   vr4,    a0,     0,    1
++    add.d      a0,     a0,     a1
++    vstelm.w   vr4,    a0,     0,    2
++    add.d      a0,     a0,     a1
++    vstelm.w   vr4,    a0,     0,    3
++.endm
++
++.macro STORE4x4_B
++    fst.s      f4,     a0,     0
++    fstx.s     f7,     a0,     a1
++    alsl.d     a0,     a1,     a0,   1
++    fst.s      f10,    a0,     0
++    fstx.s     f13,    a0,     a1
++.endm
++
++.macro INTRA_PRED_ANG4_3 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 3
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode3
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr6,    vr0,    2 //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vbsrl.v             vr9,    vr0,    4 //offset = 2
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr9,    vr8
++
++    vbsrl.v             vr12,   vr0,    6 //offset = 3
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr9,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 3
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_3 3
++INTRA_PRED_ANG4_3 33
++
++.macro INTRA_PRED_ANG4_4 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 4
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode4
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr6,    vr0,    2 //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr12,   vr0,    4 //offset = 2
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 4
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_4 4
++INTRA_PRED_ANG4_4 32
++
++.macro INTRA_PRED_ANG4_5 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 5
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode5
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr6,    vr0,    2 //offset = 1
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vbsrl.v             vr12,   vr0,    4 //offset = 2
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr12,   vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr12,   vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 5
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_5 5
++INTRA_PRED_ANG4_5 31
++
++.macro INTRA_PRED_ANG4_6 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 6
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode6
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr0,    vr5
++
++    vbsrl.v             vr6,    vr0,    2 //offset = 1
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr6,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr0,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr6,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 6
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_6 6
++INTRA_PRED_ANG4_6 30
++
++.macro INTRA_PRED_ANG4_7 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 7
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode7
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr0,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr0,    vr8
++
++    vbsrl.v             vr6,    vr0,    2 //offset = 1
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr6,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr0,    vr5
++    vmaddwod.h.bu.b     vr10,   vr0,    vr8
++    vmaddwod.h.bu.b     vr13,   vr6,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 7
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_7 7
++INTRA_PRED_ANG4_7 29
++
++.macro INTRA_PRED_ANG4_8 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 8
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode8
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr0,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr0,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr0,    vr5
++    vmaddwod.h.bu.b     vr10,   vr0,    vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 8
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_8 8
++INTRA_PRED_ANG4_8 28
++
++.macro INTRA_PRED_ANG4_9 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 9
++    vld                 vr0,    a2,     8+1
++.else
++    vld                 vr0,    a2,     0+1
++.endif
++    la.local            t1,     ang8_mode9
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = 0
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr0,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr0,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr0,    vr5
++    vmaddwod.h.bu.b     vr10,   vr0,    vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 9
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_9 9
++INTRA_PRED_ANG4_9 27
++
++function x265_intra_pred_ang4_10_lsx
++    vld                 vr0,    a2,     8+1
++    //transpose
++    vreplvei.b          vr4,    vr0,    0
++    vreplvei.b          vr7,    vr0,    1
++    vreplvei.b          vr10,   vr0,    2
++    vreplvei.b          vr13,   vr0,    3
++    //bFilter != 0
++    beqz                a4,     1f
++    vldrepl.b           vr5,    a2,     0
++    vsllwil.hu.bu       vr5,    vr5,    0
++    vreplvei.h          vr6,    vr5,    0 //topLeft
++    vsllwil.hu.bu       vr17,   vr4,    0
++    vreplvei.h          vr17,   vr17,   0 //top
++    vld                 vr8,    a2,     0+1
++    vsllwil.hu.bu       vr8,    vr8,    0
++    vsub.h              vr8,    vr8,    vr6
++    vsrai.h             vr8,    vr8,    1
++    vadd.h              vr8,    vr8,    vr17
++    vssrani.bu.h        vr4,    vr8,    0
++1:
++    STORE4x4_B
++endfunc
++
++function x265_intra_pred_ang4_26_lsx
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    1
++    addi.d              t0,     a0,     0
++    fst.s               f0,     a0,     0
++    fstx.s              f0,     a0,     a1
++    alsl.d              a0,     a1,     a0,    1
++    fst.s               f0,     a0,     0
++    fstx.s              f0,     a0,     a1
++    //bFilter != 0
++    beqz                a4,     1f
++    vsllwil.hu.bu       vr5,    vr1,    0
++    vreplvei.h          vr6,    vr5,    0 //topLeft
++    vreplvei.h          vr7,    vr5,    1 //top
++    vbsrl.v             vr8,    vr1,    8+1 ////srcPix[width2 + 1 + y]
++    vsllwil.hu.bu       vr8,    vr8,    0
++    vsub.h              vr8,    vr8,    vr6
++    vsrai.h             vr8,    vr8,    1
++    vadd.h              vr8,    vr8,    vr7
++    vssrani.bu.h        vr4,    vr8,    0
++    //Update Col 0
++    vstelm.b            vr4,    t0,     0,    0
++    add.d               t0,     t0,     a1
++    vstelm.b            vr4,    t0,     0,    1
++    add.d               t0,     t0,     a1
++    vstelm.b            vr4,    t0,     0,    2
++    add.d               t0,     t0,     a1
++    vstelm.b            vr4,    t0,     0,    3
++1:
++endfunc
++
++.macro INTRA_PRED_ANG4_11 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 11
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    8
++    vextrins.b          vr0,    vr1,    0x00
++.else
++    vld                 vr0,    a2,     0
++.endif
++    la.local            t1,     ang8_mode11
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr0,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr0,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr0,    vr5
++    vmaddwod.h.bu.b     vr10,   vr0,    vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 11
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_11 11
++INTRA_PRED_ANG4_11 25
++
++.macro INTRA_PRED_ANG4_12 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 12
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    8
++    vextrins.b          vr0,    vr1,    0x00
++.else
++    vld                 vr0,    a2,     0
++.endif
++    la.local            t1,     ang8_mode12
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr0,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr0,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr0,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr0,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr0,    vr5
++    vmaddwod.h.bu.b     vr10,   vr0,    vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 12
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_12 12
++INTRA_PRED_ANG4_12 24
++
++.macro INTRA_PRED_ANG4_13 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 13
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    7
++    vextrins.b          vr0,    vr1,    0x04
++    vextrins.b          vr0,    vr1,    0x10
++.else
++    vld                 vr0,    a2,     0-1
++    vextrins.b          vr0,    vr0,    0x0d
++.endif
++    la.local            t1,     ang8_mode13
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0
++    vbsrl.v             vr6,    vr0,    2 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr6,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr6,    vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11 //offset = -2
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr6,    vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 13
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_13 13
++INTRA_PRED_ANG4_13 23
++
++.macro INTRA_PRED_ANG4_14 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 14
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    7
++    vextrins.b          vr0,    vr1,    0x02
++    vextrins.b          vr0,    vr1,    0x10
++.else
++    vld                 vr0,    a2,     0-1
++    vextrins.b          vr0,    vr0,    0x0b
++.endif
++    la.local            t1,     ang8_mode14
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0
++    vbsrl.v             vr6,    vr0,    2 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr6,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr6,    vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr0,    vr8 //offset = -2
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr6,    vr5
++    vmaddwod.h.bu.b     vr10,   vr0,    vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 14
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_14 14
++INTRA_PRED_ANG4_14 22
++
++.macro INTRA_PRED_ANG4_15 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 15
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    6
++    vextrins.b          vr0,    vr1,    0x04
++    vextrins.b          vr0,    vr1,    0x12
++    vextrins.b          vr0,    vr1,    0x20
++.else
++    vld                 vr0,    a2,     0-2
++    vextrins.b          vr0,    vr0,    0x0e
++    vextrins.b          vr0,    vr0,    0x1c
++.endif
++    la.local            t1,     ang8_mode15
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0
++    vbsrl.v             vr6,    vr0,    4 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr6,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr16,   vr0,    2 //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8 //offset = -2
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11 //offset = -3
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 15
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_15 15
++INTRA_PRED_ANG4_15 21
++
++.macro INTRA_PRED_ANG4_16 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 16
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    6
++    vextrins.b          vr0,    vr1,    0x03
++    vextrins.b          vr0,    vr1,    0x12
++    vextrins.b          vr0,    vr1,    0x20
++.else
++    vld                 vr0,    a2,     0-2
++    vextrins.b          vr0,    vr0,    0x0d
++    vextrins.b          vr0,    vr0,    0x1c
++.endif
++    la.local            t1,     ang8_mode16
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0
++    vbsrl.v             vr6,    vr0,    4 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr6,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr16,   vr0,    2 //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr16,   vr8 //offset = -2
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11 //offset = -3
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr16,   vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 16
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_16 16
++INTRA_PRED_ANG4_16 20
++
++.macro INTRA_PRED_ANG4_17 mode
++function x265_intra_pred_ang4_\mode\()_lsx
++.if \mode == 17
++    vld                 vr1,    a2,     0
++    vbsrl.v             vr0,    vr1,    5
++    vextrins.b          vr0,    vr1,    0x04
++    vextrins.b          vr0,    vr1,    0x12
++    vextrins.b          vr0,    vr1,    0x21
++    vextrins.b          vr0,    vr1,    0x30
++.else
++    vld                 vr0,    a2,     0-3
++    vextrins.b          vr0,    vr0,    0x0f
++    vextrins.b          vr0,    vr0,    0x1d
++    vextrins.b          vr0,    vr0,    0x2c
++.endif
++    la.local            t1,     ang8_mode17
++    vld                 vr1,    t1,     16 //fraction
++
++    vreplvei.h          vr2,    vr1,    0
++    vbsrl.v             vr23,   vr0,    1
++    vilvl.b             vr0,    vr23,   vr0
++    vbsrl.v             vr6,    vr0,    6 //offset = -1
++    vmulwev.h.bu.b      vr4,    vr6,    vr2 //(32 - fraction) * ref[offset + x]
++
++    vbsrl.v             vr16,   vr0,    4 //offset = -2
++    vreplvei.h          vr5,    vr1,    1
++    vmulwev.h.bu.b      vr7,    vr16,   vr5
++
++    vbsrl.v             vr12,   vr0,    2 //offset = -3
++    vreplvei.h          vr8,    vr1,    2
++    vmulwev.h.bu.b      vr10,   vr12,   vr8
++
++    vreplvei.h          vr11,   vr1,    3
++    vmulwev.h.bu.b      vr13,   vr0,    vr11 //offset = -4
++
++    vmaddwod.h.bu.b     vr4,    vr6,    vr2 //fraction * ref[offset + x + 1]
++    vmaddwod.h.bu.b     vr7,    vr16,   vr5
++    vmaddwod.h.bu.b     vr10,   vr12,   vr8
++    vmaddwod.h.bu.b     vr13,   vr0,    vr11
++
++    vssrarni.bu.h       vr4,    vr4,    5 //+ 16) >> 5)
++    vssrarni.bu.h       vr7,    vr7,    5
++    vssrarni.bu.h       vr10,   vr10,   5
++    vssrarni.bu.h       vr13,   vr13,   5
++
++.if \mode == 17
++    TRANSPOSE4x4_B_STORE
++.else
++    STORE4x4_B
++.endif
++endfunc
++.endm
++
++INTRA_PRED_ANG4_17 17
++INTRA_PRED_ANG4_17 19
++
++function x265_intra_pred_ang4_18_lsx
++    vld                 vr13,   a2,     0-3
++    vextrins.b          vr13,   vr13,   0x0e
++    vextrins.b          vr13,   vr13,   0x1d
++    vextrins.b          vr13,   vr13,   0x2c
++    vbsrl.v             vr4,    vr13,   3
++    vbsrl.v             vr7,    vr13,   2
++    vbsrl.v             vr10,   vr13,   1
++    STORE4x4_B
++endfunc
++
++/*
++ * void x265_intra_pred_dc4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter)
++ */
++function x265_intra_pred_dc4_lsx
++   vld                  vr0,    a2,     1
++   vbsrl.v              vr1,    vr0,    8
++   vilvl.b              vr2,    vr1,    vr0
++   vhaddw.hu.bu         vr2,    vr2,    vr2
++   vhaddw.wu.hu         vr2,    vr2,    vr2
++   vhaddw.du.wu         vr2,    vr2,    vr2
++   vaddi.hu             vr2,    vr2,    4
++   vreplvei.h           vr2,    vr2,    0
++   vssrani.bu.h         vr3,    vr2,    3 //dcVal
++   or                   t0,     zero,   a0
++   //store dc 4x4
++   fst.s                f3,     a0,     0
++   fstx.s               f3,     a0,     a1
++   alsl.d               a0,     a1,     a0,   1
++   fst.s                f3,     a0,     0
++   fstx.s               f3,     a0,     a1
++   beqz                 a4,     1f
++   //do dc filter
++   vsllwil.hu.bu        vr2,    vr3,    0   //dst[x]
++   vsllwil.hu.bu        vr4,    vr0,    0   //above[x]
++   vslli.h              vr5,    vr2,    1
++   vadd.h               vr5,    vr5,    vr2 //3 * dst[x]
++   vadd.h               vr6,    vr5,    vr4
++   vaddi.hu             vr6,    vr6,    2
++   vssrani.bu.h         vr6,    vr6,    2   //dst[x] = (pixel)((above[x] +  3 * dst[x] + 2) >> 2);
++   vbsrl.v              vr8,    vr0,    8   //left[y]
++   vextrins.b           vr0,    vr0,    0x18
++   vhaddw.hu.bu         vr0,    vr0,    vr0 //above[0] + left[0]
++   vslli.h              vr7,    vr2,    1   //2 * dst[0]
++   vadd.h               vr7,    vr7,    vr0
++   vaddi.hu             vr7,    vr7,    2
++   vssrani.bu.h         vr7,    vr7,    2   //dst[0] = (pixel)((above[0] + left[0] + 2 * dst[0] + 2) >> 2);
++   vextrins.b           vr6,    vr7,    0x00
++   fst.s                f6,     t0,     0   //filter row 0
++   vsllwil.hu.bu        vr8,    vr8,    0
++   vadd.h               vr8,    vr8,    vr5
++   vaddi.hu             vr8,    vr8,    2
++   vssrani.bu.h         vr8,    vr8,    2
++   //filter col 0
++   add.d                t0,     t0,     a1
++   vstelm.b             vr8,    t0,     0,    1
++   add.d                t0,     t0,     a1
++   vstelm.b             vr8,    t0,     0,    2
++   add.d                t0,     t0,     a1
++   vstelm.b             vr8,    t0,     0,    3
++1:
++endfunc
++
++function x265_intra_pred_dc8_lsx
++   vld                  vr0,    a2,     1
++   vld                  vr1,    a2,     17
++   vilvl.b              vr2,    vr1,    vr0
++   vhaddw.hu.bu         vr2,    vr2,    vr2
++   vhaddw.wu.hu         vr2,    vr2,    vr2
++   vhaddw.du.wu         vr2,    vr2,    vr2
++   vhaddw.qu.du         vr2,    vr2,    vr2
++   vaddi.hu             vr2,    vr2,    8
++   vreplvei.h           vr2,    vr2,    0
++   vssrani.bu.h         vr3,    vr2,    4 //dcVal
++   or                   t0,     zero,   a0
++   //store dc 8x8
++   .rept 3
++   fst.d                f3,     a0,     0
++   fstx.d               f3,     a0,     a1
++   alsl.d               a0,     a1,     a0,   1
++   .endr
++   fst.d                f3,     a0,     0
++   fstx.d               f3,     a0,     a1
++   beqz                 a4,     1f
++   //do dc filter
++   vsllwil.hu.bu        vr2,    vr3,    0   //dst[x]
++   vsllwil.hu.bu        vr4,    vr0,    0   //above[x]
++   vslli.h              vr5,    vr2,    1
++   vadd.h               vr5,    vr5,    vr2 //3 * dst[x]
++   vadd.h               vr6,    vr5,    vr4
++   vaddi.hu             vr6,    vr6,    2
++   vssrani.bu.h         vr6,    vr6,    2   //dst[x] = (pixel)((above[x] +  3 * dst[x] + 2) >> 2);
++   vextrins.b           vr0,    vr1,    0x10
++   vhaddw.hu.bu         vr0,    vr0,    vr0 //above[0] + left[0]
++   vslli.h              vr7,    vr2,    1   //2 * dst[0]
++   vadd.h               vr7,    vr7,    vr0
++   vaddi.hu             vr7,    vr7,    2
++   vssrani.bu.h         vr7,    vr7,    2   //dst[0] = (pixel)((above[0] + left[0] + 2 * dst[0] + 2) >> 2);
++   vextrins.b           vr6,    vr7,    0x00
++   fst.d                f6,     t0,     0   //filter row 0
++   vsllwil.hu.bu        vr8,    vr1,    0
++   vadd.h               vr8,    vr8,    vr5
++   vaddi.hu             vr8,    vr8,    2
++   vssrani.bu.h         vr8,    vr8,    2
++   //filter col 0
++   add.d                t0,     t0,     a1
++   .irp i, 1,2,3,4,5,6
++   vstelm.b             vr8,    t0,     0,    \i
++   add.d                t0,     t0,     a1
++   .endr
++   vstelm.b             vr8,    t0,     0,    7
++1:
++endfunc
++
++function x265_intra_pred_dc16_lsx
++   vld                  vr0,    a2,     1
++   vld                  vr1,    a2,     33
++   vilvh.b              vr3,    vr1,    vr0
++   vilvl.b              vr2,    vr1,    vr0
++   vhaddw.hu.bu         vr2,    vr2,    vr2
++   vhaddw.hu.bu         vr3,    vr3,    vr3
++   vadd.h               vr3,    vr3,    vr2
++   vhaddw.wu.hu         vr3,    vr3,    vr3
++   vhaddw.du.wu         vr3,    vr3,    vr3
++   vhaddw.qu.du         vr3,    vr3,    vr3
++   vaddi.hu             vr3,    vr3,    16
++   vssrani.bu.h         vr3,    vr3,    5 //dcVal
++   vreplvei.b           vr3,    vr3,    0
++   or                   t0,     zero,   a0
++   //store dc 16x16
++   .rept 7
++   vst                  vr3,    a0,     0
++   vstx                 vr3,    a0,     a1
++   alsl.d               a0,     a1,     a0,   1
++   .endr
++   vst                  vr3,    a0,     0
++   vstx                 vr3,    a0,     a1
++   beqz                 a4,     1f
++   //do dc filter
++   vsllwil.hu.bu        vr4,    vr3,    0   //dst[x]
++   vsllwil.hu.bu        vr6,    vr0,    0   //above[x]
++   vexth.hu.bu          vr7,    vr0
++   vslli.h              vr8,    vr4,    1
++   vadd.h               vr8,    vr8,    vr4 //3 * dst[x]
++   vadd.h               vr9,    vr8,    vr6
++   vaddi.hu             vr9,    vr9,    2
++   vadd.h               vr10,   vr8,    vr7
++   vaddi.hu             vr10,   vr10,   2
++   vssrani.bu.h         vr10,   vr9,    2   //dst[x] = (pixel)((above[x] +  3 * dst[x] + 2) >> 2);
++   vextrins.b           vr0,    vr1,    0x10
++   vhaddw.hu.bu         vr0,    vr0,    vr0 //above[0] + left[0]
++   vslli.h              vr11,   vr4,    1   //2 * dst[0]
++   vadd.h               vr11,   vr11,   vr0
++   vaddi.hu             vr11,   vr11,   2
++   vssrani.bu.h         vr11,   vr11,   2   //dst[0] = (pixel)((above[0] + left[0] + 2 * dst[0] + 2) >> 2);
++   vextrins.b           vr10,   vr11,   0x00
++   vst                  vr10,   t0,     0   //filter row 0
++   vsllwil.hu.bu        vr12,   vr1,    0   //left[y]
++   vexth.hu.bu          vr13,   vr1
++   vadd.h               vr12,   vr12,   vr8 //left[y] + 3 * *dst
++   vaddi.hu             vr12,   vr12,   2
++   vadd.h               vr13,   vr13,   vr8
++   vaddi.hu             vr13,   vr13,   2
++   vssrani.bu.h         vr13,   vr12,   2
++   //filter col 0
++   add.d                t0,     t0,     a1
++   .irp i, 1,2,3,4,5,6,7,8,9,10,11,12,13,14
++   vstelm.b             vr13,   t0,     0,    \i
++   add.d                t0,     t0,     a1
++   .endr
++   vstelm.b             vr13,   t0,     0,    15
++1:
++endfunc
++
++function x265_intra_pred_dc32_lsx
++   vld                  vr0,    a2,     1
++   vld                  vr4,    a2,     1+16
++   vld                  vr1,    a2,     65
++   vld                  vr5,    a2,     65+16
++   vilvh.b              vr3,    vr1,    vr0
++   vilvl.b              vr2,    vr1,    vr0
++   vilvh.b              vr7,    vr5,    vr4
++   vilvl.b              vr6,    vr5,    vr4
++   vhaddw.hu.bu         vr2,    vr2,    vr2
++   vhaddw.hu.bu         vr3,    vr3,    vr3
++   vhaddw.hu.bu         vr6,    vr6,    vr6
++   vhaddw.hu.bu         vr7,    vr7,    vr7
++   vadd.h               vr3,    vr3,    vr2
++   vadd.h               vr3,    vr3,    vr6
++   vadd.h               vr3,    vr3,    vr7
++   vhaddw.wu.hu         vr3,    vr3,    vr3
++   vhaddw.du.wu         vr3,    vr3,    vr3
++   vhaddw.qu.du         vr3,    vr3,    vr3
++   vaddi.hu             vr3,    vr3,    16
++   vaddi.hu             vr3,    vr3,    16
++   vssrani.bu.h         vr3,    vr3,    6 //dcVal
++   vreplvei.b           vr3,    vr3,    0
++   //store dc 32x32
++   .rept 31
++   vst                  vr3,    a0,     0
++   vst                  vr3,    a0,     16
++   add.d                a0,     a0,     a1
++   .endr
++   vst                  vr3,    a0,     0
++   vst                  vr3,    a0,     16
++endfunc
++
++function x265_intra_pred_dc32_lasx
++   xvld                 xr0,    a2,     1
++   xvld                 xr1,    a2,     65
++   xvilvh.b             xr3,    xr1,    xr0
++   xvilvl.b             xr2,    xr1,    xr0
++   xvhaddw.hu.bu        xr2,    xr2,    xr2
++   xvhaddw.hu.bu        xr3,    xr3,    xr3
++   xvadd.h              xr3,    xr3,    xr2
++   xvhaddw.wu.hu        xr3,    xr3,    xr3
++   xvhaddw.du.wu        xr3,    xr3,    xr3
++   xvhaddw.qu.du        xr3,    xr3,    xr3
++   xvpermi.q            xr4,    xr3,    0x01
++   vadd.h               vr3,    vr3,    vr4
++   vaddi.hu             vr3,    vr3,    16
++   vaddi.hu             vr3,    vr3,    16
++   vssrani.bu.h         vr3,    vr3,    6 //dcVal
++   xvreplve0.b          xr3,    xr3
++   //store dc 32x32
++   .rept 15
++   xvst                 xr3,    a0,     0
++   xvstx                xr3,    a0,     a1
++   alsl.d               a0,     a1,     a0,   1
++   .endr
++   xvst                 xr3,    a0,     0
++   xvstx                xr3,    a0,     a1
++endfunc
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0011-FROMLIST-LoongArch64-Optimize-functions-in-intrapred.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0011-FROMLIST-LoongArch64-Optimize-functions-in-intrapred.patch
@@ -1,0 +1,818 @@
+From 79faea3aeed0a871b119567bd32a9b9c033f41b0 Mon Sep 17 00:00:00 2001
+From: Wu Zhenjiang <wuzhenjiang@loongson.cn>
+Date: Thu, 13 Jun 2024 09:31:28 +0800
+Subject: [PATCH 11/15] FROMLIST: LoongArch64: Optimize functions in
+ intrapred8.S file - Patch 2
+
+The optimized functions are as follows:
+intra_filter_4x4_lsx/intra_filter_4x4_lasx
+intra_filter_8x8_lsx/intra_filter_8x8_lasx
+intra_filter_16x16_lsx/intra_filter_16x16_lasx
+intra_filter_32x32_lsx/intra_filter_32x32_lasx
+intra_pred_planar_4x4_lsx
+intra_pred_planar_8x8_lsx
+intra_pred_planar_16x16_lsx
+intra_pred_planar_32x32_lsx
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/loongarch64/asm-primitives.cpp |  16 +
+ source/common/loongarch64/intrapred.h        |  16 +
+ source/common/loongarch64/intrapred8.S       | 719 +++++++++++++++++++
+ 3 files changed, 751 insertions(+)
+
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 883c63b60..08ad496f1 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -352,6 +352,16 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         CHROMA_PU_422(8,  64, lsx);
+ 
+         // intra_pred
++        p.cu[BLOCK_4x4].intra_filter = PFX(intra_filter_4x4_lsx);
++        p.cu[BLOCK_8x8].intra_filter = PFX(intra_filter_8x8_lsx);
++        p.cu[BLOCK_16x16].intra_filter = PFX(intra_filter_16x16_lsx);
++        p.cu[BLOCK_32x32].intra_filter = PFX(intra_filter_32x32_lsx);
++
++        p.cu[BLOCK_4x4].intra_pred[PLANAR_IDX]   = PFX(intra_pred_planar_4x4_lsx);
++        p.cu[BLOCK_8x8].intra_pred[PLANAR_IDX]   = PFX(intra_pred_planar_8x8_lsx);
++        p.cu[BLOCK_16x16].intra_pred[PLANAR_IDX] = PFX(intra_pred_planar_16x16_lsx);
++        p.cu[BLOCK_32x32].intra_pred[PLANAR_IDX] = PFX(intra_pred_planar_32x32_lsx);
++
+         p.cu[BLOCK_4x4].intra_pred[2] = PFX(intra_pred_ang4_2_lsx);
+         p.cu[BLOCK_4x4].intra_pred[3] = PFX(intra_pred_ang4_3_lsx);
+         p.cu[BLOCK_4x4].intra_pred[4] = PFX(intra_pred_ang4_4_lsx);
+@@ -612,6 +622,12 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x48].addAvg, addAvg_32x48_lasx);
+         ASSIGN2(p.chroma[X265_CSP_I422].pu[CHROMA_422_32x64].addAvg, addAvg_32x64_lasx);
+ 
++        // intra_filter
++        p.cu[BLOCK_4x4].intra_filter = PFX(intra_filter_4x4_lasx);
++        p.cu[BLOCK_8x8].intra_filter = PFX(intra_filter_8x8_lasx);
++        p.cu[BLOCK_16x16].intra_filter = PFX(intra_filter_16x16_lasx);
++        p.cu[BLOCK_32x32].intra_filter = PFX(intra_filter_32x32_lasx);
++
+         //intra_pred
+         p.cu[BLOCK_8x8].intra_pred[3] = PFX(intra_pred_ang8_3_lasx);
+         p.cu[BLOCK_8x8].intra_pred[4] = PFX(intra_pred_ang8_4_lasx);
+diff --git a/source/common/loongarch64/intrapred.h b/source/common/loongarch64/intrapred.h
+index 5220e2166..f0835eb21 100644
+--- a/source/common/loongarch64/intrapred.h
++++ b/source/common/loongarch64/intrapred.h
+@@ -30,6 +30,22 @@
+ extern "C" {
+ #endif /* __cplusplus */
+ 
++void x265_intra_filter_4x4_lsx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_8x8_lsx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_16x16_lsx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_32x32_lsx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_4x4_lasx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_8x8_lasx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_16x16_lasx(const pixel *samples, pixel *filtered);
++void x265_intra_filter_32x32_lasx(const pixel *samples, pixel *filtered);
++
++void x265_intra_pred_planar_4x4_lsx(pixel *dst, intptr_t dstStride, const pixel *srcPix, int /*dirMode*/, int /*bFilter*/);
++void x265_intra_pred_planar_8x8_lsx(pixel *dst, intptr_t dstStride, const pixel *srcPix, int /*dirMode*/, int /*bFilter*/);
++void x265_intra_pred_planar_16x16_lsx(pixel *dst, intptr_t dstStride, const pixel *srcPix, int /*dirMode*/, int /*bFilter*/);
++void x265_intra_pred_planar_32x32_lsx(pixel *dst, intptr_t dstStride, const pixel *srcPix, int /*dirMode*/, int /*bFilter*/);
++void x265_intra_pred_planar_16x16_lasx(pixel *dst, intptr_t dstStride, const pixel *srcPix, int /*dirMode*/, int /*bFilter*/);
++void x265_intra_pred_planar_32x32_lasx(pixel *dst, intptr_t dstStride, const pixel *srcPix, int /*dirMode*/, int /*bFilter*/);
++
+ void x265_intra_pred_ang8_2_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
+ void x265_intra_pred_ang8_3_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
+ void x265_intra_pred_ang8_4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
+diff --git a/source/common/loongarch64/intrapred8.S b/source/common/loongarch64/intrapred8.S
+index 19969ca8a..8c9e53c7b 100644
+--- a/source/common/loongarch64/intrapred8.S
++++ b/source/common/loongarch64/intrapred8.S
+@@ -23,6 +23,725 @@
+ 
+ #include "loongson_asm.S"
+ 
++.macro INTRAFILTER_LSX_16 offset, src0, src1, src2, src3, src4, src5, dst0, dst1
++    // load samples[offset ~ offset+15], samples[offset+1 ~ offset+16], samples[offset+2 ~ offset+17]
++    vld             \src0,  a0,     \offset
++    vld             \src2,  a0,     \offset + 1
++    vld             \src3,  a0,     \offset + 9
++    vld             \src4,  a0,     \offset + 2
++    vexth.hu.bu     \src1,  \src0
++    vsllwil.hu.bu   \src0,  \src0,  0
++    vsllwil.hu.bu   \src2,  \src2,  1
++    vsllwil.hu.bu   \src3,  \src3,  1
++    vexth.hu.bu     \src5,  \src4
++    vsllwil.hu.bu   \src4,  \src4,  0
++
++    // calculate filtered[offset+1 ~ offset+16]
++    vadd.h          \dst0,  \src0,  \src2
++    vadd.h          \dst1,  \src1,  \src3
++    vadd.h          \dst0,  \dst0,  \src4
++    vadd.h          \dst1,  \dst1,  \src5
++    vaddi.hu        \dst0,  \dst0,  2
++    vaddi.hu        \dst1,  \dst1,  2
++.endm
++
++// void x265_intra_filter_4x4_lsx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_4x4_lsx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     8
++    ld.bu           t2,     a0,     16
++
++    // calculate filtered[1~16]
++    INTRAFILTER_LSX_16      0,  vr0,  vr1,  vr2,  vr3,  vr4,  vr5,  vr6,  vr7
++
++    // calculate filtered[0]
++    vpickve2gr.hu   t5,     vr0,    1
++    alsl.d          t5,     t0,     t5,     1
++    vpickve2gr.hu   t6,     vr1,    1
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++
++    // calculate filtered[tuSize2 + 1]
++    alsl.d          t6,     t6,     t0,     1
++    vpickve2gr.hu   t4,     vr1,    2
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    vinsgr2vr.h     vr7,    t6,     0
++    vsrlni.b.h      vr7,    vr6,    2
++
++    // calculate filtered[tuSize2] and filtered[tuSize2 + tuSize2]
++    vinsgr2vr.b     vr7,    t1,     7
++    vinsgr2vr.b     vr7,    t2,     15
++    vst             vr7,    a1,     1       // store filtered[1~16]
++endfunc
++
++// void x265_intra_filter_8x8_lsx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_8x8_lsx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     16
++    ld.bu           t2,     a0,     32
++
++    // calculate filtered[1~32]
++    INTRAFILTER_LSX_16      0,  vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      16, vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++
++    // calculate filtered[0]
++    vpickve2gr.hu   t5,     vr0,    1
++    alsl.d          t5,     t0,     t5,     1
++    vpickve2gr.hu   t6,     vr2,    1
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++
++    // calculate filtered[tuSize2 + 1]
++    alsl.d          t6,     t6,     t0,     1
++    vpickve2gr.hu   t4,     vr2,    2
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    vinsgr2vr.h     vr14,   t6,     0
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++
++    // calculate filtered[tuSize2] and filtered[tuSize2 + tuSize2]
++    vinsgr2vr.b     vr13,   t1,     15
++    vinsgr2vr.b     vr15,   t2,     15
++    vst             vr13,   a1,     1
++    vst             vr15,   a1,     17
++endfunc
++
++// void x265_intra_filter_16x16_lsx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_16x16_lsx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     32
++    ld.bu           t2,     a0,     64
++
++    // calculate filtered[1~32]
++    INTRAFILTER_LSX_16      0,  vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      16, vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++
++    // calculate filtered[0]
++    vpickve2gr.hu   t5,     vr0,    1
++    alsl.d          t5,     t0,     t5,     1
++    vpickve2gr.hu   t6,     vr11,   7
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++    vinsgr2vr.b     vr15,   t1,     15
++    vst             vr13,   a1,     1
++    vst             vr15,   a1,     17
++
++    // calculate filtered[33~64]
++    INTRAFILTER_LSX_16      32, vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      48, vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++
++    // calculate filtered[tuSize2 + 1]
++    alsl.d          t6,     t6,     t0,     1
++    vpickve2gr.hu   t4,     vr0,    2
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    vinsgr2vr.h     vr12,   t6,     0
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++    vinsgr2vr.b     vr15,   t2,     15
++    vst             vr13,   a1,     33
++    vst             vr15,   a1,     49
++endfunc
++
++// void x265_intra_filter_32x32_lsx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_32x32_lsx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     64
++    ld.bu           t2,     a0,     128
++
++    // calculate filtered[1~32]
++    INTRAFILTER_LSX_16      0,  vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      16, vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++    vst             vr13,   a1,     1
++    vst             vr15,   a1,     17
++    vpickve2gr.hu   t5,     vr0,    1       // save samples[1] for calculating samples[65]
++
++    // calculate filtered[33~64]
++    INTRAFILTER_LSX_16      32, vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      48, vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++
++    // calculate filtered[0]
++    alsl.d          t5,     t0,     t5,     1
++    vpickve2gr.hu   t6,     vr11,   7
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++    vinsgr2vr.b     vr15,   t1,     15
++    vst             vr13,   a1,     33
++    vst             vr15,   a1,     49
++
++    // calculate filtered[65~96]
++    INTRAFILTER_LSX_16      64, vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      80, vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++
++    // calculate filtered[tuSize2 + 1]
++    alsl.d          t6,     t6,     t0,     1
++    vpickve2gr.hu   t4,     vr0,    2
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    vinsgr2vr.h     vr12,   t6,     0
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++    vst             vr13,   a1,     65
++    vst             vr15,   a1,     81
++
++    // calculate filtered[97~128]
++    INTRAFILTER_LSX_16      96, vr0,  vr1,  vr4,  vr5,  vr8,  vr9,  vr12, vr13
++    INTRAFILTER_LSX_16      112,vr2,  vr3,  vr6,  vr7,  vr10, vr11, vr14, vr15
++    vsrlni.b.h      vr13,   vr12,   2
++    vsrlni.b.h      vr15,   vr14,   2
++    vinsgr2vr.b     vr15,   t2,     15
++    vst             vr13,   a1,     97
++    vst             vr15,   a1,     113
++endfunc
++
++.macro INTRAFILTER_LASX_16 src0, src1, src2, dst0, offset
++    // load samples[offset ~ offset+15], samples[offset+1 ~ offset+16], samples[offset+2 ~ offset+17]
++    xvld            \src0,  a0,     \offset
++    xvld            \src1,  a0,     \offset + 1
++    xvld            \src2,  a0,     \offset + 2
++    vext2xv.hu.bu   \src0,  \src0
++    vext2xv.hu.bu   \src1,  \src1
++    xvslli.h        \src1,  \src1,  1
++    vext2xv.hu.bu   \src2,  \src2
++
++    // calculate filtered[[offset+1 ~ offset+16]
++    xvadd.h         \dst0,  \src0,  \src1
++    xvadd.h         \dst0,  \dst0,  \src2
++    xvssrarni.bu.h  \dst0,  \dst0,  2
++.endm
++
++// void x265_intra_filter_4x4_lasx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_4x4_lasx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     8
++    ld.bu           t2,     a0,     16
++
++    // calculate filtered[1~16]
++    INTRAFILTER_LASX_16     xr0,  xr1,  xr2,  xr3,  0
++
++    // calculate filtered[0]
++    ld.bu           t5,     a0,     1
++    alsl.d          t5,     t0,     t5,     1
++    ld.bu           t6,     a0,     9
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++
++    // store filtered[1~16]
++    xvpermi.d       xr3,    xr3,    0b00001000
++    vst             vr3,    a1,     1
++    st.b            t1,     a1,     8               // store filtered[8]
++
++    // calculate filtered[tuSize2 + 1]
++    slli.d          t6,     t6,     1
++    add.d           t6,     t6,     t0
++    ld.bu           t4,     a0,     10
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    srli.d          t6,     t6,     2
++    st.b            t6,     a1,     9
++    st.b            t2,     a1,     16              // store filtered[16]
++endfunc
++
++// void x265_intra_filter_8x8_lasx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_8x8_lasx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     16
++    ld.bu           t2,     a0,     32
++
++    // calculate filtered[1 ~ 32]
++    INTRAFILTER_LASX_16     xr0,  xr2,  xr4,  xr6,  0
++    INTRAFILTER_LASX_16     xr1,  xr3,  xr5,  xr7,  16
++
++    // calculate filtered[0]
++    ld.bu           t5,     a0,     1
++    alsl.d          t5,     t0,     t5,     1
++    ld.bu           t6,     a0,     17
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++
++    // store filtered[1~32]
++    xvshuf4i.d      xr6,    xr7,    0b00001000
++    xvpermi.d       xr6,    xr6,    0b11011000
++    xvst            xr6,    a1,     1
++    st.b            t1,     a1,     16              // store filtered[16]
++
++    slli.d          t6,     t6,     1
++    add.d           t6,     t6,     t0
++    ld.bu           t4,     a0,     18
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    srli.d          t6,     t6,     2
++    st.b            t6,     a1,     17              // store filtered[17]
++    st.b            t2,     a1,     32              // store filtered[32]
++endfunc
++
++// void x265_intra_filter_16x16_lasx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_16x16_lasx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     32
++    ld.bu           t2,     a0,     64
++
++    // calculate filtered[1 ~ 64]
++    INTRAFILTER_LASX_16     xr0,  xr4,  xr8,  xr12, 0
++    INTRAFILTER_LASX_16     xr1,  xr5,  xr9,  xr13, 16
++    INTRAFILTER_LASX_16     xr2,  xr6,  xr10, xr14, 32
++    INTRAFILTER_LASX_16     xr3,  xr7,  xr11, xr15, 48
++
++    // calculate filtered[0]
++    ld.bu           t5,     a0,     1
++    alsl.d          t5,     t0,     t5,     1
++    ld.bu           t6,     a0,     33
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++
++    // store filtered[1~32]
++    xvshuf4i.d      xr12,   xr13,   0b00001000
++    xvpermi.d       xr12,   xr12,   0b11011000
++    xvst            xr12,   a1,     1
++    st.b            t1,     a1,     32              // store filtered[32]
++
++    // store filtered[33~64]
++    xvshuf4i.d      xr14,   xr15,   0b00001000
++    xvpermi.d       xr14,   xr14,   0b11011000
++    xvst            xr14,   a1,     33
++    alsl.d          t6,     t6,     t0,     1
++    ld.bu           t4,     a0,     34
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    srli.d          t6,     t6,     2
++    st.b            t6,     a1,     33              // store filtered[33]
++    st.b            t2,     a1,     64              // store filtered[64]
++endfunc
++
++// void x265_intra_filter_32x32_lasx(const pixel* samples, pixel* filtered)
++function x265_intra_filter_32x32_lasx
++    ld.bu           t0,     a0,     0
++    ld.bu           t1,     a0,     64
++    ld.bu           t2,     a0,     128
++
++    //calculate filtered[1~64]
++    INTRAFILTER_LASX_16     xr0,  xr4,  xr8,  xr12, 0
++    INTRAFILTER_LASX_16     xr1,  xr5,  xr9,  xr13, 16
++    INTRAFILTER_LASX_16     xr2,  xr6,  xr10, xr14, 32
++    INTRAFILTER_LASX_16     xr3,  xr7,  xr11, xr15, 48
++
++    // store filtered[1~32]
++    xvshuf4i.d      xr12,   xr13,   0b00001000
++    xvpermi.d       xr12,   xr12,   0b11011000
++    xvst            xr12,   a1,     1
++    // store filtered[33~64]
++    xvshuf4i.d      xr14,   xr15,   0b00001000
++    xvpermi.d       xr14,   xr14,   0b11011000
++    xvst            xr14,   a1,     33
++
++    // calculate filtered[65~128]
++    INTRAFILTER_LASX_16     xr0,  xr4,  xr8,  xr12, 64
++    INTRAFILTER_LASX_16     xr1,  xr5,  xr9,  xr13, 80
++    INTRAFILTER_LASX_16     xr2,  xr6,  xr10, xr14, 96
++    INTRAFILTER_LASX_16     xr3,  xr7,  xr11, xr15, 112
++
++    // calculate filtered[0]
++    ld.bu           t5,     a0,     1
++    alsl.d          t5,     t0,     t5,     1
++    ld.bu           t6,     a0,     65
++    add.d           t5,     t6,     t5
++    addi.d          t5,     t5,     2
++    srli.d          t5,     t5,     2
++    st.b            t5,     a1,     0
++
++    // store filtered[65~96]
++    xvshuf4i.d      xr12,   xr13,   0b00001000
++    xvpermi.d       xr12,   xr12,   0b11011000
++    xvst            xr12,   a1,     65
++    // store filtered[97~128]
++    xvshuf4i.d      xr14,   xr15,   0b00001000
++    xvpermi.d       xr14,   xr14,   0b11011000
++    xvst            xr14,   a1,     97
++    st.b            t1,     a1,     64              // store filtered[64]
++    alsl.d          t6,     t6,     t0,     1
++    ld.bu           t4,     a0,     66
++    add.d           t6,     t6,     t4
++    addi.d          t6,     t6,     2
++    srli.d          t6,     t6,     2
++    st.b            t6,     a1,     65              // store filtered[65]
++    st.b            t2,     a1,     128             // store filtered[128]
++endfunc
++
++.macro CALCULATE_INTRA_PRED_PLANAR  type, src0, src1, src2, src3, \
++                                    src4, src5, src6, dst0, dst1
++    \type\()vreplgr2vr.h    \dst0,    zero
++    \type\()vreplgr2vr.h    \dst1,    zero
++    \type\()vmadd.h         \dst0,    \src0,    \src1
++    \type\()vmadd.h         \dst1,    \src2,    \src3
++    \type\()vadd.h          \dst0,    \dst0,    \src4
++    \type\()vadd.h          \dst1,    \dst1,    \src5
++    \type\()vadd.h          \dst0,    \dst0,    \src6
++    \type\()vadd.h          \dst0,    \dst1,    \dst0
++.endm
++
++// void x265_intra_pred_planar_4x4_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int /*dirMode*/, int /*bFilter*/)
++const planar_4x4_lsx
++.short 3, 2, 1, 0, 1, 2, 3, 4
++endconst
++function x265_intra_pred_planar_4x4_lsx     // blkSize = 1 << 2 = 4
++    // prepare data
++    ld.bu           t2,     a2,     5
++    ld.bu           t3,     a2,     13
++    fld.d           f0,     a2,     1
++    fld.d           f1,     a2,     9
++    vsllwil.hu.bu   vr0,    vr0,    0
++    vsllwil.hu.bu   vr1,    vr1,    0
++
++    la.local        t4,     planar_4x4_lsx
++    vld             vr2,    t4,     0
++    vld             vr3,    t4,     8
++
++    vreplgr2vr.h    vr4,    t2
++    vreplgr2vr.h    vr5,    t3
++    vreplgr2vr.h    vr6,    t3
++    vmul.h          vr4,    vr3,    vr4
++    addi.d          t7,     zero,   4
++    vreplgr2vr.h    vr7,    t7
++
++    addi.d          t4,     zero,   0
++    addi.d          t5,     zero,   3
++    addi.d          t6,     a0,     0
++
++.LOOP_INTRA_PRED_PLANAR_4x4_LSX:
++    vreplve.h       vr9,    vr1,    t4
++    vreplgr2vr.h    vr10,    t5
++    CALCULATE_INTRA_PRED_PLANAR  , vr2, vr9, vr10, vr0, vr4, vr6, vr7, vr8, vr11
++    vsrlni.b.h      vr8,    vr8,    3
++    vstelm.w        vr8,    t6,     0,      0       // store dst[y*dstStride+x]
++
++    // prepare for next loop
++    addi.d          t4,     t4,     1
++    addi.d          t5,     t5,     -1
++    vadd.h          vr6,    vr6,    vr5
++    add.d           t6,     t6,     a1
++    blt             t4,     t7,     .LOOP_INTRA_PRED_PLANAR_4x4_LSX
++endfunc
++
++// void x265_intra_pred_planar_8x8_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int /*dirMode*/, int /*bFilter*/)
++const planar_8x8_lsx
++.short 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8
++endconst
++function x265_intra_pred_planar_8x8_lsx     // blkSize = 1 << 3 = 8
++    // prepare data
++    ld.bu           t2,     a2,     9
++    ld.bu           t3,     a2,     25
++    fld.d           f0,     a2,     1
++    fld.d           f1,     a2,     17
++    vsllwil.hu.bu   vr0,    vr0,    0
++    vsllwil.hu.bu   vr1,    vr1,    0
++
++    la.local        t4,     planar_8x8_lsx
++    vld             vr2,    t4,     0
++    vld             vr3,    t4,     16
++
++    vreplgr2vr.h    vr4,    t2
++    vreplgr2vr.h    vr5,    t3
++    vreplgr2vr.h    vr6,    t3
++    vmul.h          vr4,    vr3,    vr4
++    addi.d          t7,     zero,   8
++    vreplgr2vr.h    vr7,    t7
++
++    addi.d          t4,     zero,   0
++    addi.d          t5,     zero,   7
++    addi.d          t6,     a0,     0
++
++.LOOP_INTRA_PRED_PLANAR_8x8_LSX:
++    vreplve.h       vr9,    vr1,    t4
++    vreplgr2vr.h    vr10,    t5
++    CALCULATE_INTRA_PRED_PLANAR  , vr2, vr9, vr10, vr0, vr4, vr6, vr7, vr8, vr11
++    vsrlni.b.h      vr8,    vr8,    4
++    vstelm.d        vr8,    t6,     0,      0       // store dst[y*dstStride+x]
++
++    // prepare for next loop
++    addi.d          t4,     t4,     1
++    addi.d          t5,     t5,     -1
++    vadd.h          vr6,    vr6,    vr5
++    add.d           t6,     t6,     a1
++    blt             t4,     t7,     .LOOP_INTRA_PRED_PLANAR_8x8_LSX
++endfunc
++
++// void x265_intra_pred_planar_16x16_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int /*dirMode*/, int /*bFilter*/)
++const planar_16x16_lsx
++.short 15, 14, 13, 12, 11, 10, 9,  8
++.short 7,  6,  5,  4,  3,  2,  1,  0
++.short 1,  2,  3,  4,  5,  6,  7,  8
++.short 9,  10, 11, 12, 13, 14, 15, 16
++endconst
++function x265_intra_pred_planar_16x16_lsx   // blkSize = 1 << 4 = 16
++    // prepare data
++    ld.bu           t2,     a2,     17
++    ld.bu           t3,     a2,     49
++    fld.d           f0,     a2,     1
++    fld.d           f10,    a2,     9
++    vld             vr1,    a2,     33
++    vsllwil.hu.bu   vr0,    vr0,    0
++    vsllwil.hu.bu   vr10,   vr10,   0
++
++    la.local        t4,     planar_16x16_lsx
++    vld             vr2,    t4,     0
++    vld             vr12,   t4,     16
++    vld             vr3,    t4,     32
++    vld             vr13,   t4,     48
++
++    vreplgr2vr.h    vr4,    t2
++    vreplgr2vr.h    vr5,    t3
++    vreplgr2vr.h    vr6,    t3
++    vmul.h          vr14,   vr13,   vr4
++    vmul.h          vr4,    vr3,    vr4
++    addi.d          t7,     zero,   16
++    vreplgr2vr.h    vr7,    t7
++
++    addi.d          t4,     zero,   0
++    addi.d          t5,     zero,   15
++    addi.d          t6,     a0,     0
++
++.LOOP_INTRA_PRED_PLANAR_16x16_LSX:
++    vreplve.b       vr9,    vr1,    t4
++    vsllwil.hu.bu   vr9,    vr9,    0
++    vreplgr2vr.h    vr11,   t5
++    CALCULATE_INTRA_PRED_PLANAR  , vr2,  vr9, vr11, vr0,  vr4,  vr6, vr7, vr8,  vr15
++    CALCULATE_INTRA_PRED_PLANAR  , vr12, vr9, vr11, vr10, vr14, vr6, vr7, vr18, vr16
++    vsrlni.b.h      vr18,   vr8,    5
++    vst             vr18,   t6,     0       // store dst[y*dstStride+x]
++
++    // prepare for next loop
++    addi.d          t4,     t4,     1
++    addi.d          t5,     t5,     -1
++    vadd.h          vr6,    vr6,    vr5
++    add.d           t6,     t6,     a1
++    blt             t4,     t7,     .LOOP_INTRA_PRED_PLANAR_16x16_LSX
++endfunc
++
++// void x265_intra_pred_planar_32x32_lsx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int /*dirMode*/, int /*bFilter*/)
++const planar_32x32_lsx
++.short 31, 30, 29, 28, 27, 26, 25, 24
++.short 23, 22, 21, 20, 19, 18, 17, 16
++.short 15, 14, 13, 12, 11, 10,  9,  8
++.short  7,  6,  5,  4,  3,  2,  1,  0
++.short  1,  2,  3,  4,  5,  6,  7,  8
++.short  9, 10, 11, 12, 13, 14, 15, 16
++.short 17, 18, 19, 20, 21, 22, 23, 24
++.short 25, 26, 27, 28, 29, 30, 31, 32
++endconst
++function x265_intra_pred_planar_32x32_lsx   // blkSize = 1 << 5 = 32
++    // prepare data
++    ld.bu           t2,     a2,     33
++    ld.bu           t3,     a2,     97
++    fld.d           f0,     a2,     1
++    fld.d           f1,     a2,     9
++    fld.d           f2,     a2,     17
++    fld.d           f3,     a2,     25
++    vld             vr4,    a2,     65
++    vld             vr21,   a2,     81
++    vsllwil.hu.bu   vr0,    vr0,    0
++    vsllwil.hu.bu   vr1,    vr1,    0
++    vsllwil.hu.bu   vr2,    vr2,    0
++    vsllwil.hu.bu   vr3,    vr3,    0
++
++    la.local        t4,     planar_32x32_lsx
++    vld             vr5,    t4,     0
++    vld             vr6,    t4,     16
++    vld             vr7,    t4,     32
++    vld             vr8,    t4,     48
++    vld             vr9,    t4,     64
++    vld             vr10,   t4,     80
++    vld             vr11,   t4,     96
++    vld             vr12,   t4,     112
++
++    vreplgr2vr.h    vr13,   t2
++    vmul.h          vr9,    vr13,   vr9
++    vmul.h          vr10,   vr13,   vr10
++    vmul.h          vr11,   vr13,   vr11
++    vmul.h          vr12,   vr13,   vr12
++    vreplgr2vr.h    vr13,   t3
++    vreplgr2vr.h    vr14,   t3
++    addi.d          t7,     zero,   32
++    vreplgr2vr.h    vr15,   t7
++
++    addi.d          t4,     zero,   0
++    addi.d          t5,     zero,   31
++    addi.d          t6,     a0,     0
++    addi.d          t8,     zero,   16
++    vreplve.b       vr20,   vr4,    t4
++.LOOP_INTRA_PRED_PLANAR_32x32_LSX:
++    vsllwil.hu.bu   vr20,   vr20,   0
++    vreplgr2vr.h    vr22,   t5
++    CALCULATE_INTRA_PRED_PLANAR  , vr5,  vr20, vr22, vr0,  vr9,  vr14, vr15, vr16, vr23
++    CALCULATE_INTRA_PRED_PLANAR  , vr6,  vr20, vr22, vr1,  vr10, vr14, vr15, vr17, vr23
++    vsrlni.b.h      vr17,   vr16,   6
++    vst             vr17,   t6,     0
++    CALCULATE_INTRA_PRED_PLANAR  , vr7,  vr20, vr22, vr2,  vr11, vr14, vr15, vr18, vr23
++    CALCULATE_INTRA_PRED_PLANAR  , vr8,  vr20, vr22, vr3,  vr12, vr14, vr15, vr19, vr23
++    vsrlni.b.h      vr19,   vr18,   6
++    vst             vr19,   t6,     16      // store dst[y*dstStride+(16~31)]
++
++    // prepare for next loop
++    addi.d          t4,     t4,     1
++    addi.d          t5,     t5,     -1
++    vadd.h          vr14,   vr14,   vr13
++    add.d           t6,     t6,     a1
++    // if y >= 16, switch to high-short part loop
++    bge             t4,     t8,     .INTRA_PRED_PLANAR_32x32_LSX_SWITCH_TO_HIHG_HALF_PART_LOOP
++    vreplve.b       vr20,   vr4,    t4
++
++.INTRA_PRED_PLANAR_32x32_LSX_WHILE_JUDGE:
++    blt             t4,     t7,     .LOOP_INTRA_PRED_PLANAR_32x32_LSX
++    b               .INTRA_PRED_PLANAR_32x32_LSX_TERMINATE
++
++.INTRA_PRED_PLANAR_32x32_LSX_SWITCH_TO_HIHG_HALF_PART_LOOP:
++    // new_index = y - 16, for get the high-short part data of left[]
++    sub.d           a3,     t4,     t8
++    vreplve.b       vr20,   vr21,   a3      // rep left[y] to vr20, y = {16 ~ 31}
++    b               .INTRA_PRED_PLANAR_32x32_LSX_WHILE_JUDGE
++.INTRA_PRED_PLANAR_32x32_LSX_TERMINATE:
++endfunc
++
++// void x265_intra_pred_planar_16x16_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int /*dirMode*/, int /*bFilter*/)
++const planar_16x16_lasx
++.short 15, 14, 13, 12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1,  0
++.short  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16
++endconst
++function x265_intra_pred_planar_16x16_lasx  // blkSize = 1 << 4 = 16
++    // prepare data
++    ld.bu           t2,     a2,     17
++    ld.bu           t3,     a2,     49
++    vld             vr0,    a2,     1
++    vld             vr1,    a2,     33
++    vext2xv.hu.bu   xr0,    xr0
++
++    la.local        t4,     planar_16x16_lasx
++    xvld            xr2,    t4,     0
++    xvld            xr3,    t4,     32
++
++    xvreplgr2vr.h   xr4,    t2
++    xvreplgr2vr.h   xr5,    t3
++    xvreplgr2vr.h   xr6,    t3
++    xvmul.h         xr4,    xr3,    xr4
++    addi.d          t7,     zero,   16
++    xvreplgr2vr.h   xr7,    t7
++
++    addi.d          t4,     zero,   0
++    addi.d          t5,     zero,   15
++    addi.d          t6,     a0,     0
++
++.LOOP_INTRA_PRED_PLANAR_16x16_LASX:
++    xvreplve.b      xr9,    xr1,    t4
++    vext2xv.hu.bu   xr9,    xr9
++    xvreplgr2vr.h   xr10,   t5
++    CALCULATE_INTRA_PRED_PLANAR       x, xr2, xr9, xr10, xr0, xr4, xr6, xr7, xr8, xr11
++    xvsrlni.b.h     xr8,    xr8,    5
++    xvpermi.d       xr8,    xr8,    0b00001000
++    vst             vr8,    t6,     0
++
++    // prepare for next loop
++    addi.d          t4,     t4,     1
++    addi.d          t5,     t5,     -1
++    xvadd.h         xr6,    xr6,    xr5
++    add.d           t6,     t6,     a1
++    blt             t4,     t7,     .LOOP_INTRA_PRED_PLANAR_16x16_LASX
++endfunc
++
++// void x265_intra_pred_planar_32x32_lasx(pixel* dst, intptr_t dstStride, const pixel* srcPix, int /*dirMode*/, int /*bFilter*/)
++const planar_32x32_lasx
++.short 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
++.short 15, 14, 13, 12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1,  0
++.short  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16
++.short 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
++endconst
++function x265_intra_pred_planar_32x32_lasx   // blkSize = 1 << 5 = 32
++    // prepare data
++    ld.bu           t2,     a2,     33
++    ld.bu           t3,     a2,     97
++    vld             vr0,    a2,     1
++    vld             vr10,   a2,     17
++    vld             vr1,    a2,     65
++    vld             vr11,   a2,     81
++    vext2xv.hu.bu   xr0,    xr0
++    vext2xv.hu.bu   xr10,   xr10
++
++    la.local        t4,     planar_32x32_lasx
++    xvld            xr2,    t4,     0
++    xvld            xr12,   t4,     32
++    xvld            xr3,    t4,     64
++    xvld            xr13,   t4,     96
++
++    xvreplgr2vr.h   xr4,    t2
++    xvreplgr2vr.h   xr5,    t3
++    xvreplgr2vr.h   xr6,    t3
++    xvmul.h         xr14,   xr13,   xr4
++    xvmul.h         xr4,    xr3,    xr4
++    addi.d          t7,     zero,   32
++    xvreplgr2vr.h   xr7,    t7
++
++    addi.d          t4,     zero,   0
++    addi.d          t5,     zero,   31
++    addi.d          t6,     a0,     0
++    addi.d          a4,     zero,   16
++    xvreplve.b      xr9,    xr1,    t4
++    vext2xv.hu.bu   xr9,    xr9
++.LOOP_INTRA_PRED_PLANAR_32x32_LASX:
++    xvreplgr2vr.h   xr19,   t5
++    CALCULATE_INTRA_PRED_PLANAR     x, xr2,  xr9, xr19, xr0,  xr4,  xr6,  xr7, xr8,  xr13
++    CALCULATE_INTRA_PRED_PLANAR     x, xr12, xr9, xr19, xr10, xr14, xr6,  xr7, xr18, xr23
++    xvsrlni.b.h     xr8,    xr8,    6
++    xvsrlni.b.h     xr18,   xr18,   6
++    xvpermi.d       xr8,    xr8,    0b00001000
++    xvpermi.d       xr18,   xr18,   0b00001000
++    xvpermi.q       xr18,   xr8,    0b00100000
++    xvst            xr18,   t6,     0
++
++    // prepare for next loop
++    addi.d          t4,     t4,     1
++    addi.d          t5,     t5,     -1
++    xvadd.h         xr6,    xr6,    xr5
++    add.d           t6,     t6,     a1
++    // if y >= 16, switch to high-short part loop
++    bge             t4,     a4,     .INTRA_PRED_PLANAR_32x32_LASX_SWITCH_TO_HIHG_HALF_PART_LOOP
++    xvreplve.b      xr9,    xr1,    t4
++    vext2xv.hu.bu   xr9,    xr9
++
++.INTRA_PRED_PLANAR_32x32_LASX_WHILE_JUDGE:
++    blt             t4,     t7,     .LOOP_INTRA_PRED_PLANAR_32x32_LASX
++    b               .INTRA_PRED_PLANAR_32x32_LASX_TERMINATE
++
++.INTRA_PRED_PLANAR_32x32_LASX_SWITCH_TO_HIHG_HALF_PART_LOOP:
++    // new_index = y - 16, for get the high-short part data of left[]
++    sub.d           a3,     t4,     a4
++    xvreplve.b      xr9,    xr11,   a3
++    vext2xv.hu.bu   xr9,    xr9
++    b               .INTRA_PRED_PLANAR_32x32_LASX_WHILE_JUDGE
++
++.INTRA_PRED_PLANAR_32x32_LASX_TERMINATE:
++endfunc
++
+ /*
+ void intra_pred_ang8_c(pixel* dst, intptr_t dstStride, const pixel *srcPix0,
+                       int dirMode, int bFilter)
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0012-FROMLIST-LoongArch64-Optimize-functions-in-pixel-pro.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0012-FROMLIST-LoongArch64-Optimize-functions-in-pixel-pro.patch
@@ -1,0 +1,10479 @@
+From 9b4753c08588eef14e60a2184c27738204cabbcd Mon Sep 17 00:00:00 2001
+From: yuanhecai <yuanhecai@loongson.cn>
+Date: Thu, 13 Jun 2024 10:07:31 +0800
+Subject: [PATCH 12/15] FROMLIST: LoongArch64: Optimize functions in pixel
+ processing module
+
+These functions optimized with lsx or lasx are contained in
+the pixel.S, sad.S and ssd.S files.
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |    2 +-
+ source/common/loongarch64/asm-primitives.cpp |  595 ++
+ source/common/loongarch64/pixel.S            | 5491 ++++++++++++++++++
+ source/common/loongarch64/pixel.h            |  251 +
+ source/common/loongarch64/sad.S              | 2880 +++++++++
+ source/common/loongarch64/ssd.S              | 1150 ++++
+ 6 files changed, 10368 insertions(+), 1 deletion(-)
+ create mode 100644 source/common/loongarch64/pixel.S
+ create mode 100644 source/common/loongarch64/sad.S
+ create mode 100644 source/common/loongarch64/ssd.S
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index d9d16d6ff..f83346ad3 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -142,7 +142,7 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S)
++    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S pixel.S ssd.S sad.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 08ad496f1..0354b5780 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -38,6 +38,173 @@
+ namespace X265_NS {
+ // private x265 namespace
+ 
++template<int size>
++int psyCost_pp_lsx(const pixel *source, intptr_t sstride, const pixel *recon, intptr_t rstride)
++{
++    static pixel zeroBuf[8] /* = { 0 } */;
++
++    if (size)
++    {
++        int dim = 1 << (size + 2);
++        uint32_t totEnergy = 0;
++        for (int i = 0; i < dim; i += 8)
++        {
++            for (int j = 0; j < dim; j += 8)
++            {
++                /* AC energy, measured by sa8d (AC + DC) minus SAD (DC) */
++                int sourceEnergy = PFX(pixel_sa8d_8x8_lsx)(source + i * sstride + j, sstride, zeroBuf, 0) -
++                                   (PFX(pixel_sad_8x8_lsx)(source + i * sstride + j, sstride, zeroBuf, 0) >> 2);
++                int reconEnergy =  PFX(pixel_sa8d_8x8_lsx)(recon + i * rstride + j, rstride, zeroBuf, 0) -
++                                   (PFX(pixel_sad_8x8_lsx)(recon + i * rstride + j, rstride, zeroBuf, 0) >> 2);
++
++                totEnergy += abs(sourceEnergy - reconEnergy);
++            }
++        }
++        return totEnergy;
++    }
++    else
++    {
++        int sourceEnergy = PFX(pixel_satd_4x4_lsx)(source, sstride, zeroBuf, 0) - (PFX(pixel_sad_4x4_lsx)(source, sstride, zeroBuf, 0) >> 2);
++        int reconEnergy = PFX(pixel_satd_4x4_lsx)(recon, rstride, zeroBuf, 0) - (PFX(pixel_sad_4x4_lsx)(recon, rstride, zeroBuf, 0) >> 2);
++        return abs(sourceEnergy - reconEnergy);
++    }
++}
++
++template<int size>
++int psyCost_pp_lasx(const pixel *source, intptr_t sstride, const pixel *recon, intptr_t rstride)
++{
++    static pixel zeroBuf[8] /* = { 0 } */;
++
++    if (size)
++    {
++        int dim = 1 << (size + 2);
++        uint32_t totEnergy = 0;
++        for (int i = 0; i < dim; i += 8)
++        {
++            for (int j = 0; j < dim; j += 8)
++            {
++                /* AC energy, measured by sa8d (AC + DC) minus SAD (DC) */
++                int sourceEnergy = PFX(pixel_sa8d_8x8_lasx)(source + i * sstride + j, sstride, zeroBuf, 0) -
++                                   (PFX(pixel_sad_8x8_lsx)(source + i * sstride + j, sstride, zeroBuf, 0) >> 2);
++                int reconEnergy =  PFX(pixel_sa8d_8x8_lasx)(recon + i * rstride + j, rstride, zeroBuf, 0) -
++                                   (PFX(pixel_sad_8x8_lsx)(recon + i * rstride + j, rstride, zeroBuf, 0) >> 2);
++
++                totEnergy += abs(sourceEnergy - reconEnergy);
++            }
++        }
++        return totEnergy;
++    }
++    else
++    {
++        int sourceEnergy = PFX(pixel_satd_4x4_lsx)(source, sstride, zeroBuf, 0) - (PFX(pixel_sad_4x4_lsx)(source, sstride, zeroBuf, 0) >> 2);
++        int reconEnergy = PFX(pixel_satd_4x4_lsx)(recon, rstride, zeroBuf, 0) - (PFX(pixel_sad_4x4_lsx)(recon, rstride, zeroBuf, 0) >> 2);
++        return abs(sourceEnergy - reconEnergy);
++    }
++}
++
++typedef void (*intra_pred_ang_lsx)(pixel* dst, intptr_t dstStride, const pixel* srcPix, int dirMode, int bFilter);
++
++intra_pred_ang_lsx PFX(intra_pred_ang8_19_lsx) = PFX(intra_pred_ang8_17_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_20_lsx) = PFX(intra_pred_ang8_16_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_21_lsx) = PFX(intra_pred_ang8_15_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_22_lsx) = PFX(intra_pred_ang8_14_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_23_lsx) = PFX(intra_pred_ang8_13_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_24_lsx) = PFX(intra_pred_ang8_12_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_25_lsx) = PFX(intra_pred_ang8_11_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_27_lsx) = PFX(intra_pred_ang8_9_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_28_lsx) = PFX(intra_pred_ang8_8_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_29_lsx) = PFX(intra_pred_ang8_7_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_30_lsx) = PFX(intra_pred_ang8_6_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_31_lsx) = PFX(intra_pred_ang8_5_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_32_lsx) = PFX(intra_pred_ang8_4_lsx);
++intra_pred_ang_lsx PFX(intra_pred_ang8_33_lsx) = PFX(intra_pred_ang8_3_lsx);
++
++intra_pred_ang_lsx PFX(intra_pred_ang16_34_lsx) = PFX(intra_pred_ang16_2_lsx);
++
++#define intra_pred_lsx(number)                                                 \
++intra_pred_ang_lsx intra_pred##number##_lsx[35] __attribute__((aligned(8)))= { \
++        NULL,                                                                  \
++        NULL,                                                                  \
++        PFX(intra_pred_ang##number##_2_lsx),                                   \
++        PFX(intra_pred_ang##number##_3_lsx),                                   \
++        PFX(intra_pred_ang##number##_4_lsx),                                   \
++        PFX(intra_pred_ang##number##_5_lsx),                                   \
++        PFX(intra_pred_ang##number##_6_lsx),                                   \
++        PFX(intra_pred_ang##number##_7_lsx),                                   \
++        PFX(intra_pred_ang##number##_8_lsx),                                   \
++        PFX(intra_pred_ang##number##_9_lsx),                                   \
++        PFX(intra_pred_ang##number##_10_lsx),                                  \
++        PFX(intra_pred_ang##number##_11_lsx),                                  \
++        PFX(intra_pred_ang##number##_12_lsx),                                  \
++        PFX(intra_pred_ang##number##_13_lsx),                                  \
++        PFX(intra_pred_ang##number##_14_lsx),                                  \
++        PFX(intra_pred_ang##number##_15_lsx),                                  \
++        PFX(intra_pred_ang##number##_16_lsx),                                  \
++        PFX(intra_pred_ang##number##_17_lsx),                                  \
++        PFX(intra_pred_ang##number##_18_lsx),                                  \
++        PFX(intra_pred_ang##number##_19_lsx),                                  \
++        PFX(intra_pred_ang##number##_20_lsx),                                  \
++        PFX(intra_pred_ang##number##_21_lsx),                                  \
++        PFX(intra_pred_ang##number##_22_lsx),                                  \
++        PFX(intra_pred_ang##number##_23_lsx),                                  \
++        PFX(intra_pred_ang##number##_24_lsx),                                  \
++        PFX(intra_pred_ang##number##_25_lsx),                                  \
++        PFX(intra_pred_ang##number##_26_lsx),                                  \
++        PFX(intra_pred_ang##number##_27_lsx),                                  \
++        PFX(intra_pred_ang##number##_28_lsx),                                  \
++        PFX(intra_pred_ang##number##_29_lsx),                                  \
++        PFX(intra_pred_ang##number##_30_lsx),                                  \
++        PFX(intra_pred_ang##number##_31_lsx),                                  \
++        PFX(intra_pred_ang##number##_32_lsx),                                  \
++        PFX(intra_pred_ang##number##_33_lsx),                                  \
++        PFX(intra_pred_ang##number##_34_lsx)                                   \
++};
++
++intra_pred_lsx(4);
++intra_pred_lsx(8);
++intra_pred_lsx(16);
++intra_pred_lsx(32);
++
++#define all_angs_pred_lsx(number1, number2)                                     \
++static void all_angs_pred##number1##_lsx(pixel *dest, pixel *refPix,            \
++                                        pixel *filtPix, int bLuma)              \
++{                                                                               \
++    const int size = number1;                                                   \
++    for (int mode = 2; mode <= 34; mode++)                                      \
++    {                                                                           \
++        pixel *srcPix  = (g_intraFilterFlags[mode] & size ? filtPix  : refPix); \
++        pixel *out = dest + ((mode - 2) << (number2));                          \
++                                                                                \
++        intra_pred##number1##_lsx[mode](out, size, srcPix, mode, bLuma);        \
++                                                                                \
++        bool modeHor = (mode < 18);                                             \
++        if (modeHor)                                                            \
++        {                                                                       \
++            if (size == 8)                                                      \
++            {                                                                   \
++                x265_transpose_8x8_lsx(out, out, size);                         \
++            }                                                                   \
++            else if (size == 16)                                                \
++            {                                                                   \
++                x265_transpose_16x16_lsx(out, out, size);                       \
++            }                                                                   \
++            else if (size == 32)                                                \
++            {                                                                   \
++                x265_transpose_32x32_lsx(out, out, size);                       \
++            }                                                                   \
++            else                                                                \
++            {                                                                   \
++                x265_transpose_4x4_lsx(out, out, size);                         \
++            }                                                                   \
++        }                                                                       \
++    }                                                                           \
++}
++
++all_angs_pred_lsx(4, 4)
++all_angs_pred_lsx(8, 6)
++all_angs_pred_lsx(16, 8)
++all_angs_pred_lsx(32, 10)
++
+ #define LUMA(W, H, CPU) \
+     p.pu[LUMA_ ## W ## x ## H].luma_vpp     = PFX(interp_8tap_vert_pp_ ## W ## x ## H ## _ ##CPU); \
+     p.pu[LUMA_ ## W ## x ## H].luma_vps     = PFX(interp_8tap_vert_ps_ ## W ## x ## H ## _ ##CPU); \
+@@ -79,6 +246,17 @@ namespace X265_NS {
+     p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].p2s[NONALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I444].pu[LUMA_ ## W ## x ## H].p2s[ALIGNED] = PFX(filterPixelToShort_ ## W ## x ## H ## _ ##CPU);
+ 
++#define LUMA_CU(W, H, CPU) \
++    p.cu[BLOCK_ ## W ## x ## H].psy_cost_pp = psyCost_pp_ ##CPU<BLOCK_ ## W ## x ## H>; \
++    p.cu[BLOCK_ ## W ## x ## H].sse_pp      = PFX(pixel_sse_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].sse_ss      = PFX(pixel_sse_ss_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].var         = PFX(pixel_var_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].ssd_s[NONALIGNED] = PFX(pixel_ssd_s_## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].ssd_s[ALIGNED] = PFX(pixel_ssd_s_## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].transpose     = PFX(transpose_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].calcresidual[NONALIGNED] = PFX(pixel_getResidual_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].calcresidual[ALIGNED]    = PFX(pixel_getResidual_ ## W ## x ## H ##_ ## CPU);;
++
+ #define LUMA_PU(W, H, CPU) \
+     p.pu[LUMA_ ## W ## x ## H].addAvg[NONALIGNED] = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
+     p.pu[LUMA_ ## W ## x ## H].addAvg[ALIGNED] = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
+@@ -91,6 +269,33 @@ namespace X265_NS {
+     p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].addAvg[NONALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].addAvg[ALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
+ 
++#define ALL_LUMA_PU_TYPED(prim, fncdef, fname, cpu) \
++    p.pu[LUMA_4x4].prim   = fncdef PFX(fname ## _4x4_ ## cpu); \
++    p.pu[LUMA_8x8].prim   = fncdef PFX(fname ## _8x8_ ## cpu); \
++    p.pu[LUMA_16x16].prim = fncdef PFX(fname ## _16x16_ ## cpu); \
++    p.pu[LUMA_32x32].prim = fncdef PFX(fname ## _32x32_ ## cpu); \
++    p.pu[LUMA_64x64].prim = fncdef PFX(fname ## _64x64_ ## cpu); \
++    p.pu[LUMA_8x4].prim   = fncdef PFX(fname ## _8x4_ ## cpu); \
++    p.pu[LUMA_4x8].prim   = fncdef PFX(fname ## _4x8_ ## cpu); \
++    p.pu[LUMA_16x8].prim  = fncdef PFX(fname ## _16x8_ ## cpu); \
++    p.pu[LUMA_8x16].prim  = fncdef PFX(fname ## _8x16_ ## cpu); \
++    p.pu[LUMA_16x32].prim = fncdef PFX(fname ## _16x32_ ## cpu); \
++    p.pu[LUMA_32x16].prim = fncdef PFX(fname ## _32x16_ ## cpu); \
++    p.pu[LUMA_64x32].prim = fncdef PFX(fname ## _64x32_ ## cpu); \
++    p.pu[LUMA_32x64].prim = fncdef PFX(fname ## _32x64_ ## cpu); \
++    p.pu[LUMA_16x12].prim = fncdef PFX(fname ## _16x12_ ## cpu); \
++    p.pu[LUMA_12x16].prim = fncdef PFX(fname ## _12x16_ ## cpu); \
++    p.pu[LUMA_16x4].prim  = fncdef PFX(fname ## _16x4_ ## cpu); \
++    p.pu[LUMA_4x16].prim  = fncdef PFX(fname ## _4x16_ ## cpu); \
++    p.pu[LUMA_32x24].prim = fncdef PFX(fname ## _32x24_ ## cpu); \
++    p.pu[LUMA_24x32].prim = fncdef PFX(fname ## _24x32_ ## cpu); \
++    p.pu[LUMA_32x8].prim  = fncdef PFX(fname ## _32x8_ ## cpu); \
++    p.pu[LUMA_8x32].prim  = fncdef PFX(fname ## _8x32_ ## cpu); \
++    p.pu[LUMA_64x48].prim = fncdef PFX(fname ## _64x48_ ## cpu); \
++    p.pu[LUMA_48x64].prim = fncdef PFX(fname ## _48x64_ ## cpu); \
++    p.pu[LUMA_64x16].prim = fncdef PFX(fname ## _64x16_ ## cpu); \
++    p.pu[LUMA_16x64].prim = fncdef PFX(fname ## _16x64_ ## cpu)
++
+ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ {
+ #if HAVE_LSX
+@@ -498,11 +703,186 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.cu[BLOCK_32x32].intra_pred[33] = PFX(intra_pred_ang32_33_lsx);
+         p.cu[BLOCK_32x32].intra_pred[34] = PFX(intra_pred_ang32_34_lsx);
+ 
++        p.cu[BLOCK_4x4].intra_pred_allangs   = all_angs_pred4_lsx;
++        p.cu[BLOCK_8x8].intra_pred_allangs   = all_angs_pred8_lsx;
++        p.cu[BLOCK_16x16].intra_pred_allangs = all_angs_pred16_lsx;
++        p.cu[BLOCK_32x32].intra_pred_allangs = all_angs_pred32_lsx;
++
+         //intra_pred_dc
+         p.cu[BLOCK_4x4].intra_pred[DC_IDX] = PFX(intra_pred_dc4_lsx);
+         p.cu[BLOCK_8x8].intra_pred[DC_IDX] = PFX(intra_pred_dc8_lsx);
+         p.cu[BLOCK_16x16].intra_pred[DC_IDX] = PFX(intra_pred_dc16_lsx);
+         p.cu[BLOCK_32x32].intra_pred[DC_IDX] = PFX(intra_pred_dc32_lsx);
++
++        // luma satd
++        ALL_LUMA_PU_TYPED(satd, , pixel_satd, lsx);
++
++        // chroma satd
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_2x2].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_4x4].satd   = PFX(pixel_satd_4x4_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x8].satd   = PFX(pixel_satd_8x8_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x16].satd = PFX(pixel_satd_16x16_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x32].satd = PFX(pixel_satd_32x32_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_4x2].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_2x4].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x4].satd   = PFX(pixel_satd_8x4_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_4x8].satd   = PFX(pixel_satd_4x8_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x8].satd  = PFX(pixel_satd_16x8_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x16].satd  = PFX(pixel_satd_8x16_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x16].satd = PFX(pixel_satd_32x16_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x32].satd = PFX(pixel_satd_16x32_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x6].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_6x8].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x2].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_2x8].satd   = NULL;
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x12].satd = PFX(pixel_satd_16x12_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_12x16].satd = PFX(pixel_satd_12x16_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x4].satd  = PFX(pixel_satd_16x4_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_4x16].satd  = PFX(pixel_satd_4x16_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x24].satd = PFX(pixel_satd_32x24_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_24x32].satd = PFX(pixel_satd_24x32_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x8].satd  = PFX(pixel_satd_32x8_lsx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x32].satd  = PFX(pixel_satd_8x32_lsx);
++
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x4].satd   = PFX(pixel_satd_4x4_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x8].satd   = PFX(pixel_satd_4x8_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x16].satd  = PFX(pixel_satd_4x16_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x4].satd   = PFX(pixel_satd_8x4_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x8].satd   = PFX(pixel_satd_8x8_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x16].satd  = PFX(pixel_satd_8x16_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x8].satd  = PFX(pixel_satd_16x8_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x16].satd = PFX(pixel_satd_16x16_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_2x4].satd   = NULL;
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x32].satd = PFX(pixel_satd_16x32_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x64].satd = PFX(pixel_satd_32x64_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_2x8].satd   = NULL;
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x32].satd  = PFX(pixel_satd_8x32_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x32].satd = PFX(pixel_satd_32x32_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x64].satd = PFX(pixel_satd_16x64_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x12].satd  = PFX(pixel_satd_8x12_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_6x16].satd  = NULL;
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_2x16].satd  = NULL;
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x24].satd = PFX(pixel_satd_16x24_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_12x32].satd = PFX(pixel_satd_12x32_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x32].satd  = PFX(pixel_satd_4x32_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x48].satd = PFX(pixel_satd_32x48_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_24x64].satd = PFX(pixel_satd_24x64_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x16].satd = PFX(pixel_satd_32x16_lsx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x64].satd  = PFX(pixel_satd_8x64_lsx);
++
++        // sa8d
++        p.cu[BLOCK_4x4].sa8d   = PFX(pixel_satd_4x4_lsx);
++        p.cu[BLOCK_8x8].sa8d   = PFX(pixel_sa8d_8x8_lsx);
++        p.cu[BLOCK_16x16].sa8d = PFX(pixel_sa8d_16x16_lsx);
++        p.cu[BLOCK_32x32].sa8d = PFX(pixel_sa8d_32x32_lsx);
++        p.cu[BLOCK_64x64].sa8d = PFX(pixel_sa8d_64x64_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_8x8].sa8d       = PFX(pixel_satd_4x4_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_16x16].sa8d     = PFX(pixel_sa8d_16x16_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_32x32].sa8d     = PFX(pixel_sa8d_32x32_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_64x64].sa8d     = PFX(pixel_sa8d_64x64_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_8x8].sa8d       = PFX(pixel_satd_4x8_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_8x16].sa8d  = PFX(pixel_sa8d_8x16_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].sa8d = PFX(pixel_sa8d_16x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].sa8d = PFX(pixel_sa8d_32x64_lsx);
++
++        // sad_x4
++        ALL_LUMA_PU_TYPED(sad_x4, , pixel_sad_x4, lsx);
++
++        // sad
++        ALL_LUMA_PU_TYPED(sad, , pixel_sad, lsx);
++
++        LUMA_CU(4, 4, lsx);
++        LUMA_CU(8, 8, lsx);
++        LUMA_CU(16, 16, lsx);
++        LUMA_CU(32, 32, lsx);
++        LUMA_CU(64, 64, lsx);
++
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_4x4].sse_pp   = PFX(pixel_sse_4x4_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_8x8].sse_pp   = PFX(pixel_sse_8x8_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].sse_pp = PFX(pixel_sse_16x16_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].sse_pp = PFX(pixel_sse_32x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_4x8].sse_pp   = PFX(pixel_sse_4x8_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_8x16].sse_pp  = PFX(pixel_sse_8x16_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].sse_pp = PFX(pixel_sse_16x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].sse_pp = PFX(pixel_sse_32x64_lsx);
++
++        p.weight_pp = PFX(weight_pp_lsx);
++        p.weight_sp = PFX(weight_sp_lsx);
++
++        p.cu[BLOCK_4x4].sub_ps   = PFX(pixel_sub_ps_4x4_lsx);
++        p.cu[BLOCK_8x8].sub_ps   = PFX(pixel_sub_ps_8x8_lsx);
++        p.cu[BLOCK_16x16].sub_ps = PFX(pixel_sub_ps_16x16_lsx);
++        p.cu[BLOCK_32x32].sub_ps = PFX(pixel_sub_ps_32x32_lsx);
++        p.cu[BLOCK_64x64].sub_ps = PFX(pixel_sub_ps_64x64_lsx);
++
++        // chroma sub_ps
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_4x4].sub_ps   = PFX(pixel_sub_ps_4x4_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_8x8].sub_ps   = PFX(pixel_sub_ps_8x8_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].sub_ps = PFX(pixel_sub_ps_16x16_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].sub_ps = PFX(pixel_sub_ps_32x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_4x8].sub_ps   = PFX(pixel_sub_ps_4x8_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_8x16].sub_ps  = PFX(pixel_sub_ps_8x16_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].sub_ps = PFX(pixel_sub_ps_16x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].sub_ps = PFX(pixel_sub_ps_32x64_lsx);
++
++        p.cu[BLOCK_4x4].add_ps[NONALIGNED]   = PFX(pixel_add_ps_4x4_lsx);
++        p.cu[BLOCK_8x8].add_ps[NONALIGNED]   = PFX(pixel_add_ps_8x8_lsx);
++        p.cu[BLOCK_16x16].add_ps[NONALIGNED] = PFX(pixel_add_ps_16x16_lsx);
++        p.cu[BLOCK_32x32].add_ps[NONALIGNED] = PFX(pixel_add_ps_32x32_lsx);
++        p.cu[BLOCK_64x64].add_ps[NONALIGNED] = PFX(pixel_add_ps_64x64_lsx);
++
++        p.cu[BLOCK_4x4].add_ps[ALIGNED]   = PFX(pixel_add_ps_4x4_lsx);
++        p.cu[BLOCK_8x8].add_ps[ALIGNED]   = PFX(pixel_add_ps_8x8_lsx);
++        p.cu[BLOCK_16x16].add_ps[ALIGNED] = PFX(pixel_add_ps_16x16_lsx);
++        p.cu[BLOCK_32x32].add_ps[ALIGNED] = PFX(pixel_add_ps_32x32_lsx);
++        p.cu[BLOCK_64x64].add_ps[ALIGNED] = PFX(pixel_add_ps_64x64_lsx);
++
++        // chroma add_ps
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_4x4].add_ps[NONALIGNED]   = PFX(pixel_add_ps_4x4_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_8x8].add_ps[NONALIGNED]   = PFX(pixel_add_ps_8x8_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].add_ps[NONALIGNED] = PFX(pixel_add_ps_16x16_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].add_ps[NONALIGNED] = PFX(pixel_add_ps_32x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_4x8].add_ps[NONALIGNED]   = PFX(pixel_add_ps_4x8_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_8x16].add_ps[NONALIGNED]  = PFX(pixel_add_ps_8x16_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].add_ps[NONALIGNED] = PFX(pixel_add_ps_16x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].add_ps[NONALIGNED] = PFX(pixel_add_ps_32x64_lsx);
++
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_4x4].add_ps[ALIGNED]   = PFX(pixel_add_ps_4x4_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_8x8].add_ps[ALIGNED]   = PFX(pixel_add_ps_8x8_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].add_ps[ALIGNED] = PFX(pixel_add_ps_16x16_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].add_ps[ALIGNED] = PFX(pixel_add_ps_32x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_4x8].add_ps[ALIGNED]   = PFX(pixel_add_ps_4x8_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_8x16].add_ps[ALIGNED]  = PFX(pixel_add_ps_8x16_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].add_ps[ALIGNED] = PFX(pixel_add_ps_16x32_lsx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].add_ps[ALIGNED] = PFX(pixel_add_ps_32x64_lsx);
++
++        // sad_x3
++        ALL_LUMA_PU_TYPED(sad_x3, , pixel_sad_x3, lsx);
++
++        // normFact_c
++        p.cu[BLOCK_8x8].normFact   = PFX(pixel_normFact_8x8_lsx);
++        p.cu[BLOCK_16x16].normFact = PFX(pixel_normFact_16x16_lsx);
++        p.cu[BLOCK_32x32].normFact = PFX(pixel_normFact_32x32_lsx);
++        p.cu[BLOCK_64x64].normFact = PFX(pixel_normFact_64x64_lsx);
++
++        p.planecopy_cp = PFX(pixel_planecopy_cp_lsx);
++        p.planecopy_sp = PFX(pixel_planecopy_sp_lsx);
++        p.planecopy_sp_shl = PFX(pixel_planecopy_sp_shl_lsx);
++        p.planecopy_pp_shr = PFX(pixel_planecopy_pp_shr_lsx);
++
++        p.scale1D_128to64[NONALIGNED] = PFX(scale1D_128to64_lsx);
++        p.scale1D_128to64[ALIGNED] = PFX(scale1D_128to64_lsx);
++        p.scale2D_64to32 = PFX(scale2D_64to32_lsx);
++
++        // ssimDist
++        p.cu[BLOCK_4x4].ssimDist   = x265_ssimDist4_lsx;
++        p.cu[BLOCK_8x8].ssimDist   = x265_ssimDist8_lsx;
++        p.cu[BLOCK_16x16].ssimDist = x265_ssimDist16_lsx;
++        p.cu[BLOCK_32x32].ssimDist = x265_ssimDist32_lsx;
++        p.cu[BLOCK_64x64].ssimDist = x265_ssimDist64_lsx;
++
++        p.ssim_end_4 = PFX(ssim_end4_lsx);
++        p.ssim_4x4x2_core = PFX(ssim_4x4x2_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -671,6 +1051,221 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.cu[BLOCK_16x16].intra_pred[15] = PFX(intra_pred_ang16_15_lasx);
+         p.cu[BLOCK_16x16].intra_pred[16] = PFX(intra_pred_ang16_16_lasx);
+         p.cu[BLOCK_16x16].intra_pred[17] = PFX(intra_pred_ang16_17_lasx);
++
++        // luma satd
++        p.pu[LUMA_4x8].satd   = PFX(pixel_satd_4x8_lasx);
++        p.pu[LUMA_4x16].satd  = PFX(pixel_satd_4x16_lasx);
++        p.pu[LUMA_8x8].satd   = PFX(pixel_satd_8x8_lasx);
++        p.pu[LUMA_8x16].satd  = PFX(pixel_satd_8x16_lasx);
++        p.pu[LUMA_8x32].satd  = PFX(pixel_satd_8x32_lasx);
++        p.pu[LUMA_12x16].satd = PFX(pixel_satd_12x16_lasx);
++        p.pu[LUMA_16x8].satd  = PFX(pixel_satd_16x8_lasx);
++        p.pu[LUMA_16x16].satd = PFX(pixel_satd_16x16_lasx);
++        p.pu[LUMA_16x32].satd = PFX(pixel_satd_16x32_lasx);
++        p.pu[LUMA_16x64].satd = PFX(pixel_satd_16x64_lasx);
++        p.pu[LUMA_24x32].satd = PFX(pixel_satd_24x32_lasx);
++        p.pu[LUMA_32x8].satd  = PFX(pixel_satd_32x8_lasx);
++        p.pu[LUMA_32x16].satd = PFX(pixel_satd_32x16_lasx);
++        p.pu[LUMA_32x24].satd = PFX(pixel_satd_32x24_lasx);
++        p.pu[LUMA_32x32].satd = PFX(pixel_satd_32x32_lasx);
++        p.pu[LUMA_32x64].satd = PFX(pixel_satd_32x64_lasx);
++        p.pu[LUMA_48x64].satd = PFX(pixel_satd_48x64_lasx);
++        p.pu[LUMA_64x16].satd = PFX(pixel_satd_64x16_lasx);
++        p.pu[LUMA_64x32].satd = PFX(pixel_satd_64x32_lasx);
++        p.pu[LUMA_64x48].satd = PFX(pixel_satd_64x48_lasx);
++        p.pu[LUMA_64x64].satd = PFX(pixel_satd_64x64_lasx);
++
++        // chroma satd
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_4x8].satd   = PFX(pixel_satd_4x8_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_4x16].satd  = PFX(pixel_satd_4x16_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x16].satd  = PFX(pixel_satd_8x16_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x8].satd   = PFX(pixel_satd_8x8_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x8].satd  = PFX(pixel_satd_16x8_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x16].satd = PFX(pixel_satd_16x16_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x32].satd  = PFX(pixel_satd_8x32_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x32].satd = PFX(pixel_satd_16x32_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_16x32].satd = PFX(pixel_satd_16x64_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x8].satd  = PFX(pixel_satd_32x8_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x16].satd = PFX(pixel_satd_32x16_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x24].satd = PFX(pixel_satd_32x24_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x32].satd = PFX(pixel_satd_32x32_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_8x32].satd  = PFX(pixel_satd_8x32_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_12x16].satd = PFX(pixel_satd_12x16_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_24x32].satd = PFX(pixel_satd_24x32_lasx);
++
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x8].satd   = PFX(pixel_satd_4x8_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x16].satd  = PFX(pixel_satd_4x16_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x8].satd   = PFX(pixel_satd_8x8_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x16].satd  = PFX(pixel_satd_8x16_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x8].satd  = PFX(pixel_satd_16x8_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x16].satd = PFX(pixel_satd_16x16_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x32].satd  = PFX(pixel_satd_8x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x64].satd  = PFX(pixel_satd_8x64_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x24].satd = PFX(pixel_satd_16x24_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x32].satd = PFX(pixel_satd_16x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_16x64].satd = PFX(pixel_satd_16x64_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x16].satd = PFX(pixel_satd_32x16_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x32].satd = PFX(pixel_satd_32x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x64].satd = PFX(pixel_satd_32x64_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x48].satd = PFX(pixel_satd_32x48_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x32].satd  = PFX(pixel_satd_8x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_8x64].satd  = PFX(pixel_satd_8x64_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_4x32].satd  = PFX(pixel_satd_4x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_12x32].satd = PFX(pixel_satd_12x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_24x64].satd = PFX(pixel_satd_24x64_lasx);
++
++        p.pu[LUMA_24x32].sad = x265_pixel_sad_24x32_lasx;
++        p.pu[LUMA_32x8].sad  = x265_pixel_sad_32x8_lasx;
++        p.pu[LUMA_32x16].sad = x265_pixel_sad_32x16_lasx;
++        p.pu[LUMA_32x24].sad = x265_pixel_sad_32x24_lasx;
++        p.pu[LUMA_32x32].sad = x265_pixel_sad_32x32_lasx;
++        p.pu[LUMA_32x64].sad = x265_pixel_sad_32x64_lasx;
++        p.pu[LUMA_48x64].sad = x265_pixel_sad_48x64_lasx;
++        p.pu[LUMA_64x16].sad = x265_pixel_sad_64x16_lasx;
++        p.pu[LUMA_64x32].sad = x265_pixel_sad_64x32_lasx;
++        p.pu[LUMA_64x48].sad = x265_pixel_sad_64x48_lasx;
++        p.pu[LUMA_64x64].sad = x265_pixel_sad_64x64_lasx;
++
++        // sad_x4
++        p.pu[LUMA_8x4].sad_x4   = x265_pixel_sad_x4_8x4_lasx;
++        p.pu[LUMA_8x8].sad_x4   = x265_pixel_sad_x4_8x8_lasx;
++        p.pu[LUMA_8x16].sad_x4  = x265_pixel_sad_x4_8x16_lasx;
++        p.pu[LUMA_8x32].sad_x4  = x265_pixel_sad_x4_8x32_lasx;
++        p.pu[LUMA_12x16].sad_x4 = x265_pixel_sad_x4_12x16_lasx;
++        p.pu[LUMA_16x4].sad_x4  = x265_pixel_sad_x4_16x4_lasx;
++        p.pu[LUMA_16x8].sad_x4  = x265_pixel_sad_x4_16x8_lasx;
++        p.pu[LUMA_16x12].sad_x4 = x265_pixel_sad_x4_16x12_lasx;
++        p.pu[LUMA_16x16].sad_x4 = x265_pixel_sad_x4_16x16_lasx;
++        p.pu[LUMA_16x32].sad_x4 = x265_pixel_sad_x4_16x32_lasx;
++        p.pu[LUMA_16x64].sad_x4 = x265_pixel_sad_x4_16x64_lasx;
++        p.pu[LUMA_24x32].sad_x4 = x265_pixel_sad_x4_24x32_lasx;
++        p.pu[LUMA_32x8].sad_x4  = x265_pixel_sad_x4_32x8_lasx;
++        p.pu[LUMA_32x16].sad_x4 = x265_pixel_sad_x4_32x16_lasx;
++        p.pu[LUMA_32x24].sad_x4 = x265_pixel_sad_x4_32x24_lasx;
++        p.pu[LUMA_32x32].sad_x4 = x265_pixel_sad_x4_32x32_lasx;
++        p.pu[LUMA_32x64].sad_x4 = x265_pixel_sad_x4_32x64_lasx;
++        p.pu[LUMA_64x16].sad_x4 = x265_pixel_sad_x4_64x16_lasx;
++        p.pu[LUMA_64x32].sad_x4 = x265_pixel_sad_x4_64x32_lasx;
++        p.pu[LUMA_64x48].sad_x4 = x265_pixel_sad_x4_64x48_lasx;
++        p.pu[LUMA_64x64].sad_x4 = x265_pixel_sad_x4_64x64_lasx;
++        p.pu[LUMA_48x64].sad_x4 = x265_pixel_sad_x4_48x64_lasx;
++
++        // sad_x3
++        p.pu[LUMA_12x16].sad_x3 = x265_pixel_sad_x3_12x16_lasx;
++        p.pu[LUMA_16x8].sad_x3  = x265_pixel_sad_x3_16x8_lasx;
++        p.pu[LUMA_16x12].sad_x3 = x265_pixel_sad_x3_16x12_lasx;
++        p.pu[LUMA_16x16].sad_x3 = x265_pixel_sad_x3_16x16_lasx;
++        p.pu[LUMA_16x32].sad_x3 = x265_pixel_sad_x3_16x32_lasx;
++        p.pu[LUMA_16x64].sad_x3 = x265_pixel_sad_x3_16x64_lasx;
++        p.pu[LUMA_24x32].sad_x3 = x265_pixel_sad_x3_24x32_lasx;
++        p.pu[LUMA_32x8].sad_x3  = x265_pixel_sad_x3_32x8_lasx;
++        p.pu[LUMA_32x24].sad_x3 = x265_pixel_sad_x3_32x24_lasx;
++        p.pu[LUMA_32x16].sad_x3 = x265_pixel_sad_x3_32x16_lasx;
++        p.pu[LUMA_32x32].sad_x3 = x265_pixel_sad_x3_32x32_lasx;
++        p.pu[LUMA_32x64].sad_x3 = x265_pixel_sad_x3_32x64_lasx;
++        p.pu[LUMA_64x16].sad_x3 = x265_pixel_sad_x3_64x16_lasx;
++        p.pu[LUMA_64x32].sad_x3 = x265_pixel_sad_x3_64x32_lasx;
++        p.pu[LUMA_64x48].sad_x3 = x265_pixel_sad_x3_64x48_lasx;
++        p.pu[LUMA_64x64].sad_x3 = x265_pixel_sad_x3_64x64_lasx;
++        p.pu[LUMA_48x64].sad_x3 = x265_pixel_sad_x3_48x64_lasx;
++
++        // sa8d
++        p.cu[BLOCK_8x8].sa8d   = PFX(pixel_sa8d_8x8_lasx);
++        p.cu[BLOCK_16x16].sa8d = PFX(pixel_sa8d_16x16_lasx);
++        p.cu[BLOCK_32x32].sa8d = PFX(pixel_sa8d_32x32_lasx);
++        p.cu[BLOCK_64x64].sa8d = PFX(pixel_sa8d_64x64_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_16x16].sa8d     = PFX(pixel_sa8d_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_32x32].sa8d     = PFX(pixel_sa8d_32x32_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_64x64].sa8d     = PFX(pixel_sa8d_64x64_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_8x8].sa8d       = PFX(pixel_satd_4x8_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_8x16].sa8d  = PFX(pixel_sa8d_8x16_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].sa8d = PFX(pixel_sa8d_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].sa8d = PFX(pixel_sa8d_32x64_lasx);
++
++        // psy_cost_pp
++        p.cu[BLOCK_4x4].psy_cost_pp   = psyCost_pp_lasx<BLOCK_4x4>;
++        p.cu[BLOCK_8x8].psy_cost_pp   = psyCost_pp_lasx<BLOCK_8x8>;
++        p.cu[BLOCK_16x16].psy_cost_pp = psyCost_pp_lasx<BLOCK_16x16>;
++        p.cu[BLOCK_32x32].psy_cost_pp = psyCost_pp_lasx<BLOCK_32x32>;
++        p.cu[BLOCK_64x64].psy_cost_pp = psyCost_pp_lasx<BLOCK_64x64>;
++
++        p.cu[BLOCK_32x32].sub_ps = PFX(pixel_sub_ps_32x32_lasx);
++        p.cu[BLOCK_64x64].sub_ps = PFX(pixel_sub_ps_64x64_lasx);
++
++        // chroma sub_ps
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].sub_ps = PFX(pixel_sub_ps_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].sub_ps = PFX(pixel_sub_ps_32x64_lasx);
++
++        p.cu[BLOCK_16x16].add_ps[NONALIGNED] = PFX(pixel_add_ps_16x16_lasx);
++        p.cu[BLOCK_32x32].add_ps[NONALIGNED] = PFX(pixel_add_ps_32x32_lasx);
++        p.cu[BLOCK_64x64].add_ps[NONALIGNED] = PFX(pixel_add_ps_64x64_lsx);
++
++        p.cu[BLOCK_16x16].add_ps[ALIGNED] = PFX(pixel_add_ps_16x16_lasx);
++        p.cu[BLOCK_32x32].add_ps[ALIGNED] = PFX(pixel_add_ps_32x32_lasx);
++        p.cu[BLOCK_64x64].add_ps[ALIGNED] = PFX(pixel_add_ps_64x64_lasx);
++
++        // chroma add_ps
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].add_ps[NONALIGNED] = PFX(pixel_add_ps_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].add_ps[NONALIGNED] = PFX(pixel_add_ps_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].add_ps[NONALIGNED] = PFX(pixel_add_ps_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].add_ps[NONALIGNED] = PFX(pixel_add_ps_32x64_lasx);
++
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].add_ps[ALIGNED] = PFX(pixel_add_ps_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].add_ps[ALIGNED] = PFX(pixel_add_ps_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].add_ps[ALIGNED] = PFX(pixel_add_ps_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].add_ps[ALIGNED] = PFX(pixel_add_ps_32x64_lasx);
++
++        // var
++        p.cu[BLOCK_8x8].var   = PFX(pixel_var_8x8_lasx);
++        p.cu[BLOCK_16x16].var = PFX(pixel_var_16x16_lasx);
++        p.cu[BLOCK_32x32].var = PFX(pixel_var_32x32_lasx);
++        p.cu[BLOCK_64x64].var = PFX(pixel_var_64x64_lasx);
++
++        // sse_pp
++        p.cu[BLOCK_16x16].sse_pp = PFX(pixel_sse_16x16_lasx);
++        p.cu[BLOCK_32x32].sse_pp = PFX(pixel_sse_32x32_lasx);
++        p.cu[BLOCK_64x64].sse_pp = PFX(pixel_sse_64x64_lasx);
++
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].sse_pp = PFX(pixel_sse_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].sse_pp = PFX(pixel_sse_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].sse_pp = PFX(pixel_sse_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].sse_pp = PFX(pixel_sse_32x64_lasx);
++
++        // sse_ss
++        p.cu[BLOCK_8x8].sse_ss = PFX(pixel_sse_ss_8x8_lasx);
++        p.cu[BLOCK_16x16].sse_ss = PFX(pixel_sse_ss_16x16_lasx);
++        p.cu[BLOCK_32x32].sse_ss = PFX(pixel_sse_ss_32x32_lasx);
++        p.cu[BLOCK_64x64].sse_ss = PFX(pixel_sse_ss_64x64_lasx);
++
++        // ssd_s
++        p.cu[BLOCK_16x16].ssd_s[NONALIGNED] = PFX(pixel_ssd_s_16x16_lasx);
++        p.cu[BLOCK_16x16].ssd_s[ALIGNED]    = PFX(pixel_ssd_s_16x16_lasx);
++        p.cu[BLOCK_32x32].ssd_s[NONALIGNED] = PFX(pixel_ssd_s_32x32_lasx);
++        p.cu[BLOCK_32x32].ssd_s[ALIGNED]    = PFX(pixel_ssd_s_32x32_lasx);
++        p.cu[BLOCK_64x64].ssd_s[NONALIGNED] = PFX(pixel_ssd_s_64x64_lasx);
++        p.cu[BLOCK_64x64].ssd_s[ALIGNED]    = PFX(pixel_ssd_s_64x64_lasx);
++
++        // calcresidual
++        p.cu[BLOCK_64x64].calcresidual[NONALIGNED] = PFX(pixel_getResidual_64x64_lasx);
++        p.cu[BLOCK_32x32].calcresidual[NONALIGNED] = PFX(pixel_getResidual_32x32_lasx);
++        p.cu[BLOCK_64x64].calcresidual[ALIGNED] = PFX(pixel_getResidual_64x64_lasx);
++        p.cu[BLOCK_32x32].calcresidual[ALIGNED] = PFX(pixel_getResidual_32x32_lasx);
++
++        // normFact_c
++        p.cu[BLOCK_8x8].normFact   = PFX(pixel_normFact_8x8_lasx);
++        p.cu[BLOCK_16x16].normFact = PFX(pixel_normFact_16x16_lasx);
++        p.cu[BLOCK_32x32].normFact = PFX(pixel_normFact_32x32_lasx);
++        p.cu[BLOCK_64x64].normFact = PFX(pixel_normFact_64x64_lasx);
++
++        p.scale1D_128to64[NONALIGNED] = PFX(scale1D_128to64_lasx);
++        p.scale1D_128to64[ALIGNED] = PFX(scale1D_128to64_lasx);
++        p.scale2D_64to32 = PFX(scale2D_64to32_lasx);
++
++        // ssimDist
++        p.cu[BLOCK_8x8].ssimDist   = x265_ssimDist8_lasx;
++        p.cu[BLOCK_16x16].ssimDist = x265_ssimDist16_lasx;
++        p.cu[BLOCK_32x32].ssimDist = x265_ssimDist32_lasx;
++        p.cu[BLOCK_64x64].ssimDist = x265_ssimDist64_lasx;
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/pixel.S b/source/common/loongarch64/pixel.S
+new file mode 100644
+index 000000000..7c35ef2e4
+--- /dev/null
++++ b/source/common/loongarch64/pixel.S
+@@ -0,0 +1,5491 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Hecai Yuan <yuanhecai@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "loongson_asm.S"
++
++.macro pixel_satd_8x4_core_lsx in0, in1, out
++    FLDD_LOADX_4  \in0,   a1,     t0,   t1, f0, f1, f2, f3
++    FLDD_LOADX_4  \in1,   a3,     t2,   t3, f4, f5, f6, f7
++    vilvl.d       vr0,    vr1,    vr0
++    vilvl.d       vr1,    vr3,    vr2
++    vilvl.d       vr2,    vr5,    vr4
++    vilvl.d       vr3,    vr7,    vr6
++
++    vsubwev.h.bu  vr4,    vr0,    vr2
++    vsubwod.h.bu  vr5,    vr0,    vr2
++    vsubwev.h.bu  vr6,    vr1,    vr3
++    vsubwod.h.bu  vr7,    vr1,    vr3
++    vadd.h        vr0,    vr4,    vr5
++    vsub.h        vr1,    vr4,    vr5
++    vadd.h        vr2,    vr6,    vr7
++    vsub.h        vr3,    vr6,    vr7
++    vpackev.h     vr4,    vr1,    vr0
++    vpackod.h     vr5,    vr1,    vr0
++    vpackev.h     vr6,    vr3,    vr2
++    vpackod.h     vr7,    vr3,    vr2
++    vadd.h        vr8,    vr4,    vr5
++    vsub.h        vr9,    vr4,    vr5
++    vadd.h        vr10,   vr6,    vr7
++    vsub.h        vr11,   vr6,    vr7
++    vilvl.d       vr4,    vr9,    vr8
++    vilvh.d       vr5,    vr9,    vr8
++    vilvl.d       vr6,    vr11,   vr10
++    vilvh.d       vr7,    vr11,   vr10
++    vadd.h        vr8,    vr4,    vr5
++    vsub.h        vr9,    vr4,    vr5
++    vadd.h        vr10,   vr6,    vr7
++    vsub.h        vr11,   vr6,    vr7
++    vadd.h        vr0,    vr8,    vr10
++    vsub.h        vr1,    vr8,    vr10
++    vadd.h        vr2,    vr9,    vr11
++    vsub.h        vr3,    vr9,    vr11
++    vadda.h       vr4,    vr1,    vr0
++    vadda.h       vr5,    vr3,    vr2
++    vadd.h        \out,   vr5,    vr4
++.endm
++
++
++/*
++ * int satd_8x4(const pixel* pix1, intptr_t stride_pix1,
++ *              const pixel* pix2, intptr_t stride_pix2)
++ */
++function x265_pixel_satd_8x4_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++
++    vhaddw.wu.hu  vr12,   vr12,   vr12
++    vhaddw.du.wu  vr12,   vr12,   vr12
++    vhaddw.qu.du  vr12,   vr12,   vr12
++    vpickve2gr.wu t4,     vr12,   0
++    srli.d        a0,     t4,     1
++endfunc
++
++.macro pixel_satd_4x4_core_lsx out
++    vilvl.w         vr1,   vr2,  vr1
++    vilvl.w         vr3,   vr4,  vr3
++    vilvl.d         vr1,   vr3,  vr1
++    vilvl.w         vr5,   vr6,  vr5
++    vilvl.w         vr7,   vr8,  vr7
++    vilvl.d         vr5,   vr7,  vr5
++
++    vsubwev.h.bu    vr9,   vr1,  vr5
++    vsubwod.h.bu    vr10,  vr1,  vr5
++    vadd.h          vr11,  vr9,  vr10  /* a0 + a1 */
++    vsub.h          vr12,  vr9,  vr10  /* a0 - a1 */
++    vpackev.h       vr9,   vr12, vr11
++    vpackod.h       vr10,  vr12, vr11
++    vadd.h          vr11,  vr9,  vr10  /* b0 + b1 */
++    vsub.h          vr12,  vr9,  vr10  /* b0 - b1 */
++    vpackev.w       vr9,   vr12, vr11
++    vpackod.w       vr10,  vr12, vr11
++    vadd.h          vr11,  vr9,  vr10  /* HADAMARD4 */
++    vsub.h          vr12,  vr9,  vr10
++    vpackev.d       vr9,   vr12, vr11
++    vpackod.d       vr10,  vr12, vr11
++    vadd.h          vr11,  vr9,  vr10
++    vsub.h          vr12,  vr9,  vr10
++    vpackev.d       vr9,   vr12, vr11
++    vpackod.d       vr10,  vr12, vr11
++    vadda.h         \out,  vr9,  vr10
++.endm
++
++function x265_pixel_satd_4x4_lsx
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++
++    // Load data from pix1 and pix2
++    FLDS_LOADX_4    a0,    a1,   t2,  t4,  f1, f2, f3, f4
++    FLDS_LOADX_4    a2,    a3,   t3,  t5,  f5, f6, f7, f8
++    pixel_satd_4x4_core_lsx vr13
++    vhaddw.wu.hu    vr13,  vr13, vr13
++    vhaddw.du.wu    vr13,  vr13, vr13
++    vhaddw.qu.du    vr13,  vr13, vr13
++    vpickve2gr.wu   t5,    vr13,  0
++    srli.d          a0,    t5,   1
++endfunc
++
++.macro pixel_satd_4x h
++function x265_pixel_satd_4x\h\()_lsx
++    slli.d        t2,     a1,     1
++    slli.d        t3,     a3,     1
++    add.d         t4,     a1,     t2
++    add.d         t5,     a3,     t3
++
++    // Load data from pix1 and pix2
++    FLDS_LOADX_4  a0,     a1,     t2,  t4,  f1, f2, f3, f4
++    FLDS_LOADX_4  a2,     a3,     t3,  t5,  f5, f6, f7, f8
++    pixel_satd_4x4_core_lsx vr13
++    vhaddw.wu.hu  vr13,   vr13,   vr13
++.rept (\h>>2)-1
++    alsl.d        a0,     a1,     a0,  2
++    alsl.d        a2,     a3,     a2,  2
++    FLDS_LOADX_4  a0,     a1,     t2,  t4,  f1, f2, f3, f4
++    FLDS_LOADX_4  a2,     a3,     t3,  t5,  f5, f6, f7, f8
++    pixel_satd_4x4_core_lsx vr14
++    vhaddw.wu.hu  vr14,   vr14,   vr14
++    vadd.w        vr13,   vr14,   vr13
++.endr
++    vhaddw.du.wu  vr13,   vr13,   vr13
++    vhaddw.qu.du  vr13,   vr13,   vr13
++    vpickve2gr.wu t5,     vr13,   0
++    srli.d        a0,     t5,     1
++endfunc
++.endm
++
++pixel_satd_4x 8
++pixel_satd_4x 16
++pixel_satd_4x 32
++
++function x265_pixel_satd_4x8_lasx
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++    // Load data from pix1 and pix2
++    LSX_LOADX_4     a0,    a1,   t2,  t4,  vr1, vr2, vr3, vr4
++    LSX_LOADX_4     a2,    a3,   t3,  t5,  vr5, vr6, vr7, vr8
++    vilvl.w         vr1,   vr2,  vr1
++    vilvl.w         vr3,   vr4,  vr3
++    vilvl.d         vr9,   vr3,  vr1
++    vilvl.w         vr5,   vr6,  vr5
++    vilvl.w         vr7,   vr8,  vr7
++    vilvl.d         vr10,  vr7,  vr5
++
++    slli.d          t0,    a1,   2
++    slli.d          t1,    a3,   2
++    add.d           a0,    a0,   t0
++    add.d           a2,    a2,   t1
++    // Load data from pix1 and pix2
++    LSX_LOADX_4     a0,    a1,   t2,  t4,  vr1, vr2, vr3, vr4
++    LSX_LOADX_4     a2,    a3,   t3,  t5,  vr5, vr6, vr7, vr8
++    vilvl.w         vr1,   vr2,  vr1
++    vilvl.w         vr3,   vr4,  vr3
++    vilvl.d         vr1,   vr3,  vr1
++    vilvl.w         vr5,   vr6,  vr5
++    vilvl.w         vr7,   vr8,  vr7
++    vilvl.d         vr5,   vr7,  vr5
++    xvpermi.q       xr1,   xr9,  0x20
++    xvpermi.q       xr5,   xr10, 0x20
++
++    xvsubwev.h.bu   xr9,   xr1,  xr5
++    xvsubwod.h.bu   xr10,  xr1,  xr5
++    xvadd.h         xr11,  xr9,  xr10  /* a0 + a1 */
++    xvsub.h         xr12,  xr9,  xr10  /* a0 - a1 */
++    xvpackev.h      xr9,   xr12, xr11
++    xvpackod.h      xr10,  xr12, xr11
++    xvadd.h         xr11,  xr9,  xr10  /* b0 + b1 */
++    xvsub.h         xr12,  xr9,  xr10  /* b0 - b1 */
++    xvpackev.w      xr9,   xr12, xr11
++    xvpackod.w      xr10,  xr12, xr11
++    xvadd.h         xr11,  xr9,  xr10  /* HADAMARD4 */
++    xvsub.h         xr12,  xr9,  xr10
++    xvpackev.d      xr9,   xr12, xr11
++    xvpackod.d      xr10,  xr12, xr11
++    xvadd.h         xr11,  xr9,  xr10
++    xvsub.h         xr12,  xr9,  xr10
++    xvpackev.d      xr9,   xr12, xr11
++    xvpackod.d      xr10,  xr12, xr11
++    xvadda.h        xr9,   xr9,  xr10
++    xvhaddw.wu.hu   xr9,   xr9,  xr9
++    xvhaddw.du.wu   xr9,   xr9,  xr9
++    xvhaddw.qu.du   xr9,   xr9,  xr9
++    xvpickve2gr.wu  t6,    xr9,  0
++    xvpickve2gr.wu  t7,    xr9,  4
++    add.d           t6,    t6,   t7
++    srli.d          a0,    t6,   1
++endfunc
++
++.macro pixel_satd_4x8_core_lasx out
++    LSX_LOADX_4 a0, a1, t2, t4, vr1, vr2, vr3, vr4
++    LSX_LOADX_4 a2, a3, t3, t5, vr5, vr6, vr7, vr8
++    vilvl.w         vr1,     vr2,     vr1
++    vilvl.w         vr3,     vr4,     vr3
++    vilvl.d         vr9,     vr3,     vr1
++    vilvl.w         vr5,     vr6,     vr5
++    vilvl.w         vr7,     vr8,     vr7
++    vilvl.d         vr10,    vr7,     vr5
++
++    slli.d          t0,      a1,      2
++    slli.d          t1,      a3,      2
++    add.d           a0,      a0,      t0
++    LSX_LOADX_4 a0, a1, t2, t4, vr1, vr2, vr3, vr4
++    add.d           a2,      a2,      t1
++    LSX_LOADX_4 a2, a3, t3, t5, vr5, vr6, vr7, vr8
++    vilvl.w         vr1,     vr2,     vr1
++    vilvl.w         vr3,     vr4,     vr3
++    vilvl.d         vr1,     vr3,     vr1
++    vilvl.w         vr5,     vr6,     vr5
++    vilvl.w         vr7,     vr8,     vr7
++    vilvl.d         vr5,     vr7,     vr5
++    xvpermi.q       xr1,     xr9,     0x20
++    xvpermi.q       xr5,     xr10,    0x20
++
++    xvsubwev.h.bu   xr9,     xr1,     xr5
++    xvsubwod.h.bu   xr10,    xr1,     xr5
++    xvadd.h         xr11,    xr9,     xr10  /* a0 + a1 */
++    xvsub.h         xr12,    xr9,     xr10  /* a0 - a1 */
++    xvpackev.h      xr9,     xr12,    xr11
++    xvpackod.h      xr10,    xr12,    xr11
++    xvadd.h         xr11,    xr9,     xr10  /* b0 + b1 */
++    xvsub.h         xr12,    xr9,     xr10  /* b0 - b1 */
++    xvpackev.w      xr9,     xr12,    xr11
++    xvpackod.w      xr10,    xr12,    xr11
++    xvadd.h         xr11,    xr9,     xr10  /* HADAMARD4 */
++    xvsub.h         xr12,    xr9,     xr10
++    xvpackev.d      xr9,     xr12,    xr11
++    xvpackod.d      xr10,    xr12,    xr11
++    xvadd.h         xr11,    xr9,     xr10
++    xvsub.h         xr12,    xr9,     xr10
++    xvpackev.d      xr9,     xr12,    xr11
++    xvpackod.d      xr10,    xr12,    xr11
++    xvadda.h        \out,    xr9,     xr10
++.endm
++
++.macro pixel_satd_4x_lasx h
++function x265_pixel_satd_4x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    add.d           t4,      a1,      t2
++    add.d           t5,      a3,      t3
++
++    pixel_satd_4x8_core_lasx xr13
++    xvhaddw.wu.hu   xr13,    xr13,    xr13
++
++.rept (\h>>3)-1
++    add.d           a0,      a0,      t0
++    add.d           a2,      a2,      t1
++    pixel_satd_4x8_core_lasx xr14
++    xvhaddw.wu.hu   xr14,    xr14,    xr14
++    xvadd.w         xr13,    xr13,    xr14
++.endr
++
++    xvhaddw.du.wu   xr13,    xr13,    xr13
++    xvhaddw.qu.du   xr13,    xr13,    xr13
++    xvpickve2gr.wu  t6,      xr13,    0
++    xvpickve2gr.wu  t7,      xr13,    4
++    add.d           t7,      t6,      t7
++    srli.d          a0,      t7,      1
++endfunc
++.endm
++
++pixel_satd_4x_lasx 16
++pixel_satd_4x_lasx 32
++
++function x265_pixel_satd_8x8_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t5,      a3,      1
++    add.d           t3,      a1,      t2
++    add.d           t6,      a3,      t5
++    slli.d          t4,      t2,      1
++    slli.d          t7,      t5,      1
++    LSX_LOADX_4 a0, a1, t2, t3, vr0, vr1, vr2, vr3
++    add.d           a0,      a0,      t4
++    LSX_LOADX_4 a0, a1, t2, t3, vr4, vr5, vr6, vr7
++    LSX_LOADX_4 a2, a3, t5, t6, vr8, vr9, vr10, vr11
++    add.d           a2,      a2,      t7
++    LSX_LOADX_4 a2, a3, t5, t6, vr12, vr13, vr14, vr15
++
++    vilvl.d         vr0,     vr1,     vr0
++    vilvl.d         vr1,     vr3,     vr2
++    vilvl.d         vr2,     vr5,     vr4
++    vilvl.d         vr3,     vr7,     vr6
++    xvpermi.q       xr0,     xr2,     0x02
++    xvpermi.q       xr1,     xr3,     0x02
++    vilvl.d         vr2,     vr9,     vr8
++    vilvl.d         vr3,     vr11,    vr10
++    vilvl.d         vr4,     vr13,    vr12
++    vilvl.d         vr5,     vr15,    vr14
++    xvpermi.q       xr2,     xr4,     0x02
++    xvpermi.q       xr3,     xr5,     0x02
++
++    // HADAMARD4
++    xvsubwev.h.bu   xr4,     xr0,     xr2
++    xvsubwod.h.bu   xr5,     xr0,     xr2
++    xvsubwev.h.bu   xr6,     xr1,     xr3
++    xvsubwod.h.bu   xr7,     xr1,     xr3
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvpackev.h      xr4,     xr1,     xr0
++    xvpackod.h      xr5,     xr1,     xr0
++    xvpackev.h      xr6,     xr3,     xr2
++    xvpackod.h      xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvilvl.h        xr4,     xr1,     xr0
++    xvilvh.h        xr5,     xr1,     xr0
++    xvilvl.h        xr6,     xr3,     xr2
++    xvilvh.h        xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr1,     xr4,     xr5
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr0,     xr2
++    xvadd.h         xr5,     xr1,     xr3
++    xvsub.h         xr6,     xr0,     xr2
++    xvsub.h         xr7,     xr1,     xr3
++    xvadda.h        xr0,     xr4,     xr5
++    xvadda.h        xr1,     xr6,     xr7
++    xvadd.h         xr0,     xr0,     xr1
++    xvhaddw.wu.hu   xr0,     xr0,     xr0
++    xvhaddw.du.wu   xr0,     xr0,     xr0
++    xvhaddw.qu.du   xr0,     xr0,     xr0
++    xvpickve2gr.wu  t0,      xr0,     0
++    xvpickve2gr.wu  t1,      xr0,     4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++
++.macro pixel_satd_8x h
++function x265_pixel_satd_8x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++.rept (\h>>2)-1
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_8x 8
++pixel_satd_8x 12
++pixel_satd_8x 16
++pixel_satd_8x 32
++pixel_satd_8x 64
++
++.macro pixel_satd_8x8_core_lasx out
++    LSX_LOADX_4 a0, a1, t2, t3, vr0, vr1, vr2, vr3
++    add.d           a0,      a0,      t4
++    LSX_LOADX_4 a0, a1, t2, t3, vr4, vr5, vr6, vr7
++    LSX_LOADX_4 a2, a3, t5, t6, vr8, vr9, vr10, vr11
++    add.d           a2,      a2,      t7
++    LSX_LOADX_4 a2, a3, t5, t6, vr12, vr13, vr14, vr15
++    vilvl.d         vr0,     vr1,     vr0
++    vilvl.d         vr1,     vr3,     vr2
++    vilvl.d         vr2,     vr5,     vr4
++    vilvl.d         vr3,     vr7,     vr6
++    xvpermi.q       xr0,     xr2,     0x02
++    xvpermi.q       xr1,     xr3,     0x02
++    vilvl.d         vr2,     vr9,     vr8
++    vilvl.d         vr3,     vr11,    vr10
++    vilvl.d         vr4,     vr13,    vr12
++    vilvl.d         vr5,     vr15,    vr14
++    xvpermi.q       xr2,     xr4,     0x02
++    xvpermi.q       xr3,     xr5,     0x02
++
++    // HADAMARD4
++    xvsubwev.h.bu   xr4,     xr0,     xr2
++    xvsubwod.h.bu   xr5,     xr0,     xr2
++    xvsubwev.h.bu   xr6,     xr1,     xr3
++    xvsubwod.h.bu   xr7,     xr1,     xr3
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvpackev.h      xr4,     xr1,     xr0
++    xvpackod.h      xr5,     xr1,     xr0
++    xvpackev.h      xr6,     xr3,     xr2
++    xvpackod.h      xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvilvl.h        xr4,     xr1,     xr0
++    xvilvh.h        xr5,     xr1,     xr0
++    xvilvl.h        xr6,     xr3,     xr2
++    xvilvh.h        xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr1,     xr4,     xr5
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr0,     xr2
++    xvadd.h         xr5,     xr1,     xr3
++    xvsub.h         xr6,     xr0,     xr2
++    xvsub.h         xr7,     xr1,     xr3
++    xvadda.h        xr0,     xr4,     xr5
++    xvadda.h        xr1,     xr6,     xr7
++    xvadd.h         \out,    xr0,     xr1
++.endm
++
++.macro pixel_satd_8x_lasx h
++function x265_pixel_satd_8x\h\()_lasx
++    slli.d          t2,      a1,      1
++    add.d           t3,      a1,      t2
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      1
++    add.d           t6,      a3,      t5
++    slli.d          t7,      a3,      2
++
++    pixel_satd_8x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++.rept (\h>>3)-1
++    add.d           a0,      a0,      t4
++    add.d           a2,      a2,      t7
++
++    pixel_satd_8x8_core_lasx xr17
++    xvhaddw.wu.hu   xr17,    xr17,    xr17
++    xvadd.w         xr16,    xr17,    xr16
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++pixel_satd_8x_lasx 16
++pixel_satd_8x_lasx 32
++pixel_satd_8x_lasx 64
++
++function x265_pixel_satd_16x4_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    pixel_satd_8x4_core_lsx t5, t6, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++
++function x265_pixel_satd_16x8_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      t2,      1
++    slli.d          t5,      t3,      1
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    // Load data from pix1 and pix2
++    LSX_LOADX_4 a0, a1, t2, t6, vr0, vr1, vr2, vr3
++    add.d           a0,      a0,      t4
++    LSX_LOADX_4 a0, a1, t2, t6, vr4, vr5, vr6, vr7
++    LSX_LOADX_4 a2, a3, t3, t7, vr8, vr9, vr10, vr11
++    add.d           a2,      a2,      t5
++    LSX_LOADX_4 a2, a3, t3, t7,  vr12, vr13, vr14, vr15
++    xvpermi.q       xr0,     xr4,     0x02
++    xvpermi.q       xr1,     xr5,     0x02
++    xvpermi.q       xr2,     xr6,     0x02
++    xvpermi.q       xr3,     xr7,     0x02
++    xvpermi.q       xr8,     xr12,    0x02
++    xvpermi.q       xr9,     xr13,    0x02
++    xvpermi.q       xr10,    xr14,    0x02
++    xvpermi.q       xr11,    xr15,    0x02
++
++    // HADAMARD4
++    xvsubwev.h.bu   xr4,     xr0,     xr8
++    xvsubwod.h.bu   xr5,     xr0,     xr8
++    xvsubwev.h.bu   xr6,     xr1,     xr9
++    xvsubwod.h.bu   xr7,     xr1,     xr9
++    xvsubwev.h.bu   xr8,     xr2,     xr10
++    xvsubwod.h.bu   xr9,     xr2,     xr10
++    xvsubwev.h.bu   xr12,    xr3,     xr11
++    xvsubwod.h.bu   xr13,    xr3,     xr11
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr8,     xr9
++    xvsub.h         xr5,     xr8,     xr9
++    xvadd.h         xr6,     xr12,    xr13
++    xvsub.h         xr7,     xr12,    xr13
++    xvpackev.h      xr8,     xr5,     xr4
++    xvpackod.h      xr9,     xr5,     xr4
++    xvpackev.h      xr10,    xr7,     xr6
++    xvpackod.h      xr11,    xr7,     xr6
++    xvpackev.h      xr4,     xr1,     xr0
++    xvpackod.h      xr5,     xr1,     xr0
++    xvpackev.h      xr6,     xr3,     xr2
++    xvpackod.h      xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr8,     xr9
++    xvsub.h         xr5,     xr8,     xr9
++    xvadd.h         xr6,     xr10,    xr11
++    xvsub.h         xr7,     xr10,    xr11
++    xvilvl.h        xr8,     xr1,     xr0
++    xvilvl.h        xr9,     xr3,     xr2
++    xvilvl.h        xr10,    xr5,     xr4
++    xvilvl.h        xr11,    xr7,     xr6
++    xvilvh.h        xr0,     xr1,     xr0
++    xvilvh.h        xr1,     xr3,     xr2
++    xvilvh.h        xr2,     xr5,     xr4
++    xvilvh.h        xr3,     xr7,     xr6
++    xvadd.h         xr4,     xr8,     xr9
++    xvadd.h         xr6,     xr10,    xr11
++    xvsub.h         xr5,     xr8,     xr9
++    xvsub.h         xr7,     xr10,    xr11
++    xvadd.h         xr8,     xr4,     xr6
++    xvadd.h         xr9,     xr5,     xr7
++    xvsub.h         xr10,    xr4,     xr6
++    xvsub.h         xr11,    xr5,     xr7
++    xvadd.h         xr4,     xr0,     xr1
++    xvadd.h         xr6,     xr2,     xr3
++    xvsub.h         xr5,     xr0,     xr1
++    xvsub.h         xr7,     xr2,     xr3
++    xvadd.h         xr0,     xr4,     xr6
++    xvadd.h         xr1,     xr5,     xr7
++    xvsub.h         xr2,     xr4,     xr6
++    xvsub.h         xr3,     xr5,     xr7
++    xvadda.h        xr8,     xr8,     xr9
++    xvadda.h        xr9,     xr10,    xr11
++    xvadda.h        xr0,     xr0,     xr1
++    xvadda.h        xr1,     xr2,     xr3
++    xvadd.h         xr8,     xr8,     xr9
++    xvadd.h         xr0,     xr0,     xr1
++    xvadd.h         xr0,     xr0,     xr8
++
++    xvhaddw.wu.hu   xr0,     xr0,     xr0
++    xvhaddw.du.wu   xr0,     xr0,     xr0
++    xvhaddw.qu.du   xr0,     xr0,     xr0
++    xvpickve2gr.wu  t0,      xr0,     0
++    xvpickve2gr.wu  t1,      xr0,     4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++
++.macro pixel_satd_12x_lsx h
++function x265_pixel_satd_12x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr21
++    vhaddw.wu.hu    vr21,    vr21,    vr21
++
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    FLDS_LOADX_4 t5, a1, t0, t1, f1, f2, f3, f4
++    FLDS_LOADX_4 t6, a3, t2, t3, f5, f6, f7, f8
++    pixel_satd_4x4_core_lsx vr22
++    vhaddw.wu.hu    vr22,    vr22,    vr22
++
++.rept (\h>>2)-1
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr14
++    vhaddw.wu.hu    vr14,    vr14,    vr14
++
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    FLDS_LOADX_4 t5, a1, t0, t1, f1, f2, f3, f4
++    FLDS_LOADX_4 t6, a3, t2, t3, f5, f6, f7, f8
++    pixel_satd_4x4_core_lsx vr20
++    vhaddw.wu.hu    vr20,    vr20,    vr20
++
++    vadd.w          vr21,    vr21,    vr14
++    vadd.w          vr22,    vr22,    vr20
++.endr
++
++    vadd.w          vr12,    vr21,    vr22
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_12x_lsx 16
++pixel_satd_12x_lsx 32
++
++.macro pixel_satd_16x_lsx h
++function x265_pixel_satd_16x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    pixel_satd_8x4_core_lsx t5, t6, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++
++.rept (\h>>2)-1
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr14
++    vhaddw.wu.hu    vr14,    vr14,    vr14
++
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    pixel_satd_8x4_core_lsx t5, t6, vr15
++    vhaddw.wu.hu    vr15,    vr15,    vr15
++
++    vadd.w          vr12,    vr14,    vr12
++    vadd.w          vr13,    vr15,    vr13
++.endr
++    vadd.w          vr12,    vr12,    vr13
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_16x_lsx 8
++pixel_satd_16x_lsx 12
++pixel_satd_16x_lsx 16
++pixel_satd_16x_lsx 24
++pixel_satd_16x_lsx 32
++
++function x265_pixel_satd_16x64_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    pixel_satd_8x4_core_lsx t5, t6, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++
++.rept 15
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++
++    addi.d          t5,      a0,      8
++    addi.d          t6,      a2,      8
++    pixel_satd_8x4_core_lsx t5, t6, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++
++.macro pixel_satd_24x_lsx h
++function x265_pixel_satd_24x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++.rept 2
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++.endr
++
++.rept (\h>>2)-1
++    addi.d          a0,      a0,      -16
++    addi.d          a2,      a2,      -16
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++
++.rept 2
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++.endr
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_24x_lsx 32
++pixel_satd_24x_lsx 64
++
++.macro pixel_satd_32x8_lsx h
++function x265_pixel_satd_32x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++.rept 3
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++.endr
++
++.rept (\h>>2)-1
++    addi.d          a0,      a0,      -24
++    addi.d          a2,      a2,      -24
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr14
++    vhaddw.wu.hu    vr14,    vr14,    vr14
++    vadd.w          vr12,    vr12,    vr14
++
++.rept 3
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr15
++    vhaddw.wu.hu    vr15,    vr15,    vr15
++    vadd.w          vr12,    vr12,    vr15
++.endr
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_32x8_lsx 8
++pixel_satd_32x8_lsx 16
++
++.macro pixel_satd_32x24_lsx h
++function x265_pixel_satd_32x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++.rept 3
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++.endr
++
++.rept (\h>>2)-1
++    addi.d          a0,      a0,      -24
++    addi.d          a2,      a2,      -24
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++
++.rept 3
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++.endr
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_32x24_lsx 24
++pixel_satd_32x24_lsx 32
++pixel_satd_32x24_lsx 48
++pixel_satd_32x24_lsx 64
++
++function x265_pixel_satd_48x64_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++.rept 5
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++.endr
++
++.rept 15
++    addi.d          a0,      a0,      -40
++    addi.d          a2,      a2,      -40
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++.rept 5
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++.endr
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++
++.macro pixel_satd_64x_lsx h
++function x265_pixel_satd_64x\h\()_lsx
++    slli.d          t0,      a1,      1
++    add.d           t1,      t0,      a1
++    slli.d          t2,      a3,      1
++    add.d           t3,      t2,      a3
++
++    pixel_satd_8x4_core_lsx a0, a2, vr12
++    vhaddw.wu.hu    vr12,    vr12,    vr12
++
++.rept 7
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr12,    vr13
++.endr
++
++.rept (\h>>2)-1
++    addi.d          a0,      a0,      -56
++    addi.d          a2,      a2,      -56
++    alsl.d          a0,      a1,      a0,      2
++    alsl.d          a2,      a3,      a2,      2
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++
++.rept 7
++    addi.d          a0,      a0,      8
++    addi.d          a2,      a2,      8
++    pixel_satd_8x4_core_lsx a0, a2, vr13
++    vhaddw.wu.hu    vr13,    vr13,    vr13
++    vadd.w          vr12,    vr13,    vr12
++.endr
++.endr
++
++    vhaddw.du.wu    vr12,    vr12,    vr12
++    vhaddw.qu.du    vr12,    vr12,    vr12
++    vpickve2gr.wu   t4,      vr12,    0
++    srli.d          a0,      t4,      1
++endfunc
++.endm
++
++pixel_satd_64x_lsx 16
++pixel_satd_64x_lsx 32
++pixel_satd_64x_lsx 48
++pixel_satd_64x_lsx 64
++
++.macro pixel_satd_12x8_core_lasx out
++    LSX_LOADX_4 a0, a1, t2, t6, vr0, vr1, vr2, vr3
++    add.d           t0,      a0,      t4
++    LSX_LOADX_4 t0, a1, t2, t6, vr4, vr5, vr6, vr7
++    LSX_LOADX_4 a2, a3, t3, t7, vr8, vr9, vr10, vr11
++    add.d           t1,      a2,      t5
++    LSX_LOADX_4 t1, a3, t3, t7, vr12, vr13, vr14, vr15
++
++.irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7, \
++    vr8, vr9, vr10, vr11, vr12, vr13, vr14, vr15
++    vinsgr2vr.w     \i,    zero,    3
++.endr
++
++    xvpermi.q       xr0,     xr4,     0x02
++    xvpermi.q       xr1,     xr5,     0x02
++    xvpermi.q       xr2,     xr6,     0x02
++    xvpermi.q       xr3,     xr7,     0x02
++    xvpermi.q       xr8,     xr12,    0x02
++    xvpermi.q       xr9,     xr13,    0x02
++    xvpermi.q       xr10,    xr14,    0x02
++    xvpermi.q       xr11,    xr15,    0x02
++
++    // HADAMARD4
++    xvsubwev.h.bu   xr4,     xr0,     xr8
++    xvsubwod.h.bu   xr5,     xr0,     xr8
++    xvsubwev.h.bu   xr6,     xr1,     xr9
++    xvsubwod.h.bu   xr7,     xr1,     xr9
++    xvsubwev.h.bu   xr8,     xr2,     xr10
++    xvsubwod.h.bu   xr9,     xr2,     xr10
++    xvsubwev.h.bu   xr12,    xr3,     xr11
++    xvsubwod.h.bu   xr13,    xr3,     xr11
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr8,     xr9
++    xvsub.h         xr5,     xr8,     xr9
++    xvadd.h         xr6,     xr12,    xr13
++    xvsub.h         xr7,     xr12,    xr13
++    xvpackev.h      xr8,     xr5,     xr4
++    xvpackod.h      xr9,     xr5,     xr4
++    xvpackev.h      xr10,    xr7,     xr6
++    xvpackod.h      xr11,    xr7,     xr6
++    xvpackev.h      xr4,     xr1,     xr0
++    xvpackod.h      xr5,     xr1,     xr0
++    xvpackev.h      xr6,     xr3,     xr2
++    xvpackod.h      xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr8,     xr9
++    xvsub.h         xr5,     xr8,     xr9
++    xvadd.h         xr6,     xr10,    xr11
++    xvsub.h         xr7,     xr10,    xr11
++    xvilvl.h        xr8,     xr1,     xr0
++    xvilvl.h        xr9,     xr3,     xr2
++    xvilvl.h        xr10,    xr5,     xr4
++    xvilvl.h        xr11,    xr7,     xr6
++    xvilvh.h        xr0,     xr1,     xr0
++    xvilvh.h        xr1,     xr3,     xr2
++    xvilvh.h        xr2,     xr5,     xr4
++    xvilvh.h        xr3,     xr7,     xr6
++    xvadd.h         xr4,     xr8,     xr9
++    xvadd.h         xr6,     xr10,    xr11
++    xvsub.h         xr5,     xr8,     xr9
++    xvsub.h         xr7,     xr10,    xr11
++    xvadd.h         xr8,     xr4,     xr6
++    xvadd.h         xr9,     xr5,     xr7
++    xvsub.h         xr10,    xr4,     xr6
++    xvsub.h         xr11,    xr5,     xr7
++    xvadd.h         xr4,     xr0,     xr1
++    xvadd.h         xr6,     xr2,     xr3
++    xvsub.h         xr5,     xr0,     xr1
++    xvsub.h         xr7,     xr2,     xr3
++    xvadd.h         xr0,     xr4,     xr6
++    xvadd.h         xr1,     xr5,     xr7
++    xvsub.h         xr2,     xr4,     xr6
++    xvsub.h         xr3,     xr5,     xr7
++    xvadda.h        xr8,     xr8,     xr9
++    xvadda.h        xr9,     xr10,    xr11
++    xvadda.h        xr0,     xr0,     xr1
++    xvadda.h        xr1,     xr2,     xr3
++    xvadd.h         xr8,     xr8,     xr9
++    xvadd.h         xr0,     xr0,     xr1
++    xvadd.h         \out,    xr0,     xr8
++.endm
++
++.macro pixel_satd_12x_lasx h
++function x265_pixel_satd_12x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_12x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++.rept (\h>>3)-1
++    alsl.d          a0,      t4,      a0,    1
++    alsl.d          a2,      t5,      a2,    1
++    pixel_satd_12x8_core_lasx xr17
++    xvhaddw.wu.hu   xr17,    xr17,    xr17
++    xvadd.w         xr16,    xr17,    xr16
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++pixel_satd_12x_lasx 16
++pixel_satd_12x_lasx 32
++
++.macro pixel_satd_16x8_core_lasx out
++    LSX_LOADX_4 a0, a1, t2, t6, vr0, vr1, vr2, vr3
++    add.d           t0,      a0,      t4
++    LSX_LOADX_4 t0, a1, t2, t6, vr4, vr5, vr6, vr7
++    LSX_LOADX_4 a2, a3, t3, t7, vr8, vr9, vr10, vr11
++    add.d           t1,      a2,      t5
++    LSX_LOADX_4 t1, a3, t3, t7, vr12, vr13, vr14, vr15
++    xvpermi.q       xr0,     xr4,     0x02
++    xvpermi.q       xr1,     xr5,     0x02
++    xvpermi.q       xr2,     xr6,     0x02
++    xvpermi.q       xr3,     xr7,     0x02
++    xvpermi.q       xr8,     xr12,    0x02
++    xvpermi.q       xr9,     xr13,    0x02
++    xvpermi.q       xr10,    xr14,    0x02
++    xvpermi.q       xr11,    xr15,    0x02
++
++    // HADAMARD4
++    xvsubwev.h.bu   xr4,     xr0,     xr8
++    xvsubwod.h.bu   xr5,     xr0,     xr8
++    xvsubwev.h.bu   xr6,     xr1,     xr9
++    xvsubwod.h.bu   xr7,     xr1,     xr9
++    xvsubwev.h.bu   xr8,     xr2,     xr10
++    xvsubwod.h.bu   xr9,     xr2,     xr10
++    xvsubwev.h.bu   xr12,    xr3,     xr11
++    xvsubwod.h.bu   xr13,    xr3,     xr11
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr8,     xr9
++    xvsub.h         xr5,     xr8,     xr9
++    xvadd.h         xr6,     xr12,    xr13
++    xvsub.h         xr7,     xr12,    xr13
++    xvpackev.h      xr8,     xr5,     xr4
++    xvpackod.h      xr9,     xr5,     xr4
++    xvpackev.h      xr10,    xr7,     xr6
++    xvpackod.h      xr11,    xr7,     xr6
++    xvpackev.h      xr4,     xr1,     xr0
++    xvpackod.h      xr5,     xr1,     xr0
++    xvpackev.h      xr6,     xr3,     xr2
++    xvpackod.h      xr7,     xr3,     xr2
++    xvadd.h         xr0,     xr4,     xr5
++    xvsub.h         xr1,     xr4,     xr5
++    xvadd.h         xr2,     xr6,     xr7
++    xvsub.h         xr3,     xr6,     xr7
++    xvadd.h         xr4,     xr8,     xr9
++    xvsub.h         xr5,     xr8,     xr9
++    xvadd.h         xr6,     xr10,    xr11
++    xvsub.h         xr7,     xr10,    xr11
++    xvilvl.h        xr8,     xr1,     xr0
++    xvilvl.h        xr9,     xr3,     xr2
++    xvilvl.h        xr10,    xr5,     xr4
++    xvilvl.h        xr11,    xr7,     xr6
++    xvilvh.h        xr0,     xr1,     xr0
++    xvilvh.h        xr1,     xr3,     xr2
++    xvilvh.h        xr2,     xr5,     xr4
++    xvilvh.h        xr3,     xr7,     xr6
++    xvadd.h         xr4,     xr8,     xr9
++    xvadd.h         xr6,     xr10,    xr11
++    xvsub.h         xr5,     xr8,     xr9
++    xvsub.h         xr7,     xr10,    xr11
++    xvadd.h         xr8,     xr4,     xr6
++    xvadd.h         xr9,     xr5,     xr7
++    xvsub.h         xr10,    xr4,     xr6
++    xvsub.h         xr11,    xr5,     xr7
++    xvadd.h         xr4,     xr0,     xr1
++    xvadd.h         xr6,     xr2,     xr3
++    xvsub.h         xr5,     xr0,     xr1
++    xvsub.h         xr7,     xr2,     xr3
++    xvadd.h         xr0,     xr4,     xr6
++    xvadd.h         xr1,     xr5,     xr7
++    xvsub.h         xr2,     xr4,     xr6
++    xvsub.h         xr3,     xr5,     xr7
++    xvadda.h        xr8,     xr8,     xr9
++    xvadda.h        xr9,     xr10,    xr11
++    xvadda.h        xr0,     xr0,     xr1
++    xvadda.h        xr1,     xr2,     xr3
++    xvadd.h         xr8,     xr8,     xr9
++    xvadd.h         xr0,     xr0,     xr1
++    xvadd.h         \out,    xr0,     xr8
++.endm
++
++.macro pixel_satd_16x_lasx h
++function x265_pixel_satd_16x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++.rept (\h>>3)-1
++    alsl.d          a0,      t4,      a0,    1
++    alsl.d          a2,      t5,      a2,    1
++    pixel_satd_16x8_core_lasx xr17
++    xvhaddw.wu.hu   xr17,    xr17,    xr17
++    xvadd.w         xr16,    xr17,    xr16
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++pixel_satd_16x_lasx 16
++pixel_satd_16x_lasx 24
++pixel_satd_16x_lasx 32
++pixel_satd_16x_lasx 64
++
++.macro pixel_satd_24x_lasx h
++function x265_pixel_satd_24x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_12x8_core_lasx xr16
++    addi.d          a0,      a0,      12
++    addi.d          a2,      a2,      12
++    pixel_satd_12x8_core_lasx xr17
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++    xvhaddw.wu.hu   xr17,    xr17,    xr17
++    xvadd.w         xr16,    xr16,    xr17
++
++.rept (\h>>3)-1
++    addi.d  a0, a0, -12
++    addi.d  a2, a2, -12
++    alsl.d          a0,      t4,      a0,    1
++    alsl.d          a2,      t5,      a2,    1
++    pixel_satd_12x8_core_lasx xr17
++    xvhaddw.wu.hu   xr17,    xr17,    xr17
++    xvadd.w         xr16,    xr17,    xr16
++    addi.d          a0,      a0,      12
++    addi.d          a2,      a2,      12
++    pixel_satd_12x8_core_lasx xr17
++    xvhaddw.wu.hu   xr17,    xr17,    xr17
++    xvadd.w         xr16,    xr16,    xr17
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++pixel_satd_24x_lasx 32
++pixel_satd_24x_lasx 64
++
++function x265_pixel_satd_32x8_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++
++.macro pixel_satd_32x_lasx h
++function x265_pixel_satd_32x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++.rept (\h>>3)-1
++    addi.d          a0,      a0,      -16
++    addi.d          a2,      a2,      -16
++
++    alsl.d          a0,      a1,      a0,    3
++    alsl.d          a2,      a3,      a2,    3
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++.macro pixel_satd_32x24_lasx h
++function x265_pixel_satd_32x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++.rept (\h>>3)-1
++    addi.d          a0,      a0,      -16
++    addi.d          a2,      a2,      -16
++
++    alsl.d          a0,      a1,      a0,    3
++    alsl.d          a2,      a3,      a2,    3
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++pixel_satd_32x_lasx 16
++pixel_satd_32x24_lasx 24
++pixel_satd_32x24_lasx 32
++pixel_satd_32x24_lasx 48
++
++function x265_pixel_satd_32x64_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++.rept 7
++    addi.d          a0,      a0,      -16
++    addi.d          a2,      a2,      -16
++
++    alsl.d          a0,      a1,      a0,    3
++    alsl.d          a2,      a3,      a2,    3
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++
++function x265_pixel_satd_48x64_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++.rept 2
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++
++.rept 7
++    addi.d          a0,      a0,      -32
++    addi.d          a2,      a2,      -32
++
++    alsl.d          a0,      a1,      a0,    3
++    alsl.d          a2,      a3,      a2,    3
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++.rept 2
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++
++.macro pixel_satd_64x_lasx h
++function x265_pixel_satd_64x\h\()_lasx
++    slli.d          t2,      a1,      1
++    slli.d          t3,      a3,      1
++    slli.d          t4,      a1,      2
++    slli.d          t5,      a3,      2
++    add.d           t6,      a1,      t2
++    add.d           t7,      a3,      t3
++
++    pixel_satd_16x8_core_lasx xr16
++    xvhaddw.wu.hu   xr16,    xr16,    xr16
++
++.rept 3
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++
++.rept (\h>>3)-1
++    addi.d          a0,      a0,      -48
++    addi.d          a2,      a2,      -48
++
++    alsl.d          a0,      a1,      a0,    3
++    alsl.d          a2,      a3,      a2,    3
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++
++.rept 3
++    addi.d          a0,      a0,      16
++    addi.d          a2,      a2,      16
++    pixel_satd_16x8_core_lasx xr18
++    xvhaddw.wu.hu   xr18,    xr18,    xr18
++    xvadd.w         xr16,    xr16,    xr18
++.endr
++.endr
++
++    xvhaddw.du.wu   xr16,    xr16,    xr16
++    xvhaddw.qu.du   xr16,    xr16,    xr16
++    xvpickve2gr.wu  t0,      xr16,    0
++    xvpickve2gr.wu  t1,      xr16,    4
++    add.w           t0,      t0,      t1
++    srli.d          a0,      t0,      1
++endfunc
++.endm
++
++pixel_satd_64x_lasx 16
++pixel_satd_64x_lasx 32
++pixel_satd_64x_lasx 48
++pixel_satd_64x_lasx 64
++
++.macro pixel_sa8d_8x8_core_lsx out0, out1, out2, out3
++    FLDD_LOADX_4  a0,     a1,     t0, t1, f0, f1, f2, f3
++    FLDD_LOADX_4  a2,     a3,     t2, t3, f4, f5, f6, f7
++    vilvl.d       vr0,    vr1,    vr0
++    vilvl.d       vr1,    vr3,    vr2
++    vilvl.d       vr4,    vr5,    vr4
++    vilvl.d       vr5,    vr7,    vr6
++    vsubwev.h.bu  vr2,    vr0,    vr4
++    vsubwod.h.bu  vr3,    vr0,    vr4
++    vsubwev.h.bu  vr6,    vr1,    vr5
++    vsubwod.h.bu  vr7,    vr1,    vr5
++    vadd.h        vr8,    vr2,    vr3
++    vsub.h        vr9,    vr2,    vr3
++    vadd.h        vr10,   vr6,    vr7
++    vsub.h        vr11,   vr6,    vr7
++    vpackev.h     vr0,    vr9,    vr8
++    vpackod.h     vr1,    vr9,    vr8
++    vpackev.h     vr2,    vr11,   vr10
++    vpackod.h     vr3,    vr11,   vr10
++    vadd.h        vr4,    vr0,    vr1
++    vsub.h        vr5,    vr0,    vr1
++    vadd.h        vr6,    vr2,    vr3
++    vsub.h        vr7,    vr2,    vr3
++    vilvl.d       vr0,    vr5,    vr4
++    vilvh.d       vr1,    vr5,    vr4
++    vilvl.d       vr2,    vr7,    vr6
++    vilvh.d       vr3,    vr7,    vr6
++    vadd.h        vr4,    vr0,    vr1
++    vsub.h        vr5,    vr0,    vr1
++    vadd.h        vr6,    vr2,    vr3
++    vsub.h        vr7,    vr2,    vr3
++
++    // vr12 vr13 vr14 vr15
++    vpickev.w     vr0,    vr5,    vr4
++    vpickod.w     vr1,    vr5,    vr4
++    vpickev.w     vr2,    vr7,    vr6
++    vpickod.w     vr3,    vr7,    vr6
++    vadd.h        vr8,    vr0,    vr1
++    vsub.h        vr9,    vr0,    vr1
++    vadd.h        vr10,   vr2,    vr3
++    vsub.h        vr11,   vr2,    vr3
++    vadd.h        vr12,   vr8,    vr10
++    vadd.h        vr13,   vr9,    vr11
++    vsub.h        vr14,   vr8,    vr10
++    vsub.h        vr15,   vr9,    vr11
++
++    alsl.d        t4,     a1,     a0,    2
++    alsl.d        t5,     a3,     a2,    2
++    FLDD_LOADX_4  t4,     a1,     t0, t1, f0, f1, f2, f3
++    FLDD_LOADX_4  t5,     a3,     t2, t3, f4, f5, f6, f7
++    vilvl.d       vr0,    vr1,    vr0
++    vilvl.d       vr1,    vr3,    vr2
++    vilvl.d       vr4,    vr5,    vr4
++    vilvl.d       vr5,    vr7,    vr6
++    vsubwev.h.bu  vr2,    vr0,    vr4
++    vsubwod.h.bu  vr3,    vr0,    vr4
++    vsubwev.h.bu  vr6,    vr1,    vr5
++    vsubwod.h.bu  vr7,    vr1,    vr5
++    vadd.h        vr8,    vr2,    vr3
++    vsub.h        vr9,    vr2,    vr3
++    vadd.h        vr10,   vr6,    vr7
++    vsub.h        vr11,   vr6,    vr7
++    vpackev.h     vr0,    vr9,    vr8
++    vpackod.h     vr1,    vr9,    vr8
++    vpackev.h     vr2,    vr11,   vr10
++    vpackod.h     vr3,    vr11,   vr10
++    vadd.h        vr4,    vr0,    vr1
++    vsub.h        vr5,    vr0,    vr1
++    vadd.h        vr6,    vr2,    vr3
++    vsub.h        vr7,    vr2,    vr3
++    vilvl.d       vr0,    vr5,    vr4
++    vilvh.d       vr1,    vr5,    vr4
++    vilvl.d       vr2,    vr7,    vr6
++    vilvh.d       vr3,    vr7,    vr6
++    vadd.h        vr4,    vr0,    vr1
++    vsub.h        vr5,    vr0,    vr1
++    vadd.h        vr6,    vr2,    vr3
++    vsub.h        vr7,    vr2,    vr3
++
++    // vr4 vr5 vr6 vr7
++    vpickev.w     vr0,    vr5,    vr4
++    vpickod.w     vr1,    vr5,    vr4
++    vpickev.w     vr2,    vr7,    vr6
++    vpickod.w     vr3,    vr7,    vr6
++    vadd.h        vr8,    vr0,    vr1
++    vsub.h        vr9,    vr0,    vr1
++    vadd.h        vr10,   vr2,    vr3
++    vsub.h        vr11,   vr2,    vr3
++    vadd.h        vr4,    vr8,    vr10
++    vadd.h        vr5,    vr9,    vr11
++    vsub.h        vr6,    vr8,    vr10
++    vsub.h        vr7,    vr9,    vr11
++
++    vadd.h        vr0,    vr12,   vr4
++    vadd.h        vr1,    vr13,   vr5
++    vadd.h        vr2,    vr14,   vr6
++    vadd.h        vr3,    vr15,   vr7
++    vsub.h        vr8,    vr12,   vr4
++    vsub.h        vr9,    vr13,   vr5
++    vsub.h        vr10,   vr14,   vr6
++    vsub.h        vr11,   vr15,   vr7
++    vadda.h       \out0,  vr0,    vr8
++    vadda.h       \out1,  vr1,    vr9
++    vadda.h       \out2,  vr2,    vr10
++    vadda.h       \out3,  vr3,    vr11
++.endm
++
++function x265_pixel_sa8d_8x8_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr17,   vr0,    vr1
++    vhaddw.wu.hu  vr17,   vr17,   vr17
++    vhaddw.d.w    vr17,   vr17,   vr17
++    vhaddw.q.d    vr17,   vr17,   vr17
++    vpickve2gr.w  t5,     vr17,   0
++    addi.d        t5,     t5,     2
++    srli.d        a0,     t5,     2
++endfunc
++
++function x265_pixel_sa8d_8x16_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr17,   vr0,    vr1
++    vhaddw.wu.hu  vr17,   vr17,   vr17
++    vhaddw.d.w    vr17,   vr17,   vr17
++    vhaddw.q.d    vr17,   vr17,   vr17
++    vpickve2gr.w  t6,     vr17,   0
++    addi.d        t6,     t6,     2
++    srli.d        t6,     t6,     2
++
++    alsl.d        a0,     a1,     a0,    3
++    alsl.d        a2,     a3,     a2,    3
++
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr17,   vr0,    vr1
++    vhaddw.wu.hu  vr17,   vr17,   vr17
++    vhaddw.d.w    vr17,   vr17,   vr17
++    vhaddw.q.d    vr17,   vr17,   vr17
++    vpickve2gr.w  t7,     vr17,   0
++    addi.d        t7,     t7,     2
++    srli.d        t7,     t7,     2
++
++    add.d         a0,     t7,     t6
++endfunc
++
++.macro pixel_sa8d_16x16_core_lsx out
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr16,   vr0,    vr1
++
++    addi.d        a0,     t6,     8
++    addi.d        a2,     t7,     8
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr17,   vr0,    vr1
++
++    alsl.d        a0,     a1,     t6,   3
++    alsl.d        a2,     a3,     t7,   3
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr18,   vr0,    vr1
++
++    addi.d        a0,     a0,     8
++    addi.d        a2,     a2,     8
++    pixel_sa8d_8x8_core_lsx vr0, vr1, vr2, vr3
++    vadd.h        vr0,    vr0,    vr1
++    vadd.h        vr1,    vr2,    vr3
++    vadd.h        vr19,   vr0,    vr1
++
++    vhaddw.wu.hu  vr16,   vr16,   vr16
++    vhaddw.wu.hu  vr17,   vr17,   vr17
++    vhaddw.wu.hu  vr18,   vr18,   vr18
++    vhaddw.wu.hu  vr19,   vr19,   vr19
++    vadd.w        vr16,   vr17,   vr16
++    vadd.w        vr18,   vr19,   vr18
++    vadd.w        vr17,   vr18,   vr16
++    vhaddw.d.w    vr17,   vr17,   vr17
++    vhaddw.q.d    vr17,   vr17,   vr17
++    vpickve2gr.w  t4,     vr17,   0
++    addi.d        t4,     t4,     2
++    srli.d        \out,   t4,     2
++.endm
++
++function x265_pixel_sa8d_16x16_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx a0
++endfunc
++
++function x265_pixel_sa8d_16x32_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t8
++
++    alsl.d        t6,     a1,     t6,     3
++    alsl.d        t7,     a3,     t7,     3
++    alsl.d        t6,     a1,     t6,     3
++    alsl.d        t7,     a3,     t7,     3
++    add.d         a0,     t6,     zero
++    add.d         a2,     t7,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         a0,     t8,     t5
++endfunc
++
++function x265_pixel_sa8d_32x32_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t8
++
++    addi.d        a0,     t6,     16
++    addi.d        a2,     t7,     16
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++
++    addi.d        t6,     t6,     -16
++    addi.d        t7,     t7,     -16
++    alsl.d        t6,     a1,     t6,     3
++    alsl.d        t7,     a3,     t7,     3
++    alsl.d        t6,     a1,     t6,     3
++    alsl.d        t7,     a3,     t7,     3
++
++    add.d         a0,     t6,     zero
++    add.d         a2,     t7,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t8,     t5
++
++    addi.d        a0,     t6,     16
++    addi.d        a2,     t7,     16
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         a0,     t8,     t5
++endfunc
++
++function x265_pixel_sa8d_32x64_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t8
++
++    addi.d        a0,     t6,     16
++    addi.d        a2,     t7,     16
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++
++.rept 3
++    addi.d        t6,     t6,     -16
++    addi.d        t7,     t7,     -16
++
++    alsl.d        t6,     a1,     t6,     3
++    alsl.d        t7,     a3,     t7,     3
++    alsl.d        a0,     a1,     t6,     3
++    alsl.d        a2,     a3,     t7,     3
++
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++
++    addi.d        a0,     t6,     16
++    addi.d        a2,     t7,     16
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++.endr
++    add.d         a0,     t8,     zero
++
++endfunc
++
++function x265_pixel_sa8d_64x64_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     t0,     a1
++    slli.d        t2,     a3,     1
++    add.d         t3,     t2,     a3
++
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t8
++
++.rept 3
++    addi.d        a0,     t6,     16
++    addi.d        a2,     t7,     16
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++.endr
++
++.rept 3
++    addi.d        t6,     t6,     -48
++    addi.d        t7,     t7,     -48
++
++    alsl.d        t6,     a1,     t6,     3
++    alsl.d        t7,     a3,     t7,     3
++    alsl.d        a0,     a1,     t6,     3
++    alsl.d        a2,     a3,     t7,     3
++
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++
++.rept 3
++    addi.d        a0,     t6,     16
++    addi.d        a2,     t7,     16
++    add.d         t6,     a0,     zero
++    add.d         t7,     a2,     zero
++    pixel_sa8d_16x16_core_lsx t5
++    add.d         t8,     t5,     t8
++.endr
++.endr
++
++    add.d         a0,     t8,     zero
++endfunc
++
++.macro pixel_sa8d_8x4_lasx out0, out1
++    // Load data from pix1 and pix2
++    FLDD_LOADX_4    a0,    a1,   t2,  t4,  f1, f2, f3, f4
++    FLDD_LOADX_4    a2,    a3,   t3,  t5,  f5, f6, f7, f8
++    vilvl.d         vr1,   vr2,  vr1
++    vilvl.d         vr3,   vr4,  vr3
++    vilvl.d         vr5,   vr6,  vr5
++    vilvl.d         vr7,   vr8,  vr7
++    xvpermi.q       xr1,   xr3,  0x02
++    xvpermi.q       xr5,   xr7,  0x02
++    xvsubwev.h.bu   xr9,   xr1,  xr5
++    xvsubwod.h.bu   xr10,  xr1,  xr5
++    xvadd.h         xr11,  xr9,  xr10  /* a0 + a1 */
++    xvsub.h         xr12,  xr9,  xr10  /* a0 - a1 */
++    xvpackev.h      xr9,   xr12, xr11
++    xvpackod.h      xr10,  xr12, xr11
++    xvadd.h         xr11,  xr9,  xr10  /* HADAMARD4 */
++    xvsub.h         xr12,  xr9,  xr10
++    xvpackev.w      xr9,   xr12, xr11
++    xvpackod.w      xr10,  xr12, xr11
++    xvadd.h         xr11,  xr9,  xr10
++    xvsub.h         xr12,  xr9,  xr10
++    xvpackev.d      xr9,   xr12, xr11
++    xvpackod.d      xr10,  xr12, xr11
++    xvadd.h         xr11,  xr9,  xr10  /* HADAMARD4 */
++    xvsub.h         xr12,  xr9,  xr10
++    xvor.v          xr13,  xr11, xr11
++    xvor.v          xr14,  xr12, xr12
++    xvpermi.q       xr11,  xr12, 0x02
++    xvpermi.q       xr13,  xr14, 0x13
++    xvadd.h         \out0, xr11, xr13
++    xvsub.h         \out1, xr11, xr13
++.endm
++
++.macro pixel_sa8d_8x8_core_lasx out
++    pixel_sa8d_8x4_lasx xr15, xr16
++
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sa8d_8x4_lasx xr9, xr10
++
++    xvadd.h         xr17,  xr15, xr9
++    xvadd.h         xr18,  xr16, xr10
++    xvsub.h         xr19,  xr15, xr9
++    xvsub.h         xr20,  xr16, xr10
++    xvadda.h        xr17,  xr17, xr18
++    xvadda.h        xr19,  xr19, xr20
++    xvadd.h         xr17,  xr17, xr19
++
++    xvhaddw.wu.hu   xr17,  xr17, xr17
++    xvhaddw.d.w     xr17,  xr17, xr17
++    xvhaddw.q.d     xr17,  xr17, xr17
++    xvpickve2gr.w   t6,    xr17, 0
++    xvpickve2gr.w   t7,    xr17, 4
++    add.d           t6,    t6,   t7
++    addi.d          t6,    t6,   2
++    srli.d          \out,  t6,   2
++.endm
++
++function x265_pixel_sa8d_8x8_lasx
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++
++    pixel_sa8d_8x8_core_lasx a0
++endfunc
++
++function x265_pixel_sa8d_8x16_lasx
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++
++    pixel_sa8d_8x8_core_lasx t8
++
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sa8d_8x8_core_lasx a0
++    add.d           a0,    a0,   t8
++endfunc
++
++.macro pixel_sa8d_16x16_core_lasx out
++    pixel_sa8d_8x4_lasx xr15, xr16
++
++    add.d           a0,    a0,   t6
++    add.d           a2,    a2,   t7
++
++    pixel_sa8d_8x4_lasx xr9, xr10
++
++    xvadd.h         xr17,  xr15, xr9
++    xvadd.h         xr18,  xr16, xr10
++    xvsub.h         xr19,  xr15, xr9
++    xvsub.h         xr20,  xr16, xr10
++    xvadda.h        xr17,  xr17, xr18
++    xvadda.h        xr19,  xr19, xr20
++    xvadd.h         xr21,  xr17, xr19
++
++    add.d           a0,    a0,   t6
++    add.d           a2,    a2,   t7
++
++    pixel_sa8d_8x4_lasx xr15, xr16
++
++    add.d           a0,    a0,   t6
++    add.d           a2,    a2,   t7
++
++    pixel_sa8d_8x4_lasx xr9, xr10
++
++    xvadd.h         xr17,  xr15, xr9
++    xvadd.h         xr18,  xr16, xr10
++    xvsub.h         xr19,  xr15, xr9
++    xvsub.h         xr20,  xr16, xr10
++    xvadda.h        xr17,  xr17, xr18
++    xvadda.h        xr19,  xr19, xr20
++    xvadd.h         xr22,  xr17, xr19
++
++    addi.d          a0,    a0,   8
++    addi.d          a2,    a2,   8
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++
++    pixel_sa8d_8x4_lasx xr15, xr16
++
++    add.d           a0,    a0,   t6
++    add.d           a2,    a2,   t7
++
++    pixel_sa8d_8x4_lasx xr9, xr10
++
++    xvadd.h         xr17,  xr15, xr9
++    xvadd.h         xr18,  xr16, xr10
++    xvsub.h         xr19,  xr15, xr9
++    xvsub.h         xr20,  xr16, xr10
++    xvadda.h        xr17,  xr17, xr18
++    xvadda.h        xr19,  xr19, xr20
++    xvadd.h         xr23,  xr17, xr19
++
++    add.d           a0,    a0,   t6
++    add.d           a2,    a2,   t7
++
++    pixel_sa8d_8x4_lasx xr15, xr16
++
++    add.d           a0,    a0,   t6
++    add.d           a2,    a2,   t7
++
++    pixel_sa8d_8x4_lasx xr9, xr10
++
++    xvadd.h         xr17,  xr15, xr9
++    xvadd.h         xr18,  xr16, xr10
++    xvsub.h         xr19,  xr15, xr9
++    xvsub.h         xr20,  xr16, xr10
++    xvadda.h        xr17,  xr17, xr18
++    xvadda.h        xr19,  xr19, xr20
++    xvadd.h         xr24,  xr17, xr19
++
++    xvadd.h         xr21,  xr21, xr22
++    xvadd.h         xr23,  xr23, xr24
++    xvhaddw.wu.hu   xr21,  xr21, xr21
++    xvhaddw.wu.hu   xr23,  xr23, xr23
++    xvadd.w         xr21,  xr21, xr23
++    xvhaddw.du.wu   xr21,  xr21, xr21
++    xvhaddw.qu.du   xr21,  xr21, xr21
++    xvpickve2gr.du  t0,    xr21, 0
++    xvpickve2gr.du  t1,    xr21, 2
++    add.d           t0,    t0,   t1
++    addi.d          t0,    t0,   2
++    srli.d          \out,  t0,   2
++.endm
++
++function x265_pixel_sa8d_16x16_lasx
++    addi.d          sp,    sp,  -8
++    fst.d           f24,   sp,   0
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++    slli.d          t6,    a1,   2
++    slli.d          t7,    a3,   2
++
++    pixel_sa8d_16x16_core_lasx a0
++
++    fld.d           f24,   sp,   0
++    addi.d          sp,    sp,   8
++endfunc
++
++function x265_pixel_sa8d_16x32_lasx
++    addi.d          sp,    sp,  -8
++    fst.d           f24,   sp,   0
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++    slli.d          t6,    a1,   2
++    slli.d          t7,    a3,   2
++
++    pixel_sa8d_16x16_core_lasx t8
++
++    addi.d          a0,    a0,   -8
++    addi.d          a2,    a2,   -8
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++
++    alsl.d          a0,    t6,   a0,   2
++    alsl.d          a2,    t7,   a2,   2
++
++    pixel_sa8d_16x16_core_lasx a0
++
++    add.d           a0,    a0,   t8
++    fld.d           f24,   sp,   0
++    addi.d          sp,    sp,   8
++endfunc
++
++.macro pixel_sa8d_32x32_core_lasx out
++    pixel_sa8d_16x16_core_lasx t8
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    addi.d          a0,    a0,   8
++    addi.d          a2,    a2,   8
++    pixel_sa8d_16x16_core_lasx a4
++    add.d           t8,    t8,   a4
++
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    addi.d          a0,    a0,   -24
++    addi.d          a2,    a2,   -24
++    alsl.d          a0,    t6,   a0,  2
++    alsl.d          a2,    t7,   a2,  2
++    pixel_sa8d_16x16_core_lasx a4
++    add.d           t8,    t8,   a4
++
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    addi.d          a0,    a0,   8
++    addi.d          a2,    a2,   8
++    pixel_sa8d_16x16_core_lasx a4
++    add.d           \out,  t8,   a4
++.endm
++
++function x265_pixel_sa8d_32x32_lasx
++    addi.d          sp,    sp,  -8
++    fst.d           f24,   sp,   0
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++    slli.d          t6,    a1,   2
++    slli.d          t7,    a3,   2
++
++    pixel_sa8d_32x32_core_lasx a0
++
++    fld.d           f24,   sp,   0
++    addi.d          sp,    sp,   8
++endfunc
++
++function x265_pixel_sa8d_32x64_lasx
++    addi.d          sp,    sp,  -8
++    fst.d           f24,   sp,   0
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++    slli.d          t6,    a1,   2
++    slli.d          t7,    a3,   2
++    addi.d          a5,    a0,   0
++    addi.d          a6,    a2,   0
++
++    pixel_sa8d_32x32_core_lasx a7
++
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    alsl.d          a0,    t6,   a5,   3
++    alsl.d          a2,    t7,   a6,   3
++
++    pixel_sa8d_32x32_core_lasx a0
++
++    add.d           a0,    a0,   a7
++
++    fld.d           f24,   sp,   0
++    addi.d          sp,    sp,   8
++endfunc
++
++function x265_pixel_sa8d_64x64_lasx
++    addi.d          sp,    sp,  -8
++    fst.d           f24,   sp,   0
++    slli.d          t2,    a1,   1
++    slli.d          t3,    a3,   1
++    add.d           t4,    a1,   t2
++    add.d           t5,    a3,   t3
++    slli.d          t6,    a1,   2
++    slli.d          t7,    a3,   2
++    addi.d          a5,    a0,   0
++    addi.d          a6,    a2,   0
++
++    pixel_sa8d_32x32_core_lasx a7
++
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    alsl.d          a0,    t6,   a5,   3
++    alsl.d          a2,    t7,   a6,   3
++
++    pixel_sa8d_32x32_core_lasx t0
++    add.d           a7,    t0,   a7
++
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    addi.d          a0,    a5,   32
++    addi.d          a2,    a6,   32
++    addi.d          a5,    a0,   0
++    addi.d          a6,    a2,   0
++
++    pixel_sa8d_32x32_core_lasx t0
++    add.d           a7,    t0,   a7
++
++    sub.d           t6,    zero, t6
++    sub.d           t7,    zero, t7
++    alsl.d          a0,    t6,   a5,   3
++    alsl.d          a2,    t7,   a6,   3
++
++    pixel_sa8d_32x32_core_lasx a0
++    add.d           a0,    a0,   a7
++
++    fld.d           f24,   sp,   0
++    addi.d          sp,    sp,   8
++endfunc
++
++function x265_weight_pp_lsx
++    ld.d            t0,    sp,   0   // offset
++    slli.w          a5,    a5,   6   // w0 << correction
++
++    nor             t5,    a5,   a5
++    clz.w           t1,    t5
++    blt             t1,    a7,   .unfoldedShift
++
++    srl.w           t1,    a5,   a7
++    vreplgr2vr.b    vr0,   t1
++    srl.w           a6,    a6,   a7
++    add.w           a6,    a6,   t0
++    vreplgr2vr.h    vr1,   a6
++
++    mul.w           t2,    t1,   a6
++    addi.w          t2,    t2,   255
++    add.w           t2,    t2,   t0
++    srli.w          t2,    t2,   16
++    bnez            t2,    .widenTo32Bit
++
++    // 16-bit arithmetic is enough.
++.loopHpp:
++    addi.w          t1,    a3,   0
++    addi.d          t3,    a0,   0
++    addi.d          t4,    a1,   0
++.loopWpp:
++    vld             vr2,   t3,   0
++    vor.v           vr3,   vr1,  vr1
++    vor.v           vr4,   vr1,  vr1
++    addi.d          t1,    t1,   -16
++    vmaddwev.h.b    vr3,   vr2,  vr0
++    vmaddwod.h.b    vr4,   vr2,  vr0
++    vilvl.h         vr5,   vr4,  vr3
++    vilvh.h         vr6,   vr4,  vr3
++    vssrarni.bu.h   vr6,   vr5,  0
++    vst             vr6,   t4,   0
++    addi.d          t3,    t3,   16
++    addi.d          t4,    t4,   16
++    bnez            t1,    .loopWpp
++    add.d           a1,    a1,   a2
++    add.d           a0,    a0,   a2
++    addi.w          a4,    a4,   -1
++    bnez            a4,    .loopHpp
++    b               .weight_pp_lsx_end
++
++    // 32-bit arithmetic is needed.
++.widenTo32Bit:
++.loopHpp32:
++    addi.w          t1,    a3,   0
++    addi.d          t3,    a0,   0
++    addi.d          t4,    a1,   0
++.loopWpp32:
++    vor.v           vr3,   vr1,  vr1
++    vor.v           vr4,   vr1,  vr1
++    fld.d           f2,    t3,   0
++    addi.d          t1,    t1,   -8
++    vsllwil.hu.bu   vr2,   vr2,  0
++    vmaddwev.w.h    vr3,   vr2,  vr0
++    vmaddwod.w.h    vr4,   vr2,  vr0
++    vilvl.w         vr5,   vr4,  vr3
++    vilvh.w         vr6,   vr4,  vr3
++    vssrarni.hu.w   vr6,   vr5,  0
++    vssrarni.bu.h   vr6,   vr6,  0
++    vstelm.d        vr6,   t4,   0,   0
++    addi.d          t3,    t3,   8
++    addi.d          t4,    t4,   8
++    bnez            t1,    .loopWpp32
++    add.d           a1,    a1,   a2
++    add.d           a0,    a0,   a2
++    addi.w          a4,    a4,   -1
++    bnez            a4,    .loopHpp32
++    b               .weight_pp_lsx_end
++
++.unfoldedShift:
++    vreplgr2vr.h    vr0,   a5
++    vreplgr2vr.w    vr1,   a6    // round
++    vreplgr2vr.w    vr10,  a7
++    vreplgr2vr.w    vr11,  t0    // offset
++.loopHppUS:
++    addi.d          t3,    a0,   0
++    addi.d          t4,    a1,   0
++    addi.d          t1,    a3,   0
++.loopWppUS:
++    vor.v           vr3,   vr1,  vr1
++    vor.v           vr4,   vr1,  vr1
++    fld.d           f2,    t3,   0
++    addi.d          t1,    t1,   -8
++    vsllwil.hu.bu   vr2,   vr2,  0
++    vmaddwev.w.h    vr3,   vr2,  vr0
++    vmaddwod.w.h    vr4,   vr2,  vr0
++    vilvl.w         vr5,   vr4,  vr3
++    vilvh.w         vr6,   vr4,  vr3
++    vsrl.w          vr5,   vr5,  vr10
++    vsrl.w          vr6,   vr6,  vr10
++    vadd.w          vr5,   vr5,  vr11
++    vadd.w          vr6,   vr6,  vr11
++    vssrarni.hu.w   vr6,   vr5,  0
++    vssrarni.bu.h   vr6,   vr6,  0
++    vstelm.d        vr6,   t4,   0,    0
++    addi.d          t3,    t3,   8
++    addi.d          t4,    t4,   8
++    bnez            t1,    .loopWppUS
++    add.d           a1,    a1,   a2
++    add.d           a0,    a0,   a2
++    addi.w          a4,    a4,   -1
++    bnez            a4,    .loopHppUS
++
++.weight_pp_lsx_end:
++
++endfunc
++
++function x265_pixel_sub_ps_4x4_lsx
++    slli.d          a1,    a1,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++    FLDS_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDS_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.w         vr1,   vr1,  vr0
++    vilvl.w         vr3,   vr3,  vr2
++    vilvl.w         vr5,   vr5,  vr4
++    vilvl.w         vr7,   vr7,  vr6
++    vilvl.d         vr0,   vr3,  vr1
++    vilvl.d         vr2,   vr7,  vr5
++    vsubwev.h.bu    vr1,   vr0,  vr2
++    vsubwod.h.bu    vr3,   vr0,  vr2
++    vilvl.h         vr4,   vr3,  vr1
++    vilvh.h         vr6,   vr3,  vr1
++    vstelm.d        vr4,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr4,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.d        vr6,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr6,   a0,   0,    1
++endfunc
++
++function x265_pixel_sub_ps_4x8_lsx
++    slli.d          a1,    a1,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++    FLDS_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDS_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.w         vr1,   vr1,  vr0
++    vilvl.w         vr3,   vr3,  vr2
++    vilvl.w         vr5,   vr5,  vr4
++    vilvl.w         vr7,   vr7,  vr6
++    vilvl.d         vr0,   vr3,  vr1
++    vilvl.d         vr2,   vr7,  vr5
++    vsubwev.h.bu    vr1,   vr0,  vr2
++    vsubwod.h.bu    vr3,   vr0,  vr2
++    vilvl.h         vr4,   vr3,  vr1
++    vilvh.h         vr6,   vr3,  vr1
++    vstelm.d        vr4,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr4,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.d        vr6,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr6,   a0,   0,    1
++    add.d           a0,    a0,   a1
++
++    alsl.d          a2,    a4,   a2,   2
++    alsl.d          a3,    a5,   a3,   2
++
++    FLDS_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDS_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.w         vr1,   vr1,  vr0
++    vilvl.w         vr3,   vr3,  vr2
++    vilvl.w         vr5,   vr5,  vr4
++    vilvl.w         vr7,   vr7,  vr6
++    vilvl.d         vr0,   vr3,  vr1
++    vilvl.d         vr2,   vr7,  vr5
++    vsubwev.h.bu    vr1,   vr0,  vr2
++    vsubwod.h.bu    vr3,   vr0,  vr2
++    vilvl.h         vr4,   vr3,  vr1
++    vilvh.h         vr6,   vr3,  vr1
++    vstelm.d        vr4,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr4,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.d        vr6,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr6,   a0,   0,    1
++endfunc
++
++.macro pixel_sub_ps_8x h
++function x265_pixel_sub_ps_8x\h\()_lsx
++    slli.d          a1,    a1,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++
++.rept (\h>>2)
++    FLDD_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDD_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.d         vr1,   vr1,  vr0
++    vilvl.d         vr3,   vr3,  vr2
++    vilvl.d         vr5,   vr5,  vr4
++    vilvl.d         vr7,   vr7,  vr6
++    vsubwev.h.bu    vr0,   vr1,  vr5
++    vsubwod.h.bu    vr2,   vr1,  vr5
++    vsubwev.h.bu    vr4,   vr3,  vr7
++    vsubwod.h.bu    vr6,   vr3,  vr7
++    vilvl.h         vr8,   vr2,  vr0
++    vilvh.h         vr9,   vr2,  vr0
++    vilvl.h         vr1,   vr6,  vr4
++    vilvh.h         vr5,   vr6,  vr4
++    vst             vr8,   a0,   0
++    vstx            vr9,   a0,   a1
++    alsl.d          a0,    a1,   a0,  1
++    vst             vr1,   a0,   0
++    vstx            vr5,   a0,   a1
++
++    alsl.d          a2,    a4,   a2,  2
++    alsl.d          a3,    a5,   a3,  2
++    alsl.d          a0,    a1,   a0,  1
++.endr
++endfunc
++.endm
++
++pixel_sub_ps_8x 8
++pixel_sub_ps_8x 16
++
++.macro sub_ps_16x4_core_lsx
++    LSX_LOADX_4 a2, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 a3, a5, t2, t3, vr4, vr5, vr6, vr7
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++
++    vilvl.h         vr0,   vr9,  vr8
++    vilvh.h         vr1,   vr9,  vr8
++    vilvl.h         vr2,   vr11, vr10
++    vilvh.h         vr3,   vr11, vr10
++    vilvl.h         vr4,   vr13, vr12
++    vilvh.h         vr5,   vr13, vr12
++    vilvl.h         vr6,   vr15, vr14
++    vilvh.h         vr7,   vr15, vr14
++
++    addi.d          t4,    a0,   16
++    vst             vr0,   a0,   0
++    vst             vr1,   t4,   0
++    vstx            vr2,   a0,   a1
++    vstx            vr3,   t4,   a1
++    alsl.d          a0,    a1,   a0,  1
++    addi.d          t4,    a0,   16
++    vst             vr4,   a0,   0
++    vst             vr5,   t4,   0
++    vstx            vr6,   a0,   a1
++    vstx            vr7,   t4,   a1
++.endm
++
++.macro pixel_sub_ps_16x h
++function x265_pixel_sub_ps_16x\h\()_lsx
++    slli.d          a1,    a1,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++
++.rept (\h>>2)
++
++    sub_ps_16x4_core_lsx
++
++    alsl.d          a2,    a4,   a2,  2
++    alsl.d          a3,    a5,   a3,  2
++    alsl.d          a0,    a1,   a0,  1
++.endr
++endfunc
++.endm
++
++pixel_sub_ps_16x 16
++pixel_sub_ps_16x 32
++
++.macro sub_ps_32x4_core_lsx
++    LSX_LOADX_4 a2, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 a3, a5, t2, t3, vr4, vr5, vr6, vr7
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++
++    vilvl.h         vr16,  vr9,  vr8
++    vilvh.h         vr17,  vr9,  vr8
++    vilvl.h         vr18,  vr11, vr10
++    vilvh.h         vr19,  vr11, vr10
++    vilvl.h         vr20,  vr13, vr12
++    vilvh.h         vr21,  vr13, vr12
++    vilvl.h         vr22,  vr15, vr14
++    vilvh.h         vr23,  vr15, vr14
++
++    addi.d          t5,    a2,   16
++    addi.d          t6,    a3,   16
++
++    LSX_LOADX_4 t5, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 t6, a5, t2, t3, vr4, vr5, vr6, vr7
++
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++
++    vilvl.h         vr0,   vr9,  vr8
++    vilvh.h         vr1,   vr9,  vr8
++    vilvl.h         vr2,   vr11, vr10
++    vilvh.h         vr3,   vr11, vr10
++    vilvl.h         vr4,   vr13, vr12
++    vilvh.h         vr5,   vr13, vr12
++    vilvl.h         vr6,   vr15, vr14
++    vilvh.h         vr7,   vr15, vr14
++
++    vst             vr16,  a0,   0
++    vst             vr17,  a0,   16
++    vst             vr0,   a0,   32
++    vst             vr1,   a0,   48
++    add.d           a0,    a0,   a1
++    vst             vr18,  a0,   0
++    vst             vr19,  a0,   16
++    vst             vr2,   a0,   32
++    vst             vr3,   a0,   48
++    add.d           a0,    a0,   a1
++    vst             vr20,  a0,   0
++    vst             vr21,  a0,   16
++    vst             vr4,   a0,   32
++    vst             vr5,   a0,   48
++    add.d           a0,    a0,   a1
++    vst             vr22,  a0,   0
++    vst             vr23,  a0,   16
++    vst             vr6,   a0,   32
++    vst             vr7,   a0,   48
++    add.d           a0,    a0,   a1
++.endm
++
++.macro pixel_sub_ps_32x h
++function x265_pixel_sub_ps_32x\h\()_lsx
++    slli.d          a1,    a1,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++
++.rept (\h>>2)
++    sub_ps_32x4_core_lsx
++
++    alsl.d          a2,    a4,   a2,  2
++    alsl.d          a3,    a5,   a3,  2
++.endr
++endfunc
++.endm
++
++pixel_sub_ps_32x 32
++pixel_sub_ps_32x 64
++
++.macro sub_ps_64x4_core_lsx
++    LSX_LOADX_4 a2, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 a3, a5, t2, t3, vr4, vr5, vr6, vr7
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++
++    vilvl.h         vr16,  vr9,  vr8
++    vilvh.h         vr17,  vr9,  vr8
++    vilvl.h         vr18,  vr11, vr10
++    vilvh.h         vr19,  vr11, vr10
++    vilvl.h         vr20,  vr13, vr12
++    vilvh.h         vr21,  vr13, vr12
++    vilvl.h         vr22,  vr15, vr14
++    vilvh.h         vr23,  vr15, vr14
++
++    addi.d          t5,    a2,   16
++    addi.d          t6,    a3,   16
++
++    LSX_LOADX_4 t5, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 t6, a5, t2, t3, vr4, vr5, vr6, vr7
++
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++
++    vilvl.h         vr0,   vr9,  vr8
++    vilvh.h         vr1,   vr9,  vr8
++    vilvl.h         vr2,   vr11, vr10
++    vilvh.h         vr3,   vr11, vr10
++    vilvl.h         vr4,   vr13, vr12
++    vilvh.h         vr5,   vr13, vr12
++    vilvl.h         vr6,   vr15, vr14
++    vilvh.h         vr7,   vr15, vr14
++
++    addi.d          t4,    a0,   0
++    vst             vr16,  t4,   0
++    vst             vr17,  t4,   16
++    vst             vr0,   t4,   32
++    vst             vr1,   t4,   48
++    add.d           t4,    t4,   a1
++    vst             vr18,  t4,   0
++    vst             vr19,  t4,   16
++    vst             vr2,   t4,   32
++    vst             vr3,   t4,   48
++    add.d           t4,    t4,   a1
++    vst             vr20,  t4,   0
++    vst             vr21,  t4,   16
++    vst             vr4,   t4,   32
++    vst             vr5,   t4,   48
++    add.d           t4,    t4,   a1
++    vst             vr22,  t4,   0
++    vst             vr23,  t4,   16
++    vst             vr6,   t4,   32
++    vst             vr7,   t4,   48
++
++    addi.d          t5,    t5,   16
++    addi.d          t6,    t6,   16
++    addi.d          t4,    a0,   64
++
++    LSX_LOADX_4 t5, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 t6, a5, t2, t3, vr4, vr5, vr6, vr7
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++
++    vilvl.h         vr16,  vr9,  vr8
++    vilvh.h         vr17,  vr9,  vr8
++    vilvl.h         vr18,  vr11, vr10
++    vilvh.h         vr19,  vr11, vr10
++    vilvl.h         vr20,  vr13, vr12
++    vilvh.h         vr21,  vr13, vr12
++    vilvl.h         vr22,  vr15, vr14
++    vilvh.h         vr23,  vr15, vr14
++
++    addi.d          t5,    t5,   16
++    addi.d          t6,    t6,   16
++
++    LSX_LOADX_4 t5, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 t6, a5, t2, t3, vr4, vr5, vr6, vr7
++
++    vsubwev.h.bu    vr8,   vr0,  vr4
++    vsubwod.h.bu    vr9,   vr0,  vr4
++    vsubwev.h.bu    vr10,  vr1,  vr5
++    vsubwod.h.bu    vr11,  vr1,  vr5
++    vsubwev.h.bu    vr12,  vr2,  vr6
++    vsubwod.h.bu    vr13,  vr2,  vr6
++    vsubwev.h.bu    vr14,  vr3,  vr7
++    vsubwod.h.bu    vr15,  vr3,  vr7
++    vilvl.h         vr0,   vr9,  vr8
++    vilvh.h         vr1,   vr9,  vr8
++    vilvl.h         vr2,   vr11, vr10
++    vilvh.h         vr3,   vr11, vr10
++    vilvl.h         vr4,   vr13, vr12
++    vilvh.h         vr5,   vr13, vr12
++    vilvl.h         vr6,   vr15, vr14
++    vilvh.h         vr7,   vr15, vr14
++
++    vst             vr16,  t4,   0
++    vst             vr17,  t4,   16
++    vst             vr0,   t4,   32
++    vst             vr1,   t4,   48
++    add.d           t4,    t4,   a1
++    vst             vr18,  t4,   0
++    vst             vr19,  t4,   16
++    vst             vr2,   t4,   32
++    vst             vr3,   t4,   48
++    add.d           t4,    t4,   a1
++    vst             vr20,  t4,   0
++    vst             vr21,  t4,   16
++    vst             vr4,   t4,   32
++    vst             vr5,   t4,   48
++    add.d           t4,    t4,   a1
++    vst             vr22,  t4,   0
++    vst             vr23,  t4,   16
++    vst             vr6,   t4,   32
++    vst             vr7,   t4,   48
++.endm
++
++function x265_pixel_sub_ps_64x64_lsx
++    slli.d          a1,    a1,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++
++.rept 16
++    sub_ps_64x4_core_lsx
++
++    alsl.d          a2,    a4,   a2,  2
++    alsl.d          a3,    a5,   a3,  2
++    alsl.d          a0,    a1,   a0,  2
++.endr
++endfunc
++
++.macro sub_ps_32x2_core_lasx
++    xvld             xr0,   a2,   0
++    xvldx            xr1,   a2,   a4
++    xvld             xr2,   a3,   0
++    xvldx            xr3,   a3,   a5
++
++    xvsubwev.h.bu    xr10,  xr0,  xr2
++    xvsubwod.h.bu    xr11,  xr0,  xr2
++    xvsubwev.h.bu    xr12,  xr1,  xr3
++    xvsubwod.h.bu    xr13,  xr1,  xr3
++
++    xvilvl.h         xr2,   xr11, xr10
++    xvilvh.h         xr3,   xr11, xr10
++    xvilvl.h         xr4,   xr13, xr12
++    xvilvh.h         xr5,   xr13, xr12
++
++    xvor.v           xr6,   xr3,  xr3
++    xvor.v           xr7,   xr5,  xr5
++    xvpermi.q        xr3,   xr2,  0x20
++    xvpermi.q        xr6,   xr2,  0x31
++    xvpermi.q        xr5,   xr4,  0x20
++    xvpermi.q        xr7,   xr4,  0x31
++
++    xvst             xr3,   a0,   0
++    xvst             xr6,   a0,   32
++    add.d            t4,    a0,   a1
++    xvst             xr5,   t4,   0
++    xvst             xr7,   t4,   32
++.endm
++
++.macro pixel_sub_ps_32x_lasx h
++function x265_pixel_sub_ps_32x\h\()_lasx
++    slli.d          a1,    a1,   1
++
++.rept (\h>>1)
++
++    sub_ps_32x2_core_lasx
++
++    alsl.d          a2,    a4,   a2,  1
++    alsl.d          a3,    a5,   a3,  1
++    alsl.d          a0,    a1,   a0,  1
++.endr
++endfunc
++.endm
++
++pixel_sub_ps_32x_lasx 32
++pixel_sub_ps_32x_lasx 64
++
++function x265_pixel_sub_ps_64x64_lasx
++    slli.d           a1,    a1,   1
++
++.rept 32
++
++    xvld             xr0,   a2,   0
++    xvldx            xr1,   a2,   a4
++    xvld             xr2,   a3,   0
++    xvldx            xr3,   a3,   a5
++
++    xvsubwev.h.bu    xr10,  xr0,  xr2
++    xvsubwod.h.bu    xr11,  xr0,  xr2
++    xvsubwev.h.bu    xr12,  xr1,  xr3
++    xvsubwod.h.bu    xr13,  xr1,  xr3
++
++    xvilvl.h         xr2,   xr11, xr10
++    xvilvh.h         xr3,   xr11, xr10
++    xvilvl.h         xr4,   xr13, xr12
++    xvilvh.h         xr5,   xr13, xr12
++
++    xvor.v           xr6,   xr3,  xr3
++    xvor.v           xr7,   xr5,  xr5
++    xvpermi.q        xr3,   xr2,  0x20
++    xvpermi.q        xr6,   xr2,  0x31
++    xvpermi.q        xr5,   xr4,  0x20
++    xvpermi.q        xr7,   xr4,  0x31
++
++    add.d            t4,    a0,   a1
++    xvst             xr3,   a0,   0
++    xvst             xr6,   a0,   32
++    xvst             xr5,   t4,   0
++    xvst             xr7,   t4,   32
++
++    addi.d           t6,    a2,   32
++    addi.d           t7,    a3,   32
++
++    xvld             xr0,   t6,   0
++    xvldx            xr1,   t6,   a4
++    xvld             xr2,   t7,   0
++    xvldx            xr3,   t7,   a5
++
++    xvsubwev.h.bu    xr10,  xr0,  xr2
++    xvsubwod.h.bu    xr11,  xr0,  xr2
++    xvsubwev.h.bu    xr12,  xr1,  xr3
++    xvsubwod.h.bu    xr13,  xr1,  xr3
++
++    xvilvl.h         xr2,   xr11, xr10
++    xvilvh.h         xr3,   xr11, xr10
++    xvilvl.h         xr4,   xr13, xr12
++    xvilvh.h         xr5,   xr13, xr12
++
++    xvor.v           xr6,   xr3,  xr3
++    xvor.v           xr7,   xr5,  xr5
++    xvpermi.q        xr3,   xr2,  0x20
++    xvpermi.q        xr6,   xr2,  0x31
++    xvpermi.q        xr5,   xr4,  0x20
++    xvpermi.q        xr7,   xr4,  0x31
++
++    xvst             xr3,   a0,   64
++    xvst             xr6,   a0,   96
++    xvst             xr5,   t4,   64
++    xvst             xr7,   t4,   96
++
++    alsl.d          a2,    a4,   a2,  1
++    alsl.d          a3,    a5,   a3,  1
++    alsl.d          a0,    a1,   a0,  1
++
++.endr
++endfunc
++
++function x265_pixel_add_ps_4x4_lsx
++    slli.w          a5,    a5,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++    FLDS_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDD_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.w         vr1,   vr1,  vr0
++    vilvl.w         vr3,   vr3,  vr2
++    vilvl.d         vr5,   vr5,  vr4
++    vilvl.d         vr7,   vr7,  vr6
++    vsllwil.hu.bu   vr1,   vr1,  0
++    vsllwil.hu.bu   vr3,   vr3,  0
++    vadd.h          vr2,   vr5,  vr1
++    vadd.h          vr4,   vr7,  vr3
++    vssrarni.bu.h   vr4,   vr2,  0
++    vstelm.w        vr4,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    2
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    3
++endfunc
++
++function x265_pixel_add_ps_4x8_lsx
++    slli.w          a5,    a5,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++    FLDS_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDD_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.w         vr1,   vr1,  vr0
++    vilvl.w         vr3,   vr3,  vr2
++    vilvl.d         vr5,   vr5,  vr4
++    vilvl.d         vr7,   vr7,  vr6
++    vsllwil.hu.bu   vr1,   vr1,  0
++    vsllwil.hu.bu   vr3,   vr3,  0
++    vadd.h          vr2,   vr5,  vr1
++    vadd.h          vr4,   vr7,  vr3
++    vssrarni.bu.h   vr4,   vr2,  0
++    vstelm.w        vr4,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    2
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    3
++    add.d           a0,    a0,   a1
++
++    alsl.d          a2,    a4,   a2,   2
++    alsl.d          a3,    a5,   a3,   2
++
++    FLDS_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    FLDD_LOADX_4 a3, a5, t2, t3, f4, f5, f6, f7
++    vilvl.w         vr1,   vr1,  vr0
++    vilvl.w         vr3,   vr3,  vr2
++    vilvl.d         vr5,   vr5,  vr4
++    vilvl.d         vr7,   vr7,  vr6
++    vsllwil.hu.bu   vr1,   vr1,  0
++    vsllwil.hu.bu   vr3,   vr3,  0
++    vadd.h          vr2,   vr5,  vr1
++    vadd.h          vr4,   vr7,  vr3
++    vssrarni.bu.h   vr4,   vr2,  0
++    vstelm.w        vr4,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    2
++    add.d           a0,    a0,   a1
++    vstelm.w        vr4,   a0,   0,    3
++    add.d           a0,    a0,   a1
++endfunc
++
++.macro pixel_add_ps_8x h
++function x265_pixel_add_ps_8x\h\()_lsx
++    slli.w          a5,    a5,   1
++    slli.d          t0,    a4,   1
++    add.d           t1,    a4,   t0
++    slli.d          t2,    a5,   1
++    add.d           t3,    a5,   t2
++.rept (\h>>2)
++    FLDD_LOADX_4 a2, a4, t0, t1, f0, f1, f2, f3
++    LSX_LOADX_4 a3, a5, t2, t3, vr4, vr5, vr6, vr7
++    vsllwil.hu.bu   vr0,   vr0,  0
++    vsllwil.hu.bu   vr1,   vr1,  0
++    vsllwil.hu.bu   vr2,   vr2,  0
++    vsllwil.hu.bu   vr3,   vr3,  0
++    vadd.h          vr8,   vr4,  vr0
++    vadd.h          vr9,   vr5,  vr1
++    vadd.h          vr10,  vr6,  vr2
++    vadd.h          vr11,  vr7,  vr3
++    vssrarni.bu.h   vr9,   vr8,  0
++    vssrarni.bu.h   vr11,  vr10, 0
++    vstelm.d        vr9,   a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr9,   a0,   0,    1
++    add.d           a0,    a0,   a1
++    vstelm.d        vr11,  a0,   0,    0
++    add.d           a0,    a0,   a1
++    vstelm.d        vr11,  a0,   0,    1
++    add.d           a0,    a0,   a1
++
++    alsl.d          a2,    a4,   a2,   2
++    alsl.d          a3,    a5,   a3,   2
++.endr
++endfunc
++.endm
++
++pixel_add_ps_8x 8
++pixel_add_ps_8x 16
++
++.macro pixel_add_ps_16x h
++function x265_pixel_add_ps_16x\h\()_lsx
++    slli.w          a5,    a5,    1
++    slli.d          t0,    a4,    1
++    add.d           t1,    a4,    t0
++    slli.d          t2,    a5,    1
++    add.d           t3,    a5,    t2
++    addi.d          t5,    a3,    0
++.rept (\h>>2)
++    LSX_LOADX_4 a2, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 t5, a5, t2, t3, vr4, vr5, vr6, vr7
++    addi.d          a3,    t5,    16
++    LSX_LOADX_4 a3, a5, t2, t3, vr8, vr9, vr10, vr11
++
++    vsllwil.hu.bu   vr12,  vr0,   0
++    vexth.hu.bu     vr13,  vr0
++    vsllwil.hu.bu   vr14,  vr1,   0
++    vexth.hu.bu     vr15,  vr1
++    vadd.h          vr16,  vr4,   vr12
++    vadd.h          vr17,  vr8,   vr13
++    vadd.h          vr18,  vr5,   vr14
++    vadd.h          vr19,  vr9,   vr15
++    vssrarni.bu.h   vr17,  vr16,  0
++    vssrarni.bu.h   vr19,  vr18,  0
++    vst             vr17,  a0,    0
++    vstx            vr19,  a0,    a1
++
++    alsl.d          a0,    a1,    a0,   1
++    vsllwil.hu.bu   vr12,  vr2,   0
++    vexth.hu.bu     vr13,  vr2
++    vsllwil.hu.bu   vr14,  vr3,   0
++    vexth.hu.bu     vr15,  vr3
++    vadd.h          vr16,  vr6,   vr12
++    vadd.h          vr17,  vr10,  vr13
++    vadd.h          vr18,  vr7,   vr14
++    vadd.h          vr19,  vr11,  vr15
++    vssrarni.bu.h   vr17,  vr16,  0
++    vssrarni.bu.h   vr19,  vr18,  0
++    vst             vr17,  a0,    0
++    vstx            vr19,  a0,    a1
++
++    alsl.d          a0,    a1,    a0,  1
++    alsl.d          a2,    a4,    a2,  2
++    alsl.d          t5,    a5,    t5,  2
++.endr
++endfunc
++.endm
++
++pixel_add_ps_16x 16
++pixel_add_ps_16x 32
++
++.macro pixel_add_ps_32x h
++function x265_pixel_add_ps_32x\h\()_lsx
++    slli.w          a5,    a5,    1
++.rept \h
++    vld             vr0,   a2,    0
++    vld             vr1,   a2,    16
++    vld             vr2,   a3,    0
++    vld             vr3,   a3,    16
++    vld             vr4,   a3,    32
++    vld             vr5,   a3,    48
++    vsllwil.hu.bu   vr6,   vr0,   0
++    vexth.hu.bu     vr7,   vr0
++    vsllwil.hu.bu   vr8,   vr1,   0
++    vexth.hu.bu     vr9,   vr1
++    vadd.h          vr10,  vr2,   vr6
++    vadd.h          vr11,  vr3,   vr7
++    vadd.h          vr12,  vr4,   vr8
++    vadd.h          vr13,  vr5,   vr9
++    vssrarni.bu.h   vr11,  vr10,  0
++    vssrarni.bu.h   vr13,  vr12,  0
++    vst             vr11,  a0,    0
++    vst             vr13,  a0,    16
++    add.d           a2,    a4,    a2
++    add.d           a3,    a5,    a3
++    add.d           a0,    a1,    a0
++.endr
++endfunc
++.endm
++
++pixel_add_ps_32x 32
++pixel_add_ps_32x 64
++
++function x265_pixel_add_ps_64x64_lsx
++    slli.w          a5,    a5,    1
++.rept 64
++    vld             vr0,   a2,    0
++    vld             vr1,   a2,    16
++    vld             vr2,   a2,    32
++    vld             vr3,   a2,    48
++    vld             vr4,   a3,    0
++    vld             vr5,   a3,    16
++    vld             vr6,   a3,    32
++    vld             vr7,   a3,    48
++    vld             vr8,   a3,    64
++    vld             vr9,   a3,    80
++    vld             vr10,  a3,    96
++    vld             vr11,  a3,    112
++    vsllwil.hu.bu   vr12,  vr0,   0
++    vexth.hu.bu     vr13,  vr0
++    vsllwil.hu.bu   vr14,  vr1,   0
++    vexth.hu.bu     vr15,  vr1
++    vsllwil.hu.bu   vr16,  vr2,   0
++    vexth.hu.bu     vr17,  vr2
++    vsllwil.hu.bu   vr18,  vr3,   0
++    vexth.hu.bu     vr19,  vr3
++    vadd.h          vr4,   vr4,   vr12
++    vadd.h          vr5,   vr5,   vr13
++    vadd.h          vr6,   vr6,   vr14
++    vadd.h          vr7,   vr7,   vr15
++    vadd.h          vr8,   vr8,   vr16
++    vadd.h          vr9,   vr9,   vr17
++    vadd.h          vr10,  vr10,  vr18
++    vadd.h          vr11,  vr11,  vr19
++    vssrarni.bu.h   vr5,   vr4,   0
++    vssrarni.bu.h   vr7,   vr6,   0
++    vssrarni.bu.h   vr9,   vr8,   0
++    vssrarni.bu.h   vr11,  vr10,  0
++    vst             vr5,   a0,    0
++    vst             vr7,   a0,    16
++    vst             vr9,   a0,    32
++    vst             vr11,  a0,    48
++
++    add.d           a2,    a4,    a2
++    add.d           a3,    a5,    a3
++    add.d           a0,    a1,    a0
++.endr
++endfunc
++
++.macro pixel_add_ps_16x_lasx h
++function x265_pixel_add_ps_16x\h\()_lasx
++    slli.w          a5,    a5,     1
++    slli.d          t0,    a4,     1
++    add.d           t1,    a4,     t0
++    slli.d          t2,    a5,     1
++    add.d           t3,    a5,     t2
++    addi.d          t5,    a3,     0
++.rept (\h>>2)
++    LSX_LOADX_4 a2, a4, t0, t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4 t5, a5, t2, t3, vr4, vr5, vr6, vr7
++    addi.d          a3,    t5,    16
++    LSX_LOADX_4 a3, a5, t2, t3, vr8, vr9, vr10, vr11
++
++    vext2xv.hu.bu   xr12,  xr0
++    vext2xv.hu.bu   xr13,  xr1
++    vext2xv.hu.bu   xr14,  xr2
++    vext2xv.hu.bu   xr15,  xr3
++    xvpermi.q       xr8,   xr4,    0x20
++    xvpermi.q       xr9,   xr5,    0x20
++    xvpermi.q       xr10,  xr6,    0x20
++    xvpermi.q       xr11,  xr7,    0x20
++    xvadd.h         xr16,  xr8,    xr12
++    xvadd.h         xr17,  xr9,    xr13
++    xvadd.h         xr18,  xr10,   xr14
++    xvadd.h         xr19,  xr11,   xr15
++    xvssrarni.bu.h  xr17,  xr16,   0
++    xvssrarni.bu.h  xr19,  xr18,   0
++    xvpermi.d       xr12,  xr17,   0xd8
++    xvpermi.d       xr13,  xr19,   0xd8
++    xvpermi.q       xr14,  xr12,   0x01
++    xvpermi.q       xr15,  xr13,   0x01
++    vst             vr12,  a0,     0
++    vstx            vr14,  a0,     a1
++    alsl.d          a0,    a1,     a0,   1
++    vst             vr13,  a0,     0
++    vstx            vr15,  a0,     a1
++
++    alsl.d          a0,    a1,     a0,   1
++    alsl.d          a2,    a4,     a2,   2
++    alsl.d          t5,    a5,     t5,   2
++.endr
++endfunc
++.endm
++
++pixel_add_ps_16x_lasx 16
++pixel_add_ps_16x_lasx 32
++
++.macro pixel_add_ps_32x_lasx h
++function x265_pixel_add_ps_32x\h\()_lasx
++    slli.w          a5,    a5,    1
++    addi.d          t5,    a3,    0
++.rept (\h>>1)
++
++    xvld            xr0,   a2,    0
++    xvldx           xr1,   a2,    a4
++    xvld            xr2,   t5,    0
++    xvldx           xr3,   t5,    a5
++    addi.d          a3,    t5,    32
++    xvld            xr4,   a3,    0
++    xvldx           xr5,   a3,    a5
++    xvpermi.q       xr20,  xr0,   0x01
++    xvpermi.q       xr21,  xr1,   0x01
++    vext2xv.hu.bu   xr6,   xr0
++    vext2xv.hu.bu   xr7,   xr20
++    vext2xv.hu.bu   xr8,   xr1
++    vext2xv.hu.bu   xr9,   xr21
++    xvadd.h         xr10,  xr6,   xr2
++    xvadd.h         xr11,  xr7,   xr4
++    xvadd.h         xr12,  xr8,   xr3
++    xvadd.h         xr13,  xr9,   xr5
++    xvssrarni.bu.h  xr11,  xr10,  0
++    xvssrarni.bu.h  xr13,  xr12,  0
++    xvpermi.d       xr11,  xr11,  0xd8
++    xvpermi.d       xr13,  xr13,  0xd8
++    xvst            xr11,  a0,    0
++    xvstx           xr13,  a0,    a1
++
++    alsl.d          a0,    a1,    a0,   1
++    alsl.d          a2,    a4,    a2,   1
++    alsl.d          t5,    a5,    t5,   1
++.endr
++endfunc
++.endm
++
++pixel_add_ps_32x_lasx 32
++pixel_add_ps_32x_lasx 64
++
++function x265_pixel_add_ps_64x64_lasx
++    slli.w          a5,    a5,    1
++
++.rept 32
++
++    add.d           t3,    a2,    a4
++    xvld            xr0,   a2,    0
++    xvld            xr1,   a2,    32
++    xvld            xr2,   t3,    0
++    xvld            xr3,   t3,    32
++
++    add.d           t5,    a3,    a5
++    xvld            xr4,   a3,    0
++    xvld            xr5,   a3,    32
++    xvld            xr6,   a3,    64
++    xvld            xr7,   a3,    96
++    xvld            xr8,   t5,    0
++    xvld            xr9,   t5,    32
++    xvld            xr10,  t5,    64
++    xvld            xr11,  t5,    96
++
++    xvpermi.q       xr20,  xr0,   0x01
++    xvpermi.q       xr21,  xr1,   0x01
++    xvpermi.q       xr22,  xr2,   0x01
++    xvpermi.q       xr23,  xr3,   0x01
++    vext2xv.hu.bu   xr12,  xr0
++    vext2xv.hu.bu   xr13,  xr20
++    vext2xv.hu.bu   xr14,  xr1
++    vext2xv.hu.bu   xr15,  xr21
++    vext2xv.hu.bu   xr16,  xr2
++    vext2xv.hu.bu   xr17,  xr22
++    vext2xv.hu.bu   xr18,  xr3
++    vext2xv.hu.bu   xr19,  xr23
++    xvadd.h         xr4,   xr4,   xr12
++    xvadd.h         xr5,   xr5,   xr13
++    xvadd.h         xr6,   xr6,   xr14
++    xvadd.h         xr7,   xr7,   xr15
++    xvadd.h         xr8,   xr8,   xr16
++    xvadd.h         xr9,   xr9,   xr17
++    xvadd.h         xr10,  xr10,  xr18
++    xvadd.h         xr11,  xr11,  xr19
++    xvssrarni.bu.h  xr5,   xr4,   0
++    xvssrarni.bu.h  xr7,   xr6,   0
++    xvssrarni.bu.h  xr9,   xr8,   0
++    xvssrarni.bu.h  xr11,  xr10,  0
++    xvpermi.d       xr5,   xr5,   0xd8
++    xvpermi.d       xr7,   xr7,   0xd8
++    xvpermi.d       xr9,   xr9,   0xd8
++    xvpermi.d       xr11,  xr11,  0xd8
++    xvst            xr5,   a0,    0
++    xvst            xr7,   a0,    32
++    add.d           t2,    a0,    a1
++    xvst            xr9,   t2,    0
++    xvst            xr11,  t2,    32
++
++    alsl.d          a0,    a1,    a0,    1
++    alsl.d          a2,    a4,    a2,    1
++    alsl.d          a3,    a5,    a3,    1
++.endr
++endfunc
++
++function x265_pixel_var_4x4_lsx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++    FLDS_LOADX_4   a0,     a1,     t0, t1, f0, f1, f2, f3
++    vilvl.w        vr4,    vr1,    vr0
++    vilvl.w        vr5,    vr3,    vr2
++    vilvl.d        vr6,    vr5,    vr4
++    vhaddw.hu.bu   vr7,    vr6,    vr6
++
++    vmulwev.h.bu   vr0,    vr6,    vr6
++    vmulwod.h.bu   vr1,    vr6,    vr6
++    vhaddw.wu.hu   vr0,    vr0,    vr0
++    vhaddw.wu.hu   vr1,    vr1,    vr1
++    vadd.w         vr2,    vr0,    vr1
++
++    vhaddw.wu.hu   vr7,    vr7,    vr7
++    vhaddw.du.wu   vr7,    vr7,    vr7
++    vhaddw.qu.du   vr7,    vr7,    vr7
++    vpickve2gr.wu  t0,     vr7,    0
++
++    vhaddw.du.wu   vr2,    vr2,    vr2
++    vhaddw.qu.du   vr2,    vr2,    vr2
++    vpickve2gr.wu  t1,     vr2,    0
++    slli.d         t1,     t1,     32
++    add.d          a0,     t0,     t1
++endfunc
++
++function x265_pixel_var_8x8_lsx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++    FLDD_LOADX_4   a0,     a1,     t0, t1, f0, f1, f2, f3
++    vilvl.d        vr4,    vr1,    vr0
++    vilvl.d        vr5,    vr3,    vr2
++    vhaddw.hu.bu   vr6,    vr4,    vr4
++    vhaddw.hu.bu   vr7,    vr5,    vr5
++    vadd.h         vr7,    vr6,    vr7
++
++    vmulwev.h.bu   vr0,    vr4,    vr4
++    vmulwod.h.bu   vr1,    vr4,    vr4
++    vmulwev.h.bu   vr2,    vr5,    vr5
++    vmulwod.h.bu   vr3,    vr5,    vr5
++    vhaddw.wu.hu   vr0,    vr0,    vr0
++    vhaddw.wu.hu   vr1,    vr1,    vr1
++    vhaddw.wu.hu   vr2,    vr2,    vr2
++    vhaddw.wu.hu   vr3,    vr3,    vr3
++    vadd.w         vr4,    vr0,    vr1
++    vadd.w         vr5,    vr2,    vr3
++    vadd.w         vr8,    vr4,    vr5
++
++    alsl.d         a0,     a1,     a0,   2
++
++    FLDD_LOADX_4   a0,     a1,     t0, t1, f0, f1, f2, f3
++    vilvl.d        vr4,    vr1,    vr0
++    vilvl.d        vr5,    vr3,    vr2
++    vhaddw.hu.bu   vr6,    vr4,    vr4
++    vhaddw.hu.bu   vr9,    vr5,    vr5
++    vadd.h         vr9,    vr6,    vr9
++
++    vmulwev.h.bu   vr0,    vr4,    vr4
++    vmulwod.h.bu   vr1,    vr4,    vr4
++    vmulwev.h.bu   vr2,    vr5,    vr5
++    vmulwod.h.bu   vr3,    vr5,    vr5
++    vhaddw.wu.hu   vr0,    vr0,    vr0
++    vhaddw.wu.hu   vr1,    vr1,    vr1
++    vhaddw.wu.hu   vr2,    vr2,    vr2
++    vhaddw.wu.hu   vr3,    vr3,    vr3
++    vadd.w         vr4,    vr0,    vr1
++    vadd.w         vr5,    vr2,    vr3
++    vadd.w         vr10,   vr4,    vr5
++
++    vadd.h         vr7,    vr7,    vr9
++    vadd.w         vr2,    vr8,    vr10
++    vhaddw.wu.hu   vr7,    vr7,    vr7
++    vhaddw.du.wu   vr7,    vr7,    vr7
++    vhaddw.qu.du   vr7,    vr7,    vr7
++    vpickve2gr.wu  t0,     vr7,    0
++
++    vhaddw.du.wu   vr2,    vr2,    vr2
++    vhaddw.qu.du   vr2,    vr2,    vr2
++    vpickve2gr.wu  t1,     vr2,    0
++    slli.d         t1,     t1,     32
++    add.d          a0,     t0,     t1
++endfunc
++
++.macro pixel_var_16x4_core_lsx out0, out1
++    LSX_LOADX_4    a0,     a1,     t0, t1, vr0, vr1, vr2, vr3
++
++    vhaddw.hu.bu   vr4,    vr0,    vr0
++    vhaddw.hu.bu   vr5,    vr1,    vr1
++    vhaddw.hu.bu   vr6,    vr2,    vr2
++    vhaddw.hu.bu   vr7,    vr3,    vr3
++    vadd.h         vr8,    vr4,    vr5
++    vadd.h         vr15,   vr6,    vr7
++    vadd.h         \out0,  vr15,   vr8
++
++    vmulwev.h.bu   vr4,    vr0,    vr0
++    vmulwod.h.bu   vr5,    vr0,    vr0
++    vmulwev.h.bu   vr6,    vr1,    vr1
++    vmulwod.h.bu   vr7,    vr1,    vr1
++    vmulwev.h.bu   vr15,   vr2,    vr2
++    vmulwod.h.bu   vr16,   vr2,    vr2
++    vmulwev.h.bu   vr17,   vr3,    vr3
++    vmulwod.h.bu   vr18,   vr3,    vr3
++
++    vhaddw.wu.hu   vr4,    vr4,    vr4
++    vhaddw.wu.hu   vr5,    vr5,    vr5
++    vhaddw.wu.hu   vr6,    vr6,    vr6
++    vhaddw.wu.hu   vr7,    vr7,    vr7
++    vhaddw.wu.hu   vr15,   vr15,   vr15
++    vhaddw.wu.hu   vr16,   vr16,   vr16
++    vhaddw.wu.hu   vr17,   vr17,   vr17
++    vhaddw.wu.hu   vr18,   vr18,   vr18
++
++    vadd.w         vr0,    vr4,    vr15
++    vadd.w         vr1,    vr5,    vr16
++    vadd.w         vr2,    vr6,    vr17
++    vadd.w         vr3,    vr7,    vr18
++    vadd.w         vr4,    vr0,    vr1
++    vadd.w         vr15,   vr2,    vr3
++    vadd.w         \out1,  vr4,    vr15
++.endm
++
++function x265_pixel_var_16x16_lsx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++
++    pixel_var_16x4_core_lsx vr9, vr10
++
++.rept 3
++    alsl.d a0, a1, a0, 2
++    pixel_var_16x4_core_lsx vr11, vr12
++    vadd.h         vr9,    vr9,     vr11
++    vadd.w         vr10,   vr10,    vr12
++.endr
++
++    vhaddw.wu.hu   vr9,    vr9,    vr9
++    vhaddw.du.wu   vr9,    vr9,    vr9
++    vhaddw.qu.du   vr9,    vr9,    vr9
++    vpickve2gr.wu  t0,     vr9,    0
++
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vpickve2gr.wu  t1,     vr10,   0
++    slli.d         t1,     t1,     32
++    add.d          a0,     t0,     t1
++endfunc
++
++function x265_pixel_var_32x32_lsx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++
++    pixel_var_16x4_core_lsx vr9, vr10
++    addi.d         a0,     a0,     16
++    pixel_var_16x4_core_lsx vr11, vr12
++    vadd.h         vr9,    vr9,    vr11
++    vadd.w         vr10,   vr10,   vr12
++
++.rept 7
++    addi.d         a0,     a0,     -16
++    alsl.d         a0,     a1,     a0,   2
++    pixel_var_16x4_core_lsx vr11, vr12
++    vadd.h         vr9,    vr9,    vr11
++    vadd.w         vr10,   vr10,   vr12
++
++    addi.d         a0,     a0,     16
++    pixel_var_16x4_core_lsx vr11, vr12
++    vadd.h         vr9,    vr9,    vr11
++    vadd.w         vr10,   vr10,   vr12
++.endr
++
++    vhaddw.wu.hu   vr9,    vr9,    vr9
++    vhaddw.du.wu   vr9,    vr9,    vr9
++    vhaddw.qu.du   vr9,    vr9,    vr9
++    vpickve2gr.wu  t0,     vr9,    0
++
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vpickve2gr.wu  t1,     vr10,   0
++    slli.d         t1,     t1,     32
++    add.d          a0,     t0,     t1
++endfunc
++
++function x265_pixel_var_64x64_lsx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++
++    pixel_var_16x4_core_lsx vr9, vr10
++    vhaddw.wu.hu vr9, vr9, vr9
++.rept 3
++    addi.d         a0,     a0,     16
++    pixel_var_16x4_core_lsx vr11, vr12
++    vhaddw.wu.hu vr11, vr11, vr11
++    vadd.w         vr9,    vr9,    vr11
++    vadd.w         vr10,   vr10,   vr12
++.endr
++
++.rept 15
++    addi.d         a0,     a0,     -48
++    alsl.d         a0,     a1,     a0,   2
++    pixel_var_16x4_core_lsx vr11, vr12
++    vhaddw.wu.hu vr11, vr11, vr11
++    vadd.w         vr9,    vr9,    vr11
++    vadd.w         vr10,   vr10,   vr12
++.rept 3
++    addi.d         a0,     a0,     16
++    pixel_var_16x4_core_lsx vr11, vr12
++    vhaddw.wu.hu vr11, vr11, vr11
++    vadd.w         vr9,    vr9,    vr11
++    vadd.w         vr10,   vr10,   vr12
++.endr
++.endr
++
++    //vhaddw.wu.hu   vr9,    vr9,    vr9
++    vhaddw.du.wu   vr9,    vr9,    vr9
++    vhaddw.qu.du   vr9,    vr9,    vr9
++    vpickve2gr.wu  t0,     vr9,    0
++
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vpickve2gr.wu  t1,     vr10,   0
++    slli.d         t1,     t1,     32
++    add.d          a0,     t0,     t1
++endfunc
++
++function x265_pixel_var_8x8_lasx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++    FLDD_LOADX_4   a0,     a1,     t0, t1, f0, f1, f2, f3
++    alsl.d         a0,     a1,     a0,   2
++    FLDD_LOADX_4   a0,     a1,     t0, t1, f4, f5, f6, f7
++    vilvl.d        vr0,    vr1,    vr0
++    vilvl.d        vr1,    vr3,    vr2
++    vilvl.d        vr4,    vr5,    vr4
++    vilvl.d        vr5,    vr7,    vr6
++    xvpermi.q      xr4,    xr0,    0x20
++    xvpermi.q      xr5,    xr1,    0x20
++    xvhaddw.hu.bu  xr6,    xr4,    xr4
++    xvhaddw.hu.bu  xr7,    xr5,    xr5
++    xvadd.h        xr16,   xr6,    xr7
++
++    xvmulwev.h.bu  xr8,    xr4,    xr4
++    xvmulwod.h.bu  xr9,    xr4,    xr4
++    xvmulwev.h.bu  xr10,   xr5,    xr5
++    xvmulwod.h.bu  xr11,   xr5,    xr5
++    xvhaddw.wu.hu  xr8,    xr8,    xr8
++    xvhaddw.wu.hu  xr9,    xr9,    xr9
++    xvhaddw.wu.hu  xr10,   xr10,   xr10
++    xvhaddw.wu.hu  xr11,   xr11,   xr11
++    xvadd.w        xr14,   xr8,    xr9
++    xvadd.w        xr15,   xr10,   xr11
++    xvadd.w        xr17,   xr14,   xr15
++
++    xvhaddw.wu.hu  xr16,   xr16,   xr16
++    xvhaddw.du.wu  xr16,   xr16,   xr16
++    xvhaddw.qu.du  xr16,   xr16,   xr16
++    xvpickve2gr.wu t4,     xr16,   0
++    xvpickve2gr.wu t7,     xr16,   4
++    add.w          t4,     t4,     t7    // sum
++
++    xvhaddw.du.wu  xr17,   xr17,   xr17
++    xvhaddw.qu.du  xr17,   xr17,   xr17
++    xvpickve2gr.du t6,     xr17,   0     // sqr
++    xvpickve2gr.du t7,     xr17,   2
++    add.d          t6,     t6,     t7
++
++    slli.d         t5,     t6,     32
++    add.d          a0,     t4,     t5
++endfunc
++
++function x265_pixel_var_16x16_lasx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++    LSX_LOADX_4    a0,     a1,     t0, t1, vr0, vr1, vr2, vr3
++    xvpermi.q      xr2,    xr0,    0x20
++    xvpermi.q      xr3,    xr1,    0x20
++    xvhaddw.hu.bu  xr4,    xr2,    xr2
++    xvhaddw.hu.bu  xr5,    xr3,    xr3
++    xvadd.h        xr13,   xr4,    xr5
++
++    xvmulwev.h.bu  xr9,    xr2,    xr2
++    xvmulwod.h.bu  xr10,   xr2,    xr2
++    xvmulwev.h.bu  xr11,   xr3,    xr3
++    xvmulwod.h.bu  xr12,   xr3,    xr3
++    xvhaddw.wu.hu  xr9,    xr9,    xr9
++    xvhaddw.wu.hu  xr10,   xr10,   xr10
++    xvhaddw.wu.hu  xr11,   xr11,   xr11
++    xvhaddw.wu.hu  xr12,   xr12,   xr12
++    xvadd.w        xr0,    xr10,   xr9
++    xvadd.w        xr1,    xr12,   xr11
++    xvadd.w        xr14,   xr0,    xr1
++
++.rept 3
++    alsl.d         a0,     a1,     a0,   2
++    LSX_LOADX_4    a0,     a1,     t0, t1, vr0, vr1, vr2, vr3
++
++    xvpermi.q      xr2,    xr0,    0x20
++    xvpermi.q      xr3,    xr1,    0x20
++    xvhaddw.hu.bu  xr4,    xr2,    xr2
++    xvhaddw.hu.bu  xr5,    xr3,    xr3
++    xvadd.h        xr6,    xr4,    xr5
++    xvadd.h        xr13,   xr6,    xr13
++
++    xvmulwev.h.bu  xr9,    xr2,    xr2
++    xvmulwod.h.bu  xr10,   xr2,    xr2
++    xvmulwev.h.bu  xr11,   xr3,    xr3
++    xvmulwod.h.bu  xr12,   xr3,    xr3
++    xvhaddw.wu.hu  xr9,    xr9,    xr9
++    xvhaddw.wu.hu  xr10,   xr10,   xr10
++    xvhaddw.wu.hu  xr11,   xr11,   xr11
++    xvhaddw.wu.hu  xr12,   xr12,   xr12
++    xvadd.w        xr0,    xr10,   xr9
++    xvadd.w        xr1,    xr12,   xr11
++    xvadd.w        xr7,    xr0,    xr1
++    xvadd.w        xr14,   xr7,    xr14
++.endr
++
++    xvhaddw.wu.hu  xr13,   xr13,   xr13
++    xvhaddw.du.wu  xr13,   xr13,   xr13
++    xvhaddw.qu.du  xr13,   xr13,   xr13
++    xvpickve2gr.wu t4,     xr13,   0
++    xvpickve2gr.wu t7,     xr13,   4
++    add.w          t4,     t4,     t7
++
++    xvhaddw.du.wu  xr14,   xr14,   xr14
++    xvhaddw.qu.du  xr14,   xr14,   xr14
++    xvpickve2gr.du t6,     xr14,   0     // sqr
++    xvpickve2gr.du t7,     xr14,   2
++    add.d          t6,     t6,     t7
++
++    slli.d         t5,     t6,     32
++    add.d          a0,     t4,     t5
++endfunc
++
++.macro pixel_var_32x4_core_lasx out0, out1
++    LASX_LOADX_4   a0,     a1,     t0, t1, xr0, xr1, xr2, xr3
++    xvhaddw.hu.bu  xr4,    xr0,    xr0
++    xvhaddw.hu.bu  xr5,    xr1,    xr1
++    xvhaddw.hu.bu  xr6,    xr2,    xr2
++    xvhaddw.hu.bu  xr7,    xr3,    xr3
++    xvadd.h        xr10,   xr4,    xr5
++    xvadd.h        xr11,   xr6,    xr7
++    xvadd.h        \out0,  xr11,   xr10
++
++    xvmulwev.h.bu  xr4,    xr0,    xr0
++    xvmulwod.h.bu  xr5,    xr0,    xr0
++    xvmulwev.h.bu  xr6,    xr1,    xr1
++    xvmulwod.h.bu  xr7,    xr1,    xr1
++    xvmulwev.h.bu  xr8,    xr2,    xr2
++    xvmulwod.h.bu  xr9,    xr2,    xr2
++    xvmulwev.h.bu  xr10,   xr3,    xr3
++    xvmulwod.h.bu  xr11,   xr3,    xr3
++    xvhaddw.wu.hu  xr4,    xr4,    xr4
++    xvhaddw.wu.hu  xr5,    xr5,    xr5
++    xvhaddw.wu.hu  xr6,    xr6,    xr6
++    xvhaddw.wu.hu  xr7,    xr7,    xr7
++    xvhaddw.wu.hu  xr8,    xr8,    xr8
++    xvhaddw.wu.hu  xr9,    xr9,    xr9
++    xvhaddw.wu.hu  xr10,   xr10,   xr10
++    xvhaddw.wu.hu  xr11,   xr11,   xr11
++    xvadd.w        xr0,    xr4,    xr5
++    xvadd.w        xr1,    xr6,    xr7
++    xvadd.w        xr2,    xr8,    xr9
++    xvadd.w        xr3,    xr10,   xr11
++    xvadd.w        xr4,    xr0,    xr1
++    xvadd.w        xr5,    xr2,    xr3
++    xvadd.w        \out1,  xr4,    xr5
++.endm
++
++function x265_pixel_var_32x32_lasx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++
++    pixel_var_32x4_core_lasx xr13, xr14
++
++.rept 7
++    alsl.d a0, a1, a0, 2
++    pixel_var_32x4_core_lasx xr15, xr16
++    xvadd.h        xr13,   xr13,   xr15
++    xvadd.w        xr14,   xr14,   xr16
++.endr
++
++    xvhaddw.wu.hu  xr13,   xr13,   xr13
++    xvhaddw.du.wu  xr13,   xr13,   xr13
++    xvhaddw.qu.du  xr13,   xr13,   xr13
++    xvpickve2gr.wu t4,     xr13,   0
++    xvpickve2gr.wu t7,     xr13,   4
++    add.w          t4,     t4,     t7
++
++    xvhaddw.du.wu  xr14,   xr14,   xr14
++    xvhaddw.qu.du  xr14,   xr14,   xr14
++    xvpickve2gr.du t6,     xr14,   0     // sqr
++    xvpickve2gr.du t7,     xr14,   2
++    add.d          t6,     t6,     t7
++
++    slli.d         t5,     t6,     32
++    add.d          a0,     t4,     t5
++endfunc
++
++function x265_pixel_var_64x64_lasx
++    slli.d         t0,     a1,     1
++    add.d          t1,     t0,     a1
++
++    pixel_var_32x4_core_lasx xr13, xr14
++    addi.d         a0,     a0,     32
++    pixel_var_32x4_core_lasx xr15, xr16
++    xvadd.h        xr13,   xr15,   xr13
++    xvadd.w        xr14,   xr14,   xr16
++
++.rept 15
++    addi.d         a0,     a0,     -32
++    alsl.d         a0,     a1,     a0,    2
++    pixel_var_32x4_core_lasx xr15, xr16
++    xvadd.h        xr13,   xr13,   xr15
++    xvadd.w        xr14,   xr14,   xr16
++
++    addi.d         a0,     a0,     32
++    pixel_var_32x4_core_lasx xr15, xr16
++    xvadd.h        xr13,   xr15,   xr13
++    xvadd.w        xr14,   xr14,   xr16
++.endr
++
++    xvhaddw.wu.hu  xr13,   xr13,   xr13
++    xvhaddw.du.wu  xr13,   xr13,   xr13
++    xvhaddw.qu.du  xr13,   xr13,   xr13
++    xvpickve2gr.wu t4,     xr13,   0
++    xvpickve2gr.wu t7,     xr13,   4
++    add.w          t4,     t4,     t7
++
++    xvhaddw.du.wu  xr14,   xr14,   xr14
++    xvhaddw.qu.du  xr14,   xr14,   xr14
++    xvpickve2gr.du t6,     xr14,   0     // sqr
++    xvpickve2gr.du t7,     xr14,   2
++    add.d          t6,     t6,     t7
++
++    slli.d         t5,     t6,     32
++    add.d          a0,     t4,     t5
++endfunc
++
++function x265_pixel_getResidual_4x4_lsx
++    slli.d         t3,     a3,     1
++
++    fld.s          f0,     a0,     0
++    fld.s          f1,     a1,     0
++    fldx.s         f2,     a0,     a3
++    fldx.s         f3,     a1,     a3
++    vilvl.w        vr2,    vr2,    vr0
++    vilvl.w        vr3,    vr3,    vr1
++    vsllwil.hu.bu  vr2,    vr2,    0
++    vsllwil.hu.bu  vr3,    vr3,    0
++    vsub.h         vr4,    vr2,    vr3
++    vstelm.d       vr4,    a2,     0,   0
++    add.d          a2,     a2,     t3
++    vstelm.d       vr4,    a2,     0,   1
++
++    alsl.d         a0,     a3,     a0,  1
++    alsl.d         a1,     a3,     a1,  1
++    add.d          a2,     a2,     t3
++
++    fld.s          f0,     a0,     0
++    fld.s          f1,     a1,     0
++    fldx.s         f2,     a0,     a3
++    fldx.s         f3,     a1,     a3
++    vilvl.w        vr2,    vr2,    vr0
++    vilvl.w        vr3,    vr3,    vr1
++    vsllwil.hu.bu  vr2,    vr2,    0
++    vsllwil.hu.bu  vr3,    vr3,    0
++    vsub.h         vr4,    vr2,    vr3
++    vstelm.d       vr4,    a2,     0,   0
++    add.d          a2,     a2,     t3
++    vstelm.d       vr4,    a2,     0,   1
++endfunc
++
++function x265_pixel_getResidual_8x8_lsx
++    slli.d         t3,     a3,     1
++
++.rept 4
++    fld.d          f0,     a0,     0
++    fld.d          f1,     a1,     0
++    fldx.d         f2,     a0,     a3
++    fldx.d         f3,     a1,     a3
++    vsllwil.hu.bu  vr0,    vr0,    0
++    vsllwil.hu.bu  vr1,    vr1,    0
++    vsllwil.hu.bu  vr2,    vr2,    0
++    vsllwil.hu.bu  vr3,    vr3,    0
++    vsub.h         vr4,    vr0,    vr1
++    vsub.h         vr5,    vr2,    vr3
++    vst            vr4,    a2,     0
++    vstx           vr5,    a2,     t3
++
++    alsl.d         a0,     a3,     a0,  1
++    alsl.d         a1,     a3,     a1,  1
++    alsl.d         a2,     t3,     a2,  1
++.endr
++endfunc
++
++function x265_pixel_getResidual_16x16_lsx
++    slli.d         t3,     a3,     1
++
++.rept 8
++    vld            vr0,    a0,     0
++    vld            vr1,    a1,     0
++    vldx           vr2,    a0,     a3
++    vldx           vr3,    a1,     a3
++    vsubwev.h.bu   vr4,    vr0,    vr1
++    vsubwod.h.bu   vr5,    vr0,    vr1
++    vsubwev.h.bu   vr6,    vr2,    vr3
++    vsubwod.h.bu   vr7,    vr2,    vr3
++    vilvl.h        vr8,    vr5,    vr4
++    vilvh.h        vr9,    vr5,    vr4
++    vilvl.h        vr10,   vr7,    vr6
++    vilvh.h        vr11,   vr7,    vr6
++
++    add.d          t2,     a2,     t3
++    vst            vr8,    a2,     0
++    vst            vr9,    a2,     16
++    vst            vr10,   t2,     0
++    vst            vr11,   t2,     16
++
++    alsl.d         a0,     a3,     a0,  1
++    alsl.d         a1,     a3,     a1,  1
++    alsl.d         a2,     t3,     a2,  1
++.endr
++endfunc
++
++function x265_pixel_getResidual_32x32_lsx
++    slli.d         t3,     a3,     1
++
++.rept 32
++    vld            vr0,    a0,     0
++    vld            vr1,    a1,     0
++    vld            vr2,    a0,     16
++    vld            vr3,    a1,     16
++    vsubwev.h.bu   vr4,    vr0,    vr1
++    vsubwod.h.bu   vr5,    vr0,    vr1
++    vsubwev.h.bu   vr6,    vr2,    vr3
++    vsubwod.h.bu   vr7,    vr2,    vr3
++    vilvl.h        vr8,    vr5,    vr4
++    vilvh.h        vr9,    vr5,    vr4
++    vilvl.h        vr10,   vr7,    vr6
++    vilvh.h        vr11,   vr7,    vr6
++    vst            vr8,    a2,     0
++    vst            vr9,    a2,     16
++    vst            vr10,   a2,     32
++    vst            vr11,   a2,     48
++
++    add.d          a0,     a3,     a0
++    add.d          a1,     a3,     a1
++    add.d          a2,     t3,     a2
++.endr
++endfunc
++
++function x265_pixel_getResidual_64x64_lsx
++    slli.d         t3,     a3,     1
++
++.rept 64
++    vld            vr0,    a0,     0
++    vld            vr1,    a1,     0
++    vld            vr2,    a0,     16
++    vld            vr3,    a1,     16
++    vld            vr10,   a0,     32
++    vld            vr11,   a1,     32
++    vld            vr12,   a0,     48
++    vld            vr13,   a1,     48
++    vsubwev.h.bu   vr4,    vr0,    vr1
++    vsubwod.h.bu   vr5,    vr0,    vr1
++    vsubwev.h.bu   vr6,    vr2,    vr3
++    vsubwod.h.bu   vr7,    vr2,    vr3
++    vsubwev.h.bu   vr14,   vr10,   vr11
++    vsubwod.h.bu   vr15,   vr10,   vr11
++    vsubwev.h.bu   vr16,   vr12,   vr13
++    vsubwod.h.bu   vr17,   vr12,   vr13
++    vilvl.h        vr0,    vr5,    vr4
++    vilvh.h        vr1,    vr5,    vr4
++    vilvl.h        vr2,    vr7,    vr6
++    vilvh.h        vr3,    vr7,    vr6
++    vilvl.h        vr10,   vr15,   vr14
++    vilvh.h        vr11,   vr15,   vr14
++    vilvl.h        vr12,   vr17,   vr16
++    vilvh.h        vr13,   vr17,   vr16
++    vst            vr0,    a2,     0
++    vst            vr1,    a2,     16
++    vst            vr2,    a2,     32
++    vst            vr3,    a2,     48
++    vst            vr10,   a2,     64
++    vst            vr11,   a2,     80
++    vst            vr12,   a2,     96
++    vst            vr13,   a2,     112
++
++    add.d          a0,     a3,     a0
++    add.d          a1,     a3,     a1
++    add.d          a2,     t3,     a2
++.endr
++endfunc
++
++function x265_pixel_getResidual_32x32_lasx
++    slli.d         t3,     a3,     1
++
++.rept 16
++    xvld           xr0,    a0,     0
++    xvld           xr1,    a1,     0
++    xvldx          xr2,    a0,     a3
++    xvldx          xr3,    a1,     a3
++    xvsubwev.h.bu  xr4,    xr0,    xr1
++    xvsubwod.h.bu  xr5,    xr0,    xr1
++    xvsubwev.h.bu  xr6,    xr2,    xr3
++    xvsubwod.h.bu  xr7,    xr2,    xr3
++    xvilvl.h       xr8,    xr5,    xr4
++    xvilvh.h       xr9,    xr5,    xr4
++    xvilvl.h       xr10,   xr7,    xr6
++    xvilvh.h       xr11,   xr7,    xr6
++    xvpermi.q      xr12,   xr8,    0x10
++    xvpermi.q      xr13,   xr10,   0x10
++    xvpermi.q      xr8,    xr9,    0x02
++    xvpermi.q      xr10,   xr11,   0x02
++    xvpermi.q      xr9,    xr12,   0x31
++    xvpermi.q      xr11,   xr13,   0x31
++    xvst           xr8,    a2,     0
++    xvst           xr9,    a2,     32
++    add.d          t2,     a2,     t3
++    xvst           xr10,   t2,     0
++    xvst           xr11,   t2,     32
++
++    alsl.d         a0,     a3,     a0,  1
++    alsl.d         a1,     a3,     a1,  1
++    alsl.d         a2,     t3,     a2,  1
++.endr
++endfunc
++
++function x265_pixel_getResidual_64x64_lasx
++    slli.d         t3,     a3,     1
++
++.rept 64
++    xvld           xr0,    a0,     0
++    xvld           xr1,    a1,     0
++    xvld           xr2,    a0,     32
++    xvld           xr3,    a1,     32
++    xvsubwev.h.bu  xr4,    xr0,    xr1
++    xvsubwod.h.bu  xr5,    xr0,    xr1
++    xvsubwev.h.bu  xr6,    xr2,    xr3
++    xvsubwod.h.bu  xr7,    xr2,    xr3
++    xvilvl.h       xr8,    xr5,    xr4
++    xvilvh.h       xr9,    xr5,    xr4
++    xvilvl.h       xr10,   xr7,    xr6
++    xvilvh.h       xr11,   xr7,    xr6
++    xvpermi.q      xr12,   xr8,    0x10
++    xvpermi.q      xr13,   xr10,   0x10
++    xvpermi.q      xr8,    xr9,    0x02
++    xvpermi.q      xr10,   xr11,   0x02
++    xvpermi.q      xr9,    xr12,   0x31
++    xvpermi.q      xr11,   xr13,   0x31
++    xvst           xr8,    a2,     0
++    xvst           xr9,    a2,     32
++    xvst           xr10,   a2,     64
++    xvst           xr11,   a2,     96
++
++    add.d          a0,     a3,     a0
++    add.d          a1,     a3,     a1
++    add.d          a2,     t3,     a2
++.endr
++endfunc
++
++.macro pixel_normFact_8x8_core_lsx out0, out1, out2, out3
++    vld            vr0,    a0,     0
++    vld            vr1,    a0,     16
++    vld            vr2,    a0,     32
++    vld            vr3,    a0,     48
++    vsrl.b         vr0,    vr0,    vr4
++    vsrl.b         vr1,    vr1,    vr4
++    vsrl.b         vr2,    vr2,    vr4
++    vsrl.b         vr3,    vr3,    vr4
++    vsllwil.hu.bu  vr5,    vr0,    0
++    vexth.hu.bu    vr6,    vr0
++    vsllwil.hu.bu  vr7,    vr1,    0
++    vexth.hu.bu    vr8,    vr1
++    vsllwil.hu.bu  vr9,    vr2,    0
++    vexth.hu.bu    vr10,   vr2
++    vsllwil.hu.bu  vr11,   vr3,    0
++    vexth.hu.bu    vr12,   vr3
++
++    vmaddwev.w.h   \out0,  vr5,    vr5
++    vmaddwev.w.h   \out1,  vr6,    vr6
++    vmaddwev.w.h   \out2,  vr7,    vr7
++    vmaddwev.w.h   \out3,  vr8,    vr8
++    vmaddwod.w.h   \out0,  vr5,    vr5
++    vmaddwod.w.h   \out1,  vr6,    vr6
++    vmaddwod.w.h   \out2,  vr7,    vr7
++    vmaddwod.w.h   \out3,  vr8,    vr8
++    vmaddwev.w.h   \out0,  vr9,    vr9
++    vmaddwev.w.h   \out1,  vr10,   vr10
++    vmaddwev.w.h   \out2,  vr11,   vr11
++    vmaddwev.w.h   \out3,  vr12,   vr12
++    vmaddwod.w.h   \out0,  vr9,    vr9
++    vmaddwod.w.h   \out1,  vr10,   vr10
++    vmaddwod.w.h   \out2,  vr11,   vr11
++    vmaddwod.w.h   \out3,  vr12,   vr12
++.endm
++
++function x265_pixel_normFact_8x8_lsx
++    vreplgr2vr.b   vr4,    a2
++
++    vxor.v         vr13,   vr13,   vr13
++    vxor.v         vr14,   vr14,   vr14
++    vxor.v         vr15,   vr15,   vr15
++    vxor.v         vr16,   vr16,   vr16
++
++    pixel_normFact_8x8_core_lsx vr13, vr14, vr15, vr16
++
++    vadd.w         vr13,   vr13,   vr14
++    vadd.w         vr15,   vr15,   vr16
++    vadd.w         vr12,   vr13,   vr15
++    vhaddw.du.wu   vr12,   vr12,   vr12
++    vhaddw.qu.du   vr12,   vr12,   vr12
++    vstelm.d       vr12,   a3,     0,      0
++endfunc
++
++.macro pixel_normFact_lsx w, h
++function x265_pixel_normFact_\w\()x\h\()_lsx
++    vreplgr2vr.b   vr4,    a2
++
++    vxor.v         vr13,   vr13,   vr13
++    vxor.v         vr14,   vr14,   vr14
++    vxor.v         vr15,   vr15,   vr15
++    vxor.v         vr16,   vr16,   vr16
++
++    pixel_normFact_8x8_core_lsx vr13, vr14, vr15, vr16
++
++.rept (\w)*(\h)/64-1
++    addi.d         a0,     a0,     64
++
++    pixel_normFact_8x8_core_lsx vr13, vr14, vr15, vr16
++.endr
++
++    vadd.w         vr13,   vr13,   vr14
++    vadd.w         vr15,   vr15,   vr16
++    vadd.w         vr12,   vr13,   vr15
++    vhaddw.du.wu   vr12,   vr12,   vr12
++    vhaddw.qu.du   vr12,   vr12,   vr12
++    vstelm.d       vr12,   a3,     0,      0
++endfunc
++.endm
++
++pixel_normFact_lsx 16, 16
++pixel_normFact_lsx 32, 32
++pixel_normFact_lsx 64, 64
++
++.macro pixel_normFact_8x8_core_lasx out0, out1, out2, out3
++    xvld           xr0,    a0,     0
++    xvld           xr1,    a0,     32
++    xvsrl.b        xr0,    xr0,    xr4
++    xvsrl.b        xr1,    xr1,    xr4
++    xvsllwil.hu.bu xr5,    xr0,    0
++    xvexth.hu.bu   xr6,    xr0
++    xvsllwil.hu.bu xr7,    xr1,    0
++    xvexth.hu.bu   xr8,    xr1
++
++    xvmaddwev.w.h  \out0,  xr5,    xr5
++    xvmaddwev.w.h  \out1,  xr6,    xr6
++    xvmaddwev.w.h  \out2,  xr7,    xr7
++    xvmaddwev.w.h  \out3,  xr8,    xr8
++    xvmaddwod.w.h  \out0,  xr5,    xr5
++    xvmaddwod.w.h  \out1,  xr6,    xr6
++    xvmaddwod.w.h  \out2,  xr7,    xr7
++    xvmaddwod.w.h  \out3,  xr8,    xr8
++.endm
++
++function x265_pixel_normFact_8x8_lasx
++    xvreplgr2vr.b  xr4,    a2
++
++    xvxor.v        xr13,   xr13,   xr13
++    xvxor.v        xr14,   xr14,   xr14
++    xvxor.v        xr15,   xr15,   xr15
++    xvxor.v        xr16,   xr16,   xr16
++
++    pixel_normFact_8x8_core_lasx xr13, xr14, xr15, xr16
++
++    xvadd.w        xr13,   xr13,   xr14
++    xvadd.w        xr15,   xr15,   xr16
++    xvadd.w        xr12,   xr13,   xr15
++    xvpermi.q      xr17,   xr12,   0x01
++    vadd.w         vr12,   vr12,   vr17
++    vhaddw.du.wu   vr12,   vr12,   vr12
++    vhaddw.qu.du   vr12,   vr12,   vr12
++    vstelm.d       vr12,   a3,     0,      0
++endfunc
++
++.macro pixel_normFact_lasx w, h
++function x265_pixel_normFact_\w\()x\h\()_lasx
++    xvreplgr2vr.b  xr4,    a2
++
++    xvxor.v        xr13,   xr13,   xr13
++    xvxor.v        xr14,   xr14,   xr14
++    xvxor.v        xr15,   xr15,   xr15
++    xvxor.v        xr16,   xr16,   xr16
++
++    pixel_normFact_8x8_core_lasx xr13, xr14, xr15, xr16
++
++.rept (\w)*(\h)/64-1
++    addi.d         a0,     a0,     64
++
++    pixel_normFact_8x8_core_lasx xr13, xr14, xr15, xr16
++.endr
++
++    xvadd.w        xr13,   xr13,   xr14
++    xvadd.w        xr15,   xr15,   xr16
++    xvadd.w        xr12,   xr13,   xr15
++    xvpermi.q      xr17,   xr12,   0x01
++    vadd.w         vr12,   vr12,   vr17
++    vhaddw.du.wu   vr12,   vr12,   vr12
++    vhaddw.qu.du   vr12,   vr12,   vr12
++    vstelm.d       vr12,   a3,     0,      0
++endfunc
++.endm
++
++pixel_normFact_lasx 16, 16
++pixel_normFact_lasx 32, 32
++pixel_normFact_lasx 64, 64
++
++function x265_pixel_planecopy_cp_lsx
++    vreplgr2vr.b   vr2,    a6
++    addi.w         a5,     a5,     -1
++
++.loop_h:
++    addi.d         t0,     a0,     0
++    addi.d         t1,     a2,     0
++    add.d          t2,     zero,   zero
++.loop_w:
++    vld            vr0,    t0,     0
++    vsll.b         vr0,    vr0,    vr2
++    vst            vr0,    t1,     0
++    addi.d         t2,     t2,     16
++    addi.d         t0,     t0,     16
++    addi.d         t1,     t1,     16
++    blt            t2,     a4,     .loop_w
++
++    add.d          a0,     a0,     a1
++    add.d          a2,     a2,     a3
++    addi.w         a5,     a5,     -1
++    bnez           a5,     .loop_h
++
++    add.d          t3,     a4,     zero
++    srli.d         t3,     t3,     3
++.loopw8:
++    fld.d          f0,     a0,     0
++    vsll.b         vr0,    vr0,    vr2
++    vstelm.d       vr0,    a2,     0,     0
++    addi.d         a4,     a4,     -8
++    addi.d         t3,     t3,     -1
++    addi.d         a0,     a0,     8
++    addi.d         a2,     a2,     8
++    bnez           t3,     .loopw8
++
++    addi.d         a5,     zero,   8
++    sub.d          a5,     a5,     a4
++    sub.d          a0,     a0,     a5
++    sub.d          a2,     a2,     a5
++    fld.d          f0,     a0,     0
++    vsll.b         vr0,    vr0,    vr2
++    vstelm.d       vr0,    a2,     0,     0
++endfunc
++
++function x265_pixel_planecopy_sp_lsx
++    vreplgr2vr.h   vr10,   a6      // shift
++    vreplgr2vr.h   vr11,   a7      // mask
++    addi.w         a5,     a5,     -1
++    slli.d         a1,     a1,     1
++.sp_loop_h:
++    addi.d         t0,     a0,     0
++    addi.d         t1,     a2,     0
++    add.d          t2,     zero,   zero
++.sp_loop_w:
++    vld            vr0,    t0,     0
++    vld            vr1,    t0,     16
++    vsrl.h         vr0,    vr0,    vr10
++    vsrl.h         vr1,    vr1,    vr10
++    vand.v         vr0,    vr0,    vr11
++    vand.v         vr1,    vr1,    vr11
++    vssrarni.bu.h  vr1,    vr0,    0
++    vst            vr1,    t1,     0
++    addi.d         t2,     t2,     16
++    addi.d         t0,     t0,     32
++    addi.d         t1,     t1,     16
++    blt            t2,     a4,     .sp_loop_w
++
++    add.d          a0,     a0,     a1
++    add.d          a2,     a2,     a3
++    addi.w         a5,     a5,     -1
++    bnez           a5,     .sp_loop_h
++
++    add.d          t3,     a4,     zero
++    srli.d         t3,     t3,     4
++.sp_loopw32:
++    vld            vr0,    a0,     0
++    vld            vr1,    a0,     16
++    vsrl.h         vr0,    vr0,    vr10
++    vsrl.h         vr1,    vr1,    vr10
++    vand.v         vr0,    vr0,    vr11
++    vand.v         vr1,    vr1,    vr11
++    vssrarni.bu.h  vr1,    vr0,    0
++    vst            vr1,    a2,     0
++    addi.d         a4,     a4,     -16
++    addi.d         t3,     t3,     -1
++    addi.d         a0,     a0,     32
++    addi.d         a2,     a2,     16
++    bnez           t3,     .sp_loopw32
++
++    addi.d         a5,     zero,   16
++    sub.d          a5,     a5,     a4
++    sub.d          a0,     a0,     a5
++    sub.d          a0,     a0,     a5
++    sub.d          a2,     a2,     a5
++    vld            vr0,    a0,     0
++    vld            vr1,    a0,     16
++    vsrl.h         vr0,    vr0,    vr10
++    vsrl.h         vr1,    vr1,    vr10
++    vand.v         vr0,    vr0,    vr11
++    vand.v         vr1,    vr1,    vr11
++    vssrarni.bu.h  vr1,    vr0,    0
++    vst            vr1,    a2,     0
++endfunc
++
++function x265_pixel_planecopy_sp_shl_lsx
++    vreplgr2vr.h   vr10,   a6      // shift
++    vreplgr2vr.h   vr11,   a7      // mask
++    addi.w         a5,     a5,     -1
++    slli.d         a1,     a1,     1
++.spshl_loop_h:
++    addi.d         t0,     a0,     0
++    addi.d         t1,     a2,     0
++    add.d          t2,     zero,   zero
++.spshl_loop_w:
++    vld            vr0,    t0,     0
++    vld            vr1,    t0,     16
++    vsll.h         vr0,    vr0,    vr10
++    vsll.h         vr1,    vr1,    vr10
++    vand.v         vr0,    vr0,    vr11
++    vand.v         vr1,    vr1,    vr11
++    vssrarni.bu.h  vr1,    vr0,    0
++    vst            vr1,    t1,     0
++    addi.d         t2,     t2,     16
++    addi.d         t0,     t0,     32
++    addi.d         t1,     t1,     16
++    blt            t2,     a4,     .spshl_loop_w
++
++    add.d          a0,     a0,     a1
++    add.d          a2,     a2,     a3
++    addi.w         a5,     a5,     -1
++    bnez           a5,     .spshl_loop_h
++
++    add.d          t3,     a4,     zero
++    srli.d         t3,     t3,     4
++.spshl_loopw32:
++    vld            vr0,    a0,     0
++    vld            vr1,    a0,     16
++    vsll.h         vr0,    vr0,    vr10
++    vsll.h         vr1,    vr1,    vr10
++    vand.v         vr0,    vr0,    vr11
++    vand.v         vr1,    vr1,    vr11
++    vssrarni.bu.h  vr1,    vr0,    0
++    vst            vr1,    a2,     0
++    addi.d         a4,     a4,     -16
++    addi.d         t3,     t3,     -1
++    addi.d         a0,     a0,     32
++    addi.d         a2,     a2,     16
++    bnez           t3,     .spshl_loopw32
++
++    addi.d         a5,     zero,   16
++    sub.d          a5,     a5,     a4
++    sub.d          a0,     a0,     a5
++    sub.d          a0,     a0,     a5
++    sub.d          a2,     a2,     a5
++    vld            vr0,    a0,     0
++    vld            vr1,    a0,     16
++    vsll.h         vr0,    vr0,    vr10
++    vsll.h         vr1,    vr1,    vr10
++    vand.v         vr0,    vr0,    vr11
++    vand.v         vr1,    vr1,    vr11
++    vssrarni.bu.h  vr1,    vr0,    0
++    vst            vr1,    a2,     0
++endfunc
++
++function x265_pixel_planecopy_pp_shr_lsx
++    vreplgr2vr.b   vr2,    a6
++    addi.w         a5,     a5,     -1
++
++.ppshr_loop_h:
++    addi.d         t0,     a0,     0
++    addi.d         t1,     a2,     0
++    add.d          t2,     zero,   zero
++.ppshr_loop_w:
++    vld            vr0,    t0,     0
++    vsrl.b         vr0,    vr0,    vr2
++    vst            vr0,    t1,     0
++    addi.d         t2,     t2,     16
++    addi.d         t0,     t0,     16
++    addi.d         t1,     t1,     16
++    blt            t2,     a4,     .ppshr_loop_w
++
++    add.d          a0,     a0,     a1
++    add.d          a2,     a2,     a3
++    addi.w         a5,     a5,     -1
++    bnez           a5,     .ppshr_loop_h
++
++    add.d          t3,     a4,     zero
++    srli.d         t3,     t3,     3
++.ppshr_loopw8:
++    fld.d          f0,     a0,     0
++    vsrl.b         vr0,    vr0,    vr2
++    vstelm.d       vr0,    a2,     0,     0
++    addi.d         a4,     a4,     -8
++    addi.d         t3,     t3,     -1
++    addi.d         a0,     a0,     8
++    addi.d         a2,     a2,     8
++    bnez           t3,     .ppshr_loopw8
++
++    addi.d         a5,     zero,   8
++    sub.d          a5,     a5,     a4
++    sub.d          a0,     a0,     a5
++    sub.d          a2,     a2,     a5
++    fld.d          f0,     a0,     0
++    vsrl.b         vr0,    vr0,    vr2
++    vstelm.d       vr0,    a2,     0,     0
++endfunc
++
++function x265_scale2D_64to32_lsx
++    addi.d         t0,     zero,   32
++
++.loop_scale2D_lsx:
++    vld            vr0,    a1,     0
++    vld            vr1,    a1,     16
++    vld            vr2,    a1,     32
++    vld            vr3,    a1,     48
++    add.d          a1,     a1,     a2
++    addi.d         t0,     t0,     -1
++    vld            vr4,    a1,     0
++    vld            vr5,    a1,     16
++    vld            vr6,    a1,     32
++    vld            vr7,    a1,     48
++    add.d          a1,     a1,     a2
++
++.irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vhaddw.hu.bu   \i,     \i,     \i
++.endr
++    vadd.h         vr0,    vr0,    vr4
++    vadd.h         vr1,    vr1,    vr5
++    vadd.h         vr2,    vr2,    vr6
++    vadd.h         vr3,    vr3,    vr7
++    vssrarni.bu.h  vr1,    vr0,    2
++    vssrarni.bu.h  vr3,    vr2,    2
++    vst            vr1,    a0,     0
++    vst            vr3,    a0,     16
++    addi.d         a0,     a0,     32
++    bnez           t0,     .loop_scale2D_lsx
++endfunc
++
++function x265_scale1D_128to64_lsx
++.rept 2
++    vld            vr0,    a1,     0
++    vld            vr1,    a1,     16
++    vld            vr2,    a1,     32
++    vld            vr3,    a1,     48
++    vld            vr4,    a1,     64
++    vld            vr5,    a1,     80
++    vld            vr6,    a1,     96
++    vld            vr7,    a1,     112
++
++    vpickev.b      vr8,    vr1,    vr0
++    vpickod.b      vr9,    vr1,    vr0
++    vpickev.b      vr10,   vr3,    vr2
++    vpickod.b      vr11,   vr3,    vr2
++    vpickev.b      vr12,   vr5,    vr4
++    vpickod.b      vr13,   vr5,    vr4
++    vpickev.b      vr14,   vr7,    vr6
++    vpickod.b      vr15,   vr7,    vr6
++    vavgr.bu       vr0,    vr8,    vr9
++    vavgr.bu       vr1,    vr10,   vr11
++    vavgr.bu       vr2,    vr12,   vr13
++    vavgr.bu       vr3,    vr14,   vr15
++    vst            vr0,    a0,     0
++    vst            vr1,    a0,     16
++    vst            vr2,    a0,     32
++    vst            vr3,    a0,     48
++    addi.d         a0,     a0,     64
++    addi.d         a1,     a1,     128
++.endr
++endfunc
++
++function x265_scale2D_64to32_lasx
++    addi.d         t0,     zero,   32
++
++.loop_scale2D_lasx:
++    xvld           xr0,    a1,     0
++    xvld           xr1,    a1,     32
++    add.d          a1,     a1,     a2
++    addi.d         t0,     t0,     -1
++    xvld           xr4,    a1,     0
++    xvld           xr5,    a1,     32
++    add.d          a1,     a1,     a2
++
++.irp i, xr0, xr1, xr4, xr5
++    xvhaddw.hu.bu  \i,     \i,     \i
++.endr
++    xvadd.h        xr0,    xr0,    xr4
++    xvadd.h        xr1,    xr1,    xr5
++    xvssrarni.bu.h xr1,    xr0,    2
++    xvpermi.d      xr2,    xr1,    0xd8
++    xvst           xr2,    a0,     0
++    addi.d         a0,     a0,     32
++    bnez           t0,     .loop_scale2D_lasx
++endfunc
++
++function x265_scale1D_128to64_lasx
++.rept 2
++    xvld           xr0,    a1,     0
++    xvld           xr1,    a1,     32
++    xvld           xr2,    a1,     64
++    xvld           xr3,    a1,     96
++
++    xvpickev.b     xr8,    xr1,    xr0
++    xvpickod.b     xr9,    xr1,    xr0
++    xvpickev.b     xr10,   xr3,    xr2
++    xvpickod.b     xr11,   xr3,    xr2
++    xvavgr.bu      xr0,    xr8,    xr9
++    xvavgr.bu      xr1,    xr10,   xr11
++    xvpermi.d      xr2,    xr0,    0xd8
++    xvpermi.d      xr3,    xr1,    0xd8
++    xvst           xr2,    a0,     0
++    xvst           xr3,    a0,     32
++    addi.d         a0,     a0,     64
++    addi.d         a1,     a1,     128
++.endr
++endfunc
++
++function x265_transpose_4x4_lsx
++    fld.s          f0,     a1,     0
++    fldx.s         f1,     a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    fld.s          f2,     a1,     0
++    fldx.s         f3,     a1,     a2
++
++    vilvl.b        vr1,    vr1,    vr0
++    vilvl.b        vr3,    vr3,    vr2
++    vilvl.h        vr4,    vr3,    vr1
++    vst            vr4,    a0,     0
++endfunc
++
++function x265_transpose_8x8_lsx
++    fld.d          f0,     a1,     0
++    fldx.d         f1,     a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    fld.d          f2,     a1,     0
++    fldx.d         f3,     a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    fld.d          f4,     a1,     0
++    fldx.d         f5,     a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    fld.d          f6,     a1,     0
++    fldx.d         f7,     a1,     a2
++
++    vilvl.b        vr1,    vr1,    vr0
++    vilvl.b        vr3,    vr3,    vr2
++    vilvl.b        vr5,    vr5,    vr4
++    vilvl.b        vr7,    vr7,    vr6
++    vilvl.h        vr2,    vr3,    vr1
++    vilvh.h        vr4,    vr3,    vr1
++    vilvl.h        vr6,    vr7,    vr5
++    vilvh.h        vr8,    vr7,    vr5
++    vilvl.w        vr0,    vr6,    vr2
++    vilvh.w        vr1,    vr6,    vr2
++    vilvl.w        vr3,    vr8,    vr4
++    vilvh.w        vr5,    vr8,    vr4
++
++    vst            vr0,    a0,     0
++    vst            vr1,    a0,     16
++    vst            vr3,    a0,     32
++    vst            vr5,    a0,     48
++endfunc
++
++.macro transpose_16x16_core_lsx in0, in1, in2, in3, in4, in5, in6, in7, \
++                                in8, in9, in10, in11, in12, in13, in14, in15, in16
++    vilvl.b        vr16,   vr2,    vr0
++    vilvl.b        vr17,   vr3,    vr1
++    vilvl.b        vr18,   vr6,    vr4
++    vilvl.b        vr19,   vr7,    vr5
++    vilvl.b        vr20,   vr17,   vr16
++    vilvl.b        vr21,   vr19,   vr18
++    vilvh.b        vr22,   vr17,   vr16
++    vilvh.b        vr23,   vr19,   vr18
++    vilvl.w        vr24,   vr21,   vr20
++    vilvl.w        vr25,   vr23,   vr22
++    vilvh.w        vr26,   vr21,   vr20
++    vilvh.w        vr27,   vr23,   vr22
++
++    vilvl.b        vr16,   vr10,   vr8
++    vilvl.b        vr17,   vr11,   vr9
++    vilvl.b        vr18,   vr14,   vr12
++    vilvl.b        vr19,   vr15,   vr13
++    vilvl.b        vr20,   vr17,   vr16
++    vilvl.b        vr21,   vr19,   vr18
++    vilvh.b        vr22,   vr17,   vr16
++    vilvh.b        vr23,   vr19,   vr18
++    vilvl.w        vr16,   vr21,   vr20
++    vilvl.w        vr17,   vr23,   vr22
++    vilvh.w        vr18,   vr21,   vr20
++    vilvh.w        vr19,   vr23,   vr22
++
++    vilvl.d        vr20,   vr16,   vr24
++    vilvl.d        vr21,   vr18,   vr26
++    vilvh.d        vr22,   vr16,   vr24
++    vilvh.d        vr23,   vr18,   vr26
++    vst            vr20,   \in16,  \in0
++    vst            vr22,   \in16,  \in1
++    vst            vr21,   \in16,  \in2
++    vst            vr23,   \in16,  \in3
++
++    vilvl.d        vr20,   vr17,   vr25
++    vilvl.d        vr21,   vr19,   vr27
++    vilvh.d        vr22,   vr17,   vr25
++    vilvh.d        vr23,   vr19,   vr27
++    vst            vr20,   \in16,  \in4
++    vst            vr22,   \in16,  \in5
++    vst            vr21,   \in16,  \in6
++    vst            vr23,   \in16,  \in7
++
++    vilvh.b        vr16,   vr2,    vr0
++    vilvh.b        vr17,   vr3,    vr1
++    vilvh.b        vr18,   vr6,    vr4
++    vilvh.b        vr19,   vr7,    vr5
++    vilvl.b        vr20,   vr17,   vr16
++    vilvl.b        vr21,   vr19,   vr18
++    vilvh.b        vr22,   vr17,   vr16
++    vilvh.b        vr23,   vr19,   vr18
++    vilvl.w        vr24,   vr21,   vr20
++    vilvl.w        vr25,   vr23,   vr22
++    vilvh.w        vr26,   vr21,   vr20
++    vilvh.w        vr27,   vr23,   vr22
++
++    vilvh.b        vr16,   vr10,   vr8
++    vilvh.b        vr17,   vr11,   vr9
++    vilvh.b        vr18,   vr14,   vr12
++    vilvh.b        vr19,   vr15,   vr13
++    vilvl.b        vr20,   vr17,   vr16
++    vilvl.b        vr21,   vr19,   vr18
++    vilvh.b        vr22,   vr17,   vr16
++    vilvh.b        vr23,   vr19,   vr18
++    vilvl.w        vr16,   vr21,   vr20
++    vilvl.w        vr17,   vr23,   vr22
++    vilvh.w        vr18,   vr21,   vr20
++    vilvh.w        vr19,   vr23,   vr22
++
++    vilvl.d        vr20,   vr16,   vr24
++    vilvl.d        vr21,   vr18,   vr26
++    vilvh.d        vr22,   vr16,   vr24
++    vilvh.d        vr23,   vr18,   vr26
++    vst            vr20,   \in16,  \in8
++    vst            vr22,   \in16,  \in9
++    vst            vr21,   \in16,  \in10
++    vst            vr23,   \in16,  \in11
++
++    vilvl.d        vr20,   vr17,   vr25
++    vilvl.d        vr21,   vr19,   vr27
++    vilvh.d        vr22,   vr17,   vr25
++    vilvh.d        vr23,   vr19,   vr27
++    vst            vr20,   \in16,  \in12
++    vst            vr22,   \in16,  \in13
++    vst            vr21,   \in16,  \in14
++    vst            vr23,   \in16,  \in15
++.endm
++
++.macro vld_16x16_b_lsx
++    vld            vr0,    a1,     0
++    vldx           vr1,    a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr2,    a1,     0
++    vldx           vr3,    a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr4,    a1,     0
++    vldx           vr5,    a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr6,    a1,     0
++    vldx           vr7,    a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr8,    a1,     0
++    vldx           vr9,    a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr10,   a1,     0
++    vldx           vr11,   a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr12,   a1,     0
++    vldx           vr13,   a1,     a2
++    alsl.d         a1,     a2,     a1,   1
++    vld            vr14,   a1,     0
++    vldx           vr15,   a1,     a2
++.endm
++
++function x265_transpose_16x16_lsx
++    addi.d         sp,     sp,     -32
++    fst.d          f24,    sp,     0
++    fst.d          f25,    sp,     8
++    fst.d          f26,    sp,     16
++    fst.d          f27,    sp,     24
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 16, 32, 48, 64, 80, 96, 112, \
++                             128, 144, 160, 176, 192, 208, 224, 240, a0
++
++    fld.d          f24,    sp,     0
++    fld.d          f25,    sp,     8
++    fld.d          f26,    sp,     16
++    fld.d          f27,    sp,     24
++    addi.d         sp,     sp,     32
++endfunc
++
++function x265_transpose_32x32_lsx
++    addi.d         sp,     sp,     -32
++    fst.d          f24,    sp,     0
++    fst.d          f25,    sp,     8
++    fst.d          f26,    sp,     16
++    fst.d          f27,    sp,     24
++
++    bne            a0,     a1,     .COMPARE_A0A1
++    addi.d         sp,     sp,     -256
++
++    addi.d         t0,     a1,     0
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 32, 64, 96, 128, 160, 192, 224, \
++                             256, 288, 320, 352, 384, 416, 448, 480, a0
++
++    alsl.d         a1,     a2,     a1,   1
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 16, 32, 48, 64, 80, 96, 112, \
++                             128, 144, 160, 176, 192, 208, 224, 240, sp
++
++    addi.d         a1,     t0,     16
++
++    vld_16x16_b_lsx
++
++    vld            vr16,   sp,     0
++    vld            vr17,   sp,     16
++    vld            vr18,   sp,     32
++    vld            vr19,   sp,     48
++    vld            vr20,   sp,     64
++    vld            vr21,   sp,     80
++    vld            vr22,   sp,     96
++    vld            vr23,   sp,     112
++
++    vst            vr16,   a0,     16
++    vst            vr17,   a0,     48
++    vst            vr18,   a0,     80
++    vst            vr19,   a0,     112
++    vst            vr20,   a0,     144
++    vst            vr21,   a0,     176
++    vst            vr22,   a0,     208
++    vst            vr23,   a0,     240
++
++    addi.d         t5,     sp,     128
++    addi.d         t6,     a0,     272-16
++
++    vld            vr16,   t5,     0
++    vld            vr17,   t5,     16
++    vld            vr18,   t5,     32
++    vld            vr19,   t5,     48
++    vld            vr20,   t5,     64
++    vld            vr21,   t5,     80
++    vld            vr22,   t5,     96
++    vld            vr23,   t5,     112
++
++    vst            vr16,   t6,     16
++    vst            vr17,   t6,     48
++    vst            vr18,   t6,     80
++    vst            vr19,   t6,     112
++    vst            vr20,   t6,     144
++    vst            vr21,   t6,     176
++    vst            vr22,   t6,     208
++    vst            vr23,   t6,     240
++
++    addi.d         a0,     a0,     512
++
++    transpose_16x16_core_lsx 0, 32, 64, 96, 128, 160, 192, 224, \
++                             256, 288, 320, 352, 384, 416, 448, 480, a0
++
++    alsl.d         a1,     a2,     a1,   1
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 16, 48, 80, 112, 144, 176, 208, 240, \
++                             272, 304, 336, 368, 400, 432, 464, 496, a0
++
++    addi.d         sp,     sp,     256
++    b              .TRANSPOSE_32X32_END
++.COMPARE_A0A1:
++
++    addi.d         t0,     a1,     0
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 32, 64, 96, 128, 160, 192, 224, \
++                             256, 288, 320, 352, 384, 416, 448, 480, a0
++
++    alsl.d         a1,     a2,     a1,   1
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 16, 48, 80, 112, 144, 176, 208, 240, \
++                             272, 304, 336, 368, 400, 432, 464, 496, a0
++
++    addi.d         a1,     t0,     16
++    addi.d         a0,     a0,     512
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 32, 64, 96, 128, 160, 192, 224, \
++                             256, 288, 320, 352, 384, 416, 448, 480, a0
++
++    alsl.d         a1,     a2,     a1,   1
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 16, 48, 80, 112, 144, 176, 208, 240, \
++                             272, 304, 336, 368, 400, 432, 464, 496, a0
++
++.TRANSPOSE_32X32_END:
++    fld.d          f24,    sp,     0
++    fld.d          f25,    sp,     8
++    fld.d          f26,    sp,     16
++    fld.d          f27,    sp,     24
++    addi.d         sp,     sp,     32
++endfunc
++
++function x265_transpose_64x64_lsx
++    addi.d         sp,     sp,     -32
++    fst.d          f24,    sp,     0
++    fst.d          f25,    sp,     8
++    fst.d          f26,    sp,     16
++    fst.d          f27,    sp,     24
++
++    addi.d         t0,     a1,     0
++    addi.d         t1,     a0,     0
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 64, 128, 192, 256, 320, 384, 448, \
++                             512, 576, 640, 704, 768, 832, 896, 960, a0
++
++.rept 3
++    alsl.d         a1,     a2,     a1,   1
++    addi.d         a0,     a0,     16
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 64, 128, 192, 256, 320, 384, 448, \
++                             512, 576, 640, 704, 768, 832, 896, 960, a0
++.endr
++
++.rept 3
++    addi.d         a0,     a0,     -48
++    addi.d         t0,     t0,     16
++    addi.d         a1,     t0,     0
++    addi.d         a0,     a0,     512
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 64, 128, 192, 256, 320, 384, 448, \
++                             512, 576, 640, 704, 768, 832, 896, 960, a0
++
++.rept 3
++    alsl.d         a1,     a2,     a1,   1
++    addi.d         a0,     a0,     16
++
++    vld_16x16_b_lsx
++
++    transpose_16x16_core_lsx 0, 64, 128, 192, 256, 320, 384, 448, \
++                             512, 576, 640, 704, 768, 832, 896, 960, a0
++.endr
++.endr
++
++    fld.d          f24,    sp,     0
++    fld.d          f25,    sp,     8
++    fld.d          f26,    sp,     16
++    fld.d          f27,    sp,     24
++    addi.d         sp,     sp,     32
++endfunc
++
++function x265_ssimDist4_lsx
++    fld.s          f0,     a0,     0
++    fld.s          f1,     a2,     0
++    fldx.s         f2,     a0,     a1
++    fldx.s         f3,     a2,     a3
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++    fld.s          f4,     a0,     0
++    fld.s          f5,     a2,     0
++    fldx.s         f6,     a0,     a1
++    fldx.s         f7,     a2,     a3
++
++    // ssBlock
++    vilvl.w        vr2,    vr2,    vr0
++    vilvl.w        vr6,    vr6,    vr4
++    vilvl.w        vr3,    vr3,    vr1
++    vilvl.w        vr7,    vr7,    vr5
++    vilvl.d        vr6,    vr6,    vr2
++    vilvl.d        vr7,    vr7,    vr3
++    vsubwev.h.bu   vr8,    vr6,    vr7
++    vsubwod.h.bu   vr9,    vr6,    vr7
++    vmulwev.w.h    vr2,    vr8,    vr8
++    vmulwod.w.h    vr3,    vr8,    vr8
++    vmulwev.w.h    vr4,    vr9,    vr9
++    vmulwod.w.h    vr5,    vr9,    vr9
++    vadd.w         vr2,    vr2,    vr3
++    vadd.w         vr4,    vr4,    vr5
++    vadd.w         vr10,   vr2,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    // ac_k
++    vsllwil.hu.bu  vr22,   vr6,    0
++    vexth.hu.bu    vr23,   vr6
++    vmulwev.w.hu   vr2,    vr22,   vr22
++    vmulwod.w.hu   vr3,    vr22,   vr22
++    vmaddwev.w.h   vr2,    vr23,   vr23
++    vmaddwod.w.h   vr3,    vr23,   vr23
++    vadd.w         vr10,   vr2,    vr3
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist8_lsx
++
++.irp i, vr12, vr13, vr14, vr15, vr16, vr17, vr18, vr19
++    vxor.v         \i,     \i,     \i
++.endr
++
++.rept 2
++    fld.d          f0,     a0,     0
++    fld.d          f1,     a2,     0
++    fldx.d         f2,     a0,     a1
++    fldx.d         f3,     a2,     a3
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++    fld.d          f4,     a0,     0
++    fld.d          f5,     a2,     0
++    fldx.d         f6,     a0,     a1
++    fldx.d         f7,     a2,     a3
++
++    // ssBlock
++    vilvl.d        vr2,    vr2,    vr0
++    vilvl.d        vr6,    vr6,    vr4
++    vilvl.d        vr3,    vr3,    vr1
++    vilvl.d        vr7,    vr7,    vr5
++    vsubwev.h.bu   vr8,    vr2,    vr3
++    vsubwod.h.bu   vr9,    vr2,    vr3
++    vsubwev.h.bu   vr10,   vr6,    vr7
++    vsubwod.h.bu   vr11,   vr6,    vr7
++    vmaddwev.w.h   vr12,   vr8,    vr8
++    vmaddwod.w.h   vr13,   vr8,    vr8
++    vmaddwev.w.h   vr14,   vr9,    vr9
++    vmaddwod.w.h   vr15,   vr9,    vr9
++    vmaddwev.w.h   vr12,   vr10,   vr10
++    vmaddwod.w.h   vr13,   vr10,   vr10
++    vmaddwev.w.h   vr14,   vr11,   vr11
++    vmaddwod.w.h   vr15,   vr11,   vr11
++
++    // ac_k
++    vsllwil.hu.bu  vr20,   vr2,    0
++    vexth.hu.bu    vr21,   vr2
++    vsllwil.hu.bu  vr22,   vr6,    0
++    vexth.hu.bu    vr23,   vr6
++    vmaddwev.w.hu  vr16,   vr20,   vr20
++    vmaddwod.w.hu  vr17,   vr20,   vr20
++    vmaddwev.w.hu  vr18,   vr21,   vr21
++    vmaddwod.w.hu  vr19,   vr21,   vr21
++    vmaddwev.w.hu  vr16,   vr22,   vr22
++    vmaddwod.w.hu  vr17,   vr22,   vr22
++    vmaddwev.w.hu  vr18,   vr23,   vr23
++    vmaddwod.w.hu  vr19,   vr23,   vr23
++
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++.endr
++
++    vadd.w         vr12,   vr12,   vr13
++    vadd.w         vr14,   vr14,   vr15
++    vadd.w         vr10,   vr12,   vr14
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    vadd.w         vr4,    vr16,   vr17
++    vadd.w         vr8,    vr18,   vr19
++    vadd.w         vr10,   vr8,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist16_lsx
++
++.irp i, vr12, vr13, vr14, vr15, vr16, vr17, vr18, vr19
++    vxor.v         \i,     \i,     \i
++.endr
++
++.rept 8
++    vld            vr0,    a0,     0
++    vld            vr1,    a2,     0
++    vldx           vr2,    a0,     a1
++    vldx           vr3,    a2,     a3
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++
++    // ssBlock
++    vsubwev.h.bu   vr8,    vr0,    vr1
++    vsubwod.h.bu   vr9,    vr0,    vr1
++    vsubwev.h.bu   vr10,   vr2,    vr3
++    vsubwod.h.bu   vr11,   vr2,    vr3
++    vmaddwev.w.h   vr12,   vr8,    vr8
++    vmaddwod.w.h   vr13,   vr8,    vr8
++    vmaddwev.w.h   vr14,   vr9,    vr9
++    vmaddwod.w.h   vr15,   vr9,    vr9
++    vmaddwev.w.h   vr12,   vr10,   vr10
++    vmaddwod.w.h   vr13,   vr10,   vr10
++    vmaddwev.w.h   vr14,   vr11,   vr11
++    vmaddwod.w.h   vr15,   vr11,   vr11
++
++    // ac_k
++    vsllwil.hu.bu  vr20,   vr0,    0
++    vexth.hu.bu    vr21,   vr0
++    vsllwil.hu.bu  vr22,   vr2,    0
++    vexth.hu.bu    vr23,   vr2
++    vmaddwev.w.hu  vr16,   vr20,   vr20
++    vmaddwod.w.hu  vr17,   vr20,   vr20
++    vmaddwev.w.hu  vr18,   vr21,   vr21
++    vmaddwod.w.hu  vr19,   vr21,   vr21
++    vmaddwev.w.hu  vr16,   vr22,   vr22
++    vmaddwod.w.hu  vr17,   vr22,   vr22
++    vmaddwev.w.hu  vr18,   vr23,   vr23
++    vmaddwod.w.hu  vr19,   vr23,   vr23
++.endr
++    vadd.w         vr12,   vr12,   vr13
++    vadd.w         vr14,   vr14,   vr15
++    vadd.w         vr10,   vr12,   vr14
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    vadd.w         vr16,   vr16,   vr17
++    vadd.w         vr18,   vr18,   vr19
++    vadd.w         vr10,   vr16,   vr18
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist32_lsx
++
++.irp i, vr12, vr13, vr14, vr15, vr16, vr17, vr18, vr19
++    vxor.v         \i,     \i,     \i
++.endr
++
++.rept 32
++    vld            vr0,    a0,     0
++    vld            vr1,    a2,     0
++    vld            vr2,    a0,     16
++    vld            vr3,    a2,     16
++    add.d          a0,     a1,     a0
++    add.d          a2,     a3,     a2
++
++    // ssBlock
++    vsubwev.h.bu   vr8,    vr0,    vr1
++    vsubwod.h.bu   vr9,    vr0,    vr1
++    vsubwev.h.bu   vr10,   vr2,    vr3
++    vsubwod.h.bu   vr11,   vr2,    vr3
++    vmaddwev.w.h   vr12,   vr8,    vr8
++    vmaddwod.w.h   vr13,   vr8,    vr8
++    vmaddwev.w.h   vr14,   vr9,    vr9
++    vmaddwod.w.h   vr15,   vr9,    vr9
++    vmaddwev.w.h   vr12,   vr10,   vr10
++    vmaddwod.w.h   vr13,   vr10,   vr10
++    vmaddwev.w.h   vr14,   vr11,   vr11
++    vmaddwod.w.h   vr15,   vr11,   vr11
++
++    // ac_k
++    vsllwil.hu.bu  vr20,   vr0,    0
++    vexth.hu.bu    vr21,   vr0
++    vsllwil.hu.bu  vr22,   vr2,    0
++    vexth.hu.bu    vr23,   vr2
++    vmaddwev.w.hu  vr16,   vr20,   vr20
++    vmaddwod.w.hu  vr17,   vr20,   vr20
++    vmaddwev.w.hu  vr18,   vr21,   vr21
++    vmaddwod.w.hu  vr19,   vr21,   vr21
++    vmaddwev.w.hu  vr16,   vr22,   vr22
++    vmaddwod.w.hu  vr17,   vr22,   vr22
++    vmaddwev.w.hu  vr18,   vr23,   vr23
++    vmaddwod.w.hu  vr19,   vr23,   vr23
++.endr
++    vadd.w         vr12,   vr12,   vr13
++    vadd.w         vr14,   vr14,   vr15
++    vadd.w         vr10,   vr12,   vr14
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    vadd.w         vr16,   vr16,   vr17
++    vadd.w         vr18,   vr18,   vr19
++    vadd.w         vr10,   vr16,   vr18
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist64_lsx
++
++.irp i, vr12, vr13, vr14, vr15, vr16, vr17, vr18, vr19
++    vxor.v         \i,     \i,     \i
++.endr
++
++.rept 64
++    vld            vr0,    a0,     0
++    vld            vr1,    a2,     0
++    vld            vr2,    a0,     16
++    vld            vr3,    a2,     16
++    vld            vr4,    a0,     32
++    vld            vr5,    a2,     32
++    vld            vr6,    a0,     48
++    vld            vr7,    a2,     48
++    add.d          a0,     a1,     a0
++    add.d          a2,     a3,     a2
++
++    // ssBlock
++    vsubwev.h.bu   vr8,    vr0,    vr1
++    vsubwod.h.bu   vr9,    vr0,    vr1
++    vsubwev.h.bu   vr10,   vr2,    vr3
++    vsubwod.h.bu   vr11,   vr2,    vr3
++    vsubwev.h.bu   vr20,   vr4,    vr5
++    vsubwod.h.bu   vr21,   vr4,    vr5
++    vsubwev.h.bu   vr22,   vr6,    vr7
++    vsubwod.h.bu   vr23,   vr6,    vr7
++
++    vmaddwev.w.h   vr12,   vr8,    vr8
++    vmaddwod.w.h   vr13,   vr8,    vr8
++    vmaddwev.w.h   vr14,   vr9,    vr9
++    vmaddwod.w.h   vr15,   vr9,    vr9
++    vmaddwev.w.h   vr12,   vr10,   vr10
++    vmaddwod.w.h   vr13,   vr10,   vr10
++    vmaddwev.w.h   vr14,   vr11,   vr11
++    vmaddwod.w.h   vr15,   vr11,   vr11
++    vmaddwev.w.h   vr12,   vr20,   vr20
++    vmaddwod.w.h   vr13,   vr20,   vr20
++    vmaddwev.w.h   vr14,   vr21,   vr21
++    vmaddwod.w.h   vr15,   vr21,   vr21
++    vmaddwev.w.h   vr12,   vr22,   vr22
++    vmaddwod.w.h   vr13,   vr22,   vr22
++    vmaddwev.w.h   vr14,   vr23,   vr23
++    vmaddwod.w.h   vr15,   vr23,   vr23
++
++    // ac_k
++    vsllwil.hu.bu  vr20,   vr0,    0
++    vexth.hu.bu    vr21,   vr0
++    vsllwil.hu.bu  vr22,   vr2,    0
++    vexth.hu.bu    vr23,   vr2
++    vsllwil.hu.bu  vr8,    vr4,    0
++    vexth.hu.bu    vr9,    vr4
++    vsllwil.hu.bu  vr10,   vr6,    0
++    vexth.hu.bu    vr11,   vr6
++
++    vmaddwev.w.hu  vr16,   vr20,   vr20
++    vmaddwod.w.hu  vr17,   vr20,   vr20
++    vmaddwev.w.hu  vr18,   vr21,   vr21
++    vmaddwod.w.hu  vr19,   vr21,   vr21
++    vmaddwev.w.hu  vr16,   vr22,   vr22
++    vmaddwod.w.hu  vr17,   vr22,   vr22
++    vmaddwev.w.hu  vr18,   vr23,   vr23
++    vmaddwod.w.hu  vr19,   vr23,   vr23
++    vmaddwev.w.hu  vr16,   vr8,    vr8
++    vmaddwod.w.hu  vr17,   vr8,    vr8
++    vmaddwev.w.hu  vr18,   vr9,    vr9
++    vmaddwod.w.hu  vr19,   vr9,    vr9
++    vmaddwev.w.hu  vr16,   vr10,   vr10
++    vmaddwod.w.hu  vr17,   vr10,   vr10
++    vmaddwev.w.hu  vr18,   vr11,   vr11
++    vmaddwod.w.hu  vr19,   vr11,   vr11
++.endr
++    vadd.w         vr12,   vr12,   vr13
++    vadd.w         vr14,   vr14,   vr15
++    vadd.w         vr10,   vr12,   vr14
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    vadd.w         vr4,    vr16,   vr17
++    vadd.w         vr8,    vr18,   vr19
++    vadd.w         vr10,   vr8,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist8_lasx
++
++.irp i, xr12, xr13, xr14, xr15, xr16, xr17, xr18, xr19
++    xvxor.v        \i,     \i,     \i
++.endr
++
++.rept 2
++    fld.d          f0,     a0,     0
++    fld.d          f1,     a2,     0
++    fldx.d         f2,     a0,     a1
++    fldx.d         f3,     a2,     a3
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++    fld.d          f4,     a0,     0
++    fld.d          f5,     a2,     0
++    fldx.d         f6,     a0,     a1
++    fldx.d         f7,     a2,     a3
++
++    // ssBlock
++    vilvl.d        vr2,    vr2,    vr0
++    vilvl.d        vr6,    vr6,    vr4
++    vilvl.d        vr3,    vr3,    vr1
++    vilvl.d        vr7,    vr7,    vr5
++    xvpermi.q      xr6,    xr2,    0x20
++    xvpermi.q      xr7,    xr3,    0x20
++    xvsubwev.h.bu  xr10,   xr6,    xr7
++    xvsubwod.h.bu  xr11,   xr6,    xr7
++    xvmaddwev.w.h  xr12,   xr10,   xr10
++    xvmaddwod.w.h  xr13,   xr10,   xr10
++    xvmaddwev.w.h  xr14,   xr11,   xr11
++    xvmaddwod.w.h  xr15,   xr11,   xr11
++
++    // ac_k
++    xvsllwil.hu.bu xr0,    xr6,    0
++    xvexth.hu.bu   xr1,    xr6
++    xvmaddwev.w.hu xr16,   xr0,    xr0
++    xvmaddwod.w.hu xr17,   xr0,    xr0
++    xvmaddwev.w.hu xr18,   xr1,    xr1
++    xvmaddwod.w.hu xr19,   xr1,    xr1
++
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++.endr
++
++    xvadd.w        xr12,   xr12,   xr13
++    xvadd.w        xr14,   xr14,   xr15
++    xvadd.w        xr10,   xr12,   xr14
++    xvpermi.q      xr12,   xr10,   0x01
++    vadd.w         vr10,   vr10,   vr12
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    xvadd.w        xr8,    xr18,   xr19
++    xvadd.w        xr8,    xr8,    xr16
++    xvadd.w        xr8,    xr8,    xr17
++    xvpermi.q      xr4,    xr8,    0x01
++    vadd.w         vr10,   vr8,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist16_lasx
++
++.irp i, xr12, xr13, xr14, xr15, xr16, xr17, xr18, xr19
++    xvxor.v        \i,     \i,     \i
++.endr
++
++.rept 8
++    vld            vr0,    a0,     0
++    vld            vr1,    a2,     0
++    vldx           vr2,    a0,     a1
++    vldx           vr3,    a2,     a3
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++
++    xvpermi.q      xr2,    xr0,    0x20
++    xvpermi.q      xr3,    xr1,    0x20
++
++    // ssBlock
++    xvsubwev.h.bu  xr10,   xr2,    xr3
++    xvsubwod.h.bu  xr11,   xr2,    xr3
++    xvmaddwev.w.h  xr12,   xr10,   xr10
++    xvmaddwod.w.h  xr13,   xr10,   xr10
++    xvmaddwev.w.h  xr14,   xr11,   xr11
++    xvmaddwod.w.h  xr15,   xr11,   xr11
++
++    // ac_k
++    xvsllwil.hu.bu xr0,    xr2,    0
++    xvexth.hu.bu   xr1,    xr2
++    xvmaddwev.w.hu xr16,   xr0,    xr0
++    xvmaddwod.w.hu xr17,   xr0,    xr0
++    xvmaddwev.w.hu xr18,   xr1,    xr1
++    xvmaddwod.w.hu xr19,   xr1,    xr1
++.endr
++
++    xvadd.w        xr12,   xr12,   xr13
++    xvadd.w        xr14,   xr14,   xr15
++    xvadd.w        xr10,   xr12,   xr14
++    xvpermi.q      xr12,   xr10,   0x01
++    vadd.w         vr10,   vr10,   vr12
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    xvadd.w        xr8,    xr18,   xr19
++    xvadd.w        xr8,    xr8,    xr16
++    xvadd.w        xr8,    xr8,    xr17
++    xvpermi.q      xr4,    xr8,    0x01
++    vadd.w         vr10,   vr8,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist32_lasx
++
++.irp i, xr12, xr13, xr14, xr15, xr16, xr17, xr18, xr19
++    xvxor.v        \i,     \i,     \i
++.endr
++
++.rept 16
++    xvld           xr0,    a0,     0
++    xvld           xr1,    a2,     0
++    xvldx          xr2,    a0,     a1
++    xvldx          xr3,    a2,     a3
++    alsl.d         a0,     a1,     a0,   1
++    alsl.d         a2,     a3,     a2,   1
++
++    // ssBlock
++    xvsubwev.h.bu  xr8,    xr0,    xr1
++    xvsubwod.h.bu  xr9,    xr0,    xr1
++    xvsubwev.h.bu  xr10,   xr2,    xr3
++    xvsubwod.h.bu  xr11,   xr2,    xr3
++    xvmaddwev.w.h  xr12,   xr8,    xr8
++    xvmaddwod.w.h  xr13,   xr8,    xr8
++    xvmaddwev.w.h  xr14,   xr9,    xr9
++    xvmaddwod.w.h  xr15,   xr9,    xr9
++    xvmaddwev.w.h  xr12,   xr10,   xr10
++    xvmaddwod.w.h  xr13,   xr10,   xr10
++    xvmaddwev.w.h  xr14,   xr11,   xr11
++    xvmaddwod.w.h  xr15,   xr11,   xr11
++
++    // ac_k
++    xvsllwil.hu.bu xr8,    xr0,    0
++    xvexth.hu.bu   xr9,    xr0
++    xvsllwil.hu.bu xr10,   xr2,    0
++    xvexth.hu.bu   xr11,   xr2
++
++    xvmaddwev.w.hu xr16,   xr8,    xr8
++    xvmaddwod.w.hu xr17,   xr8,    xr8
++    xvmaddwev.w.hu xr18,   xr9,    xr9
++    xvmaddwod.w.hu xr19,   xr9,    xr9
++    xvmaddwev.w.hu xr16,   xr10,   xr10
++    xvmaddwod.w.hu xr17,   xr10,   xr10
++    xvmaddwev.w.hu xr18,   xr11,   xr11
++    xvmaddwod.w.hu xr19,   xr11,   xr11
++.endr
++
++    xvadd.w        xr12,   xr12,   xr13
++    xvadd.w        xr14,   xr14,   xr15
++    xvadd.w        xr10,   xr12,   xr14
++    xvpermi.q      xr12,   xr10,   0x01
++    vadd.w         vr10,   vr10,   vr12
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    xvadd.w        xr9,    xr16,   xr17
++    xvadd.w        xr8,    xr18,   xr19
++    xvadd.w        xr8,    xr8,    xr9
++    xvpermi.q      xr4,    xr8,    0x01
++    vadd.w         vr10,   vr8,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++function x265_ssimDist64_lasx
++
++.irp i, xr12, xr13, xr14, xr15, xr16, xr17, xr18, xr19
++    xvxor.v        \i,     \i,     \i
++.endr
++
++.rept 64
++    xvld           xr0,    a0,     0
++    xvld           xr1,    a2,     0
++    xvld           xr2,    a0,     32
++    xvld           xr3,    a2,     32
++    add.d          a0,     a1,     a0
++    add.d          a2,     a3,     a2
++
++    // ssBlock
++    xvsubwev.h.bu  xr8,    xr0,    xr1
++    xvsubwod.h.bu  xr9,    xr0,    xr1
++    xvsubwev.h.bu  xr10,   xr2,    xr3
++    xvsubwod.h.bu  xr11,   xr2,    xr3
++    xvmaddwev.w.h  xr12,   xr8,    xr8
++    xvmaddwod.w.h  xr13,   xr8,    xr8
++    xvmaddwev.w.h  xr14,   xr9,    xr9
++    xvmaddwod.w.h  xr15,   xr9,    xr9
++    xvmaddwev.w.h  xr12,   xr10,   xr10
++    xvmaddwod.w.h  xr13,   xr10,   xr10
++    xvmaddwev.w.h  xr14,   xr11,   xr11
++    xvmaddwod.w.h  xr15,   xr11,   xr11
++
++    // ac_k
++    xvsllwil.hu.bu xr8,    xr0,    0
++    xvexth.hu.bu   xr9,    xr0
++    xvsllwil.hu.bu xr10,   xr2,    0
++    xvexth.hu.bu   xr11,   xr2
++
++    xvmaddwev.w.hu xr16,   xr8,    xr8
++    xvmaddwod.w.hu xr17,   xr8,    xr8
++    xvmaddwev.w.hu xr18,   xr9,    xr9
++    xvmaddwod.w.hu xr19,   xr9,    xr9
++    xvmaddwev.w.hu xr16,   xr10,   xr10
++    xvmaddwod.w.hu xr17,   xr10,   xr10
++    xvmaddwev.w.hu xr18,   xr11,   xr11
++    xvmaddwod.w.hu xr19,   xr11,   xr11
++.endr
++
++    xvadd.w        xr12,   xr12,   xr13
++    xvadd.w        xr14,   xr14,   xr15
++    xvadd.w        xr10,   xr12,   xr14
++    xvpermi.q      xr12,   xr10,   0x01
++    vadd.w         vr10,   vr10,   vr12
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.d       vr10,   a4,     0,     0
++
++    xvadd.w        xr9,    xr16,   xr17
++    xvadd.w        xr8,    xr18,   xr19
++    xvadd.w        xr8,    xr8,    xr9
++    xvpermi.q      xr4,    xr8,    0x01
++    vadd.w         vr10,   vr8,    vr4
++    vhaddw.du.wu   vr10,   vr10,   vr10
++    vhaddw.qu.du   vr10,   vr10,   vr10
++    vstelm.w       vr10,   a6,     0,     0
++endfunc
++
++const IF_INTERNAL_PREC_VALUE
++.rept 8
++.short 8192
++.endr
++endconst
++
++function x265_weight_sp_lsx
++    slli.d         a2,     a2,     1
++
++    ld.d           t7,     sp,     0  // shift
++    ld.d           t8,     sp,     8  // offset
++    andi           t0,     a4,     7
++    srli.w         t1,     a4,     3
++    la.local       t4,     IF_INTERNAL_PREC_VALUE
++    vreplgr2vr.h   vr4,    a6         // w0
++    vreplgr2vr.w   vr10,   t8         // offset
++    vreplgr2vr.w   vr11,   a7         // round
++    vreplgr2vr.w   vr12,   t7         // shift
++    vld            vr13,   t4,     0  // IF_INTERNAL_PREC
++    beqz           t1,     .splooph1
++
++.splooph:
++    addi.d         t2,     a0,     0
++    addi.d         t3,     a1,     0
++    addi.d         t5,     t1,     0
++.sploopw:
++    vld            vr1,    t2,     0
++    vmulwev.w.h    vr2,    vr1,    vr4
++    vmulwod.w.h    vr3,    vr1,    vr4
++    vmaddwev.w.h   vr2,    vr4,    vr13
++    vmaddwod.w.h   vr3,    vr4,    vr13
++    vadd.w         vr2,    vr2,    vr11
++    vadd.w         vr3,    vr3,    vr11
++    vsra.w         vr2,    vr2,    vr12
++    vsra.w         vr3,    vr3,    vr12
++    vadd.w         vr2,    vr2,    vr10
++    vadd.w         vr3,    vr3,    vr10
++    vilvl.w        vr6,    vr3,    vr2
++    vilvh.w        vr7,    vr3,    vr2
++    vssrarni.h.w   vr7,    vr6,    0
++    vssrarni.bu.h  vr7,    vr7,    0
++    vstelm.d       vr7,    t3,     0,    0
++    addi.d         t5,     t5,     -1
++    addi.d         t2,     t2,     16
++    addi.d         t3,     t3,     8
++    beqz           t5,     .spwidthless8
++    b              .sploopw
++.spwidthless8:
++
++    andi           t0,     a4,     7
++
++    beqz           t0,     .sploophend
++
++    vld            vr1,    t2,     0
++    vmulwev.w.h    vr2,    vr1,    vr4
++    vmulwod.w.h    vr3,    vr1,    vr4
++    vmaddwev.w.h   vr2,    vr4,    vr13
++    vmaddwod.w.h   vr3,    vr4,    vr13
++    vadd.w         vr2,    vr2,    vr11
++    vadd.w         vr3,    vr3,    vr11
++    vsra.w         vr2,    vr2,    vr12
++    vsra.w         vr3,    vr3,    vr12
++    vadd.w         vr2,    vr2,    vr10
++    vadd.w         vr3,    vr3,    vr10
++    vilvl.w        vr6,    vr3,    vr2
++    vilvh.w        vr7,    vr3,    vr2
++    vssrarni.h.w   vr7,    vr6,    0
++    vssrarni.bu.h  vr7,    vr7,    0
++.vstless8:
++    vstelm.b       vr7,    t3,     0,    0
++    vbsrl.v        vr7,    vr7,    1
++    addi.d         t3,     t3,     1
++    addi.d         t0,     t0,     -1
++    bnez           t0,     .vstless8
++
++.sploophend:
++    add.d          a0,     a0,     a2
++    add.d          a1,     a1,     a3
++    addi.d         a5,     a5,     -1
++    bnez           a5,     .splooph
++    b              .spend
++
++.splooph1:
++    addi.d         t2,     a0,     0
++    addi.d         t3,     a1,     0
++    andi           t0,     a4,     7
++
++    vld            vr1,    t2,     0
++    vmulwev.w.h    vr2,    vr1,    vr4
++    vmulwod.w.h    vr3,    vr1,    vr4
++    vmaddwev.w.h   vr2,    vr4,    vr13
++    vmaddwod.w.h   vr3,    vr4,    vr13
++    vadd.w         vr2,    vr2,    vr11
++    vadd.w         vr3,    vr3,    vr11
++    vsra.w         vr2,    vr2,    vr12
++    vsra.w         vr3,    vr3,    vr12
++    vadd.w         vr2,    vr2,    vr10
++    vadd.w         vr3,    vr3,    vr10
++    vilvl.w        vr6,    vr3,    vr2
++    vilvh.w        vr7,    vr3,    vr2
++    vssrarni.h.w   vr7,    vr6,    0
++    vssrarni.bu.h  vr7,    vr7,    0
++.vstless81:
++    vstelm.b       vr7,    t3,     0,  0
++    vbsrl.v        vr7,    vr7,    1
++    addi.d         t3,     t3,     1
++    addi.d         t0,     t0,     -1
++    bnez           t0,     .vstless81
++
++    add.d          a0,     a0,     a2
++    add.d          a1,     a1,     a3
++    addi.d         a5,     a5,     -1
++    bnez           a5,     .splooph1
++.spend:
++endfunc
++
++const ssim_c1c2
++.word 416, 416, 416, 416
++.word 235963, 235963, 235963, 235963
++endconst
++
++function x265_ssim_end4_lsx
++    vld            vr0,    a0,     0
++    vld            vr1,    a0,     16
++    vld            vr2,    a0,     32
++    vld            vr3,    a0,     48
++    vld            vr4,    a0,     64
++    vld            vr5,    a1,     0
++    vld            vr6,    a1,     16
++    vld            vr7,    a1,     32
++    vld            vr8,    a1,     48
++    vld            vr9,    a1,     64
++
++    vadd.w         vr0,    vr0,    vr5
++    vadd.w         vr1,    vr1,    vr6
++    vadd.w         vr2,    vr2,    vr7
++    vadd.w         vr3,    vr3,    vr8
++    vadd.w         vr4,    vr4,    vr9
++
++    vadd.w         vr5,    vr0,    vr1
++    vadd.w         vr6,    vr1,    vr2
++    vadd.w         vr7,    vr2,    vr3
++    vadd.w         vr8,    vr3,    vr4
++    LSX_TRANSPOSE4x4_W vr5, vr6, vr7, vr8, vr0, vr1, vr2, vr3, \
++                       vr9, vr10
++
++    vmul.w         vr4,    vr1,    vr0  // s2*s1
++    vmul.w         vr5,    vr1,    vr1  // s2*s2
++    vmadd.w        vr5,    vr0,    vr0  // s1*s1 + s2*s2
++    vslli.w        vr4,    vr4,    1    // 2 * fs1 * fs2
++    vslli.w        vr3,    vr3,    7
++    vslli.w        vr2,    vr2,    6
++    la.local       t5,     ssim_c1c2
++    vsub.w         vr3,    vr3,    vr4  // vocar*2
++    vsub.w         vr2,    vr2,    vr5  // vars
++    vld            vr9,    t5,     0    // ssim_c1
++    vld            vr10,   t5,     16   // ssim_c2
++    vadd.w         vr4,    vr4,    vr9
++    vadd.w         vr3,    vr3,    vr10
++    vadd.w         vr5,    vr5,    vr9
++    vadd.w         vr2,    vr2,    vr10
++
++    vffint.s.w     vr4,    vr4
++    vffint.s.w     vr3,    vr3
++    vffint.s.w     vr5,    vr5
++    vffint.s.w     vr2,    vr2
++
++    vfmul.s        vr9,    vr4,    vr3
++    vfmul.s        vr10,   vr5,    vr2
++    vfdiv.s        vr11,   vr9,    vr10  // ssim
++    vreplgr2vr.w   vr0,    zero
++.widthless4:
++    fadd.s         f0,     f11,    f0
++    vbsrl.v        vr11,   vr11,   4
++    addi.w         a2,     a2,     -1
++    bnez           a2,     .widthless4
++endfunc
++
++function x265_ssim_4x4x2_lsx
++    addi.d         t0,     a0,     0
++    addi.d         t1,     a2,     0
++
++.rept 2
++    fld.s          f0,     a0,     0
++    fldx.s         f1,     a0,     a1
++    alsl.d         a0,     a1,     a0, 1
++    fld.s          f2,     a0,     0
++    fldx.s         f3,     a0,     a1
++
++    fld.s          f4,     a2,     0
++    fldx.s         f5,     a2,     a3
++    alsl.d         a2,     a3,     a2, 1
++    fld.s          f6,     a2,     0
++    fldx.s         f7,     a2,     a3
++
++    vilvl.w        vr1,    vr1,    vr0
++    vilvl.w        vr3,    vr3,    vr2
++    vilvl.w        vr5,    vr5,    vr4
++    vilvl.w        vr7,    vr7,    vr6
++    vilvl.d        vr0,    vr3,    vr1
++    vilvl.d        vr2,    vr7,    vr5
++    vhaddw.hu.bu   vr8,    vr0,    vr0
++    vhaddw.hu.bu   vr9,    vr2,    vr2
++    vhaddw.wu.hu   vr8,    vr8,    vr8
++    vhaddw.wu.hu   vr9,    vr9,    vr9
++    vhaddw.du.wu   vr8,    vr8,    vr8
++    vhaddw.du.wu   vr9,    vr9,    vr9
++    vhaddw.qu.du   vr8,    vr8,    vr8  // s1
++    vhaddw.qu.du   vr9,    vr9,    vr9  // s2
++
++    vsllwil.hu.bu  vr1,    vr1,    0
++    vsllwil.hu.bu  vr3,    vr3,    0
++    vsllwil.hu.bu  vr5,    vr5,    0
++    vsllwil.hu.bu  vr7,    vr7,    0
++
++    vmulwev.w.h    vr0,    vr3,    vr3
++    vmulwod.w.h    vr4,    vr3,    vr3
++    vmulwev.w.h    vr6,    vr1,    vr5
++    vmaddwev.w.h   vr0,    vr7,    vr7
++    vmaddwod.w.h   vr4,    vr7,    vr7
++    vmaddwod.w.h   vr6,    vr1,    vr5
++    vmaddwev.w.h   vr0,    vr1,    vr1
++    vmaddwod.w.h   vr4,    vr1,    vr1
++    vmaddwev.w.h   vr6,    vr3,    vr7
++    vmaddwev.w.h   vr0,    vr5,    vr5
++    vmaddwod.w.h   vr4,    vr5,    vr5
++    vmaddwod.w.h   vr6,    vr3,    vr7
++    vadd.w         vr0,    vr0,    vr4
++    vhaddw.d.w     vr6,    vr6,    vr6
++    vhaddw.d.w     vr0,    vr0,    vr0
++    vhaddw.q.d     vr6,    vr6,    vr6  // s12
++    vhaddw.q.d     vr0,    vr0,    vr0  // ss
++
++    vilvl.w        vr9,    vr9,    vr8
++    vilvl.w        vr6,    vr6,    vr0
++    vilvl.d        vr7,    vr6,    vr9
++    vst            vr7,    a4,     0
++
++    addi.d         a0,     t0,     4
++    addi.d         a2,     t1,     4
++    addi.d         a4,     a4,     16
++.endr
++endfunc
+diff --git a/source/common/loongarch64/pixel.h b/source/common/loongarch64/pixel.h
+index ed1cb75c8..494a593fe 100644
+--- a/source/common/loongarch64/pixel.h
++++ b/source/common/loongarch64/pixel.h
+@@ -94,6 +94,257 @@ extern "C" {
+ 
+ DECL_PIXELS(lsx);
+ 
++int x265_pixel_satd_4x4_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_4x8_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_4x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_4x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x4_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x8_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x12_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_12x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_12x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x4_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x8_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x12_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x24_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_24x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_24x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x8_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x24_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x48_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_48x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x48_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++
++int x265_pixel_satd_4x8_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_4x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_4x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x8_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_8x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_12x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_12x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x8_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x24_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_16x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_24x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_24x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x8_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x24_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x48_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_32x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_48x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x48_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_satd_64x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++
++FUNCDEF_PU(void, pixel_sad_x4, lsx, const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++
++void x265_pixel_sad_x4_8x4_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_8x8_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_8x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_8x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_12x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_16x4_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_16x8_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_16x12_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_16x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_16x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_16x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_24x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_32x8_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_32x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_32x24_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_32x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_32x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_64x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_64x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_64x48_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_64x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x4_48x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, const pixel* pix5, intptr_t frefstride, int32_t* res);
++
++int x265_pixel_sa8d_8x8_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_8x16_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_16x16_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_16x32_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_32x32_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_32x64_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_64x64_lsx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++
++int x265_pixel_sa8d_8x8_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_8x16_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_16x16_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_16x32_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_32x32_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_32x64_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int x265_pixel_sa8d_64x64_lasx(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++
++FUNCDEF_PU(int, pixel_sad, lsx, const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++
++int x265_pixel_sad_24x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_32x8_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_32x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_32x24_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_32x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_32x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_48x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_64x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_64x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_64x48_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int x265_pixel_sad_64x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++
++FUNCDEF_PU(void, pixel_sad_x3, lsx, const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++
++void x265_pixel_sad_x3_12x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_16x8_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_16x12_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_16x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_16x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_16x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_24x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_32x8_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_32x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_32x24_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_32x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_32x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_64x16_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_64x32_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_64x48_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_64x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++void x265_pixel_sad_x3_48x64_lasx(const pixel* pix1, const pixel* pix2, const pixel* pix3, const pixel* pix4, intptr_t frefstride, int32_t* res);
++
++uint32_t x265_pixel_sse_4x4_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_4x8_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_8x8_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_8x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_16x16_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_16x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_32x32_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_32x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_64x64_lsx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++
++uint32_t x265_pixel_sse_16x16_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_16x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_32x32_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_32x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_64x64_lasx(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++
++uint32_t x265_pixel_sse_ss_4x4_lsx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_8x8_lsx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_16x16_lsx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_32x32_lsx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_64x64_lsx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++
++uint32_t x265_pixel_sse_ss_8x8_lasx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_16x16_lasx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_32x32_lasx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++uint32_t x265_pixel_sse_ss_64x64_lasx(const int16_t* pix1, intptr_t stride_pix1, const int16_t* pix2, intptr_t stride_pix2);
++
++void x265_weight_pp_lsx(const pixel* src, pixel* dst, intptr_t stride, int width, int height, int w0, int round, int shift, int offset);
++void x265_weight_sp_lsx(const int16_t* src, pixel* dst, intptr_t srcStride, intptr_t dstStride, int width, int height, int w0, int round, int shift, int offset);
++
++FUNCDEF_PU(void, pixel_sub_ps, lsx, int16_t* a, intptr_t dstride, const pixel* b0, const pixel* b1, intptr_t sstride0, intptr_t sstride1);
++
++void x265_pixel_sub_ps_32x32_lasx(int16_t* a, intptr_t dstride, const pixel* b0, const pixel* b1, intptr_t sstride0, intptr_t sstride1);
++void x265_pixel_sub_ps_32x64_lasx(int16_t* a, intptr_t dstride, const pixel* b0, const pixel* b1, intptr_t sstride0, intptr_t sstride1);
++void x265_pixel_sub_ps_64x64_lasx(int16_t* a, intptr_t dstride, const pixel* b0, const pixel* b1, intptr_t sstride0, intptr_t sstride1);
++
++FUNCDEF_PU(void, pixel_add_ps, lsx, pixel* a, intptr_t dstride, const pixel* b0, const int16_t* b1, intptr_t sstride0, intptr_t sstride1);
++
++void x265_pixel_add_ps_16x16_lasx(pixel* a, intptr_t dstride, const pixel* b0, const int16_t* b1, intptr_t sstride0, intptr_t sstride1);
++void x265_pixel_add_ps_16x32_lasx(pixel* a, intptr_t dstride, const pixel* b0, const int16_t* b1, intptr_t sstride0, intptr_t sstride1);
++void x265_pixel_add_ps_32x32_lasx(pixel* a, intptr_t dstride, const pixel* b0, const int16_t* b1, intptr_t sstride0, intptr_t sstride1);
++void x265_pixel_add_ps_32x64_lasx(pixel* a, intptr_t dstride, const pixel* b0, const int16_t* b1, intptr_t sstride0, intptr_t sstride1);
++void x265_pixel_add_ps_64x64_lasx(pixel* a, intptr_t dstride, const pixel* b0, const int16_t* b1, intptr_t sstride0, intptr_t sstride1);
++
++uint64_t x265_pixel_var_4x4_lsx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_8x8_lsx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_16x16_lsx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_32x32_lsx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_64x64_lsx(const pixel* pix, intptr_t i_stride);
++
++uint64_t x265_pixel_var_8x8_lasx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_16x16_lasx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_32x32_lasx(const pixel* pix, intptr_t i_stride);
++uint64_t x265_pixel_var_64x64_lasx(const pixel* pix, intptr_t i_stride);
++
++uint32_t x265_pixel_ssd_s_4x4_lsx(const int16_t* a, intptr_t dstride);
++uint32_t x265_pixel_ssd_s_8x8_lsx(const int16_t* a, intptr_t dstride);
++uint32_t x265_pixel_ssd_s_16x16_lsx(const int16_t* a, intptr_t dstride);
++uint32_t x265_pixel_ssd_s_32x32_lsx(const int16_t* a, intptr_t dstride);
++uint32_t x265_pixel_ssd_s_64x64_lsx(const int16_t* a, intptr_t dstride);
++
++uint32_t x265_pixel_ssd_s_16x16_lasx(const int16_t* a, intptr_t dstride);
++uint32_t x265_pixel_ssd_s_32x32_lasx(const int16_t* a, intptr_t dstride);
++uint32_t x265_pixel_ssd_s_64x64_lasx(const int16_t* a, intptr_t dstride);
++
++void x265_pixel_getResidual_4x4_lsx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void x265_pixel_getResidual_8x8_lsx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void x265_pixel_getResidual_16x16_lsx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void x265_pixel_getResidual_32x32_lsx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void x265_pixel_getResidual_64x64_lsx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++
++void x265_pixel_getResidual_32x32_lasx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void x265_pixel_getResidual_64x64_lasx(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++
++void x265_pixel_normFact_8x8_lsx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++void x265_pixel_normFact_16x16_lsx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++void x265_pixel_normFact_32x32_lsx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++void x265_pixel_normFact_64x64_lsx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++
++void x265_pixel_normFact_8x8_lasx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++void x265_pixel_normFact_16x16_lasx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++void x265_pixel_normFact_32x32_lasx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++void x265_pixel_normFact_64x64_lasx(const pixel* src, uint32_t blockSize, int shift, uint64_t *z_k);
++
++void x265_pixel_planecopy_cp_lsx(const uint8_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift);
++void x265_pixel_planecopy_sp_lsx(const uint16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift, uint16_t mask);
++void x265_pixel_planecopy_sp_shl_lsx(const uint16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift, uint16_t mask);
++void x265_pixel_planecopy_pp_shr_lsx(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift);
++
++void x265_scale1D_128to64_lsx(pixel *dst, const pixel *src);
++void x265_scale2D_64to32_lsx(pixel* dst, const pixel* src, intptr_t stride);
++
++void x265_scale1D_128to64_lasx(pixel *dst, const pixel *src);
++void x265_scale2D_64to32_lasx(pixel* dst, const pixel* src, intptr_t stride);
++
++void x265_transpose_4x4_lsx(pixel* dst, const pixel* src, intptr_t stride);
++void x265_transpose_8x8_lsx(pixel* dst, const pixel* src, intptr_t stride);
++void x265_transpose_16x16_lsx(pixel* dst, const pixel* src, intptr_t stride);
++void x265_transpose_32x32_lsx(pixel* dst, const pixel* src, intptr_t stride);
++void x265_transpose_64x64_lsx(pixel* dst, const pixel* src, intptr_t stride);
++
++void x265_ssimDist4_lsx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist8_lsx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist16_lsx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist32_lsx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist64_lsx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++
++void x265_ssimDist8_lasx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist16_lasx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist32_lasx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++void x265_ssimDist64_lasx(const pixel* fenc, uint32_t fStride, const pixel* recon, intptr_t rstride, uint64_t *ssBlock, int shift, uint64_t *ac_k);
++
++float x265_ssim_end4_lsx(int sum0[5][4], int sum1[5][4], int width);
++void x265_ssim_4x4x2_lsx(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]);
++
+ void x265_pixel_avg_32x8_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
+ void x265_pixel_avg_32x16_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
+ void x265_pixel_avg_32x24_lasx(pixel* dst, intptr_t dstride, const pixel* src0, intptr_t sstride0, const pixel* src1, intptr_t sstride1, int);
+diff --git a/source/common/loongarch64/sad.S b/source/common/loongarch64/sad.S
+new file mode 100644
+index 000000000..719d2d0a0
+--- /dev/null
++++ b/source/common/loongarch64/sad.S
+@@ -0,0 +1,2880 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Hecai Yuan <yuanhecai@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "loongson_asm.S"
++
++#define FENC_STRIDE 64
++
++.macro SUM_VEC_x4 in0, in1, in2, in3
++    vhaddw.wu.hu   \in0,   \in0,  \in0
++    vhaddw.wu.hu   \in1,   \in1,  \in1
++    vhaddw.wu.hu   \in2,   \in2,  \in2
++    vhaddw.wu.hu   \in3,   \in3,  \in3
++    vhaddw.du.wu   \in0,   \in0,  \in0
++    vhaddw.du.wu   \in1,   \in1,  \in1
++    vhaddw.du.wu   \in2,   \in2,  \in2
++    vhaddw.du.wu   \in3,   \in3,  \in3
++    vhaddw.qu.du   \in0,   \in0,  \in0
++    vhaddw.qu.du   \in1,   \in1,  \in1
++    vhaddw.qu.du   \in2,   \in2,  \in2
++    vhaddw.qu.du   \in3,   \in3,  \in3
++.endm
++
++.macro pixel_sad_x4_4x4_core_lsx out0, out1, out2, out3
++    fld.s          f0,     a0,    0
++    fld.s          f1,     a0,    FENC_STRIDE
++    fld.s          f2,     a0,    FENC_STRIDE<<1
++    fld.s          f3,     a0,    FENC_STRIDE*3
++    FLDS_LOADX_4   a1,     a5,    t1,  t2,  f4, f8,  f12, f16
++    FLDS_LOADX_4   a2,     a5,    t1,  t2,  f5, f9,  f13, f17
++    FLDS_LOADX_4   a3,     a5,    t1,  t2,  f6, f10, f14, f18
++    FLDS_LOADX_4   a4,     a5,    t1,  t2,  f7, f11, f15, f19
++
++    vilvl.w        vr0,    vr1,   vr0
++    vilvl.w        vr2,    vr3,   vr2
++    vilvl.d        vr0,    vr2,   vr0
++    vilvl.w        vr4,    vr8,   vr4
++    vilvl.w        vr12,   vr16,  vr12
++    vilvl.d        vr1,    vr12,  vr4
++    vilvl.w        vr5,    vr9,   vr5
++    vilvl.w        vr13,   vr17,  vr13
++    vilvl.d        vr2,    vr13,  vr5
++    vilvl.w        vr6,    vr10,  vr6
++    vilvl.w        vr14,   vr18,  vr14
++    vilvl.d        vr3,    vr14,  vr6
++    vilvl.w        vr7,    vr11,  vr7
++    vilvl.w        vr15,   vr19,  vr15
++    vilvl.d        vr4,    vr15,  vr7
++
++    vabsd.bu       vr1,    vr0,   vr1
++    vabsd.bu       vr2,    vr0,   vr2
++    vabsd.bu       vr3,    vr0,   vr3
++    vabsd.bu       vr4,    vr0,   vr4
++    vhaddw.hu.bu   \out0,  vr1,   vr1
++    vhaddw.hu.bu   \out1,  vr2,   vr2
++    vhaddw.hu.bu   \out2,  vr3,   vr3
++    vhaddw.hu.bu   \out3,  vr4,   vr4
++.endm
++
++function x265_pixel_sad_x4_4x4_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_4x4_core_lsx vr20, vr21, vr22, vr23
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    // Store data to p_sad_array
++    vstelm.w       vr20,   a6,    0,  0
++    vstelm.w       vr21,   a6,    4,  0
++    vstelm.w       vr22,   a6,    8,  0
++    vstelm.w       vr23,   a6,   12,  0
++endfunc
++
++function x265_pixel_sad_x4_4x8_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_4x4_core_lsx vr20, vr21, vr22, vr23
++
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_4x4_core_lsx vr1, vr2, vr3, vr4
++
++    vadd.h         vr16,   vr20,  vr1
++    vadd.h         vr17,   vr21,  vr2
++    vadd.h         vr18,   vr22,  vr3
++    vadd.h         vr19,   vr23,  vr4
++
++    SUM_VEC_x4 vr16, vr17, vr18, vr19
++
++    // Store data to p_sad_array
++    vstelm.w       vr16,   a6,    0,      0
++    vstelm.w       vr17,   a6,    4,      0
++    vstelm.w       vr18,   a6,    8,      0
++    vstelm.w       vr19,   a6,    12,     0
++endfunc
++
++function x265_pixel_sad_x4_4x16_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_4x4_core_lsx vr20, vr21, vr22, vr23
++
++.rept 3
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_4x4_core_lsx vr1, vr2, vr3, vr4
++
++    vadd.h         vr20,   vr20,  vr1
++    vadd.h         vr21,   vr21,  vr2
++    vadd.h         vr22,   vr22,  vr3
++    vadd.h         vr23,   vr23,  vr4
++.endr
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    // Store data to p_sad_array
++    vstelm.w       vr20,   a6,    0,      0
++    vstelm.w       vr21,   a6,    4,      0
++    vstelm.w       vr22,   a6,    8,      0
++    vstelm.w       vr23,   a6,    12,     0
++endfunc
++
++.macro pixel_sad_x4_8x4_core_lsx in0, in1, in2, in3, in4, out0, out1, out2, out3
++    fld.d          f0,     \in0,  0
++    fld.d          f1,     \in0,  FENC_STRIDE
++    fld.d          f2,     \in0,  FENC_STRIDE<<1
++    fld.d          f3,     \in0,  FENC_STRIDE*3
++    FLDD_LOADX_4   \in1,   a5,    t1,  t2,  f4, f8,  f12, f16
++    FLDD_LOADX_4   \in2,   a5,    t1,  t2,  f5, f9,  f13, f17
++    FLDD_LOADX_4   \in3,   a5,    t1,  t2,  f6, f10, f14, f18
++    FLDD_LOADX_4   \in4,   a5,    t1,  t2,  f7, f11, f15, f19
++    vilvl.d        vr0,    vr1,   vr0
++    vilvl.d        vr2,    vr3,   vr2
++    vilvl.d        vr4,    vr8,   vr4
++    vilvl.d        vr12,   vr16,  vr12
++    vilvl.d        vr5,    vr9,   vr5
++    vilvl.d        vr13,   vr17,  vr13
++    vilvl.d        vr6,    vr10,  vr6
++    vilvl.d        vr14,   vr18,  vr14
++    vilvl.d        vr7,    vr11,  vr7
++    vilvl.d        vr15,   vr19,  vr15
++    vabsd.bu       vr4,    vr0,   vr4
++    vabsd.bu       vr5,    vr0,   vr5
++    vabsd.bu       vr6,    vr0,   vr6
++    vabsd.bu       vr7,    vr0,   vr7
++    vabsd.bu       vr12,   vr2,   vr12
++    vabsd.bu       vr13,   vr2,   vr13
++    vabsd.bu       vr14,   vr2,   vr14
++    vabsd.bu       vr15,   vr2,   vr15
++    vhaddw.hu.bu   vr4,    vr4,   vr4
++    vhaddw.hu.bu   vr5,    vr5,   vr5
++    vhaddw.hu.bu   vr6,    vr6,   vr6
++    vhaddw.hu.bu   vr7,    vr7,   vr7
++    vhaddw.hu.bu   vr12,   vr12,  vr12
++    vhaddw.hu.bu   vr13,   vr13,  vr13
++    vhaddw.hu.bu   vr14,   vr14,  vr14
++    vhaddw.hu.bu   vr15,   vr15,  vr15
++    vadd.h         \out0,  vr4,   vr12
++    vadd.h         \out1,  vr5,   vr13
++    vadd.h         \out2,  vr6,   vr14
++    vadd.h         \out3,  vr7,   vr15
++.endm
++
++function x265_pixel_sad_x4_8x4_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_8x4_core_lsx a0, a1, a2, a3, a4, vr16, vr17, vr18, vr19
++
++    SUM_VEC_x4 vr16, vr17, vr18, vr19
++
++    vstelm.w       vr16,   a6,    0,      0
++    vstelm.w       vr17,   a6,    4,      0
++    vstelm.w       vr18,   a6,    8,      0
++    vstelm.w       vr19,   a6,    12,     0
++endfunc
++
++.macro pixel_sad_x4_8x_lsx h
++function x265_pixel_sad_x4_8x\h\()_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_8x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++.rept (\h>>2)-1
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_8x4_core_lsx a0, a1, a2, a3, a4, vr16, vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++.endr
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++.endm
++
++pixel_sad_x4_8x_lsx 8
++pixel_sad_x4_8x_lsx 16
++pixel_sad_x4_8x_lsx 32
++
++.macro pixel_sad_x4_16x4_core_lsx in0, in1, in2, in3, in4, out0, out1, out2, out3
++    vld            vr0,    \in0,  0
++    vld            vr1,    \in0,  FENC_STRIDE
++    vld            vr2,    \in0,  FENC_STRIDE<<1
++    vld            vr3,    \in0,  FENC_STRIDE*3
++    LSX_LOADX_4    \in1,   a5,    t1,  t2,  vr4, vr8, vr12, vr16
++    LSX_LOADX_4    \in2,   a5,    t1,  t2,  vr5, vr9, vr13, vr17
++    LSX_LOADX_4    \in3,   a5,    t1,  t2,  vr6, vr10, vr14, vr18
++    LSX_LOADX_4    \in4,   a5,    t1,  t2,  vr7, vr11, vr15, vr19
++    vabsd.bu       vr4,    vr0,   vr4
++    vabsd.bu       vr5,    vr0,   vr5
++    vabsd.bu       vr6,    vr0,   vr6
++    vabsd.bu       vr7,    vr0,   vr7
++    vabsd.bu       vr8,    vr1,   vr8
++    vabsd.bu       vr9,    vr1,   vr9
++    vabsd.bu       vr10,   vr1,   vr10
++    vabsd.bu       vr11,   vr1,   vr11
++    vabsd.bu       vr12,   vr2,   vr12
++    vabsd.bu       vr13,   vr2,   vr13
++    vabsd.bu       vr14,   vr2,   vr14
++    vabsd.bu       vr15,   vr2,   vr15
++    vabsd.bu       vr16,   vr3,   vr16
++    vabsd.bu       vr17,   vr3,   vr17
++    vabsd.bu       vr18,   vr3,   vr18
++    vabsd.bu       vr19,   vr3,   vr19
++    vhaddw.hu.bu   vr4,    vr4,   vr4
++    vhaddw.hu.bu   vr5,    vr5,   vr5
++    vhaddw.hu.bu   vr6,    vr6,   vr6
++    vhaddw.hu.bu   vr7,    vr7,   vr7
++    vhaddw.hu.bu   vr8,    vr8,   vr8
++    vhaddw.hu.bu   vr9,    vr9,   vr9
++    vhaddw.hu.bu   vr10,   vr10,  vr10
++    vhaddw.hu.bu   vr11,   vr11,  vr11
++    vhaddw.hu.bu   vr12,   vr12,  vr12
++    vhaddw.hu.bu   vr13,   vr13,  vr13
++    vhaddw.hu.bu   vr14,   vr14,  vr14
++    vhaddw.hu.bu   vr15,   vr15,  vr15
++    vhaddw.hu.bu   vr16,   vr16,  vr16
++    vhaddw.hu.bu   vr17,   vr17,  vr17
++    vhaddw.hu.bu   vr18,   vr18,  vr18
++    vhaddw.hu.bu   vr19,   vr19,  vr19
++    vadd.h         vr0,    vr4,   vr8
++    vadd.h         vr1,    vr12,  vr16
++    vadd.h         \out0,  vr0,   vr1
++    vadd.h         vr0,    vr5,   vr9
++    vadd.h         vr1,    vr13,  vr17
++    vadd.h         \out1,  vr0,   vr1
++    vadd.h         vr0,    vr6,   vr10
++    vadd.h         vr1,    vr14,  vr18
++    vadd.h         \out2,  vr0,   vr1
++    vadd.h         vr0,    vr7,   vr11
++    vadd.h         vr1,    vr15,  vr19
++    vadd.h         \out3,  vr0,   vr1
++.endm
++
++function x265_pixel_sad_x4_12x16_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++.rept 3
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++.endr
++
++    vinsgr2vr.w    vr20,   zero,  3
++    vinsgr2vr.w    vr21,   zero,  3
++    vinsgr2vr.w    vr22,   zero,  3
++    vinsgr2vr.w    vr23,   zero,  3
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++
++function x265_pixel_sad_x4_16x4_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++
++.macro pixel_sad_x4_16x_lsx h
++function x265_pixel_sad_x4_16x\h\()_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++.rept (\h>>2)-1
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++.endr
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++.endm
++
++pixel_sad_x4_16x_lsx 8
++pixel_sad_x4_16x_lsx 12
++pixel_sad_x4_16x_lsx 16
++pixel_sad_x4_16x_lsx 32
++pixel_sad_x4_16x_lsx 64
++
++function x265_pixel_sad_x4_24x32_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++    addi.d         t3,     a1,    16
++    addi.d         t4,     a2,    16
++    addi.d         t5,     a3,    16
++    addi.d         t6,     a4,    16
++    addi.d         t7,     a0,    16
++
++    pixel_sad_x4_8x4_core_lsx t7, t3, t4, t5, t6, vr16,vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++
++.rept 7
++
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++
++    alsl.d         t3,     a5,    t3,   2
++    alsl.d         t4,     a5,    t4,   2
++    alsl.d         t5,     a5,    t5,   2
++    alsl.d         t6,     a5,    t6,   2
++    addi.d         t7,     t7,    FENC_STRIDE<<2
++    pixel_sad_x4_8x4_core_lsx t7, t3, t4, t5, t6, vr16,vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++
++.endr
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++
++.macro pixel_sad_x4_32x4_core_lsx
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16, vr17, vr18, vr19
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++
++    alsl.d         t3,     a5,    t3,   2
++    alsl.d         t4,     a5,    t4,   2
++    alsl.d         t5,     a5,    t5,   2
++    alsl.d         t6,     a5,    t6,   2
++    addi.d         t7,     t7,    FENC_STRIDE<<2
++    pixel_sad_x4_16x4_core_lsx t7, t3, t4, t5, t6, vr16, vr17, vr18, vr19
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++.endm
++
++.macro pixel_sad_x4_32x_lsx h
++function x265_pixel_sad_x4_32x\h\()_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++    addi.d         t3,     a1,    16
++    addi.d         t4,     a2,    16
++    addi.d         t5,     a3,    16
++    addi.d         t6,     a4,    16
++    addi.d         t7,     a0,    16
++
++    pixel_sad_x4_16x4_core_lsx t7, t3, t4, t5, t6, vr16,vr17, vr18, vr19
++
++    vadd.h         vr20,   vr16,  vr20
++    vadd.h         vr21,   vr17,  vr21
++    vadd.h         vr22,   vr18,  vr22
++    vadd.h         vr23,   vr19,  vr23
++
++.rept (\h>>2)-1
++
++    pixel_sad_x4_32x4_core_lsx
++
++.endr
++
++    SUM_VEC_x4 vr20, vr21, vr22, vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++.endm
++
++pixel_sad_x4_32x_lsx 8
++pixel_sad_x4_32x_lsx 16
++pixel_sad_x4_32x_lsx 24
++pixel_sad_x4_32x_lsx 32
++pixel_sad_x4_32x_lsx 64
++
++.macro pixel_sad_x4_64x4_core_lsx
++    addi.d         a1,     a1,    -48
++    addi.d         a2,     a2,    -48
++    addi.d         a3,     a3,    -48
++    addi.d         a4,     a4,    -48
++    addi.d         a0,     a0,    -48
++
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++
++    vadd.w         vr20,   vr16,  vr20
++    vadd.w         vr21,   vr17,  vr21
++    vadd.w         vr22,   vr18,  vr22
++    vadd.w         vr23,   vr19,  vr23
++.rept 3
++    addi.d         a1,     a1,    16
++    addi.d         a2,     a2,    16
++    addi.d         a3,     a3,    16
++    addi.d         a4,     a4,    16
++    addi.d         a0,     a0,    16
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++
++    vadd.w         vr20,   vr16,  vr20
++    vadd.w         vr21,   vr17,  vr21
++    vadd.w         vr22,   vr18,  vr22
++    vadd.w         vr23,   vr19,  vr23
++.endr
++.endm
++
++.macro pixel_sad_x4_64x_lsx h
++function x265_pixel_sad_x4_64x\h\()_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++    vhaddw.wu.hu   vr20,   vr20,  vr20
++    vhaddw.wu.hu   vr21,   vr21,  vr21
++    vhaddw.wu.hu   vr22,   vr22,  vr22
++    vhaddw.wu.hu   vr23,   vr23,  vr23
++
++.rept 3
++    addi.d         a1,     a1,    16
++    addi.d         a2,     a2,    16
++    addi.d         a3,     a3,    16
++    addi.d         a4,     a4,    16
++    addi.d         a0,     a0,    16
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++
++    vadd.w         vr20,   vr16,  vr20
++    vadd.w         vr21,   vr17,  vr21
++    vadd.w         vr22,   vr18,  vr22
++    vadd.w         vr23,   vr19,  vr23
++.endr
++
++.rept (\h>>2)-1
++    pixel_sad_x4_64x4_core_lsx
++.endr
++
++    vhaddw.du.wu   vr20,   vr20,  vr20
++    vhaddw.du.wu   vr21,   vr21,  vr21
++    vhaddw.du.wu   vr22,   vr22,  vr22
++    vhaddw.du.wu   vr23,   vr23,  vr23
++    vhaddw.qu.du   vr20,   vr20,  vr20
++    vhaddw.qu.du   vr21,   vr21,  vr21
++    vhaddw.qu.du   vr22,   vr22,  vr22
++    vhaddw.qu.du   vr23,   vr23,  vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++.endm
++
++pixel_sad_x4_64x_lsx 16
++pixel_sad_x4_64x_lsx 32
++pixel_sad_x4_64x_lsx 48
++pixel_sad_x4_64x_lsx 64
++
++function x265_pixel_sad_x4_48x64_lsx
++    slli.d         t1,     a5,    1
++    add.d          t2,     a5,    t1
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr20, vr21, vr22, vr23
++
++    vhaddw.wu.hu   vr20,   vr20,  vr20
++    vhaddw.wu.hu   vr21,   vr21,  vr21
++    vhaddw.wu.hu   vr22,   vr22,  vr22
++    vhaddw.wu.hu   vr23,   vr23,  vr23
++
++.rept 2
++    addi.d         a1,     a1,    16
++    addi.d         a2,     a2,    16
++    addi.d         a3,     a3,    16
++    addi.d         a4,     a4,    16
++    addi.d         a0,     a0,    16
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++
++    vadd.w         vr20,   vr16,  vr20
++    vadd.w         vr21,   vr17,  vr21
++    vadd.w         vr22,   vr18,  vr22
++    vadd.w         vr23,   vr19,  vr23
++.endr
++
++.rept 15
++    addi.d         a1,     a1,    -32
++    addi.d         a2,     a2,    -32
++    addi.d         a3,     a3,    -32
++    addi.d         a4,     a4,    -32
++    addi.d         a0,     a0,    -32
++
++    alsl.d         a1,     a5,    a1,   2
++    alsl.d         a2,     a5,    a2,   2
++    alsl.d         a3,     a5,    a3,   2
++    alsl.d         a4,     a5,    a4,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++
++    vadd.w         vr20,   vr16,  vr20
++    vadd.w         vr21,   vr17,  vr21
++    vadd.w         vr22,   vr18,  vr22
++    vadd.w         vr23,   vr19,  vr23
++.rept 2
++    addi.d         a1,     a1,    16
++    addi.d         a2,     a2,    16
++    addi.d         a3,     a3,    16
++    addi.d         a4,     a4,    16
++    addi.d         a0,     a0,    16
++
++    pixel_sad_x4_16x4_core_lsx a0, a1, a2, a3, a4, vr16,vr17, vr18, vr19
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++
++    vadd.w         vr20,   vr16,  vr20
++    vadd.w         vr21,   vr17,  vr21
++    vadd.w         vr22,   vr18,  vr22
++    vadd.w         vr23,   vr19,  vr23
++.endr
++.endr
++
++    vhaddw.du.wu   vr20,   vr20,  vr20
++    vhaddw.du.wu   vr21,   vr21,  vr21
++    vhaddw.du.wu   vr22,   vr22,  vr22
++    vhaddw.du.wu   vr23,   vr23,  vr23
++    vhaddw.qu.du   vr20,   vr20,  vr20
++    vhaddw.qu.du   vr21,   vr21,  vr21
++    vhaddw.qu.du   vr22,   vr22,  vr22
++    vhaddw.qu.du   vr23,   vr23,  vr23
++
++    vstelm.w       vr20,   a6,    0,    0
++    vstelm.w       vr21,   a6,    4,    0
++    vstelm.w       vr22,   a6,    8,    0
++    vstelm.w       vr23,   a6,    12,   0
++endfunc
++
++.macro pixel_sad_x4_8x4_core_lasx out0, out1, out2, out3
++    // Load data from p_src, p_ref0, p_ref1, p_ref2 and p_ref3
++    FLDD_LOADX_4   a1,     a5,    t1,  t2,  f4, f8,  f14, f18
++    FLDD_LOADX_4   a2,     a5,    t1,  t2,  f5, f9,  f15, f19
++    FLDD_LOADX_4   a3,     a5,    t1,  t2,  f6, f10, f16, f20
++    FLDD_LOADX_4   a4,     a5,    t1,  t2,  f7, f11, f17, f21
++    vilvl.d        vr4,    vr5,   vr4
++    vilvl.d        vr6,    vr7,   vr6
++    vilvl.d        vr8,    vr9,   vr8
++    vilvl.d        vr10,   vr11,  vr10
++    vilvl.d        vr14,   vr15,  vr14
++    vilvl.d        vr16,   vr17,  vr16
++    vilvl.d        vr18,   vr19,  vr18
++    vilvl.d        vr20,   vr21,  vr20
++    xvpermi.q      xr4,    xr6,   0x02
++    xvpermi.q      xr8,    xr10,  0x02
++    xvpermi.q      xr14,   xr16,  0x02
++    xvpermi.q      xr18,   xr20,  0x02
++    // Calculate the absolute value of the difference
++    xvldrepl.d     xr7,    a0,    0
++    xvldrepl.d     xr11,   a0,    FENC_STRIDE
++    xvldrepl.d     xr17,   a0,    FENC_STRIDE<<1
++    xvldrepl.d     xr21,   a0,    FENC_STRIDE*3
++    xvabsd.bu      xr5,    xr7,   xr4
++    xvabsd.bu      xr9,    xr11,  xr8
++    xvabsd.bu      xr10,   xr17,  xr14
++    xvabsd.bu      xr11,   xr21,  xr18
++    xvaddwev.h.bu  \out0,  xr5,   xr9
++    xvaddwod.h.bu  \out1,  xr5,   xr9
++    xvaddwev.h.bu  \out2,  xr10,  xr11
++    xvaddwod.h.bu  \out3,  xr10,  xr11
++.endm
++
++function x265_pixel_sad_x4_8x4_lasx
++    slli.d         t1,     a5,    1
++    add.d          t2,     t1,    a5
++    slli.d         t3,     a5,    2
++
++    pixel_sad_x4_8x4_core_lasx xr0, xr1, xr2, xr3
++
++    xvadd.h        xr5,    xr0,   xr1
++    xvadd.h        xr10,   xr2,   xr3
++    xvadd.h        xr10,   xr10,  xr5
++    xvhaddw.wu.hu  xr10,   xr10,  xr10
++    xvhaddw.du.wu  xr10,   xr10,  xr10
++    xvpermi.q      xr5,    xr10,  0x01
++    xvpickev.w     xr10,   xr5,   xr10
++
++    vst            vr10,   a6,    0
++endfunc
++
++.macro pixel_sad_x4_8x_lasx h
++function x265_pixel_sad_x4_8x\h\()_lasx
++    slli.d         t1,     a5,    1
++    add.d          t2,     t1,    a5
++    slli.d         t3,     a5,    2
++
++    pixel_sad_x4_8x4_core_lasx xr0, xr1, xr2, xr3
++
++.rept (\h>>2)-1
++    add.d          a1,     a1,    t3
++    add.d          a2,     a2,    t3
++    add.d          a3,     a3,    t3
++    add.d          a4,     a4,    t3
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x4_8x4_core_lasx xr12, xr13, xr14, xr15
++
++    xvadd.h        xr0,    xr0,   xr12
++    xvadd.h        xr1,    xr1,   xr13
++    xvadd.h        xr2,    xr2,   xr14
++    xvadd.h        xr3,    xr3,   xr15
++.endr
++
++    xvadd.h        xr5,    xr0,   xr1
++    xvadd.h        xr10,   xr2,   xr3
++    xvadd.h        xr10,   xr10,  xr5
++    xvhaddw.wu.hu  xr10,   xr10,  xr10
++    xvhaddw.du.wu  xr10,   xr10,  xr10
++    xvpermi.q      xr5,    xr10,  0x01
++    xvpickev.w     xr10,   xr5,   xr10
++
++    vst            vr10,   a6,    0
++endfunc
++.endm
++
++pixel_sad_x4_8x_lasx 8
++pixel_sad_x4_8x_lasx 16
++pixel_sad_x4_8x_lasx 32
++
++.macro pixel_sad_x4_16x2_core_lasx out0, out1, out2, out3
++    vld            vr2,    a0,    0
++    vld            vr3,    a0,    FENC_STRIDE
++    vld            vr4,    a1,    0
++    vldx           vr8,    a1,    a5
++    vld            vr5,    a2,    0
++    vldx           vr9,    a2,    a5
++    vld            vr6,    a3,    0
++    vldx           vr10,   a3,    a5
++    vld            vr7,    a4,    0
++    vldx           vr11,   a4,    a5
++    xvpermi.q      xr2,    xr3,   0x02
++    xvpermi.q      xr4,    xr8,   0x02
++    xvpermi.q      xr5,    xr9,   0x02
++    xvpermi.q      xr6,    xr10,  0x02
++    xvpermi.q      xr7,    xr11,  0x02
++    // Calculate the absolute value of the difference
++    xvabsd.bu      xr8,    xr2,   xr4
++    xvabsd.bu      xr9,    xr2,   xr5
++    xvabsd.bu      xr10,   xr2,   xr6
++    xvabsd.bu      xr11,   xr2,   xr7
++    xvhaddw.hu.bu  \out0,  xr8,   xr8
++    xvhaddw.hu.bu  \out1,  xr9,   xr9
++    xvhaddw.hu.bu  \out2,  xr10,  xr10
++    xvhaddw.hu.bu  \out3,  xr11,  xr11
++.endm
++
++.macro pixel_sad_x4_16x2_core1_lasx
++    xvori.b        xr17,   xr12,  0
++    xvori.b        xr18,   xr13,  0
++    xvpermi.q      xr12,   xr14,  0x02
++    xvpermi.q      xr14,   xr17,  0x31
++    xvpermi.q      xr13,   xr15,  0x02
++    xvpermi.q      xr15,   xr18,  0x31
++    xvadd.h        xr12,   xr12,  xr14
++    xvadd.h        xr13,   xr13,  xr15
++    xvhaddw.w.h    xr12,   xr12,  xr12
++    xvhaddw.w.h    xr13,   xr13,  xr13
++    xvhaddw.d.w    xr12,   xr12,  xr12
++    xvhaddw.d.w    xr13,   xr13,  xr13
++    xvhaddw.q.d    xr12,   xr12,  xr12
++    xvhaddw.q.d    xr13,   xr13,  xr13
++    xvpackev.w     xr13,   xr13,  xr12
++.endm
++
++function x265_pixel_sad_x4_16x4_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_16x2_core_lasx xr12, xr13, xr14, xr15
++
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_16x2_core_lasx xr8, xr9, xr10, xr11
++
++    xvadd.h        xr12,   xr12,  xr8
++    xvadd.h        xr13,   xr13,  xr9
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++
++    pixel_sad_x4_16x2_core1_lasx
++
++    // Store data to p_sad_array
++    xvstelm.d      xr13,   a6,    0,    0
++    xvstelm.d      xr13,   a6,    8,    2
++endfunc
++
++.macro pixel_sad_x4_16x_lasx h
++function x265_pixel_sad_x4_16x\h\()_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_16x2_core_lasx xr12, xr13, xr14, xr15
++
++.rept (\h>>1)-1
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_16x2_core_lasx xr8, xr9, xr10, xr11
++
++    xvadd.h        xr12,   xr12,  xr8
++    xvadd.h        xr13,   xr13,  xr9
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++.endr
++
++    pixel_sad_x4_16x2_core1_lasx
++
++    xvstelm.d      xr13,   a6,    0,    0
++    xvstelm.d      xr13,   a6,    8,    2
++endfunc
++.endm
++
++pixel_sad_x4_16x_lasx 8
++pixel_sad_x4_16x_lasx 12
++pixel_sad_x4_16x_lasx 16
++pixel_sad_x4_16x_lasx 32
++pixel_sad_x4_16x_lasx 64
++
++function x265_pixel_sad_x4_12x16_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_16x2_core_lasx xr12, xr13, xr14, xr15
++
++.rept 7
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_16x2_core_lasx xr8, xr9, xr10, xr11
++
++    xvadd.h        xr12,   xr12,  xr8
++    xvadd.h        xr13,   xr13,  xr9
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++.endr
++
++.irp i, xr12, xr13, xr14, xr15
++    xvinsgr2vr.w   \i,     zero,  3
++    xvinsgr2vr.w   \i,     zero,  7
++.endr
++
++    pixel_sad_x4_16x2_core1_lasx
++
++    xvstelm.d      xr13,   a6,    0,    0
++    xvstelm.d      xr13,   a6,    8,    2
++endfunc
++
++.macro pixel_sad_x4_32x2_lasx out0, out1, out2, out3
++    xvld           xr0,    a0,    0
++    xvld           xr1,    a0,    FENC_STRIDE
++    xvld           xr2,    a1,    0
++    xvldx          xr3,    a1,    a5
++    xvld           xr4,    a2,    0
++    xvldx          xr5,    a2,    a5
++    xvld           xr6,    a3,    0
++    xvldx          xr7,    a3,    a5
++    xvld           xr8,    a4,    0
++    xvldx          xr9,    a4,    a5
++
++    xvabsd.bu      xr10,   xr0,   xr2
++    xvabsd.bu      xr11,   xr0,   xr4
++    xvabsd.bu      xr12,   xr0,   xr6
++    xvabsd.bu      xr13,   xr0,   xr8
++    xvabsd.bu      xr2,    xr1,   xr3
++    xvabsd.bu      xr4,    xr1,   xr5
++    xvabsd.bu      xr6,    xr1,   xr7
++    xvabsd.bu      xr8,    xr1,   xr9
++
++.irp i, xr10, xr11, xr12, xr13, xr2, xr4, xr6, xr8
++    xvhaddw.hu.bu  \i,     \i,    \i
++.endr
++   xvadd.h         \out0,  xr10,  xr2
++   xvadd.h         \out1,  xr11,  xr4
++   xvadd.h         \out2,  xr12,  xr6
++   xvadd.h         \out3,  xr13,  xr8
++.endm
++
++.macro pixel_sad_x4_32x_lasx h
++function x265_pixel_sad_x4_32x\h\()_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_32x2_lasx xr14, xr15, xr16, xr17
++
++.rept (\h>>1)-1
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr16,   xr12,  xr16
++    xvadd.h        xr17,   xr13,  xr17
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++.endr
++
++    xvhaddw.w.h    xr14,   xr14,  xr14
++    xvhaddw.w.h    xr15,   xr15,  xr15
++    xvhaddw.w.h    xr16,   xr16,  xr16
++    xvhaddw.w.h    xr17,   xr17,  xr17
++    xvhaddw.d.w    xr14,   xr14,  xr14
++    xvhaddw.d.w    xr15,   xr15,  xr15
++    xvhaddw.d.w    xr16,   xr16,  xr16
++    xvhaddw.d.w    xr17,   xr17,  xr17
++
++    xvpickev.w     xr10,   xr15,  xr14
++    xvpickev.w     xr11,   xr17,  xr16
++    xvhaddw.d.w    xr10,   xr10,  xr10
++    xvhaddw.d.w    xr11,   xr11,  xr11
++    xvpickev.w     xr12,   xr11,  xr10
++    xvpermi.q      xr13,   xr12,  0x01
++
++    vadd.w         vr13,   vr13,  vr12
++    vst            vr13,   a6,    0
++endfunc
++.endm
++
++pixel_sad_x4_32x_lasx 8
++pixel_sad_x4_32x_lasx 16
++pixel_sad_x4_32x_lasx 24
++pixel_sad_x4_32x_lasx 32
++pixel_sad_x4_32x_lasx 64
++
++function x265_pixel_sad_x4_24x32_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_32x2_lasx xr14, xr15, xr16, xr17
++
++.rept 15
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr16,   xr12,  xr16
++    xvadd.h        xr17,   xr13,  xr17
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++.endr
++
++    xvinsgr2vr.d   xr14,   zero,  3
++    xvinsgr2vr.d   xr15,   zero,  3
++    xvinsgr2vr.d   xr16,   zero,  3
++    xvinsgr2vr.d   xr17,   zero,  3
++
++    xvhaddw.w.h    xr14,   xr14,  xr14
++    xvhaddw.w.h    xr15,   xr15,  xr15
++    xvhaddw.w.h    xr16,   xr16,  xr16
++    xvhaddw.w.h    xr17,   xr17,  xr17
++    xvhaddw.d.w    xr14,   xr14,  xr14
++    xvhaddw.d.w    xr15,   xr15,  xr15
++    xvhaddw.d.w    xr16,   xr16,  xr16
++    xvhaddw.d.w    xr17,   xr17,  xr17
++    xvpickev.w     xr10,   xr15,  xr14
++    xvpickev.w     xr11,   xr17,  xr16
++    xvhaddw.d.w    xr10,   xr10,  xr10
++    xvhaddw.d.w    xr11,   xr11,  xr11
++    xvpickev.w     xr12,   xr11,  xr10
++    xvpermi.q      xr13,   xr12,  0x01
++
++    vadd.w         vr13,   vr13,  vr12
++    vst            vr13,   a6,    0
++endfunc
++
++.macro pixel_sad_x4_64x_lasx h
++function x265_pixel_sad_x4_64x\h\()_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_32x2_lasx xr14, xr15, xr16, xr17
++
++    addi.d         a0,     a0,    32
++    addi.d         a1,     a1,    32
++    addi.d         a2,     a2,    32
++    addi.d         a3,     a3,    32
++    addi.d         a4,     a4,    32
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr16,   xr12,  xr16
++    xvadd.h        xr17,   xr13,  xr17
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++
++.rept (\h>>1)-1
++    addi.d         a0,     a0,    -32
++    addi.d         a1,     a1,    -32
++    addi.d         a2,     a2,    -32
++    addi.d         a3,     a3,    -32
++    addi.d         a4,     a4,    -32
++
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr16,   xr12,  xr16
++    xvadd.h        xr17,   xr13,  xr17
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++
++    addi.d         a0,     a0,    32
++    addi.d         a1,     a1,    32
++    addi.d         a2,     a2,    32
++    addi.d         a3,     a3,    32
++    addi.d         a4,     a4,    32
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr16,   xr12,  xr16
++    xvadd.h        xr17,   xr13,  xr17
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++.endr
++
++    xvhaddw.w.h    xr14,   xr14,  xr14
++    xvhaddw.w.h    xr15,   xr15,  xr15
++    xvhaddw.w.h    xr16,   xr16,  xr16
++    xvhaddw.w.h    xr17,   xr17,  xr17
++    xvhaddw.d.w    xr14,   xr14,  xr14
++    xvhaddw.d.w    xr15,   xr15,  xr15
++    xvhaddw.d.w    xr16,   xr16,  xr16
++    xvhaddw.d.w    xr17,   xr17,  xr17
++
++    xvpickev.w     xr10,   xr15,  xr14
++    xvpickev.w     xr11,   xr17,  xr16
++    xvhaddw.d.w    xr10,   xr10,  xr10
++    xvhaddw.d.w    xr11,   xr11,  xr11
++    xvpickev.w     xr12,   xr11,  xr10
++    xvpermi.q      xr13,   xr12,  0x01
++
++    vadd.w         vr13,   vr13,  vr12
++    vst            vr13,   a6,    0
++endfunc
++.endm
++
++pixel_sad_x4_64x_lasx 16
++pixel_sad_x4_64x_lasx 32
++
++.macro pixel_sad_x4_64x48_lasx h
++function x265_pixel_sad_x4_64x\h\()_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_32x2_lasx xr14, xr15, xr16, xr17
++
++    xvhaddw.w.h    xr14,   xr14,  xr14
++    xvhaddw.w.h    xr15,   xr15,  xr15
++    xvhaddw.w.h    xr16,   xr16,  xr16
++    xvhaddw.w.h    xr17,   xr17,  xr17
++
++    addi.d         a0,     a0,    32
++    addi.d         a1,     a1,    32
++    addi.d         a2,     a2,    32
++    addi.d         a3,     a3,    32
++    addi.d         a4,     a4,    32
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvhaddw.w.h    xr10,   xr10,  xr10
++    xvhaddw.w.h    xr11,   xr11,  xr11
++    xvhaddw.w.h    xr12,   xr12,  xr12
++    xvhaddw.w.h    xr13,   xr13,  xr13
++
++    xvadd.w        xr16,   xr12,  xr16
++    xvadd.w        xr17,   xr13,  xr17
++    xvadd.w        xr14,   xr14,  xr10
++    xvadd.w        xr15,   xr15,  xr11
++
++.rept (\h>>1)-1
++    addi.d         a0,     a0,    -32
++    addi.d         a1,     a1,    -32
++    addi.d         a2,     a2,    -32
++    addi.d         a3,     a3,    -32
++    addi.d         a4,     a4,    -32
++
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvhaddw.w.h    xr10,   xr10,  xr10
++    xvhaddw.w.h    xr11,   xr11,  xr11
++    xvhaddw.w.h    xr12,   xr12,  xr12
++    xvhaddw.w.h    xr13,   xr13,  xr13
++
++    xvadd.w        xr16,   xr12,  xr16
++    xvadd.w        xr17,   xr13,  xr17
++    xvadd.w        xr14,   xr14,  xr10
++    xvadd.w        xr15,   xr15,  xr11
++
++    addi.d         a0,     a0,    32
++    addi.d         a1,     a1,    32
++    addi.d         a2,     a2,    32
++    addi.d         a3,     a3,    32
++    addi.d         a4,     a4,    32
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvhaddw.w.h    xr10,   xr10,  xr10
++    xvhaddw.w.h    xr11,   xr11,  xr11
++    xvhaddw.w.h    xr12,   xr12,  xr12
++    xvhaddw.w.h    xr13,   xr13,  xr13
++
++    xvadd.w        xr16,   xr12,  xr16
++    xvadd.w        xr17,   xr13,  xr17
++    xvadd.w        xr14,   xr14,  xr10
++    xvadd.w        xr15,   xr15,  xr11
++.endr
++
++    xvhaddw.d.w    xr14,   xr14,  xr14
++    xvhaddw.d.w    xr15,   xr15,  xr15
++    xvhaddw.d.w    xr16,   xr16,  xr16
++    xvhaddw.d.w    xr17,   xr17,  xr17
++
++    xvpickev.w     xr10,   xr15,  xr14
++    xvpickev.w     xr11,   xr17,  xr16
++    xvhaddw.d.w    xr10,   xr10,  xr10
++    xvhaddw.d.w    xr11,   xr11,  xr11
++    xvpickev.w     xr12,   xr11,  xr10
++    xvpermi.q      xr13,   xr12,  0x01
++
++    vadd.w         vr13,   vr13,  vr12
++    vst            vr13,   a6,    0
++endfunc
++.endm
++
++pixel_sad_x4_64x48_lasx 48
++pixel_sad_x4_64x48_lasx 64
++
++function x265_pixel_sad_x4_48x64_lasx
++    slli.d         t1,     a5,    1
++
++    pixel_sad_x4_32x2_lasx xr14, xr15, xr16, xr17
++
++    addi.d         a0,     a0,    32
++    addi.d         a1,     a1,    32
++    addi.d         a2,     a2,    32
++    addi.d         a3,     a3,    32
++    addi.d         a4,     a4,    32
++
++    pixel_sad_x4_32x2_lasx xr18, xr19, xr20, xr21
++
++.rept 31
++    addi.d         a0,     a0,    -32
++    addi.d         a1,     a1,    -32
++    addi.d         a2,     a2,    -32
++    addi.d         a3,     a3,    -32
++    addi.d         a4,     a4,    -32
++
++    addi.d         a0,     a0,    FENC_STRIDE<<1
++    add.d          a1,     a1,    t1
++    add.d          a2,     a2,    t1
++    add.d          a3,     a3,    t1
++    add.d          a4,     a4,    t1
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr16,   xr12,  xr16
++    xvadd.h        xr17,   xr13,  xr17
++    xvadd.h        xr14,   xr14,  xr10
++    xvadd.h        xr15,   xr15,  xr11
++
++    addi.d         a0,     a0,    32
++    addi.d         a1,     a1,    32
++    addi.d         a2,     a2,    32
++    addi.d         a3,     a3,    32
++    addi.d         a4,     a4,    32
++
++    pixel_sad_x4_32x2_lasx xr10, xr11, xr12, xr13
++
++    xvadd.h        xr20,   xr12,  xr20
++    xvadd.h        xr21,   xr13,  xr21
++    xvadd.h        xr18,   xr18,  xr10
++    xvadd.h        xr19,   xr19,  xr11
++.endr
++
++    xvreplgr2vr.w  xr23,   zero
++    xvpermi.q      xr18,   xr23,  0x02
++    xvpermi.q      xr19,   xr23,  0x02
++    xvpermi.q      xr20,   xr23,  0x02
++    xvpermi.q      xr21,   xr23,  0x02
++
++    xvhaddw.w.h    xr14,   xr14,  xr14
++    xvhaddw.w.h    xr15,   xr15,  xr15
++    xvhaddw.w.h    xr16,   xr16,  xr16
++    xvhaddw.w.h    xr17,   xr17,  xr17
++    xvhaddw.w.h    xr18,   xr18,  xr18
++    xvhaddw.w.h    xr19,   xr19,  xr19
++    xvhaddw.w.h    xr20,   xr20,  xr20
++    xvhaddw.w.h    xr21,   xr21,  xr21
++
++    xvadd.w        xr14,   xr14,  xr18
++    xvadd.w        xr15,   xr15,  xr19
++    xvadd.w        xr16,   xr16,  xr20
++    xvadd.w        xr17,   xr17,  xr21
++    xvhaddw.d.w    xr14,   xr14,  xr14
++    xvhaddw.d.w    xr15,   xr15,  xr15
++    xvhaddw.d.w    xr16,   xr16,  xr16
++    xvhaddw.d.w    xr17,   xr17,  xr17
++    xvpickev.w     xr10,   xr15,  xr14
++    xvpickev.w     xr11,   xr17,  xr16
++    xvhaddw.d.w    xr10,   xr10,  xr10
++    xvhaddw.d.w    xr11,   xr11,  xr11
++    xvpickev.w     xr12,   xr11,  xr10
++    xvpermi.q      xr13,   xr12,  0x01
++
++    vadd.w         vr13,   vr13,  vr12
++    vst            vr13,   a6,    0
++endfunc
++
++.macro pixel_sad_4x4_core_lsx out
++    FLDS_LOADX_4    a0,    a1,   t1,  t3,  f3, f5, f7, f9
++    FLDS_LOADX_4    a2,    a3,   t2,  t4,  f4, f6, f8, f10
++    vilvl.w         vr3,   vr5,  vr3
++    vilvl.w         vr4,   vr6,  vr4
++    vilvl.w         vr7,   vr9,  vr7
++    vilvl.w         vr8,   vr10, vr8
++    vilvl.d         vr3,   vr7,  vr3
++    vilvl.d         vr4,   vr8,  vr4
++    vabsd.bu        vr5,   vr3,  vr4
++    vhaddw.hu.bu    \out,  vr5,  vr5
++.endm
++
++function x265_pixel_sad_4x4_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_4x4_core_lsx vr11
++
++    vhaddw.wu.hu    vr11,  vr11, vr11
++    vhaddw.du.wu    vr11,  vr11, vr11
++    vhaddw.qu.du    vr11,  vr11, vr11
++    vpickve2gr.wu   a0,    vr11,  0
++endfunc
++
++.macro pixel_sad_4x_lsx h
++function x265_pixel_sad_4x\h\()_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_4x4_core_lsx vr11
++
++.rept (\h>>2)-1
++    alsl.d          a0,    a1,   a0,  2
++    alsl.d          a2,    a3,   a2,  2
++    pixel_sad_4x4_core_lsx vr12
++    vadd.h          vr11,  vr11, vr12
++.endr
++
++    vhaddw.wu.hu    vr11,  vr11, vr11
++    vhaddw.du.wu    vr11,  vr11, vr11
++    vhaddw.qu.du    vr11,  vr11, vr11
++    vpickve2gr.wu   a0,    vr11, 0
++endfunc
++.endm
++
++pixel_sad_4x_lsx 8
++pixel_sad_4x_lsx 16
++
++.macro pixel_sad_8x4_core_lsx out
++    FLDD_LOADX_4    a0,    a1,   t1,  t3,  f3, f5, f7, f9
++    FLDD_LOADX_4    a2,    a3,   t2,  t4,  f4, f6, f8, f10
++    vilvl.d         vr3,   vr5,  vr3
++    vilvl.d         vr7,   vr9,  vr7
++    vilvl.d         vr4,   vr6,  vr4
++    vilvl.d         vr8,   vr10, vr8
++    vabsd.bu        vr11,  vr3,  vr4
++    vabsd.bu        vr12,  vr7,  vr8
++    vhaddw.hu.bu    vr11,  vr11, vr11
++    vhaddw.hu.bu    vr12,  vr12, vr12
++    vadd.h          \out,  vr11, vr12
++.endm
++
++function x265_pixel_sad_8x4_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_8x4_core_lsx vr6
++
++    vhaddw.wu.hu    vr6,   vr6,  vr6
++    vhaddw.du.wu    vr6,   vr6,  vr6
++    vhaddw.qu.du    vr6,   vr6,  vr6
++    vpickve2gr.wu   a0,    vr6,  0
++endfunc
++
++.macro pixel_sad_8x_lsx h
++function x265_pixel_sad_8x\h\()_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_8x4_core_lsx vr13
++
++.rept (\h>>2)-1
++    alsl.d          a0,    a1,   a0,  2
++    alsl.d          a2,    a3,   a2,  2
++    pixel_sad_8x4_core_lsx vr14
++    vadd.h          vr13,  vr13, vr14
++.endr
++    vhaddw.wu.hu    vr13,  vr13,  vr13
++    vhaddw.du.wu    vr13,  vr13,  vr13
++    vhaddw.qu.du    vr13,  vr13,  vr13
++    vpickve2gr.wu   a0,    vr13,  0
++endfunc
++.endm
++
++pixel_sad_8x_lsx 8
++pixel_sad_8x_lsx 16
++pixel_sad_8x_lsx 32
++
++.macro pixel_sad_16x4_core_lsx out
++    LSX_LOADX_4     a0,    a1,   t1, t3, vr0, vr1, vr2, vr3
++    LSX_LOADX_4     a2,    a3,   t2, t4, vr4, vr5, vr6, vr7
++    vabsd.bu        vr8,   vr0,  vr4
++    vabsd.bu        vr9,   vr1,  vr5
++    vabsd.bu        vr10,  vr2,  vr6
++    vabsd.bu        vr11,  vr3,  vr7
++    vhaddw.hu.bu    vr8,   vr8,  vr8
++    vhaddw.hu.bu    vr9,   vr9,  vr9
++    vhaddw.hu.bu    vr10,  vr10, vr10
++    vhaddw.hu.bu    vr11,  vr11, vr11
++    vadd.h          vr8,   vr8,  vr9
++    vadd.h          vr9,   vr10, vr11
++    vadd.h          \out,  vr8,  vr9
++.endm
++
++function x265_pixel_sad_12x16_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_16x4_core_lsx vr13
++
++.rept 3
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++    pixel_sad_16x4_core_lsx vr12
++    vadd.h          vr13,  vr12, vr13
++.endr
++
++    vhaddw.wu.hu    vr13,  vr13, vr13
++    vpickve2gr.wu   t1,    vr13, 2
++    vhaddw.du.wu    vr13,  vr13, vr13
++    vpickve2gr.wu   t2,    vr13, 0
++    add.w           a0,    t1,   t2
++endfunc
++
++function x265_pixel_sad_16x4_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_16x4_core_lsx vr13
++
++    vhaddw.wu.hu    vr13,  vr13, vr13
++    vhaddw.du.wu    vr13,  vr13, vr13
++    vhaddw.qu.du    vr13,  vr13, vr13
++    vpickve2gr.wu   a0,    vr13, 0
++endfunc
++
++.macro pixel_sad_16x_lsx h
++function x265_pixel_sad_16x\h\()_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_16x4_core_lsx vr13
++
++.rept (\h>>2)-1
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++    pixel_sad_16x4_core_lsx vr12
++    vadd.h          vr13,  vr12, vr13
++.endr
++
++    vhaddw.wu.hu    vr13,  vr13, vr13
++    vhaddw.du.wu    vr13,  vr13, vr13
++    vhaddw.qu.du    vr13,  vr13, vr13
++    vpickve2gr.wu   a0,    vr13, 0
++endfunc
++.endm
++
++pixel_sad_16x_lsx 8
++pixel_sad_16x_lsx 12
++pixel_sad_16x_lsx 16
++pixel_sad_16x_lsx 32
++pixel_sad_16x_lsx 64
++
++function x265_pixel_sad_24x32_lsx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_16x4_core_lsx vr13
++
++    addi.d          a0,    a0,   16
++    addi.d          a2,    a2,   16
++    pixel_sad_8x4_core_lsx vr15
++    vadd.h          vr16,  vr15, vr13
++
++.rept 7
++    addi.d          a0,    a0,   -16
++    addi.d          a2,    a2,   -16
++
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sad_16x4_core_lsx vr13
++
++    addi.d          a0,    a0,   16
++    addi.d          a2,    a2,   16
++    pixel_sad_8x4_core_lsx vr15
++
++    vadd.h          vr16,  vr16, vr13
++    vadd.h          vr16,  vr16, vr15
++.endr
++    vhaddw.wu.hu    vr16,  vr16, vr16
++    vhaddw.du.wu    vr16,  vr16, vr16
++    vhaddw.qu.du    vr16,  vr16, vr16
++    vpickve2gr.wu   a0,    vr16, 0
++endfunc
++
++.macro pixel_sad_32x_lsx h
++function x265_pixel_sad_32x\h\()_lsx
++    slli.d          t1,    a1,    1
++    slli.d          t2,    a3,    1
++    add.d           t3,    a1,    t1
++    add.d           t4,    a3,    t2
++
++    pixel_sad_16x4_core_lsx vr12
++
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr13
++    vadd.h          vr13,  vr12,  vr13
++
++.rept (\h>>2)-1
++    addi.d          a0,    a0,    -16
++    addi.d          a2,    a2,    -16
++
++    alsl.d          a0,    a1,    a0,   2
++    alsl.d          a2,    a3,    a2,   2
++
++    pixel_sad_16x4_core_lsx vr14
++
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr15
++    vadd.h          vr14,  vr14,  vr15
++    vadd.h          vr13,  vr13,  vr14
++.endr
++
++    vhaddw.wu.hu    vr13,  vr13,  vr13
++    vhaddw.du.wu    vr13,  vr13,  vr13
++    vhaddw.qu.du    vr13,  vr13,  vr13
++    vpickve2gr.wu   a0,    vr13,  0
++endfunc
++.endm
++
++pixel_sad_32x_lsx 8
++pixel_sad_32x_lsx 16
++pixel_sad_32x_lsx 24
++pixel_sad_32x_lsx 32
++pixel_sad_32x_lsx 64
++
++function x265_pixel_sad_64x16_lsx
++    slli.d          t1,    a1,    1
++    slli.d          t2,    a3,    1
++    add.d           t3,    a1,    t1
++    add.d           t4,    a3,    t2
++
++    pixel_sad_16x4_core_lsx vr19
++
++.rept 3
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr13
++    vadd.h          vr19,  vr19,  vr13
++.endr
++
++.rept 3
++    addi.d          a0,    a0,    -48
++    addi.d          a2,    a2,    -48
++
++    alsl.d          a0,    a1,    a0,   2
++    alsl.d          a2,    a3,    a2,   2
++
++    pixel_sad_16x4_core_lsx vr14
++    vadd.h          vr19,  vr19,  vr14
++
++.rept 3
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr15
++    vadd.h          vr19,  vr19,  vr15
++.endr
++.endr
++
++    vhaddw.wu.hu    vr19,  vr19,  vr19
++    vhaddw.du.wu    vr19,  vr19,  vr19
++    vhaddw.qu.du    vr19,  vr19,  vr19
++    vpickve2gr.wu   a0,    vr19,  0
++endfunc
++
++function x265_pixel_sad_64x32_lsx
++    slli.d          t1,    a1,    1
++    slli.d          t2,    a3,    1
++    add.d           t3,    a1,    t1
++    add.d           t4,    a3,    t2
++
++    pixel_sad_16x4_core_lsx vr19
++
++.rept 3
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr13
++    vadd.h          vr19,  vr19,  vr13
++.endr
++
++.rept 7
++    addi.d          a0,    a0,    -48
++    addi.d          a2,    a2,    -48
++
++    alsl.d          a0,    a1,    a0,   2
++    alsl.d          a2,    a3,    a2,   2
++
++    pixel_sad_16x4_core_lsx vr14
++    vadd.h          vr19,  vr19,  vr14
++
++.rept 3
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr15
++    vadd.h          vr19,  vr19,  vr15
++.endr
++.endr
++
++    vhaddw.wu.hu    vr19,  vr19,  vr19
++    vhaddw.du.wu    vr19,  vr19,  vr19
++    vhaddw.qu.du    vr19,  vr19,  vr19
++    vpickve2gr.wu   a0,    vr19,  0
++endfunc
++
++.macro pixel_sad_64x48_lsx h
++function x265_pixel_sad_64x\h\()_lsx
++    slli.d          t1,    a1,    1
++    slli.d          t2,    a3,    1
++    add.d           t3,    a1,    t1
++    add.d           t4,    a3,    t2
++
++    pixel_sad_16x4_core_lsx vr12
++    vhaddw.wu.hu    vr19,  vr12,  vr12
++
++.rept 3
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr13
++    vhaddw.wu.hu    vr13,  vr13,  vr13
++    vadd.w          vr19,  vr19,  vr13
++.endr
++
++.rept (\h>>2)-1
++    addi.d          a0,    a0,    -48
++    addi.d          a2,    a2,    -48
++
++    alsl.d          a0,    a1,    a0,   2
++    alsl.d          a2,    a3,    a2,   2
++
++    pixel_sad_16x4_core_lsx vr14
++    vhaddw.wu.hu    vr14,  vr14,  vr14
++    vadd.w          vr19,  vr19,  vr14
++
++.rept 3
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr15
++    vhaddw.wu.hu    vr15,  vr15,  vr15
++    vadd.w          vr19,  vr19,  vr15
++.endr
++.endr
++
++    vhaddw.du.wu    vr19,  vr19,  vr19
++    vhaddw.qu.du    vr19,  vr19,  vr19
++    vpickve2gr.wu   a0,    vr19,  0
++endfunc
++.endm
++
++pixel_sad_64x48_lsx 48
++pixel_sad_64x48_lsx 64
++
++function x265_pixel_sad_48x64_lsx
++    slli.d          t1,    a1,    1
++    slli.d          t2,    a3,    1
++    add.d           t3,    a1,    t1
++    add.d           t4,    a3,    t2
++
++    pixel_sad_16x4_core_lsx vr12
++    vhaddw.wu.hu    vr19,  vr12,  vr12
++
++.rept 2
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr13
++    vhaddw.wu.hu    vr13,  vr13,  vr13
++    vadd.w          vr19,  vr19,  vr13
++.endr
++
++.rept 15
++    addi.d          a0,    a0,    -32
++    addi.d          a2,    a2,    -32
++
++    alsl.d          a0,    a1,    a0,   2
++    alsl.d          a2,    a3,    a2,   2
++
++    pixel_sad_16x4_core_lsx vr14
++    vhaddw.wu.hu    vr14,  vr14,  vr14
++    vadd.w          vr19,  vr19,  vr14
++
++.rept 2
++    addi.d          a0,    a0,    16
++    addi.d          a2,    a2,    16
++
++    pixel_sad_16x4_core_lsx vr15
++    vhaddw.wu.hu    vr15,  vr15,  vr15
++    vadd.w          vr19,  vr19,  vr15
++.endr
++.endr
++
++    vhaddw.du.wu    vr19,  vr19,  vr19
++    vhaddw.qu.du    vr19,  vr19,  vr19
++    vpickve2gr.wu   a0,    vr19,  0
++endfunc
++
++.macro pixel_sad_32x4_core_lasx out
++    LASX_LOADX_4    a0,    a1,   t1, t3, xr0, xr1, xr2, xr3
++    LASX_LOADX_4    a2,    a3,   t2, t4, xr4, xr5, xr6, xr7
++
++    xvabsd.bu       xr8,   xr0,  xr4
++    xvabsd.bu       xr9,   xr1,  xr5
++    xvabsd.bu       xr10,  xr2,  xr6
++    xvabsd.bu       xr11,  xr3,  xr7
++    xvhaddw.hu.bu   xr8,   xr8,  xr8
++    xvhaddw.hu.bu   xr9,   xr9,  xr9
++    xvhaddw.hu.bu   xr10,  xr10, xr10
++    xvhaddw.hu.bu   xr11,  xr11, xr11
++    xvadd.h         xr0,   xr8,  xr9
++    xvadd.h         xr1,   xr11, xr10
++    xvadd.h         \out,  xr0,  xr1
++.endm
++
++.macro pixel_sad_32x_lasx h
++function x265_pixel_sad_32x\h\()_lasx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_32x4_core_lasx xr12
++
++.rept (\h>>2)-1
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sad_32x4_core_lasx xr13
++
++    xvadd.h         xr12,  xr13,  xr12
++.endr
++
++    xvhaddw.w.h     xr12,  xr12,  xr12
++    xvhaddw.d.w     xr12,  xr12,  xr12
++    xvhaddw.q.d     xr12,  xr12,  xr12
++    xvpickve2gr.w   t2,    xr12,  0
++    xvpickve2gr.w   t3,    xr12,  4
++    add.d           a0,    t2,   t3
++endfunc
++.endm
++
++pixel_sad_32x_lasx 8
++pixel_sad_32x_lasx 16
++pixel_sad_32x_lasx 24
++pixel_sad_32x_lasx 32
++pixel_sad_32x_lasx 64
++
++.macro pixel_sad_64x_lasx h
++function x265_pixel_sad_64x\h\()_lasx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_32x4_core_lasx xr12
++    addi.d a0, a0, 32
++    addi.d a2, a2, 32
++    pixel_sad_32x4_core_lasx xr13
++    xvadd.h xr12, xr13, xr12
++
++.rept (\h>>2)-1
++    addi.d a0, a0, -32
++    addi.d a2, a2, -32
++
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sad_32x4_core_lasx xr13
++    xvadd.h         xr12,  xr13,  xr12
++
++    addi.d a0, a0, 32
++    addi.d a2, a2, 32
++    pixel_sad_32x4_core_lasx xr13
++    xvadd.h xr12, xr13, xr12
++.endr
++
++    xvhaddw.w.h     xr12,  xr12,  xr12
++    xvhaddw.d.w     xr12,  xr12,  xr12
++    xvhaddw.q.d     xr12,  xr12,  xr12
++    xvpickve2gr.w   t2,    xr12,  0
++    xvpickve2gr.w   t3,    xr12,  4
++    add.d           a0,    t2,   t3
++endfunc
++.endm
++
++.macro pixel_sad_64x48_lasx h
++function x265_pixel_sad_64x\h\()_lasx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_32x4_core_lasx xr12
++    xvhaddw.wu.hu   xr12,  xr12, xr12
++    addi.d          a0,    a0,   32
++    addi.d          a2,    a2,   32
++    pixel_sad_32x4_core_lasx xr13
++    xvhaddw.wu.hu   xr13,  xr13, xr13
++    xvadd.w         xr12,  xr13, xr12
++
++.rept (\h>>2)-1
++    addi.d          a0,    a0,   -32
++    addi.d          a2,    a2,   -32
++
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sad_32x4_core_lasx xr13
++    xvhaddw.wu.hu   xr13,  xr13, xr13
++    xvadd.w         xr12,  xr13, xr12
++
++    addi.d          a0,    a0,   32
++    addi.d          a2,    a2,   32
++    pixel_sad_32x4_core_lasx xr13
++    xvhaddw.wu.hu   xr13,  xr13, xr13
++    xvadd.w         xr12,  xr13, xr12
++.endr
++
++    xvhaddw.d.w     xr12,  xr12,  xr12
++    xvhaddw.q.d     xr12,  xr12,  xr12
++    xvpickve2gr.w   t2,    xr12,  0
++    xvpickve2gr.w   t3,    xr12,  4
++    add.d           a0,    t2,   t3
++endfunc
++.endm
++
++pixel_sad_64x_lasx 16
++pixel_sad_64x_lasx 32
++pixel_sad_64x48_lasx 48
++pixel_sad_64x48_lasx 64
++
++function x265_pixel_sad_24x32_lasx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_32x4_core_lasx xr12
++.rept 7
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sad_32x4_core_lasx xr13
++
++    xvadd.h         xr12,  xr13,  xr12
++.endr
++
++    xvhaddw.w.h     xr12,  xr12,  xr12
++    xvhaddw.d.w     xr12,  xr12,  xr12
++    xvinsgr2vr.d    xr12,  zero,  3
++    xvhaddw.q.d     xr12,  xr12,  xr12
++    xvpickve2gr.w   t2,    xr12,  0
++    xvpickve2gr.w   t3,    xr12,  4
++    add.d           a0,    t2,    t3
++endfunc
++
++function x265_pixel_sad_48x64_lasx
++    slli.d          t1,    a1,   1
++    slli.d          t2,    a3,   1
++    add.d           t3,    a1,   t1
++    add.d           t4,    a3,   t2
++
++    pixel_sad_32x4_core_lasx xr12
++    xvhaddw.wu.hu   xr12,  xr12, xr12
++    addi.d          a0,    a0,   32
++    addi.d          a2,    a2,   32
++    pixel_sad_16x4_core_lsx vr13
++    vhaddw.wu.hu    vr13,  vr13, vr13
++
++.rept 15
++    addi.d          a0,    a0,   -32
++    addi.d          a2,    a2,   -32
++
++    alsl.d          a0,    a1,   a0,   2
++    alsl.d          a2,    a3,   a2,   2
++
++    pixel_sad_32x4_core_lasx xr14
++    xvhaddw.wu.hu   xr14,  xr14, xr14
++    xvadd.w         xr12,  xr14, xr12
++
++    addi.d          a0,    a0,   32
++    addi.d          a2,    a2,   32
++    pixel_sad_16x4_core_lsx vr15
++    vhaddw.wu.hu    vr15,  vr15, vr15
++    vadd.w          vr13,  vr13, vr15
++.endr
++
++    xvinsgr2vr.d    xr13,  zero,  2
++    xvinsgr2vr.d    xr13,  zero,  3
++    xvadd.w         xr12,  xr12,  xr13
++    xvhaddw.d.w     xr12,  xr12,  xr12
++    xvhaddw.q.d     xr12,  xr12,  xr12
++    xvpickve2gr.w   t2,    xr12,  0
++    xvpickve2gr.w   t3,    xr12,  4
++    add.d           a0,    t2,    t3
++endfunc
++
++.macro pixel_sad_x3_4x4_core_lsx out0, out1, out2
++    fld.s          f3,     a0,    0
++    fld.s          f7,     a0,    FENC_STRIDE
++    fld.s          f11,    a0,    FENC_STRIDE<<1
++    fld.s          f15,    a0,    FENC_STRIDE*3
++    FLDS_LOADX_4   a1,     a4,    t1,  t2,  f4, f8,  f12, f16
++    FLDS_LOADX_4   a2,     a4,    t1,  t2,  f5, f9,  f13, f17
++    FLDS_LOADX_4   a3,     a4,    t1,  t2,  f6, f10, f14, f18
++
++    vilvl.w        vr3,    vr7,   vr3
++    vilvl.w        vr4,    vr8,   vr4
++    vilvl.w        vr5,    vr9,   vr5
++    vilvl.w        vr6,    vr10,  vr6
++    vilvl.w        vr11,   vr15,  vr11
++    vilvl.w        vr12,   vr16,  vr12
++    vilvl.w        vr13,   vr17,  vr13
++    vilvl.w        vr14,   vr18,  vr14
++    vilvl.d        vr3,    vr11,  vr3
++    vilvl.d        vr4,    vr12,  vr4
++    vilvl.d        vr5,    vr13,  vr5
++    vilvl.d        vr6,    vr14,  vr6
++
++    vabsd.bu       \out0,  vr3,   vr4
++    vabsd.bu       \out1,  vr3,   vr5
++    vabsd.bu       \out2,  vr3,   vr6
++.endm
++
++.macro SUM_VEC_x3 in0, in1, in2
++    vhaddw.wu.hu   \in0,   \in0,  \in0
++    vhaddw.wu.hu   \in1,   \in1,  \in1
++    vhaddw.wu.hu   \in2,   \in2,  \in2
++    vhaddw.du.wu   \in0,   \in0,  \in0
++    vhaddw.du.wu   \in1,   \in1,  \in1
++    vhaddw.du.wu   \in2,   \in2,  \in2
++    vhaddw.qu.du   \in0,   \in0,  \in0
++    vhaddw.qu.du   \in1,   \in1,  \in1
++    vhaddw.qu.du   \in2,   \in2,  \in2
++.endm
++
++function x265_pixel_sad_x3_4x4_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_4x4_core_lsx vr7, vr8, vr9
++
++    vhaddw.hu.bu   vr7,    vr7,   vr7
++    vhaddw.hu.bu   vr8,    vr8,   vr8
++    vhaddw.hu.bu   vr9,    vr9,   vr9
++
++    SUM_VEC_x3 vr7, vr8, vr9
++
++    vstelm.w       vr7,    a5,    0,  0
++    vstelm.w       vr8,    a5,    4,  0
++    vstelm.w       vr9,    a5,    8,  0
++endfunc
++
++.macro pixel_sad_x3_4x8_core_lsx out0, out1, out2
++    pixel_sad_x3_4x4_core_lsx vr0, vr1, vr2
++
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_4x4_core_lsx vr7, vr8, vr9
++
++    vhaddw.hu.bu   vr0,    vr0,   vr0
++    vhaddw.hu.bu   vr1,    vr1,   vr1
++    vhaddw.hu.bu   vr2,    vr2,   vr2
++    vhaddw.hu.bu   vr7,    vr7,   vr7
++    vhaddw.hu.bu   vr8,    vr8,   vr8
++    vhaddw.hu.bu   vr9,    vr9,   vr9
++    vadd.h         \out0,  vr7,   vr0
++    vadd.h         \out1,  vr8,   vr1
++    vadd.h         \out2,  vr9,   vr2
++.endm
++
++function x265_pixel_sad_x3_4x8_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_4x8_core_lsx vr7, vr8, vr9
++
++    SUM_VEC_x3 vr7, vr8, vr9
++
++    vstelm.w       vr7,    a5,    0,  0
++    vstelm.w       vr8,    a5,    4,  0
++    vstelm.w       vr9,    a5,    8,  0
++endfunc
++
++function x265_pixel_sad_x3_4x16_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_4x8_core_lsx vr19, vr20, vr21
++
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    pixel_sad_x3_4x8_core_lsx vr7, vr8, vr9
++
++    vadd.h         vr7,    vr7,   vr19
++    vadd.h         vr8,    vr8,   vr20
++    vadd.h         vr9,    vr9,   vr21
++    SUM_VEC_x3 vr7, vr8, vr9
++
++    vstelm.w       vr7,    a5,    0,  0
++    vstelm.w       vr8,    a5,    4,  0
++    vstelm.w       vr9,    a5,    8,  0
++endfunc
++
++.macro pixel_sad_x3_8x4_core_lsx out0, out1, out2
++    fld.d          f3,     a0,    0
++    fld.d          f7,     a0,    FENC_STRIDE
++    fld.d          f11,    a0,    FENC_STRIDE<<1
++    fld.d          f15,    a0,    FENC_STRIDE*3
++    FLDD_LOADX_4   a1,     a4,    t1,  t2,  f4, f8,  f12, f16
++    FLDD_LOADX_4   a2,     a4,    t1,  t2,  f5, f9,  f13, f17
++    FLDD_LOADX_4   a3,     a4,    t1,  t2,  f6, f10, f14, f18
++
++    vilvl.d        vr3,    vr7,   vr3
++    vilvl.d        vr4,    vr8,   vr4
++    vilvl.d        vr5,    vr9,   vr5
++    vilvl.d        vr6,    vr10,  vr6
++    vilvl.d        vr11,   vr15,  vr11
++    vilvl.d        vr12,   vr16,  vr12
++    vilvl.d        vr13,   vr17,  vr13
++    vilvl.d        vr14,   vr18,  vr14
++    vabsd.bu       vr7,    vr3,   vr4
++    vabsd.bu       vr8,    vr3,   vr5
++    vabsd.bu       vr9,    vr3,   vr6
++    vabsd.bu       vr3,    vr11,  vr12
++    vabsd.bu       vr4,    vr11,  vr13
++    vabsd.bu       vr5,    vr11,  vr14
++    vhaddw.hu.bu   vr7,    vr7,   vr7
++    vhaddw.hu.bu   vr8,    vr8,   vr8
++    vhaddw.hu.bu   vr9,    vr9,   vr9
++    vhaddw.hu.bu   vr3,    vr3,   vr3
++    vhaddw.hu.bu   vr4,    vr4,   vr4
++    vhaddw.hu.bu   vr5,    vr5,   vr5
++    vadd.h         \out0,  vr7,   vr3
++    vadd.h         \out1,  vr8,   vr4
++    vadd.h         \out2,  vr9,   vr5
++.endm
++
++function x265_pixel_sad_x3_8x4_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_8x4_core_lsx vr7, vr8, vr9
++
++    SUM_VEC_x3 vr7, vr8, vr9
++
++    vstelm.w       vr7,    a5,    0,  0
++    vstelm.w       vr8,    a5,    4,  0
++    vstelm.w       vr9,    a5,    8,  0
++endfunc
++
++.macro sad_x3_8x_lsx h
++function x265_pixel_sad_x3_8x\h\()_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_8x4_core_lsx vr20, vr21, vr22
++
++.rept (\h>>2)-1
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_8x4_core_lsx vr7, vr8, vr9
++
++    vadd.h         vr20,   vr7,   vr20
++    vadd.h         vr21,   vr8,   vr21
++    vadd.h         vr22,   vr9,   vr22
++.endr
++
++    SUM_VEC_x3 vr20, vr21, vr22
++
++    vstelm.w       vr20,   a5,    0,  0
++    vstelm.w       vr21,   a5,    4,  0
++    vstelm.w       vr22,   a5,    8,  0
++endfunc
++.endm
++
++sad_x3_8x_lsx 8
++sad_x3_8x_lsx 16
++sad_x3_8x_lsx 32
++
++.macro pixel_sad_x3_16x4_core_lsx out0, out1, out2
++    vld            vr0,    a0,    0
++    vld            vr1,    a0,    FENC_STRIDE
++    vld            vr2,    a0,    FENC_STRIDE<<1
++    vld            vr3,    a0,    FENC_STRIDE*3
++    LSX_LOADX_4    a1,     a4,    t1,  t2,  vr4, vr7, vr10, vr13
++    LSX_LOADX_4    a2,     a4,    t1,  t2,  vr5, vr8, vr11, vr14
++    LSX_LOADX_4    a3,     a4,    t1,  t2,  vr6, vr9, vr12, vr15
++    vabsd.bu       vr4,    vr0,   vr4
++    vabsd.bu       vr5,    vr0,   vr5
++    vabsd.bu       vr6,    vr0,   vr6
++    vabsd.bu       vr7,    vr1,   vr7
++    vabsd.bu       vr8,    vr1,   vr8
++    vabsd.bu       vr9,    vr1,   vr9
++    vabsd.bu       vr10,   vr2,   vr10
++    vabsd.bu       vr11,   vr2,   vr11
++    vabsd.bu       vr12,   vr2,   vr12
++    vabsd.bu       vr13,   vr3,   vr13
++    vabsd.bu       vr14,   vr3,   vr14
++    vabsd.bu       vr15,   vr3,   vr15
++    vhaddw.hu.bu   vr4,    vr4,   vr4
++    vhaddw.hu.bu   vr5,    vr5,   vr5
++    vhaddw.hu.bu   vr6,    vr6,   vr6
++    vhaddw.hu.bu   vr7,    vr7,   vr7
++    vhaddw.hu.bu   vr8,    vr8,   vr8
++    vhaddw.hu.bu   vr9,    vr9,   vr9
++    vhaddw.hu.bu   vr10,   vr10,  vr10
++    vhaddw.hu.bu   vr11,   vr11,  vr11
++    vhaddw.hu.bu   vr12,   vr12,  vr12
++    vhaddw.hu.bu   vr13,   vr13,  vr13
++    vhaddw.hu.bu   vr14,   vr14,  vr14
++    vhaddw.hu.bu   vr15,   vr15,  vr15
++    vadd.h         vr0,    vr7,   vr4
++    vadd.h         vr1,    vr13,  vr10
++    vadd.h         vr2,    vr8,   vr5
++    vadd.h         vr3,    vr14,  vr11
++    vadd.h         vr4,    vr9,   vr6
++    vadd.h         vr7,    vr15,  vr12
++    vadd.h         \out0,  vr1,   vr0
++    vadd.h         \out1,  vr3,   vr2
++    vadd.h         \out2,  vr7,   vr4
++.endm
++
++function x265_pixel_sad_x3_16x4_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_16x4_core_lsx vr16, vr17, vr18
++
++    SUM_VEC_x3 vr16, vr17, vr18
++
++    vstelm.w       vr16,    a5,    0,  0
++    vstelm.w       vr17,    a5,    4,  0
++    vstelm.w       vr18,    a5,    8,  0
++endfunc
++
++.macro sad_x3_16x_lsx h
++function x265_pixel_sad_x3_16x\h\()_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_16x4_core_lsx vr16, vr17, vr18
++
++.rept (\h>>2)-1
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++    pixel_sad_x3_16x4_core_lsx vr8, vr9, vr10
++
++    vadd.h         vr16,    vr16,  vr8
++    vadd.h         vr17,    vr17,  vr9
++    vadd.h         vr18,    vr18,  vr10
++.endr
++
++    SUM_VEC_x3 vr16, vr17, vr18
++
++    vstelm.w       vr16,    a5,    0,  0
++    vstelm.w       vr17,    a5,    4,  0
++    vstelm.w       vr18,    a5,    8,  0
++endfunc
++.endm
++
++sad_x3_16x_lsx 8
++sad_x3_16x_lsx 12
++sad_x3_16x_lsx 16
++sad_x3_16x_lsx 32
++sad_x3_16x_lsx 64
++
++function x265_pixel_sad_x3_12x16_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_16x4_core_lsx vr16, vr17, vr18
++
++.rept 3
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_16x4_core_lsx vr8, vr9, vr10
++
++    vadd.h         vr16,   vr16,  vr8
++    vadd.h         vr17,   vr17,  vr9
++    vadd.h         vr18,   vr18,  vr10
++.endr
++
++    vinsgr2vr.w    vr16,   zero,  3
++    vinsgr2vr.w    vr17,   zero,  3
++    vinsgr2vr.w    vr18,   zero,  3
++
++    SUM_VEC_x3 vr16, vr17, vr18
++
++    vstelm.w       vr16,    a5,    0,  0
++    vstelm.w       vr17,    a5,    4,  0
++    vstelm.w       vr18,    a5,    8,  0
++endfunc
++
++.macro pixel_sad_x3_24x4_lsx out0, out1, out2
++    pixel_sad_x3_16x4_core_lsx \out0, \out1, \out2
++
++    addi.d         a1,     a1,     16
++    addi.d         a2,     a2,     16
++    addi.d         a3,     a3,     16
++    addi.d         a0,     a0,     16
++
++    pixel_sad_x3_8x4_core_lsx vr16, vr17, vr18
++
++    vadd.h         \out0,  \out0,  vr16
++    vadd.h         \out1,  \out1,  vr17
++    vadd.h         \out2,  \out2,  vr18
++.endm
++
++function x265_pixel_sad_x3_24x32_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_24x4_lsx vr19, vr20, vr21
++
++.rept 7
++    addi.d         a1,  a1,  -16
++    addi.d         a2,  a2,  -16
++    addi.d         a3,  a3,  -16
++    addi.d         a0,  a0,  -16
++
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_24x4_lsx vr0, vr1, vr2
++
++    vadd.h         vr19,   vr0,  vr19
++    vadd.h         vr20,   vr1,  vr20
++    vadd.h         vr21,   vr2,  vr21
++.endr
++
++    SUM_VEC_x3 vr19, vr20, vr21
++
++    vstelm.w       vr19,    a5,    0,  0
++    vstelm.w       vr20,    a5,    4,  0
++    vstelm.w       vr21,    a5,    8,  0
++endfunc
++
++.macro pixel_sad_x3_32x4_core_lsx out0, out1, out2
++    pixel_sad_x3_16x4_core_lsx \out0, \out1, \out2
++
++    addi.d         a1,     a1,     16
++    addi.d         a2,     a2,     16
++    addi.d         a3,     a3,     16
++    addi.d         a0,     a0,     16
++
++    pixel_sad_x3_16x4_core_lsx vr8, vr9, vr10
++
++    vadd.h         \out0,  \out0,  vr8
++    vadd.h         \out1,  \out1,  vr9
++    vadd.h         \out2,  \out2,  vr10
++.endm
++
++.macro sad_x3_32x_lsx h
++function x265_pixel_sad_x3_32x\h\()_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_32x4_core_lsx vr16, vr17, vr18
++
++.rept (\h>>2)-1
++    addi.d         a1,     a1,    -16
++    addi.d         a2,     a2,    -16
++    addi.d         a3,     a3,    -16
++    addi.d         a0,     a0,    -16
++
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_32x4_core_lsx vr19, vr20, vr21
++
++    vadd.h         vr16,   vr16,  vr19
++    vadd.h         vr17,   vr17,  vr20
++    vadd.h         vr18,   vr18,  vr21
++.endr
++
++    SUM_VEC_x3 vr16, vr17, vr18
++
++    vstelm.w       vr16,    a5,    0,  0
++    vstelm.w       vr17,    a5,    4,  0
++    vstelm.w       vr18,    a5,    8,  0
++endfunc
++.endm
++
++sad_x3_32x_lsx 8
++sad_x3_32x_lsx 16
++sad_x3_32x_lsx 24
++sad_x3_32x_lsx 32
++sad_x3_32x_lsx 64
++
++.macro pixel_sad_x3_48x4_core_lsx out0, out1, out2
++    pixel_sad_x3_16x4_core_lsx \out0, \out1, \out2
++
++.rept 2
++    addi.d         a1,     a1,     16
++    addi.d         a2,     a2,     16
++    addi.d         a3,     a3,     16
++    addi.d         a0,     a0,     16
++
++    pixel_sad_x3_16x4_core_lsx vr8, vr9, vr10
++
++    vadd.h         \out0,  \out0,  vr8
++    vadd.h         \out1,  \out1,  vr9
++    vadd.h         \out2,  \out2,  vr10
++.endr
++.endm
++
++function x265_pixel_sad_x3_48x64_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_48x4_core_lsx vr16, vr17, vr18
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++
++.rept 15
++    addi.d         a1,     a1,    -32
++    addi.d         a2,     a2,    -32
++    addi.d         a3,     a3,    -32
++    addi.d         a0,     a0,    -32
++
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_48x4_core_lsx vr19, vr20, vr21
++
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++    vhaddw.wu.hu   vr20,   vr20,  vr20
++    vhaddw.wu.hu   vr21,   vr21,  vr21
++
++    vadd.w         vr16,   vr16,  vr19
++    vadd.w         vr17,   vr17,  vr20
++    vadd.w         vr18,   vr18,  vr21
++.endr
++
++    vhaddw.du.wu   vr16,   vr16,  vr16
++    vhaddw.du.wu   vr17,   vr17,  vr17
++    vhaddw.du.wu   vr18,   vr18,  vr18
++    vhaddw.qu.du   vr16,   vr16,  vr16
++    vhaddw.qu.du   vr17,   vr17,  vr17
++    vhaddw.qu.du   vr18,   vr18,  vr18
++
++    vstelm.w       vr16,    a5,    0,  0
++    vstelm.w       vr17,    a5,    4,  0
++    vstelm.w       vr18,    a5,    8,  0
++endfunc
++
++.macro pixel_sad_x3_64x4_core_lsx out0, out1, out2
++    pixel_sad_x3_16x4_core_lsx \out0, \out1, \out2
++
++.rept 3
++    addi.d         a1,     a1,     16
++    addi.d         a2,     a2,     16
++    addi.d         a3,     a3,     16
++    addi.d         a0,     a0,     16
++
++    pixel_sad_x3_16x4_core_lsx vr8, vr9, vr10
++
++    vadd.h         \out0,  \out0,  vr8
++    vadd.h         \out1,  \out1,  vr9
++    vadd.h         \out2,  \out2,  vr10
++.endr
++.endm
++
++.macro sad_x3_64x_lsx h
++function x265_pixel_sad_x3_64x\h\()_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_64x4_core_lsx vr16, vr17, vr18
++
++.rept (\h>>2)-1
++    addi.d         a1,     a1,    -48
++    addi.d         a2,     a2,    -48
++    addi.d         a3,     a3,    -48
++    addi.d         a0,     a0,    -48
++
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_64x4_core_lsx vr19, vr20, vr21
++
++    vadd.h         vr16,   vr16,  vr19
++    vadd.h         vr17,   vr17,  vr20
++    vadd.h         vr18,   vr18,  vr21
++.endr
++
++    SUM_VEC_x3 vr16, vr17, vr18
++
++    vstelm.w       vr16,    a5,    0,  0
++    vstelm.w       vr17,    a5,    4,  0
++    vstelm.w       vr18,    a5,    8,  0
++endfunc
++.endm
++
++sad_x3_64x_lsx 16
++sad_x3_64x_lsx 32
++
++.macro sad_x3_64x48_lsx h
++function x265_pixel_sad_x3_64x\h\()_lsx
++    slli.d         t1,     a4,    1
++    add.d          t2,     a4,    t1
++
++    pixel_sad_x3_64x4_core_lsx vr16, vr17, vr18
++
++    vhaddw.wu.hu   vr16,   vr16,  vr16
++    vhaddw.wu.hu   vr17,   vr17,  vr17
++    vhaddw.wu.hu   vr18,   vr18,  vr18
++
++.rept (\h>>2)-1
++    addi.d         a1,     a1,    -48
++    addi.d         a2,     a2,    -48
++    addi.d         a3,     a3,    -48
++    addi.d         a0,     a0,    -48
++
++    alsl.d         a1,     a4,    a1,   2
++    alsl.d         a2,     a4,    a2,   2
++    alsl.d         a3,     a4,    a3,   2
++    addi.d         a0,     a0,    FENC_STRIDE<<2
++
++    pixel_sad_x3_64x4_core_lsx vr19, vr20, vr21
++
++    vhaddw.wu.hu   vr19,   vr19,  vr19
++    vhaddw.wu.hu   vr20,   vr20,  vr20
++    vhaddw.wu.hu   vr21,   vr21,  vr21
++
++    vadd.w         vr16,   vr16,  vr19
++    vadd.w         vr17,   vr17,  vr20
++    vadd.w         vr18,   vr18,  vr21
++.endr
++
++    vhaddw.du.wu   vr16,   vr16,  vr16
++    vhaddw.du.wu   vr17,   vr17,  vr17
++    vhaddw.du.wu   vr18,   vr18,  vr18
++    vhaddw.qu.du   vr16,   vr16,  vr16
++    vhaddw.qu.du   vr17,   vr17,  vr17
++    vhaddw.qu.du   vr18,   vr18,  vr18
++    vstelm.w       vr16,   a5,    0,  0
++    vstelm.w       vr17,   a5,    4,  0
++    vstelm.w       vr18,   a5,    8,  0
++endfunc
++.endm
++
++sad_x3_64x48_lsx 48
++sad_x3_64x48_lsx 64
++
++.macro pixel_sad_x3_16x2_core_lasx out0, out1, out2
++    vld           vr0,      a0,     0
++    vld           vr1,      a0,     FENC_STRIDE
++    vld           vr2,      a1,     0
++    vldx          vr3,      a1,     a4
++    vld           vr4,      a2,     0
++    vldx          vr5,      a2,     a4
++    vld           vr6,      a3,     0
++    vldx          vr7,      a3,     a4
++
++    xvpermi.q     xr1,      xr0,    0x20
++    xvpermi.q     xr3,      xr2,    0x20
++    xvpermi.q     xr5,      xr4,    0x20
++    xvpermi.q     xr7,      xr6,    0x20
++    xvabsd.bu     xr8,      xr1,    xr3
++    xvabsd.bu     xr9,      xr1,    xr5
++    xvabsd.bu     xr10,     xr1,    xr7
++    xvhaddw.hu.bu \out0,    xr8,    xr8
++    xvhaddw.hu.bu \out1,    xr9,    xr9
++    xvhaddw.hu.bu \out2,    xr10,   xr10
++.endm
++
++.macro pixel_sad_x3_16x_lasx h
++function x265_pixel_sad_x3_16x\h\()_lasx
++    slli.d        t1,       a4,     1
++
++    pixel_sad_x3_16x2_core_lasx xr20, xr21, xr22
++
++.rept (\h>>1)-1
++    addi.d        a0,       a0,     FENC_STRIDE<<1
++    add.d         a1,       a1,     t1
++    add.d         a2,       a2,     t1
++    add.d         a3,       a3,     t1
++
++    pixel_sad_x3_16x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr20,     xr0,    xr20
++    xvadd.h       xr21,     xr1,    xr21
++    xvadd.h       xr22,     xr2,    xr22
++.endr
++
++    xvhaddw.w.h   xr20,     xr20,   xr20
++    xvhaddw.w.h   xr21,     xr21,   xr21
++    xvhaddw.w.h   xr22,     xr22,   xr22
++    xvhaddw.d.w   xr20,     xr20,   xr20
++    xvhaddw.d.w   xr21,     xr21,   xr21
++    xvhaddw.d.w   xr22,     xr22,   xr22
++    xvhaddw.q.d   xr20,     xr20,   xr20
++    xvhaddw.q.d   xr21,     xr21,   xr21
++    xvhaddw.q.d   xr22,     xr22,   xr22
++    xvpermi.q     xr3,      xr20,   0x01
++    xvpermi.q     xr4,      xr21,   0x01
++    xvpermi.q     xr5,      xr22,   0x01
++    vadd.w        vr20,     vr3,    vr20
++    vadd.w        vr21,     vr4,    vr21
++    vadd.w        vr22,     vr5,    vr22
++
++    vstelm.w      vr20,     a5,     0,    0
++    vstelm.w      vr21,     a5,     4,    0
++    vstelm.w      vr22,     a5,     8,    0
++endfunc
++.endm
++
++pixel_sad_x3_16x_lasx 4
++pixel_sad_x3_16x_lasx 8
++pixel_sad_x3_16x_lasx 12
++pixel_sad_x3_16x_lasx 16
++pixel_sad_x3_16x_lasx 32
++pixel_sad_x3_16x_lasx 64
++
++function x265_pixel_sad_x3_12x16_lasx
++    slli.d        t1,       a4,     1
++
++    pixel_sad_x3_16x2_core_lasx xr20, xr21, xr22
++
++.rept 7
++
++    addi.d        a0,       a0,     FENC_STRIDE<<1
++    add.d         a1,       a1,     t1
++    add.d         a2,       a2,     t1
++    add.d         a3,       a3,     t1
++
++    pixel_sad_x3_16x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr20,     xr0,    xr20
++    xvadd.h       xr21,     xr1,    xr21
++    xvadd.h       xr22,     xr2,    xr22
++.endr
++
++.irp i, xr20, xr21, xr22
++    xvinsgr2vr.w  \i,       zero,   3
++    xvinsgr2vr.w  \i,       zero,   7
++.endr
++
++    xvhaddw.w.h   xr20,     xr20,   xr20
++    xvhaddw.w.h   xr21,     xr21,   xr21
++    xvhaddw.w.h   xr22,     xr22,   xr22
++    xvhaddw.d.w   xr20,     xr20,   xr20
++    xvhaddw.d.w   xr21,     xr21,   xr21
++    xvhaddw.d.w   xr22,     xr22,   xr22
++    xvhaddw.q.d   xr20,     xr20,   xr20
++    xvhaddw.q.d   xr21,     xr21,   xr21
++    xvhaddw.q.d   xr22,     xr22,   xr22
++    xvpermi.q     xr3,      xr20,   0x01
++    xvpermi.q     xr4,      xr21,   0x01
++    xvpermi.q     xr5,      xr22,   0x01
++    vadd.w        vr20,     vr3,    vr20
++    vadd.w        vr21,     vr4,    vr21
++    vadd.w        vr22,     vr5,    vr22
++
++    vstelm.w      vr20,     a5,     0,    0
++    vstelm.w      vr21,     a5,     4,    0
++    vstelm.w      vr22,     a5,     8,    0
++endfunc
++
++.macro pixel_sad_x3_32x2_core_lasx out0, out1, out2
++    xvld          xr0,      a0,    0
++    xvld          xr1,      a0,    FENC_STRIDE
++    xvld          xr2,      a1,    0
++    xvldx         xr3,      a1,    a4
++    xvld          xr4,      a2,    0
++    xvldx         xr5,      a2,    a4
++    xvld          xr6,      a3,    0
++    xvldx         xr7,      a3,    a4
++
++    xvabsd.bu     xr8,      xr0,   xr2
++    xvabsd.bu     xr9,      xr0,   xr4
++    xvabsd.bu     xr10,     xr0,   xr6
++    xvabsd.bu     xr11,     xr1,   xr3
++    xvabsd.bu     xr12,     xr1,   xr5
++    xvabsd.bu     xr13,     xr1,   xr7
++.irp i, xr8, xr9, xr10,  xr11, xr12, xr13
++    xvhaddw.hu.bu \i,       \i,    \i
++.endr
++    xvadd.h       \out0,    xr8,   xr11
++    xvadd.h       \out1,    xr9,   xr12
++    xvadd.h       \out2,    xr10,  xr13
++.endm
++
++.macro pixel_sad_x3_32x_lasx h
++function x265_pixel_sad_x3_32x\h\()_lasx
++    slli.d        t1,       a4,     1
++
++    pixel_sad_x3_32x2_core_lasx xr20, xr21, xr22
++
++.rept (\h>>1)-1
++    addi.d        a0,       a0,     FENC_STRIDE<<1
++    add.d         a1,       a1,     t1
++    add.d         a2,       a2,     t1
++    add.d         a3,       a3,     t1
++
++    pixel_sad_x3_32x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr20,     xr0,    xr20
++    xvadd.h       xr21,     xr1,    xr21
++    xvadd.h       xr22,     xr2,    xr22
++.endr
++
++    xvhaddw.w.h   xr20,     xr20,   xr20
++    xvhaddw.w.h   xr21,     xr21,   xr21
++    xvhaddw.w.h   xr22,     xr22,   xr22
++    xvhaddw.d.w   xr20,     xr20,   xr20
++    xvhaddw.d.w   xr21,     xr21,   xr21
++    xvhaddw.d.w   xr22,     xr22,   xr22
++    xvhaddw.q.d   xr20,     xr20,   xr20
++    xvhaddw.q.d   xr21,     xr21,   xr21
++    xvhaddw.q.d   xr22,     xr22,   xr22
++    xvpermi.q     xr3,      xr20,   0x01
++    xvpermi.q     xr4,      xr21,   0x01
++    xvpermi.q     xr5,      xr22,   0x01
++    vadd.w        vr20,     vr3,    vr20
++    vadd.w        vr21,     vr4,    vr21
++    vadd.w        vr22,     vr5,    vr22
++
++    vstelm.w      vr20,     a5,     0,    0
++    vstelm.w      vr21,     a5,     4,    0
++    vstelm.w      vr22,     a5,     8,    0
++endfunc
++.endm
++
++pixel_sad_x3_32x_lasx 8
++pixel_sad_x3_32x_lasx 16
++pixel_sad_x3_32x_lasx 24
++pixel_sad_x3_32x_lasx 32
++pixel_sad_x3_32x_lasx 64
++
++function x265_pixel_sad_x3_24x32_lasx
++    slli.d        t1,       a4,     1
++
++    pixel_sad_x3_32x2_core_lasx xr20, xr21, xr22
++
++.rept 15
++    addi.d        a0,       a0,     FENC_STRIDE<<1
++    add.d         a1,       a1,     t1
++    add.d         a2,       a2,     t1
++    add.d         a3,       a3,     t1
++
++    pixel_sad_x3_32x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr20,     xr0,    xr20
++    xvadd.h       xr21,     xr1,    xr21
++    xvadd.h       xr22,     xr2,    xr22
++.endr
++
++    xvinsgr2vr.d  xr20,     zero,  3
++    xvinsgr2vr.d  xr21,     zero,  3
++    xvinsgr2vr.d  xr22,     zero,  3
++    xvhaddw.w.h   xr20,     xr20,   xr20
++    xvhaddw.w.h   xr21,     xr21,   xr21
++    xvhaddw.w.h   xr22,     xr22,   xr22
++    xvhaddw.d.w   xr20,     xr20,   xr20
++    xvhaddw.d.w   xr21,     xr21,   xr21
++    xvhaddw.d.w   xr22,     xr22,   xr22
++    xvhaddw.q.d   xr20,     xr20,   xr20
++    xvhaddw.q.d   xr21,     xr21,   xr21
++    xvhaddw.q.d   xr22,     xr22,   xr22
++    xvpermi.q     xr3,      xr20,   0x01
++    xvpermi.q     xr4,      xr21,   0x01
++    xvpermi.q     xr5,      xr22,   0x01
++    vadd.w        vr20,     vr3,    vr20
++    vadd.w        vr21,     vr4,    vr21
++    vadd.w        vr22,     vr5,    vr22
++
++    vstelm.w      vr20,     a5,     0,    0
++    vstelm.w      vr21,     a5,     4,    0
++    vstelm.w      vr22,     a5,     8,    0
++endfunc
++
++.macro pixel_sad_x3_64x_lasx h
++function x265_pixel_sad_x3_64x\h\()_lasx
++    slli.d        t1,       a4,     1
++
++    pixel_sad_x3_32x2_core_lasx xr20, xr21, xr22
++
++    addi.d        a0,       a0,     32
++    addi.d        a1,       a1,     32
++    addi.d        a2,       a2,     32
++    addi.d        a3,       a3,     32
++
++    pixel_sad_x3_32x2_core_lasx xr17, xr18, xr19
++
++.rept (\h>>1)-1
++    addi.d        a0,       a0,     -32
++    addi.d        a1,       a1,     -32
++    addi.d        a2,       a2,     -32
++    addi.d        a3,       a3,     -32
++
++    addi.d        a0,       a0,     FENC_STRIDE<<1
++    add.d         a1,       a1,     t1
++    add.d         a2,       a2,     t1
++    add.d         a3,       a3,     t1
++
++    pixel_sad_x3_32x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr20,     xr0,    xr20
++    xvadd.h       xr21,     xr1,    xr21
++    xvadd.h       xr22,     xr2,    xr22
++
++    addi.d        a0,       a0,     32
++    addi.d        a1,       a1,     32
++    addi.d        a2,       a2,     32
++    addi.d        a3,       a3,     32
++
++    pixel_sad_x3_32x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr17,     xr0,    xr17
++    xvadd.h       xr18,     xr1,    xr18
++    xvadd.h       xr19,     xr2,    xr19
++.endr
++
++.irp i, xr17, xr18, xr19, xr20, xr21, xr22
++    xvhaddw.w.h   \i,       \i,     \i
++.endr
++
++    xvadd.w       xr20,     xr20, xr17
++    xvadd.w       xr21,     xr21, xr18
++    xvadd.w       xr22,     xr22, xr19
++
++    xvhaddw.d.w   xr20,     xr20,   xr20
++    xvhaddw.d.w   xr21,     xr21,   xr21
++    xvhaddw.d.w   xr22,     xr22,   xr22
++    xvhaddw.q.d   xr20,     xr20,   xr20
++    xvhaddw.q.d   xr21,     xr21,   xr21
++    xvhaddw.q.d   xr22,     xr22,   xr22
++    xvpermi.q     xr3,      xr20,   0x01
++    xvpermi.q     xr4,      xr21,   0x01
++    xvpermi.q     xr5,      xr22,   0x01
++    vadd.w        vr20,     vr3,    vr20
++    vadd.w        vr21,     vr4,    vr21
++    vadd.w        vr22,     vr5,    vr22
++
++    vstelm.w      vr20,     a5,     0,    0
++    vstelm.w      vr21,     a5,     4,    0
++    vstelm.w      vr22,     a5,     8,    0
++endfunc
++.endm
++
++pixel_sad_x3_64x_lasx 16
++pixel_sad_x3_64x_lasx 32
++pixel_sad_x3_64x_lasx 48
++pixel_sad_x3_64x_lasx 64
++
++function x265_pixel_sad_x3_48x64_lasx
++    slli.d        t1,       a4,     1
++
++    pixel_sad_x3_32x2_core_lasx xr20, xr21, xr22
++
++    addi.d        a0,       a0,     32
++    addi.d        a1,       a1,     32
++    addi.d        a2,       a2,     32
++    addi.d        a3,       a3,     32
++
++    pixel_sad_x3_32x2_core_lasx xr17, xr18, xr19
++
++.rept 31
++    addi.d        a0,       a0,     -32
++    addi.d        a1,       a1,     -32
++    addi.d        a2,       a2,     -32
++    addi.d        a3,       a3,     -32
++
++    addi.d        a0,       a0,     FENC_STRIDE<<1
++    add.d         a1,       a1,     t1
++    add.d         a2,       a2,     t1
++    add.d         a3,       a3,     t1
++
++    pixel_sad_x3_32x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr20,     xr0,    xr20
++    xvadd.h       xr21,     xr1,    xr21
++    xvadd.h       xr22,     xr2,    xr22
++
++    addi.d        a0,       a0,     32
++    addi.d        a1,       a1,     32
++    addi.d        a2,       a2,     32
++    addi.d        a3,       a3,     32
++
++    pixel_sad_x3_32x2_core_lasx xr0, xr1, xr2
++
++    xvadd.h       xr17,     xr0,    xr17
++    xvadd.h       xr18,     xr1,    xr18
++    xvadd.h       xr19,     xr2,    xr19
++.endr
++
++    xvreplgr2vr.w xr23,     zero
++    xvpermi.q     xr17,     xr23,   0x02
++    xvpermi.q     xr18,     xr23,   0x02
++    xvpermi.q     xr19,     xr23,   0x02
++
++.irp i, xr17, xr18, xr19, xr20, xr21, xr22
++    xvhaddw.w.h   \i,       \i,     \i
++.endr
++
++    xvadd.w       xr20,     xr20, xr17
++    xvadd.w       xr21,     xr21, xr18
++    xvadd.w       xr22,     xr22, xr19
++    xvhaddw.d.w   xr20,     xr20,   xr20
++    xvhaddw.d.w   xr21,     xr21,   xr21
++    xvhaddw.d.w   xr22,     xr22,   xr22
++    xvhaddw.q.d   xr20,     xr20,   xr20
++    xvhaddw.q.d   xr21,     xr21,   xr21
++    xvhaddw.q.d   xr22,     xr22,   xr22
++    xvpermi.q     xr3,      xr20,   0x01
++    xvpermi.q     xr4,      xr21,   0x01
++    xvpermi.q     xr5,      xr22,   0x01
++    vadd.w        vr20,     vr3,    vr20
++    vadd.w        vr21,     vr4,    vr21
++    vadd.w        vr22,     vr5,    vr22
++
++    vstelm.w      vr20,     a5,     0,    0
++    vstelm.w      vr21,     a5,     4,    0
++    vstelm.w      vr22,     a5,     8,    0
++endfunc
+diff --git a/source/common/loongarch64/ssd.S b/source/common/loongarch64/ssd.S
+new file mode 100644
+index 000000000..9fa292a15
+--- /dev/null
++++ b/source/common/loongarch64/ssd.S
+@@ -0,0 +1,1150 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Hecai Yuan <yuanhecai@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "loongson_asm.S"
++
++.macro pixel_sse_4x4_core_lsx out
++    FLDS_LOADX_4  a0,     a1,     t0,   t1, f0, f1, f2, f3
++    FLDS_LOADX_4  a2,     a3,     t2,   t3, f4, f5, f6, f7
++
++    vilvl.w       vr0,    vr1,    vr0
++    vilvl.w       vr1,    vr3,    vr2
++    vilvl.w       vr4,    vr5,    vr4
++    vilvl.w       vr5,    vr7,    vr6
++    vilvl.d       vr0,    vr1,    vr0
++    vilvl.d       vr4,    vr5,    vr4
++    vsubwev.h.bu  vr1,    vr0,    vr4
++    vsubwod.h.bu  vr2,    vr0,    vr4
++    vmul.h        vr5,    vr1,    vr1
++    vmul.h        vr6,    vr2,    vr2
++    vhaddw.wu.hu  vr5,    vr5,    vr5
++    vhaddw.wu.hu  vr6,    vr6,    vr6
++    vadd.w        \out,   vr5,    vr6
++.endm
++
++function x265_pixel_sse_4x4_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_4x4_core_lsx vr5
++
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
++
++function x265_pixel_sse_4x8_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_4x4_core_lsx vr10
++
++    alsl.d        a0,     a1,     a0,    2
++    alsl.d        a2,     a3,     a2,    2
++    pixel_sse_4x4_core_lsx vr5
++
++    vadd.w        vr5,    vr5,    vr10
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
++
++.macro pixel_sse_8x4_core_lsx out
++    FLDD_LOADX_4  a0,     a1,     t0,   t1, f0, f1, f2, f3
++    FLDD_LOADX_4  a2,     a3,     t2,   t3, f4, f5, f6, f7
++    vilvl.d       vr0,    vr1,    vr0
++    vilvl.d       vr1,    vr3,    vr2
++    vilvl.d       vr4,    vr5,    vr4
++    vilvl.d       vr5,    vr7,    vr6
++    vsubwev.h.bu  vr2,    vr0,    vr4
++    vsubwod.h.bu  vr3,    vr0,    vr4
++    vsubwev.h.bu  vr6,    vr1,    vr5
++    vsubwod.h.bu  vr7,    vr1,    vr5
++    vmul.h        vr2,    vr2,    vr2
++    vmul.h        vr3,    vr3,    vr3
++    vmul.h        vr6,    vr6,    vr6
++    vmul.h        vr7,    vr7,    vr7
++    vhaddw.wu.hu  vr2,    vr2,    vr2
++    vhaddw.wu.hu  vr3,    vr3,    vr3
++    vhaddw.wu.hu  vr6,    vr6,    vr6
++    vhaddw.wu.hu  vr7,    vr7,    vr7
++    vadd.w        vr2,    vr2,    vr3
++    vadd.w        vr6,    vr6,    vr7
++    vadd.w        \out,   vr2,    vr6
++.endm
++
++function x265_pixel_sse_8x8_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_8x4_core_lsx vr10
++
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_8x4_core_lsx vr11
++
++    vadd.w        vr10,   vr10,   vr11
++    vhaddw.d.w    vr10,   vr10,   vr10
++    vhaddw.q.d    vr10,   vr10,   vr10
++    vpickve2gr.w  a0,     vr10,   0
++endfunc
++
++function x265_pixel_sse_8x16_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_8x4_core_lsx vr10
++
++.rept 3
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_8x4_core_lsx vr11
++    vadd.w        vr10,   vr10,   vr11
++.endr
++
++    vhaddw.d.w    vr10,   vr10,   vr10
++    vhaddw.q.d    vr10,   vr10,   vr10
++    vpickve2gr.w  a0,     vr10,   0
++endfunc
++
++.macro pixel_sse_16x4_core_lsx out
++    LSX_LOADX_4   a0,     a1,     t0,   t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4   a2,     a3,     t2,   t3, vr4, vr5, vr6, vr7
++    vsubwev.h.bu  vr8,    vr0,    vr4
++    vsubwod.h.bu  vr9,    vr0,    vr4
++    vsubwev.h.bu  vr10,   vr1,    vr5
++    vsubwod.h.bu  vr11,   vr1,    vr5
++    vsubwev.h.bu  vr12,   vr2,    vr6
++    vsubwod.h.bu  vr13,   vr2,    vr6
++    vsubwev.h.bu  vr14,   vr3,    vr7
++    vsubwod.h.bu  vr15,   vr3,    vr7
++    vmul.h        vr8,    vr8,    vr8
++    vmul.h        vr9,    vr9,    vr9
++    vmul.h        vr10,   vr10,   vr10
++    vmul.h        vr11,   vr11,   vr11
++    vmul.h        vr12,   vr12,   vr12
++    vmul.h        vr13,   vr13,   vr13
++    vmul.h        vr14,   vr14,   vr14
++    vmul.h        vr15,   vr15,   vr15
++    vhaddw.wu.hu  vr8,    vr8,    vr8
++    vhaddw.wu.hu  vr9,    vr9,    vr9
++    vhaddw.wu.hu  vr10,   vr10,   vr10
++    vhaddw.wu.hu  vr11,   vr11,   vr11
++    vhaddw.wu.hu  vr12,   vr12,   vr12
++    vhaddw.wu.hu  vr13,   vr13,   vr13
++    vhaddw.wu.hu  vr14,   vr14,   vr14
++    vhaddw.wu.hu  vr15,   vr15,   vr15
++    vadd.w        vr8,    vr8,    vr9
++    vadd.w        vr9,    vr10,   vr11
++    vadd.w        vr10,   vr12,   vr13
++    vadd.w        vr11,   vr14,   vr15
++    vadd.w        vr8,    vr8,    vr9
++    vadd.w        vr9,    vr10,   vr11
++    vadd.w        \out,   vr8,    vr9
++.endm
++
++function x265_pixel_sse_16x16_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_16x4_core_lsx vr16
++
++.rept 3
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++.endr
++
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++
++function x265_pixel_sse_16x32_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_16x4_core_lsx vr16
++
++.rept 7
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++.endr
++
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++
++.macro pixel_sse_32x_lsx h
++function x265_pixel_sse_32x\h\()_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_16x4_core_lsx vr16
++
++    addi.d        a0,     a0,     16
++    addi.d        a2,     a2,     16
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++
++.rept (\h>>2)-1
++    addi.d        a0,     a0,     -16
++    addi.d        a2,     a2,     -16
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++
++    addi.d        a0,     a0,     16
++    addi.d        a2,     a2,     16
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++.endr
++
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++.endm
++
++pixel_sse_32x_lsx 32
++pixel_sse_32x_lsx 64
++
++function x265_pixel_sse_64x64_lsx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_16x4_core_lsx vr16
++
++.rept 3
++    addi.d        a0,     a0,     16
++    addi.d        a2,     a2,     16
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++.endr
++
++.rept 15
++    addi.d        a0,     a0,     -48
++    addi.d        a2,     a2,     -48
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++
++.rept 3
++    addi.d        a0,     a0,     16
++    addi.d        a2,     a2,     16
++
++    pixel_sse_16x4_core_lsx vr17
++    vadd.w        vr16,   vr16,   vr17
++.endr
++.endr
++
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++
++.macro pixel_sse_16x4_core_lasx out
++    LSX_LOADX_4    a0,     a1,     t0,   t1, vr0, vr1, vr2, vr3
++    LSX_LOADX_4    a2,     a3,     t2,   t3, vr4, vr5, vr6, vr7
++
++    xvpermi.q      xr1,    xr0,    0x20
++    xvpermi.q      xr3,    xr2,    0x20
++    xvpermi.q      xr5,    xr4,    0x20
++    xvpermi.q      xr7,    xr6,    0x20
++
++    xvsubwev.h.bu  xr10,   xr1,    xr5
++    xvsubwod.h.bu  xr11,   xr1,    xr5
++    xvsubwev.h.bu  xr14,   xr3,    xr7
++    xvsubwod.h.bu  xr15,   xr3,    xr7
++    xvmul.h        xr10,   xr10,   xr10
++    xvmul.h        xr11,   xr11,   xr11
++    xvmul.h        xr14,   xr14,   xr14
++    xvmul.h        xr15,   xr15,   xr15
++    xvhaddw.wu.hu  xr10,   xr10,   xr10
++    xvhaddw.wu.hu  xr11,   xr11,   xr11
++    xvhaddw.wu.hu  xr14,   xr14,   xr14
++    xvhaddw.wu.hu  xr15,   xr15,   xr15
++    xvadd.w        xr8,    xr10,   xr11
++    xvadd.w        xr9,    xr14,   xr15
++    xvadd.w        \out,   xr8,    xr9
++.endm
++
++.macro pixel_sse_16x_lasx h
++function x265_pixel_sse_16x\h\()_lasx
++    slli.d        t0,     a1,     1
++    add.d         t1,     a1,     t0
++    slli.d        t2,     a3,     1
++    add.d         t3,     a3,     t2
++
++    pixel_sse_16x4_core_lasx xr16
++
++.rept (\h>>2)-1
++    alsl.d        a0,     a1,     a0,   2
++    alsl.d        a2,     a3,     a2,   2
++    pixel_sse_16x4_core_lasx xr17
++    xvadd.w       xr16,   xr16,   xr17
++.endr
++
++    xvpermi.q     xr17,   xr16,   0x01
++    vadd.w        vr16,   vr16,   vr17
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++.endm
++
++pixel_sse_16x_lasx 16
++pixel_sse_16x_lasx 32
++
++.macro pixel_sse_32x2_core_lasx out
++    xvld           xr0,    a0,     0
++    xvldx          xr1,    a0,     a1
++    xvld           xr2,    a2,     0
++    xvldx          xr3,    a2,     a3
++
++    xvsubwev.h.bu  xr10,   xr0,    xr2
++    xvsubwod.h.bu  xr11,   xr0,    xr2
++    xvsubwev.h.bu  xr14,   xr1,    xr3
++    xvsubwod.h.bu  xr15,   xr1,    xr3
++    xvmulwev.w.h   xr20,   xr10,   xr10
++    xvmulwod.w.h   xr21,   xr10,   xr10
++    xvmaddwev.w.h  xr20,   xr11,   xr11
++    xvmaddwod.w.h  xr21,   xr11,   xr11
++    xvmaddwev.w.h  xr20,   xr14,   xr14
++    xvmaddwod.w.h  xr21,   xr14,   xr14
++    xvmaddwev.w.h  xr20,   xr15,   xr15
++    xvmaddwod.w.h  xr21,   xr15,   xr15
++    xvadd.w        \out,   xr20,   xr21
++.endm
++
++.macro pixel_sse_32x_lasx h
++function x265_pixel_sse_32x\h\()_lasx
++
++    pixel_sse_32x2_core_lasx xr16
++
++.rept (\h>>1)-1
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++    pixel_sse_32x2_core_lasx xr17
++    xvadd.w       xr16,   xr16,   xr17
++.endr
++
++    xvpermi.q     xr17,   xr16,   0x01
++    vadd.w        vr16,   vr16,   vr17
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++.endm
++
++pixel_sse_32x_lasx 32
++pixel_sse_32x_lasx 64
++
++function x265_pixel_sse_64x64_lasx
++
++    pixel_sse_32x2_core_lasx xr16
++    addi.d        a0,     a0,     32
++    addi.d        a2,     a2,     32
++    pixel_sse_32x2_core_lasx xr17
++    xvadd.w xr16, xr16, xr17
++
++.rept 31
++    addi.d        a0,     a0,     -32
++    addi.d        a2,     a2,     -32
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++    pixel_sse_32x2_core_lasx xr17
++    xvadd.w       xr16,   xr16,   xr17
++
++    addi.d        a0,     a0,     32
++    addi.d        a2,     a2,     32
++    pixel_sse_32x2_core_lasx xr17
++    xvadd.w       xr16,   xr16,   xr17
++.endr
++
++    xvpermi.q     xr17,   xr16,   0x01
++    vadd.w        vr16,   vr16,   vr17
++    vhaddw.d.w    vr16,   vr16,   vr16
++    vhaddw.q.d    vr16,   vr16,   vr16
++    vpickve2gr.w  a0,     vr16,   0
++endfunc
++
++function x265_pixel_ssd_s_4x4_lsx
++    slli.d        a1,     a1,     1
++    fld.d         f0,     a0,     0
++    fldx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0, 1
++    fld.d         f2,     a0,     0
++    fldx.d        f3,     a0,     a1
++    vilvl.d       vr1,    vr1,    vr0
++    vilvl.d       vr3,    vr3,    vr2
++    vmulwev.w.h   vr5,    vr1,    vr1
++    vmulwev.w.h   vr6,    vr3,    vr3
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr3,    vr3
++    vadd.w        vr7,    vr5,    vr6
++    vhaddw.d.w    vr7,    vr7,    vr7
++    vhaddw.q.d    vr7,    vr7,    vr7
++    vpickve2gr.w  a0,     vr7,    0
++endfunc
++
++
++function x265_pixel_ssd_s_8x8_lsx
++    slli.d        a1,     a1,     1
++
++    vld           vr0,    a0,     0
++    vldx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,   1
++    vld           vr2,    a0,     0
++    vldx          vr3,    a0,     a1
++    vmulwev.w.h   vr4,    vr0,    vr0
++    vmulwev.w.h   vr5,    vr1,    vr1
++    vmulwev.w.h   vr6,    vr2,    vr2
++    vmulwev.w.h   vr7,    vr3,    vr3
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++
++    alsl.d        a0,     a1,     a0,   1
++    vld           vr0,    a0,     0
++    vldx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,   1
++    vld           vr2,    a0,     0
++    vldx          vr3,    a0,     a1
++    vmaddwev.w.h  vr4,    vr0,    vr0
++    vmaddwev.w.h  vr5,    vr1,    vr1
++    vmaddwev.w.h  vr6,    vr2,    vr2
++    vmaddwev.w.h  vr7,    vr3,    vr3
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++
++    vadd.w        vr8,    vr5,    vr4
++    vadd.w        vr9,    vr7,    vr6
++    vadd.w        vr7,    vr8,    vr9
++
++    vhaddw.d.w    vr7,    vr7,    vr7
++    vhaddw.q.d    vr7,    vr7,    vr7
++    vpickve2gr.w  a0,     vr7,    0
++endfunc
++
++function x265_pixel_ssd_s_16x16_lsx
++    slli.d        a1,     a1,     1
++
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    add.d         a0,     a0,     a1
++    vld           vr2,    a0,     0
++    vld           vr3,    a0,     16
++
++    vmulwev.w.h   vr4,    vr0,    vr0
++    vmulwev.w.h   vr5,    vr1,    vr1
++    vmulwev.w.h   vr6,    vr2,    vr2
++    vmulwev.w.h   vr7,    vr3,    vr3
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++
++.rept 7
++    add.d         a0,     a1,     a0
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    add.d         a0,     a1,     a0
++    vld           vr2,    a0,     0
++    vld           vr3,    a0,     16
++    vmaddwev.w.h  vr4,    vr0,    vr0
++    vmaddwev.w.h  vr5,    vr1,    vr1
++    vmaddwev.w.h  vr6,    vr2,    vr2
++    vmaddwev.w.h  vr7,    vr3,    vr3
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++.endr
++    vadd.w        vr8,    vr5,    vr4
++    vadd.w        vr9,    vr7,    vr6
++    vadd.w        vr7,    vr8,    vr9
++    vhaddw.d.w    vr7,    vr7,    vr7
++    vhaddw.q.d    vr7,    vr7,    vr7
++    vpickve2gr.w  a0,     vr7,    0
++endfunc
++
++function x265_pixel_ssd_s_32x32_lsx
++    slli.d        a1,     a1,     1
++
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    vld           vr2,    a0,     32
++    vld           vr3,    a0,     48
++
++    vmulwev.w.h   vr4,    vr0,    vr0
++    vmulwev.w.h   vr5,    vr1,    vr1
++    vmulwev.w.h   vr6,    vr2,    vr2
++    vmulwev.w.h   vr7,    vr3,    vr3
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++
++.rept 31
++    add.d         a0,     a1,     a0
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    vld           vr2,    a0,     32
++    vld           vr3,    a0,     48
++    vmaddwev.w.h  vr4,    vr0,    vr0
++    vmaddwev.w.h  vr5,    vr1,    vr1
++    vmaddwev.w.h  vr6,    vr2,    vr2
++    vmaddwev.w.h  vr7,    vr3,    vr3
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++.endr
++    vadd.w        vr8,    vr5,    vr4
++    vadd.w        vr9,    vr7,    vr6
++    vadd.w        vr7,    vr8,    vr9
++    vhaddw.d.w    vr7,    vr7,    vr7
++    vhaddw.q.d    vr7,    vr7,    vr7
++    vpickve2gr.w  a0,     vr7,    0
++endfunc
++
++function x265_pixel_ssd_s_64x64_lsx
++    slli.d        a1,     a1,     1
++
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    vld           vr2,    a0,     32
++    vld           vr3,    a0,     48
++    vld           vr10,   a0,     64
++    vld           vr11,   a0,     80
++    vld           vr12,   a0,     96
++    vld           vr13,   a0,     112
++    vmulwev.w.h   vr4,    vr0,    vr0
++    vmulwev.w.h   vr5,    vr1,    vr1
++    vmulwev.w.h   vr6,    vr2,    vr2
++    vmulwev.w.h   vr7,    vr3,    vr3
++    vmulwev.w.h   vr14,   vr10,   vr10
++    vmulwev.w.h   vr15,   vr11,   vr11
++    vmulwev.w.h   vr16,   vr12,   vr12
++    vmulwev.w.h   vr17,   vr13,   vr13
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++    vmaddwod.w.h  vr14,   vr10,   vr10
++    vmaddwod.w.h  vr15,   vr11,   vr11
++    vmaddwod.w.h  vr16,   vr12,   vr12
++    vmaddwod.w.h  vr17,   vr13,   vr13
++
++.rept 63
++    add.d         a0,     a1,     a0
++
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    vld           vr2,    a0,     32
++    vld           vr3,    a0,     48
++    vld           vr10,   a0,     64
++    vld           vr11,   a0,     80
++    vld           vr12,   a0,     96
++    vld           vr13,   a0,     112
++    vmaddwev.w.h  vr4,    vr0,    vr0
++    vmaddwev.w.h  vr5,    vr1,    vr1
++    vmaddwev.w.h  vr6,    vr2,    vr2
++    vmaddwev.w.h  vr7,    vr3,    vr3
++    vmaddwev.w.h  vr14,   vr10,   vr10
++    vmaddwev.w.h  vr15,   vr11,   vr11
++    vmaddwev.w.h  vr16,   vr12,   vr12
++    vmaddwev.w.h  vr17,   vr13,   vr13
++    vmaddwod.w.h  vr4,    vr0,    vr0
++    vmaddwod.w.h  vr5,    vr1,    vr1
++    vmaddwod.w.h  vr6,    vr2,    vr2
++    vmaddwod.w.h  vr7,    vr3,    vr3
++    vmaddwod.w.h  vr14,   vr10,   vr10
++    vmaddwod.w.h  vr15,   vr11,   vr11
++    vmaddwod.w.h  vr16,   vr12,   vr12
++    vmaddwod.w.h  vr17,   vr13,   vr13
++.endr
++    vadd.w        vr8,    vr5,    vr4
++    vadd.w        vr9,    vr7,    vr6
++    vadd.w        vr18,   vr15,   vr14
++    vadd.w        vr19,   vr17,   vr16
++    vadd.w        vr7,    vr8,    vr9
++    vadd.w        vr17,   vr18,   vr19
++    vadd.w        vr7,    vr7,    vr17
++    vhaddw.d.w    vr7,    vr7,    vr7
++    vhaddw.q.d    vr7,    vr7,    vr7
++    vpickve2gr.w  a0,     vr7,    0
++endfunc
++
++function x265_pixel_ssd_s_16x16_lasx
++    slli.d        a1,     a1,     1
++
++    xvld           xr0,   a0,     0
++    xvldx          xr1,   a0,     a1
++    alsl.d         a0,    a1,     a0,  1
++    xvld           xr2,   a0,     0
++    xvldx          xr3,   a0,     a1
++    xvmulwev.w.h   xr4,   xr0,    xr0
++    xvmulwev.w.h   xr5,   xr1,    xr1
++    xvmulwev.w.h   xr6,   xr2,    xr2
++    xvmulwev.w.h   xr7,   xr3,    xr3
++    xvmaddwod.w.h  xr4,   xr0,    xr0
++    xvmaddwod.w.h  xr5,   xr1,    xr1
++    xvmaddwod.w.h  xr6,   xr2,    xr2
++    xvmaddwod.w.h  xr7,   xr3,    xr3
++
++.rept 3
++    alsl.d        a0,     a1,     a0,  1
++    xvld          xr0,    a0,     0
++    xvldx         xr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,  1
++    xvld          xr2,    a0,     0
++    xvldx         xr3,    a0,     a1
++
++    xvmaddwev.w.h xr4,    xr0,    xr0
++    xvmaddwev.w.h xr5,    xr1,    xr1
++    xvmaddwev.w.h xr6,    xr2,    xr2
++    xvmaddwev.w.h xr7,    xr3,    xr3
++    xvmaddwod.w.h xr4,    xr0,    xr0
++    xvmaddwod.w.h xr5,    xr1,    xr1
++    xvmaddwod.w.h xr6,    xr2,    xr2
++    xvmaddwod.w.h xr7,    xr3,    xr3
++.endr
++    xvadd.w       xr8,    xr5,    xr4
++    xvadd.w       xr9,    xr7,    xr6
++    xvadd.w       xr7,    xr8,    xr9
++    xvhaddw.d.w   xr7,    xr7,    xr7
++    xvhaddw.q.d   xr7,    xr7,    xr7
++    xvpickve2gr.w t0,     xr7,    0
++    xvpickve2gr.w t1,     xr7,    4
++    add.w         a0,     t0,     t1
++endfunc
++
++function x265_pixel_ssd_s_32x32_lasx
++    slli.d        a1,     a1,     1
++
++    xvld           xr0,   a0,     0
++    xvld           xr1,   a0,     32
++    add.d          a0,    a0,     a1
++    xvld           xr2,   a0,     0
++    xvld           xr3,   a0,     32
++    xvmulwev.w.h   xr4,   xr0,    xr0
++    xvmulwev.w.h   xr5,   xr1,    xr1
++    xvmulwev.w.h   xr6,   xr2,    xr2
++    xvmulwev.w.h   xr7,   xr3,    xr3
++    xvmaddwod.w.h  xr4,   xr0,    xr0
++    xvmaddwod.w.h  xr5,   xr1,    xr1
++    xvmaddwod.w.h  xr6,   xr2,    xr2
++    xvmaddwod.w.h  xr7,   xr3,    xr3
++
++.rept 15
++    add.d         a0,     a1,     a0
++    xvld          xr0,    a0,     0
++    xvld          xr1,    a0,     32
++    add.d         a0,     a0,     a1
++    xvld          xr2,    a0,     0
++    xvld          xr3,    a0,     32
++
++    xvmaddwev.w.h xr4,    xr0,    xr0
++    xvmaddwev.w.h xr5,    xr1,    xr1
++    xvmaddwev.w.h xr6,    xr2,    xr2
++    xvmaddwev.w.h xr7,    xr3,    xr3
++    xvmaddwod.w.h xr4,    xr0,    xr0
++    xvmaddwod.w.h xr5,    xr1,    xr1
++    xvmaddwod.w.h xr6,    xr2,    xr2
++    xvmaddwod.w.h xr7,    xr3,    xr3
++.endr
++    xvadd.w       xr8,    xr5,    xr4
++    xvadd.w       xr9,    xr7,    xr6
++    xvadd.w       xr7,    xr8,    xr9
++    xvhaddw.d.w   xr7,    xr7,    xr7
++    xvhaddw.q.d   xr7,    xr7,    xr7
++    xvpickve2gr.w t0,     xr7,    0
++    xvpickve2gr.w t1,     xr7,    4
++    add.w         a0,     t0,     t1
++endfunc
++
++function x265_pixel_ssd_s_64x64_lasx
++    slli.d        a1,     a1,     1
++
++    xvld           xr0,   a0,     0
++    xvld           xr1,   a0,     32
++    xvld           xr2,   a0,     64
++    xvld           xr3,   a0,     96
++    xvmulwev.w.h   xr4,   xr0,    xr0
++    xvmulwev.w.h   xr5,   xr1,    xr1
++    xvmulwev.w.h   xr6,   xr2,    xr2
++    xvmulwev.w.h   xr7,   xr3,    xr3
++    xvmaddwod.w.h  xr4,   xr0,    xr0
++    xvmaddwod.w.h  xr5,   xr1,    xr1
++    xvmaddwod.w.h  xr6,   xr2,    xr2
++    xvmaddwod.w.h  xr7,   xr3,    xr3
++
++.rept 63
++    add.d         a0,     a1,     a0
++    xvld          xr0,    a0,     0
++    xvld          xr1,    a0,     32
++    xvld          xr2,    a0,     64
++    xvld          xr3,    a0,     96
++
++    xvmaddwev.w.h xr4,    xr0,    xr0
++    xvmaddwev.w.h xr5,    xr1,    xr1
++    xvmaddwev.w.h xr6,    xr2,    xr2
++    xvmaddwev.w.h xr7,    xr3,    xr3
++    xvmaddwod.w.h xr4,    xr0,    xr0
++    xvmaddwod.w.h xr5,    xr1,    xr1
++    xvmaddwod.w.h xr6,    xr2,    xr2
++    xvmaddwod.w.h xr7,    xr3,    xr3
++.endr
++    xvadd.w       xr8,    xr5,    xr4
++    xvadd.w       xr9,    xr7,    xr6
++    xvadd.w       xr7,    xr8,    xr9
++    xvhaddw.d.w   xr7,    xr7,    xr7
++    xvhaddw.q.d   xr7,    xr7,    xr7
++    xvpickve2gr.w t0,     xr7,    0
++    xvpickve2gr.w t1,     xr7,    4
++    add.w         a0,     t0,     t1
++endfunc
++
++function x265_pixel_sse_ss_4x4_lsx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++    vld           vr0,    a0,     0
++    vldx          vr1,    a0,     a1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++    vld           vr4,    a0,     0
++    vldx          vr5,    a0,     a1
++    vld           vr6,    a2,     0
++    vldx          vr7,    a2,     a3
++    vilvl.d       vr1,    vr1,    vr0
++    vilvl.d       vr3,    vr3,    vr2
++    vilvl.d       vr5,    vr5,    vr4
++    vilvl.d       vr7,    vr7,    vr6
++    vsubwev.w.h   vr8,    vr1,    vr3
++    vsubwod.w.h   vr9,    vr1,    vr3
++    vsubwev.w.h   vr10,   vr5,    vr7
++    vsubwod.w.h   vr11,   vr5,    vr7
++    vmul.w        vr4,    vr8,    vr8
++    vmul.w        vr5,    vr9,    vr9
++    vmadd.w       vr4,    vr10,   vr10
++    vmadd.w       vr5,    vr11,   vr11
++    vadd.w        vr5,    vr5,    vr4
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
++
++.macro pixel_sse_ss_8x4_core_lsx out
++    vld           vr0,    a0,     0
++    vldx          vr1,    a0,     a1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++    vld           vr4,    a0,     0
++    vldx          vr5,    a0,     a1
++    vld           vr6,    a2,     0
++    vldx          vr7,    a2,     a3
++    vsubwev.w.h   vr8,    vr0,    vr2
++    vsubwod.w.h   vr9,    vr0,    vr2
++    vsubwev.w.h   vr10,   vr1,    vr3
++    vsubwod.w.h   vr11,   vr1,    vr3
++    vsubwev.w.h   vr12,   vr4,    vr6
++    vsubwod.w.h   vr13,   vr4,    vr6
++    vsubwev.w.h   vr14,   vr5,    vr7
++    vsubwod.w.h   vr15,   vr5,    vr7
++    vmul.w        vr4,    vr8,    vr8
++    vmul.w        vr5,    vr9,    vr9
++    vmadd.w       vr4,    vr10,   vr10
++    vmadd.w       vr5,    vr11,   vr11
++    vmadd.w       vr4,    vr12,   vr12
++    vmadd.w       vr5,    vr13,   vr13
++    vmadd.w       vr4,    vr14,   vr14
++    vmadd.w       vr5,    vr15,   vr15
++    vadd.w        \out,   vr4,    vr5
++.endm
++
++function x265_pixel_sse_ss_8x8_lsx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_8x4_core_lsx vr20
++
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++
++    pixel_sse_ss_8x4_core_lsx vr5
++
++    vadd.w        vr5,    vr5,    vr20
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
++
++.macro pixel_sse_ss_16x2_core_lsx out
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    vld           vr2,    a2,     0
++    vld           vr3,    a2,     16
++    add.d         a0,     a0,     a1
++    add.d         a2,     a3,     a2
++    vld           vr4,    a0,     0
++    vld           vr5,    a0,     16
++    vld           vr6,    a2,     0
++    vld           vr7,    a2,     16
++    vsubwev.w.h   vr8,    vr0,    vr2
++    vsubwod.w.h   vr9,    vr0,    vr2
++    vsubwev.w.h   vr10,   vr1,    vr3
++    vsubwod.w.h   vr11,   vr1,    vr3
++    vsubwev.w.h   vr12,   vr4,    vr6
++    vsubwod.w.h   vr13,   vr4,    vr6
++    vsubwev.w.h   vr14,   vr5,    vr7
++    vsubwod.w.h   vr15,   vr5,    vr7
++    vmul.w        vr4,    vr8,    vr8
++    vmul.w        vr5,    vr9,    vr9
++    vmadd.w       vr4,    vr10,   vr10
++    vmadd.w       vr5,    vr11,   vr11
++    vmadd.w       vr4,    vr12,   vr12
++    vmadd.w       vr5,    vr13,   vr13
++    vmadd.w       vr4,    vr14,   vr14
++    vmadd.w       vr5,    vr15,   vr15
++    vadd.w        \out,   vr4,    vr5
++.endm
++
++function x265_pixel_sse_ss_16x16_lsx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_16x2_core_lsx vr20
++
++.rept 7
++    add.d         a0,     a0,     a1
++    add.d         a2,     a3,     a2
++    pixel_sse_ss_16x2_core_lsx vr5
++    vadd.w        vr20,   vr5,    vr20
++.endr
++
++    vhaddw.d.w    vr20,   vr20,   vr20
++    vhaddw.q.d    vr20,   vr20,   vr20
++    vpickve2gr.w  a0,     vr20,   0
++endfunc
++
++.macro pixel_sse_ss_32x1_core_lsx out
++    vld           vr0,    a0,     0
++    vld           vr1,    a0,     16
++    vld           vr2,    a0,     32
++    vld           vr3,    a0,     48
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    vld           vr6,    a2,     32
++    vld           vr7,    a2,     48
++    vsubwev.w.h   vr8,    vr0,    vr4
++    vsubwod.w.h   vr9,    vr0,    vr4
++    vsubwev.w.h   vr10,   vr1,    vr5
++    vsubwod.w.h   vr11,   vr1,    vr5
++    vsubwev.w.h   vr12,   vr2,    vr6
++    vsubwod.w.h   vr13,   vr2,    vr6
++    vsubwev.w.h   vr14,   vr3,    vr7
++    vsubwod.w.h   vr15,   vr3,    vr7
++    vmul.w        vr4,    vr8,    vr8
++    vmul.w        vr5,    vr9,    vr9
++    vmadd.w       vr4,    vr10,   vr10
++    vmadd.w       vr5,    vr11,   vr11
++    vmadd.w       vr4,    vr12,   vr12
++    vmadd.w       vr5,    vr13,   vr13
++    vmadd.w       vr4,    vr14,   vr14
++    vmadd.w       vr5,    vr15,   vr15
++    vadd.w        \out,   vr4,    vr5
++.endm
++
++function x265_pixel_sse_ss_32x32_lsx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_32x1_core_lsx vr20
++
++.rept 31
++    add.d         a0,     a0,     a1
++    add.d         a2,     a3,     a2
++    pixel_sse_ss_32x1_core_lsx vr5
++    vadd.w        vr20,   vr5,    vr20
++.endr
++
++    vhaddw.d.w    vr20,   vr20,   vr20
++    vhaddw.q.d    vr20,   vr20,   vr20
++    vpickve2gr.w  a0,     vr20,   0
++endfunc
++
++function x265_pixel_sse_ss_64x64_lsx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_32x1_core_lsx vr20
++
++    addi.d        a0,     a0,     64
++    addi.d        a2,     a2,     64
++    pixel_sse_ss_32x1_core_lsx vr5
++    vadd.w        vr20,   vr5, vr20
++
++.rept 63
++    addi.d        a0,     a0,     -64
++    addi.d        a2,     a2,     -64
++    add.d         a0,     a0,     a1
++    add.d         a2,     a3,     a2
++    pixel_sse_ss_32x1_core_lsx vr5
++    vadd.w        vr20,   vr5,    vr20
++
++    addi.d        a0,     a0,     64
++    addi.d        a2,     a2,     64
++    pixel_sse_ss_32x1_core_lsx vr5
++    vadd.w        vr20,   vr5,    vr20
++.endr
++
++    vhaddw.d.w    vr20,   vr20,   vr20
++    vhaddw.q.d    vr20,   vr20,   vr20
++    vpickve2gr.w  a0,     vr20,   0
++endfunc
++
++.macro pixel_sse_ss_8x4_core_lasx out
++    vld           vr0,    a0,     0
++    vldx          vr1,    a0,     a1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++    vld           vr4,    a0,     0
++    vldx          vr5,    a0,     a1
++    vld           vr6,    a2,     0
++    vldx          vr7,    a2,     a3
++    xvpermi.q     xr1,    xr0,    0x20
++    xvpermi.q     xr3,    xr2,    0x20
++    xvpermi.q     xr5,    xr4,    0x20
++    xvpermi.q     xr7,    xr6,    0x20
++
++    xvsubwev.w.h   xr10,  xr1,    xr3
++    xvsubwod.w.h   xr11,  xr1,    xr3
++    xvsubwev.w.h   xr14,  xr5,    xr7
++    xvsubwod.w.h   xr15,  xr5,    xr7
++    xvmul.w        xr4,   xr10,   xr10
++    xvmul.w        xr5,   xr11,   xr11
++    xvmadd.w       xr4,   xr14,   xr14
++    xvmadd.w       xr5,   xr15,   xr15
++    xvadd.w        \out,  xr4,    xr5
++.endm
++
++function x265_pixel_sse_ss_8x8_lasx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_8x4_core_lasx xr20
++
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++
++    pixel_sse_ss_8x4_core_lasx xr5
++
++    xvadd.w        xr5,    xr5,    xr20
++    xvpermi.q      xr6,    xr5,    0x01
++    vadd.w         vr5,    vr5,    vr6
++    vhaddw.d.w     vr5,    vr5,    vr5
++    vhaddw.q.d     vr5,    vr5,    vr5
++    vpickve2gr.w   a0,     vr5,    0
++endfunc
++
++.macro pixel_sse_ss_16x4_core_lasx out
++    xvld          xr0,    a0,     0
++    xvldx         xr1,    a0,     a1
++    xvld          xr2,    a2,     0
++    xvldx         xr3,    a2,     a3
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++    xvld          xr4,    a0,     0
++    xvldx         xr5,    a0,     a1
++    xvld          xr6,    a2,     0
++    xvldx         xr7,    a2,     a3
++    xvsubwev.w.h  xr8,    xr0,    xr2
++    xvsubwod.w.h  xr9,    xr0,    xr2
++    xvsubwev.w.h  xr10,   xr1,    xr3
++    xvsubwod.w.h  xr11,   xr1,    xr3
++    xvsubwev.w.h  xr12,   xr4,    xr6
++    xvsubwod.w.h  xr13,   xr4,    xr6
++    xvsubwev.w.h  xr14,   xr5,    xr7
++    xvsubwod.w.h  xr15,   xr5,    xr7
++    xvmul.w       xr4,    xr8,    xr8
++    xvmul.w       xr5,    xr9,    xr9
++    xvmadd.w      xr4,    xr10,   xr10
++    xvmadd.w      xr5,    xr11,   xr11
++    xvmadd.w      xr4,    xr12,   xr12
++    xvmadd.w      xr5,    xr13,   xr13
++    xvmadd.w      xr4,    xr14,   xr14
++    xvmadd.w      xr5,    xr15,   xr15
++    xvadd.w       \out,   xr4,    xr5
++.endm
++
++function x265_pixel_sse_ss_16x16_lasx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_16x4_core_lasx xr20
++
++.rept 3
++    alsl.d        a0,     a1,     a0,   1
++    alsl.d        a2,     a3,     a2,   1
++
++    pixel_sse_ss_16x4_core_lasx xr5
++    xvadd.w       xr20,   xr5,    xr20
++.endr
++
++    xvpermi.q     xr6,    xr20,   0x01
++    vadd.w        vr5,    vr20,   vr6
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
++
++.macro pixel_sse_ss_32x2_core_lasx out
++    xvld          xr0,    a0,     0
++    xvld          xr1,    a0,     32
++    xvld          xr2,    a2,     0
++    xvld          xr3,    a2,     32
++    add.d         a0,     a1,     a0
++    add.d         a2,     a3,     a2
++    xvld          xr4,    a0,     0
++    xvld          xr5,    a0,     32
++    xvld          xr6,    a2,     0
++    xvld          xr7,    a2,     32
++    xvsubwev.w.h  xr8,    xr0,    xr2
++    xvsubwod.w.h  xr9,    xr0,    xr2
++    xvsubwev.w.h  xr10,   xr1,    xr3
++    xvsubwod.w.h  xr11,   xr1,    xr3
++    xvsubwev.w.h  xr12,   xr4,    xr6
++    xvsubwod.w.h  xr13,   xr4,    xr6
++    xvsubwev.w.h  xr14,   xr5,    xr7
++    xvsubwod.w.h  xr15,   xr5,    xr7
++    xvmul.w       xr4,    xr8,    xr8
++    xvmul.w       xr5,    xr9,    xr9
++    xvmadd.w      xr4,    xr10,   xr10
++    xvmadd.w      xr5,    xr11,   xr11
++    xvmadd.w      xr4,    xr12,   xr12
++    xvmadd.w      xr5,    xr13,   xr13
++    xvmadd.w      xr4,    xr14,   xr14
++    xvmadd.w      xr5,    xr15,   xr15
++    xvadd.w       \out,   xr4,    xr5
++.endm
++
++function x265_pixel_sse_ss_32x32_lasx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_32x2_core_lasx xr20
++
++.rept 15
++    add.d         a0,     a1,     a0
++    add.d         a2,     a3,     a2
++    pixel_sse_ss_32x2_core_lasx xr7
++    xvadd.w       xr20,   xr7,    xr20
++.endr
++
++    xvpermi.q     xr6,    xr20,   0x01
++    vadd.w        vr5,    vr20,   vr6
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
++
++.macro pixel_sse_ss_64x1_core_lasx out
++    xvld          xr0,    a0,     0
++    xvld          xr1,    a0,     32
++    xvld          xr2,    a0,     64
++    xvld          xr3,    a0,     96
++    xvld          xr4,    a2,     0
++    xvld          xr5,    a2,     32
++    xvld          xr6,    a2,     64
++    xvld          xr7,    a2,     96
++    xvsubwev.w.h  xr8,    xr0,    xr4
++    xvsubwod.w.h  xr9,    xr0,    xr4
++    xvsubwev.w.h  xr10,   xr1,    xr5
++    xvsubwod.w.h  xr11,   xr1,    xr5
++    xvsubwev.w.h  xr12,   xr2,    xr6
++    xvsubwod.w.h  xr13,   xr2,    xr6
++    xvsubwev.w.h  xr14,   xr3,    xr7
++    xvsubwod.w.h  xr15,   xr3,    xr7
++    xvmul.w       xr4,    xr8,    xr8
++    xvmul.w       xr5,    xr9,    xr9
++    xvmadd.w      xr4,    xr10,   xr10
++    xvmadd.w      xr5,    xr11,   xr11
++    xvmadd.w      xr4,    xr12,   xr12
++    xvmadd.w      xr5,    xr13,   xr13
++    xvmadd.w      xr4,    xr14,   xr14
++    xvmadd.w      xr5,    xr15,   xr15
++    xvadd.w       \out,   xr4,    xr5
++.endm
++
++function x265_pixel_sse_ss_64x64_lasx
++    slli.d        a1,     a1,     1
++    slli.d        a3,     a3,     1
++
++    pixel_sse_ss_64x1_core_lasx xr20
++
++.rept 63
++    add.d         a0,     a1,     a0
++    add.d         a2,     a3,     a2
++    pixel_sse_ss_64x1_core_lasx xr7
++    xvadd.w       xr20,   xr7,    xr20
++.endr
++
++    xvpermi.q     xr6,    xr20,   0x01
++    vadd.w        vr5,    vr20,   vr6
++    vhaddw.d.w    vr5,    vr5,    vr5
++    vhaddw.q.d    vr5,    vr5,    vr5
++    vpickve2gr.w  a0,     vr5,    0
++endfunc
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0013-FROMLIST-LoongArch64-Optimize-functions-in-mc-a2.S-f.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0013-FROMLIST-LoongArch64-Optimize-functions-in-mc-a2.S-f.patch
@@ -1,0 +1,785 @@
+From cc6d1253f61efc9c72865185543ea0c2455e6228 Mon Sep 17 00:00:00 2001
+From: Wu Zhenjiang <wuzhenjiang@loongson.cn>
+Date: Thu, 13 Jun 2024 10:27:49 +0800
+Subject: [PATCH 13/15] FROMLIST: LoongArch64: Optimize functions in mc-a2.S
+ file
+
+Optimize functions in mc-a2.S file with lsx and lasx.
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |   2 +-
+ source/common/loongarch64/asm-primitives.cpp |  16 +
+ source/common/loongarch64/mc-a2.S            | 692 +++++++++++++++++++
+ source/common/loongarch64/pixel.h            |   8 +
+ 4 files changed, 717 insertions(+), 1 deletion(-)
+ create mode 100644 source/common/loongarch64/mc-a2.S
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index f83346ad3..753fdcd78 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -142,7 +142,7 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S pixel.S ssd.S sad.S)
++    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S pixel.S ssd.S sad.S mc-a2.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 0354b5780..1a944743d 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -883,6 +883,14 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ 
+         p.ssim_end_4 = PFX(ssim_end4_lsx);
+         p.ssim_4x4x2_core = PFX(ssim_4x4x2_lsx);
++
++        // mc
++        p.frameInitLowres    = PFX(frame_init_lowres_core_lsx);
++        p.frameInitLowerRes  = PFX(frame_init_lowres_core_lsx);
++        p.frameSubSampleLuma = PFX(frame_subsample_luma_lsx);
++
++        p.fix8Unpack = PFX(cutree_fix8_unpack_lsx);
++        p.fix8Pack   = PFX(cutree_fix8_pack_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -1266,6 +1274,14 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         p.cu[BLOCK_16x16].ssimDist = x265_ssimDist16_lasx;
+         p.cu[BLOCK_32x32].ssimDist = x265_ssimDist32_lasx;
+         p.cu[BLOCK_64x64].ssimDist = x265_ssimDist64_lasx;
++
++        // mc
++        p.frameInitLowres    = PFX(frame_init_lowres_core_lasx);
++        p.frameInitLowerRes  = PFX(frame_init_lowres_core_lasx);
++        p.frameSubSampleLuma = PFX(frame_subsample_luma_lasx);
++
++        p.fix8Unpack = PFX(cutree_fix8_unpack_lasx);
++        p.fix8Pack   = PFX(cutree_fix8_pack_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/mc-a2.S b/source/common/loongarch64/mc-a2.S
+new file mode 100644
+index 000000000..8b3b37c9e
+--- /dev/null
++++ b/source/common/loongarch64/mc-a2.S
+@@ -0,0 +1,692 @@
++/*****************************************************************************
++ * mc-a2.S: loongarch motion compensation
++ *****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: wuzhenjiang <wuzhenjiang@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "loongson_asm.S"
++
++.macro CALCULATE_FRAMEINITLOWRES_LSX_8 offset0
++    // load src0、src1、src2
++    vldx            vr0,    a0,     \offset0
++    vldx            vr4,    t1,     \offset0
++    vldx            vr8,    t2,     \offset0
++    addi.d          \offset0,   \offset0,   1
++    vldx            vr2,    a0,     \offset0
++    vldx            vr6,    t1,     \offset0
++    vldx            vr10,   t2,     \offset0
++
++    vexth.hu.bu     vr1,    vr0
++    vsllwil.hu.bu   vr0,    vr0,    0
++    vexth.hu.bu     vr3,    vr2
++    vsllwil.hu.bu   vr2,    vr2,    0
++    vexth.hu.bu     vr5,    vr4
++    vsllwil.hu.bu   vr4,    vr4,    0
++    vexth.hu.bu     vr7,    vr6
++    vsllwil.hu.bu   vr6,    vr6,    0
++    vexth.hu.bu     vr9,    vr8
++    vsllwil.hu.bu   vr8,    vr8,    0
++    vexth.hu.bu     vr11,   vr10
++    vsllwil.hu.bu   vr10,   vr10,   0
++
++    // ((src0[2 * x] + src1[2 * x] + 1) >> 1)
++    vadd.h          vr12,   vr0,    vr4
++    vadd.h          vr13,   vr1,    vr5
++    vsrari.h        vr12,   vr12,   1
++    vsrari.h        vr13,   vr13,   1
++
++    // ((src0[2 * x + 1] + src1[2 * x + 1] + 1) >> 1)
++    vadd.h          vr14,   vr2,    vr6
++    vadd.h          vr15,   vr3,    vr7
++    vsrari.h        vr14,   vr14,   1
++    vsrari.h        vr15,   vr15,   1
++
++    vadd.h          vr12,   vr12,   vr14
++    vadd.h          vr13,   vr13,   vr15
++    vsrarni.b.h     vr13,   vr12,   1
++    vpickev.b       vr12,   vr13,   vr13    // get dst0[x ~ x+7]
++    vpickod.b       vr13,   vr13,   vr13    // get dsth[x ~ x+7]
++
++    // ((src1[2 * x] + src2[2 * x] + 1) >> 1)
++    vadd.h          vr16,   vr4,    vr8
++    vadd.h          vr17,   vr5,    vr9
++    vsrari.h        vr16,   vr16,   1
++    vsrari.h        vr17,   vr17,   1
++
++    // ((src1[2 * x + 1] + src2[2 * x + 1] + 1) >> 1)
++    vadd.h          vr18,   vr6,    vr10
++    vadd.h          vr19,   vr7,    vr11
++    vsrari.h        vr18,   vr18,   1
++    vsrari.h        vr19,   vr19,   1
++
++    // (((src1[2 * x] + src2[2 * x] + 1) >> 1) + ((src1[2 * x + 1] + src2[2 * x + 1] + 1) >> 1) + 1) >> 1
++    vadd.h          vr16,   vr16,   vr18
++    vadd.h          vr17,   vr17,   vr19
++    vsrarni.b.h     vr17,   vr16,   1
++    vpickev.b       vr16,   vr17,   vr17    // get dstv[x ~ x+7]
++    vpickod.b       vr17,   vr17,   vr17    // get dstc[x ~ x+7]
++.endm
++
++.macro STORE_RESULT_FRAMEINITLOWRES_LSX size, offset0
++    add.d           t5,     a1,     t7
++    vstelm.\size    vr12,   t5,     0,      \offset0
++    add.d           t6,     a2,     t7
++    vstelm.\size    vr13,   t6,     0,      \offset0
++    add.d           t5,     a3,     t7
++    vstelm.\size    vr16,   t5,     0,      \offset0
++    add.d           t6,     a4,     t7
++    vstelm.\size    vr17,   t6,     0,      \offset0
++.endm
++
++/*-----------------------------------------------------------------------------
++void x265_frame_init_lowres_core_lsx(const pixel *src0, pixel *dst0, pixel *dsth, pixel *dstv, pixel *dstc,
++                    intptr_t src_stride, intptr_t dst_stride, int width, int height);
++-----------------------------------------------------------------------------*/
++// *src0->a0, *dst0->a1, *dsth->a2, *dstv->a3, *dstc->a4, src_stride->a5, dst_stride->a6, width->a7, height->sp+0
++function x265_frame_init_lowres_core_lsx
++    ld.w            t0,     sp,     0       // save height
++    andi            t4,     a7,     7       // width % 8
++    srli.d          a7,     a7,     3       // width / 8
++
++.LOOP_HEIGHT_FRAME_INIT_LOWRES_CORE_LSX:
++    add.d           t1,     a0,     a5      // *src1
++    add.d           t2,     t1,     a5      // *src2
++    addi.d          t3,     zero,   0
++    addi.d          t7,     zero,   0
++    addi.d          t8,     zero,   0       // index
++
++.LOOP_WIDTH_FRAME_INIT_LOWRES_CORE_LSX:
++    bge             t8,     a7,     .HANDLING_MANTISSA_FRAMEINITLOWRES_LSX_7
++    CALCULATE_FRAMEINITLOWRES_LSX_8   t3
++    STORE_RESULT_FRAMEINITLOWRES_LSX  d, 0
++
++    // prepare for next inner-loop
++    addi.d          t3,     t3,     15
++    addi.d          t7,     t7,     8
++    addi.d          t8,     t8,     1       // index++
++    b               .LOOP_WIDTH_FRAME_INIT_LOWRES_CORE_LSX
++
++.HANDLING_MANTISSA_FRAMEINITLOWRES_LSX_7:
++    bge             zero,   t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMEINITLOWRES_LSX
++    CALCULATE_FRAMEINITLOWRES_LSX_8   t3              // calculate mantissa
++    addi.d          t8,     zero,   0
++.irp   offset0, 0, 1, 2, 3, 4, 5, 6
++    STORE_RESULT_FRAMEINITLOWRES_LSX  b, \offset0
++    addi.d          t8,     t8,     1
++    addi.d          t7,     t7,     1
++    bge             t8,     t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMEINITLOWRES_LSX
++.endr
++
++.PREPARE_FOR_NEXT_OUTERLOOP_FRAMEINITLOWRES_LSX:
++    // prepare for next outer-loop
++    add.d           a0,     a0,     a5
++    add.d           a0,     a0,     a5      // src0 += src_stride * 2
++    add.d           a1,     a1,     a6      // dst0 += dst_stride
++    add.d           a2,     a2,     a6      // dsth += dst_stride
++    add.d           a3,     a3,     a6      // dstv += dst_stride
++    add.d           a4,     a4,     a6      // dstc += dst_stride
++    addi.d          t0,     t0,     -1      // height--
++    blt             zero,   t0,     .LOOP_HEIGHT_FRAME_INIT_LOWRES_CORE_LSX
++endfunc
++
++.macro CALCULATE_FRAMEINITLOWRES_LASX_16 offset0
++    // load src0、src1、src2
++    xvldx           xr0,    a0,     \offset0
++    xvldx           xr4,    t1,     \offset0
++    xvldx           xr8,    t2,     \offset0
++    addi.d          \offset0,   \offset0,   1
++    xvldx           xr2,    a0,     \offset0
++    xvldx           xr6,    t1,     \offset0
++    xvldx           xr10,   t2,     \offset0
++
++    xvpermi.q       xr1,    xr0,    0b00000001
++    vext2xv.hu.bu   xr1,    xr1
++    vext2xv.hu.bu   xr0,    xr0
++    xvpermi.q       xr3,    xr2,    0b00000001
++    vext2xv.hu.bu   xr3,    xr3
++    vext2xv.hu.bu   xr2,    xr2
++    xvpermi.q       xr5,    xr4,    0b00000001
++    vext2xv.hu.bu   xr5,    xr5
++    vext2xv.hu.bu   xr4,    xr4
++    xvpermi.q       xr7,    xr6,    0b00000001
++    vext2xv.hu.bu   xr7,    xr7
++    vext2xv.hu.bu   xr6,    xr6
++    xvpermi.q       xr9,    xr8,    0b00000001
++    vext2xv.hu.bu   xr9,    xr9
++    vext2xv.hu.bu   xr8,    xr8
++    xvpermi.q       xr11,   xr10,   0b00000001
++    vext2xv.hu.bu   xr11,   xr11
++    vext2xv.hu.bu   xr10,   xr10
++
++    // ((src0[2 * x] + src1[2 * x] + 1) >> 1)
++    xvadd.h         xr12,   xr0,    xr4
++    xvadd.h         xr13,   xr1,    xr5
++    xvsrari.h       xr12,   xr12,   1
++    xvsrari.h       xr13,   xr13,   1
++
++    // ((src0[2 * x + 1] + src1[2 * x + 1] + 1) >> 1)
++    xvadd.h         xr14,   xr2,    xr6
++    xvadd.h         xr15,   xr3,    xr7
++    xvsrari.h       xr14,   xr14,   1
++    xvsrari.h       xr15,   xr15,   1
++
++    xvadd.h         xr12,   xr12,   xr14
++    xvadd.h         xr13,   xr13,   xr15
++    xvsrarni.b.h    xr13,   xr12,   1
++    xvpermi.d       xr13,   xr13,   0b11011000
++    xvpickev.b      xr12,   xr13,   xr13            // get dst0[x ~ x+15]
++    xvpickod.b      xr13,   xr13,   xr13            // get dsth[x ~ x+15]
++
++    xvpermi.d       xr12,   xr12,   0b00001000
++    xvpermi.d       xr13,   xr13,   0b00001000
++
++    // ((src1[2 * x] + src2[2 * x] + 1) >> 1)
++    xvadd.h         xr16,   xr4,    xr8
++    xvadd.h         xr17,   xr5,    xr9
++    xvsrari.h       xr16,   xr16,   1
++    xvsrari.h       xr17,   xr17,   1
++
++    // ((src1[2 * x + 1] + src2[2 * x + 1] + 1) >> 1)
++    xvadd.h         xr18,   xr6,    xr10
++    xvadd.h         xr19,   xr7,    xr11
++    xvsrari.h       xr18,   xr18,   1
++    xvsrari.h       xr19,   xr19,   1
++
++    xvadd.h         xr16,   xr16,   xr18
++    xvadd.h         xr17,   xr17,   xr19
++    xvsrarni.b.h    xr17,   xr16,   1
++    xvpermi.d       xr17,   xr17,   0b11011000
++    xvpickev.b      xr16,   xr17,   xr17            // get dstv[x ~ x+15]
++    xvpickod.b      xr17,   xr17,   xr17            // get dstc[x ~ x+15]
++    xvpermi.d       xr16,   xr16,   0b00001000
++    xvpermi.d       xr17,   xr17,   0b00001000
++.endm
++
++.macro STORE_RESULT_FRAMEINITLOWRES_LASX offset0
++    vstx            vr12,   a1,     \offset0
++    vstx            vr13,   a2,     \offset0
++    vstx            vr16,   a3,     \offset0
++    vstx            vr17,   a4,     \offset0
++.endm
++
++/*-----------------------------------------------------------------------------
++void x265_frame_init_lowres_core_lasx(const pixel *src0, pixel *dst0, pixel *dsth, pixel *dstv, pixel *dstc,
++                    intptr_t src_stride, intptr_t dst_stride, int width, int height);
++-----------------------------------------------------------------------------*/
++function x265_frame_init_lowres_core_lasx
++    ld.w            t0,     sp,     0       // save height
++    andi            t4,     a7,     15      // width % 16
++    srli.d          a7,     a7,     4       // width / 16
++
++.LOOP_HEIGHT_FRAME_INIT_LOWRES_CORE_LASX:
++    add.d           t1,     a0,     a5      // *src1
++    add.d           t2,     t1,     a5      // *src2
++    addi.d          t3,     zero,   0
++    addi.d          t7,     zero,   0
++    addi.d          t8,     zero,   0       // index
++
++.LOOP_WIDTH_FRAME_INIT_LOWRES_CORE_LASX:
++    bge             t8,     a7,     .HANDLING_MANTISSA_FRAMEINITLOWRES_LASX_15
++    CALCULATE_FRAMEINITLOWRES_LASX_16   t3
++    STORE_RESULT_FRAMEINITLOWRES_LASX   t7
++
++    // prepare for next inner-loop
++    addi.d          t3,     t3,     31
++    addi.d          t7,     t7,     16
++    addi.d          t8,     t8,     1       // index++
++    b               .LOOP_WIDTH_FRAME_INIT_LOWRES_CORE_LASX
++
++.HANDLING_MANTISSA_FRAMEINITLOWRES_LASX_15:
++    bge             zero,   t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMEINITLOWRES_LASX
++    CALCULATE_FRAMEINITLOWRES_LASX_16   t3              // calculate mantissa
++    addi.d          t8,     zero,   0
++
++.irp   offset0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
++    STORE_RESULT_FRAMEINITLOWRES_LSX  b, \offset0
++    addi.d          t8,     t8,     1
++    addi.d          t7,     t7,     1
++    bge             t8,     t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMEINITLOWRES_LASX
++.endr
++
++.PREPARE_FOR_NEXT_OUTERLOOP_FRAMEINITLOWRES_LASX:
++    // prepare for next outer-loop
++    alsl.d          a0,     a5,     a0,     1
++    add.d           a1,     a1,     a6
++    add.d           a2,     a2,     a6
++    add.d           a3,     a3,     a6
++    add.d           a4,     a4,     a6
++    addi.d          t0,     t0,     -1
++    blt             zero,   t0,     .LOOP_HEIGHT_FRAME_INIT_LOWRES_CORE_LASX
++endfunc
++
++.macro CALCULATE_FRAMESUBSAMPLELUMA_LSX_8 offset0
++    // load inRow[offset0 ~ offset0+15], inRowBelow[offset0 ~ offset0+15]
++    vldx            vr1,    a0,     \offset0
++    vldx            vr3,    t0,     \offset0
++    vaddwev.h.bu    vr4,    vr1,    vr3
++    vaddwod.h.bu    vr5,    vr1,    vr3
++    vsrari.h        vr4,    vr4,    1
++    vsrari.h        vr5,    vr5,    1
++    vadd.h          vr6,    vr4,    vr5
++    vsrarni.b.h     vr6,    vr6,    1
++.endm
++
++/*-----------------------------------------------------------------------------
++void x265_frame_subsample_luma_lsx(const pixel* src0, pixel* dst0,
++            intptr_t src_stride, intptr_t dst_stride, int width, int height)
++-----------------------------------------------------------------------------*/
++function x265_frame_subsample_luma_lsx
++    andi            t4,     a4,     7       // width % 8
++    srli.d          a4,     a4,     3       // width / 8
++
++.LOOP_HEIGHT_FRAME_SUBSAMPLE_LUMA_LSX:
++    add.d           t0,     a0,     a2      // *inRowBelow
++    addi.d          t1,     zero,   0
++    addi.d          t2,     zero,   0
++    addi.d          t8,     zero,   0       // index
++
++.LOOP_WIDTH_FRAME_SUBSAMPLE_LUMA_LSX:
++    bge             t8,     a4,     .HANDLING_MANTISSA_FRAMESUBSAMPLELUMA_LSX_7
++    CALCULATE_FRAMESUBSAMPLELUMA_LSX_8  t1
++    add.d           t3,     a1,     t2
++    vstelm.d        vr6,    t3,     0,      0
++
++    // prepare for next inner-loop
++    addi.d          t1,     t1,     16
++    addi.d          t2,     t2,     8
++    addi.d          t8,     t8,     1       // index++
++    b               .LOOP_WIDTH_FRAME_SUBSAMPLE_LUMA_LSX
++
++.HANDLING_MANTISSA_FRAMESUBSAMPLELUMA_LSX_7:
++    bge             zero,   t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMESUBSAMPLELUMA_LSX
++    CALCULATE_FRAMESUBSAMPLELUMA_LSX_8  t1              // calculate mantissa
++    addi.d          t8,     zero,   0
++    add.d           t3,     a1,     t2
++.irp   offset0, 0, 1, 2, 3, 4, 5, 6
++    vstelm.b        vr6,    t3,     0,      \offset0
++    addi.d          t8,     t8,     1
++    addi.d          t3,     t3,     1
++    bge             t8,     t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMESUBSAMPLELUMA_LSX
++.endr
++
++.PREPARE_FOR_NEXT_OUTERLOOP_FRAMESUBSAMPLELUMA_LSX:
++    // prepare for next outer-loop
++    add.d           a0,     a0,     a2
++    add.d           a0,     a0,     a2
++    add.d           a1,     a1,     a3
++    addi.d          a5,     a5,     -1
++    blt             zero,   a5,     .LOOP_HEIGHT_FRAME_SUBSAMPLE_LUMA_LSX
++endfunc
++
++.macro CALCULATE_FRAMESUBSAMPLELUMA_LASX_16 offset0
++    // load inRow[offset0 ~ offset0+31], inRowBelow[offset0 ~ offset0+31]
++    xvldx           xr1,    a0,     \offset0
++    xvldx           xr3,    t0,     \offset0
++    xvaddwev.h.bu   xr4,    xr1,    xr3
++    xvaddwod.h.bu   xr5,    xr1,    xr3
++    xvsrari.h       xr4,    xr4,    1
++    xvsrari.h       xr5,    xr5,    1
++    xvadd.h         xr6,    xr4,    xr5
++    xvsrarni.b.h    xr6,    xr6,    1
++    xvpermi.d       xr6,    xr6,    0b00001000
++.endm
++
++/*-----------------------------------------------------------------------------
++void x265_frame_subsample_luma_lasx(const pixel* src0, pixel* dst0,
++            intptr_t src_stride, intptr_t dst_stride, int width, int height)
++-----------------------------------------------------------------------------*/
++function x265_frame_subsample_luma_lasx
++    andi            t4,     a4,     15      // width % 16
++    srli.d          a4,     a4,     4       // width / 16
++
++.LOOP_HEIGHT_FRAME_SUBSAMPLE_LUMA_LASX:
++    add.d           t0,     a0,     a2      // *inRowBelow
++    addi.d          t1,     zero,   0
++    addi.d          t2,     zero,   0
++    addi.d          t8,     zero,   0       // index
++
++.LOOP_WIDTH_FRAME_SUBSAMPLE_LUMA_LASX:
++    bge             t8,     a4,     .HANDLING_MANTISSA_FRAMESUBSAMPLELUMA_LASX_15
++    CALCULATE_FRAMESUBSAMPLELUMA_LASX_16  t1
++    vstx            vr6,    a1,     t2
++    addi.d          t1,     t1,     32
++    addi.d          t2,     t2,     16
++    addi.d          t8,     t8,     1       // index++
++    b               .LOOP_WIDTH_FRAME_SUBSAMPLE_LUMA_LASX
++
++.HANDLING_MANTISSA_FRAMESUBSAMPLELUMA_LASX_15:
++    bge             zero,   t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMESUBSAMPLELUMA_LASX
++    CALCULATE_FRAMESUBSAMPLELUMA_LASX_16    t1              // calculate mantissa
++    addi.d          t8,     zero,   0
++    add.d           t3,     a1,     t2
++.irp   offset0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
++    vstelm.b        vr6,    t3,     0,      \offset0
++    addi.d          t8,     t8,     1
++    addi.d          t3,     t3,     1
++    bge             t8,     t4,     .PREPARE_FOR_NEXT_OUTERLOOP_FRAMESUBSAMPLELUMA_LASX
++.endr
++
++.PREPARE_FOR_NEXT_OUTERLOOP_FRAMESUBSAMPLELUMA_LASX:
++    // prepare for next loop
++    add.d           a0,     a0,     a2
++    add.d           a0,     a0,     a2
++    add.d           a1,     a1,     a3
++    addi.d          a5,     a5,     -1
++    blt             zero,   a5,     .LOOP_HEIGHT_FRAME_SUBSAMPLE_LUMA_LASX
++endfunc
++
++
++.macro HANDLING_MANTISSA_MC_A2_3  size, dst0, dst1, dst2, count, dst_adress, \
++                        dst_stride, index0, index1, index2, terminate_lable
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    vstelm.\size    \dst0,          \dst_adress,    0,      \index0
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    vstelm.\size    \dst1,          \dst_adress,    0,      \index1
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    vstelm.\size    \dst2,          \dst_adress,    0,      \index2
++.endm
++
++.macro HANDLING_MANTISSA_MC_A2_7  size, dst0, dst1, count, dst_adress, \
++                            dst_stride, index0, index1, terminate_lable
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    xvstelm.\size   \dst0,          \dst_adress,    0,      \index0
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    xvstelm.\size   \dst0,          \dst_adress,    0,      \index0 + 1
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    xvstelm.\size   \dst0,          \dst_adress,    0,      \index0 + 2
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    xvstelm.\size   \dst0,          \dst_adress,    0,      \index0 + 3
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    xvstelm.\size   \dst1,          \dst_adress,    0,      \index1
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    xvstelm.\size   \dst1,          \dst_adress,    0,      \index1 + 1
++    addi.d          \count,         \count,         -1
++    blt             \count,         zero,           \terminate_lable
++    addi.d          \dst_adress,    \dst_adress,    \dst_stride
++    xvstelm.\size   \dst1,          \dst_adress,    0,      \index1 + 2
++.endm
++
++const mbtree_propagate_cost_lsx
++.dword 0x4070000000000000, 0x3FE0000000000000
++endconst
++
++// void x265_cutree_fix8_unpack_lsx(double *dst, uint16_t *src, int count)
++function x265_cutree_fix8_unpack_lsx
++    la.local        t0,     mbtree_propagate_cost_lsx
++    fld.d           f0,     t0,     0       // load double(256.0)
++    vreplvei.d      vr0,    vr0,    0
++    vfrecip.d       vr0,    vr0             // 1/256
++
++    // get loop-count
++    srli.d          t4,     a2,     2
++    andi            t5,     a2,     3
++    srli.d          t8,     t4,     1
++    andi            t3,     t4,     1
++
++.LOOP_CUTREE_FIX8_UNPACK_LSX:
++    vld             vr1,    a1,     0
++    vexth.w.h       vr11,   vr1
++    vsllwil.w.h     vr1,    vr1,    0
++    vffintl.d.w     vr2,    vr1
++    vffinth.d.w     vr3,    vr1
++    vffintl.d.w     vr12,   vr11
++    vffinth.d.w     vr13,   vr11
++    vfmul.d         vr4,    vr2,    vr0
++    vfmul.d         vr5,    vr3,    vr0
++    vfmul.d         vr14,   vr12,   vr0
++    vfmul.d         vr15,   vr13,   vr0
++
++    addi.d          t8,     t8,     -1      // loop-count --
++    blt             t8,     zero,   .HANDLING_MANTISSA_CUTREE_FIX8_UNPACK_LSX
++
++    // store 8 * dst[]
++    vst             vr4,    a0,     0
++    vst             vr5,    a0,     16
++    addi.d          a0,     a0,     32
++    vst             vr14,   a0,     0
++    vst             vr15,   a0,     16
++    addi.d          a0,     a0,     32
++    addi.d          a1,     a1,     16
++    b               .LOOP_CUTREE_FIX8_UNPACK_LSX
++
++// handling mantissa
++.HANDLING_MANTISSA_CUTREE_FIX8_UNPACK_LSX:
++    blt             zero,   t3,     .OD_LOOP_COUNT_UNPACK_LSX
++
++.EV_LOOP_COUNT_UNPACK_LSX:
++    HANDLING_MANTISSA_MC_A2_3   d, vr4, vr4, vr5, t5, a0, 8, 0, 1, 0, \
++                                .TERMINATE_CUTREE_FIX8_UNPACK_LSX
++    b               .TERMINATE_CUTREE_FIX8_UNPACK_LSX
++
++.OD_LOOP_COUNT_UNPACK_LSX:
++    vst             vr4,    a0,     0
++    vst             vr5,    a0,     16
++    addi.d          a0,     a0,     32
++    HANDLING_MANTISSA_MC_A2_3   d, vr14, vr14, vr15, t5, a0, 8, 0, 1, 0, \
++                                .TERMINATE_CUTREE_FIX8_UNPACK_LSX
++
++.TERMINATE_CUTREE_FIX8_UNPACK_LSX:
++endfunc
++
++// void x265_cutree_fix8_unpack_lasx(double *dst, uint16_t *src, int count)
++function x265_cutree_fix8_unpack_lasx
++    la.local        t0,     mbtree_propagate_cost_lsx
++    fld.d           f0,     t0,     0       // load double(256.0)
++    xvreplve0.d     xr0,    xr0
++    xvfrecip.d      xr0,    xr0             // 1/256
++
++    // get loop-count
++    srli.d          t4,     a2,     3
++    andi            t5,     a2,     7
++    srli.d          t8,     t4,     1
++    andi            t3,     t4,     1
++
++.LOOP_CUTREE_FIX8_UNPACK_LASX:
++    xvld           xr1,    a1,     0
++    xvexth.w.h     xr11,   xr1
++    xvsllwil.w.h   xr1,    xr1,    0
++    xvffintl.d.w    xr2,    xr1
++    xvffinth.d.w    xr3,    xr1
++    xvffintl.d.w    xr12,   xr11
++    xvffinth.d.w    xr13,   xr11
++    xvfmul.d        xr4,    xr2,    xr0
++    xvfmul.d        xr5,    xr3,    xr0
++    xvfmul.d        xr14,   xr12,   xr0
++    xvfmul.d        xr15,   xr13,   xr0
++    xvor.v          xr6,    xr5,    xr5
++    xvor.v          xr16,   xr15,   xr15
++
++    // shuf
++    xvpermi.q       xr5,    xr4,    0b00100000
++    xvpermi.q       xr15,   xr14,   0b00100000
++    xvpermi.q       xr6,    xr4,    0b00110001
++    xvpermi.q       xr16,   xr14,   0b00110001
++
++    addi.d          t8,     t8,     -1      // loop-count --
++    blt             t8,     zero,   .HANDLING_MANTISSA_CUTREE_FIX8_UNPACK_LASX
++
++    // store 8 * dst[]
++    xvst            xr5,    a0,     0
++    xvst            xr15,   a0,     32
++    xvst            xr6,    a0,     64
++    xvst            xr16,   a0,     96
++    addi.d          a0,     a0,     128
++    addi.d          a1,     a1,     32
++    b               .LOOP_CUTREE_FIX8_UNPACK_LASX
++
++// handling mantissa
++.HANDLING_MANTISSA_CUTREE_FIX8_UNPACK_LASX:
++    blt             zero,   t3,     .OD_LOOP_COUNT_UNPACK_LASX
++
++.EV_LOOP_COUNT_UNPACK_LASX:
++    HANDLING_MANTISSA_MC_A2_7  d, xr5, xr15, t5, a0, 8, 0, 0, \
++                                .TERMINATE_CUTREE_FIX8_UNPACK_LASX
++    b               .TERMINATE_CUTREE_FIX8_UNPACK_LASX
++
++.OD_LOOP_COUNT_UNPACK_LASX:
++    xvst            xr5,    a0,     0
++    xvst            xr15,   a0,     32
++    addi.d          a0,     a0,     64
++    HANDLING_MANTISSA_MC_A2_7  d, xr6, xr16, t5, a0, 8, 0, 0, \
++                                .TERMINATE_CUTREE_FIX8_UNPACK_LASX
++
++.TERMINATE_CUTREE_FIX8_UNPACK_LASX:
++endfunc
++
++// void x265_cutree_fix8_pack_lsx(uint16_t *dst, double *src, int count)
++function x265_cutree_fix8_pack_lsx
++    la.local        t0,     mbtree_propagate_cost_lsx
++    fld.d           f0,     t0,     0       // load double(256.0)
++    vreplvei.d      vr0,    vr0,    0
++
++    // get loop-count
++    srli.d          t4,     a2,     2
++    andi            t5,     a2,     3
++    srli.d          t8,     t4,     1
++    andi            t3,     t4,     1
++
++.LOOP_CUTREE_FIX8_PACK_LSX:
++    // load 8 * src[]
++    vld             vr1,    a1,     0
++    vld             vr2,    a1,     16
++    vld             vr3,    a1,     32
++    vld             vr4,    a1,     48
++
++    vfmul.d         vr1,    vr1,    vr0
++    vfmul.d         vr2,    vr2,    vr0
++    vfmul.d         vr3,    vr3,    vr0
++    vfmul.d         vr4,    vr4,    vr0
++    vfrintrz.d      vr1,    vr1
++    vfrintrz.d      vr2,    vr2
++    vfrintrz.d      vr3,    vr3
++    vfrintrz.d      vr4,    vr4
++    vftint.w.d      vr1,    vr2,    vr1
++    vftint.w.d      vr3,    vr4,    vr3
++    vsrlni.h.w      vr1,    vr1,    0
++    vsrlni.h.w      vr3,    vr3,    0
++    vilvl.d         vr1,    vr3,    vr1
++
++    addi.d          t8,     t8,     -1      // loop-count --
++    blt             t8,     zero,   .HANDLING_MANTISSA_CUTREE_FIX8_PACK_LSX
++
++    // store 8 * dst[]
++    vst             vr1,    a0,     0
++    addi.d          a0,     a0,     16
++    addi.d          a1,     a1,     64
++    b               .LOOP_CUTREE_FIX8_PACK_LSX
++
++// handling mantissa
++.HANDLING_MANTISSA_CUTREE_FIX8_PACK_LSX:
++    blt             zero,   t3,     .OD_LOOP_COUNT_PACK_LSX
++
++.EV_LOOP_COUNT_PACK_LSX:
++    HANDLING_MANTISSA_MC_A2_3   h, vr1, vr1, vr1, t5, a0, 2, 0, 1, 2, \
++                                .TERMINATE_CUTREE_FIX8_PACK_LSX
++    b               .TERMINATE_CUTREE_FIX8_PACK_LSX
++
++.OD_LOOP_COUNT_PACK_LSX:
++    vstelm.d        vr1,    a0,     0,      0
++    addi.d          a0,     a0,     8
++    HANDLING_MANTISSA_MC_A2_3   h, vr1, vr1, vr1, t5, a0, 2, 4, 5, 6, \
++                                .TERMINATE_CUTREE_FIX8_PACK_LSX
++
++.TERMINATE_CUTREE_FIX8_PACK_LSX:
++endfunc
++
++// void x265_cutree_fix8_pack_lasx(uint16_t *dst, double *src, int count)
++function x265_cutree_fix8_pack_lasx
++    la.local        t0,     mbtree_propagate_cost_lsx
++    fld.d           f0,     t0,     0       // load double(256.0)
++    xvreplve0.d     xr0,    xr0
++
++    // get loop-count
++    srli.d          t4,     a2,     3
++    andi            t5,     a2,     7
++    srli.d          t8,     t4,     1
++    andi            t3,     t4,     1
++
++.LOOP_CUTREE_FIX8_PACK_LASX:
++    // load 16 * src[]
++    xvld            xr1,    a1,     0
++    xvld            xr2,    a1,     32
++    xvld            xr3,    a1,     64
++    xvld            xr4,    a1,     96
++
++    xvfmul.d        xr1,    xr1,    xr0
++    xvfmul.d        xr2,    xr2,    xr0
++    xvfmul.d        xr3,    xr3,    xr0
++    xvfmul.d        xr4,    xr4,    xr0
++    xvfrintrz.d     xr1,    xr1
++    xvfrintrz.d     xr2,    xr2
++    xvfrintrz.d     xr3,    xr3
++    xvfrintrz.d     xr4,    xr4
++    xvftint.w.d     xr1,    xr2,    xr1
++    xvftint.w.d     xr3,    xr4,    xr3
++    xvpermi.d       xr1,    xr1,    0b11011000
++    xvpermi.d       xr3,    xr3,    0b11011000
++    xvsrlni.h.w     xr1,    xr1,    0
++    xvsrlni.h.w     xr3,    xr3,    0
++    xvilvl.d        xr1,    xr3,    xr1
++    xvpermi.d       xr1,    xr1,    0b11011000
++
++    addi.d          t8,     t8,     -1      // loop-count --
++    blt             t8,     zero,   .HANDLING_MANTISSA_CUTREE_FIX8_PACK_LASX
++
++    // store 16 * dst[]
++    xvst            xr1,    a0,     0
++    addi.d          a0,     a0,     32
++    addi.d          a1,     a1,     128
++    b               .LOOP_CUTREE_FIX8_PACK_LASX
++
++// handling mantissa
++.HANDLING_MANTISSA_CUTREE_FIX8_PACK_LASX:
++    blt             zero,   t3,     .OD_LOOP_COUNT_PACK_LASX
++
++.EV_LOOP_COUNT_PACK_LASX:
++    HANDLING_MANTISSA_MC_A2_7  h, xr1, xr1, t5, a0, 2, 0, 4, \
++                                .TERMINATE_CUTREE_FIX8_PACK_LASX
++    b               .TERMINATE_CUTREE_FIX8_PACK_LASX
++
++.OD_LOOP_COUNT_PACK_LASX:
++    vst             vr1,    a0,     0
++    addi.d          a0,     a0,     16
++    HANDLING_MANTISSA_MC_A2_7  h, xr1, xr1, t5, a0, 2, 8, 12, \
++                                .TERMINATE_CUTREE_FIX8_PACK_LASX
++
++.TERMINATE_CUTREE_FIX8_PACK_LASX:
++endfunc
+diff --git a/source/common/loongarch64/pixel.h b/source/common/loongarch64/pixel.h
+index 494a593fe..731664e70 100644
+--- a/source/common/loongarch64/pixel.h
++++ b/source/common/loongarch64/pixel.h
+@@ -370,6 +370,14 @@ void x265_addAvg_64x32_lasx(const int16_t* src0, const int16_t* src1, pixel* dst
+ void x265_addAvg_64x48_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
+ void x265_addAvg_64x64_lasx(const int16_t* src0, const int16_t* src1, pixel* dst, intptr_t src0Stride, intptr_t src1Stride, intptr_t dstStride);
+ 
++void x265_frame_init_lowres_core_lsx(const pixel *src0, pixel *dst0, pixel *dsth, pixel *dstv, pixel *dstc, intptr_t src_stride, intptr_t dst_stride, int width, int height);
++void x265_frame_init_lowres_core_lasx(const pixel *src0, pixel *dst0, pixel *dsth, pixel *dstv, pixel *dstc, intptr_t src_stride, intptr_t dst_stride, int width, int height);
++void x265_frame_subsample_luma_lsx(const pixel *src0, pixel *dst0, intptr_t src_stride, intptr_t dst_stride, int width, int height);
++void x265_frame_subsample_luma_lasx(const pixel *src0, pixel *dst0, intptr_t src_stride, intptr_t dst_stride, int width, int height);
++void x265_cutree_fix8_unpack_lsx(double *dst, uint16_t *src, int count);
++void x265_cutree_fix8_unpack_lasx(double *dst, uint16_t *src, int count);
++void x265_cutree_fix8_pack_lsx(uint16_t *dst, double *src, int count);
++void x265_cutree_fix8_pack_lasx(uint16_t *dst, double *src, int count);
+ #undef FUNCDEF_PU
+ #undef DECL_PIXELS
+ #undef FUNCDEF_CHROMA_PU
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0014-FROMLIST-LoongArch64-Optimize-functions-in-blockcopy.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0014-FROMLIST-LoongArch64-Optimize-functions-in-blockcopy.patch
@@ -1,0 +1,2459 @@
+From a4584b75900808c5e54619cc7759bd8983693ec6 Mon Sep 17 00:00:00 2001
+From: jinbo <jinbo@loongson.cn>
+Date: Thu, 13 Jun 2024 11:00:34 +0800
+Subject: [PATCH 14/15] FROMLIST: LoongArch64: Optimize functions in
+ blockcopy8.S file - Patch 1
+
+Optimize functions related to block copying, block filling and
+other opreations with lsx and lasx.
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/CMakeLists.txt                 |    4 +-
+ source/common/loongarch64/asm-primitives.cpp |  110 +
+ source/common/loongarch64/blockcopy8.S       | 2049 ++++++++++++++++++
+ source/common/loongarch64/blockcopy8.h       |  178 ++
+ 4 files changed, 2339 insertions(+), 2 deletions(-)
+ create mode 100644 source/common/loongarch64/blockcopy8.S
+ create mode 100644 source/common/loongarch64/blockcopy8.h
+
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index 753fdcd78..4ea0dc5b6 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -138,11 +138,11 @@ if(ENABLE_ASSEMBLY AND LOONGARCH64)
+         message(STATUS "Detected CXX compiler using -O3 optimization level")
+     endif()
+ 
+-    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h pixel.h intrapred.h)
++    set(C_SRCS asm-primitives.cpp loopfilter.h ipfilter8.h dct.h pixel.h intrapred.h blockcopy8.h)
+     enable_language(ASM)
+ 
+     # add loongarch assembly/intrinsic files here
+-    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S pixel.S ssd.S sad.S mc-a2.S)
++    set(A_SRCS loopfilter.S ipfilter8.S dct.S mc-a.S intrapred8.S pixel.S ssd.S sad.S mc-a2.S blockcopy8.S)
+ 
+     set(LOONGARCH64_ASMS "${A_SRCS}" CACHE INTERNAL "LOONGARCH64 Assembly Sources")
+     foreach(SRC ${C_SRCS})
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 1a944743d..197e8df96 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -30,6 +30,7 @@
+ #include "dct.h"
+ #include "pixel.h"
+ #include "intrapred.h"
++#include "blockcopy8.h"
+ 
+ #define ASSIGN2(func, fname) \
+     func[ALIGNED] = PFX(fname); \
+@@ -253,22 +254,37 @@ all_angs_pred_lsx(32, 10)
+     p.cu[BLOCK_ ## W ## x ## H].var         = PFX(pixel_var_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].ssd_s[NONALIGNED] = PFX(pixel_ssd_s_## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].ssd_s[ALIGNED] = PFX(pixel_ssd_s_## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].copy_ss     = PFX(blockcopy_ss_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].copy_sp     = PFX(blockcopy_sp_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].copy_ps     = PFX(blockcopy_ps_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].transpose     = PFX(transpose_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].calcresidual[NONALIGNED] = PFX(pixel_getResidual_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].calcresidual[ALIGNED]    = PFX(pixel_getResidual_ ## W ## x ## H ##_ ## CPU);;
+ 
+ #define LUMA_PU(W, H, CPU) \
++    p.pu[LUMA_ ## W ## x ## H].copy_pp = PFX(blockcopy_pp_ ## W ## x ## H ## _ ##CPU); \
+     p.pu[LUMA_ ## W ## x ## H].addAvg[NONALIGNED] = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
+     p.pu[LUMA_ ## W ## x ## H].addAvg[ALIGNED] = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
+ 
+ #define CHROMA_PU_420(W, H, CPU) \
++    p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].copy_pp = PFX(blockcopy_pp_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].addAvg[NONALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I420].pu[CHROMA_420_ ## W ## x ## H].addAvg[ALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
+ 
+ #define CHROMA_PU_422(W, H, CPU) \
++    p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].copy_pp = PFX(blockcopy_pp_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].addAvg[NONALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU); \
+     p.chroma[X265_CSP_I422].pu[CHROMA_422_ ## W ## x ## H].addAvg[ALIGNED]  = PFX(addAvg_ ## W ## x ## H ## _ ##CPU);
+ 
++#define CHROMA_CU_420(W, H, CPU) \
++    p.chroma[X265_CSP_I420].cu[BLOCK_420_ ## W ## x ## H].copy_ss = PFX(blockcopy_ss_ ## W ## x ## H ##_ ## CPU); \
++    p.chroma[X265_CSP_I420].cu[BLOCK_420_ ## W ## x ## H].copy_sp = PFX(blockcopy_sp_ ## W ## x ## H ##_ ## CPU);
++
++#define CHROMA_CU_422(W, H, CPU) \
++    p.chroma[X265_CSP_I422].cu[BLOCK_422_ ## W ## x ## H].copy_ss = PFX(blockcopy_ss_ ## W ## x ## H ##_ ## CPU); \
++    p.chroma[X265_CSP_I422].cu[BLOCK_422_ ## W ## x ## H].copy_sp = PFX(blockcopy_sp_ ## W ## x ## H ##_ ## CPU); \
++    p.chroma[X265_CSP_I422].cu[BLOCK_422_ ## W ## x ## H].copy_ps = PFX(blockcopy_ps_ ## W ## x ## H ##_ ## CPU);
++
+ #define ALL_LUMA_PU_TYPED(prim, fncdef, fname, cpu) \
+     p.pu[LUMA_4x4].prim   = fncdef PFX(fname ## _4x4_ ## cpu); \
+     p.pu[LUMA_8x8].prim   = fncdef PFX(fname ## _8x8_ ## cpu); \
+@@ -296,6 +312,13 @@ all_angs_pred_lsx(32, 10)
+     p.pu[LUMA_64x16].prim = fncdef PFX(fname ## _64x16_ ## cpu); \
+     p.pu[LUMA_16x64].prim = fncdef PFX(fname ## _16x64_ ## cpu)
+ 
++#define ALL_LUMA_TU_TYPED(prim, fncdef, fname, cpu) \
++    p.cu[BLOCK_4x4].prim   = fncdef PFX(fname ## _4x4_ ## cpu); \
++    p.cu[BLOCK_8x8].prim   = fncdef PFX(fname ## _8x8_ ## cpu); \
++    p.cu[BLOCK_16x16].prim = fncdef PFX(fname ## _16x16_ ## cpu); \
++    p.cu[BLOCK_32x32].prim = fncdef PFX(fname ## _32x32_ ## cpu); \
++    p.cu[BLOCK_64x64].prim = fncdef PFX(fname ## _64x64_ ## cpu)
++
+ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ {
+ #if HAVE_LSX
+@@ -797,6 +820,23 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         LUMA_CU(32, 32, lsx);
+         LUMA_CU(64, 64, lsx);
+ 
++        CHROMA_CU_420(2, 2, lsx);
++        CHROMA_CU_420(4, 4, lsx);
++        CHROMA_CU_420(8, 8, lsx);
++        CHROMA_CU_420(16, 16, lsx);
++        CHROMA_CU_420(32, 32, lsx);
++
++        CHROMA_CU_422(2, 4, lsx);
++        CHROMA_CU_422(4, 8, lsx);
++        CHROMA_CU_422(8, 16, lsx);
++        CHROMA_CU_422(16, 32, lsx);
++        CHROMA_CU_422(32, 64, lsx);
++
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_4x4].copy_ps  = PFX(blockcopy_ps_4x4_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_8x8].copy_ps  = PFX(blockcopy_ps_8x8_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].copy_ps= PFX(blockcopy_ps_16x16_lsx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].copy_ps= PFX(blockcopy_ps_32x32_lsx);
++
+         p.chroma[X265_CSP_I420].cu[BLOCK_420_4x4].sse_pp   = PFX(pixel_sse_4x4_lsx);
+         p.chroma[X265_CSP_I420].cu[BLOCK_420_8x8].sse_pp   = PFX(pixel_sse_8x8_lsx);
+         p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].sse_pp = PFX(pixel_sse_16x16_lsx);
+@@ -859,6 +899,10 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         // sad_x3
+         ALL_LUMA_PU_TYPED(sad_x3, , pixel_sad_x3, lsx);
+ 
++        // Block_fill
++        ALL_LUMA_TU_TYPED(blockfill_s[ALIGNED], , blockfill_s, lsx);
++        ALL_LUMA_TU_TYPED(blockfill_s[NONALIGNED], , blockfill_s, lsx);
++
+         // normFact_c
+         p.cu[BLOCK_8x8].normFact   = PFX(pixel_normFact_8x8_lsx);
+         p.cu[BLOCK_16x16].normFact = PFX(pixel_normFact_16x16_lsx);
+@@ -891,6 +935,12 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ 
+         p.fix8Unpack = PFX(cutree_fix8_unpack_lsx);
+         p.fix8Pack   = PFX(cutree_fix8_pack_lsx);
++
++        //copy_cnt
++        p.cu[BLOCK_4x4].copy_cnt   = PFX(copy_count_4_lsx);
++        p.cu[BLOCK_8x8].copy_cnt   = PFX(copy_count_8_lsx);
++        p.cu[BLOCK_16x16].copy_cnt = PFX(copy_count_16_lsx);
++        p.cu[BLOCK_32x32].copy_cnt = PFX(copy_count_32_lsx);
+     }
+ #endif /* HAVE_LSX */
+ 
+@@ -1282,6 +1332,66 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ 
+         p.fix8Unpack = PFX(cutree_fix8_unpack_lasx);
+         p.fix8Pack   = PFX(cutree_fix8_pack_lasx);
++
++        // Block_fill
++        p.cu[BLOCK_16x16].blockfill_s[NONALIGNED] = PFX(blockfill_s_16x16_lasx);
++        p.cu[BLOCK_32x32].blockfill_s[NONALIGNED] = PFX(blockfill_s_32x32_lasx);
++        p.cu[BLOCK_64x64].blockfill_s[NONALIGNED] = PFX(blockfill_s_64x64_lasx);
++
++        p.cu[BLOCK_16x16].blockfill_s[ALIGNED] = PFX(blockfill_s_16x16_lasx);
++        p.cu[BLOCK_32x32].blockfill_s[ALIGNED] = PFX(blockfill_s_32x32_lasx);
++        p.cu[BLOCK_64x64].blockfill_s[ALIGNED] = PFX(blockfill_s_64x64_lasx);
++
++        //copy_pp
++        p.pu[LUMA_24x32].copy_pp = PFX(blockcopy_pp_24x32_lasx);
++        p.pu[LUMA_32x8].copy_pp = PFX(blockcopy_pp_32x8_lasx);
++        p.pu[LUMA_32x16].copy_pp = PFX(blockcopy_pp_32x16_lasx);
++        p.pu[LUMA_32x24].copy_pp = PFX(blockcopy_pp_32x24_lasx);
++        p.pu[LUMA_32x32].copy_pp = PFX(blockcopy_pp_32x32_lasx);
++        p.pu[LUMA_32x64].copy_pp = PFX(blockcopy_pp_32x64_lasx);
++        p.pu[LUMA_48x64].copy_pp = PFX(blockcopy_pp_48x64_lasx);
++        p.pu[LUMA_64x16].copy_pp = PFX(blockcopy_pp_64x16_lasx);
++        p.pu[LUMA_64x32].copy_pp = PFX(blockcopy_pp_64x32_lasx);
++        p.pu[LUMA_64x48].copy_pp = PFX(blockcopy_pp_64x48_lasx);
++        p.pu[LUMA_64x64].copy_pp = PFX(blockcopy_pp_64x64_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_24x32].copy_pp = PFX(blockcopy_pp_24x32_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x8].copy_pp = PFX(blockcopy_pp_32x8_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x16].copy_pp = PFX(blockcopy_pp_32x16_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x24].copy_pp = PFX(blockcopy_pp_32x24_lasx);
++        p.chroma[X265_CSP_I420].pu[CHROMA_420_32x32].copy_pp = PFX(blockcopy_pp_32x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_24x64].copy_pp = PFX(blockcopy_pp_24x64_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x16].copy_pp = PFX(blockcopy_pp_32x16_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x32].copy_pp = PFX(blockcopy_pp_32x32_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x48].copy_pp = PFX(blockcopy_pp_32x48_lasx);
++        p.chroma[X265_CSP_I422].pu[CHROMA_422_32x64].copy_pp = PFX(blockcopy_pp_32x64_lasx);
++
++        //copy_ss
++        p.cu[BLOCK_16x16].copy_ss = PFX(blockcopy_ss_16x16_lasx);
++        p.cu[BLOCK_32x32].copy_ss = PFX(blockcopy_ss_32x32_lasx);
++        p.cu[BLOCK_64x64].copy_ss = PFX(blockcopy_ss_64x64_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].copy_ss = PFX(blockcopy_ss_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].copy_ss = PFX(blockcopy_ss_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].copy_ss = PFX(blockcopy_ss_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].copy_ss = PFX(blockcopy_ss_32x64_lasx);
++        //copy_sp
++        p.cu[BLOCK_16x16].copy_sp = PFX(blockcopy_sp_16x16_lasx);
++        p.cu[BLOCK_32x32].copy_sp = PFX(blockcopy_sp_32x32_lasx);
++        p.cu[BLOCK_64x64].copy_sp = PFX(blockcopy_sp_64x64_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].copy_sp = PFX(blockcopy_sp_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].copy_sp = PFX(blockcopy_sp_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].copy_sp = PFX(blockcopy_sp_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].copy_sp = PFX(blockcopy_sp_32x64_lasx);
++        //copy_ps
++        p.cu[BLOCK_16x16].copy_ps = PFX(blockcopy_ps_16x16_lasx);
++        p.cu[BLOCK_32x32].copy_ps = PFX(blockcopy_ps_32x32_lasx);
++        p.cu[BLOCK_64x64].copy_ps = PFX(blockcopy_ps_64x64_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_16x16].copy_ps = PFX(blockcopy_ps_16x16_lasx);
++        p.chroma[X265_CSP_I420].cu[BLOCK_420_32x32].copy_ps = PFX(blockcopy_ps_32x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_16x32].copy_ps = PFX(blockcopy_ps_16x32_lasx);
++        p.chroma[X265_CSP_I422].cu[BLOCK_422_32x64].copy_ps = PFX(blockcopy_ps_32x64_lasx);
++        //copy_cnt
++        p.cu[BLOCK_16x16].copy_cnt = PFX(copy_count_16_lasx);
++        p.cu[BLOCK_32x32].copy_cnt = PFX(copy_count_32_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/blockcopy8.S b/source/common/loongarch64/blockcopy8.S
+new file mode 100644
+index 000000000..475590abe
+--- /dev/null
++++ b/source/common/loongarch64/blockcopy8.S
+@@ -0,0 +1,2049 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: jinbo <jinbo@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "loongson_asm.S"
++
++/*
++ *void blockcopy_pp_c(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride)
++ */
++function x265_blockcopy_pp_2x2_lsx
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++
++    vstelm.h      vr0,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr1,    a0,     0,     0
++endfunc
++
++function x265_blockcopy_pp_2x4_lsx
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++
++    vstelm.h      vr0,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr2,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr3,    a0,     0,     0
++endfunc
++
++.macro BLOCKCOPY_PP_W2_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++.rept \h/4 -1
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    vstelm.h      vr0,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr2,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr3,    a0,     0,     0
++    add.d         a0,     a0,     a1
++.endr
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++
++    vstelm.h      vr0,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr2,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr3,    a0,     0,     0
++endfunc
++.endm
++
++BLOCKCOPY_PP_W2_H4 2, 8
++BLOCKCOPY_PP_W2_H4 2, 16
++
++function x265_blockcopy_pp_4x2_lsx
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++endfunc
++
++function x265_blockcopy_pp_4x4_lsx
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.s         f2,     a0,     0
++    fstx.s        f3,     a0,     a1
++endfunc
++
++.macro BLOCKCOPY_PP_W4_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++.rept \h/4 -1
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.s         f2,     a0,     0
++    fstx.s        f3,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++.endr
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.s         f2,     a0,     0
++    fstx.s        f3,     a0,     a1
++endfunc
++.endm
++
++BLOCKCOPY_PP_W4_H4 4, 8
++BLOCKCOPY_PP_W4_H4 4, 16
++BLOCKCOPY_PP_W4_H4 4, 32
++
++function x265_blockcopy_pp_6x8_lsx
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f4,     a2,     0
++    fldx.d        f5,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f6,     a2,     0
++    fldx.d        f7,     a2,     a3
++
++    fst.s         f0,     a0,     0
++    vstelm.h      vr0,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f1,     a0,     0
++    vstelm.h      vr1,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f2,     a0,     0
++    vstelm.h      vr2,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f3,     a0,     0
++    vstelm.h      vr3,    a0,     4,     2
++    add.d         a0,     a0,     a1
++
++    fst.s         f4,     a0,     0
++    vstelm.h      vr4,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f5,     a0,     0
++    vstelm.h      vr5,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f6,     a0,     0
++    vstelm.h      vr6,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f7,     a0,     0
++    vstelm.h      vr7,    a0,     4,     2
++endfunc
++
++function x265_blockcopy_pp_6x16_lsx
++    li.w          t0,     16/4
++1:
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    fst.s         f0,     a0,     0
++    vstelm.h      vr0,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f1,     a0,     0
++    vstelm.h      vr1,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f2,     a0,     0
++    vstelm.h      vr2,    a0,     4,     2
++    add.d         a0,     a0,     a1
++    fst.s         f3,     a0,     0
++    vstelm.h      vr3,    a0,     4,     2
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++function x265_blockcopy_pp_8x2_lsx
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++endfunc
++
++function x265_blockcopy_pp_8x4_lsx
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++endfunc
++
++function x265_blockcopy_pp_8x6_lsx
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f4,     a2,     0
++    fldx.d        f5,     a2,     a3
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f4,     a0,     0
++    fstx.d        f5,     a0,     a1
++endfunc
++
++.macro BLOCKCOPY_PP_W8_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++.rept \h/4 -1
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++.endr
++
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++endfunc
++.endm
++
++BLOCKCOPY_PP_W8_H4 8, 8
++BLOCKCOPY_PP_W8_H4 8, 12
++BLOCKCOPY_PP_W8_H4 8, 16
++BLOCKCOPY_PP_W8_H4 8, 32
++BLOCKCOPY_PP_W8_H4 8, 64
++
++.macro BLOCKCOPY_PP_W12_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++.rept \h/4 -1
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    fst.d         f0,     a0,     0
++    vstelm.w      vr0,    a0,     8,     2
++    add.d         a0,     a0,     a1
++    fst.d         f1,     a0,     0
++    vstelm.w      vr1,    a0,     8,     2
++    add.d         a0,     a0,     a1
++    fst.d         f2,     a0,     0
++    vstelm.w      vr2,    a0,     8,     2
++    add.d         a0,     a0,     a1
++    fst.d         f3,     a0,     0
++    vstelm.w      vr3,    a0,     8,     2
++    add.d         a0,     a0,     a1
++.endr
++
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++
++    fst.d         f0,     a0,     0
++    vstelm.w      vr0,    a0,     8,     2
++    add.d         a0,     a0,     a1
++    fst.d         f1,     a0,     0
++    vstelm.w      vr1,    a0,     8,     2
++    add.d         a0,     a0,     a1
++    fst.d         f2,     a0,     0
++    vstelm.w      vr2,    a0,     8,     2
++    add.d         a0,     a0,     a1
++    fst.d         f3,     a0,     0
++    vstelm.w      vr3,    a0,     8,     2
++endfunc
++.endm
++
++BLOCKCOPY_PP_W12_H4 12, 16
++BLOCKCOPY_PP_W12_H4 12, 32
++
++.macro BLOCKCOPY_PP_W16_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++    li.w          t0,     \h/4
++1:
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    vst           vr0,    a0,     0
++    vstx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    vst           vr2,    a0,     0
++    vstx          vr3,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++BLOCKCOPY_PP_W16_H4 16, 4
++BLOCKCOPY_PP_W16_H4 16, 12
++
++.macro BLOCKCOPY_PP_W16_H8 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++    li.w          t0,     \h/8
++1:
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vld           vr2,    a2,     0
++    vldx          vr3,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    vld           vr4,    a2,     0
++    vldx          vr5,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vld           vr6,    a2,     0
++    vldx          vr7,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    vst           vr0,    a0,     0
++    vstx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    vst           vr2,    a0,     0
++    vstx          vr3,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    vst           vr4,    a0,     0
++    vstx          vr5,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    vst           vr6,    a0,     0
++    vstx          vr7,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++BLOCKCOPY_PP_W16_H8 16, 8
++BLOCKCOPY_PP_W16_H8 16, 16
++BLOCKCOPY_PP_W16_H8 16, 24
++BLOCKCOPY_PP_W16_H8 16, 32
++BLOCKCOPY_PP_W16_H8 16, 64
++
++.macro BLOCKCOPY_PP_W24_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++    li.w          t0,     \h/4
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr2,    a2,     0
++    vld           vr3,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr6,    a2,     0
++    vld           vr7,    a2,     16
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vstelm.d      vr1,    a0,     16,    0
++    add.d         a0,     a0,     a1
++    vst           vr2,    a0,     0
++    vstelm.d      vr3,    a0,     16,    0
++    add.d         a0,     a0,     a1
++    vst           vr4,    a0,     0
++    vstelm.d      vr5,    a0,     16,    0
++    add.d         a0,     a0,     a1
++    vst           vr6,    a0,     0
++    vstelm.d      vr7,    a0,     16,    0
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++BLOCKCOPY_PP_W24_H4 24, 32
++BLOCKCOPY_PP_W24_H4 24, 64
++
++.macro BLOCKCOPY_PP_W32_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++    li.w          t0,     \h/4
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr2,    a2,     0
++    vld           vr3,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr6,    a2,     0
++    vld           vr7,    a2,     16
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr2,    a0,     0
++    vst           vr3,    a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr4,    a0,     0
++    vst           vr5,    a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr6,    a0,     0
++    vst           vr7,    a0,     16
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++BLOCKCOPY_PP_W32_H4 32, 8
++BLOCKCOPY_PP_W32_H4 32, 16
++BLOCKCOPY_PP_W32_H4 32, 24
++BLOCKCOPY_PP_W32_H4 32, 32
++BLOCKCOPY_PP_W32_H4 32, 48
++BLOCKCOPY_PP_W32_H4 32, 64
++
++.macro LASX_BLOCKCOPY_PP_W32_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lasx
++    li.w          t0,     \h/4
++1:
++    xvld          xr0,    a2,     0
++    xvldx         xr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,   1
++    xvld          xr2,    a2,     0
++    xvldx         xr3,    a2,     a3
++    alsl.d        a2,     a3,     a2,   1
++.if \w == 32
++    xvst          xr0,    a0,     0
++    xvstx         xr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,   1
++    xvst          xr2,    a0,     0
++    xvstx         xr3,    a0,     a1
++    alsl.d        a0,     a1,     a0,   1
++.else
++    vst           vr0,    a0,     0
++    xvpermi.q     xr0,    xr0,    0x01
++    fst.d         f0,     a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr1,    a0,     0
++    xvpermi.q     xr1,    xr1,    0x01
++    fst.d         f1,     a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr2,    a0,     0
++    xvpermi.q     xr2,    xr2,    0x01
++    fst.d         f2,     a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr3,    a0,     0
++    xvpermi.q     xr3,    xr3,    0x01
++    fst.d         f3,     a0,     16
++    add.d         a0,     a0,     a1
++.endif
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_PP_W32_H4 32, 8
++LASX_BLOCKCOPY_PP_W32_H4 32, 16
++LASX_BLOCKCOPY_PP_W32_H4 32, 24
++LASX_BLOCKCOPY_PP_W32_H4 32, 32
++LASX_BLOCKCOPY_PP_W32_H4 32, 48
++LASX_BLOCKCOPY_PP_W32_H4 32, 64
++
++LASX_BLOCKCOPY_PP_W32_H4 24, 32
++LASX_BLOCKCOPY_PP_W32_H4 24, 64
++
++.macro BLOCKCOPY_PP_W48_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++    li.w          t0,     \h/4
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    add.d         a2,     a2,     a3
++    vld           vr3,    a2,     0
++    vld           vr4,    a2,     16
++    vld           vr5,    a2,     32
++    add.d         a2,     a2,     a3
++    vld           vr6,    a2,     0
++    vld           vr7,    a2,     16
++    vld           vr8,    a2,     32
++    add.d         a2,     a2,     a3
++    vld           vr9,    a2,     0
++    vld           vr10,   a2,     16
++    vld           vr11,   a2,     32
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    add.d         a0,     a0,     a1
++    vst           vr3,    a0,     0
++    vst           vr4,    a0,     16
++    vst           vr5,    a0,     32
++    add.d         a0,     a0,     a1
++    vst           vr6,    a0,     0
++    vst           vr7,    a0,     16
++    vst           vr8,    a0,     32
++    add.d         a0,     a0,     a1
++    vst           vr9,    a0,     0
++    vst           vr10,   a0,     16
++    vst           vr11,   a0,     32
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++BLOCKCOPY_PP_W48_H4 48, 64
++
++.macro BLOCKCOPY_PP_W64_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lsx
++    li.w          t0,     \h/4
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    vld           vr3,    a2,     48
++    add.d         a2,     a2,     a3
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    vld           vr6,    a2,     32
++    vld           vr7,    a2,     48
++    add.d         a2,     a2,     a3
++    vld           vr8,    a2,     0
++    vld           vr9,    a2,     16
++    vld           vr10,   a2,     32
++    vld           vr11,   a2,     48
++    add.d         a2,     a2,     a3
++    vld           vr12,   a2,     0
++    vld           vr13,   a2,     16
++    vld           vr14,   a2,     32
++    vld           vr15,   a2,     48
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    vst           vr3,    a0,     48
++    add.d         a0,     a0,     a1
++    vst           vr4,    a0,     0
++    vst           vr5,    a0,     16
++    vst           vr6,    a0,     32
++    vst           vr7,    a0,     48
++    add.d         a0,     a0,     a1
++    vst           vr8,    a0,     0
++    vst           vr9,    a0,     16
++    vst           vr10,   a0,     32
++    vst           vr11,   a0,     48
++    add.d         a0,     a0,     a1
++    vst           vr12,   a0,     0
++    vst           vr13,   a0,     16
++    vst           vr14,   a0,     32
++    vst           vr15,   a0,     48
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++BLOCKCOPY_PP_W64_H4 64, 16
++BLOCKCOPY_PP_W64_H4 64, 32
++BLOCKCOPY_PP_W64_H4 64, 48
++BLOCKCOPY_PP_W64_H4 64, 64
++
++.macro LASX_BLOCKCOPY_PP_W64_H4 w, h
++function x265_blockcopy_pp_\w\()x\h\()_lasx
++    li.w          t0,     \h/4
++1:
++    xvld          xr0,    a2,     0
++    xvld          xr1,    a2,     32
++    add.d         a2,     a2,     a3
++    xvld          xr2,    a2,     0
++    xvld          xr3,    a2,     32
++    add.d         a2,     a2,     a3
++    xvld          xr4,    a2,     0
++    xvld          xr5,    a2,     32
++    add.d         a2,     a2,     a3
++    xvld          xr6,    a2,     0
++    xvld          xr7,    a2,     32
++    add.d         a2,     a2,     a3
++.if \w == 64
++    xvst          xr0,    a0,     0
++    xvst          xr1,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr2,    a0,     0
++    xvst          xr3,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr4,    a0,     0
++    xvst          xr5,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr6,    a0,     0
++    xvst          xr7,    a0,     32
++    add.d         a0,     a0,     a1
++.else
++    xvst          xr0,    a0,     0
++    vst           vr1,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr2,    a0,     0
++    vst           vr3,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr4,    a0,     0
++    vst           vr5,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr6,    a0,     0
++    vst           vr7,    a0,     32
++    add.d         a0,     a0,     a1
++.endif
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_PP_W64_H4 64, 16
++LASX_BLOCKCOPY_PP_W64_H4 64, 32
++LASX_BLOCKCOPY_PP_W64_H4 64, 48
++LASX_BLOCKCOPY_PP_W64_H4 64, 64
++
++LASX_BLOCKCOPY_PP_W64_H4 48, 64
++
++function x265_blockfill_s_4x4_lsx
++    slli.d        a1,      a1,    1
++    vreplgr2vr.h  vr10,    a2
++    vstelm.d      vr10,    a0,    0,    0
++.rept 3
++    add.d         a0,      a0,    a1
++    vstelm.d      vr10,    a0,    0,    0
++.endr
++endfunc
++
++function x265_blockfill_s_8x8_lsx
++    vreplgr2vr.h  vr10,    a2
++    slli.d        a1,      a1,    1
++    vst           vr10,    a0,    0
++    vstx          vr10,    a0,    a1
++.rept 3
++    alsl.d        a0,      a1,    a0,   1
++    vst           vr10,    a0,    0
++    vstx          vr10,    a0,    a1
++.endr
++endfunc
++
++function x265_blockfill_s_16x16_lsx
++    vreplgr2vr.h  vr10,    a2
++    addi.d        t4,      a0,    16
++    slli.d        a1,      a1,    1
++    vst           vr10,    a0,    0
++    vst           vr10,    t4,    0
++    vstx          vr10,    a0,    a1
++    vstx          vr10,    t4,    a1
++.rept 7
++    alsl.d        a0,      a1,    a0,   1
++    addi.d        t4,      a0,    16
++    vst           vr10,    a0,    0
++    vst           vr10,    t4,    0
++    vstx          vr10,    a0,    a1
++    vstx          vr10,    t4,    a1
++.endr
++endfunc
++
++function x265_blockfill_s_32x32_lsx
++    vreplgr2vr.h  vr10,    a2
++    slli.d        a1,      a1,    1
++.rept 32
++    vst           vr10,    a0,    0
++    vst           vr10,    a0,    16
++    vst           vr10,    a0,    32
++    vst           vr10,    a0,    48
++    add.d         a0,      a0,    a1
++.endr
++endfunc
++
++function x265_blockfill_s_64x64_lsx
++    vreplgr2vr.h  vr10,    a2
++    slli.d        a1,      a1,    1
++.rept 64
++.irp i, 0, 16, 32, 48, 64, 80, 96, 112
++    vst           vr10,    a0,    \i
++.endr
++    add.d         a0,      a0,    a1
++.endr
++endfunc
++
++function x265_blockfill_s_16x16_lasx
++    xvreplgr2vr.h  xr10,    a2
++    slli.d         a1,      a1,    1
++    xvst           xr10,    a0,    0
++    xvstx          xr10,    a0,    a1
++.rept 7
++    alsl.d         a0,      a1,    a0,   1
++    xvst           xr10,    a0,    0
++    xvstx          xr10,    a0,    a1
++.endr
++endfunc
++
++function x265_blockfill_s_32x32_lasx
++    xvreplgr2vr.h  xr10,    a2
++    slli.d         a1,      a1,    1
++.rept 32
++    xvst           xr10,    a0,    0
++    xvst           xr10,    a0,    32
++    add.d          a0,      a0,    a1
++.endr
++endfunc
++
++function x265_blockfill_s_64x64_lasx
++    xvreplgr2vr.h  xr10,    a2
++    slli.d         a1,      a1,    1
++.rept 64
++.irp i, 0, 32, 64, 96
++    xvst           xr10,    a0,    \i
++.endr
++    add.d          a0,      a0,    a1
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_4x4_lsx
++    slli.d         a2,      a2,    1
++    fld.d          f0,      a1,    0
++    fldx.d         f1,      a1,    a2
++    vreplgr2vr.h   vr3,     a3
++    vilvl.d        vr2,     vr1,   vr0
++    vsll.h         vr4,     vr2,   vr3
++    vst            vr4,     a0,    0
++
++    alsl.d         a1,      a2,    a1,   1
++
++    fld.d          f0,      a1,    0
++    fldx.d         f1,      a1,    a2
++    vreplgr2vr.h   vr3,     a3
++    vilvl.d        vr2,     vr1,   vr0
++    vsll.h         vr4,     vr2,   vr3
++    vst            vr4,     a0,    16
++endfunc
++
++function x265_cpy2Dto1D_shl_8x8_lsx
++    slli.d         a2,      a2,    1
++.rept 4
++    vld            vr0,     a1,    0
++    vldx           vr1,     a1,    a2
++    vreplgr2vr.h   vr3,     a3
++    vsll.h         vr4,     vr0,   vr3
++    vsll.h         vr5,     vr1,   vr3
++    vst            vr4,     a0,    0
++    vst            vr5,     a0,    16
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    32
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_16x16_lsx
++    slli.d         a2,      a2,    1
++.rept 8
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    add.d          t1,      a1,    a2
++    vld            vr2,     t1,    0
++    vld            vr3,     t1,    16
++    vreplgr2vr.h   vr4,     a3
++    vsll.h         vr5,     vr0,   vr4
++    vsll.h         vr6,     vr1,   vr4
++    vsll.h         vr7,     vr2,   vr4
++    vsll.h         vr8,     vr3,   vr4
++    vst            vr5,     a0,    0
++    vst            vr6,     a0,    16
++    vst            vr7,     a0,    32
++    vst            vr8,     a0,    48
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    64
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_32x32_lsx
++    slli.d         a2,      a2,    1
++.rept 16
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr10,    a1,    32
++    vld            vr11,    a1,    48
++    add.d          t1,      a1,    a2
++    vld            vr2,     t1,    0
++    vld            vr3,     t1,    16
++    vld            vr12,    t1,    32
++    vld            vr13,    t1,    48
++    vreplgr2vr.h   vr4,     a3
++.irp i, vr0, vr1, vr10, vr11, vr2, vr3, vr12, vr13
++    vsll.h         \i,      \i,   vr4
++.endr
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr10,    a0,    32
++    vst            vr11,    a0,    48
++    vst            vr2,     a0,    64
++    vst            vr3,     a0,    80
++    vst            vr12,    a0,    96
++    vst            vr13,    a0,    112
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_64x64_lsx
++    slli.d         a2,      a2,    1
++.rept 64
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr2,     a1,    32
++    vld            vr3,     a1,    48
++    vld            vr4,     a1,    64
++    vld            vr5,     a1,    80
++    vld            vr6,     a1,    96
++    vld            vr7,     a1,    112
++    vreplgr2vr.h   vr8,     a3
++.irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vsll.h         \i,      \i,    vr8
++.endr
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr2,     a0,    32
++    vst            vr3,     a0,    48
++    vst            vr4,     a0,    64
++    vst            vr5,     a0,    80
++    vst            vr6,     a0,    96
++    vst            vr7,     a0,    112
++    add.d          a1,      a2,    a1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_8x8_lasx
++    slli.d         a2,      a2,    1
++.rept 4
++    vld            vr0,     a1,    0
++    vldx           vr1,     a1,    a2
++    xvpermi.q      xr1,     xr0,   0x20
++    xvreplgr2vr.h  xr3,     a3
++    xvsll.h        xr4,     xr1,   xr3
++    xvst           xr4,     a0,    0
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    32
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_16x16_lasx
++    slli.d         a2,      a2,    1
++.rept 8
++    xvld           xr0,     a1,    0
++    xvldx          xr1,     a1,    a2
++    xvreplgr2vr.h  xr4,     a3
++    xvsll.h        xr6,     xr0,   xr4
++    xvsll.h        xr8,     xr1,   xr4
++    xvst           xr6,     a0,    0
++    xvst           xr8,     a0,    32
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    64
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_32x32_lasx
++    slli.d         a2,      a2,    1
++.rept 16
++    xvld           xr0,     a1,    0
++    xvldx          xr1,     a1,    a2
++    addi.d         t1,      a1,    32
++    xvld           xr2,     t1,    0
++    xvldx          xr3,     t1,    a2
++    xvreplgr2vr.h  xr4,     a3
++    xvsll.h        xr6,     xr0,   xr4
++    xvsll.h        xr7,     xr2,   xr4
++    xvsll.h        xr8,     xr1,   xr4
++    xvsll.h        xr9,     xr3,   xr4
++    xvst           xr6,     a0,    0
++    xvst           xr7,     a0,    32
++    xvst           xr8,     a0,    64
++    xvst           xr9,     a0,    96
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shl_64x64_lasx
++    slli.d         a2,      a2,    1
++.rept 64
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsll.h        xr6,     xr0,   xr4
++    xvsll.h        xr7,     xr2,   xr4
++    xvsll.h        xr8,     xr1,   xr4
++    xvsll.h        xr9,     xr3,   xr4
++    xvst           xr6,     a0,    0
++    xvst           xr7,     a0,    32
++    xvst           xr8,     a0,    64
++    xvst           xr9,     a0,    96
++    add.d          a1,      a2,    a1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++/*
++ * void x265_blockcopy_ss_2x2_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb)
++ */
++function x265_blockcopy_ss_2x2_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++endfunc
++
++function x265_blockcopy_ss_2x4_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.s         f2,     a0,     0
++    fstx.s        f3,     a0,     a1
++endfunc
++
++function x265_blockcopy_ss_4x4_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++endfunc
++
++function x265_blockcopy_ss_4x8_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.d         f2,     a2,     0
++    fldx.d        f3,     a2,     a3
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.d         f2,     a0,     0
++    fstx.d        f3,     a0,     a1
++endfunc
++
++.macro LSX_BLOCKCOPY_SS_8xN h
++function x265_blockcopy_ss_8x\h\()_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    vst           vr0,    a0,     0
++    vstx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SS_8xN 8
++LSX_BLOCKCOPY_SS_8xN 16
++
++.macro LSX_BLOCKCOPY_SS_16xN h
++function x265_blockcopy_ss_16x\h\()_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr2,    a2,     0
++    vld           vr3,    a2,     16
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr2,    a0,     0
++    vst           vr3,    a0,     16
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SS_16xN 16
++LSX_BLOCKCOPY_SS_16xN 32
++
++.macro LASX_BLOCKCOPY_SS_16xN h
++function x265_blockcopy_ss_16x\h\()_lasx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    xvld          xr0,    a2,     0
++    xvldx         xr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++
++    xvst          xr0,    a0,     0
++    xvstx         xr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_SS_16xN 16
++LASX_BLOCKCOPY_SS_16xN 32
++
++.macro LSX_BLOCKCOPY_SS_32xN h
++function x265_blockcopy_ss_32x\h\()_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    vld           vr3,    a2,     48
++    add.d         a2,     a2,     a3
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    vld           vr6,    a2,     32
++    vld           vr7,    a2,     48
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    vst           vr3,    a0,     48
++    add.d         a0,     a0,     a1
++    vst           vr4,    a0,     0
++    vst           vr5,    a0,     16
++    vst           vr6,    a0,     32
++    vst           vr7,    a0,     48
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SS_32xN 32
++LSX_BLOCKCOPY_SS_32xN 64
++
++.macro LASX_BLOCKCOPY_SS_32xN h
++function x265_blockcopy_ss_32x\h\()_lasx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    xvld          xr0,    a2,     0
++    xvld          xr1,    a2,     32
++    add.d         a2,     a2,     a3
++    xvld          xr2,    a2,     0
++    xvld          xr3,    a2,     32
++    add.d         a2,     a2,     a3
++
++    xvst          xr0,    a0,     0
++    xvst          xr1,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr2,    a0,     0
++    xvst          xr3,    a0,     32
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_SS_32xN 32
++LASX_BLOCKCOPY_SS_32xN 64
++
++function x265_blockcopy_ss_64x64_lsx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     64/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    vld           vr3,    a2,     48
++    vld           vr4,    a2,     64
++    vld           vr5,    a2,     80
++    vld           vr6,    a2,     96
++    vld           vr7,    a2,     112
++    add.d         a2,     a2,     a3
++    vld           vr8,    a2,     0
++    vld           vr9,    a2,     16
++    vld           vr10,   a2,     32
++    vld           vr11,   a2,     48
++    vld           vr12,   a2,     64
++    vld           vr13,   a2,     80
++    vld           vr14,   a2,     96
++    vld           vr15,   a2,     112
++    add.d         a2,     a2,     a3
++
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    vst           vr3,    a0,     48
++    vst           vr4,    a0,     64
++    vst           vr5,    a0,     80
++    vst           vr6,    a0,     96
++    vst           vr7,    a0,     112
++    add.d         a0,     a0,     a1
++    vst           vr8,    a0,     0
++    vst           vr9,    a0,     16
++    vst           vr10,   a0,     32
++    vst           vr11,   a0,     48
++    vst           vr12,   a0,     64
++    vst           vr13,   a0,     80
++    vst           vr14,   a0,     96
++    vst           vr15,   a0,     112
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++function x265_blockcopy_ss_64x64_lasx
++    add.w         a3,     a3,     a3
++    add.w         a1,     a1,     a1
++    li.w          t0,     64/2
++1:
++    xvld          xr0,    a2,     0
++    xvld          xr1,    a2,     32
++    xvld          xr2,    a2,     64
++    xvld          xr3,    a2,     96
++    add.d         a2,     a2,     a3
++    xvld          xr4,    a2,     0
++    xvld          xr5,    a2,     32
++    xvld          xr6,    a2,     64
++    xvld          xr7,    a2,     96
++    add.d         a2,     a2,     a3
++
++    xvst          xr0,    a0,     0
++    xvst          xr1,    a0,     32
++    xvst          xr2,    a0,     64
++    xvst          xr3,    a0,     96
++    add.d         a0,     a0,     a1
++    xvst          xr4,    a0,     0
++    xvst          xr5,    a0,     32
++    xvst          xr6,    a0,     64
++    xvst          xr7,    a0,     96
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++/*
++ * void x265_blockcopy_sp_2x2_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb)
++ */
++function x265_blockcopy_sp_2x2_lsx
++    add.w         a3,     a3,     a3
++
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    vssrani.bu.h  vr1,    vr0,    0
++
++    vstelm.h      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr1,    a0,     0,     4
++endfunc
++
++function x265_blockcopy_sp_2x4_lsx
++    add.w         a3,     a3,     a3
++
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++    vssrani.bu.h  vr1,    vr0,    0
++    vssrani.bu.h  vr3,    vr2,    0
++
++    vstelm.h      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr1,    a0,     0,     4
++    add.d         a0,     a0,     a1
++    vstelm.h      vr3,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.h      vr3,    a0,     0,     4
++endfunc
++
++.macro LSX_BLOCKCOPY_SP_4xN h
++function x265_blockcopy_sp_4x\h\()_lsx
++    add.w         a3,     a3,     a3
++    li.w          t0,     \h/2
++1:
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vssrani.bu.h  vr1,    vr0,    0
++
++    vstelm.w      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.w      vr1,    a0,     0,     2
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SP_4xN 4
++LSX_BLOCKCOPY_SP_4xN 8
++
++.macro LSX_BLOCKCOPY_SP_8xN h
++function x265_blockcopy_sp_8x\h\()_lsx
++    add.w         a3,     a3,     a3
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vssrani.bu.h  vr1,    vr0,    0
++
++    vstelm.d      vr1,    a0,     0,     0
++    add.d         a0,     a0,     a1
++    vstelm.d      vr1,    a0,     0,     1
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SP_8xN 8
++LSX_BLOCKCOPY_SP_8xN 16
++
++.macro LSX_BLOCKCOPY_SP_16xN h
++function x265_blockcopy_sp_16x\h\()_lsx
++    add.w         a3,     a3,     a3
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr2,    a2,     0
++    vld           vr3,    a2,     16
++    add.d         a2,     a2,     a3
++    vssrani.bu.h  vr1,    vr0,    0
++    vssrani.bu.h  vr3,    vr2,    0
++
++    vst           vr1,    a0,     0
++    vstx          vr3,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SP_16xN 16
++LSX_BLOCKCOPY_SP_16xN 32
++
++.macro LASX_BLOCKCOPY_SP_16xN h
++function x265_blockcopy_sp_16x\h\()_lasx
++    add.w         a3,     a3,     a3
++    li.w          t0,     \h/2
++1:
++    xvld          xr0,    a2,     0
++    xvldx         xr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    xvssrani.bu.h xr1,    xr0,    0
++    xvpermi.d     xr0,    xr1,    0xd8
++    xvpermi.q     xr1,    xr0,    0x01
++
++    vst           vr0,    a0,     0
++    vstx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_SP_16xN 16
++LASX_BLOCKCOPY_SP_16xN 32
++
++.macro LSX_BLOCKCOPY_SP_32xN h
++function x265_blockcopy_sp_32x\h\()_lsx
++    add.w         a3,     a3,     a3
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    vld           vr3,    a2,     48
++    add.d         a2,     a2,     a3
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    vld           vr6,    a2,     32
++    vld           vr7,    a2,     48
++    add.d         a2,     a2,     a3
++    vssrani.bu.h  vr1,    vr0,    0
++    vssrani.bu.h  vr3,    vr2,    0
++    vssrani.bu.h  vr5,    vr4,    0
++    vssrani.bu.h  vr7,    vr6,    0
++
++    vst           vr1,    a0,     0
++    vst           vr3,    a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr5,    a0,     0
++    vst           vr7,    a0,     16
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_SP_32xN 32
++LSX_BLOCKCOPY_SP_32xN 64
++
++.macro LASX_BLOCKCOPY_SP_32xN h
++function x265_blockcopy_sp_32x\h\()_lasx
++    add.w         a3,     a3,     a3
++    li.w          t0,     \h/2
++1:
++    xvld          xr0,    a2,     0
++    xvld          xr1,    a2,     32
++    add.d         a2,     a2,     a3
++    xvld          xr2,    a2,     0
++    xvld          xr3,    a2,     32
++    add.d         a2,     a2,     a3
++    xvssrani.bu.h xr1,    xr0,    0
++    xvssrani.bu.h xr3,    xr2,    0
++    xvpermi.d     xr0,    xr1,    0xd8
++    xvpermi.d     xr1,    xr3,    0xd8
++
++    xvst          xr0,    a0,     0
++    xvstx         xr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_SP_32xN 32
++LASX_BLOCKCOPY_SP_32xN 64
++
++function x265_blockcopy_sp_64x64_lsx
++    add.w         a3,     a3,     a3
++    li.w          t0,     64/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    vld           vr3,    a2,     48
++    vld           vr4,    a2,     64
++    vld           vr5,    a2,     80
++    vld           vr6,    a2,     96
++    vld           vr7,    a2,     112
++    add.d         a2,     a2,     a3
++    vld           vr8,    a2,     0
++    vld           vr9,    a2,     16
++    vld           vr10,   a2,     32
++    vld           vr11,   a2,     48
++    vld           vr12,   a2,     64
++    vld           vr13,   a2,     80
++    vld           vr14,   a2,     96
++    vld           vr15,   a2,     112
++    add.d         a2,     a2,     a3
++    vssrani.bu.h  vr1,    vr0,    0
++    vssrani.bu.h  vr3,    vr2,    0
++    vssrani.bu.h  vr5,    vr4,    0
++    vssrani.bu.h  vr7,    vr6,    0
++    vssrani.bu.h  vr9,    vr8,    0
++    vssrani.bu.h  vr11,   vr10,   0
++    vssrani.bu.h  vr13,   vr12,   0
++    vssrani.bu.h  vr15,   vr14,   0
++
++    vst           vr1,    a0,     0
++    vst           vr3,    a0,     16
++    vst           vr5,    a0,     32
++    vst           vr7,    a0,     48
++    add.d         a0,     a0,     a1
++    vst           vr9,    a0,     0
++    vst           vr11,   a0,     16
++    vst           vr13,   a0,     32
++    vst           vr15,   a0,     48
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++function x265_blockcopy_sp_64x64_lasx
++    add.w         a3,     a3,     a3
++    li.w          t0,     64/2
++1:
++    xvld          xr0,    a2,     0
++    xvld          xr1,    a2,     32
++    xvld          xr2,    a2,     64
++    xvld          xr3,    a2,     96
++    add.d         a2,     a2,     a3
++    xvld          xr4,    a2,     0
++    xvld          xr5,    a2,     32
++    xvld          xr6,    a2,     64
++    xvld          xr7,    a2,     96
++    add.d         a2,     a2,     a3
++    xvssrani.bu.h xr1,    xr0,    0
++    xvssrani.bu.h xr3,    xr2,    0
++    xvssrani.bu.h xr5,    xr4,    0
++    xvssrani.bu.h xr7,    xr6,    0
++    xvpermi.d     xr0,    xr1,    0xd8
++    xvpermi.d     xr2,    xr3,    0xd8
++    xvpermi.d     xr4,    xr5,    0xd8
++    xvpermi.d     xr6,    xr7,    0xd8
++
++    xvst          xr0,    a0,     0
++    xvst          xr2,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr4,    a0,     0
++    xvst          xr6,    a0,     32
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++/*
++ * void x265_blockcopy_ps_2x4_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb)
++ */
++function x265_blockcopy_ps_2x4_lsx
++    add.w         a1,     a1,     a1
++
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    fld.s         f2,     a2,     0
++    fldx.s        f3,     a2,     a3
++    vsllwil.hu.bu vr0,    vr0,    0
++    vsllwil.hu.bu vr1,    vr1,    0
++    vsllwil.hu.bu vr2,    vr2,    0
++    vsllwil.hu.bu vr3,    vr3,    0
++
++    fst.s         f0,     a0,     0
++    fstx.s        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++    fst.s         f2,     a0,     0
++    fstx.s        f3,     a0,     a1
++endfunc
++
++.macro LSX_BLOCKCOPY_PS_4xN h
++function x265_blockcopy_ps_4x\h\()_lsx
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    fld.s         f0,     a2,     0
++    fldx.s        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vsllwil.hu.bu vr0,    vr0,    0
++    vsllwil.hu.bu vr1,    vr1,    0
++
++    fst.d         f0,     a0,     0
++    fstx.d        f1,     a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_PS_4xN 4
++LSX_BLOCKCOPY_PS_4xN 8
++
++.macro LSX_BLOCKCOPY_PS_8xN h
++function x265_blockcopy_ps_8x\h\()_lsx
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    fld.d         f0,     a2,     0
++    fldx.d        f1,     a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vsllwil.hu.bu vr0,    vr0,    0
++    vsllwil.hu.bu vr1,    vr1,    0
++
++    vst           vr0,    a0,     0
++    vstx          vr1,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_PS_8xN 8
++LSX_BLOCKCOPY_PS_8xN 16
++
++.macro LSX_BLOCKCOPY_PS_16xN h
++function x265_blockcopy_ps_16x\h\()_lsx
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    vexth.hu.bu   vr2,    vr0
++    vexth.hu.bu   vr3,    vr1
++    vsllwil.hu.bu vr0,    vr0,    0
++    vsllwil.hu.bu vr1,    vr1,    0
++
++    vst           vr0,    a0,     0
++    vst           vr2,    a0,     16
++    add.d         a0,     a0,     a1
++    vst           vr1,    a0,     0
++    vst           vr3,    a0,     16
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_PS_16xN 16
++LSX_BLOCKCOPY_PS_16xN 32
++
++.macro LASX_BLOCKCOPY_PS_16xN h
++function x265_blockcopy_ps_16x\h\()_lasx
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vldx          vr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    xvpermi.q     xr1,    xr0,    0x20
++    xvpermi.d     xr1,    xr1,    0xd8
++    xvexth.hu.bu  xr2,    xr1
++    xvsllwil.hu.bu xr1,   xr1,    0
++
++    xvst          xr1,    a0,     0
++    xvstx         xr2,    a0,     a1
++    alsl.d        a0,     a1,     a0,    1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_PS_16xN 16
++LASX_BLOCKCOPY_PS_16xN 32
++
++.macro LSX_BLOCKCOPY_PS_32xN h
++function x265_blockcopy_ps_32x\h\()_lsx
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    add.d         a2,     a2,     a3
++    vld           vr4,    a2,     0
++    vld           vr5,    a2,     16
++    add.d         a2,     a2,     a3
++    vexth.hu.bu   vr2,    vr0
++    vexth.hu.bu   vr3,    vr1
++    vsllwil.hu.bu vr0,    vr0,    0
++    vsllwil.hu.bu vr1,    vr1,    0
++    vexth.hu.bu   vr6,    vr4
++    vexth.hu.bu   vr7,    vr5
++    vsllwil.hu.bu vr4,    vr4,    0
++    vsllwil.hu.bu vr5,    vr5,    0
++
++    vst           vr0,    a0,     0
++    vst           vr2,    a0,     16
++    vst           vr1,    a0,     32
++    vst           vr3,    a0,     48
++    add.d         a0,     a0,     a1
++    vst           vr4,    a0,     0
++    vst           vr6,    a0,     16
++    vst           vr5,    a0,     32
++    vst           vr7,    a0,     48
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LSX_BLOCKCOPY_PS_32xN 32
++LSX_BLOCKCOPY_PS_32xN 64
++
++.macro LASX_BLOCKCOPY_PS_32xN h
++function x265_blockcopy_ps_32x\h\()_lasx
++    add.w         a1,     a1,     a1
++    li.w          t0,     \h/2
++1:
++    xvld          xr0,    a2,     0
++    xvldx         xr1,    a2,     a3
++    alsl.d        a2,     a3,     a2,    1
++    xvpermi.d     xr0,    xr0,    0xd8
++    xvpermi.d     xr1,    xr1,    0xd8
++    xvexth.hu.bu  xr2,    xr0
++    xvexth.hu.bu  xr3,    xr1
++    xvsllwil.hu.bu xr0,   xr0,    0
++    xvsllwil.hu.bu xr1,   xr1,    0
++
++    xvst          xr0,    a0,     0
++    xvst          xr2,    a0,     32
++    add.d         a0,     a0,     a1
++    xvst          xr1,    a0,     0
++    xvst          xr3,    a0,     32
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++.endm
++
++LASX_BLOCKCOPY_PS_32xN 32
++LASX_BLOCKCOPY_PS_32xN 64
++
++function x265_blockcopy_ps_64x64_lsx
++    add.w         a1,     a1,     a1
++    li.w          t0,     64/2
++1:
++    vld           vr0,    a2,     0
++    vld           vr1,    a2,     16
++    vld           vr2,    a2,     32
++    vld           vr3,    a2,     48
++    add.d         a2,     a2,     a3
++    vld           vr8,    a2,     0
++    vld           vr9,    a2,     16
++    vld           vr10,   a2,     32
++    vld           vr11,   a2,     48
++    add.d         a2,     a2,     a3
++    vexth.hu.bu   vr4,    vr0
++    vexth.hu.bu   vr5,    vr1
++    vexth.hu.bu   vr6,    vr2
++    vexth.hu.bu   vr7,    vr3
++    vsllwil.hu.bu vr0,    vr0,    0
++    vsllwil.hu.bu vr1,    vr1,    0
++    vsllwil.hu.bu vr2,    vr2,    0
++    vsllwil.hu.bu vr3,    vr3,    0
++    vexth.hu.bu   vr12,   vr8
++    vexth.hu.bu   vr13,   vr9
++    vexth.hu.bu   vr14,   vr10
++    vexth.hu.bu   vr15,   vr11
++    vsllwil.hu.bu vr8,    vr8,    0
++    vsllwil.hu.bu vr9,    vr9,    0
++    vsllwil.hu.bu vr10,   vr10,   0
++    vsllwil.hu.bu vr11,   vr11,   0
++
++    vst           vr0,    a0,     0
++    vst           vr4,    a0,     16
++    vst           vr1,    a0,     32
++    vst           vr5,    a0,     48
++    vst           vr2,    a0,     64
++    vst           vr6,    a0,     80
++    vst           vr3,    a0,     96
++    vst           vr7,    a0,     112
++    add.d         a0,     a0,     a1
++    vst           vr8,    a0,     0
++    vst           vr12,   a0,     16
++    vst           vr9,    a0,     32
++    vst           vr13,   a0,     48
++    vst           vr10,   a0,     64
++    vst           vr14,   a0,     80
++    vst           vr11,   a0,     96
++    vst           vr15,   a0,     112
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++function x265_blockcopy_ps_64x64_lasx
++    add.w         a1,     a1,     a1
++    li.w          t0,     64/2
++1:
++    xvld          xr0,    a2,     0
++    xvld          xr1,    a2,     32
++    add.d         a2,     a2,     a3
++    xvld          xr4,    a2,     0
++    xvld          xr5,    a2,     32
++    add.d         a2,     a2,     a3
++    xvpermi.d     xr0,    xr0,    0xd8
++    xvpermi.d     xr1,    xr1,    0xd8
++    xvpermi.d     xr2,    xr4,    0xd8
++    xvpermi.d     xr3,    xr5,    0xd8
++    xvexth.hu.bu  xr4,    xr0
++    xvexth.hu.bu  xr5,    xr1
++    xvexth.hu.bu  xr6,    xr2
++    xvexth.hu.bu  xr7,    xr3
++    xvsllwil.hu.bu xr0,   xr0,    0
++    xvsllwil.hu.bu xr1,   xr1,    0
++    xvsllwil.hu.bu xr2,   xr2,    0
++    xvsllwil.hu.bu xr3,   xr3,    0
++
++    xvst          xr0,    a0,     0
++    xvst          xr4,    a0,     32
++    xvst          xr1,    a0,     64
++    xvst          xr5,    a0,     96
++    add.d         a0,     a0,     a1
++    xvst          xr2,    a0,     0
++    xvst          xr6,    a0,     32
++    xvst          xr3,    a0,     64
++    xvst          xr7,    a0,     96
++    add.d         a0,     a0,     a1
++
++    addi.w        t0,     t0,     -1
++    bnez          t0,     1b
++endfunc
++
++/*
++ *uint32_t x265_copy_count_4_lsx(int16_t* coeff, const int16_t* residual, intptr_t resiStride)
++ */
++function x265_copy_count_4_lsx
++    add.w         a2,     a2,     a2
++
++    fld.d         f0,     a1,     0
++    fldx.d        f1,     a1,     a2
++    alsl.d        a1,     a2,     a1,    1
++    fld.d         f2,     a1,     0
++    fldx.d        f3,     a1,     a2
++    //store coeff
++    vpackev.d     vr0,    vr1,    vr0
++    vpackev.d     vr1,    vr3,    vr2
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    //numSig
++    vssrani.b.h   vr1,    vr0,    0
++    vseqi.b       vr1,    vr1,    0
++    vaddi.bu      vr1,    vr1,    1
++    vhaddw.hu.bu  vr1,    vr1,    vr1
++    vhaddw.wu.hu  vr1,    vr1,    vr1
++    vhaddw.du.wu  vr1,    vr1,    vr1
++    vhaddw.qu.du  vr1,    vr1,    vr1
++    vpickve2gr.hu t0,     vr1,    0
++    or            a0,     zero,   t0
++endfunc
++
++function x265_copy_count_8_lsx
++    add.w         a2,     a2,     a2
++    xor           t2,     t2,     t2
++    li.w          t3,     8/4
++1:
++    vld           vr0,    a1,     0
++    vldx          vr1,    a1,     a2
++    alsl.d        a1,     a2,     a1,    1
++    vld           vr2,    a1,     0
++    vldx          vr3,    a1,     a2
++    alsl.d        a1,     a2,     a1,    1
++    //store coeff
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    vst           vr3,    a0,     48
++    addi.d        a0,     a0,     64
++    //numSig
++    vssrani.b.h   vr1,    vr0,    0
++    vssrani.b.h   vr3,    vr2,    0
++    vseqi.b       vr1,    vr1,    0
++    vseqi.b       vr3,    vr3,    0
++    vadd.b        vr1,    vr1,    vr3
++    vaddi.bu      vr1,    vr1,    2
++    vhaddw.hu.bu  vr1,    vr1,    vr1
++    vhaddw.wu.hu  vr1,    vr1,    vr1
++    vhaddw.du.wu  vr1,    vr1,    vr1
++    vhaddw.qu.du  vr1,    vr1,    vr1
++    vpickve2gr.hu t0,     vr1,    0
++    add.w         t2,     t2,     t0
++    addi.w        t3,     t3,     -1
++    bnez          t3,     1b
++    or            a0,     zero,   t2
++endfunc
++
++function x265_copy_count_16_lsx
++    add.w         a2,     a2,     a2
++    xor           t2,     t2,     t2
++    li.w          t3,     16/2
++1:
++    vld           vr0,    a1,     0
++    vld           vr1,    a1,     16
++    add.d         a1,     a1,     a2
++    vld           vr2,    a1,     0
++    vld           vr3,    a1,     16
++    add.d         a1,     a1,     a2
++    //store coeff
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    vst           vr3,    a0,     48
++    addi.d        a0,     a0,     64
++    //numSig
++    vssrani.b.h   vr1,    vr0,    0
++    vssrani.b.h   vr3,    vr2,    0
++    vseqi.b       vr1,    vr1,    0
++    vseqi.b       vr3,    vr3,    0
++    vadd.b        vr1,    vr1,    vr3
++    vaddi.bu      vr1,    vr1,    2
++    vhaddw.hu.bu  vr1,    vr1,    vr1
++    vhaddw.wu.hu  vr1,    vr1,    vr1
++    vhaddw.du.wu  vr1,    vr1,    vr1
++    vhaddw.qu.du  vr1,    vr1,    vr1
++    vpickve2gr.hu t0,     vr1,    0
++    add.w         t2,     t2,     t0
++    addi.w        t3,     t3,     -1
++    bnez          t3,     1b
++    or            a0,     zero,   t2
++endfunc
++
++function x265_copy_count_16_lasx
++    add.w         a2,     a2,     a2
++    xor           t2,     t2,     t2
++    li.w          t3,     16/4
++1:
++    xvld          xr0,    a1,     0
++    xvldx         xr1,    a1,     a2
++    alsl.d        a1,     a2,     a1,    1
++    xvld          xr2,    a1,     0
++    xvldx         xr3,    a1,     a2
++    alsl.d        a1,     a2,     a1,    1
++    //store coeff
++    xvst          xr0,    a0,     0
++    xvst          xr1,    a0,     32
++    xvst          xr2,    a0,     64
++    xvst          xr3,    a0,     96
++    addi.d        a0,     a0,     128
++    //numSig
++    xvssrani.b.h  xr1,    xr0,    0
++    xvssrani.b.h  xr3,    xr2,    0
++    xvseqi.b      xr1,    xr1,    0
++    xvseqi.b      xr3,    xr3,    0
++    xvadd.b       xr1,    xr1,    xr3
++    xvaddi.bu     xr1,    xr1,    2
++    xvpermi.q     xr0,    xr1,    0x01
++    vadd.b        vr1,    vr1,    vr0
++    vhaddw.hu.bu  vr1,    vr1,    vr1
++    vhaddw.wu.hu  vr1,    vr1,    vr1
++    vhaddw.du.wu  vr1,    vr1,    vr1
++    vhaddw.qu.du  vr1,    vr1,    vr1
++    vpickve2gr.hu t0,     vr1,    0
++    add.w         t2,     t2,     t0
++    addi.w        t3,     t3,     -1
++    bnez          t3,     1b
++    or            a0,     zero,   t2
++endfunc
++
++function x265_copy_count_32_lsx
++    add.w         a2,     a2,     a2
++    xor           t2,     t2,     t2
++    li.w          t3,     32/2
++1:
++    vld           vr0,    a1,     0
++    vld           vr1,    a1,     16
++    vld           vr2,    a1,     32
++    vld           vr3,    a1,     48
++    add.d         a1,     a1,     a2
++    vld           vr4,    a1,     0
++    vld           vr5,    a1,     16
++    vld           vr6,    a1,     32
++    vld           vr7,    a1,     48
++    add.d         a1,     a1,     a2
++    //store coeff
++    vst           vr0,    a0,     0
++    vst           vr1,    a0,     16
++    vst           vr2,    a0,     32
++    vst           vr3,    a0,     48
++    vst           vr4,    a0,     64
++    vst           vr5,    a0,     80
++    vst           vr6,    a0,     96
++    vst           vr7,    a0,     112
++    addi.d        a0,     a0,     128
++    //numSig
++    vssrani.b.h   vr1,    vr0,    0
++    vssrani.b.h   vr3,    vr2,    0
++    vssrani.b.h   vr5,    vr4,    0
++    vssrani.b.h   vr7,    vr6,    0
++    vseqi.b       vr1,    vr1,    0
++    vseqi.b       vr3,    vr3,    0
++    vseqi.b       vr5,    vr5,    0
++    vseqi.b       vr7,    vr7,    0
++    vadd.b        vr1,    vr1,    vr3
++    vadd.b        vr1,    vr1,    vr5
++    vadd.b        vr1,    vr1,    vr7
++    vaddi.bu      vr1,    vr1,    4
++    vhaddw.hu.bu  vr1,    vr1,    vr1
++    vhaddw.wu.hu  vr1,    vr1,    vr1
++    vhaddw.du.wu  vr1,    vr1,    vr1
++    vhaddw.qu.du  vr1,    vr1,    vr1
++    vpickve2gr.hu t0,     vr1,    0
++    add.w         t2,     t2,     t0
++    addi.w        t3,     t3,     -1
++    bnez          t3,     1b
++    or            a0,     zero,   t2
++endfunc
++
++function x265_copy_count_32_lasx
++    add.w         a2,     a2,     a2
++    xor           t2,     t2,     t2
++    li.w          t3,     32/2
++1:
++    xvld          xr0,    a1,     0
++    xvld          xr1,    a1,     32
++    add.d         a1,     a1,     a2
++    xvld          xr2,    a1,     0
++    xvld          xr3,    a1,     32
++    add.d         a1,     a1,     a2
++    //store coeff
++    xvst          xr0,    a0,     0
++    xvst          xr1,    a0,     32
++    xvst          xr2,    a0,     64
++    xvst          xr3,    a0,     96
++    addi.d        a0,     a0,     128
++    //numSig
++    xvssrani.b.h  xr1,    xr0,    0
++    xvssrani.b.h  xr3,    xr2,    0
++    xvseqi.b      xr1,    xr1,    0
++    xvseqi.b      xr3,    xr3,    0
++    xvadd.b       xr1,    xr1,    xr3
++    xvaddi.bu     xr1,    xr1,    2
++    xvpermi.q     xr0,    xr1,    0x01
++    vadd.b        vr1,    vr1,    vr0
++    vhaddw.hu.bu  vr1,    vr1,    vr1
++    vhaddw.wu.hu  vr1,    vr1,    vr1
++    vhaddw.du.wu  vr1,    vr1,    vr1
++    vhaddw.qu.du  vr1,    vr1,    vr1
++    vpickve2gr.hu t0,     vr1,    0
++    add.w         t2,     t2,     t0
++    addi.w        t3,     t3,     -1
++    bnez          t3,     1b
++    or            a0,     zero,   t2
++endfunc
+diff --git a/source/common/loongarch64/blockcopy8.h b/source/common/loongarch64/blockcopy8.h
+new file mode 100644
+index 000000000..f1583189f
+--- /dev/null
++++ b/source/common/loongarch64/blockcopy8.h
+@@ -0,0 +1,178 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: jinbo <jinbo@loongson.cn>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_LOONGARCH_BLOCKCOPY8_H
++#define X265_LOONGARCH_BLOCKCOPY8_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++#undef FUNCDEF_PU
++#define FUNCDEF_PU(ret, name, cpu, ...) \
++    ret PFX(name ## _4x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x4_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x8_   ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x8_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x4_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x16_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x8_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x32_  ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x48_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _48x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x64_ ## cpu)(__VA_ARGS__)
++
++#define FUNCDEF_CHROMA_PU(ret, name, cpu, ...) \
++    FUNCDEF_PU(ret, name, cpu, __VA_ARGS__); \
++    ret PFX(name ## _2x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x4_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x6_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _6x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _6x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x6_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _2x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x2_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x4_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x12_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _12x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x4_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _4x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _32x48_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _48x32_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _16x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x16_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _8x64_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x8_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _64x24_ ## cpu)(__VA_ARGS__); \
++    ret PFX(name ## _24x64_ ## cpu)(__VA_ARGS__);
++
++#define FUNCDEF_TU(ret, name, cpu, ...) \
++    ret PFX(name ## _4x4_ ## cpu(__VA_ARGS__)); \
++    ret PFX(name ## _8x8_ ## cpu(__VA_ARGS__)); \
++    ret PFX(name ## _16x16_ ## cpu(__VA_ARGS__)); \
++    ret PFX(name ## _32x32_ ## cpu(__VA_ARGS__)); \
++    ret PFX(name ## _64x64_ ## cpu(__VA_ARGS__))
++
++FUNCDEF_CHROMA_PU(void, blockcopy_pp, lsx, pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++
++FUNCDEF_TU(void, blockfill_s, lsx, int16_t* dst, intptr_t dstride, int16_t val);
++
++void x265_blockcopy_ss_2x2_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_2x4_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_4x4_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_4x8_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_8x8_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_8x16_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_16x16_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_16x32_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_32x32_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_32x64_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_64x64_lsx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_2x2_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_2x4_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_4x4_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_4x8_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_8x8_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_8x16_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_16x16_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_16x32_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_32x32_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_32x64_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_64x64_lsx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ps_2x4_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_4x4_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_4x8_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_8x8_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_8x16_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_16x16_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_16x32_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_32x32_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_32x64_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_64x64_lsx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++uint32_t x265_copy_count_4_lsx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
++uint32_t x265_copy_count_8_lsx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
++uint32_t x265_copy_count_16_lsx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
++uint32_t x265_copy_count_32_lsx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
++
++void x265_blockfill_s_16x16_lasx(int16_t* dst, intptr_t dstride, int16_t val);
++void x265_blockfill_s_32x32_lasx(int16_t* dst, intptr_t dstride, int16_t val);
++void x265_blockfill_s_64x64_lasx(int16_t* dst, intptr_t dstride, int16_t val);
++void x265_blockcopy_pp_24x32_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_24x64_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_32x8_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_32x16_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_32x24_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_32x32_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_32x48_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_32x64_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_48x64_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_64x16_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_64x32_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_64x48_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_pp_64x64_lasx(pixel* dst, intptr_t dstStride, const pixel* src, intptr_t srcStride);
++void x265_blockcopy_ss_16x16_lasx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_16x32_lasx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_32x32_lasx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_32x64_lasx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ss_64x64_lasx(int16_t* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_16x16_lasx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_16x32_lasx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_32x32_lasx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_32x64_lasx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_sp_64x64_lasx(pixel* a, intptr_t stridea, const int16_t* b, intptr_t strideb);
++void x265_blockcopy_ps_16x16_lasx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_16x32_lasx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_32x32_lasx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_32x64_lasx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++void x265_blockcopy_ps_64x64_lasx(int16_t* a, intptr_t stridea, const pixel* b, intptr_t strideb);
++uint32_t x265_copy_count_16_lasx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
++uint32_t x265_copy_count_32_lasx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
++
++#undef FUNCDEF_PU
++#undef FUNCDEF_CHROMA_PU
++
++#ifdef __cplusplus
++}
++#endif /*__cplusplus*/
++
++#endif //X265_LOONGARCH_BLOCKCOPY8_H
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/patches/0015-FROMLIST-LoongArch64-Optimize-functions-in-blockcopy.patch
+++ b/runtime-multimedia/x265/autobuild/patches/0015-FROMLIST-LoongArch64-Optimize-functions-in-blockcopy.patch
@@ -1,0 +1,709 @@
+From e6e00eb355382a1a39d36acf56973ae9330ff836 Mon Sep 17 00:00:00 2001
+From: yuanhecai <yuanhecai@loongson.cn>
+Date: Thu, 13 Jun 2024 11:12:16 +0800
+Subject: [PATCH 15/15] FROMLIST: LoongArch64: Optimize functions in
+ blockcopy8.S file - Patch 2
+
+The optimized functions are as follows:
+x265_cpy2Dto1D_shl*_lsx/_lasx
+x265_cpy2Dto1D_shr*_lsx/_lasx
+x265_cpy1Dto2D_shl*_lsx/_lasx
+x265_cpy1Dto2D_shr*_lsx/_lasx
+
+Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ source/common/loongarch64/asm-primitives.cpp |  36 +-
+ source/common/loongarch64/blockcopy8.S       | 580 +++++++++++++++++++
+ source/common/loongarch64/blockcopy8.h       |  28 +
+ 3 files changed, 643 insertions(+), 1 deletion(-)
+
+diff --git a/source/common/loongarch64/asm-primitives.cpp b/source/common/loongarch64/asm-primitives.cpp
+index 197e8df96..6f88d2bd5 100644
+--- a/source/common/loongarch64/asm-primitives.cpp
++++ b/source/common/loongarch64/asm-primitives.cpp
+@@ -1,5 +1,5 @@
+ /*****************************************************************************
+- * Copyright (C) 2013-2024 MulticoreWare, Inc
++ * Copyright (C) 2024 MulticoreWare, Inc
+  *
+  * Authors: Hao Chen <chenhao@loongson.cn>
+  *
+@@ -257,6 +257,11 @@ all_angs_pred_lsx(32, 10)
+     p.cu[BLOCK_ ## W ## x ## H].copy_ss     = PFX(blockcopy_ss_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].copy_sp     = PFX(blockcopy_sp_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].copy_ps     = PFX(blockcopy_ps_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].cpy2Dto1D_shl = PFX(cpy2Dto1D_shl_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].cpy2Dto1D_shr = PFX(cpy2Dto1D_shr_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].cpy1Dto2D_shl[NONALIGNED] = PFX(cpy1Dto2D_shl_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].cpy1Dto2D_shl[ALIGNED] = PFX(cpy1Dto2D_shl_ ## W ## x ## H ##_ ## CPU); \
++    p.cu[BLOCK_ ## W ## x ## H].cpy1Dto2D_shr = PFX(cpy1Dto2D_shr_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].transpose     = PFX(transpose_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].calcresidual[NONALIGNED] = PFX(pixel_getResidual_ ## W ## x ## H ##_ ## CPU); \
+     p.cu[BLOCK_ ## W ## x ## H].calcresidual[ALIGNED]    = PFX(pixel_getResidual_ ## W ## x ## H ##_ ## CPU);;
+@@ -1392,6 +1397,35 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+         //copy_cnt
+         p.cu[BLOCK_16x16].copy_cnt = PFX(copy_count_16_lasx);
+         p.cu[BLOCK_32x32].copy_cnt = PFX(copy_count_32_lasx);
++
++        // cpy2Dto1D_shl
++        p.cu[BLOCK_8x8].cpy2Dto1D_shl   = PFX(cpy2Dto1D_shl_8x8_lasx);
++        p.cu[BLOCK_16x16].cpy2Dto1D_shl = PFX(cpy2Dto1D_shl_16x16_lasx);
++        p.cu[BLOCK_32x32].cpy2Dto1D_shl = PFX(cpy2Dto1D_shl_32x32_lasx);
++        p.cu[BLOCK_64x64].cpy2Dto1D_shl = PFX(cpy2Dto1D_shl_64x64_lasx);
++
++        // cpy2Dto1D_shr
++        p.cu[BLOCK_8x8].cpy2Dto1D_shr   = PFX(cpy2Dto1D_shr_8x8_lasx);
++        p.cu[BLOCK_16x16].cpy2Dto1D_shr = PFX(cpy2Dto1D_shr_16x16_lasx);
++        p.cu[BLOCK_32x32].cpy2Dto1D_shr = PFX(cpy2Dto1D_shr_32x32_lasx);
++        p.cu[BLOCK_64x64].cpy2Dto1D_shr = PFX(cpy2Dto1D_shr_64x64_lasx);
++
++        // cpy1Dto2D_shl
++        p.cu[BLOCK_8x8].cpy1Dto2D_shl[NONALIGNED]   = PFX(cpy1Dto2D_shl_8x8_lasx);
++        p.cu[BLOCK_16x16].cpy1Dto2D_shl[NONALIGNED] = PFX(cpy1Dto2D_shl_16x16_lasx);
++        p.cu[BLOCK_32x32].cpy1Dto2D_shl[NONALIGNED] = PFX(cpy1Dto2D_shl_32x32_lasx);
++        p.cu[BLOCK_64x64].cpy1Dto2D_shl[NONALIGNED] = PFX(cpy1Dto2D_shl_64x64_lasx);
++
++        p.cu[BLOCK_8x8].cpy1Dto2D_shl[ALIGNED]   = PFX(cpy1Dto2D_shl_8x8_lasx);
++        p.cu[BLOCK_16x16].cpy1Dto2D_shl[ALIGNED] = PFX(cpy1Dto2D_shl_16x16_lasx);
++        p.cu[BLOCK_32x32].cpy1Dto2D_shl[ALIGNED] = PFX(cpy1Dto2D_shl_32x32_lasx);
++        p.cu[BLOCK_64x64].cpy1Dto2D_shl[ALIGNED] = PFX(cpy1Dto2D_shl_64x64_lasx);
++
++        // cpy1Dto2D_shr
++        p.cu[BLOCK_8x8].cpy1Dto2D_shr   = PFX(cpy1Dto2D_shr_8x8_lasx);
++        p.cu[BLOCK_16x16].cpy1Dto2D_shr = PFX(cpy1Dto2D_shr_16x16_lasx);
++        p.cu[BLOCK_32x32].cpy1Dto2D_shr = PFX(cpy1Dto2D_shr_32x32_lasx);
++        p.cu[BLOCK_64x64].cpy1Dto2D_shr = PFX(cpy1Dto2D_shr_64x64_lasx);
+     }
+ #endif /* HAVE_LASX */
+ }
+diff --git a/source/common/loongarch64/blockcopy8.S b/source/common/loongarch64/blockcopy8.S
+index 475590abe..42752a7c4 100644
+--- a/source/common/loongarch64/blockcopy8.S
++++ b/source/common/loongarch64/blockcopy8.S
+@@ -2047,3 +2047,583 @@ function x265_copy_count_32_lasx
+     bnez          t3,     1b
+     or            a0,     zero,   t2
+ endfunc
++
++function x265_cpy2Dto1D_shr_4x4_lsx
++    slli.d         a2,      a2,    1
++    fld.d          f0,      a1,    0
++    fldx.d         f1,      a1,    a2
++    vreplgr2vr.h   vr3,     a3
++    vilvl.d        vr2,     vr1,   vr0
++    vsrar.h        vr4,     vr2,   vr3
++    vst            vr4,     a0,    0
++
++    alsl.d         a1,      a2,    a1,   1
++
++    fld.d          f0,      a1,    0
++    fldx.d         f1,      a1,    a2
++    vreplgr2vr.h   vr3,     a3
++    vilvl.d        vr2,     vr1,   vr0
++    vsrar.h        vr4,     vr2,   vr3
++    vst            vr4,     a0,    16
++endfunc
++
++function x265_cpy2Dto1D_shr_8x8_lsx
++    slli.d         a2,      a2,    1
++.rept 4
++    vld            vr0,     a1,    0
++    vldx           vr1,     a1,    a2
++    vreplgr2vr.h   vr3,     a3
++    vsrar.h        vr4,     vr0,   vr3
++    vsrar.h        vr5,     vr1,   vr3
++    vst            vr4,     a0,    0
++    vst            vr5,     a0,    16
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    32
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_16x16_lsx
++    slli.d         a2,      a2,    1
++.rept 8
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    add.d          t1,      a1,    a2
++    vld            vr2,     t1,    0
++    vld            vr3,     t1,    16
++    vreplgr2vr.h   vr4,     a3
++    vsrar.h        vr5,     vr0,   vr4
++    vsrar.h        vr6,     vr1,   vr4
++    vsrar.h        vr7,     vr2,   vr4
++    vsrar.h        vr8,     vr3,   vr4
++    vst            vr5,     a0,    0
++    vst            vr6,     a0,    16
++    vst            vr7,     a0,    32
++    vst            vr8,     a0,    48
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    64
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_32x32_lsx
++    slli.d         a2,      a2,    1
++.rept 16
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr10,    a1,    32
++    vld            vr11,    a1,    48
++    add.d          t1,      a1,    a2
++    vld            vr2,     t1,    0
++    vld            vr3,     t1,    16
++    vld            vr12,    t1,    32
++    vld            vr13,    t1,    48
++    vreplgr2vr.h   vr4,     a3
++
++.irp i, vr0, vr1, vr10, vr11, vr2, vr3, vr12, vr13
++    vsrar.h        \i,      \i,   vr4
++.endr
++
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr10,    a0,    32
++    vst            vr11,    a0,    48
++    vst            vr2,     a0,    64
++    vst            vr3,     a0,    80
++    vst            vr12,    a0,    96
++    vst            vr13,    a0,    112
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_64x64_lsx
++    slli.d         a2,      a2,    1
++.rept 64
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr2,     a1,    32
++    vld            vr3,     a1,    48
++    vld            vr4,     a1,    64
++    vld            vr5,     a1,    80
++    vld            vr6,     a1,    96
++    vld            vr7,     a1,    112
++    vreplgr2vr.h   vr8,     a3
++
++.irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vsrar.h        \i,      \i,    vr8
++.endr
++
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr2,     a0,    32
++    vst            vr3,     a0,    48
++    vst            vr4,     a0,    64
++    vst            vr5,     a0,    80
++    vst            vr6,     a0,    96
++    vst            vr7,     a0,    112
++    add.d          a1,      a2,    a1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_8x8_lasx
++    slli.d         a2,      a2,    1
++.rept 4
++    vld            vr0,     a1,    0
++    vldx           vr1,     a1,    a2
++    xvpermi.q      xr1,     xr0,   0x20
++    xvreplgr2vr.h  xr3,     a3
++    xvsrar.h       xr4,     xr1,   xr3
++    xvst           xr4,     a0,    0
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    32
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_16x16_lasx
++    slli.d         a2,      a2,    1
++.rept 8
++    xvld           xr0,     a1,    0
++    xvldx          xr1,     a1,    a2
++    xvreplgr2vr.h  xr4,     a3
++    xvsrar.h       xr6,     xr0,   xr4
++    xvsrar.h       xr8,     xr1,   xr4
++    xvst           xr6,     a0,    0
++    xvst           xr8,     a0,    32
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    64
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_32x32_lasx
++    slli.d         a2,      a2,    1
++.rept 16
++    xvld           xr0,     a1,    0
++    xvldx          xr1,     a1,    a2
++    addi.d         t1,      a1,    32
++    xvld           xr2,     t1,    0
++    xvldx          xr3,     t1,    a2
++    xvreplgr2vr.h  xr4,     a3
++    xvsrar.h       xr6,     xr0,   xr4
++    xvsrar.h       xr7,     xr2,   xr4
++    xvsrar.h       xr8,     xr1,   xr4
++    xvsrar.h       xr9,     xr3,   xr4
++    xvst           xr6,     a0,    0
++    xvst           xr7,     a0,    32
++    xvst           xr8,     a0,    64
++    xvst           xr9,     a0,    96
++    alsl.d         a1,      a2,    a1,   1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy2Dto1D_shr_64x64_lasx
++    slli.d         a2,      a2,    1
++.rept 64
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsrar.h       xr6,     xr0,   xr4
++    xvsrar.h       xr7,     xr2,   xr4
++    xvsrar.h       xr8,     xr1,   xr4
++    xvsrar.h       xr9,     xr3,   xr4
++    xvst           xr6,     a0,    0
++    xvst           xr7,     a0,    32
++    xvst           xr8,     a0,    64
++    xvst           xr9,     a0,    96
++    add.d          a1,      a2,    a1
++    addi.d         a0,      a0,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_4x4_lsx
++    slli.d         a2,      a2,    1
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vreplgr2vr.h   vr3,     a3
++    vsll.h         vr4,     vr0,   vr3
++    vsll.h         vr5,     vr1,   vr3
++    vstelm.d       vr4,     a0,    0,    0
++    add.d          a0,      a0,    a2
++    vstelm.d       vr4,     a0,    0,    1
++    add.d          a0,      a0,    a2
++    vstelm.d       vr5,     a0,    0,    0
++    add.d          a0,      a0,    a2
++    vstelm.d       vr5,     a0,    0,    1
++endfunc
++
++function x265_cpy1Dto2D_shl_8x8_lsx
++    slli.d         a2,      a2,    1
++.rept 4
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vreplgr2vr.h   vr3,     a3
++    vsll.h         vr4,     vr0,   vr3
++    vsll.h         vr5,     vr1,   vr3
++    vst            vr4,     a0,    0
++    vstx           vr5,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    addi.d         a1,      a1,    32
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_16x16_lsx
++    slli.d         a2,      a2,    1
++.rept 8
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr2,     a1,    32
++    vld            vr3,     a1,    48
++    vreplgr2vr.h   vr4,     a3
++    vsll.h         vr5,     vr0,   vr4
++    vsll.h         vr6,     vr1,   vr4
++    vsll.h         vr7,     vr2,   vr4
++    vsll.h         vr8,     vr3,   vr4
++    vst            vr5,     a0,    0
++    vst            vr6,     a0,    16
++    add.d          a0,      a2,    a0
++    vst            vr7,     a0,    0
++    vst            vr8,     a0,    16
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    64
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_32x32_lsx
++    slli.d         a2,      a2,    1
++.rept 16
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr10,    a1,    32
++    vld            vr11,    a1,    48
++    vld            vr2,     a1,    64
++    vld            vr3,     a1,    80
++    vld            vr12,    a1,    96
++    vld            vr13,    a1,    112
++    vreplgr2vr.h   vr4,     a3
++.irp i, vr0, vr1, vr10, vr11, vr2, vr3, vr12, vr13
++    vsll.h         \i,      \i,   vr4
++.endr
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr10,    a0,    32
++    vst            vr11,    a0,    48
++    add.d          a0,      a0,    a2
++    vst            vr2,     a0,    0
++    vst            vr3,     a0,    16
++    vst            vr12,    a0,    32
++    vst            vr13,    a0,    48
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_64x64_lsx
++    slli.d         a2,      a2,    1
++.rept 64
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr2,     a1,    32
++    vld            vr3,     a1,    48
++    vld            vr4,     a1,    64
++    vld            vr5,     a1,    80
++    vld            vr6,     a1,    96
++    vld            vr7,     a1,    112
++    vreplgr2vr.h   vr8,     a3
++.irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vsll.h         \i,      \i,    vr8
++.endr
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr2,     a0,    32
++    vst            vr3,     a0,    48
++    vst            vr4,     a0,    64
++    vst            vr5,     a0,    80
++    vst            vr6,     a0,    96
++    vst            vr7,     a0,    112
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_8x8_lasx
++    slli.d         a2,      a2,    1
++
++.rept 2
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvreplgr2vr.h  xr3,     a3
++    xvsll.h        xr4,     xr0,   xr3
++    xvsll.h        xr5,     xr1,   xr3
++    vst            vr4,     a0,    0
++    xvpermi.q      xr6,     xr4,   0x01
++    vstx           vr6,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    vst            vr5,     a0,    0
++    xvpermi.q      xr6,     xr5,   0x01
++    vstx           vr6,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    addi.d         a1,      a1,    64
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_16x16_lasx
++    slli.d         a2,      a2,    1
++.rept 4
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsll.h        xr5,     xr0,   xr4
++    xvsll.h        xr6,     xr1,   xr4
++    xvsll.h        xr7,     xr2,   xr4
++    xvsll.h        xr8,     xr3,   xr4
++    xvst           xr5,     a0,    0
++    xvstx          xr6,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    xvst           xr7,     a0,    0
++    xvstx          xr8,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_32x32_lasx
++    slli.d         a2,      a2,    1
++.rept 16
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsll.h        xr5,     xr0,   xr4
++    xvsll.h        xr6,     xr1,   xr4
++    xvsll.h        xr7,     xr2,   xr4
++    xvsll.h        xr8,     xr3,   xr4
++    xvst           xr5,     a0,    0
++    xvst           xr6,     a0,    32
++    add.d          a0,      a2,    a0
++    xvst           xr7,     a0,    0
++    xvst           xr8,     a0,    32
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shl_64x64_lasx
++    slli.d         a2,      a2,    1
++.rept 64
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsll.h        xr5,     xr0,   xr4
++    xvsll.h        xr6,     xr1,   xr4
++    xvsll.h        xr7,     xr2,   xr4
++    xvsll.h        xr8,     xr3,   xr4
++    xvst           xr5,     a0,    0
++    xvst           xr6,     a0,    32
++    xvst           xr7,     a0,    64
++    xvst           xr8,     a0,    96
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_4x4_lsx
++    slli.d         a2,      a2,    1
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vreplgr2vr.h   vr3,     a3
++    vsrar.h        vr4,     vr0,   vr3
++    vsrar.h        vr5,     vr1,   vr3
++    vstelm.d       vr4,     a0,    0,    0
++    add.d          a0,      a0,    a2
++    vstelm.d       vr4,     a0,    0,    1
++    add.d          a0,      a0,    a2
++    vstelm.d       vr5,     a0,    0,    0
++    add.d          a0,      a0,    a2
++    vstelm.d       vr5,     a0,    0,    1
++endfunc
++
++function x265_cpy1Dto2D_shr_8x8_lsx
++    slli.d         a2,      a2,    1
++.rept 4
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vreplgr2vr.h   vr3,     a3
++    vsrar.h        vr4,     vr0,   vr3
++    vsrar.h        vr5,     vr1,   vr3
++    vst            vr4,     a0,    0
++    vstx           vr5,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    addi.d         a1,      a1,    32
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_16x16_lsx
++    slli.d         a2,      a2,    1
++.rept 8
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr2,     a1,    32
++    vld            vr3,     a1,    48
++    vreplgr2vr.h   vr4,     a3
++    vsrar.h        vr5,     vr0,   vr4
++    vsrar.h        vr6,     vr1,   vr4
++    vsrar.h        vr7,     vr2,   vr4
++    vsrar.h        vr8,     vr3,   vr4
++    vst            vr5,     a0,    0
++    vst            vr6,     a0,    16
++    add.d          a0,      a2,    a0
++    vst            vr7,     a0,    0
++    vst            vr8,     a0,    16
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    64
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_32x32_lsx
++    slli.d         a2,      a2,    1
++.rept 16
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr10,    a1,    32
++    vld            vr11,    a1,    48
++    vld            vr2,     a1,    64
++    vld            vr3,     a1,    80
++    vld            vr12,    a1,    96
++    vld            vr13,    a1,    112
++    vreplgr2vr.h   vr4,     a3
++.irp i, vr0, vr1, vr10, vr11, vr2, vr3, vr12, vr13
++    vsrar.h        \i,      \i,   vr4
++.endr
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr10,    a0,    32
++    vst            vr11,    a0,    48
++    add.d          a0,      a0,    a2
++    vst            vr2,     a0,    0
++    vst            vr3,     a0,    16
++    vst            vr12,    a0,    32
++    vst            vr13,    a0,    48
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_64x64_lsx
++    slli.d         a2,      a2,    1
++.rept 64
++    vld            vr0,     a1,    0
++    vld            vr1,     a1,    16
++    vld            vr2,     a1,    32
++    vld            vr3,     a1,    48
++    vld            vr4,     a1,    64
++    vld            vr5,     a1,    80
++    vld            vr6,     a1,    96
++    vld            vr7,     a1,    112
++    vreplgr2vr.h   vr8,     a3
++.irp i, vr0, vr1, vr2, vr3, vr4, vr5, vr6, vr7
++    vsrar.h        \i,      \i,    vr8
++.endr
++    vst            vr0,     a0,    0
++    vst            vr1,     a0,    16
++    vst            vr2,     a0,    32
++    vst            vr3,     a0,    48
++    vst            vr4,     a0,    64
++    vst            vr5,     a0,    80
++    vst            vr6,     a0,    96
++    vst            vr7,     a0,    112
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_8x8_lasx
++    slli.d         a2,      a2,    1
++.rept 2
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvreplgr2vr.h  xr3,     a3
++    xvsrar.h       xr4,     xr0,   xr3
++    xvsrar.h       xr5,     xr1,   xr3
++    xvpermi.q      xr6,     xr4,   0x01
++    xvpermi.q      xr7,     xr5,   0x01
++    vst            vr4,     a0,    0
++    vstx           vr6,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    vst            vr5,     a0,    0
++    vstx           vr7,     a0,    a2
++    addi.d         a1,      a1,    64
++    alsl.d         a0,      a2,    a0,   1
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_16x16_lasx
++    slli.d         a2,      a2,    1
++.rept 4
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsrar.h       xr5,     xr0,   xr4
++    xvsrar.h       xr6,     xr1,   xr4
++    xvsrar.h       xr7,     xr2,   xr4
++    xvsrar.h       xr8,     xr3,   xr4
++    xvst           xr5,     a0,    0
++    xvstx          xr6,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    xvst           xr7,     a0,    0
++    xvstx          xr8,     a0,    a2
++    alsl.d         a0,      a2,    a0,   1
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_32x32_lasx
++    slli.d         a2,      a2,    1
++.rept 16
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsrar.h       xr5,     xr0,   xr4
++    xvsrar.h       xr6,     xr1,   xr4
++    xvsrar.h       xr7,     xr2,   xr4
++    xvsrar.h       xr8,     xr3,   xr4
++    xvst           xr5,     a0,    0
++    xvst           xr6,     a0,    32
++    add.d          a0,      a2,    a0
++    xvst           xr7,     a0,    0
++    xvst           xr8,     a0,    32
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
++
++function x265_cpy1Dto2D_shr_64x64_lasx
++    slli.d         a2,      a2,    1
++.rept 64
++    xvld           xr0,     a1,    0
++    xvld           xr1,     a1,    32
++    xvld           xr2,     a1,    64
++    xvld           xr3,     a1,    96
++    xvreplgr2vr.h  xr4,     a3
++    xvsrar.h       xr5,     xr0,   xr4
++    xvsrar.h       xr6,     xr1,   xr4
++    xvsrar.h       xr7,     xr2,   xr4
++    xvsrar.h       xr8,     xr3,   xr4
++    xvst           xr5,     a0,    0
++    xvst           xr6,     a0,    32
++    xvst           xr7,     a0,    64
++    xvst           xr8,     a0,    96
++    add.d          a0,      a2,    a0
++    addi.d         a1,      a1,    128
++.endr
++endfunc
+diff --git a/source/common/loongarch64/blockcopy8.h b/source/common/loongarch64/blockcopy8.h
+index f1583189f..c3ce832b5 100644
+--- a/source/common/loongarch64/blockcopy8.h
++++ b/source/common/loongarch64/blockcopy8.h
+@@ -168,6 +168,34 @@ void x265_blockcopy_ps_64x64_lasx(int16_t* a, intptr_t stridea, const pixel* b,
+ uint32_t x265_copy_count_16_lasx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
+ uint32_t x265_copy_count_32_lasx(int16_t* coeff, const int16_t* residual, intptr_t resiStride);
+ 
++FUNCDEF_TU(void, cpy2Dto1D_shl, lsx, int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++
++void x265_cpy2Dto1D_shl_8x8_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++void x265_cpy2Dto1D_shl_16x16_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++void x265_cpy2Dto1D_shl_32x32_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++void x265_cpy2Dto1D_shl_64x64_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++
++FUNCDEF_TU(void, cpy2Dto1D_shr, lsx, int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++
++void x265_cpy2Dto1D_shr_8x8_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++void x265_cpy2Dto1D_shr_16x16_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++void x265_cpy2Dto1D_shr_32x32_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++void x265_cpy2Dto1D_shr_64x64_lasx(int16_t *dst, const int16_t *src, intptr_t srcStride, int shift);
++
++FUNCDEF_TU(void, cpy1Dto2D_shl, lsx, int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++
++void x265_cpy1Dto2D_shl_8x8_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++void x265_cpy1Dto2D_shl_16x16_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++void x265_cpy1Dto2D_shl_32x32_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++void x265_cpy1Dto2D_shl_64x64_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++
++FUNCDEF_TU(void, cpy1Dto2D_shr, lsx, int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++
++void x265_cpy1Dto2D_shr_8x8_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++void x265_cpy1Dto2D_shr_16x16_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++void x265_cpy1Dto2D_shr_32x32_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++void x265_cpy1Dto2D_shr_64x64_lasx(int16_t *dst, const int16_t *src, intptr_t dstStride, int shift);
++
+ #undef FUNCDEF_PU
+ #undef FUNCDEF_CHROMA_PU
+ 
+-- 
+2.52.0
+

--- a/runtime-multimedia/x265/autobuild/prepare
+++ b/runtime-multimedia/x265/autobuild/prepare
@@ -1,7 +1,0 @@
-# On mipsel GCC will refuse to link without -fPIC. Weird.
-if [[ "${ARCH}" == "mipsel" ]]; then
-    CXXFLAGS+=" -fPIC"
-fi
-
-# x265 does not use any other variables.
-export CXXFLAGS="${CXXFLAGS} ${CPPFLAGS} ${LDFLAGS}"

--- a/runtime-multimedia/x265/spec
+++ b/runtime-multimedia/x265/spec
@@ -1,4 +1,5 @@
 VER=3.6
+REL=1
 SRCS="git::commit=tags/$VER::https://bitbucket.org/multicoreware/x265_git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7275"


### PR DESCRIPTION
Topic Description
-----------------

- x265: backport LoongArch SIMD optimisation patches
    Track patches at AOSC-Tracking/x265_git @ aosc/3.6
    \(HEAD: e6e00eb355382a1a39d36acf56973ae9330ff836\).
    Link: https://bitbucket.org/multicoreware/x265_git/pull-requests/31
- x265: \(Arch Linux patch\) fix build with GCC 15
    Build all bit-depths for all architectures, why not?

Package(s) Affected
-------------------

- x265: 3.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit x265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
