### PR TITLE
tigervnc: update to 1.16.0+xserver21.1.21

### DIFF
--- a/app-network/tigervnc/autobuild/defines
+++ b/app-network/tigervnc/autobuild/defines
@@ -1,11 +1,26 @@
 PKGNAME=tigervnc
 PKGSEC=net
-PKGDEP="fltk-1.3 gnutls libgcrypt mesa libjpeg-turbo pixman x11-app \
-        xkeyboard-config ffmpeg libxcvt xinit"
+PKGDEP="fltk-1.3 ffmpeg gcc-runtime glib glibc gmp gnutls libgcrypt \
+        libjpeg-turbo libmd libpwquality libunwind libxau libxcvt \
+        libxdmcp libxkbcommon linux-pam mesa nettle pipewire pixman \
+        systemd util-linux-runtime wayland x11-app x11-lib xinit \
+        xkeyboard-config zlib"
 BUILDDEP="x11-font x11-app x11-proto cmake imagemagick nasm patchelf"
 PKGDES="Suite of VNC servers and clients"
 
 ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DINSTALL_SYSTEMD_UNITS=ON'
+    '-DENABLE_NLS=ON'
+    '-DENABLE_H264=ON'
+    '-DBUILD_VIEWER=ON'
+    '-DENABLE_GNUTLS=ON'
+    '-DENABLE_NETTLE=ON'
+    '-DENABLE_SELINUX=OFF'
+    '-DENABLE_SYSTEMD=ON'
+    '-DENABLE_PWQUALITY=ON'
+    '-DENABLE_WAYLAND=ON'
+)
 
 # Note: Library built by CMake is needed for Xvnc
 ABSHADOW=0

--- a/app-network/tigervnc/autobuild/patches/0001-Arch-Linux-more-xsessions.patch
+++ b/app-network/tigervnc/autobuild/patches/0001-Arch-Linux-more-xsessions.patch
@@ -1,5 +1,14 @@
+From 2d4ea1f989d75d04c8978255448635dbaeafe381 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 11 Feb 2026 22:46:36 +0800
+Subject: [PATCH 1/3] Arch Linux: more xsessions
+
+---
+ unix/vncserver/vncserver.in | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
 diff --git a/unix/vncserver/vncserver.in b/unix/vncserver/vncserver.in
-index ebdd3a97..089177a9 100755
+index 03eee275..5b8c0ed6 100755
 --- a/unix/vncserver/vncserver.in
 +++ b/unix/vncserver/vncserver.in
 @@ -447,7 +447,13 @@ sub SanityCheck
