### PR TITLE
ab-download-manager: update to 1.8.6

### DIFF
--- a/app-web/ab-download-manager/spec
+++ b/app-web/ab-download-manager/spec
@@ -1,4 +1,4 @@
-VER=1.8.4
+VER=1.8.6
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/amir1376/ab-download-manager"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376269"


### PR DESCRIPTION
Topic Description
-----------------

- ab-download-manager: update to 1.8.6
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- ab-download-manager: 1.8.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit ab-download-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
