### PR TITLE
Haskell Survey 20250204

### DIFF
--- a/app-doc/pandoc/autobuild/build
+++ b/app-doc/pandoc/autobuild/build
@@ -1,9 +1,10 @@
 abinfo "Building pandoc ..."
 cabal update
-cabal v2-build pandoc-cli -j -v
+cabal v2-build pandoc-cli -j -v --allow-newer
 
 abinfo "Installing pandoc ..."
 cabal v2-install pandoc-cli \
 	-j -v \
+	--allow-newer \
 	--install-method=copy \
 	--installdir="$PKGDIR"/usr/bin

--- a/app-doc/pandoc/autobuild/defines
+++ b/app-doc/pandoc/autobuild/defines
@@ -4,5 +4,5 @@ PKGDES="Universal markup converter"
 PKGDEP="cmark texlive"
 BUILDDEP="cabal-install ghc zlib-static numactl libffi"
 
-# FIXME: ghc is only available on these archs
-FAIL_ARCH="!(amd64|arm64)"
+# Note: Sync with GHC.
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"

--- a/app-doc/pandoc/spec
+++ b/app-doc/pandoc/spec
@@ -1,4 +1,4 @@
-VER=3.6.3
+VER=3.9.0.2
 SRCS="git::commit=tags/$VER::https://github.com/jgm/pandoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2589"

--- a/lang-haskell/cabal-install/autobuild/build
+++ b/lang-haskell/cabal-install/autobuild/build
@@ -2,12 +2,14 @@ abinfo "Building Cabal using existing Cabal ..."
 cabal update
 cabal v2-build -j \
 	--prefix=/usr \
-	--project-file=cabal.project.release \
+	--project-file=cabal.release.project \
+	--allow-newer \
 	cabal-install
 
 abinfo "Installing Cabal ..."
 cabal v2-install -j \
 	--install-method=copy \
 	--installdir="$PKGDIR"/usr/bin \
-	--project-file=cabal.project.release \
+	--project-file=cabal.release.project \
+	--allow-newer \
 	cabal-install

--- a/lang-haskell/cabal-install/autobuild/build.stage2
+++ b/lang-haskell/cabal-install/autobuild/build.stage2
@@ -1,19 +1,18 @@
-abinfo "Detecting GHC compiler ..."
-GHC_VER="$(ghc --version | perl -ne '/(\d+\.\d+\.\d+)/ && print "$1"')"
-if [[ -z "${GHC_VER}" ]]; then
-  abdie "Unable to understand the GHC version output!"
-fi
-abinfo "Detected GHC version ${GHC_VER}"
+CABAL="qemu-x86_64-static ""$SRCDIR""/../cabal-3.16.1.0"
+chmod +x "$SRCDIR"/../cabal-3.16.1.0
 
-if ! test -e "$SRCDIR"/bootstrap/"linux-${GHC_VER}".json; then
-  SUPPORTED="$(find bootstrap -name 'linux-*.json' | perl -ne '/linux-(\d+\.\d+\.\d+)\.json/ && print "- $1\n"')"
-  abdie "GHC version ${GHC_VER} can't be used to bootstrap Cabal version ${PKGVER}\nAllowed GHC versions are:\n${SUPPORTED}"
-fi
-
-abinfo "Executing bootstrapping process for Cabal ..."
-"$SRCDIR"/bootstrap/bootstrap.py \
-	-d "$SRCDIR"/bootstrap/linux-${GHC_VER}.json \
-	-w /usr/bin/ghc
+abinfo "Building Cabal using prebuilt Cabal ..."
+$CABAL update
+$CABAL v2-build -j \
+	--prefix=/usr \
+	--project-file=cabal.release.project \
+	--allow-newer \
+	cabal-install
 
 abinfo "Installing Cabal ..."
-install -Dvm755 "$SRCDIR"/_build/bin/cabal "$PKGDIR"/usr/bin/cabal
+$CABAL v2-install -j \
+	--install-method=copy \
+	--installdir="$PKGDIR"/usr/bin \
+	--project-file=cabal.release.project \
+	--allow-newer \
+	cabal-install

--- a/lang-haskell/cabal-install/autobuild/defines
+++ b/lang-haskell/cabal-install/autobuild/defines
@@ -3,10 +3,11 @@ PKGSEC=haskell
 PKGDEP="gmp libffi"
 BUILDDEP="ghc cabal-install"
 BUILDDEP__ARM64="${BUILDDEP} llvm"
