### PR TITLE
makemkv: revive, 1.18.3

### DIFF
--- a/app-multimedia/makemkv/autobuild/beyond
+++ b/app-multimedia/makemkv/autobuild/beyond
@@ -7,7 +7,15 @@ mkdir -pv tmp/
 echo "accepted" | tee tmp/eula_accepted
 
 abinfo "Copying files ..."
-make install DESTDIR="$PKGDIR" PREFIX=/usr
+ARCH_OPT=()
+if ! ab_match_arch '(amd64|arm64)'; then
+  # use an emulator in this case
+  ARCH_OPT+=('ARCH=x86_64')
+  # apply a workaround
+  # (as we should avoid patching things inside the closed-source parts)
+  ln -sv amd64 bin/x86_64
+fi
+make install DESTDIR="$PKGDIR" PREFIX=/usr "${ARCH_OPT[@]}"
 
 abinfo "Copying licenses ..."
 mkdir -pv "$PKGDIR/usr/share/makemkv/"

--- a/app-multimedia/makemkv/autobuild/beyond
+++ b/app-multimedia/makemkv/autobuild/beyond
@@ -29,4 +29,7 @@ abinfo "Installing modprobe hooks ..."
 mkdir -pv "$PKGDIR/usr/lib/modules-load.d/"
 echo 'sg' > "$PKGDIR/usr/lib/modules-load.d/makemkv-sg.conf"
 
+abinfo "Copying debug symbols for open-source parts ..."
+abelf_copy_dbg_parallel "$SRCDIR"/out "${SYMDIR}"
+
 popd

--- a/app-multimedia/makemkv/autobuild/beyond
+++ b/app-multimedia/makemkv/autobuild/beyond
@@ -1,0 +1,24 @@
+abinfo "Installing closed-source parts ..."
+pushd "$SRCDIR/../makemkv-bin-$PKGVER"
+
+abinfo "Accepting to the EULA ..."
+mkdir -pv tmp/
+# set the flag for unattended installation
+echo "accepted" | tee tmp/eula_accepted
+
+abinfo "Copying files ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr
+
+abinfo "Copying licenses ..."
+mkdir -pv "$PKGDIR/usr/share/makemkv/"
+install -Dvm644 "$SRCDIR/../makemkv-bin-$PKGVER/src/eula_en_linux.txt" "$PKGDIR/usr/share/makemkv/"
+install -Dvm644 "$SRCDIR/License.txt" "$SRCDIR/LICENSE"
+
+abinfo "Fixing permission bits ..."
+chmod -v a+x "$PKGDIR/usr/lib/"*
+
+abinfo "Installing modprobe hooks ..."
+mkdir -pv "$PKGDIR/usr/lib/modules-load.d/"
+echo 'sg' > "$PKGDIR/usr/lib/modules-load.d/makemkv-sg.conf"
+
+popd

--- a/app-multimedia/makemkv/autobuild/defines
+++ b/app-multimedia/makemkv/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=makemkv
+PKGSEC="non-free/video"
+PKGDES="A converter to convert video clips from proprietary discs into a set of MKV files"
+PKGDEP="zlib qt-5 mesa openssl ffmpeg expat"
+
+# License issues
+ABSTRIP=0
+ABSPLITDBG=0
+
+ABTYPE=autotools
+ABSHADOW=0
+RECONF=0
+
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-multimedia/makemkv/autobuild/defines
+++ b/app-multimedia/makemkv/autobuild/defines
@@ -2,6 +2,10 @@ PKGNAME=makemkv
 PKGSEC="non-free/video"
 PKGDES="A converter to convert video clips from proprietary discs into a set of MKV files"
 PKGDEP="zlib qt-5 mesa openssl ffmpeg expat"
+PKGSUG="openjdk-8"
+PKGDEP__EMU="$PKGDEP box64"
+PKGDEP__LOONGARCH64="${PKGDEP__EMU}"
+PKGDEP__RISCV64="${PKGDEP__EMU}"
 
 # License issues
 ABSTRIP=0
@@ -11,4 +15,4 @@ ABTYPE=autotools
 ABSHADOW=0
 RECONF=0
 
-FAIL_ARCH="!(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/app-multimedia/makemkv/autobuild/postinst
+++ b/app-multimedia/makemkv/autobuild/postinst
@@ -1,0 +1,8 @@
+echo "Loading necessary kernel modules ..."
+modprobe -v sg
+
+cat << EOF
+By installing MakeMKV, you agree to the EULA of this software.
+A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt.
+If you do not read and agree to this EULA, please uninstall this package.
+EOF

--- a/app-multimedia/makemkv/spec
+++ b/app-multimedia/makemkv/spec
@@ -1,0 +1,8 @@
+VER=1.18.3
+SRCS="tbl::https://www.makemkv.com/download/makemkv-bin-$VER.tar.gz \
+      tbl::https://www.makemkv.com/download/makemkv-oss-$VER.tar.gz"
+# package oss parts first
+SUBDIR="makemkv-oss-$VER"
+CHKSUMS="sha256::c1ee720ae91b276a7c89be861146c5b934631831e8d6c8f453406435724e92bd \
+         sha256::bc8bb084ae3aabcd503d5bb93efc273e046e4fd4663d39a9836ce0c047fee823"
+CHKUPDATE="anitya::id=177148"

--- a/groups/ffmpeg-rebuilds
+++ b/groups/ffmpeg-rebuilds
@@ -21,6 +21,7 @@ app-multimedia/ffms2
 app-multimedia/harvid
 app-multimedia/kid3
 app-multimedia/kodi
+app-multimedia/makemkv
 app-multimedia/mocp
 app-multimedia/moonlight-embedded
 app-multimedia/moonlight-qt

--- a/groups/openssl-rebuilds
+++ b/groups/openssl-rebuilds
@@ -149,6 +149,7 @@ app-network/lighttpd
 app-network/rsync
 app-admin/lxc
 lang-python/m2crypto
+app-multimedia/makemkv
 app-i18n/meowdict
 app-creativity/mixxx
 app-multimedia/moonlight-embedded


### PR DESCRIPTION
Topic Description
-----------------

- makemkv: use box64 to enable loongarch64 and riscv64 support ...
    ... this software contains an open-source GUI and a closed-source
    decoder server, use box64 to emulate the decoder server should be enough
    to get it working.
- makemkv: revive, 1.18.3
    This reverts commit 445f7167bd92cfa87eebb4e61a1171e1d491200d.

Package(s) Affected
-------------------

- makemkv: 1.18.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit makemkv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
