### PR TITLE
Firmware Survey (Feb. 4, 2026)

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,9 +1,7 @@
-UPSTREAM_VER=20251014
-DEBIANVER=20250808-1
+UPSTREAM_VER=20260110
+DEBIANVER=20251125-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
-# When using a stable tag.
-#SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
-SRCS="git::commit=bd4d2bde91e121c5bc85e6950a374a2e0ed854ff::https://gitlab.com/kernel-firmware/linux-firmware.git \
+SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
@@ -14,6 +12,6 @@ CHKSUMS="SKIP \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::0fc198d42bbfac7060f01445d976c05de2ce13214e1a7521e6dfe4a7a6caa124"
+         sha256::a78d0ca0c92fd8cee3dfd50cb552e730896216bd0137d5697c3cebcaaa9760cc"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"

--- a/runtime-kernel/sof-firmware/spec
+++ b/runtime-kernel/sof-firmware/spec
@@ -1,4 +1,4 @@
-VER=2025.05.1
+VER=2025.12.2
 SRCS="tbl::https://github.com/thesofproject/sof-bin/releases/download/v${VER}/sof-bin-${VER}.tar.gz"
-CHKSUMS="sha256::60d54eae32694332a2120b7c44e4af403a14fe1fdf4c58d72981102b191d259c"
+CHKSUMS="sha256::533f63e3a6d94c09ce05a782657b675fa683ff20787c0979226cf563ec79f517"
 CHKUPDATE="anitya::id=246473"

--- a/topics/firmware-survey-20260204.toml
+++ b/topics/firmware-survey-20260204.toml
@@ -1,0 +1,14 @@
+security = false
+must_match_all = false
+
+[name]
+default = "Device Driver Firmware and Microcode Update (February 6, 2026)"
+zh_CN = "设备驱动固件及微码更新（2026 年 2 月 6 日）"
+
+[caution]
+default = "With enhancements for various audio, graphics, networking, and SoC devices and platforms, with a fix for unresponsive desktop or freezes on platforms based on the AMD Pheonix APUs, as well as added support for audio, graphics, NPU, and networking devices found on Intel Panther Lake platforms"
+zh_CN = "包含对数款音频、图形和网络设备，以及 SoC 平台的支持增强，修复 AMD Pheonix APU 硬件平台偶发桌面无响应或锁死的问题，并新增 Intel Panther Lake 平台音频、图形、NPU 及网络设备的支持"
+
+[packages-v2]
+"firmware-nonfree" = "< 20260110+debian20251125+1"
+"sof-firmware" = "< 2025.12.2"


### PR DESCRIPTION
Topic Description
-----------------

- linux-firmware: update to 20260110+debian20251125+1
- sof-firmware: update to 2025.12.2

Package(s) Affected
-------------------

- firmware-free: 20260110+debian20251125+1
- firmware-nonfree: 20260110+debian20251125+1
- sof-firmware: 2025.12.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sof-firmware linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
