### PR TITLE
zoxide: update to 0.9.9

### DIFF
--- a/app-utils/zoxide/spec
+++ b/app-utils/zoxide/spec
@@ -1,4 +1,4 @@
-VER=0.9.8
+VER=0.9.9
 SRCS="git::commit=tags/v$VER::https://github.com/ajeetdsouza/zoxide"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=98400"


### PR DESCRIPTION
Topic Description
-----------------

- zoxide: update to 0.9.9
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- zoxide: 0.9.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit zoxide
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
