### PR TITLE
desktop-base: add gnome icons

### DIFF
--- a/meta-bases/desktop-base/autobuild/build
+++ b/meta-bases/desktop-base/autobuild/build
@@ -1,5 +1,7 @@
 abinfo "Installing distribution logos ..."
-install -Dvm644 "$SRCDIR"/../logo/aosc-os-gdm.svg \
-    "$PKGDIR"/usr/share/pixmaps/aosc-os-gdm.svg
+install -Dvm644 "$SRCDIR"/../logo/aosc-os-gnome.svg \
+    "$PKGDIR"/usr/share/pixmaps/aosc-os-gnome.svg
+install -Dvm644 "$SRCDIR"/../logo/aosc-os-gnome-dark.svg \
+    "$PKGDIR"/usr/share/pixmaps/aosc-os-gnome-dark.svg
 install -Dvm644 "$SRCDIR"/../logo/aosc-os-kinfocenter.svg \
     "$PKGDIR"/usr/share/pixmaps/aosc-os-kinfocenter.svg

--- a/meta-bases/desktop-base/spec
+++ b/meta-bases/desktop-base/spec
@@ -1,4 +1,5 @@
 VER=18
+REL=1
 SRCS="git::rename=logo;commit=4fa52e8c97c0e8fbcd2896c5ac6f7b31a694fc65::https://github.com/AOSC-Dev/logo"
 CHKSUMS="SKIP"
 # FIXME: No release would be made from this repository.


### PR DESCRIPTION
Topic Description
-----------------

- desktop-base: add dark icon
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- desktop-base: 18-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit desktop-base
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
