### PR TITLE
Foreign Architecture Support Survey - Rework

### DIFF
--- a/app-utils/xdg-utils/autobuild/defines
+++ b/app-utils/xdg-utils/autobuild/defines
@@ -7,3 +7,12 @@ PKGSEC=x11
 AUTOTOOLS_AFTER="--mandir=/usr/share/man"
 ABSHADOW=no
 ABHOST=noarch
+
+# FIXME: libapt-pkg considers version-less provides with less priority
+# when challenged as a foreign-architecture package. Adding _spiral to
+# all provides to make sure that they get equal (?) consideration when
+# challenged during upgrades, etc.
+#
+# This allows noarch (all) Spiral provides to survive on ports with DPKG
+# foreign architectures enabled.
+PKGPROV="xdg-utils_spiral"

--- a/app-utils/xdg-utils/spec
+++ b/app-utils/xdg-utils/spec
@@ -1,5 +1,5 @@
 VER=1.2.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://gitlab.freedesktop.org/xdg/xdg-utils"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5176"

--- a/desktop-fonts/noto-fonts/02-cjk/defines
+++ b/desktop-fonts/noto-fonts/02-cjk/defines
@@ -5,7 +5,14 @@ PKGDEP="fontconfig"
 PKGDES="A font family aiming to support all languages with a harmonious look (Pan-CJK fonts)"
 
 PKGREP="fonts-noto"
-PKGPROV="fonts-noto-cjk ttf-noto-cjk"
+# FIXME: libapt-pkg considers version-less provides with less priority
+# when challenged as a foreign-architecture package. Adding _spiral to
+# all provides to make sure that they get equal (?) consideration when
+# challenged during upgrades, etc.
+#
+# This allows noarch (all) Spiral provides to survive on ports with DPKG
+# foreign architectures enabled.
+PKGPROV="fonts-noto-cjk_spiral ttf-noto-cjk_spiral"
 
 ABHOST=noarch
 

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -5,7 +5,7 @@ EMOJI_VER=2.042
 CJKSANS_VER=2.004
 CJKSERIF_VER=2.003
 VER=${UPSTREAM_VER}+emoji${EMOJI_VER}+cjksans${CJKSANS_VER}+cjkserif${CJKSERIF_VER}
-REL=1
+REL=2
 # Note: We don't use the tags any more, since it's easier to install from a
 # Git repository.
 # CJKSANSVER=${VER:24:5}


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: add _spiral marker for Provides
    FIXME: libapt-pkg considers version-less provides with less priority when
    challenged as a foreign-architecture package. Adding _spiral to all
    provides to make sure that they get equal \(?\) consideration when
    challenged during upgrades, etc.
    This allows noarch \(all\) Spiral provides to survive on ports with DPKG
    foreign architectures enabled.
- xdg-utils: add _spiral marker for Provides
    FIXME: libapt-pkg considers version-less provides with less priority when
    challenged as a foreign-architecture package. Adding _spiral to all
    provides to make sure that they get equal \(?\) consideration when
    challenged during upgrades, etc.
    This allows noarch \(all\) Spiral provides to survive on ports with DPKG
    foreign architectures enabled.

Package(s) Affected
-------------------

- noto-cjk-fonts: 2:2025.12.01+emoji2.042+cjksans2.004+cjkserif2.003-2
- noto-fonts: 2:2025.12.01+emoji2.042+cjksans2.004+cjkserif2.003-2
- xdg-utils: 3:1.2.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-utils noto-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
