### PR TITLE
libcamera: update to 0.7.0

### DIFF
--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,5 @@
 VER=1.4.10
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"

--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -6,7 +6,7 @@ PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
 PKGDEP__ARM64="${PKGDEP} libpisp"
 BUILDDEP="jinja2 ply pyyaml"
 
-PKGBREAK="pipewire<=1.4.9-2"
+PKGBREAK="pipewire<=1.4.10"
 
 # Note: `-Dpipelines=auto` to let the project decide which pipelines to compile
 # for the host CPU architecture.

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,5 +1,4 @@
-VER=0.6.0
-REL=1
+VER=0.7.0
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: update to 0.7.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libcamera: 0.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcamera:-pkgbreak pipewire libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
