### PR TITLE
tdelibs: rename imagetops to avoid leptonica conflict

### DIFF
--- a/desktop-trinity/tdelibs/autobuild/patches/0002-rename-imagetops-to-imagetops-tdeprint.patch
+++ b/desktop-trinity/tdelibs/autobuild/patches/0002-rename-imagetops-to-imagetops-tdeprint.patch
@@ -1,0 +1,78 @@
+From ea4b1f28ade4093d8e267b9a20b486079f0a54e4 Mon Sep 17 00:00:00 2001
+From: "CyberNeko-AI" <cyberneko.ai@aosc.io>
+Date: Thu, 12 Feb 2026 17:11:40 +0800
+Subject: [PATCH] Rename imagetops to imagetops-tdeprint
+
+---
+ tdeprint/filters/CMakeLists.txt                    | 2 +-
+ tdeprint/filters/Makefile.am                       | 2 +-
+ tdeprint/filters/{imagetops => imagetops-tdeprint} | 2 +-
+ tdeprint/filters/imagetops.desktop                 | 2 +-
+ tdeprint/filters/imagetops.xml                     | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+ rename tdeprint/filters/{imagetops => imagetops-tdeprint} (95%)
+
+diff --git a/tdeprint/filters/CMakeLists.txt b/tdeprint/filters/CMakeLists.txt
+index 74d9a04..b31f499 100644
+--- a/tdeprint/filters/CMakeLists.txt
++++ b/tdeprint/filters/CMakeLists.txt
+@@ -35,5 +35,5 @@ install(
+ )
+ 
+ if( WITH_IMAGETOPS_BINARY )
+-  install( PROGRAMS imagetops DESTINATION ${BIN_INSTALL_DIR} )
++  install( PROGRAMS imagetops-tdeprint DESTINATION ${BIN_INSTALL_DIR} )
+ endif()
+diff --git a/tdeprint/filters/Makefile.am b/tdeprint/filters/Makefile.am
+index f9c9f91..bd98010 100644
+--- a/tdeprint/filters/Makefile.am
++++ b/tdeprint/filters/Makefile.am
+@@ -11,4 +11,4 @@ filters_DATA = enscript.desktop enscript.xml\
+ 	       pdf2ps.desktop pdf2ps.xml \
+ 	       poster.desktop poster.xml
+ 
+-bin_SCRIPTS = imagetops
++bin_SCRIPTS = imagetops-tdeprint
+diff --git a/tdeprint/filters/imagetops b/tdeprint/filters/imagetops-tdeprint
+similarity index 95%
+rename from tdeprint/filters/imagetops
+rename to tdeprint/filters/imagetops-tdeprint
+index 634a2ca..baef7d5 100755
+--- a/tdeprint/filters/imagetops
++++ b/tdeprint/filters/imagetops-tdeprint
+@@ -19,7 +19,7 @@ done
+ temp=0
+ if test -z "$FILE" -o ! -f "$FILE" ; then
+ 	ARGS="$ARGS $FILE"
+-	FILE=`mktemp /tmp/imagetops.XXXXXX` || exit 1
++	FILE=`mktemp /tmp/imagetops-tdeprint.XXXXXX` || exit 1
+ 	cat > "$FILE"
+ 	temp=1
+ fi
+diff --git a/tdeprint/filters/imagetops.desktop b/tdeprint/filters/imagetops.desktop
+index bf09a8f..af2f43c 100644
+--- a/tdeprint/filters/imagetops.desktop
++++ b/tdeprint/filters/imagetops.desktop
+@@ -1,6 +1,6 @@
+ [TDE Print Filter Entry]
+ Name=imagetops
+-Require=exec:/imagetops
++Require=exec:/imagetops-tdeprint
+ Comment=Generic Image to PS Filter
+ MimeTypeIn=image/jpeg,image/png,image/x-png,image/bmp,image/x-bmp,image/gif,image/tiff
+ MimeTypeOut=application/postscript
+diff --git a/tdeprint/filters/imagetops.xml b/tdeprint/filters/imagetops.xml
+index aba7f88..5fbcd9f 100644
+--- a/tdeprint/filters/imagetops.xml
++++ b/tdeprint/filters/imagetops.xml
+@@ -1,6 +1,6 @@
+ <?xml version="1.0"?>
+ <kprintfilter name="imagetops">
+-	<filtercommand data="imagetops %filterargs %filterinput %filteroutput" />
++	<filtercommand data="imagetops-tdeprint %filterargs %filterinput %filteroutput" />
+ 	<filterargs>
+ 		<filterarg name="center" description="Image centering" format="-nocenter" type="bool" default="true">
+ 			<value name="true" description="Yes" />
+-- 
+2.52.0
+

--- a/desktop-trinity/tdelibs/spec
+++ b/desktop-trinity/tdelibs/spec
@@ -1,4 +1,5 @@
 VER=14.1.5
+REL=1
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdelibs-trinity-$VER.tar.xz"
 CHKSUMS="sha256::b46c1a8952d71c820f8ef92bcc0535bf821d97591b9163e0cc718250dc2a3847"
 CHKUPDATE="anitya::id=16065"


### PR DESCRIPTION
Topic Description
-----------------

- Rename TDE’s `imagetops` print filter script to `imagetops-tdeprint` to avoid colliding with Leptonica’s `/usr/bin/imagetops`.
- Update the corresponding TDE print filter definitions (XML/.desktop) and install rules to reference/install the new name.
- Goal: allow co-installation of tdelibs and leptonica without dpkg file overwrite conflicts.

Package(s) Affected
-------------------

- tdelibs: 14.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit tdelibs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
