### PR TITLE
ca-certs: update to 20260206

### DIFF
--- a/runtime-data/ca-certs/spec
+++ b/runtime-data/ca-certs/spec
@@ -1,6 +1,6 @@
-VER=20241119
-CHANGESET=fc857d1685f9cd017a2cf656a52d871b02a4cc89
-SRCS="file::rename=certdata.txt::https://hg.mozilla.org/mozilla-central/raw-file/$CHANGESET/security/nss/lib/ckfw/builtins/certdata.txt"
-CHKSUMS="sha256::c99d6d3f8d3d4e47719ba2b648992f5b58b150128d3aca3c05c566d8dc98e116"
+VER=20260206
+CHANGESET=24ffdb17f470c11d3c20509aa5e2028a0a911494
+SRCS="file::rename=certdata.txt::https://github.com/nss-dev/nss/raw/${CHANGESET}/lib/ckfw/builtins/certdata.txt"
+CHKSUMS="sha256::3b98d4e3ff57a326d9587c33633039c8c3a9cf0b55f7ca581d7598ff329eb1f3"
 
 # FIXME: Check for updates at https://hg.mozilla.org/mozilla-central/log/tip/security/nss/lib/ckfw/builtins/certdata.txt


### PR DESCRIPTION
Topic Description
-----------------

- ca-certs: update to 20260206

Package(s) Affected
-------------------

- ca-certs: 20260206

Security Update?
----------------

No

Build Order
-----------

```
#buildit ca-certs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
