### PR TITLE
iosevka-fonts: update to 34.1.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=34.0.0
+VER=34.1.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::1b07d0d2651950ad963e8306e987eb82e6ad0ed265d93127c7e860be2ce27734 \
-         sha256::2d7057ec6a10597c53d429bdc7c05d9d80eb397be475c468193d152760c9c4ca \
-         sha256::34c7bb88f953df4f6a405fc785cf82cefd3d2f2b8cd9ccee60bfffda29c15111 \
-         sha256::a578a55637589a70e57b00843e435b3478e3846e05c52dab3093f23b0d9d8ae7 \
-         sha256::ef5fb6ebb95588c8fbf31cecf64d3cef95556e0910e7ee52121898d5a76087c2 \
-         sha256::cf20593cdbe4b3a8f2882f682d7a13b5ab150b1410feed17cb2237a7bee6b726 \
-         sha256::c0d3cbbf7c6484ba447baa9fa546bd50579f15184d91e6636a16876c3e05627d \
-         sha256::e929a5b3a1a6ed78a1b9c40c9b02edd1af08dc719a1373dc8402d935a3e1f363 \
-         sha256::e6d081422e6f6406793c5b8120e250e86038907ead448974ed60573833127ce8 \
-         sha256::3b2d6c08bc75b1e50f1369046641502e16d74b8a43aa3cd25dc40f4f52fffec0 \
-         sha256::cda36237b6e4420f6fcde6fa064313e20dcfc1f80262fddbf1fe243dcc1779c8 \
-         sha256::629481dbb539d0eda4921b4d389daf5a1f183831c097051c0b26e1ecbe090efc \
-         sha256::c2e59194544a46ecd9aa1642ff1e6bfc5d8e1cfe1ccbd0231b4fe6a80a68d98a \
-         sha256::4530081558969d2a436ca3d1e71b82891c73da6143ae030fb689f4ad8d7e119f \
-         sha256::d63d5b33f062cd913ec32991b84e3f668098b93a01182d211fc5506296aa4fe2 \
-         sha256::b7c11a203c531575c3f95921a2a3c958f9459eba495cf3a12bc61791ab7b2e94 \
-         sha256::b70bbfb60ce27392f1574522b960f4efb737ef4ebbfc3a1b4b28dac13a8ccc9a \
-         sha256::e03e5fab5fee5dda10516189a20147f45dcde3a400c450809cb849af99c52447 \
-         sha256::26df2d3ef214cbbe0e693cf6bdcbf19deeb1f58ec668b7ec61652863d771a7ff \
-         sha256::96b777a152fe5bc50ebbd64e0ce0cc0f3d2b49bedc70cc7f8c004ca190a1e6f0 \
-         sha256::10d5e23a0ff9355dd4361d7a636059b11976ab08099f6de3a9c881b9128fbcfa \
-         sha256::05f7f1d5efe56ff7f1fcff8c21c2b84da4be44fe9b63d4abbc2e3950b242c585 \
-         sha256::ee4225046e9509ba77fd5505f6a1940b7138410f83bf84b974751bc15191c458 \
-         sha256::85f31752d692f26f8a55a890579c892a03870e15016db659a916b97c3e515333 \
+CHKSUMS="sha256::a8cbe150856aef9b58ec8dd8a6cbc29b9b7db34d6ed466ba57347cd1d3537efe \
+         sha256::bec2efb67ad877c140f3a645ce2969841022db055d5a8376a6f73dacea9bb5e1 \
+         sha256::70ac43efcb702ded3929e124f4aa4c06745023af697709f433693b3433b5d5cc \
+         sha256::5d259fa989af4d96d369ac6cedb7a74da908dc7e8d23b5d7aa69bf60159224ba \
+         sha256::c2d9f83fd539a3ca77e5d6a98bbc9f8911c06b1b403fd6f9ca394a2a23716f97 \
+         sha256::6afb572265667567fcc3ede85171a595149ca4e60cc3b4bd98976ec4dbdbb826 \
+         sha256::bda8738e4b1969dc67f92afe0feacfc03909c18b1a1e9a63b00a3d13b0188449 \
+         sha256::4cd9e1e2281559f1ae4063ecb48c1c463d8d7856bb6eaaa1bbc4b31f35bf9e20 \
+         sha256::1c629f0479bca9d8632573462c6e7f68564cc3a7898d16579e0cd1ab4fb06fd6 \
+         sha256::6b76a00801125c35bfb98391080331b6a189e207e842c4a7c1e96a03acaed1a3 \
+         sha256::128ca84fc59a6e483cdf4eea1db899ae3ab064c019769d7ca4e257453d289382 \
+         sha256::034f04772d73139a3d0c9181fd395add3856c4006bb2eafcd9b1f5a587af3469 \
+         sha256::bbacc3d9fa70e0e63e48c77a0f44c88bf391a54f404593cfc3ee774d818e69f9 \
+         sha256::f9623e38d8fc87121e5858e4cab930c6e67d741c9ef2694df6200c16111e1360 \
+         sha256::85fc9d6ccac45d6195a53f3a8ea71ba9eb9cbda3a67f1fa00e1051ffc109fc81 \
+         sha256::7c92403bdc3ba66e579b18f97cdf307b0529a46bec1dc5228d35372b32598764 \
+         sha256::f9f4395ddae67043ef76dad69a65bdecab1af42873b2ff32598b6cb78461bf21 \
+         sha256::7415ba8fb8e585425ddedb832e70d9b3613ae63a31907ddfdae3fd62c10239e5 \
+         sha256::82c607e807a8b95c06afc71c13d4cc83832705fcbfa97a4097cc35c84897f026 \
+         sha256::2e0a5e12d1e7684d2ed2e10f738c51a19c6d1cb2afa439a94cb4273f27adcbec \
+         sha256::ace9472b5bbca362fac68daf55f625beea925e3f422c08a56e238d79ae001376 \
+         sha256::9e05b708d3bb6e0616fee6d873ec079d6f40a92928eb66b78f3671947de55330 \
+         sha256::50562b5edf20aa3820840b71c091b8f7afc50de5c299b1dd9ddde94989c98484 \
+         sha256::b0876305da64c7efd265f93d9d053c87a580cb50cda6b4da3f80b6317fb7a598 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.1.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
