### PR TITLE
tree-sitter Survey 20260217

### DIFF
--- a/app-devel/cutter/spec
+++ b/app-devel/cutter/spec
@@ -2,4 +2,4 @@ VER=2.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/rizinorg/cutter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141382"
-REL=4
+REL=5

--- a/app-devel/tree-sitter/autobuild/defines
+++ b/app-devel/tree-sitter/autobuild/defines
@@ -7,3 +7,5 @@ BUILDDEP="rustc llvm"
 ABTYPE=rust
 USECLANG=1
 CARGO_AFTER=('-p' 'tree-sitter-cli')
+
+PKGBREAK="emacs<=30.2-3 neovim<=1:0.12.1 cutter<=2.4.1-4"

--- a/app-devel/tree-sitter/autobuild/patches/0001-AOSCOS-fix-rquickjs-build-on-riscv64.patch
+++ b/app-devel/tree-sitter/autobuild/patches/0001-AOSCOS-fix-rquickjs-build-on-riscv64.patch
@@ -1,0 +1,71 @@
+From a1ad5ae184d8dc2a535f5ccb6a55f3fea2e1a7ab Mon Sep 17 00:00:00 2001
+From: RawDiamondMC <RawDiamondMC@outlook.com>
+Date: Sat, 11 Apr 2026 17:22:20 +0800
+Subject: [PATCH] AOSCOS: fix rquickjs build on riscv64
+
+Signed-off-by: RawDiamondMC <RawDiamondMC@outlook.com>
+---
+ Cargo.lock                 | Bin 77608 -> 77524 bytes
+ crates/generate/Cargo.toml |   2 +-
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index d47018cf..571da436 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1524,8 +1524,7 @@ dependencies = [
+ [[package]]
+ name = "rquickjs"
+ version = "0.10.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a135375fbac5ba723bb6a48f432a72f81539cedde422f0121a86c7c4e96d8e0d"
++source = "git+https://github.com/AOSC-Tracking/rquickjs.git?branch=aosc/v0.10.0#c612a1feb445cba61f106a89dff9dd263ef6593f"
+ dependencies = [
+  "rquickjs-core",
+  "rquickjs-macro",
+@@ -1534,8 +1533,7 @@ dependencies = [
+ [[package]]
+ name = "rquickjs-core"
+ version = "0.10.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bccb7121a123865c8ace4dea42e7ed84d78b90cbaf4ca32c59849d8d210c9672"
++source = "git+https://github.com/AOSC-Tracking/rquickjs.git?branch=aosc/v0.10.0#c612a1feb445cba61f106a89dff9dd263ef6593f"
+ dependencies = [
+  "hashbrown 0.16.1",
+  "phf",
+@@ -1546,8 +1544,7 @@ dependencies = [
+ [[package]]
+ name = "rquickjs-macro"
+ version = "0.10.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "89f93602cc3112c7f30bf5f29e722784232138692c7df4c52ebbac7e035d900d"
++source = "git+https://github.com/AOSC-Tracking/rquickjs.git?branch=aosc/v0.10.0#c612a1feb445cba61f106a89dff9dd263ef6593f"
+ dependencies = [
+  "convert_case",
+  "fnv",
+@@ -1565,8 +1562,7 @@ dependencies = [
+ [[package]]
+ name = "rquickjs-sys"
+ version = "0.10.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "57b1b6528590d4d65dc86b5159eae2d0219709546644c66408b2441696d1d725"
++source = "git+https://github.com/AOSC-Tracking/rquickjs.git?branch=aosc/v0.10.0#c612a1feb445cba61f106a89dff9dd263ef6593f"
+ dependencies = [
+  "bindgen",
+  "cc",
+diff --git a/crates/generate/Cargo.toml b/crates/generate/Cargo.toml
+index 5e93bf40..be7d42ec 100644
+--- a/crates/generate/Cargo.toml
++++ b/crates/generate/Cargo.toml
+@@ -33,7 +33,7 @@ log.workspace = true
+ pathdiff = { version = "0.2.3", optional = true }
+ regex.workspace = true
+ regex-syntax.workspace = true
+-rquickjs = { version = "0.10.0", optional = true, features = [
++rquickjs = { git = "https://github.com/AOSC-Tracking/rquickjs.git", branch = "aosc/v0.10.0", optional = true, features = [
+   "bindgen",
+   "loader",
+   "macro",
+-- 
+2.52.0
+

--- a/app-devel/tree-sitter/spec
+++ b/app-devel/tree-sitter/spec
@@ -1,5 +1,4 @@
-VER=0.25.3
-REL=1
+VER=0.26.8
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=142464"

--- a/app-editors/emacs/autobuild/patches/0001-Support-Tree-sitter-version-0.26-and-later.patch
+++ b/app-editors/emacs/autobuild/patches/0001-Support-Tree-sitter-version-0.26-and-later.patch
@@ -1,0 +1,115 @@
+From dd0d48da09abfa9501dd77e6a732f77de833decf Mon Sep 17 00:00:00 2001
+From: Eli Zaretskii <eliz@gnu.org>
+Date: Fri, 17 Oct 2025 14:15:41 +0300
+Subject: [PATCH] Support Tree-sitter version 0.26 and later
+
+* src/treesit.c (init_treesit_functions)
+[TREE_SITTER_LANGUAGE_VERSION >= 15]: Define prototype for, and
+load 'ts_language_abi_version' instead of the deprecated (and
+removed in tree-sitter 0.26) 'ts_language_version'.
+(ts_language_abi_version) [TREE_SITTER_LANGUAGE_VERSION >= 15]:
+Define on WINDOWSNT, instead of 'ts_language_version'.
+(treesit_language_abi_version): New compatibility function.
+(treesit_load_language, Ftreesit_language_abi_version): Use
+'treesit_language_abi_version' instead of 'ts_language_version'.
+(Bug#79627)
+---
+ src/treesit.c | 36 ++++++++++++++++++++++++++++++++++--
+ 1 file changed, 34 insertions(+), 2 deletions(-)
+
+diff --git a/src/treesit.c b/src/treesit.c
+index e2986c186..f87f46542 100644
+--- a/src/treesit.c
++++ b/src/treesit.c
+@@ -34,7 +34,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ # include "w32common.h"
+ 
+ /* In alphabetical order.  */
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++#undef ts_language_abi_version
++#else
+ #undef ts_language_version
++#endif
+ #undef ts_node_child
+ #undef ts_node_child_by_field_name
+ #undef ts_node_child_count
+@@ -89,7 +93,11 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ #undef ts_tree_get_changed_ranges
+ #undef ts_tree_root_node
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
++#else
+ DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
++#endif
+ DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
+ DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
+ 	    (TSNode, const char *, uint32_t));
+@@ -166,7 +174,11 @@ init_treesit_functions (void)
+   if (!library)
+     return false;
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++  LOAD_DLL_FN (library, ts_language_abi_version);
++#else
+   LOAD_DLL_FN (library, ts_language_version);
++#endif
+   LOAD_DLL_FN (library, ts_node_child);
+   LOAD_DLL_FN (library, ts_node_child_by_field_name);
+   LOAD_DLL_FN (library, ts_node_child_count);
+@@ -224,7 +236,11 @@ init_treesit_functions (void)
+   return true;
+ }
+ 
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++#define ts_language_abi_version fn_ts_language_abi_version
++#else
+ #define ts_language_version fn_ts_language_version
++#endif
+ #define ts_node_child fn_ts_node_child
+ #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
+ #define ts_node_child_count fn_ts_node_child_count
+@@ -632,6 +648,22 @@ treesit_load_language_push_for_each_suffix (Lisp_Object lib_base_name,
+     }
+ }
+ 
++/* This function is a compatibility shim.  Tree-sitter 0.25 introduced
++   ts_language_abi_version as a replacement for ts_language_version, and
++   tree-sitter 0.26 removed ts_language_version.  Here we use the fact
++   that 0.25 bumped TREE_SITTER_LANGUAGE_VERSION to 15, to use the new
++   function instead of the old one, when Emacs is compiled against
++   tree-sitter version 0.25 or newer.  */
++static uint32_t
++treesit_language_abi_version (const TSLanguage *ts_lang)
++{
++#if TREE_SITTER_LANGUAGE_VERSION >= 15
++  return ts_language_abi_version (ts_lang);
++#else
++  return ts_language_version (ts_lang);
++#endif
++}
++
+ /* Load the dynamic library of LANGUAGE_SYMBOL and return the pointer
+    to the language definition.
+ 
+@@ -746,7 +778,7 @@ treesit_load_language (Lisp_Object language_symbol,
+     {
+       *signal_symbol = Qtreesit_load_language_error;
+       *signal_data = list2 (Qversion_mismatch,
+-			    make_fixnum (ts_language_version (lang)));
++			    make_fixnum (treesit_language_abi_version (lang)));
+       return NULL;
+     }
+   return lang;
+@@ -817,7 +849,7 @@ Return nil if a grammar library for LANGUAGE is not available.  */)
+ 						       &signal_data);
+       if (ts_language == NULL)
+ 	return Qnil;
+-      uint32_t version =  ts_language_version (ts_language);
++      uint32_t version =  treesit_language_abi_version (ts_language);
+       return make_fixnum((ptrdiff_t) version);
+     }
+ }
+-- 
+2.52.0
+

--- a/app-editors/emacs/spec
+++ b/app-editors/emacs/spec
@@ -1,5 +1,5 @@
 VER=30.2
-REL=3
+REL=4
 SRCS="tbl::https://ftp.gnu.org/gnu/emacs/emacs-$VER.tar.gz"
 CHKSUMS="sha256::1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d"
 CHKUPDATE="anitya::id=675"

--- a/app-editors/neovim/spec
+++ b/app-editors/neovim/spec
@@ -2,3 +2,4 @@ VER=0.12.2
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/neovim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9037"
+REL=1

--- a/runtime-editors/tree-sitter-c/spec
+++ b/runtime-editors/tree-sitter-c/spec
@@ -1,5 +1,4 @@
-VER=0.23.5
-REL=1
+VER=0.24.2
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter-c"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242273"

--- a/runtime-editors/tree-sitter-lua/spec
+++ b/runtime-editors/tree-sitter-lua/spec
@@ -1,5 +1,4 @@
-VER=0.3.0
-REL=1
+VER=0.5.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-lua"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=334876"

--- a/runtime-editors/tree-sitter-markdown/spec
+++ b/runtime-editors/tree-sitter-markdown/spec
@@ -1,4 +1,4 @@
-VER=0.4.1
+VER=0.5.3
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-markdown"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371613"

--- a/runtime-editors/tree-sitter-query/spec
+++ b/runtime-editors/tree-sitter-query/spec
@@ -1,5 +1,4 @@
-VER=0.5.1
-REL=1
+VER=0.8.0
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-query"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375139"

--- a/runtime-editors/tree-sitter-vim/autobuild/build
+++ b/runtime-editors/tree-sitter-vim/autobuild/build
@@ -1,3 +1,6 @@
+abinfo "Generating C bindings ..."
+tree-sitter init
+
 abinfo "Building tree-sitter-vim ..."
 make
 

--- a/runtime-editors/tree-sitter-vim/autobuild/defines
+++ b/runtime-editors/tree-sitter-vim/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=tree-sitter-vim
 PKGSEC=libs
 PKGDES="Vimscript grammar for tree-sitter"
 PKGDEP="tree-sitter"
+BUILDDEP="nodejs"
 
 ABTYPE=self

--- a/runtime-editors/tree-sitter-vim/autobuild/patches/0001-AOSCOS-generate-C-bindings.patch
+++ b/runtime-editors/tree-sitter-vim/autobuild/patches/0001-AOSCOS-generate-C-bindings.patch
@@ -1,0 +1,26 @@
+From 2bdeccd26af6935e994747b92bc0e5270f9ae25b Mon Sep 17 00:00:00 2001
+From: RawDiamondMC <RawDiamondMC@aosc.io>
+Date: Sun, 5 Apr 2026 19:57:00 +0800
+Subject: [PATCH] AOSCOS: generate C bindings
+
+Signed-off-by: RawDiamondMC <RawDiamondMC@aosc.io>
+---
+ tree-sitter.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tree-sitter.json b/tree-sitter.json
+index 7da9147..c68dc98 100644
+--- a/tree-sitter.json
++++ b/tree-sitter.json
+@@ -27,7 +27,7 @@
+     }
+   },
+   "bindings": {
+-    "c": false,
++    "c": true,
+     "go": false,
+     "java": false,
+     "node": false,
+-- 
+2.52.0
+

--- a/runtime-editors/tree-sitter-vim/spec
+++ b/runtime-editors/tree-sitter-vim/spec
@@ -1,5 +1,4 @@
-VER=0.5.0
-REL=1
+VER=0.8.1
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter-grammars/tree-sitter-vim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375138"

--- a/runtime-editors/tree-sitter-vimdoc/spec
+++ b/runtime-editors/tree-sitter-vimdoc/spec
@@ -1,5 +1,4 @@
-VER=3.0.1
-REL=1
+VER=4.1.0
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/tree-sitter-vimdoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375140"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- tree-sitter: update to 0.26.8
- tree-sitter-c: update to 0.24.1
- tree-sitter-lua: update to 0.5.0
- tree-sitter-markdown: update to 0.5.3
- tree-sitter-query: update to 0.8.0
- tree-sitter-vim: update to 0.8.1
- tree-sitter-vimdoc: update to 4.1.0
- emacs: bump REL due to tree-sitter update
  Add an upstream patch to fix tree-sitter 0.26 compability
- neovim: bump REL due to tree-sitter update
- cutter: bump REL due to tree-sitter update

Package(s) Affected
-------------------

- tree-sitter: 0.26.8
- tree-sitter-c: 0.24.1
- tree-sitter-lua: 0.5.0
- tree-sitter-markdown: 0.5.3
- tree-sitter-query: 0.8.0
- tree-sitter-vim: 0.8.1
- tree-sitter-vimdoc: 4.1.0
- emacs: 30.2-3
- neovim: 0.12.1-1
- cutter: 2.4.1-5

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit groups/tree-sitter emacs neovim cutter
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
