### PR TITLE
plasma-integration: remove noto-fonts dep

### DIFF
--- a/desktop-kde/plasma-integration/autobuild/defines
+++ b/desktop-kde/plasma-integration/autobuild/defines
@@ -3,14 +3,16 @@ PKGSEC=kde
 PKGDEP="breeze fontconfig freetype kauth kcodecs kcompletion kconfig \
         kconfigwidgets kcoreaddons ki18n kiconthemes kio kitemviews \
         kjobwidgets knotifications kservice kwayland kwidgetsaddons \
-        kwindowsystem kxmlgui noto-fonts solid"
+        kwindowsystem kxmlgui solid"
 BUILDDEP="extra-cmake-modules plasma-wayland-protocols"
 PKGDES="Qt Platform Theme integration plugins for the Plasma workspaces"
 
-CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
-             -DBUILD_QCH=ON \
-             -DBUILD_TESTING=OFF \
-             -DBUILD_WITH_QT6=OFF \
-             -DENABLE_BSYMBOLICFUNCTIONS=OFF \
-             -DKDE_INSTALL_PREFIX_SCRIPT=OFF \
-             -DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+CMAKE_AFTER=(
+    '-DBUILD_COVERAGE=OFF'
+    '-DBUILD_QCH=ON'
+    '-DBUILD_TESTING=OFF'
+    '-DBUILD_WITH_QT6=OFF'
+    '-DENABLE_BSYMBOLICFUNCTIONS=OFF'
+    '-DKDE_INSTALL_PREFIX_SCRIPT=OFF'
+    '-DKDE_INSTALL_USE_QT_SYS_PATHS=ON'
+)

--- a/desktop-kde/plasma-integration/spec
+++ b/desktop-kde/plasma-integration/spec
@@ -1,4 +1,5 @@
 VER=5.27.12
+REL=1
 SRCS="tbl::https://download.kde.org/stable/plasma/$VER/plasma-integration-$VER.tar.xz"
 CHKSUMS="sha256::a77aa5b20918798e6a8eaf98d631218843ac0c41546bdb69cfb144b68e9e1109"
 CHKUPDATE="anitya::id=8761"


### PR DESCRIPTION
Topic Description
-----------------

- plasma-integration: remove noto-fonts dep
    Decouple preinstalled fonts from packages.

Package(s) Affected
-------------------

- plasma-integration: 5.27.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit plasma-integration
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