-PKGDES="A user interface to the Cabal/Hackage automation and package management system"
+PKGDES="User interface to the Cabal/Hackage automation and package management system"
 
 NOLTO=1
 AB_FLAGS_SPECS=0
 ABSPLITDBG=0
 
-PKGEPOCH=1
+# Note: Sync with GHC.
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"

--- a/lang-haskell/cabal-install/autobuild/defines.stage2
+++ b/lang-haskell/cabal-install/autobuild/defines.stage2
@@ -1,7 +1,7 @@
 PKGNAME=cabal-install
 PKGSEC=haskell
 PKGDEP="gmp libffi"
-BUILDDEP="ghc"
+BUILDDEP="ghc qemu-x86-64-static"
 BUILDDEP__ARM64="${BUILDDEP} llvm"
 PKGDES="A user interface to the Cabal/Hackage automation and package management system"
 

--- a/lang-haskell/cabal-install/autobuild/prepare
+++ b/lang-haskell/cabal-install/autobuild/prepare
@@ -1,2 +1,0 @@
-export CFLAGS="${CFLAGS} -fPIC"
-export CXXFLAGS="${CXXFLAGS} -fPIC"

--- a/lang-haskell/cabal-install/spec
+++ b/lang-haskell/cabal-install/spec
@@ -1,4 +1,7 @@
-VER=3.10.3.0
-SRCS="git::commit=tags/cabal-install-v$VER::https://github.com/haskell/cabal"
-CHKSUMS="SKIP"
+VER=3.16.1.0
+EPOCH=1
+SRCS="git::commit=tags/cabal-install-v$VER::https://github.com/haskell/cabal \
+      file::use-url-name=true::https://repo.aosc.io/aosc-repacks/cabal-3.16.1.0"
+CHKSUMS="SKIP \
+         sha256::48d80f720ccc1ef6306c5a8092ed380df58e73c4b01e9b574af73b3142c20dba"
 CHKUPDATE="anitya::id=243"

--- a/lang-haskell/ghc/autobuild/build
+++ b/lang-haskell/ghc/autobuild/build
@@ -1,8 +1,7 @@
 abinfo "Configuring ghc ..."
 export PYTHON=/usr/bin/python3
 "$SRCDIR"/configure --prefix=/usr \
-            --with-system-libffi \
-            --disable-numa
+            --with-system-libffi
 
 abinfo "Building ghc using hadrian ..."
 cabal update

--- a/lang-haskell/ghc/autobuild/build.stage2
+++ b/lang-haskell/ghc/autobuild/build.stage2
@@ -1,8 +1,14 @@
-BOOTSTRAP_VER=9.4.8
+BOOTSTRAP_VER=9.14.1
 if ab_match_arch amd64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-x86_64-unknown-linux
 elif ab_match_arch arm64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-aarch64-unknown-linux
+elif ab_match_arch loongarch64; then
+	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-loongarch64-unknown-linux
+elif ab_match_arch ppc64el; then
+	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-powerpc64le-unknown-linux
+elif ab_match_arch riscv64; then
+	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-riscv64-unknown-linux
 fi
 
 abinfo "Configuring prebuilt ghc ..."

--- a/lang-haskell/ghc/autobuild/build.stage2
+++ b/lang-haskell/ghc/autobuild/build.stage2
@@ -3,7 +3,7 @@ if ab_match_arch amd64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-x86_64-unknown-linux
 elif ab_match_arch arm64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-aarch64-unknown-linux
-elif ab_match_arch loongarch64; then
+elif ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-loongarch64-unknown-linux
 elif ab_match_arch ppc64el; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-powerpc64le-unknown-linux

--- a/lang-haskell/ghc/autobuild/defines
+++ b/lang-haskell/ghc/autobuild/defines
@@ -11,8 +11,8 @@ AB_FLAGS_SPECS=0
 NOLTO=1
 ABSPLITDBG=0
 
-# Requires prebuilt tarballs from upstream
-FAIL_ARCH="!(amd64|arm64)"
+# Requires prebuilt tarballs
+FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"
 
 # Issue #463.
 # https://github.com/AOSC-Dev/aosc-os-abbs/issues/463
