### PR TITLE
llvm-20, llvm-21: fix handling of the musttail attribute for mips

### DIFF
--- a/app-devel/llvm-20/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,7 +1,7 @@
-From f02f326aae606d7c6953abeb3921b27787afb5e3 Mon Sep 17 00:00:00 2001
+From 0a0beb6dc848ec783400c4b4f3e72463caa2fe7b Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:48:08 -0800
-Subject: [PATCH 1/9] Fix fuzzer objects building when LTO is enabled
+Subject: [PATCH 01/11] Fix fuzzer objects building when LTO is enabled
 
 ---
  compiler-rt/lib/fuzzer/CMakeLists.txt | 2 +-
@@ -20,8 +20,6 @@ index 6db24610df1f..201b880cfbb1 100644
        COMMAND ${CMAKE_OBJCOPY} --localize-hidden ${name}.o
        COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>"
        COMMAND ${CMAKE_AR} qcs "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" ${name}.o
-
-base-commit: ec28b8f9cc7f2ac187d8a617a6d08d5e56f9120e
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0002-Fix-MSVC-detection.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0002-Fix-MSVC-detection.patch
@@ -1,7 +1,7 @@
-From 6fca9ab942e05353b8a7e90070cf64ca70b78887 Mon Sep 17 00:00:00 2001
+From 16cd88dd740783bb09014b2004f59498bc6564e2 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:47 -0800
-Subject: [PATCH 2/9] Fix MSVC detection
+Subject: [PATCH 02/11] Fix MSVC detection
 
 ---
  llvm/cmake/modules/CheckProblematicConfigurations.cmake | 2 +-
@@ -21,5 +21,5 @@ index e133873d756c..71484172cfb6 100644
    if(_FLAGS MATCHES "/arch:avx[0-9]*")
      log_problematic("Compiling LLVM with MSVC and the /arch:AVX flag is known to cause issues with parts of LLVM.\nSee https://github.com/llvm/llvm-project/issues/54645 for details.\nUse clang-cl if you want to enable AVX instructions.")
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0003-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0003-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,7 +1,7 @@
-From 90c529dc0a409e16c4ac499750d3ba311bd679bf Mon Sep 17 00:00:00 2001
+From f594949bc150ac5b56d032ca1b6309a415401445 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:26 -0800
-Subject: [PATCH 3/9] Add stub for mips64 LLDB impl
+Subject: [PATCH 03/11] Add stub for mips64 LLDB impl
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h     | 7 ++++++-
@@ -26,5 +26,5 @@ index 08f19d374e28..a042dd3dd677 100644
    // Determine the architecture of the thread given by its ID.
    static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0004-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0004-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,7 +1,7 @@
-From 6545c2ada3a67d74fa7dd0e391c09d840595e700 Mon Sep 17 00:00:00 2001
+From 5b2435571fda26de60d6b1ecfeb0f51a7a675499 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:52:51 -0800
-Subject: [PATCH 4/9] Add stub for lldb arch functions on loongson3
+Subject: [PATCH 04/11] Add stub for lldb arch functions on loongson3
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h    | 8 ++++++++
@@ -28,5 +28,5 @@ index a042dd3dd677..ee4901aa7cd3 100644
    // Invalidates cached values in register context data structures
    virtual void InvalidateAllRegisters(){}
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0005-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0005-HACK-force-enable-cacheflush-function.patch
@@ -1,7 +1,7 @@
-From ca57b2ca20ddd41b9a2e06a179222dcbaaba261b Mon Sep 17 00:00:00 2001
+From 225c51dd0426ae0f45eb41d978fcea0c7d29b4d5 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:53:18 -0800
-Subject: [PATCH 5/9] HACK: force enable cacheflush function
+Subject: [PATCH 05/11] HACK: force enable cacheflush function
 
 ---
  compiler-rt/lib/builtins/clear_cache.c | 1 +
@@ -20,5 +20,5 @@ index 2ac99b25c243..f055d3fcee4d 100644
  #include <sys/syscall.h>
  #include <unistd.h>
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0006-Fix-build-of-LinuxSignals-on-Mips.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0006-Fix-build-of-LinuxSignals-on-Mips.patch
@@ -1,7 +1,7 @@
-From 98864a1761e2e2b7017b5d1db155573f295a3dcd Mon Sep 17 00:00:00 2001
+From cfbf932ba52d16c739ab9aef5f7fad0c431b5b33 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 31 Jan 2024 14:37:12 +0800
-Subject: [PATCH 6/9] Fix build of LinuxSignals on Mips
+Subject: [PATCH 06/11] Fix build of LinuxSignals on Mips
 
 But only the build, not the functionality because lldb won't work
 anyway.
@@ -89,5 +89,5 @@ index eaecc84df15d..a087eea6d145 100644
    AddSignal(33,     "SIG33",        false,    false,  false,  "threading library internal signal 2");
    AddSignal(34,     "SIGRTMIN",     false,    false,  false,  "real time signal 0");
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0007-Compile-with-MT-on-MSVC.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0007-Compile-with-MT-on-MSVC.patch
@@ -1,7 +1,7 @@
-From 083de4a20fbe5d30b718a1d5a5b9ee615ad2f22d Mon Sep 17 00:00:00 2001
+From ed0b218ec480584b8d2ba8ff5b19fa0caf3627fe Mon Sep 17 00:00:00 2001
 From: Alex Crichton <alex@alexcrichton.com>
 Date: Sat, 10 Feb 2018 17:21:38 -0800
-Subject: [PATCH 7/9] Compile with /MT on MSVC
+Subject: [PATCH 07/11] Compile with /MT on MSVC
 
 Can't seem to figure out how to do this without this patch...
 ---
@@ -33,5 +33,5 @@ index 64c9f2380550..10eace58caee 100644
  add_subdirectory(tools/lld)
  
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0008-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0008-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
@@ -1,7 +1,7 @@
-From 7ba2dae6079b1f2e067559928aea620d3d083516 Mon Sep 17 00:00:00 2001
+From 2334da0294b0f38d2e095db0daf9fd3c090e8461 Mon Sep 17 00:00:00 2001
 From: Adrian Cruceru <cruceruadrian@gmail.com>
 Date: Mon, 25 May 2020 20:58:30 +0200
-Subject: [PATCH 8/9] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
+Subject: [PATCH 08/11] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
  nightly target.
 
 Code is guarded via defines to enable only if 'RUST_SGX' is present.
@@ -494,5 +494,5 @@ index deb5a4d4d73d..5337be4b3d50 100644
  #ifdef __APPLE__
    #if defined(FOR_DYLD)
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0009-compiler-rt-Disable-installing-of-custom-libcxx.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0009-compiler-rt-Disable-installing-of-custom-libcxx.patch
@@ -1,7 +1,7 @@
-From afeba19447eb9e358a42254106af04621759d4c1 Mon Sep 17 00:00:00 2001
+From f7210ad0e04bec72f9c1bbc5deddc6cf98908d98 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sat, 12 Apr 2025 15:25:26 +0800
-Subject: [PATCH 9/9] [compiler-rt] Disable installing of custom libcxx
+Subject: [PATCH 09/11] [compiler-rt] Disable installing of custom libcxx
 
 e7bad34475e2 ([compiler-rt] Use installed libc++(abi) for tests
 instead of build tree, 2024-11-06) removed 'INSTALL_COMMAND ""' line.
