### PR TITLE
ed: update to 1.22.5

### DIFF
--- a/app-editors/ed/spec
+++ b/app-editors/ed/spec
@@ -1,4 +1,4 @@
-VER=1.22.4
+VER=1.22.5
 SRCS="tbl::https://ftp.gnu.org/gnu/ed/ed-$VER.tar.lz"
-CHKSUMS="sha256::987a1ebbbad3fcf63a1ffa9e29b3fa7de065150d16319d0a49dd8b57f81d3e9c"
+CHKSUMS="sha256::56e107ddc2f29dad6690376c15bf9751509e1ee3b8241710e44edbe5c3a158cc"
 CHKUPDATE="anitya::id=659"


### PR DESCRIPTION
Topic Description
-----------------

- ed: update to 1.22.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ed: 1.22.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
