### PR TITLE
hashcat: add support for LoongArch, PowerPC and MIPS

### DIFF
--- a/app-penetration/hashcat/autobuild/defines
+++ b/app-penetration/hashcat/autobuild/defines
@@ -1,10 +1,7 @@
 PKGNAME=hashcat
 PKGSEC=utils
-PKGDEP="libcl minizip opencl-registry-api xxhash zlib"
+PKGDEP="libcl minizip opencl-registry-api xxhash zlib python-3"
 BUILDDEP="llvm opencl-registry-api rustc"
 PKGDES="Multithreaded password recovery utility"
 
 ABTYPE=self
-
-# FIXME: hashcat only supports x86, ARM, and RISC-V.
-FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-penetration/hashcat/autobuild/patches/0003-AOSCOS-Add-support-for-LoongArch-PowerPC-and-MIPS.patch
+++ b/app-penetration/hashcat/autobuild/patches/0003-AOSCOS-Add-support-for-LoongArch-PowerPC-and-MIPS.patch
@@ -1,0 +1,72 @@
+From 2c036ce7953a3a011eb75c12d0e6932de9dbdf59 Mon Sep 17 00:00:00 2001
+From: Suyun114 <suyun@aosc.io>
+Date: Wed, 4 Feb 2026 16:01:08 +0800
+Subject: [PATCH] AOSCOS: add support for LoongArch, PowerPC and MIPS
+
+---
+ src/bridges/bridge_argon2id_reference.c |  6 +++---
+ src/cpu_features.c                      | 22 ++++++++++++----------
+ 2 files changed, 15 insertions(+), 13 deletions(-)
+
+diff --git a/src/bridges/bridge_argon2id_reference.c b/src/bridges/bridge_argon2id_reference.c
+index 88d9df3da..27eb64341 100644
+--- a/src/bridges/bridge_argon2id_reference.c
++++ b/src/bridges/bridge_argon2id_reference.c
+@@ -18,10 +18,10 @@
+ #include "core.c"
+ #include "blake2/blake2b.c"
+ 
+-#if defined(__riscv)
+-#include "ref.c"
+-#else
++#if defined (__x86_64__) || defined (_M_X64) || defined (__i386__) || defined (_M_IX86) || defined (__aarch64__) || defined (__arm64__)
+ #include "opt.c"
++#else
++#include "ref.c"
+ #endif
+ 
+ // good: we can use this multiplier do reduce copy overhead to increase the guessing speed,
+diff --git a/src/cpu_features.c b/src/cpu_features.c
+index 46547aec1..09a80262a 100644
+--- a/src/cpu_features.c
++++ b/src/cpu_features.c
+@@ -16,17 +16,8 @@ int cpu_supports_avx2 ()     { return 0; }
+ int cpu_supports_avx512f ()  { return 0; }
+ int cpu_supports_avx512vl () { return 0; }
+ 
+-#elif defined(__riscv)
++#elif defined (__x86_64__) || defined (_M_X64) || defined (__i386__) || defined (_M_IX86)
+ 
+-// TODO: Support RVV
+-int cpu_supports_sse2 ()     { return 0; }
+-int cpu_supports_ssse3 ()    { return 0; }
+-int cpu_supports_xop ()      { return 0; }
+-int cpu_supports_avx2 ()     { return 0; }
+-int cpu_supports_avx512f ()  { return 0; }
+-int cpu_supports_avx512vl () { return 0; }
+-
+-#else
+ static inline void cpuid (u32 leaf, u32 subleaf, u32 *eax, u32 *ebx, u32 *ecx, u32 *edx)
+ {
+   __cpuid_count (leaf, subleaf, *eax, *ebx, *ecx, *edx);
+@@ -140,6 +131,17 @@ int cpu_supports_avx512vl ()
+ 
+   return (ebx & (1u << 31)) != 0;
+ }
++
++#else
++
++// TODO: Support SIMD acceleration on other architectures
++int cpu_supports_sse2 ()     { return 0; }
++int cpu_supports_ssse3 ()    { return 0; }
++int cpu_supports_xop ()      { return 0; }
++int cpu_supports_avx2 ()     { return 0; }
++int cpu_supports_avx512f ()  { return 0; }
++int cpu_supports_avx512vl () { return 0; }
++
+ #endif
+ 
+ int cpu_chipset_test ()
+-- 
+2.50.1 (Apple Git-155)
+

--- a/app-penetration/hashcat/spec
+++ b/app-penetration/hashcat/spec
@@ -1,4 +1,5 @@
 VER=7.1.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/hashcat/hashcat.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14448"


### PR DESCRIPTION
Topic Description
-----------------

- hashcat: add support for LoongArch, PowerPC and MIPS

Package(s) Affected
-------------------

- hashcat: 7.1.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hashcat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
