### PR TITLE
pytest-timeout: new, 2.4.0

### DIFF
--- a/lang-python/pytest-timeout/autobuild/defines
+++ b/lang-python/pytest-timeout/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pytest-timeout
+PKGSEC=python
+PKGDEP="setuptools pytest"
+BUILDDEP="setuptools-scm"
+PKGDES="Pytest plugin to abort hanging tests"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytest-timeout/spec
+++ b/lang-python/pytest-timeout/spec
@@ -1,0 +1,4 @@
+VER=2.4.0
+SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/pytest-dev/pytest-timeout"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=15174"


### PR DESCRIPTION
Topic Description
-----------------

- pytest-timeout: new, 2.4.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pytest-timeout: 2.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pytest-timeout
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
