### PR TITLE
needrestart: new, 3.11

### DIFF
--- a/app-admin/needrestart/autobuild/build
+++ b/app-admin/needrestart/autobuild/build
@@ -1,0 +1,13 @@
+abinfo "Building needrestart ..."
+unset PERL5LIB PERL_LOCAL_LIB_ROOT PERL_MB_OPT PERL_MM_OPT
+export PERL_MM_USE_DEFAULT=1 PERL_AUTOINSTALL='--skipdeps'
+make
+
+abinfo "Installing needrestart ..."
+make DESTDIR="$PKGDIR" install
+
+abinfo "Installing man pages for needrestart(1) ..."
+install -vDm644 "$SRCDIR"/man/needrestart.1 "$PKGDIR"/usr/share/man/man1/needrestart.1
+
+abinfo "Cleaning up empty dirs ..."
+rm -vr "$PKGDIR"/usr/lib/perl5/

--- a/app-admin/needrestart/autobuild/defines
+++ b/app-admin/needrestart/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=needrestart
+PKGDES="Utility for restarting daemons after library updates"
+PKGSEC=admin
+PKGDEP="perl perl-module-find perl-term-readkey perl-proc-processtable perl-sort-naturally perl-module-scandeps libintl-perl"
+BUILDDEP="po-debconf"
+PKGRECOM="iucode-tool"
+
+ABTYPE=self
+ABHOST=noarch

--- a/app-admin/needrestart/autobuild/patches/0001-vmlinuz-get-version-implement-decompression-for-LZ4-.patch
+++ b/app-admin/needrestart/autobuild/patches/0001-vmlinuz-get-version-implement-decompression-for-LZ4-.patch
@@ -1,0 +1,36 @@
+From f328d091ff612150c51726c950bd9150a1bfddab Mon Sep 17 00:00:00 2001
+From: Rong Bao <rong.bao@csmantle.top>
+Date: Tue, 17 Feb 2026 15:49:35 +0800
+Subject: [PATCH 1/2] vmlinuz-get-version: implement decompression for LZ4 and
+ ZSTD
+
+Kernel has introduced some new compression methods since the
+introduction of this script in 2016. Some of the examples are LZ4 and
+Zstandard. The current implementation does not handle these new formats,
+so version strings from LZ4- or ZSTD-compressed vmlinuz'es would fail to
+extract.
+
+Implement extraction from these formats by syncing with upstream
+extract-vmlinux script.
+
+Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/extract-vmlinux?id=9702969978695d9a699a1f34771580cdbb153b33
+ ("scripts/extract-vmlinux")
+Link: https://github.com/liske/needrestart/pull/355 ("vmlinuz-get-version:
+ implement decompression for LZ4 and ZSTD")
+---
+ lib/vmlinuz-get-version | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/vmlinuz-get-version b/lib/vmlinuz-get-version
+index 619a3a3..bb062b6 100755
+--- a/lib/vmlinuz-get-version
++++ b/lib/vmlinuz-get-version
+@@ -63,3 +63,5 @@ which unxz    > /dev/null && try_decompress '\3757zXZ\000' abcde unxz
+ which bunzip2 > /dev/null && try_decompress 'BZh'          xy    bunzip2
+ which unlzma  > /dev/null && try_decompress '\135\0\0\0'   xxx   unlzma
+ which lzop    > /dev/null && try_decompress '\211\114\132' xy    'lzop -d'
++which lz4     > /dev/null && try_decompress '\002!L\030'   xxx   'lz4 -d'
++which unzstd  > /dev/null && try_decompress '(\265/\375'   xxx   unzstd
+-- 
+2.53.0
+

