### PR TITLE
gearlever: update to 4.3.1

### DIFF
--- a/app-utils/gearlever/spec
+++ b/app-utils/gearlever/spec
@@ -1,5 +1,4 @@
-VER=4.3.0
+VER=4.3.1
 SRCS="git::commit=tags/$VER::https://github.com/mijorus/gearlever.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378021"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- gearlever: update to 4.3.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- gearlever: 4.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gearlever
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
