### PR TITLE
mesa: update to 25.3.5

### DIFF
--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,5 +1,5 @@
-UPSTREAM_VER=25.3.2
+UPSTREAM_VER=25.3.5
 VER=${UPSTREAM_VER//-/~}
 SRCS="tbl::https://archive.mesa3d.org/mesa-${VER}.tar.xz"
-CHKSUMS="sha256::e69dab0d0ea03e3e8cb141b032f58ea9fcf3b9c1f61b31f6592cb4bbd8d0185d"
+CHKSUMS="sha256::be472413475082df945e0f9be34f5af008baa03eb357e067ce5a611a2d44c44b"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: update to 25.3.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mesa: 1:25.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
