### PR TITLE
nano: update to 8.7.1+nanorc2024.1.16

### DIFF
--- a/app-editors/nano/spec
+++ b/app-editors/nano/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=8.7
+UPSTREAM_VER=8.7.1
 NANORC_VER=2024.1.16
 VER=${UPSTREAM_VER}+nanorc${NANORC_VER}
 SRCS="git::commit=tags/v${UPSTREAM_VER}::git://git.savannah.gnu.org/nano.git \


### PR DESCRIPTION
Topic Description
-----------------

- nano: update to 8.7.1+nanorc2024.1.16
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- nano: 8.7.1+nanorc2024.1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit nano
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
