### PR TITLE
aosc-community-wallpapers-fumo: new, 20260211

### DIFF
--- a/desktop-themes/aosc-community-wallpapers-fumo/autobuild/build
+++ b/desktop-themes/aosc-community-wallpapers-fumo/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Generating and installing wallpapers ..."
+WPMETA_LOG=info \
+wpmeta \
+    --src "$SRCDIR" \
+    --dst "$PKGDIR"

--- a/desktop-themes/aosc-community-wallpapers-fumo/autobuild/defines
+++ b/desktop-themes/aosc-community-wallpapers-fumo/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=aosc-community-wallpapers-fumo
+PKGSEC=misc
+PKGDEP=""
+BUILDDEP="wpmeta"
+PKGDES="AOSC OS wallpapers with fumofumo (ᗜˬᗜ)"
+
+ABHOST=noarch
+ABTYPE=self

--- a/desktop-themes/aosc-community-wallpapers-fumo/spec
+++ b/desktop-themes/aosc-community-wallpapers-fumo/spec
@@ -1,0 +1,4 @@
+VER=2026.02.11
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers-fumo"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=283163"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

aosc-community-wallpapers-fumo: new wallpapers package 2026.02.11

Package(s) Affected
-------------------

aosc-community-wallpapers-fumo: 1:2026.02.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-community-wallpapers-fumo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`