### PR TITLE
Python 3.14 rework (wave 2)

### DIFF
--- a/lang-python/yt-dlp-ejs/autobuild/defines
+++ b/lang-python/yt-dlp-ejs/autobuild/defines
@@ -8,18 +8,6 @@ BUILDDEP="hatchling hatch-vcs deno"
 ABTYPE=pep517
 NOPYTHON2=1
 
-# Note: From deno.
-#
-# loongson3: Missing libclang_rt.builtins.a.
-#
-# loongarch64, ppc64el, loongson3: no wasmtime/cranelift support.
-# * https://github.com/bytecodealliance/wasmtime/blob/f7a5aa34d9b1f1e74ccf5d39740221400f12bb81/cranelift/codegen/meta/src/isa/mod.rs#L11
-# * https://github.com/loongson-community/discussions/issues/59
-#
-# riscv64: fails to build ring crate
-# * https://github.com/denoland/deno/issues/18702
-FAIL_ARCH="!(amd64|arm64)"
-
-# Note: Inheriting FAIL_ARCH requires removal of noarch flag, treating as
-# architecture-specific.
-ABSPLITDBG=0
+# FIXME: This should only be built on amd64, on the assumption that
+# BuildIt! would always route noarch packages to amd64 build hosts.
+ABHOST=noarch

--- a/lang-python/yt-dlp-ejs/spec
+++ b/lang-python/yt-dlp-ejs/spec
@@ -2,4 +2,4 @@ VER=0.3.1
 SRCS="pypi::version=$VER::yt-dlp-ejs"
 CHKSUMS="sha256::7f2119eb02864800f651fa33825ddfe13d152a1f730fa103d9864f091df24227"
 CHKUPDATE="anitya::id=386809"
-REL="1"
+REL="2"

--- a/topics/python-3.14.toml
+++ b/topics/python-3.14.toml
@@ -8,4 +8,4 @@ default = "Updates Python to 3.14, including new language and runtime features s
 zh_CN = "更新 Python 至 3.14，包含自 Python 3.10 起的各类新语言及运行时特性"
 
 [packages-v2]
-"python-3" = "3.14.2"
+"python-3" = "< 3.14.2"


### PR DESCRIPTION
Topic Description
-----------------

- yt-dlp-ejs: revert back to noarch
- topics: fix version range in python-3.14.toml

Package(s) Affected
-------------------

- yt-dlp-ejs: 0.3.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit yt-dlp-ejs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