@@ -37,5 +37,5 @@ index c3e734f72392..858342bcc3a6 100644
      BUILD_ALWAYS 1
      USES_TERMINAL_CONFIGURE 1
 -- 
-2.49.0
+2.52.0
 

--- a/app-devel/llvm-20/01-runtime/patches/0010-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0010-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
@@ -1,7 +1,8 @@
-From aafe936bb0f965de562a451b189b93455298af1d Mon Sep 17 00:00:00 2001
+From d7337de6c8bd04afb74092ca85f8b5865daa3742 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 5 Jan 2026 11:49:09 +0800
-Subject: [PATCH] [RuntimeDyld][MIPS] Use AT for stub function instead of T9
+Subject: [PATCH 10/11] [RuntimeDyld][MIPS] Use AT for stub function instead of
+ T9
 
 The stub function is generated for R_MIPS_26 relocation, which could be
 used for local jumping inside a function, and do not expect any
@@ -16,7 +17,7 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 28 insertions(+), 28 deletions(-)
 
 diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
-index 6de6cc756585..9f8c1dd87c76 100644
+index b3798f15a6cc..fb4d5a993fd9 100644
 --- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
 +++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
 @@ -1003,45 +1003,45 @@ uint8_t *RuntimeDyldImpl::createStubFunction(uint8_t *Addr,

--- a/app-devel/llvm-20/01-runtime/patches/0011-MIPS-ISel-Fix-musttail-161860.patch
+++ b/app-devel/llvm-20/01-runtime/patches/0011-MIPS-ISel-Fix-musttail-161860.patch
@@ -1,0 +1,500 @@
+From 83628736174bcb6a35878f6cd51c4a005425bd63 Mon Sep 17 00:00:00 2001
+From: Djordje Todorovic <djordje.todorovic@htecgroup.com>
+Date: Tue, 27 Jan 2026 19:55:22 +0100
+Subject: [PATCH 11/11] [MIPS][ISel] Fix musttail (#161860)
+
+Properly handle clang::musttail attribute on MIPS backend.
+
+It fixes: https://github.com/llvm/llvm-project/issues/161193
+---
+ .../clang/Basic/DiagnosticCommonKinds.td      |   5 +
+ clang/lib/CodeGen/CGCall.cpp                  |  18 ++-
+ clang/lib/CodeGen/CodeGenModule.cpp           |  41 ++++--
+ .../Mips/musttail-forward-declaration.c       |  15 +++
+ clang/test/CodeGen/Mips/musttail-pic.c        |  21 +++
+ clang/test/CodeGen/Mips/musttail-visibility.c |  17 +++
+ clang/test/CodeGen/Mips/musttail-weak.c       |  13 ++
+ clang/test/CodeGen/Mips/musttail.c            |  19 +++
+ llvm/lib/Target/Mips/MipsISelLowering.cpp     |  50 +++++---
+ llvm/lib/Target/Mips/MipsSEISelLowering.cpp   |  10 +-
+ llvm/test/CodeGen/Mips/musttail.ll            | 120 ++++++++++++++++++
+ 11 files changed, 295 insertions(+), 34 deletions(-)
+ create mode 100644 clang/test/CodeGen/Mips/musttail-forward-declaration.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-pic.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-visibility.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-weak.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail.c
+ create mode 100644 llvm/test/CodeGen/Mips/musttail.ll
+
+diff --git a/clang/include/clang/Basic/DiagnosticCommonKinds.td b/clang/include/clang/Basic/DiagnosticCommonKinds.td
+index f4a155bb00bb..8eb8d61a0e84 100644
+--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
++++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
+@@ -368,6 +368,11 @@ def err_ppc_impossible_musttail: Error<
+   "indirect calls cannot be tail called on PPC|"
+   "external calls cannot be tail called on PPC}0"
+   >;
++def err_mips_impossible_musttail: Error<
++  "'musttail' attribute for this call is impossible because %select{"
++  "the MIPS16 ABI does not support tail calls|"
++  "calls outside the current linkage unit cannot be tail called on MIPS}0"
++  >;
+ def err_aix_musttail_unsupported: Error<
+   "'musttail' attribute is not supported on AIX">;
+ 
+diff --git a/clang/lib/CodeGen/CGCall.cpp b/clang/lib/CodeGen/CGCall.cpp
+index f790e78cd55a..538c8f364f91 100644
+--- a/clang/lib/CodeGen/CGCall.cpp
++++ b/clang/lib/CodeGen/CGCall.cpp
+@@ -29,6 +29,7 @@
+ #include "clang/Basic/TargetInfo.h"
+ #include "clang/CodeGen/CGFunctionInfo.h"
+ #include "clang/CodeGen/SwiftCallingConv.h"
++#include "llvm/ADT/STLExtras.h"
+ #include "llvm/ADT/StringExtras.h"
+ #include "llvm/Analysis/ValueTracking.h"
+ #include "llvm/IR/Assumptions.h"
+@@ -5819,11 +5820,20 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
+     AddObjCARCExceptionMetadata(CI);
+ 
+   // Set tail call kind if necessary.
++  bool IsPPC = getTarget().getTriple().isPPC();
++  bool IsMIPS = getTarget().getTriple().isMIPS();
++  bool HasMips16 = false;
++  if (IsMIPS) {
++    const TargetOptions &TargetOpts = getTarget().getTargetOpts();
++    HasMips16 = TargetOpts.FeatureMap.lookup("mips16");
++    if (!HasMips16)
++      HasMips16 = llvm::is_contained(TargetOpts.Features, "+mips16");
++  }
+   if (llvm::CallInst *Call = dyn_cast<llvm::CallInst>(CI)) {
+     if (TargetDecl && TargetDecl->hasAttr<NotTailCalledAttr>())
+       Call->setTailCallKind(llvm::CallInst::TCK_NoTail);
+     else if (IsMustTail) {
+-      if (getTarget().getTriple().isPPC()) {
++      if (IsPPC) {
+         if (getTarget().getTriple().isOSAIX())
+           CGM.getDiags().Report(Loc, diag::err_aix_musttail_unsupported);
+         else if (!getTarget().hasFeature("pcrelative-memops")) {
+@@ -5849,6 +5859,12 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
+           }
+         }
+       }
++      if (IsMIPS) {
++        if (HasMips16)
++          CGM.getDiags().Report(Loc, diag::err_mips_impossible_musttail) << 0;
++        else if (const auto *FD = dyn_cast_or_null<FunctionDecl>(TargetDecl))
++          CGM.addUndefinedGlobalForTailCall({FD, Loc});
++      }
+       Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+     }
+   }
+diff --git a/clang/lib/CodeGen/CodeGenModule.cpp b/clang/lib/CodeGen/CodeGenModule.cpp
+index eb8d3ceeeba4..3a22238c94e0 100644
+--- a/clang/lib/CodeGen/CodeGenModule.cpp
++++ b/clang/lib/CodeGen/CodeGenModule.cpp
+@@ -1435,16 +1435,39 @@ void CodeGenModule::Release() {
+   setVisibilityFromDLLStorageClass(LangOpts, getModule());
+ 
+   // Check the tail call symbols are truly undefined.
+-  if (getTriple().isPPC() && !MustTailCallUndefinedGlobals.empty()) {
+-    for (auto &I : MustTailCallUndefinedGlobals) {
+-      if (!I.first->isDefined())
+-        getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
+-      else {
+-        StringRef MangledName = getMangledName(GlobalDecl(I.first));
+-        llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
+-        if (!Entry || Entry->isWeakForLinker() ||
+-            Entry->isDeclarationForLinker())
++  if (!MustTailCallUndefinedGlobals.empty()) {
++    if (getTriple().isPPC()) {
++      for (auto &I : MustTailCallUndefinedGlobals) {
++        if (!I.first->isDefined())
+           getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
++        else {
++          StringRef MangledName = getMangledName(GlobalDecl(I.first));
++          llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
++          if (!Entry || Entry->isWeakForLinker() ||
++              Entry->isDeclarationForLinker())
++            getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
++        }
++      }
++    } else if (getTriple().isMIPS()) {
++      for (auto &I : MustTailCallUndefinedGlobals) {
++        const FunctionDecl *FD = I.first;
++        StringRef MangledName = getMangledName(GlobalDecl(FD));
++        llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
++
++        if (!Entry)
++          continue;
++
++        bool CalleeIsLocal;
++        if (Entry->isDeclarationForLinker()) {
++          // For declarations, only visibility can indicate locality.
++          CalleeIsLocal =
++              Entry->hasHiddenVisibility() || Entry->hasProtectedVisibility();
++        } else {
++          CalleeIsLocal = Entry->isDSOLocal();
++        }
++
++        if (!CalleeIsLocal)
++          getDiags().Report(I.second, diag::err_mips_impossible_musttail) << 1;
+       }
+     }
+   }
+diff --git a/clang/test/CodeGen/Mips/musttail-forward-declaration.c b/clang/test/CodeGen/Mips/musttail-forward-declaration.c
+new file mode 100644
+index 000000000000..b25baa76f451
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-forward-declaration.c
+@@ -0,0 +1,15 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test that a forward declaration that is later defined in the same TU
++// is allowed for musttail calls.
++
++int func(int i);
++
++int caller(int i) {
++  // expected-no-diagnostics
++  [[clang::musttail]] return func(i);
++}
++
++int func(int i) {
++  return i + 1;
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-pic.c b/clang/test/CodeGen/Mips/musttail-pic.c
+new file mode 100644
+index 000000000000..bcad84d63f19
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-pic.c
+@@ -0,0 +1,21 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -pic-level 2 \
++// RUN:   -fhalf-no-semantic-interposition -o /dev/null -emit-llvm -verify
++
++// Test musttail behavior in PIC mode with semantic interposition.
++
++int external_defined(int i) { return i; }
++static int static_func(int i) { return i; }
++__attribute__((visibility("hidden"))) int hidden_defined(int i) { return i; }
++
++int call_external(int i) {
++  // expected-error@+1 {{'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS}}
++  [[clang::musttail]] return external_defined(i);
++}
++
++int call_static(int i) {
++  [[clang::musttail]] return static_func(i);
++}
++
++int call_hidden(int i) {
++  [[clang::musttail]] return hidden_defined(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-visibility.c b/clang/test/CodeGen/Mips/musttail-visibility.c
+new file mode 100644
+index 000000000000..351563e99112
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-visibility.c
+@@ -0,0 +1,17 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test that hidden and protected visibility functions can be tail called
++// because they are guaranteed to be DSO-local.
++
++extern int hidden_func(int i) __attribute__((visibility("hidden")));
++extern int protected_func(int i) __attribute__((visibility("protected")));
++extern int default_func(int i);
++
++int call_hidden(int i) {
++  // expected-no-diagnostics
++  [[clang::musttail]] return hidden_func(i);
++}
++
++int call_protected(int i) {
++  [[clang::musttail]] return protected_func(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-weak.c b/clang/test/CodeGen/Mips/musttail-weak.c
+new file mode 100644
+index 000000000000..06c0726d3d1e
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-weak.c
+@@ -0,0 +1,13 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test musttail with weak functions.
++// Weak functions can be interposed, so they are not considered DSO-local.
++
++__attribute__((weak)) int weak_func(int i) {
++  return i;
++}
++
++int caller(int i) {
++  // expected-error@+1 {{'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS}}
++  [[clang::musttail]] return weak_func(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail.c b/clang/test/CodeGen/Mips/musttail.c
+new file mode 100644
+index 000000000000..c0c0132e7f82
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail.c
+@@ -0,0 +1,19 @@
++// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -emit-llvm 2>&1 \
++// RUN:   | FileCheck %s
++// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -target-feature +mips16 \
++// RUN:   -emit-llvm 2>&1 | FileCheck %s --check-prefix=CHECK-MIPS16
++
++// CHECK: error: 'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS
++// CHECK-MIPS16: error: 'musttail' attribute for this call is impossible because the MIPS16 ABI does not support tail calls
++
++static int local(int x) { return x; }
++
++int call_local(int x) {
++  [[clang::musttail]] return local(x);
++}
++
++extern int external(int x);
++
++int call_external(int x) {
++  [[clang::musttail]] return external(x);
++}
+diff --git a/llvm/lib/Target/Mips/MipsISelLowering.cpp b/llvm/lib/Target/Mips/MipsISelLowering.cpp
+index 85e05bc1b129..7f16239297cb 100644
+--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
++++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
+@@ -88,6 +88,10 @@ NoZeroDivCheck("mno-check-zero-division", cl::Hidden,
+ 
+ extern cl::opt<bool> EmitJalrReloc;
+ 
++static cl::opt<bool> UseMipsTailCalls("mips-tail-calls", cl::Hidden,
++                                      cl::desc("MIPS: permit tail calls."),
++                                      cl::init(false));
++
+ static const MCPhysReg Mips64DPRegs[8] = {
+   Mips::D12_64, Mips::D13_64, Mips::D14_64, Mips::D15_64,
+   Mips::D16_64, Mips::D17_64, Mips::D18_64, Mips::D19_64
+@@ -3316,23 +3320,38 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+   // Call site info for function parameters tracking.
+   MachineFunction::CallSiteInfo CSInfo;
+ 
+-  // Check if it's really possible to do a tail call. Restrict it to functions
+-  // that are part of this compilation unit.
+-  bool InternalLinkage = false;
++  // Check if it's really possible to do a tail call.
++  // For non-musttail calls, restrict to functions that won't require $gp
++  // restoration. In PIC mode, calling external functions via tail call can
++  // cause issues with $gp register handling (see D24763).
++  bool IsMustTail = CLI.CB && CLI.CB->isMustTailCall();
++  bool CalleeIsLocal = true;
++  if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
++    const GlobalValue *GV = G->getGlobal();
++    bool HasLocalLinkage = GV->hasLocalLinkage() || GV->hasPrivateLinkage();
++    bool HasHiddenVisibility =
++        GV->hasHiddenVisibility() || GV->hasProtectedVisibility();
++    if (GV->isDeclarationForLinker())
++      CalleeIsLocal = HasLocalLinkage || HasHiddenVisibility;
++    else
++      CalleeIsLocal = GV->isDSOLocal();
++  }
++
+   if (IsTailCall) {
+-    IsTailCall = isEligibleForTailCallOptimization(
+-        CCInfo, StackSize, *MF.getInfo<MipsFunctionInfo>());
+-    if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+-      InternalLinkage = G->getGlobal()->hasInternalLinkage();
+-      IsTailCall &= (InternalLinkage || G->getGlobal()->hasLocalLinkage() ||
+-                     G->getGlobal()->hasPrivateLinkage() ||
+-                     G->getGlobal()->hasHiddenVisibility() ||
+-                     G->getGlobal()->hasProtectedVisibility());
+-     }
++    if (!UseMipsTailCalls) {
++      IsTailCall = false;
++    } else {
++      bool Eligible = isEligibleForTailCallOptimization(
++          CCInfo, StackSize, *MF.getInfo<MipsFunctionInfo>());
++      if (!Eligible || !CalleeIsLocal) {
++        IsTailCall = false;
++        if (IsMustTail)
++          report_fatal_error(
++              "failed to perform tail call elimination on a call "
++              "site marked musttail");
++      }
++    }
+   }
+-  if (!IsTailCall && CLI.CB && CLI.CB->isMustTailCall())
+-    report_fatal_error("failed to perform tail call elimination on a call "
+-                       "site marked musttail");
+ 
+   if (IsTailCall)
+     ++NumTailCalls;
+@@ -3508,6 +3527,7 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+     }
+   }
+ 
++  bool InternalLinkage = false;
+   if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+     if (Subtarget.isTargetCOFF() &&
+         G->getGlobal()->hasDLLImportStorageClass()) {
+diff --git a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+index 71a70d9c2dd4..ed57f4f3c733 100644
+--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
++++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+@@ -51,10 +51,6 @@ using namespace llvm;
+ 
+ #define DEBUG_TYPE "mips-isel"
+ 
+-static cl::opt<bool>
+-UseMipsTailCalls("mips-tail-calls", cl::Hidden,
+-                    cl::desc("MIPS: permit tail calls."), cl::init(false));
+-
+ static cl::opt<bool> NoDPLoadStore("mno-ldc1-sdc1", cl::init(false),
+                                    cl::desc("Expand double precision loads and "
+                                             "stores to their single precision "
+@@ -1181,9 +1177,6 @@ MipsSETargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
+ bool MipsSETargetLowering::isEligibleForTailCallOptimization(
+     const CCState &CCInfo, unsigned NextStackOffset,
+     const MipsFunctionInfo &FI) const {
+-  if (!UseMipsTailCalls)
+-    return false;
+-
+   // Exception has to be cleared with eret.
+   if (FI.isISR())
+     return false;
+@@ -1192,8 +1185,7 @@ bool MipsSETargetLowering::isEligibleForTailCallOptimization(
+   if (CCInfo.getInRegsParamsCount() > 0 || FI.hasByvalArg())
+     return false;
+ 
+-  // Return true if the callee's argument area is no larger than the
+-  // caller's.
++  // Return true if the callee's argument area is no larger than the caller's.
+   return NextStackOffset <= FI.getIncomingArgSize();
+ }
+ 
+diff --git a/llvm/test/CodeGen/Mips/musttail.ll b/llvm/test/CodeGen/Mips/musttail.ll
+new file mode 100644
+index 000000000000..b96cb2b92398
+--- /dev/null
++++ b/llvm/test/CodeGen/Mips/musttail.ll
+@@ -0,0 +1,120 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc -mtriple=mips-unknown-linux-gnu -mips-tail-calls=1 < %s | FileCheck %s --check-prefix=MIPS32
++; RUN: llc -mtriple=mips64-unknown-linux-gnu -mips-tail-calls=1 < %s | FileCheck %s --check-prefix=MIPS64
++
++; Test musttail support for MIPS
++
++define dso_local i32 @callee_args(i32 %a, i32 %b, i32 %c) {
++  ret i32 %a;
++}
++
++define i32 @test_musttail_args(i32 %x, i32 %y, i32 %z) {
++; MIPS32-LABEL: test_musttail_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    j callee_args
++; MIPS32-NEXT:    nop
++;
++; MIPS64-LABEL: test_musttail_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j callee_args
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 @callee_args(i32 %x, i32 %y, i32 %z)
++  ret i32 %ret
++}
++
++; Test musttail with many arguments that spill to stack (involves memory)
++; MIPS O32 ABI: first 4 args in $a0-$a3, rest on stack
++define hidden i32 @many_args_callee(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
++  ret i32 %a
++}
++
++define i32 @test_musttail_many_args(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
++; MIPS32-LABEL: test_musttail_many_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 24($sp)
++; MIPS32-NEXT:    lw $2, 20($sp)
++; MIPS32-NEXT:    lw $3, 16($sp)
++; MIPS32-NEXT:    sw $3, 16($sp)
++; MIPS32-NEXT:    sw $2, 20($sp)
++; MIPS32-NEXT:    sw $1, 24($sp)
++; MIPS32-NEXT:    lw $1, 28($sp)
++; MIPS32-NEXT:    j many_args_callee
++; MIPS32-NEXT:    sw $1, 28($sp)
++;
++; MIPS64-LABEL: test_musttail_many_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j many_args_callee
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 @many_args_callee(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h)
++  ret i32 %ret
++}
++
++; Test musttail with large struct passed by value (involves memory)
++%struct.large = type { i32, i32, i32, i32, i32, i32, i32, i32 }
++
++define hidden i32 @callee_with_struct(%struct.large %s, i32 %x) {
++  ret i32 %x
++}
++
++define i32 @test_musttail_struct(%struct.large %s, i32 %x) {
++; MIPS32-LABEL: test_musttail_struct:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 28($sp)
++; MIPS32-NEXT:    lw $2, 24($sp)
++; MIPS32-NEXT:    lw $3, 20($sp)
++; MIPS32-NEXT:    lw $8, 16($sp)
++; MIPS32-NEXT:    sw $8, 16($sp)
++; MIPS32-NEXT:    sw $3, 20($sp)
++; MIPS32-NEXT:    sw $2, 24($sp)
++; MIPS32-NEXT:    sw $1, 28($sp)
++; MIPS32-NEXT:    lw $1, 32($sp)
++; MIPS32-NEXT:    j callee_with_struct
++; MIPS32-NEXT:    sw $1, 32($sp)
++;
++; MIPS64-LABEL: test_musttail_struct:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    ld $1, 0($sp)
++; MIPS64-NEXT:    j callee_with_struct
++; MIPS64-NEXT:    sd $1, 0($sp)
++  %ret = musttail call i32 @callee_with_struct(%struct.large %s, i32 %x)
++  ret i32 %ret
++}
++
++; Test musttail with mixed int and float arguments that use stack
++define hidden float @mixed_args_callee(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f) {
++  ret float %b
++}
++
++define float @test_musttail_mixed_args(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f) {
++; MIPS32-LABEL: test_musttail_mixed_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 16($sp)
++; MIPS32-NEXT:    sw $1, 16($sp)
++; MIPS32-NEXT:    lwc1 $f0, 20($sp)
++; MIPS32-NEXT:    j mixed_args_callee
++; MIPS32-NEXT:    swc1 $f0, 20($sp)
++;
++; MIPS64-LABEL: test_musttail_mixed_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j mixed_args_callee
++; MIPS64-NEXT:    nop
++  %ret = musttail call float @mixed_args_callee(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f)
++  ret float %ret
++}
++
++; Test musttail with indirect call
++define i32 @test_musttail_fptr(ptr %fptr, i32 %x) {
++; MIPS32-LABEL: test_musttail_fptr:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    move $25, $4
++; MIPS32-NEXT:    jr $25
++; MIPS32-NEXT:    nop
++;
++; MIPS64-LABEL: test_musttail_fptr:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    move $25, $4
++; MIPS64-NEXT:    jr $25
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 %fptr(ptr %fptr, i32 %x)
++  ret i32 %ret
++}
+-- 
+2.52.0
+

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,5 +1,5 @@
 VER=20.1.8
-REL=6
+REL=7
 
 # Use tarball-based source when possible
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"

--- a/app-devel/llvm-21/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,7 +1,7 @@
-From c1c0017102e03650a21c5b969a8ff3b0e353f21b Mon Sep 17 00:00:00 2001
+From 940a13625535ca7742d43d3f00f5fc896a9ae627 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:48:08 -0800
-Subject: [PATCH 1/6] Fix fuzzer objects building when LTO is enabled
+Subject: [PATCH 1/8] Fix fuzzer objects building when LTO is enabled
 
 ---
  compiler-rt/lib/fuzzer/CMakeLists.txt | 2 +-

--- a/app-devel/llvm-21/01-runtime/patches/0002-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0002-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,7 +1,7 @@
-From 120abd17e1ee0c56780a3952556e9510aecd2cce Mon Sep 17 00:00:00 2001
+From 9723cb0928baff74ef44b0fd961418193e5c26da Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:49:26 -0800
-Subject: [PATCH 2/6] Add stub for mips64 LLDB impl
+Subject: [PATCH 2/8] Add stub for mips64 LLDB impl
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h     | 7 ++++++-

--- a/app-devel/llvm-21/01-runtime/patches/0003-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0003-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,7 +1,7 @@
-From 655dcfdd892ba425aae4325dbed7c8402dc4d704 Mon Sep 17 00:00:00 2001
+From 807b31cafaf824c69b5628a113827499b1d841ed Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:52:51 -0800
-Subject: [PATCH 3/6] Add stub for lldb arch functions on loongson3
+Subject: [PATCH 3/8] Add stub for lldb arch functions on loongson3
 
 ---
  .../Plugins/Process/Linux/NativeRegisterContextLinux.h    | 8 ++++++++

--- a/app-devel/llvm-21/01-runtime/patches/0004-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0004-HACK-force-enable-cacheflush-function.patch
@@ -1,7 +1,7 @@
-From 24deae6b210e658d8fbe4a3a3f242e018ce874b6 Mon Sep 17 00:00:00 2001
+From eb2e952ad37c25d8effe9def339808699cf9bc2b Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 28 Jan 2024 04:53:18 -0800
-Subject: [PATCH 4/6] HACK: force enable cacheflush function
+Subject: [PATCH 4/8] HACK: force enable cacheflush function
 
 ---
  compiler-rt/lib/builtins/clear_cache.c | 1 +

--- a/app-devel/llvm-21/01-runtime/patches/0005-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0005-rust-Changes-needed-for-x86_64-fortanix-unknown-sgx-.patch
@@ -1,7 +1,7 @@
-From fd18d71bbba908eb85de54fee58a347446066ba7 Mon Sep 17 00:00:00 2001
+From 3b79d0f17621ba107c0daa2b46f05734efb875bb Mon Sep 17 00:00:00 2001
 From: Adrian Cruceru <cruceruadrian@gmail.com>
 Date: Mon, 25 May 2020 20:58:30 +0200
-Subject: [PATCH 5/6] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
+Subject: [PATCH 5/8] [rust] Changes needed for 'x86_64-fortanix-unknown-sgx'
  nightly target.
 
 Code is guarded via defines to enable only if 'RUST_SGX' is present.

--- a/app-devel/llvm-21/01-runtime/patches/0006-compiler-rt-Disable-installing-of-custom-libcxx.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0006-compiler-rt-Disable-installing-of-custom-libcxx.patch
@@ -1,7 +1,7 @@
-From f2158d0ed4ef52d3054a835f0f6e96d4930a80a8 Mon Sep 17 00:00:00 2001
+From c4f3e2b0e6c6fad8c7259ca9f34615e7ee121fd1 Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sat, 12 Apr 2025 15:25:26 +0800
-Subject: [PATCH 6/6] [compiler-rt] Disable installing of custom libcxx
+Subject: [PATCH 6/8] [compiler-rt] Disable installing of custom libcxx
 
 e7bad34475e2 ([compiler-rt] Use installed libc++(abi) for tests
 instead of build tree, 2024-11-06) removed 'INSTALL_COMMAND ""' line.

--- a/app-devel/llvm-21/01-runtime/patches/0007-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0007-RuntimeDyld-MIPS-Use-AT-for-stub-function-instead-of.patch
@@ -1,7 +1,8 @@
-From aafe936bb0f965de562a451b189b93455298af1d Mon Sep 17 00:00:00 2001
+From 6ec46745a819dcf2017354802fea46975acaf21b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
-Date: Mon, 5 Jan 2026 11:49:09 +0800
-Subject: [PATCH] [RuntimeDyld][MIPS] Use AT for stub function instead of T9
+Date: Mon, 12 Jan 2026 10:50:43 +0800
+Subject: [PATCH 7/8] [RuntimeDyld][MIPS] Use AT for stub function instead of
+ T9 (#174354)
 
 The stub function is generated for R_MIPS_26 relocation, which could be
 used for local jumping inside a function, and do not expect any
@@ -16,7 +17,7 @@ Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
  1 file changed, 28 insertions(+), 28 deletions(-)
 
 diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
-index 6de6cc756585..9f8c1dd87c76 100644
+index b3798f15a6cc..fb4d5a993fd9 100644
 --- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
 +++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
 @@ -1003,45 +1003,45 @@ uint8_t *RuntimeDyldImpl::createStubFunction(uint8_t *Addr,

--- a/app-devel/llvm-21/01-runtime/patches/0008-MIPS-ISel-Fix-musttail-161860.patch
+++ b/app-devel/llvm-21/01-runtime/patches/0008-MIPS-ISel-Fix-musttail-161860.patch
@@ -1,0 +1,500 @@
+From 21f365bce1578fa92eb3328fecdf7d0965e1858a Mon Sep 17 00:00:00 2001
+From: Djordje Todorovic <djordje.todorovic@htecgroup.com>
+Date: Tue, 27 Jan 2026 19:55:22 +0100
+Subject: [PATCH 8/8] [MIPS][ISel] Fix musttail (#161860)
+
+Properly handle clang::musttail attribute on MIPS backend.
+
+It fixes: https://github.com/llvm/llvm-project/issues/161193
+---
+ .../clang/Basic/DiagnosticCommonKinds.td      |   5 +
+ clang/lib/CodeGen/CGCall.cpp                  |  18 ++-
+ clang/lib/CodeGen/CodeGenModule.cpp           |  41 ++++--
+ .../Mips/musttail-forward-declaration.c       |  15 +++
+ clang/test/CodeGen/Mips/musttail-pic.c        |  21 +++
+ clang/test/CodeGen/Mips/musttail-visibility.c |  17 +++
+ clang/test/CodeGen/Mips/musttail-weak.c       |  13 ++
+ clang/test/CodeGen/Mips/musttail.c            |  19 +++
+ llvm/lib/Target/Mips/MipsISelLowering.cpp     |  50 +++++---
+ llvm/lib/Target/Mips/MipsSEISelLowering.cpp   |  10 +-
+ llvm/test/CodeGen/Mips/musttail.ll            | 120 ++++++++++++++++++
+ 11 files changed, 295 insertions(+), 34 deletions(-)
+ create mode 100644 clang/test/CodeGen/Mips/musttail-forward-declaration.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-pic.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-visibility.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-weak.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail.c
+ create mode 100644 llvm/test/CodeGen/Mips/musttail.ll
+
+diff --git a/clang/include/clang/Basic/DiagnosticCommonKinds.td b/clang/include/clang/Basic/DiagnosticCommonKinds.td
+index 0bd8a423c393..c744378ae8ec 100644
+--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
++++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
+@@ -372,6 +372,11 @@ def err_ppc_impossible_musttail: Error<
+   "indirect calls cannot be tail called on PPC|"
+   "external calls cannot be tail called on PPC}0"
+   >;
++def err_mips_impossible_musttail: Error<
++  "'musttail' attribute for this call is impossible because %select{"
++  "the MIPS16 ABI does not support tail calls|"
++  "calls outside the current linkage unit cannot be tail called on MIPS}0"
++  >;
+ def err_aix_musttail_unsupported: Error<
+   "'musttail' attribute is not supported on AIX">;
+ 
+diff --git a/clang/lib/CodeGen/CGCall.cpp b/clang/lib/CodeGen/CGCall.cpp
+index 5344a9710d64..fd5a799eaa7c 100644
+--- a/clang/lib/CodeGen/CGCall.cpp
++++ b/clang/lib/CodeGen/CGCall.cpp
+@@ -31,6 +31,7 @@
+ #include "clang/Basic/TargetInfo.h"
+ #include "clang/CodeGen/CGFunctionInfo.h"
+ #include "clang/CodeGen/SwiftCallingConv.h"
++#include "llvm/ADT/STLExtras.h"
+ #include "llvm/ADT/StringExtras.h"
+ #include "llvm/Analysis/ValueTracking.h"
+ #include "llvm/IR/Assumptions.h"
+@@ -5922,11 +5923,20 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
+     AddObjCARCExceptionMetadata(CI);
+ 
+   // Set tail call kind if necessary.
++  bool IsPPC = getTarget().getTriple().isPPC();
++  bool IsMIPS = getTarget().getTriple().isMIPS();
++  bool HasMips16 = false;
++  if (IsMIPS) {
++    const TargetOptions &TargetOpts = getTarget().getTargetOpts();
++    HasMips16 = TargetOpts.FeatureMap.lookup("mips16");
++    if (!HasMips16)
++      HasMips16 = llvm::is_contained(TargetOpts.Features, "+mips16");
++  }
+   if (llvm::CallInst *Call = dyn_cast<llvm::CallInst>(CI)) {
+     if (TargetDecl && TargetDecl->hasAttr<NotTailCalledAttr>())
+       Call->setTailCallKind(llvm::CallInst::TCK_NoTail);
+     else if (IsMustTail) {
+-      if (getTarget().getTriple().isPPC()) {
++      if (IsPPC) {
+         if (getTarget().getTriple().isOSAIX())
+           CGM.getDiags().Report(Loc, diag::err_aix_musttail_unsupported);
+         else if (!getTarget().hasFeature("pcrelative-memops")) {
+@@ -5952,6 +5962,12 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
+           }
+         }
+       }
++      if (IsMIPS) {
++        if (HasMips16)
++          CGM.getDiags().Report(Loc, diag::err_mips_impossible_musttail) << 0;
++        else if (const auto *FD = dyn_cast_or_null<FunctionDecl>(TargetDecl))
++          CGM.addUndefinedGlobalForTailCall({FD, Loc});
++      }
+       Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+     }
+   }
+diff --git a/clang/lib/CodeGen/CodeGenModule.cpp b/clang/lib/CodeGen/CodeGenModule.cpp
+index 678be0718be2..39f63e494f2a 100644
+--- a/clang/lib/CodeGen/CodeGenModule.cpp
++++ b/clang/lib/CodeGen/CodeGenModule.cpp
+@@ -1563,16 +1563,39 @@ void CodeGenModule::Release() {
+   setVisibilityFromDLLStorageClass(LangOpts, getModule());
+ 
+   // Check the tail call symbols are truly undefined.
+-  if (getTriple().isPPC() && !MustTailCallUndefinedGlobals.empty()) {
+-    for (auto &I : MustTailCallUndefinedGlobals) {
+-      if (!I.first->isDefined())
+-        getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
+-      else {
+-        StringRef MangledName = getMangledName(GlobalDecl(I.first));
+-        llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
+-        if (!Entry || Entry->isWeakForLinker() ||
+-            Entry->isDeclarationForLinker())
++  if (!MustTailCallUndefinedGlobals.empty()) {
++    if (getTriple().isPPC()) {
++      for (auto &I : MustTailCallUndefinedGlobals) {
++        if (!I.first->isDefined())
+           getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
++        else {
++          StringRef MangledName = getMangledName(GlobalDecl(I.first));
++          llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
++          if (!Entry || Entry->isWeakForLinker() ||
++              Entry->isDeclarationForLinker())
++            getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
++        }
++      }
++    } else if (getTriple().isMIPS()) {
++      for (auto &I : MustTailCallUndefinedGlobals) {
++        const FunctionDecl *FD = I.first;
++        StringRef MangledName = getMangledName(GlobalDecl(FD));
++        llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
++
++        if (!Entry)
++          continue;
++
++        bool CalleeIsLocal;
++        if (Entry->isDeclarationForLinker()) {
++          // For declarations, only visibility can indicate locality.
++          CalleeIsLocal =
++              Entry->hasHiddenVisibility() || Entry->hasProtectedVisibility();
++        } else {
++          CalleeIsLocal = Entry->isDSOLocal();
++        }
++
++        if (!CalleeIsLocal)
++          getDiags().Report(I.second, diag::err_mips_impossible_musttail) << 1;
+       }
+     }
+   }
+diff --git a/clang/test/CodeGen/Mips/musttail-forward-declaration.c b/clang/test/CodeGen/Mips/musttail-forward-declaration.c
+new file mode 100644
+index 000000000000..b25baa76f451
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-forward-declaration.c
+@@ -0,0 +1,15 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test that a forward declaration that is later defined in the same TU
++// is allowed for musttail calls.
++
++int func(int i);
++
++int caller(int i) {
++  // expected-no-diagnostics
++  [[clang::musttail]] return func(i);
++}
++
++int func(int i) {
++  return i + 1;
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-pic.c b/clang/test/CodeGen/Mips/musttail-pic.c
+new file mode 100644
+index 000000000000..bcad84d63f19
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-pic.c
+@@ -0,0 +1,21 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -pic-level 2 \
++// RUN:   -fhalf-no-semantic-interposition -o /dev/null -emit-llvm -verify
++
++// Test musttail behavior in PIC mode with semantic interposition.
++
++int external_defined(int i) { return i; }
++static int static_func(int i) { return i; }
++__attribute__((visibility("hidden"))) int hidden_defined(int i) { return i; }
++
++int call_external(int i) {
++  // expected-error@+1 {{'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS}}
++  [[clang::musttail]] return external_defined(i);
++}
++
++int call_static(int i) {
++  [[clang::musttail]] return static_func(i);
++}
++
++int call_hidden(int i) {
++  [[clang::musttail]] return hidden_defined(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-visibility.c b/clang/test/CodeGen/Mips/musttail-visibility.c
+new file mode 100644
+index 000000000000..351563e99112
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-visibility.c
+@@ -0,0 +1,17 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test that hidden and protected visibility functions can be tail called
++// because they are guaranteed to be DSO-local.
++
++extern int hidden_func(int i) __attribute__((visibility("hidden")));
++extern int protected_func(int i) __attribute__((visibility("protected")));
++extern int default_func(int i);
++
++int call_hidden(int i) {
++  // expected-no-diagnostics
++  [[clang::musttail]] return hidden_func(i);
++}
++
++int call_protected(int i) {
++  [[clang::musttail]] return protected_func(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-weak.c b/clang/test/CodeGen/Mips/musttail-weak.c
+new file mode 100644
+index 000000000000..06c0726d3d1e
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-weak.c
+@@ -0,0 +1,13 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test musttail with weak functions.
++// Weak functions can be interposed, so they are not considered DSO-local.
++
++__attribute__((weak)) int weak_func(int i) {
++  return i;
++}
++
++int caller(int i) {
++  // expected-error@+1 {{'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS}}
++  [[clang::musttail]] return weak_func(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail.c b/clang/test/CodeGen/Mips/musttail.c
+new file mode 100644
+index 000000000000..c0c0132e7f82
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail.c
+@@ -0,0 +1,19 @@
++// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -emit-llvm 2>&1 \
++// RUN:   | FileCheck %s
++// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -target-feature +mips16 \
++// RUN:   -emit-llvm 2>&1 | FileCheck %s --check-prefix=CHECK-MIPS16
++
++// CHECK: error: 'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS
++// CHECK-MIPS16: error: 'musttail' attribute for this call is impossible because the MIPS16 ABI does not support tail calls
++
++static int local(int x) { return x; }
++
++int call_local(int x) {
++  [[clang::musttail]] return local(x);
++}
++
++extern int external(int x);
++
++int call_external(int x) {
++  [[clang::musttail]] return external(x);
++}
+diff --git a/llvm/lib/Target/Mips/MipsISelLowering.cpp b/llvm/lib/Target/Mips/MipsISelLowering.cpp
+index ec6b38215166..cb7abb44d4be 100644
+--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
++++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
+@@ -88,6 +88,10 @@ NoZeroDivCheck("mno-check-zero-division", cl::Hidden,
+ 
+ extern cl::opt<bool> EmitJalrReloc;
+ 
++static cl::opt<bool> UseMipsTailCalls("mips-tail-calls", cl::Hidden,
++                                      cl::desc("MIPS: permit tail calls."),
++                                      cl::init(false));
++
+ static const MCPhysReg Mips64DPRegs[8] = {
+   Mips::D12_64, Mips::D13_64, Mips::D14_64, Mips::D15_64,
+   Mips::D16_64, Mips::D17_64, Mips::D18_64, Mips::D19_64
+@@ -3400,23 +3404,38 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+   // Call site info for function parameters tracking.
+   MachineFunction::CallSiteInfo CSInfo;
+ 
+-  // Check if it's really possible to do a tail call. Restrict it to functions
+-  // that are part of this compilation unit.
+-  bool InternalLinkage = false;
++  // Check if it's really possible to do a tail call.
++  // For non-musttail calls, restrict to functions that won't require $gp
++  // restoration. In PIC mode, calling external functions via tail call can
++  // cause issues with $gp register handling (see D24763).
++  bool IsMustTail = CLI.CB && CLI.CB->isMustTailCall();
++  bool CalleeIsLocal = true;
++  if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
++    const GlobalValue *GV = G->getGlobal();
++    bool HasLocalLinkage = GV->hasLocalLinkage() || GV->hasPrivateLinkage();
++    bool HasHiddenVisibility =
++        GV->hasHiddenVisibility() || GV->hasProtectedVisibility();
++    if (GV->isDeclarationForLinker())
++      CalleeIsLocal = HasLocalLinkage || HasHiddenVisibility;
++    else
++      CalleeIsLocal = GV->isDSOLocal();
++  }
++
+   if (IsTailCall) {
+-    IsTailCall = isEligibleForTailCallOptimization(
+-        CCInfo, StackSize, *MF.getInfo<MipsFunctionInfo>());
+-    if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+-      InternalLinkage = G->getGlobal()->hasInternalLinkage();
+-      IsTailCall &= (InternalLinkage || G->getGlobal()->hasLocalLinkage() ||
+-                     G->getGlobal()->hasPrivateLinkage() ||
+-                     G->getGlobal()->hasHiddenVisibility() ||
+-                     G->getGlobal()->hasProtectedVisibility());
+-     }
++    if (!UseMipsTailCalls) {
++      IsTailCall = false;
++    } else {
++      bool Eligible = isEligibleForTailCallOptimization(
++          CCInfo, StackSize, *MF.getInfo<MipsFunctionInfo>());
++      if (!Eligible || !CalleeIsLocal) {
++        IsTailCall = false;
++        if (IsMustTail)
++          report_fatal_error(
++              "failed to perform tail call elimination on a call "
++              "site marked musttail");
++      }
++    }
+   }
+-  if (!IsTailCall && CLI.CB && CLI.CB->isMustTailCall())
+-    report_fatal_error("failed to perform tail call elimination on a call "
+-                       "site marked musttail");
+ 
+   if (IsTailCall)
+     ++NumTailCalls;
+@@ -3591,6 +3610,7 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+     }
+   }
+ 
++  bool InternalLinkage = false;
+   if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+     if (Subtarget.isTargetCOFF() &&
+         G->getGlobal()->hasDLLImportStorageClass()) {
+diff --git a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+index 71a70d9c2dd4..ed57f4f3c733 100644
+--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
++++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+@@ -51,10 +51,6 @@ using namespace llvm;
+ 
+ #define DEBUG_TYPE "mips-isel"
+ 
+-static cl::opt<bool>
+-UseMipsTailCalls("mips-tail-calls", cl::Hidden,
+-                    cl::desc("MIPS: permit tail calls."), cl::init(false));
+-
+ static cl::opt<bool> NoDPLoadStore("mno-ldc1-sdc1", cl::init(false),
+                                    cl::desc("Expand double precision loads and "
+                                             "stores to their single precision "
+@@ -1181,9 +1177,6 @@ MipsSETargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
+ bool MipsSETargetLowering::isEligibleForTailCallOptimization(
+     const CCState &CCInfo, unsigned NextStackOffset,
+     const MipsFunctionInfo &FI) const {
+-  if (!UseMipsTailCalls)
+-    return false;
+-
+   // Exception has to be cleared with eret.
+   if (FI.isISR())
+     return false;
+@@ -1192,8 +1185,7 @@ bool MipsSETargetLowering::isEligibleForTailCallOptimization(
+   if (CCInfo.getInRegsParamsCount() > 0 || FI.hasByvalArg())
+     return false;
+ 
+-  // Return true if the callee's argument area is no larger than the
+-  // caller's.
++  // Return true if the callee's argument area is no larger than the caller's.
+   return NextStackOffset <= FI.getIncomingArgSize();
+ }
+ 
+diff --git a/llvm/test/CodeGen/Mips/musttail.ll b/llvm/test/CodeGen/Mips/musttail.ll
+new file mode 100644
+index 000000000000..b96cb2b92398
+--- /dev/null
++++ b/llvm/test/CodeGen/Mips/musttail.ll
+@@ -0,0 +1,120 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc -mtriple=mips-unknown-linux-gnu -mips-tail-calls=1 < %s | FileCheck %s --check-prefix=MIPS32
++; RUN: llc -mtriple=mips64-unknown-linux-gnu -mips-tail-calls=1 < %s | FileCheck %s --check-prefix=MIPS64
++
++; Test musttail support for MIPS
++
++define dso_local i32 @callee_args(i32 %a, i32 %b, i32 %c) {
++  ret i32 %a;
++}
++
++define i32 @test_musttail_args(i32 %x, i32 %y, i32 %z) {
++; MIPS32-LABEL: test_musttail_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    j callee_args
++; MIPS32-NEXT:    nop
++;
++; MIPS64-LABEL: test_musttail_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j callee_args
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 @callee_args(i32 %x, i32 %y, i32 %z)
++  ret i32 %ret
++}
++
++; Test musttail with many arguments that spill to stack (involves memory)
++; MIPS O32 ABI: first 4 args in $a0-$a3, rest on stack
++define hidden i32 @many_args_callee(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
++  ret i32 %a
++}
++
++define i32 @test_musttail_many_args(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
++; MIPS32-LABEL: test_musttail_many_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 24($sp)
++; MIPS32-NEXT:    lw $2, 20($sp)
++; MIPS32-NEXT:    lw $3, 16($sp)
++; MIPS32-NEXT:    sw $3, 16($sp)
++; MIPS32-NEXT:    sw $2, 20($sp)
++; MIPS32-NEXT:    sw $1, 24($sp)
++; MIPS32-NEXT:    lw $1, 28($sp)
++; MIPS32-NEXT:    j many_args_callee
++; MIPS32-NEXT:    sw $1, 28($sp)
++;
++; MIPS64-LABEL: test_musttail_many_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j many_args_callee
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 @many_args_callee(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h)
++  ret i32 %ret
++}
++
++; Test musttail with large struct passed by value (involves memory)
++%struct.large = type { i32, i32, i32, i32, i32, i32, i32, i32 }
++
++define hidden i32 @callee_with_struct(%struct.large %s, i32 %x) {
++  ret i32 %x
++}
++
++define i32 @test_musttail_struct(%struct.large %s, i32 %x) {
++; MIPS32-LABEL: test_musttail_struct:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 28($sp)
++; MIPS32-NEXT:    lw $2, 24($sp)
++; MIPS32-NEXT:    lw $3, 20($sp)
++; MIPS32-NEXT:    lw $8, 16($sp)
++; MIPS32-NEXT:    sw $8, 16($sp)
++; MIPS32-NEXT:    sw $3, 20($sp)
++; MIPS32-NEXT:    sw $2, 24($sp)
++; MIPS32-NEXT:    sw $1, 28($sp)
++; MIPS32-NEXT:    lw $1, 32($sp)
++; MIPS32-NEXT:    j callee_with_struct
++; MIPS32-NEXT:    sw $1, 32($sp)
++;
++; MIPS64-LABEL: test_musttail_struct:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    ld $1, 0($sp)
++; MIPS64-NEXT:    j callee_with_struct
++; MIPS64-NEXT:    sd $1, 0($sp)
++  %ret = musttail call i32 @callee_with_struct(%struct.large %s, i32 %x)
++  ret i32 %ret
++}
++
++; Test musttail with mixed int and float arguments that use stack
++define hidden float @mixed_args_callee(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f) {
++  ret float %b
++}
++
++define float @test_musttail_mixed_args(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f) {
++; MIPS32-LABEL: test_musttail_mixed_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 16($sp)
++; MIPS32-NEXT:    sw $1, 16($sp)
++; MIPS32-NEXT:    lwc1 $f0, 20($sp)
++; MIPS32-NEXT:    j mixed_args_callee
++; MIPS32-NEXT:    swc1 $f0, 20($sp)
++;
++; MIPS64-LABEL: test_musttail_mixed_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j mixed_args_callee
++; MIPS64-NEXT:    nop
++  %ret = musttail call float @mixed_args_callee(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f)
++  ret float %ret
++}
++
++; Test musttail with indirect call
++define i32 @test_musttail_fptr(ptr %fptr, i32 %x) {
++; MIPS32-LABEL: test_musttail_fptr:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    move $25, $4
++; MIPS32-NEXT:    jr $25
++; MIPS32-NEXT:    nop
++;
++; MIPS64-LABEL: test_musttail_fptr:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    move $25, $4
++; MIPS64-NEXT:    jr $25
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 %fptr(ptr %fptr, i32 %x)
++  ret i32 %ret
++}
+-- 
+2.52.0
+

--- a/app-devel/llvm-21/spec
+++ b/app-devel/llvm-21/spec
@@ -1,6 +1,4 @@
-VER=21.1.6
-REL=3
-
+VER=21.1.8
 # Use tarball-based source when possible
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
 SUBDIR="llvm-project-$VER.src/llvm"
@@ -8,7 +6,7 @@ SUBDIR="llvm-project-$VER.src/llvm"
 #SRCS="git::commit=tags/llvmorg-${VER}::https://github.com/llvm/llvm-project.git"
 #SUBDIR="llvm-21/llvm"
 
-CHKSUMS="sha256::ae67086eb04bed7ca11ab880349b5f1ab6f50e1b88cda376eaf8a845b935762b"
+CHKSUMS="sha256::4633a23617fa31a3ea51242586ea7fb1da7140e426bd62fc164261fe036aa142"
 CHKUPDATE="anitya::id=1830"
 
 ENVREQ="total_mem=60"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-21: update to 21.1.8
- llvm-20: fix musttail attribute handling for mips

Package(s) Affected
-------------------

- llvm-20: 20.1.8-7
- llvm-21: 21.1.8
- llvm-runtime-20: 20.1.8-7
- llvm-runtime-21: 21.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-20 llvm-21
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
