### PR TITLE
xdg-user-dirs: fix compatibility with KDE 5

### DIFF
--- a/app-admin/xdg-user-dirs/autobuild/defines
+++ b/app-admin/xdg-user-dirs/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=xdg-user-dirs
 PKGSEC=x11
-PKGDEP="bash"
-BUILDDEP="docbook-xsl"
-PKGDES="Manage user directories like ~/Desktop and ~/Music"
+PKGDEP="bash glibc"
+PKGDES="Tool to manage XDG-compliant user directories"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Ddocs=false'
+    '-Dnls=true'
+)

--- a/app-admin/xdg-user-dirs/autobuild/patches/0001-AOSCOS-fix-desktop-drop-X-systemd-skip-property-in-a.patch
+++ b/app-admin/xdg-user-dirs/autobuild/patches/0001-AOSCOS-fix-desktop-drop-X-systemd-skip-property-in-a.patch
@@ -1,0 +1,29 @@
+From d0791539b34b8d3449e3c19cf09ff5e2a61faa9d Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 17 Feb 2026 23:41:58 +0800
+Subject: [PATCH] AOSCOS: fix(desktop): drop X-systemd-skip= property in
+ autostart entry
+
+KDE 5 does not seem to honour the systemd user service (or somehow the
+service target was never referenced). Drop X-systemd-skip to make sure
+a user service is generated on KDE startup.
+
+Link: https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/commit/2a63d3f0ffb76135790bb1168a3270a599904380
+Link: https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ xdg-user-dirs.desktop | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/xdg-user-dirs.desktop b/xdg-user-dirs.desktop
+index b14a973..6b969d4 100644
+--- a/xdg-user-dirs.desktop
++++ b/xdg-user-dirs.desktop
+@@ -8,4 +8,3 @@ NoDisplay=true
+ 
+ X-GNOME-Autostart-Phase=Initialization
+ X-KDE-autostart-phase=1
+-X-systemd-skip=true
+-- 
+2.52.0
+

--- a/app-admin/xdg-user-dirs/spec
+++ b/app-admin/xdg-user-dirs/spec
@@ -1,4 +1,5 @@
 VER=0.19
+REL=1
 SRCS="tbl::https://user-dirs.freedesktop.org/releases/xdg-user-dirs-$VER.tar.xz"
 CHKSUMS="sha256::e92deb929c10d4b29329397af8a2585101247f7e6177ac6f1d28e82130ed8c19"
 CHKUPDATE="anitya::id=8637"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-user-dirs: fix compatibility with KDE 5
    KDE 5 does not seem to honour the systemd user service \(or somehow the
    service target was never referenced\). Drop X-systemd-skip to make sure
    a user service is generated on KDE startup.
    Also clean up dependencies and options.
    Track patches at AOSC-Tracking/xdg-user-dirs @ aosc/v0.19
    \(HEAD: d0791539b34b8d3449e3c19cf09ff5e2a61faa9d\).
    Link: https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/commit/2a63d3f0ffb76135790bb1168a3270a599904380
    Link: https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html

Package(s) Affected
-------------------

- xdg-user-dirs: 0.19-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-user-dirs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
