### PR TITLE
libuv: update to 1.51.0

### DIFF
--- a/runtime-common/libuv/spec
+++ b/runtime-common/libuv/spec
@@ -1,5 +1,4 @@
-VER=1.48.0
-REL=1
+VER=1.51.0
 SRCS="git::commit=tags/v$VER::https://github.com/libuv/libuv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10784"


### PR DESCRIPTION
Topic Description
-----------------

- libuv: update to 1.51.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libuv: 1.51.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libuv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