@@ -42,5 +42,3 @@ PKGBREAK="data-default-class<=0.0.1-1 data-default-instances-containers<=0.0.1-1
           haskell-x11<=1.6.1.2-1 haskell-x11-xft<=0.3.1-1 haskell-zlib<=0.6.1.1 \
           hscolour<=1.23-1 hunit<=1.3.0.0 xmonad<=0.12 xmonad-contrib<=0.12 \
           cabal-install<=2.4.1.0-1 hugs<=2006.09-1"
-
-PKGEPOCH=1

--- a/lang-haskell/ghc/autobuild/defines
+++ b/lang-haskell/ghc/autobuild/defines
@@ -12,7 +12,7 @@ NOLTO=1
 ABSPLITDBG=0
 
 # Requires prebuilt tarballs
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
 
 # Issue #463.
 # https://github.com/AOSC-Dev/aosc-os-abbs/issues/463

--- a/lang-haskell/ghc/autobuild/defines.stage2
+++ b/lang-haskell/ghc/autobuild/defines.stage2
@@ -11,8 +11,8 @@ AB_FLAGS_SPECS=0
 NOLTO=1
 ABSPLITDBG=0
 
-# Requires prebuilt tarballs from upstream
-FAIL_ARCH="!(amd64|arm64)"
+# Requires prebuilt tarballs
+FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"
 
 # Issue #463.
 # https://github.com/AOSC-Dev/aosc-os-abbs/issues/463
@@ -42,5 +42,3 @@ PKGBREAK="data-default-class<=0.0.1-1 data-default-instances-containers<=0.0.1-1
           haskell-x11<=1.6.1.2-1 haskell-x11-xft<=0.3.1-1 haskell-zlib<=0.6.1.1 \
           hscolour<=1.23-1 hunit<=1.3.0.0 xmonad<=0.12 xmonad-contrib<=0.12 \
           cabal-install<=2.4.1.0-1 hugs<=2006.09-1"
-
-PKGEPOCH=1

--- a/lang-haskell/ghc/autobuild/defines.stage2
+++ b/lang-haskell/ghc/autobuild/defines.stage2
@@ -12,7 +12,7 @@ NOLTO=1
 ABSPLITDBG=0
 
 # Requires prebuilt tarballs
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
 
 # Issue #463.
 # https://github.com/AOSC-Dev/aosc-os-abbs/issues/463

--- a/lang-haskell/ghc/autobuild/patches/0001-loongarch64-ncg.patch
+++ b/lang-haskell/ghc/autobuild/patches/0001-loongarch64-ncg.patch
@@ -1,0 +1,58 @@
+diff --git a/compiler/GHC/CmmToAsm/LA64/CodeGen.hs b/compiler/GHC/CmmToAsm/LA64/CodeGen.hs
+index a27b03b4e3..460a14dbfe 100644
+--- a/compiler/GHC/CmmToAsm/LA64/CodeGen.hs
++++ b/compiler/GHC/CmmToAsm/LA64/CodeGen.hs
+@@ -513,10 +513,19 @@ getRegister' config plat expr =
+               format = cmmTypeFormat rep
+               width = typeWidth rep
+           (off_r, _off_format, off_code) <- getSomeReg $ CmmLit (CmmInt (fromIntegral off) width)
+-          return (Any format (\dst -> off_code `snocOL`
+-                                                LD format (OpReg (formatToWidth format) dst) op `snocOL`
+-                                                ADD (OpReg W64 dst) (OpReg width dst) (OpReg width off_r)
+-                             ))
++          case width of
++            width | width `elem` [W8, W16] ->
++              return (Any format (\dst -> off_code `appOL`
++                signExtend width W64 dst dst `appOL`
++                signExtend width W64 off_r off_r `snocOL`
++                LD format (OpReg (formatToWidth format) dst) op `snocOL`
++                ADD (OpReg W64 dst) (OpReg W64 dst) (OpReg W64 off_r)
++                ))
++            _ ->
++              return (Any format (\dst -> off_code `snocOL`
++                LD format (OpReg (formatToWidth format) dst) op `snocOL`
++                ADD (OpReg W64 dst) (OpReg width dst) (OpReg width off_r)
++                ))
+ 
+         CmmLabelDiffOff {} -> pprPanic "getRegister' (CmmLit:CmmLabelOff): " (pdoc plat expr)
+         CmmBlock _ -> pprPanic "getRegister' (CmmLit:CmmLabelOff): " (pdoc plat expr)
+@@ -548,13 +557,22 @@ getRegister' config plat expr =
+       where
+         width = typeWidth (cmmRegType reg)
+     CmmRegOff reg off -> do
+-      (off_r, _off_format, off_code) <- getSomeReg $ CmmLit (CmmInt (fromIntegral off) width)
+-      (reg, _format, code) <- getSomeReg $ CmmReg reg
+-      return $ Any (intFormat width) ( \dst ->
+-                                        off_code `appOL`
+-                                        code `snocOL`
+-                                        ADD (OpReg W64 dst) (OpReg width reg) (OpReg width off_r)
+-                                     )
++      (off_r, off_format, off_code) <- getSomeReg $ CmmLit (CmmInt (fromIntegral off) width)
++      (reg, format, code) <- getSomeReg $ CmmReg reg
++      case width of
++        width | width `elem` [W8, W16] ->
++          return (Any (intFormat width) (\dst -> off_code `appOL`
++            code `appOL`
++            signExtend (formatToWidth format) W64 reg reg `appOL`
++            signExtend (formatToWidth off_format) W64 off_r off_r `snocOL`
++            ADD (OpReg W64 dst) (OpReg W64 reg) (OpReg W64 off_r)
++            ))
++        _ ->
++          return $ Any (intFormat width) ( \dst ->
++            off_code `appOL`
++            code `snocOL`
++            ADD (OpReg W64 dst) (OpReg width reg) (OpReg width off_r)
++            )
+       where
+         width = typeWidth (cmmRegType reg)
+ 