@@ -17,3 +26,6 @@ index ebdd3a97..089177a9 100755
          if (-x "$cmd") {
              $Xsession = $cmd;
              last;
+-- 
+2.52.0
+

--- a/app-network/tigervnc/autobuild/patches/0002-Arch-Linux-remove-selinux.patch
+++ b/app-network/tigervnc/autobuild/patches/0002-Arch-Linux-remove-selinux.patch
@@ -1,3 +1,13 @@
+From d3c23237e7bf65236684ee7d9434cbbc7c1661d1 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 11 Feb 2026 22:46:58 +0800
+Subject: [PATCH 2/3] Arch Linux: remove selinux
+
+---
+ unix/vncserver/tigervnc.pam          | 3 ---
+ unix/vncserver/vncserver@.service.in | 1 -
+ 2 files changed, 4 deletions(-)
+
 diff --git a/unix/vncserver/tigervnc.pam b/unix/vncserver/tigervnc.pam
 index dda76c49..b372c821 100644
 --- a/unix/vncserver/tigervnc.pam
@@ -14,10 +24,10 @@ index dda76c49..b372c821 100644
  session    optional     pam_keyinit.so force revoke
  session    required     pam_limits.so
 diff --git a/unix/vncserver/vncserver@.service.in b/unix/vncserver/vncserver@.service.in
-index 592ddb67..1ff14012 100644
+index 336498ac..a7d961d1 100644
 --- a/unix/vncserver/vncserver@.service.in
 +++ b/unix/vncserver/vncserver@.service.in
-@@ -37,7 +37,6 @@ After=syslog.target network.target systemd-user-sessions.service
+@@ -37,7 +37,6 @@ After=network.target systemd-user-sessions.service
  Type=forking
  ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/vncsession-start %i
  PIDFile=/run/vncsession-%i.pid
@@ -25,3 +35,6 @@ index 592ddb67..1ff14012 100644
  
  [Install]
  WantedBy=multi-user.target
+-- 
+2.52.0
+

--- a/app-network/tigervnc/autobuild/patches/0003-Arch-Linux-fltk-1.3.patch
+++ b/app-network/tigervnc/autobuild/patches/0003-Arch-Linux-fltk-1.3.patch
@@ -1,26 +1,44 @@
-diff --git i/CMakeLists.txt w/CMakeLists.txt
-index 986094be..9e871543 100644
---- i/CMakeLists.txt
-+++ w/CMakeLists.txt
-@@ -277,7 +277,7 @@ if(BUILD_VIEWER)
-   set(FLTK_SKIP_FLUID TRUE)
+From fa35f9d066587d7b8d6304099ecf09f7148e1257 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 11 Feb 2026 22:47:58 +0800
+Subject: [PATCH 3/3] Arch Linux: fltk 1.3
+
+---
+ CMakeLists.txt | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a5981938..1f011d22 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -267,12 +267,12 @@ if(BUILD_VIEWER)
    set(FLTK_SKIP_OPENGL TRUE)
    set(FLTK_SKIP_FORMS TRUE)
--  find_package(FLTK REQUIRED)
-+  find_package(FLTK1.3 REQUIRED)
+   if(BUILD_VIEWER STREQUAL "AUTO")
+-    find_package(FLTK)
++    find_package(FLTK1.3)
+   else()
+-    find_package(FLTK REQUIRED)
++    find_package(FLTK1.3 REQUIRED)
+   endif()
  
-   if(UNIX AND NOT APPLE)
-     # No proper handling for extra X11 libs that FLTK might need...
-@@ -305,11 +305,6 @@ if(BUILD_VIEWER)
-   set(CMAKE_REQUIRED_INCLUDES ${FLTK_INCLUDE_DIR})
-   set(CMAKE_REQUIRED_LIBRARIES ${FLTK_LIBRARIES})
+-  if(NOT FLTK_FOUND)
++  if(NOT FLTK1.3_FOUND)
+     message(WARNING "FLTK NOT found. TigerVNC viewer disabled.")
+     set(BUILD_VIEWER 0)
+   endif()
+@@ -304,11 +304,6 @@ if(BUILD_VIEWER)
+     set(CMAKE_REQUIRED_INCLUDES ${FLTK_INCLUDE_DIR})
+     set(CMAKE_REQUIRED_LIBRARIES ${FLTK_LIBRARIES})
  
--  check_cxx_source_compiles("#include <FL/Fl.H>\n#if FL_MAJOR_VERSION != 1 || FL_MINOR_VERSION != 3\n#error Wrong FLTK version\n#endif\nint main(int, char**) { return 0; }" OK_FLTK_VERSION)
--  if(NOT OK_FLTK_VERSION)
--    message(FATAL_ERROR "Incompatible version of FLTK")
--  endif()
+-    check_cxx_source_compiles("#include <FL/Fl.H>\n#if FL_MAJOR_VERSION != 1 || FL_MINOR_VERSION != 3\n#error Wrong FLTK version\n#endif\nint main(int, char**) { return 0; }" OK_FLTK_VERSION)
+-    if(NOT OK_FLTK_VERSION)
+-      message(FATAL_ERROR "Incompatible version of FLTK")
+-    endif()
 -
-   set(CMAKE_REQUIRED_FLAGS)
-   set(CMAKE_REQUIRED_INCLUDES)
-   set(CMAKE_REQUIRED_LIBRARIES)
+     set(CMAKE_REQUIRED_FLAGS)
+     set(CMAKE_REQUIRED_INCLUDES)
+     set(CMAKE_REQUIRED_LIBRARIES)
+-- 
+2.52.0
 

--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.15.0
+UPSTREAM_VER=1.16.0
 XORG_VER=21.1.21
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update to 1.16.0+xserver21.1.21

Package(s) Affected
-------------------

- tigervnc: 1.16.0+xserver21.1.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
