### PR TITLE
Python 3.14 rework

### DIFF
--- a/app-creativity/blender/autobuild/defines
+++ b/app-creativity/blender/autobuild/defines
@@ -75,3 +75,6 @@ CMAKE_AFTER__ARM64=(
 )
 
 AB_FLAGS_O3=1
+
+# FIXME: Not enough RAM on any of our MIPS builders.
+NOLTO__LOONGSON3=1

--- a/app-creativity/blender/spec
+++ b/app-creativity/blender/spec
@@ -1,4 +1,5 @@
 VER=4.4.3
+REL=1
 SRCS="tbl::https://download.blender.org/source/blender-$VER.tar.xz"
 CHKSUMS="sha256::99ecdef24ece14084016ee47c756eeb2fc8a09c8487a0296b45a117224dc5ca7"
 CHKUPDATE="anitya::id=201"

--- a/app-utils/watchman/autobuild/prepare
+++ b/app-utils/watchman/autobuild/prepare
@@ -4,3 +4,11 @@ export DESTDIR="$PKGDIR"
 # FIXME: GCC 15 fails to build this package.
 abinfo "Setting CC/CXX to GCC 14 temporarily ..."
 export CC=gcc-14 CXX=g++-14
+
+if ab_match_arch riscv64 ; then
+	# FIXME: Compiler and linker flags set too early for compiler version
+	# checks to work after CFLAGS/CXXFLAGS are set here in prepare.
+	abinfo "Removing compiler flags from GCC 15 ..."
+	export CFLAGS="${CFLAGS/-mno-fence-tso/}"
+	export CXXFLAGS="${CXXFLAGS/-mno-fence-tso/}"
+fi

--- a/app-utils/watchman/spec
+++ b/app-utils/watchman/spec
@@ -1,5 +1,5 @@
 VER=2025.09.01.00
-REL="3"
+REL="4"
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/facebook/watchman.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15760"

--- a/lang-python/python-3/autobuild/defines
+++ b/lang-python/python-3/autobuild/defines
@@ -297,7 +297,7 @@ PKGBREAK="acbs<=2:20251231 accerciser<=3.40.0-1 acme<=5.1.0 \
 	pysendfile<=2.0.1-4 pyserial<=3.5-1 pyside2<=5.15.16-2 pyside6<=6.10.0 \
 	pysmbc<=1.0.25.1-1 pysocks<=1.7.1 pysol-cards<=0.24.0 pyte<=0.8.0-4 \
 	pytest-datafiles<=3.0.0 pytest-mock<=3.15.1 pytest<=8.2.2 \
-	python-2<=2.7.18-3 python-augeas<=1.2.0 python-base<=3 \
+	python-augeas<=1.2.0 python-base<=3 \
 	python-build<=1.3.0 python-cloudflare<=2.8.15-1 python-crc<=7.0.0 \
 	python-cssselect<=1.3.0 python-daemonize<=2.5.0 \
 	python-dbusmock<=0.37.1 python-discid<=1.2.0-1 \

--- a/lang-python/python-3/autobuild/defines.stage2
+++ b/lang-python/python-3/autobuild/defines.stage2
@@ -290,7 +290,7 @@ PKGBREAK="acbs<=2:20251231 accerciser<=3.40.0-1 acme<=5.1.0 \
 	pysendfile<=2.0.1-4 pyserial<=3.5-1 pyside2<=5.15.16-2 pyside6<=6.10.0 \
 	pysmbc<=1.0.25.1-1 pysocks<=1.7.1 pysol-cards<=0.24.0 pyte<=0.8.0-4 \
 	pytest-datafiles<=3.0.0 pytest-mock<=3.15.1 pytest<=8.2.2 \
-	python-2<=2.7.18-3 python-augeas<=1.2.0 python-base<=3 \
+	python-augeas<=1.2.0 python-base<=3 \
 	python-build<=1.3.0 python-cloudflare<=2.8.15-1 python-crc<=7.0.0 \
 	python-cssselect<=1.3.0 python-daemonize<=2.5.0 \
 	python-dbusmock<=0.37.1 python-discid<=1.2.0-1 \

--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,5 +1,5 @@
 VER=3.14.2
-REL=1
+REL=2
 SRCS="tbl::https://www.python.org/ftp/python/${VER/~*/}/Python-${VER/\~/}.tar.xz"
 CHKSUMS="sha256::ce543ab854bc256b61b71e9b27f831ffd1bfd60a479d639f8be7f9757cf573e9"
 CHKUPDATE="anitya::id=13254"


### PR DESCRIPTION
Topic Description
-----------------

- watchman: remove GCC 15 specific compiler flags for riscv64
- blender: disable LTO for loongson3
    It eats too much RAM on our loongson3 builders.
- python-3: remove python-2 from PKGBREAK

Package(s) Affected
-------------------

- blender: 4.4.3-1
- python-3: 3.14.2-2
- watchman: 2025.09.01.00-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-3 blender watchman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
