### PR TITLE
vscode: update to 1.109.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.108.2
+VER=1.109.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::af054638b3f0638ad117f636d8ca559e0b310d69d9369365c7f631fe81e0e7d1"
-CHKSUMS__ARM64="sha256::848f3571c51c69533c263e5a774e9ef3b200dcc6a23c3be5bbbe291f9dabce6a"
+CHKSUMS__AMD64="sha256::5c45e63e503d608bfd02015073c18d7f5ec670fdbad270af108524ebfc53da42"
+CHKSUMS__ARM64="sha256::8b71efb19aaffbaf432eb3343e4ebc8e7d0dca0dd18481850450e0e894296039"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.109.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.109.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
