### PR TITLE
sip-4: rebuild for Python 3.14 again

### DIFF
--- a/lang-python/sip-4/spec
+++ b/lang-python/sip-4/spec
@@ -1,5 +1,5 @@
 VER=4.19.25
-REL=1
+REL=2
 SRCS="git::commit=tags/${VER}::https://github.com/Python-SIP/sip"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=25851"


### PR DESCRIPTION
Topic Description
-----------------

- sip-4: rebuild for Python 3.14 again
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- sip-4: 4.19.25-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sip-4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
