### PR TITLE
python-3: rework 3.14 update

### DIFF
--- a/lang-python/numpy/autobuild/defines
+++ b/lang-python/numpy/autobuild/defines
@@ -8,3 +8,6 @@ ABTYPE=pep517
 
 NOSTATIC=0
 NOPYTHON2=1
+
+# FIXME: lto1: fatal error: target specific builtin not available
+NOLTO__RISCV64=1

--- a/lang-python/numpy/spec
+++ b/lang-python/numpy/spec
@@ -1,4 +1,5 @@
 VER=2.4.1
+REL=1
 SRCS="tbl::https://pypi.org/packages/source/n/numpy/numpy-$VER.tar.gz"
 CHKSUMS="sha256::a1ceafc5042451a858231588a104093474c6a5c57dcc724841f5c888d237d690"
 CHKUPDATE="anitya::id=41556"

--- a/lang-python/python-3/autobuild/defines
+++ b/lang-python/python-3/autobuild/defines
@@ -316,7 +316,7 @@ PKGBREAK="acbs<=2:20251231 accerciser<=3.40.0-1 acme<=5.1.0 \
 	pytools<=2019.1-5 pytz<=2025.2 pyudev<=0.24.3 pyusb<=1.0.2-6 \
 	pywal<=3.3.0-1 pywbem<=1.7.3 pyx<=0.16 pyxattr<=0.8.1 pyxdg<=0.28 \
 	pyyaml<=1:6.0.2-1 pyzmq<=26.4.0 qasync<=0.27.1 qpageview<=0.6.2 \
-	qscintilla<=2.14.1-1 qt-6<=6.10.0 qtpy<=2.1.0 quodlibet<=4.6.0 \
+	qscintilla<=2.14.1-1 qtpy<=2.1.0 quodlibet<=4.6.0 \
 	qutebrowser<=3.6.3+pdfjs5.4.449 rackspace-novaclient<=2.1 \
 	random2<=1.0.2 ranger<=1.9.3-1 rapidfuzz<=3.2.0-1 rclone<=1.72.1 \
 	rdflib<=6.2.0-1 rdma-core<=61.0 recommonmark<=20180907-5 \

--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,4 +1,5 @@
 VER=3.14.2
+REL=1
 SRCS="tbl::https://www.python.org/ftp/python/${VER/~*/}/Python-${VER/\~/}.tar.xz"
 CHKSUMS="sha256::ce543ab854bc256b61b71e9b27f831ffd1bfd60a479d639f8be7f9757cf573e9"
 CHKUPDATE="anitya::id=13254"


### PR DESCRIPTION
Topic Description
-----------------

- python-3: drop qt-6 breakage
- numpy: \(riscv64\) disable LTO

Package(s) Affected
-------------------

- numpy: 2.4.1-1
- python-3: 3.14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit numpy python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
