### PR TITLE
girara: update to 2026.02.04

### DIFF
--- a/runtime-desktop/girara/spec
+++ b/runtime-desktop/girara/spec
@@ -1,4 +1,4 @@
-VER=0.4.5
+VER=2026.02.04
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/girara"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6750"


### PR DESCRIPTION
Topic Description
-----------------

- girara: update to 2026.02.04
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- girara: 2026.02.04

Security Update?
----------------

No

Build Order
-----------

```
#buildit girara
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
