### PR TITLE
kanshi: update to 1.9.0

### DIFF
--- a/app-utils/kanshi/autobuild/defines
+++ b/app-utils/kanshi/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=kanshi
 PKGSEC=utils
-PKGDEP="wayland libscfg libvarlink"
+PKGDEP="wayland libscfg vali"
 BUILDDEP="meson ninja scdoc"
-PKGDES="A dynamic display configuration tool for Wayland"
+PKGDES="Dynamic display configuration tool for Wayland"
 
 ABTYPE=meson

--- a/app-utils/kanshi/spec
+++ b/app-utils/kanshi/spec
@@ -1,4 +1,4 @@
-VER=1.8.0
+VER=1.9.0
 SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/emersion/kanshi.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=94895"

--- a/runtime-common/vali/autobuild/defines
+++ b/runtime-common/vali/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=vali
+PKGSEC=libs
+PKGDEP="json-c aml"
+BUILDDEP="meson ninja"
+PKGDES="C implementation and code generator of varlink"
+
+ABTYPE=meson

--- a/runtime-common/vali/spec
+++ b/runtime-common/vali/spec
@@ -1,0 +1,4 @@
+VER=0.1.1
+SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/emersion/vali.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=388247"


### PR DESCRIPTION
Topic Description
-----------------

- kanshi: update to 1.9.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- kanshi: 1.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vali kanshi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
