### PR TITLE
Zathura Survey 20260205

### DIFF
--- a/app-doc/zathura-djvu/autobuild/defines
+++ b/app-doc/zathura-djvu/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=zathura-djvu
 PKGSEC=doc
-PKGDEP="djvulibre zathura girara"
+PKGDEP="djvulibre zathura girara glib cairo"
+BUILDDEP="meson"
 PKGDES="DjVu support for Zathura"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Dtests=disabled'
+)

--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,4 +1,4 @@
-VER=0.2.11
+VER=2026.02.03
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/autobuild/defines
+++ b/app-doc/zathura-pdf-poppler/autobuild/defines
@@ -1,6 +1,10 @@
 PKGNAME=zathura-pdf-poppler
 PKGSEC=doc
-PKGDEP="poppler zathura girara"
+PKGDEP="poppler zathura girara glib"
+BUILDDEP="meson"
 PKGDES="Poppler PDF backend support for Zathura"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Dtests=disabled'
+)

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,4 +1,4 @@
-VER=0.3.4
+VER=2026.02.03
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura-ps/autobuild/defines
+++ b/app-doc/zathura-ps/autobuild/defines
@@ -1,4 +1,10 @@
 PKGNAME=zathura-ps
 PKGSEC=doc
-PKGDEP="libspectre zathura girara"
+PKGDEP="libspectre zathura girara glib cairo"
+BUILDDEP="meson"
 PKGDES="PostScript support for Zathura"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dtests=disabled'
+)

--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,4 +1,4 @@
-VER=0.2.9
+VER=2026.02.03
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"

--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -1,12 +1,14 @@
 PKGNAME=zathura
 PKGSEC=doc
-PKGDEP="girara sqlite desktop-file-utils file libseccomp texlive"
-BUILDDEP="docutils sphinx appstream-glib bash-completion fish librsvg"
-PKGDES="A minimalistic document viewer"
+PKGDEP="gtk-3 glib json-glib girara sqlite file libseccomp texlive"
+BUILDDEP="sphinx bash-completion fish librsvg"
+PKGDES="Document viewer"
 
 ABTYPE=meson
-MESON_AFTER="-Dsynctex=enabled \
-             -Dseccomp=enabled \
-             -Dmanpages=enabled \
-             -Dtests=disabled \
-             -Dconvert-icon=enabled"
+MESON_AFTER=(
+    '-Dsynctex=enabled'
+    '-Dseccomp=enabled'
+    '-Dmanpages=enabled'
+    '-Dtests=disabled'
+    '-Dconvert-icon=enabled'
+)

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=0.5.14
+VER=2026.02.03
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"

--- a/runtime-desktop/girara/autobuild/defines
+++ b/runtime-desktop/girara/autobuild/defines
@@ -1,9 +1,13 @@
 PKGNAME=girara
 PKGSEC=libs
-PKGDEP="gtk-3 json-glib glib pango glibc"
-BUILDDEP="doxygen"
-PKGDES="User interface library focused on simplicity and minimalism"
-PKGBREAK="zathura-djvu<=0.2.9-2 zathura<=0.5.2 zathura-pdf-poppler<=0.3.1 \
-          zathura-ps<=0.2.7"
+PKGDEP="glib glibc"
+BUILDDEP="meson"
+PKGDES="Common components for Zathura"
+PKGBREAK="zathura-djvu<=0.2.11 zathura<=0.5.14 zathura-pdf-poppler<=0.3.4 \
+          zathura-ps<=0.2.9"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Ddocs=disabled'
+    '-Dtests=disabled'
+)

--- a/runtime-desktop/girara/spec
+++ b/runtime-desktop/girara/spec
@@ -1,4 +1,4 @@
-VER=0.4.5
+VER=2026.02.04
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/girara"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6750"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-ps: update to 2026.02.03
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-pdf-poppler: update to 2026.02.03
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-djvu: update to 2026.02.03
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura: update to 2026.02.03
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- girara: update to 2026.02.04
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- girara: 2026.02.04
- zathura: 2026.02.03
- zathura-djvu: 2026.02.03
- zathura-pdf-poppler: 2026.02.03
- zathura-ps: 2026.02.03

Security Update?
----------------

No

Build Order
-----------

```
#buildit girara zathura zathura-djvu zathura-pdf-poppler zathura-ps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
