### PR TITLE
jujutsu: update to 0.38.0

### DIFF
--- a/app-vcs/jujutsu/spec
+++ b/app-vcs/jujutsu/spec
@@ -1,4 +1,4 @@
-VER=0.37.0
+VER=0.38.0
 SRCS="git::commit=tags/v$VER::https://github.com/jj-vcs/jj.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376676"


### PR DESCRIPTION
Topic Description
-----------------

- jujutsu: update to 0.38.0
    Co-authored-by: Rong "Mantle" Bao \(@CSharperMantle\) <rong.bao@csmantle.top>

Package(s) Affected
-------------------

- jujutsu: 0.38.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit jujutsu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