--- a/app-admin/needrestart/autobuild/patches/0002-AOSCOS-normalize-sbin-bin.patch
+++ b/app-admin/needrestart/autobuild/patches/0002-AOSCOS-normalize-sbin-bin.patch
@@ -1,0 +1,126 @@
+From ab5c3b7c0c7992dc8d606917c05e4cf81727b8bf Mon Sep 17 00:00:00 2001
+From: Rong Bao <rong.bao@csmantle.top>
+Date: Tue, 17 Feb 2026 19:09:40 +0800
+Subject: [PATCH 2/2] AOSCOS: normalize sbin -> bin
+
+---
+ Makefile                                   | 4 ++--
+ ex/99needrestart                           | 2 +-
+ ex/apt/apt-pinvoke                         | 2 +-
+ ex/icinga2/command.conf                    | 2 +-
+ ex/icinga2/needrestart-sudoers             | 4 ++--
+ ex/nagios/check_needrestart                | 2 +-
+ ex/nagios/needrestart-nagios               | 2 +-
+ ex/polkit/net.fiasko-nw.needrestart.policy | 2 +-
+ needrestart                                | 2 +-
+ 9 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 1ab274a..1332759 100644
+--- a/Makefile
++++ b/Makefile
+@@ -31,8 +31,8 @@ install: all
+ 	mkdir -p "$(DESTDIR)/usr/share/polkit-1/actions"
+ 	cp ex/polkit/net.fiasko-nw.needrestart.policy "$(DESTDIR)/usr/share/polkit-1/actions/"
+ 	
+-	mkdir -p "$(DESTDIR)/usr/sbin"
+-	cp needrestart "$(DESTDIR)/usr/sbin/"
++	mkdir -p "$(DESTDIR)/usr/bin"
++	cp needrestart "$(DESTDIR)/usr/bin/"
+ 	
+ 	mkdir -p "$(DESTDIR)/usr/lib/needrestart"
+ 	cp lib/iucode-scan-versions "$(DESTDIR)/usr/lib/needrestart/"
+diff --git a/ex/99needrestart b/ex/99needrestart
+index dcdf48d..4dd5f8f 100644
+--- a/ex/99needrestart
++++ b/ex/99needrestart
+@@ -6,4 +6,4 @@
+ # directory.
+ #
+ 
+-DPkg::Post-Invoke {"test -x /usr/sbin/needrestart && /usr/sbin/needrestart || true"; };
++DPkg::Post-Invoke {"test -x /usr/bin/needrestart && /usr/bin/needrestart || true"; };
+diff --git a/ex/apt/apt-pinvoke b/ex/apt/apt-pinvoke
+index d9d7a11..633841c 100755
+--- a/ex/apt/apt-pinvoke
++++ b/ex/apt/apt-pinvoke
+@@ -46,5 +46,5 @@ if [ -e "$RUNDIR/unpacked" ]; then
+     fi
+ 
+     rm -f "$RUNDIR/unpacked"
+-    exec /usr/sbin/needrestart "$@"
++    exec /usr/bin/needrestart "$@"
+ fi
+diff --git a/ex/icinga2/command.conf b/ex/icinga2/command.conf
+index d410b80..aefe321 100644
+--- a/ex/icinga2/command.conf
++++ b/ex/icinga2/command.conf
+@@ -1,5 +1,5 @@
+ object CheckCommand "needrestart" {
+-	command = [ "/usr/sbin/needrestart", "-p" ]
++	command = [ "/usr/bin/needrestart", "-p" ]
+ 	arguments = {
+ 		"-k" = {
+ 			description = "check for obsolete kernel"
+diff --git a/ex/icinga2/needrestart-sudoers b/ex/icinga2/needrestart-sudoers
+index ef55834..ac114f5 100644
+--- a/ex/icinga2/needrestart-sudoers
++++ b/ex/icinga2/needrestart-sudoers
+@@ -5,6 +5,6 @@
+ #
+ 
+ # Allow nagios to execute the needrestart command on debian based systems (icinga user is called "nagios")
+-nagios ALL=NOPASSWD: /usr/sbin/needrestart
++nagios ALL=NOPASSWD: /usr/bin/needrestart
+ # Allow nagios to execute the needrestart command on centos and family (icinga user is called "icinga")
+-icinga ALL=NOPASSWD: /usr/sbin/needrestart
++icinga ALL=NOPASSWD: /usr/bin/needrestart
+diff --git a/ex/nagios/check_needrestart b/ex/nagios/check_needrestart
+index 1177fc7..d979422 100755
+--- a/ex/nagios/check_needrestart
++++ b/ex/nagios/check_needrestart
+@@ -15,4 +15,4 @@
+ #   (at your option) any later version.
+ #
+ 
+-exec sudo -n -- /usr/sbin/needrestart -p
++exec sudo -n -- /usr/bin/needrestart -p
+diff --git a/ex/nagios/needrestart-nagios b/ex/nagios/needrestart-nagios
+index 74e8629..708c741 100644
+--- a/ex/nagios/needrestart-nagios
++++ b/ex/nagios/needrestart-nagios
+@@ -5,4 +5,4 @@
+ #
+ 
+ # Allow nagios to execute the needrestart command
+-nagios		ALL=NOPASSWD: /usr/sbin/needrestart -p
++nagios		ALL=NOPASSWD: /usr/bin/needrestart -p
+diff --git a/ex/polkit/net.fiasko-nw.needrestart.policy b/ex/polkit/net.fiasko-nw.needrestart.policy
+index 65d20cd..d2287da 100644
+--- a/ex/polkit/net.fiasko-nw.needrestart.policy
++++ b/ex/polkit/net.fiasko-nw.needrestart.policy
+@@ -12,7 +12,7 @@
+       <allow_inactive>auth_admin</allow_inactive>
+       <allow_active>auth_admin</allow_active>
+     </defaults>
+-    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/needrestart</annotate>
++    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/needrestart</annotate>
+     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+   </action>
+ 
+diff --git a/needrestart b/needrestart
+index ad7e4aa..1be72e4 100755
+--- a/needrestart
++++ b/needrestart
+@@ -785,7 +785,7 @@ if(defined($opt_l)) {
+ 	    }
+ 	    else {
+ 		# sysv init
+-		if($pid == 1 && $exe =~ m@^/sbin/init@) {
++		if($pid == 1 && $exe =~ m@^/bin/init@) {
+ 		    print STDERR "$LOGPREF #$pid is sysv init\n" if($nrconf{verbosity} > 1);
+ 		    $restart{q(sysv-init)}++;
+ 		    next;
+-- 
+2.53.0
+

--- a/app-admin/needrestart/spec
+++ b/app-admin/needrestart/spec
@@ -1,0 +1,4 @@
+VER=3.11
+SRCS="git::commit=tags/v$VER::https://github.com/liske/needrestart.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=375641"

--- a/app-admin/po-debconf/autobuild/patches/0001-Fix-intltool-path-for-non-Debian-systems.patch
+++ b/app-admin/po-debconf/autobuild/patches/0001-Fix-intltool-path-for-non-Debian-systems.patch
@@ -1,0 +1,62 @@
+From ed47fa80997a221129326d59dbbe8174342ae12b Mon Sep 17 00:00:00 2001
+From: Rong Bao <rong.bao@csmantle.top>
+Date: Tue, 17 Feb 2026 18:25:57 +0800
+Subject: [PATCH] Fix intltool path for non-Debian systems
+
+Signed-off-by: Rong Bao <rong.bao@csmantle.top>
+---
+ Makefile         | 4 ++--
+ debconf-updatepo | 2 +-
+ po2debconf       | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index a2fab21..3d93fd6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -9,14 +9,14 @@ fix: debconf-gettextize debconf-updatepo po2debconf
+ 
+ debconf-updatepo po2debconf: FORCE
+ 	@sed \
+-   -e 's@\(: \$${PODEBCONF_LIB=\)[^}]*}@\1$(prefix)/share/intltool-debian}@' \
++   -e 's@\(: \$${PODEBCONF_LIB=\)[^}]*}@\1$(prefix)/bin}@' \
+    -e 's@\(: \$${PODEBCONF_ENCODINGS=\)[^}]*}@\1$(prefix)/share/po-debconf/encodings}@' \
+ 		$@ > $@.tmp && mv $@.tmp $@
+ 	@chmod a+x $@
+ 
+ debconf-gettextize: FORCE
+ 	@sed \
+-   -e 's@\(\$$ENV{PODEBCONF_LIB} ||= \)[^;]*;@\1"$(prefix)/share/intltool-debian";@' \
++   -e 's@\(\$$ENV{PODEBCONF_LIB} ||= \)[^;]*;@\1"$(prefix)/bin";@' \
+    -e 's@\(\$$ENV{PODEBCONF_ENCODINGS} ||= \)[^;]*;@\1"$(prefix)/share/po-debconf/encodings";@' \
+    -e 's@\(\$$ENV{PODEBCONF_HEADER} ||= \)[^;]*;@\1"$(prefix)/share/po-debconf/pot-header";@' \
+ 		$@ > $@.tmp && mv $@.tmp $@
+diff --git a/debconf-updatepo b/debconf-updatepo
+index 194c137..7d6316e 100755
+--- a/debconf-updatepo
++++ b/debconf-updatepo
+@@ -20,7 +20,7 @@
+ #
+ #   This script is part of po-debconf
+ 
+-: ${PODEBCONF_LIB=/usr/share/intltool-debian}
++: ${PODEBCONF_LIB=/usr/bin}
+ INTLTOOL_EXTRACT=${PODEBCONF_LIB}/intltool-extract
+ export INTLTOOL_EXTRACT
+ 
+diff --git a/po2debconf b/po2debconf
+index 56c5a5b..2922037 100755
+--- a/po2debconf
++++ b/po2debconf
+@@ -20,7 +20,7 @@
+ #
+ #   This script is part of po-debconf
+ 
+-: ${PODEBCONF_LIB=/usr/share/intltool-debian}
++: ${PODEBCONF_LIB=/usr/bin}
+ : ${PODEBCONF_ENCODINGS=/usr/share/po-debconf/encodings}
+ 
+ #   Prevent automatic conversion to UTF-8 by Perl
+-- 
+2.51.0
+

--- a/app-admin/po-debconf/spec
+++ b/app-admin/po-debconf/spec
@@ -1,4 +1,5 @@
 VER=1.0.21
+REL=1
 SRCS="git::commit=tags/debian/$VER::https://salsa.debian.org/debian/po-debconf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8137"


### PR DESCRIPTION
Topic Description
-----------------

- needrestart: new, 3.11
- po-debconf: fix intltool path
    On Debian, po-debconf looks for executables intltool-merge,
    intltool-extract and intltool-update in /usr/share/intltool-debian. This
    path does not exist on AOSC, and the mentioned executables are installed
    into /usr/bin.

Package(s) Affected
-------------------

- needrestart: 3.11
- po-debconf: 1.0.21-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit po-debconf needrestart
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
