### PR TITLE
tzdata: update to 2025c

### DIFF
--- a/runtime-data/tzdata/spec
+++ b/runtime-data/tzdata/spec
@@ -1,4 +1,4 @@
-VER=2025b
+VER=2025c
 SRCS="https://data.iana.org/time-zones/releases/tzdata$VER.tar.gz"
-CHKSUMS="sha256::11810413345fc7805017e27ea9fa4885fd74cd61b2911711ad038f5d28d71474"
+CHKSUMS="sha256::4aa79e4effee53fc4029ffe5f6ebe97937282ebcdf386d5d2da91ce84142f957"
 CHKUPDATE="anitya::id=5021"


### PR DESCRIPTION
Topic Description
-----------------

- tzdata: update to 2025c
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tzdata: 2025c

Security Update?
----------------

No

Build Order
-----------

```
#buildit tzdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
