### PR TITLE
arise-linux-graphics-driver-dri: update to 25.00.51 (loongarch64: 25.00.46)

### DIFF
--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/overrides/usr/share/X11/xorg.conf.d/10-arisegpu.conf
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/overrides/usr/share/X11/xorg.conf.d/10-arisegpu.conf
@@ -1,0 +1,6 @@
+Section "OutputClass"
+	Identifier "arise"
+	MatchDriver "arise"
+	Driver "arise"
+	Option "GlxVendorLibrary" "arise"
+EndSection

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/prepare
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/prepare
@@ -15,18 +15,13 @@ for i in postinst prerm; do
         "$SRCDIR/autobuild/$i"
 done
 
-if ab_match_arch amd64; then
-    GLENFLY_DEB_ARCH="$ARCH"
-elif ab_match_arch arm64; then
-    # Note: Why, Glenfy, why?
-    GLENFLY_DEB_ARCH="aarch64"
-elif ab_match_arch loongarch64; then
+if ab_match_arch loongarch64; then
     # Note: Debian uses a different architecture name than we do.
     GLENFLY_DEB_ARCH="loong64"
 fi
 
 abinfo "Unpacking upstream deb package ..."
-dpkg-deb -X "$SRCDIR"/gf-arise-linux-graphics-driver-glvnd-dri_${PKGVER}_${GLENFLY_DEB_ARCH}.deb "$SRCDIR"
+dpkg-deb -X "$SRCDIR"/gf-arise-linux-graphics-driver-glvnd-dri_${PKGVER}_${GLENFLY_DEB_ARCH:-$ARCH}.deb "$SRCDIR"
 
 abinfo "Entering kernel module sources directory"
 cd "$SRCDIR"/usr/src/arise-"$PKGVER"

--- a/runtime-display/arise-linux-graphics-driver-dri/spec
+++ b/runtime-display/arise-linux-graphics-driver-dri/spec
@@ -1,14 +1,15 @@
-VER__AMD64=25.00.45
-VER__ARM64=25.00.45
+VER__AMD64=25.00.51
+VER__ARM64=25.00.51
 VER__LOONGARCH64=25.00.46
 __VER__AMD64="${VER__AMD64}"
 __VER__ARM64="${VER__ARM64}"
 __VER__LOONGARCH64="${VER__LOONGARCH64}"
-SRCS__AMD64="tbl::https://www.glenfly.com/down/linux/${VER__AMD64}/${VER__AMD64}_amd64.zip"
-SRCS__ARM64="tbl::https://www.glenfly.com/down/linux/${VER__ARM64}/${VER__ARM64}_aarch64.zip"
+REL=1
+SRCS__AMD64="tbl::https://www.glenfly.com/down/linux/${VER__AMD64}/${VER__AMD64}-x64.zip"
+SRCS__ARM64="tbl::https://www.glenfly.com/down/linux/${VER__ARM64}/${VER__ARM64}-aarch64.zip"
 # Note: Rename by a pattern shared by the other two to make scripting easier.
 SRCS__LOONGARCH64="file::rename=gf-arise-linux-graphics-driver-glvnd-dri_${VER__LOONGARCH64}_loong64.deb::https://archive.openkylin.top/openkylin/pool/pty/a/arise-linux-graphics-driver-dri/arise-linux-graphics-driver-dri_${VER__LOONGARCH64}_loong64.deb"
-CHKSUMS__AMD64="sha256::44a3f5f3fc2beb99df58968b20616c995724cdb3275ef0699e3b490c89cb24df"
-CHKSUMS__ARM64="sha256::7bc8b7013ca17139cdbe5e7fd90d84f50e8079d1b8d5bf9219240c142e8350f9"
+CHKSUMS__AMD64="sha256::73d75d470e98f64bcd1bfd974d2a7daac2e98e230a082d4d1f7c0a592fcce13a"
+CHKSUMS__ARM64="sha256::cfe6a558dba2cecdf3a3f3bb725c9a2f4d6231ab6627c5da90fdeee862a6500c"
 CHKSUMS__LOONGARCH64="sha256::77f12b3db4eb386dfbff636653a0ada939db2ce4a9c9d0172eb710745a87ca13"
 # FIXME: Impossible to generate CHKUPDATE for architecture-version-pairs.


### PR DESCRIPTION

<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
arise-linux-graphics-driver-dri: update to 25.00.51 (loongarch64: 25.00.46)
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
arise-linux-graphics-driver-dri
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit arise-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
