### PR TITLE
fcitx5-pinyin-moegirl: update to 20260209

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260109
+VER=20260209
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::c4667bb3110b3e53e8dbba120a80d742b96282499cc3f7c37b1205b7f4b4aea7
-         sha256::4bccd04c730c145d03eee5bb38600ea475d62b52a0827659e9b96fa9d70628ce
+CHKSUMS="sha256::669b80712e8a81544bf2bbbe53ffff662ee38972c621b4b1e9d3c5d0a58bbf04\
+         sha256::9b3bf1156fe5c2b027a014d0b1f0757277d4be7d03f7aeba8968140e9698adc2\
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx-pinyin-moegirl: update to 20260209

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260209
- rime-pinyin-moegirl: 20260209

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
