### PR TITLE
coreutils: update to 9.10

### DIFF
--- a/app-utils/coreutils/spec
+++ b/app-utils/coreutils/spec
@@ -1,5 +1,4 @@
-VER=9.9
-REL=1
+VER=9.10
 SRCS="tbl::https://ftp.gnu.org/gnu/coreutils/coreutils-$VER.tar.xz"
-CHKSUMS="sha256::19bcb6ca867183c57d77155eae946c5eced88183143b45ca51ad7d26c628ca75"
+CHKSUMS="sha256::16535a9adf0b10037364e2d612aad3d9f4eca3a344949ced74d12faf4bd51d25"
 CHKUPDATE="anitya::id=343"


### PR DESCRIPTION
Topic Description
-----------------

- coreutils: update to 9.10
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreutils: 9.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
