### PR TITLE
pycryptodome: break pycryptodomex from Python 3.14 testing topic

### DIFF
--- a/lang-python/pycryptodome/autobuild/defines
+++ b/lang-python/pycryptodome/autobuild/defines
@@ -5,8 +5,11 @@ PKGRECOM="gmp"
 BUILDDEP="python-build setuptools-python3"
 PKGDES="Collection of cryptographic algorithms and protocols"
 
-PKGBREAK="pycrypto<=2.6.1-4 pycryptodomex<=3.23.0 musicbox<=1:0.3.1 yt-dlp<=2025.12.08 mycli<=1.42.0-1"
-PKGREP="pycrypto<=2.6.1-4 pycryptodomex<=3.23.0"
+# NOTE: pycryptodomex was 3.23.0 in stable before going to 1:0
+#       However, 3.23.0-1~preXXX was shipped in Python 3.14 testing
+#       topic. Users who involved in testing may fail to upgrade their system.
+PKGBREAK="pycrypto<=2.6.1-4 pycryptodomex<=3.24.0 musicbox<=1:0.3.1 yt-dlp<=2025.12.08 mycli<=1.42.0-1"
+PKGREP="pycrypto<=2.6.1-4 pycryptodomex<=3.24.0"
 PKGPROV="pycryptodomex"
 # NOTE: building both pycryptodome and pycryptodomex in one package.
 ABTYPE=self

--- a/lang-python/pycryptodome/spec
+++ b/lang-python/pycryptodome/spec
@@ -1,4 +1,5 @@
 VER=3.22.0
+REL=1
 # NOTE was 3.22.0x in the Python 3.14 Topic.
 # To allow everyone in stable and this topic to get an upgrade, epoch
 # should be bumped.


### PR DESCRIPTION
Topic Description
-----------------

- pycryptodome: break pycryptodome from Python 3.14 testing topic
    Signed-off-by: xtex <xtexchooser@duck.com>

Package(s) Affected
-------------------

- pycryptodome: 3.22.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycryptodome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