--- a/lang-haskell/ghc/autobuild/prepare
+++ b/lang-haskell/ghc/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Relaxing dependency requirements to allow bootstrapping with newer GHC toolchains ..."
+echo "allow-newer: all" >> "$SRCDIR"/hadrian/cabal.project.local

--- a/lang-haskell/ghc/spec
+++ b/lang-haskell/ghc/spec
@@ -1,11 +1,17 @@
-VER=9.4.8
-BOOTSTRAP_VER=9.4.8
+VER=9.14.1
+BOOTSTRAP_VER=9.14.1
+EPOCH=1
 SRCS="tbl::https://www.haskell.org/ghc/dist/$VER/ghc-${VER}-src.tar.xz \
-	tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-x86_64-deb10-linux.tar.xz \
-	tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-aarch64-deb10-linux.tar.xz"
-CHKSUMS="sha256::0bf407eb67fe3e3c24b0f4c8dea8cb63e07f63ca0f76cf2058565143507ab85e \
-         sha256::fc77eaae5b89f29177bf159fd95ce438066ec64a46bf69df61b267102afdb10e \
-         sha256::278e287e1ee624712b9c6d7803d1cf915ca1cce56e013b0a16215eb8dfeb1531"
+      tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-x86_64-deb10-linux.tar.xz \
+      tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-aarch64-deb12-linux.tar.xz \
+      tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-loongarch64-unknown-linux-20260404.tar.xz \
+      tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-powerpc64le-unknown-linux-20260404.tar.xz \
+      tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-riscv64-unknown-linux-20260405.tar.xz"
+CHKSUMS="sha256::2a83779c9af86554a3289f2787a38d6aa83d00d136aa9f920361dd693c101e77 \
+         sha256::c812cbadc685eba6e92778f9de1ebd0f1ea513cdea42db2d487fbd17e88ca3d1 \
+         sha256::6aa27a377451851c851eefdd869e8f5a9217b02ce66c6ca9b418b72efee28427 \
+         sha256::9f9be922a7a8578ba1024fb51508b1a11d9af592fe413bd379790b4105b7824a \
+         sha256::4be80e33253a6eae510aee3195e1366b82bc9349d8c5d432f8cc4e58760d9f93 \
+         sha256::dee715348d70e2c6899696f49b518ea3ba0a8971af25c11795c8216df92f71cd"
 SUBDIR=ghc-${VER}
 CHKUPDATE="anitya::id=906"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ghc: update to 9.14.1
- cabal-install: update to 3.16.1.0
- pandoc: update to 3.9

Package(s) Affected
-------------------

- cabal-install: 1:3.10.3.0
- ghc: 1:9.14.1
- pandoc: 3.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghc:+stage2 cabal-install:+stage2 ghc cabal-install pandoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
