### PR TITLE
fisher: update to 4.4.8

### DIFF
--- a/app-shells/fisher/spec
+++ b/app-shells/fisher/spec
@@ -1,4 +1,4 @@
-VER=4.4.6
+VER=4.4.8
 SRCS="git::commit=tags/$VER::https://github.com/jorgebucaran/fisher"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231509"


### PR DESCRIPTION
Topic Description
-----------------

- fisher: update to 4.4.8
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- fisher: 4.4.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit fisher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
