### PR TITLE
redis: update to 8.6.0

### DIFF
--- a/app-database/redis/spec
+++ b/app-database/redis/spec
@@ -1,4 +1,4 @@
-VER=8.4.0
+VER=8.6.0
 SRCS="tbl::https://download.redis.io/releases/redis-$VER.tar.gz"
-CHKSUMS="sha256::ca909aa15252f2ecb3a048cd086469827d636bf8334f50bb94d03fba4bfc56e8"
+CHKSUMS="sha256::d7e5f65f0bb0b4753d0cf98a60f5409a7c9b430ff8ac3397d336260cf64e5a6e"
 CHKUPDATE="anitya::id=4181"


### PR DESCRIPTION
Topic Description
-----------------

- redis: update to 8.6.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- redis: 8.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit redis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
