### PR TITLE
deno: update to 2.6.10

### DIFF
--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From 1a17cfe538213353d56dd66a00c1a511e7edd34f Mon Sep 17 00:00:00 2001
+From c952ea77cfc9c9d7f166a57bd59d9374dd37a1ce Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Thu, 29 Jan 2026 23:16:48 +0800
 Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
@@ -9,10 +9,10 @@ Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 3e89f78ae..8fdafe06c 100644
+index 693c399a0..0fb374932 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -10153,8 +10153,6 @@ dependencies = [
+@@ -10446,8 +10446,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "145.0.0"
@@ -22,10 +22,10 @@ index 3e89f78ae..8fdafe06c 100644
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index b9c04b529..4c5c49929 100644
+index 4fd99f146..074400d92 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -547,3 +547,6 @@ opt-level = 3
+@@ -561,3 +561,6 @@ opt-level = 3
  opt-level = 3
  [profile.release.package.deno_npm_cache]
  opt-level = 3
@@ -33,5 +33,5 @@ index b9c04b529..4c5c49929 100644
 +[patch.crates-io]
 +v8 = { path = '../rusty_v8' }
 -- 
-2.52.0
+2.53.0
 

--- a/lang-js/deno/autobuild/patches/0002-ALPINE-Link-with-system-provided-libraries.patch
+++ b/lang-js/deno/autobuild/patches/0002-ALPINE-Link-with-system-provided-libraries.patch
@@ -1,47 +1,20 @@
-From 4bcfc3a7b353fe7e03ce78f94f453696be29c190 Mon Sep 17 00:00:00 2001
+From bbe4742a48ef5af3bef433b1540247b5ec3849a6 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 31 Jan 2026 09:18:04 +0800
 Subject: [PATCH 2/3] ALPINE: Link with system-provided libraries
 
 Link: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/deno/use-system-libs.patch
 ---
- Cargo.lock     | 11 +++++------
- Cargo.toml     |  6 +++---
- cli/Cargo.toml |  2 +-
- 3 files changed, 9 insertions(+), 10 deletions(-)
+ Cargo.lock     | 1 -
+ Cargo.toml     | 6 +++---
+ cli/Cargo.toml | 2 +-
+ 3 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 8fdafe06c..434d83868 100644
+index 0fb374932..ad0ac15bd 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -559,7 +559,7 @@ dependencies = [
-  "bitflags 2.9.3",
-  "cexpr",
-  "clang-sys",
-- "itertools 0.13.0",
-+ "itertools 0.12.1",
-  "log",
-  "prettyplease",
-  "proc-macro2",
-@@ -579,7 +579,7 @@ dependencies = [
-  "bitflags 2.9.3",
-  "cexpr",
-  "clang-sys",
-- "itertools 0.13.0",
-+ "itertools 0.12.1",
-  "log",
-  "prettyplease",
-  "proc-macro2",
-@@ -5866,7 +5866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
- dependencies = [
-  "cfg-if",
-- "windows-targets 0.52.6",
-+ "windows-targets 0.48.5",
- ]
- 
- [[package]]
-@@ -5892,7 +5892,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -6090,7 +6090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
  dependencies = [
   "bindgen 0.72.1",
@@ -49,29 +22,11 @@ index 8fdafe06c..434d83868 100644
   "pkg-config",
   "vcpkg",
  ]
-@@ -7305,7 +7304,7 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
- dependencies = [
-  "bytes",
-  "heck 0.5.0",
-- "itertools 0.13.0",
-+ "itertools 0.12.1",
-  "log",
-  "multimap",
-  "once_cell",
-@@ -7325,7 +7324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
- dependencies = [
-  "anyhow",
-- "itertools 0.13.0",
-+ "itertools 0.12.1",
-  "proc-macro2",
-  "quote",
-  "syn 2.0.87",
 diff --git a/Cargo.toml b/Cargo.toml
-index 4c5c49929..9b0802ff9 100644
+index 074400d92..c3363e77f 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -238,7 +238,7 @@ rand = "=0.8.5"
+@@ -252,7 +252,7 @@ rand = "=0.8.5"
  rayon = "1.11.0"
  regex = "^1.7.0"
  reqwest = { version = "=0.12.5", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks", "json", "http2"] } # pinned because of https://github.com/seanmonstar/reqwest/pull/1955
@@ -80,7 +35,7 @@ index 4c5c49929..9b0802ff9 100644
  rustls = { version = "=0.23.28", default-features = false, features = ["logging", "std", "tls12", "aws_lc_rs"] }
  rustls-pemfile = "2"
  rustls-tokio-stream = "=0.8.0"
-@@ -332,7 +332,7 @@ strsim = "0.11.1"
+@@ -346,7 +346,7 @@ strsim = "0.11.1"
  text-size = "=1.1.1"
  text_lines = "=0.6.0"
  unicode-width = "0.1.3"
@@ -89,7 +44,7 @@ index 4c5c49929..9b0802ff9 100644
  
  # crypto
  aead-gcm-stream = "0.4"
-@@ -380,7 +380,7 @@ cranelift = "0.116"
+@@ -394,7 +394,7 @@ cranelift = "0.116"
  cranelift-native = "0.116"
  dlopen2 = "0.6.1"
  libffi = "=4.1.2"
@@ -99,11 +54,11 @@ index 4c5c49929..9b0802ff9 100644
  
  # napi
 diff --git a/cli/Cargo.toml b/cli/Cargo.toml
-index c8e7acc4e..db2173ee2 100644
+index fef1cebe4..77ecd9d41 100644
 --- a/cli/Cargo.toml
 +++ b/cli/Cargo.toml
-@@ -32,7 +32,7 @@ harness = false
- path = "./bench/lsp_bench_standalone.rs"
+@@ -24,7 +24,7 @@ path = "integration_tests_runner.rs"
+ harness = false
  
  [features]
 -default = ["upgrade", "__vendored_zlib_ng"]
@@ -112,5 +67,5 @@ index c8e7acc4e..db2173ee2 100644
  # 1. Compile with `cargo build --profile=release-with-debug --features=dhat-heap`
  # 2. Run the executable. It will output a dhat-heap.json file.
 -- 
-2.52.0
+2.53.0
 

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-disable-self-update-feature.patch
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-disable-self-update-feature.patch
@@ -1,6 +1,6 @@
-From 40b97a769118e7071e5ac5349b61bac63e73bef6 Mon Sep 17 00:00:00 2001
+From f9e4be379d3710f4235676b834a7004ff564a618 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Sat, 31 Jan 2026 16:45:26 +0800
+Date: Wed, 18 Feb 2026 11:44:43 +0800
 Subject: [PATCH 3/3] AOSCOS: disable self-update feature
 
 ---
@@ -8,11 +8,11 @@ Subject: [PATCH 3/3] AOSCOS: disable self-update feature
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cli/Cargo.toml b/cli/Cargo.toml
-index db2173ee2..2dd742614 100644
+index 77ecd9d41..9c27dd007 100644
 --- a/cli/Cargo.toml
 +++ b/cli/Cargo.toml
-@@ -32,7 +32,7 @@ harness = false
- path = "./bench/lsp_bench_standalone.rs"
+@@ -24,7 +24,7 @@ path = "integration_tests_runner.rs"
+ harness = false
  
  [features]
 -default = ["upgrade"]
@@ -21,5 +21,5 @@ index db2173ee2..2dd742614 100644
  # 1. Compile with `cargo build --profile=release-with-debug --features=dhat-heap`
  # 2. Run the executable. It will output a dhat-heap.json file.
 -- 
-2.52.0
+2.53.0
 

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,11 +1,10 @@
-VER=2.6.8
+VER=2.6.10
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=145.0.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::61fab2832c0fd946ba40196df267d0f10cb5fc7ac375ca50d95cd463ecb775b2 \
+CHKSUMS="sha256::9d36d89e11b61626d732d71fd5a2b83afba06d02373f1fa8daffff3a0addf936 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"
 ENVREQ__ARM64="total_mem=30"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.6.10
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.6.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
