### PR TITLE
scons: update to 4.10.1

### DIFF
--- a/app-devel/scons/spec
+++ b/app-devel/scons/spec
@@ -1,5 +1,4 @@
-VER=4.10.0
+VER=4.10.1
 SRCS="git::commit=tags/$VER::https://github.com/SCons/scons.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4770"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- scons: update to 4.10.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scons: 4.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit scons
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
