### PR TITLE
libreoffice: update to 26.2.0.3

### DIFF
--- a/app-productivity/libreoffice/autobuild/build
+++ b/app-productivity/libreoffice/autobuild/build
@@ -99,7 +99,8 @@ abinfo "Autogen-ing ..."
              --with-gdrive-client-secret="XN6oYWBv7O7w_heXB8TVuldr" \
              --disable-dependency-tracking \
              --enable-pch=full \
-             --with-lang="ALL"
+             --with-lang="ALL" \
+             --enable-skia="no"
 
 if ab_match_arch loongarch64 || \
    ab_match_arch loongarch64_nosimd || \

--- a/app-productivity/libreoffice/autobuild/defines
+++ b/app-productivity/libreoffice/autobuild/defines
@@ -10,7 +10,8 @@ PKGDEP="boost bsh clucene coinmp cups curl dbus-glib desktop-file-utils glew glu
         libqxp libstaroffice libtommath libvisio libwpd libwpg libwps libxslt \
         libzmf lpsolve mariadb mythes neon nspr nss openjdk pango poppler \
         postgresql-runtime python-3 redland sane-backends serf shared-mime-info \
-        unixodbc xmlsec libnumbertext lxml vulkan abseil-cpp zxing-cpp"
+        unixodbc xmlsec libnumbertext lxml vulkan abseil-cpp zxing-cpp md4c \
+        fast-float liborcus afdko"
 BUILDDEP="abseil-cpp apache-ant apr bluez cppunit dejavu-fonts doxygen gdb glm \
           gobject-introspection gperf icu liberation-fonts mdds \
           perl-archive-zip rxvt-unicode unzip zip rpmextract \

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,4 @@
-VER=25.8.4.2
-REL=3
+VER=26.2.0.3
 SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://git.libreoffice.org/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"

--- a/runtime-doc/afdko/autobuild/defines
+++ b/runtime-doc/afdko/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=afdko
+PKGSEC=libs
+PKGDEP="glibc libxml2"
+PKGDES="Adobe Font Development Kit for OpenType"
+ABTYPE=cmakeninja

--- a/runtime-doc/afdko/spec
+++ b/runtime-doc/afdko/spec
@@ -1,0 +1,4 @@
+VER=4.0.3
+SRCS="git::commit=tags/$VER::https://github.com/adobe-type-tools/afdko"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=57202"

--- a/runtime-doc/md4c/autobuild/defines
+++ b/runtime-doc/md4c/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=md4c
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="C Markdown parser"
+ABTYPE=cmakeninja

--- a/runtime-doc/md4c/spec
+++ b/runtime-doc/md4c/spec
@@ -1,0 +1,4 @@
+VER=0.5.2
+SRCS="git::commit=tags/release-$VER::https://github.com/mity/md4c"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=371144"

--- a/runtime-productivity/liborcus/spec
+++ b/runtime-productivity/liborcus/spec
@@ -1,5 +1,4 @@
-VER=0.20.2
+VER=0.21.0
 SRCS="git::commit=tags/$VER::https://gitlab.com/orcus/orcus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1696"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: update to 26.2.0.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- afdko: new, 4.0.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- liborcus: update to 0.21.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- md4c: new, 0.5.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit liborcus libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
