### PR TITLE
[FLIGHT] linux-kernel: drop workaround for workaround for AMDGPU cache flush

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-net-stmmac-remove-broken-PCS-code.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-net-stmmac-remove-broken-PCS-code.patch
@@ -1,7 +1,7 @@
 From 27c4e5465591006b2e12dd87ba61a0ae2ae0b895 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:46 +0100
-Subject: [PATCH 001/450] UPSTREAM: net: stmmac: remove broken PCS code
+Subject: [PATCH 001/451] UPSTREAM: net: stmmac: remove broken PCS code
 
 Changing the netif_carrier_*() state behind phylink's back has always
 been prohibited because it messes up with phylinks state tracking, and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-net-stmmac-remove-xstats.pcs_-members.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-net-stmmac-remove-xstats.pcs_-members.patch
@@ -1,7 +1,7 @@
 From 8ce39c1b3c8fc4e3c9f4c1c9ad82abe7742b5e93 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:51 +0100
-Subject: [PATCH 002/450] UPSTREAM: net: stmmac: remove xstats.pcs_* members
+Subject: [PATCH 002/451] UPSTREAM: net: stmmac: remove xstats.pcs_* members
 
 As a result of the previous commit, the pcs_link, pcs_duplex and
 pcs_speed members are not used outside of the interrupt handling code,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-net-stmmac-remove-SGMII-RGMII-SMII-interrup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-net-stmmac-remove-SGMII-RGMII-SMII-interrup.patch
@@ -1,7 +1,7 @@
 From 11330944dc972570930d1f2ddea6fe39e719561a Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:56 +0100
-Subject: [PATCH 003/450] UPSTREAM: net: stmmac: remove SGMII/RGMII/SMII
+Subject: [PATCH 003/451] UPSTREAM: net: stmmac: remove SGMII/RGMII/SMII
  interrupt handling
 
 Now that the only use for the interrupt is to clear it and increment a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-net-stmmac-remove-PCS-mode-pause-handling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-net-stmmac-remove-PCS-mode-pause-handling.patch
@@ -1,7 +1,7 @@
 From ce6598bb595e7eb61208800a4abb261afad76f76 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:01 +0100
-Subject: [PATCH 004/450] UPSTREAM: net: stmmac: remove PCS "mode" pause
+Subject: [PATCH 004/451] UPSTREAM: net: stmmac: remove PCS "mode" pause
  handling
 
 Remove the "we always autoneg pause" forcing when the stmmac driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-net-stmmac-remove-unused-PCS-loopback-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-net-stmmac-remove-unused-PCS-loopback-suppo.patch
@@ -1,7 +1,7 @@
 From de6f4cfabefeefa5fbf72735bc87765e47246c31 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:06 +0100
-Subject: [PATCH 005/450] UPSTREAM: net: stmmac: remove unused PCS loopback
+Subject: [PATCH 005/451] UPSTREAM: net: stmmac: remove unused PCS loopback
  support
 
 Nothing calls stmmac_pcs_ctrl_ane() with the "loopback" argument set to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-net-stmmac-remove-hw-ps-xxx_core_init-hardw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-net-stmmac-remove-hw-ps-xxx_core_init-hardw.patch
@@ -1,7 +1,7 @@
 From 16e93e7e4946b456547d24ee6cb16585056944ea Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:11 +0100
-Subject: [PATCH 006/450] UPSTREAM: net: stmmac: remove hw->ps xxx_core_init()
+Subject: [PATCH 006/451] UPSTREAM: net: stmmac: remove hw->ps xxx_core_init()
  hardware setup
 
 After a lot of digging, it seems that the oddly named hw->ps member is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-net-stmmac-remove-RGMII-pcs-mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-net-stmmac-remove-RGMII-pcs-mode.patch
@@ -1,7 +1,7 @@
 From 881d9f33e4a5dd4ae1c8f7eb7f9fcde78cd1ede5 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:17 +0100
-Subject: [PATCH 007/450] UPSTREAM: net: stmmac: remove RGMII "pcs" mode
+Subject: [PATCH 007/451] UPSTREAM: net: stmmac: remove RGMII "pcs" mode
 
 Remove the RGMII "pcs" code in stmmac_check_pcs_mode() due to:
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-net-stmmac-move-reverse-pcs-mode-setup-to-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-net-stmmac-move-reverse-pcs-mode-setup-to-s.patch
@@ -1,7 +1,7 @@
 From 11ea7e1128b199e169ec6b47e03021efbc902b0f Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:22 +0100
-Subject: [PATCH 008/450] UPSTREAM: net: stmmac: move reverse-"pcs" mode setup
+Subject: [PATCH 008/451] UPSTREAM: net: stmmac: move reverse-"pcs" mode setup
  to stmmac_check_pcs_mode()
 
 The broken reverse-mode, selected by snps,ps-speed, is configured when

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-net-stmmac-simplify-stmmac_check_pcs_mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-net-stmmac-simplify-stmmac_check_pcs_mode.patch
@@ -1,7 +1,7 @@
 From 5cc8ce9960a0f14a6e3397dbb9ebdeec3fc7adb1 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:27 +0100
-Subject: [PATCH 009/450] UPSTREAM: net: stmmac: simplify
+Subject: [PATCH 009/451] UPSTREAM: net: stmmac: simplify
  stmmac_check_pcs_mode()
 
 Now that we only support one mode, simplify stmmac_check_pcs_mode().

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-net-stmmac-hw-ps-becomes-hw-reverse_sgmii_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-net-stmmac-hw-ps-becomes-hw-reverse_sgmii_e.patch
@@ -1,7 +1,7 @@
 From 3c203fb2cd6d3f6f8e4822300c605a784015fe9e Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:32 +0100
-Subject: [PATCH 010/450] UPSTREAM: net: stmmac: hw->ps becomes
+Subject: [PATCH 010/451] UPSTREAM: net: stmmac: hw->ps becomes
  hw->reverse_sgmii_enable
 
 After a lot of digging, it seems that the oddly named hw->ps member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-net-stmmac-do-not-require-snps-ps-speed-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-net-stmmac-do-not-require-snps-ps-speed-for.patch
@@ -1,7 +1,7 @@
 From a1617cf64ad5285ca4ba73266a3d7fd4525e8f9d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:37 +0100
-Subject: [PATCH 011/450] UPSTREAM: net: stmmac: do not require snps,ps-speed
+Subject: [PATCH 011/451] UPSTREAM: net: stmmac: do not require snps,ps-speed
  for SGMII
 
 SGMII mode does not require port-speed to be specified; this only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-net-stmmac-only-call-stmmac_pcs_ctrl_ane-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-net-stmmac-only-call-stmmac_pcs_ctrl_ane-fo.patch
@@ -1,7 +1,7 @@
 From 882bd0741d0fbc12e45f84d6e4f66c4a6babe074 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:42 +0100
-Subject: [PATCH 012/450] UPSTREAM: net: stmmac: only call
+Subject: [PATCH 012/451] UPSTREAM: net: stmmac: only call
  stmmac_pcs_ctrl_ane() for integrated SGMII PCS
 
 The internal PCS registers only exist if the core is synthesized with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-net-stmmac-provide-PCS-initialisation-hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-net-stmmac-provide-PCS-initialisation-hook.patch
@@ -1,7 +1,7 @@
 From 306909987f39794bc8ea3f6a83ee9a70e5831d8b Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:47 +0100
-Subject: [PATCH 013/450] UPSTREAM: net: stmmac: provide PCS initialisation
+Subject: [PATCH 013/451] UPSTREAM: net: stmmac: provide PCS initialisation
  hook
 
 dwmac cores provide a feature bit to indicate when the PCS block is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-net-stmmac-convert-to-phylink-PCS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-net-stmmac-convert-to-phylink-PCS-support.patch
@@ -1,7 +1,7 @@
 From 31292d9002aa530a11de7e580fd9457f95ddb8ac Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:52 +0100
-Subject: [PATCH 014/450] UPSTREAM: net: stmmac: convert to phylink PCS support
+Subject: [PATCH 014/451] UPSTREAM: net: stmmac: convert to phylink PCS support
 
 Now that stmmac's PCS support is much more simple - just a matter of
 configuring the control register - the basic conversion to phylink PCS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-net-stmmac-replace-has_xxxx-with-core_type.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-net-stmmac-replace-has_xxxx-with-core_type.patch
@@ -1,7 +1,7 @@
 From 87b77888ac17d1c368785de7054bebb56b0e9e53 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Tue, 21 Oct 2025 08:26:49 +0100
-Subject: [PATCH 015/450] UPSTREAM: net: stmmac: replace has_xxxx with
+Subject: [PATCH 015/451] UPSTREAM: net: stmmac: replace has_xxxx with
  core_type
 
 Replace the has_gmac, has_gmac4 and has_xgmac ints, of which only one

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-net-stmmac-dwc-qos-eth-simplify-switch-in-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-net-stmmac-dwc-qos-eth-simplify-switch-in-d.patch
@@ -1,7 +1,7 @@
 From 684fdbbbd9bf395f483e5963f42ab7d4a51e18cc Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:14 +0000
-Subject: [PATCH 016/450] UPSTREAM: net: stmmac: dwc-qos-eth: simplify switch()
+Subject: [PATCH 016/451] UPSTREAM: net: stmmac: dwc-qos-eth: simplify switch()
  in dwc_eth_dwmac_config_dt()
 
 Simplify the switch() statement in dwc_eth_dwmac_config_dt().

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-net-stmmac-move-common-DMA-AXI-register-bit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-net-stmmac-move-common-DMA-AXI-register-bit.patch
@@ -1,7 +1,7 @@
 From dc9515204937a3e882880bec5b1c85215b2e80ce Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:19 +0000
-Subject: [PATCH 017/450] UPSTREAM: net: stmmac: move common DMA AXI register
+Subject: [PATCH 017/451] UPSTREAM: net: stmmac: move common DMA AXI register
  bits to common.h
 
 Move the common DMA AXI register bits to common.h so they can be shared

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-net-stmmac-provide-common-stmmac_axi_blen_t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-net-stmmac-provide-common-stmmac_axi_blen_t.patch
@@ -1,7 +1,7 @@
 From 9469ca755d108acb90d9315125a3e929ff800cd0 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:25 +0000
-Subject: [PATCH 018/450] UPSTREAM: net: stmmac: provide common
+Subject: [PATCH 018/451] UPSTREAM: net: stmmac: provide common
  stmmac_axi_blen_to_mask()
 
 Provide a common stmmac_axi_blen_to_mask() function to translate the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
@@ -1,7 +1,7 @@
 From c26f3b33e557ac3d0daad998b44ff29620da2cfa Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:30 +0000
-Subject: [PATCH 019/450] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
+Subject: [PATCH 019/451] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
  to stmmac_main.c
 
 Move the call to stmmac_axi_blen_to_mask() out of the individual

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
@@ -1,7 +1,7 @@
 From 4e05bde81a8e4a0f3b777e6cee1c4c414aa97cc0 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:35 +0000
-Subject: [PATCH 020/450] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
+Subject: [PATCH 020/451] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
  to axi_blen init sites
 
 Move stmmac_axi_blen_to_mask() to the axi->axi_blen array init sites

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-net-stmmac-remove-axi_blen-array.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-net-stmmac-remove-axi_blen-array.patch
@@ -1,7 +1,7 @@
 From 65405d961b2ff7a656938824bddf7b1e6f2bdb81 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:40 +0000
-Subject: [PATCH 021/450] UPSTREAM: net: stmmac: remove axi_blen array
+Subject: [PATCH 021/451] UPSTREAM: net: stmmac: remove axi_blen array
 
 Remove the axi_blen array from struct stmmac_axi as we set this array,
 and then immediately convert it ot the register value, never looking at

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-BACKPORT-UPSTREAM-net-stmmac-add-stmmac_plat_dat_all.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-BACKPORT-UPSTREAM-net-stmmac-add-stmmac_plat_dat_all.patch
@@ -1,7 +1,7 @@
 From 550ed67d5aa96f2ec3fcfeb50669f2884421f610 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:24 +0000
-Subject: [PATCH 022/450] BACKPORT: UPSTREAM: net: stmmac: add
+Subject: [PATCH 022/451] BACKPORT: UPSTREAM: net: stmmac: add
  stmmac_plat_dat_alloc()
 
 Add a function to allocate and initialise the plat_stmmacenet_data

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-move-initialisation-of-phy_addr-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-move-initialisation-of-phy_addr-.patch
@@ -1,7 +1,7 @@
 From ed55e826c5ad7bc82b2c8fa2c5bd654d9749f3bf Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:29 +0000
-Subject: [PATCH 023/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 023/451] UPSTREAM: net: stmmac: move initialisation of
  phy_addr to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->phy_addr to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-move-initialisation-of-clk_csr-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-move-initialisation-of-clk_csr-t.patch
@@ -1,7 +1,7 @@
 From fd7d6ad7678425dc40d4d0b7e8c96a96514ddb38 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:34 +0000
-Subject: [PATCH 024/450] UPSTREAM: net: stmmac: move initialisation of clk_csr
+Subject: [PATCH 024/451] UPSTREAM: net: stmmac: move initialisation of clk_csr
  to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->clk_csr to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-net-stmmac-move-initialisation-of-maxmtu-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-net-stmmac-move-initialisation-of-maxmtu-to.patch
@@ -1,7 +1,7 @@
 From f35dd4c71ecf4db3c1846108ce547f83a46d507e Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:39 +0000
-Subject: [PATCH 025/450] UPSTREAM: net: stmmac: move initialisation of maxmtu
+Subject: [PATCH 025/451] UPSTREAM: net: stmmac: move initialisation of maxmtu
  to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->maxmtu to JUMBO_LEN to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-net-stmmac-move-initialisation-of-multicast.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-net-stmmac-move-initialisation-of-multicast.patch
@@ -1,7 +1,7 @@
 From ea03eb2c8242d1194e6114d99d4e56054726bb7a Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:44 +0000
-Subject: [PATCH 026/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 026/451] UPSTREAM: net: stmmac: move initialisation of
  multicast_filter_bins to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->multicast_filter_bins to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-net-stmmac-move-initialisation-of-unicast_f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-net-stmmac-move-initialisation-of-unicast_f.patch
@@ -1,7 +1,7 @@
 From 4e98563fff78f092d194eaff8f51aab93a0e8b9d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:49 +0000
-Subject: [PATCH 027/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 027/451] UPSTREAM: net: stmmac: move initialisation of
  unicast_filter_entries to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->unicast_filter_entries to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-net-stmmac-move-initialisation-of-queues_to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-net-stmmac-move-initialisation-of-queues_to.patch
@@ -1,7 +1,7 @@
 From ab8aaeb246a7025b2b0685a6543664dcd17ba50a Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:54 +0000
-Subject: [PATCH 028/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 028/451] UPSTREAM: net: stmmac: move initialisation of
  queues_to_use to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->tx_queues_to_use and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-net-stmmac-setup-default-RX-channel-map-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-net-stmmac-setup-default-RX-channel-map-in-.patch
@@ -1,7 +1,7 @@
 From 3051dd2ac8dcba4b3227cb52f6fba98a0132b0a3 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:00 +0000
-Subject: [PATCH 029/450] UPSTREAM: net: stmmac: setup default RX channel map
+Subject: [PATCH 029/451] UPSTREAM: net: stmmac: setup default RX channel map
  in stmmac_plat_dat_alloc()
 
 Setup the default 1:1 RX channel map in stmmac_plat_dat_alloc() and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-net-stmmac-remove-unnecessary-.use_prio-que.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-net-stmmac-remove-unnecessary-.use_prio-que.patch
@@ -1,7 +1,7 @@
 From 34d940bc2fb0b61daa7d4b91e934ebed141aabe8 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:05 +0000
-Subject: [PATCH 030/450] UPSTREAM: net: stmmac: remove unnecessary .use_prio
+Subject: [PATCH 030/451] UPSTREAM: net: stmmac: remove unnecessary .use_prio
  queue initialisation
 
 Several drivers (see below) explicitly set the queue .use_prio

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-net-stmmac-remove-unnecessary-.prio-queue-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-net-stmmac-remove-unnecessary-.prio-queue-i.patch
@@ -1,7 +1,7 @@
 From 2d678b6b3af85c86403daf87e5d9fc464cd83418 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:10 +0000
-Subject: [PATCH 031/450] UPSTREAM: net: stmmac: remove unnecessary .prio queue
+Subject: [PATCH 031/451] UPSTREAM: net: stmmac: remove unnecessary .prio queue
  initialisation
 
 stmmac_platform.c explicitly sets .prio to zero if the snps,priority

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-net-stmmac-remove-unnecessary-.pkt_route-qu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-net-stmmac-remove-unnecessary-.pkt_route-qu.patch
@@ -1,7 +1,7 @@
 From b7ab821b31e09a3115820944d0faf9d1113ebdf2 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:15 +0000
-Subject: [PATCH 032/450] UPSTREAM: net: stmmac: remove unnecessary .pkt_route
+Subject: [PATCH 032/451] UPSTREAM: net: stmmac: remove unnecessary .pkt_route
  queue initialisation
 
 PCI drivers explicitly set .pkt_route to zero. However, as the struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-arm64-dts-cix-add-DT-nodes-for-SPI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-arm64-dts-cix-add-DT-nodes-for-SPI.patch
@@ -1,7 +1,7 @@
 From dcca6861bc3f5c7f117af26db604c9c1343fc7fb Mon Sep 17 00:00:00 2001
 From: Jun Guo <jun.guo@cixtech.com>
 Date: Fri, 19 Sep 2025 09:31:18 +0800
-Subject: [PATCH 033/450] UPSTREAM: arm64: dts: cix: add DT nodes for SPI
+Subject: [PATCH 033/451] UPSTREAM: arm64: dts: cix: add DT nodes for SPI
 
 Add the device tree node for the spi controller of the CIX SKY1 SoC.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-UPSTREAM-dt-bindings-pinctrl-Add-cix-sky1-pinctrl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-UPSTREAM-dt-bindings-pinctrl-Add-cix-sky1-pinctrl.patch
@@ -1,7 +1,7 @@
 From de80d7af66225b8c896448b28e6880385b92173b Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:08 +0800
-Subject: [PATCH 034/450] UPSTREAM: dt-bindings: pinctrl: Add cix,sky1-pinctrl
+Subject: [PATCH 034/451] UPSTREAM: dt-bindings: pinctrl: Add cix,sky1-pinctrl
 
 The pin-controller is used to control the Soc pins.
 There are two pin-controllers on Cix Sky1 platform.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-UPSTREAM-pinctrl-cix-Add-pin-controller-support-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-UPSTREAM-pinctrl-cix-Add-pin-controller-support-for-.patch
@@ -1,7 +1,7 @@
 From 57d872adb462e8458ca2219fd45324c3f187e1bd Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:09 +0800
-Subject: [PATCH 035/450] UPSTREAM: pinctrl: cix: Add pin-controller support
+Subject: [PATCH 035/451] UPSTREAM: pinctrl: cix: Add pin-controller support
  for sky1
 
 There are two pin-controllers on Cix Sky1 platform.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-UPSTREAM-arm64-dts-cix-Add-pinctrl-nodes-for-sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-UPSTREAM-arm64-dts-cix-Add-pinctrl-nodes-for-sky1.patch
@@ -1,7 +1,7 @@
 From b5eeb2dbb1e74fb8dcebe1db827064d3aeec0793 Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:10 +0800
-Subject: [PATCH 036/450] UPSTREAM: arm64: dts: cix: Add pinctrl nodes for sky1
+Subject: [PATCH 036/451] UPSTREAM: arm64: dts: cix: Add pinctrl nodes for sky1
 
 Add the pin-controller nodes for Sky1 platform.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-UPSTREAM-PCI-cadence-Add-module-support-for-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-UPSTREAM-PCI-cadence-Add-module-support-for-platform.patch
@@ -1,7 +1,7 @@
 From b128035f81cb1df1203dd83fc002c0421e8f2dc6 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:56 +0800
-Subject: [PATCH 037/450] UPSTREAM: PCI: cadence: Add module support for
+Subject: [PATCH 037/451] UPSTREAM: PCI: cadence: Add module support for
  platform controller driver
 
 Add support for building PCI cadence platforms as a module.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-UPSTREAM-PCI-cadence-Split-PCIe-controller-header-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-UPSTREAM-PCI-cadence-Split-PCIe-controller-header-fi.patch
@@ -1,7 +1,7 @@
 From 5855d5f9c53ad2c6c34c19d3ee9ab51ababe2234 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:57 +0800
-Subject: [PATCH 038/450] UPSTREAM: PCI: cadence: Split PCIe controller header
+Subject: [PATCH 038/451] UPSTREAM: PCI: cadence: Split PCIe controller header
  file
 
 Split the Cadence PCIe header file by moving the Legacy (LGA) controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-UPSTREAM-PCI-cadence-Move-PCIe-RP-common-functions-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-UPSTREAM-PCI-cadence-Move-PCIe-RP-common-functions-t.patch
@@ -1,7 +1,7 @@
 From 6b02d44e5298f2791698359d05c66f53d5557c98 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:58 +0800
-Subject: [PATCH 039/450] UPSTREAM: PCI: cadence: Move PCIe RP common functions
+Subject: [PATCH 039/451] UPSTREAM: PCI: cadence: Move PCIe RP common functions
  to a separate file
 
 Move the Cadence PCIe controller RP common functions into a separate file.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-UPSTREAM-PCI-cadence-Add-support-for-High-Perf-Archi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-UPSTREAM-PCI-cadence-Add-support-for-High-Perf-Archi.patch
@@ -1,7 +1,7 @@
 From 437659e2c8f29ca86cc26bce752954ae812071d5 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:59 +0800
-Subject: [PATCH 040/450] UPSTREAM: PCI: cadence: Add support for High Perf
+Subject: [PATCH 040/451] UPSTREAM: PCI: cadence: Add support for High Perf
  Architecture (HPA) controller
 
 Add support for Cadence PCIe RP configuration for High Performance

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-UPSTREAM-dt-bindings-PCI-Add-CIX-Sky1-PCIe-Root-Comp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-UPSTREAM-dt-bindings-PCI-Add-CIX-Sky1-PCIe-Root-Comp.patch
@@ -1,7 +1,7 @@
 From 698a2f23d14e2930c1e287ef4e59c0ceb21a434d Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:00 +0800
-Subject: [PATCH 041/450] UPSTREAM: dt-bindings: PCI: Add CIX Sky1 PCIe Root
+Subject: [PATCH 041/451] UPSTREAM: dt-bindings: PCI: Add CIX Sky1 PCIe Root
  Complex bindings
 
 Document the bindings for CIX Sky1 PCIe Controller configured in Root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-UPSTREAM-PCI-sky1-Add-PCIe-host-support-for-CIX-Sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-UPSTREAM-PCI-sky1-Add-PCIe-host-support-for-CIX-Sky1.patch
@@ -1,7 +1,7 @@
 From a59430b4393a824cb036cbf8b974afd29c067082 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:02 +0800
-Subject: [PATCH 042/450] UPSTREAM: PCI: sky1: Add PCIe host support for CIX
+Subject: [PATCH 042/451] UPSTREAM: PCI: sky1: Add PCIe host support for CIX
  Sky1
 
 Add driver for the CIX Sky1 SoC PCIe Gen4 16 GT/s controller based on the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-UPSTREAM-arm64-dts-cix-Add-PCIe-Root-Complex-on-sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-UPSTREAM-arm64-dts-cix-Add-PCIe-Root-Complex-on-sky1.patch
@@ -1,7 +1,7 @@
 From 4f99c5adf673a2d6d626465a99e941265481d968 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:04 +0800
-Subject: [PATCH 043/450] UPSTREAM: arm64: dts: cix: Add PCIe Root Complex on
+Subject: [PATCH 043/451] UPSTREAM: arm64: dts: cix: Add PCIe Root Complex on
  sky1
 
 Add pcie_x*_rc node to support Sky1 PCIe driver based on the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-UPSTREAM-arm64-dts-cix-Enable-PCIe-on-the-Orion-O6-b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-UPSTREAM-arm64-dts-cix-Enable-PCIe-on-the-Orion-O6-b.patch
@@ -1,7 +1,7 @@
 From 6531c59e4adff044bc0ea2947193aa399334594e Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:05 +0800
-Subject: [PATCH 044/450] UPSTREAM: arm64: dts: cix: Enable PCIe on the Orion
+Subject: [PATCH 044/451] UPSTREAM: arm64: dts: cix: Enable PCIe on the Orion
  O6 board
 
 Add PCIe RC support on Orion O6 board.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-UPSTREAM-arm64-dts-cix-add-a-compatible-string-for-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-UPSTREAM-arm64-dts-cix-add-a-compatible-string-for-t.patch
@@ -1,7 +1,7 @@
 From 739ffa9295c2d64186861ad4908493c52734c851 Mon Sep 17 00:00:00 2001
 From: Jun Guo <jun.guo@cixtech.com>
 Date: Fri, 31 Oct 2025 15:30:03 +0800
-Subject: [PATCH 045/450] UPSTREAM: arm64: dts: cix: add a compatible string
+Subject: [PATCH 045/451] UPSTREAM: arm64: dts: cix: add a compatible string
  for the cix sky1 SoC
 
 The SPI IP design for the cix sky1 SoC uses a FIFO with a data width

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-UPSTREAM-drm-ttm-add-pgprot-handling-for-RISC-V.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-UPSTREAM-drm-ttm-add-pgprot-handling-for-RISC-V.patch
@@ -1,7 +1,7 @@
 From b87c1d080aa0b30a2904ec212aecb2500e2b8032 Mon Sep 17 00:00:00 2001
 From: Han Gao <gaohan@iscas.ac.cn>
 Date: Fri, 5 Dec 2025 10:42:07 +0800
-Subject: [PATCH 046/450] UPSTREAM: drm/ttm: add pgprot handling for RISC-V
+Subject: [PATCH 046/451] UPSTREAM: drm/ttm: add pgprot handling for RISC-V
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-UPSTREAM-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-UPSTREAM-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
@@ -1,7 +1,7 @@
 From d76dec7e0311a1007535cf2bb79266d0a5a6dd2d Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:33:43 +0800
-Subject: [PATCH 047/450] UPSTREAM: riscv: sophgo: dts: add PCIe controllers
+Subject: [PATCH 047/451] UPSTREAM: riscv: sophgo: dts: add PCIe controllers
  for SG2042
 
 Add PCIe controller nodes in DTS for Sophgo SG2042.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
@@ -1,7 +1,7 @@
 From 3ec15bd9685ae9085bc9a8d51068ce38f589a519 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:34:05 +0800
-Subject: [PATCH 048/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 048/451] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  PioneerBox
 
 Enable PCIe controllers for PioneerBox, which uses SG2042 SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From e305f1e6f3ac50d696f8d9933740a829fba0e54b Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:39:22 +0800
-Subject: [PATCH 049/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 049/451] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V1.X
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V1.X board,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 626d96d8e50242ccee9f9f4c044d3285241cde94 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:40:09 +0800
-Subject: [PATCH 050/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 050/451] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V2.0
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V2.0 board,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-UPSTREAM-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-UPSTREAM-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
@@ -1,7 +1,7 @@
 From a1a72ed91b42ee1ca73f07955fc6c8b3613ab4f9 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:50 +0800
-Subject: [PATCH 051/450] UPSTREAM: riscv: dts: sophgo: Add SPI NOR node for
+Subject: [PATCH 051/451] UPSTREAM: riscv: dts: sophgo: Add SPI NOR node for
  SG2042
 
 Add SPI NOR controller node for SG2042

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
@@ -1,7 +1,7 @@
 From e7f2871669c568acc94422492b19c337cfbe76a9 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:51 +0800
-Subject: [PATCH 052/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 052/451] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  PioneerBox
 
 Enable SPI NOR node for PioneerBox device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 2dc0fd0f9b498a09df94121316feae9df33c1e57 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:52 +0800
-Subject: [PATCH 053/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 053/451] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V1
 
 Enable SPI NOR node for SG2042_EVB_V1 device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 30445968c664dea6e2e9d9ecba70dbb4ed00b4bf Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:53 +0800
-Subject: [PATCH 054/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 054/451] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V2
 
 Enable SPI NOR node for SG2042_EVB_V2 device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-add-phy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-add-phy.patch
@@ -1,7 +1,7 @@
 From d1092daa48e13d3e2b5f61711d86217a948b124d Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Fri, 14 Nov 2025 08:38:03 +0800
-Subject: [PATCH 055/450] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: add
+Subject: [PATCH 055/451] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: add
  phy mode restriction
 
 As the ethernet controller of SG2044 and SG2042 only supports

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-UPSTREAM-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-UPSTREAM-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
@@ -1,7 +1,7 @@
 From 9b72b3f2cf4f241e8ef000f2513488edd8666e93 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 14 Oct 2025 09:48:29 +0800
-Subject: [PATCH 056/450] UPSTREAM: perf vendor events riscv: add T-HEAD C920V2
+Subject: [PATCH 056/451] UPSTREAM: perf vendor events riscv: add T-HEAD C920V2
  JSON support
 
 T-HEAD C920 has a V2 iteration, which supports Sscompmf. The V2

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-UPSTREAM-rust-macros-Add-support-for-imports_ns-to-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-UPSTREAM-rust-macros-Add-support-for-imports_ns-to-m.patch
@@ -1,7 +1,7 @@
 From 6d932d65f3381fcaf8ba78752538117b06dcc9a6 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:32 +0100
-Subject: [PATCH 057/450] UPSTREAM: rust: macros: Add support for 'imports_ns'
+Subject: [PATCH 057/451] UPSTREAM: rust: macros: Add support for 'imports_ns'
  to module!
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-UPSTREAM-pwm-Export-pwmchip_release-for-external-use.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-UPSTREAM-pwm-Export-pwmchip_release-for-external-use.patch
@@ -1,7 +1,7 @@
 From 21875928fb15c11b9ad9e3b0b4df58dcba3def21 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:01 +0200
-Subject: [PATCH 058/450] UPSTREAM: pwm: Export `pwmchip_release` for external
+Subject: [PATCH 058/451] UPSTREAM: pwm: Export `pwmchip_release` for external
  use
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-UPSTREAM-rust-pwm-Add-Kconfig-and-basic-data-structu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-UPSTREAM-rust-pwm-Add-Kconfig-and-basic-data-structu.patch
@@ -1,7 +1,7 @@
 From 766ef670b1d8c395e1cae138f3c05e1aa09eeb14 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:02 +0200
-Subject: [PATCH 059/450] UPSTREAM: rust: pwm: Add Kconfig and basic data
+Subject: [PATCH 059/451] UPSTREAM: rust: pwm: Add Kconfig and basic data
  structures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-UPSTREAM-rust-pwm-Add-complete-abstraction-layer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-UPSTREAM-rust-pwm-Add-complete-abstraction-layer.patch
@@ -1,7 +1,7 @@
 From 35585e01b98270bacd747ff60a4f2ed74839c71e Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:03 +0200
-Subject: [PATCH 060/450] UPSTREAM: rust: pwm: Add complete abstraction layer
+Subject: [PATCH 060/451] UPSTREAM: rust: pwm: Add complete abstraction layer
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-UPSTREAM-rust-pwm-Add-module_pwm_platform_driver-mac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-UPSTREAM-rust-pwm-Add-module_pwm_platform_driver-mac.patch
@@ -1,7 +1,7 @@
 From 38132b79785ca96ea823a2a4dd4baf55585a808f Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:33 +0100
-Subject: [PATCH 061/450] UPSTREAM: rust: pwm: Add module_pwm_platform_driver!
+Subject: [PATCH 061/451] UPSTREAM: rust: pwm: Add module_pwm_platform_driver!
  macro
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-UPSTREAM-rust-pwm-Drop-wrapping-of-PWM-polarity-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-UPSTREAM-rust-pwm-Drop-wrapping-of-PWM-polarity-and-.patch
@@ -1,7 +1,7 @@
 From e55f05f432d98946ceacd62c5e60134587f731c7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Uwe=20Kleine-K=C3=B6nig?= <u.kleine-koenig@baylibre.com>
 Date: Sat, 25 Oct 2025 14:23:56 +0200
-Subject: [PATCH 062/450] UPSTREAM: rust: pwm: Drop wrapping of PWM polarity
+Subject: [PATCH 062/451] UPSTREAM: rust: pwm: Drop wrapping of PWM polarity
  and state
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-UPSTREAM-rust-pwm-Fix-broken-intra-doc-link.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-UPSTREAM-rust-pwm-Fix-broken-intra-doc-link.patch
@@ -1,7 +1,7 @@
 From b08df6342b02f64d7c6e9542a1de95ace0217472 Mon Sep 17 00:00:00 2001
 From: Miguel Ojeda <ojeda@kernel.org>
 Date: Wed, 29 Oct 2025 19:19:40 +0100
-Subject: [PATCH 063/450] UPSTREAM: rust: pwm: Fix broken intra-doc link
+Subject: [PATCH 063/451] UPSTREAM: rust: pwm: Fix broken intra-doc link
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-UPSTREAM-pwm-Add-Rust-driver-for-T-HEAD-TH1520-SoC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-UPSTREAM-pwm-Add-Rust-driver-for-T-HEAD-TH1520-SoC.patch
@@ -1,7 +1,7 @@
 From f3fae9d758f3972ec07ec8cc0933ae66fcd5d174 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:04 +0200
-Subject: [PATCH 064/450] UPSTREAM: pwm: Add Rust driver for T-HEAD TH1520 SoC
+Subject: [PATCH 064/451] UPSTREAM: pwm: Add Rust driver for T-HEAD TH1520 SoC
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-UPSTREAM-dt-bindings-pwm-thead-Add-T-HEAD-TH1520-PWM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-UPSTREAM-dt-bindings-pwm-thead-Add-T-HEAD-TH1520-PWM.patch
@@ -1,7 +1,7 @@
 From df4b7f36fd2e89cdf51f1e27cf7fd97423bcf400 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:05 +0200
-Subject: [PATCH 065/450] UPSTREAM: dt-bindings: pwm: thead: Add T-HEAD TH1520
+Subject: [PATCH 065/451] UPSTREAM: dt-bindings: pwm: thead: Add T-HEAD TH1520
  PWM controller
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-UPSTREAM-pwm-Fix-Rust-formatting.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-UPSTREAM-pwm-Fix-Rust-formatting.patch
@@ -1,7 +1,7 @@
 From 6d0ea7fa464cbc10b0cb7dc002c85b7fe69515f8 Mon Sep 17 00:00:00 2001
 From: Miguel Ojeda <ojeda@kernel.org>
 Date: Wed, 29 Oct 2025 19:25:02 +0100
-Subject: [PATCH 066/450] UPSTREAM: pwm: Fix Rust formatting
+Subject: [PATCH 066/451] UPSTREAM: pwm: Fix Rust formatting
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-UPSTREAM-pwm-th1520-Fix-clippy-warning-for-redundant.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-UPSTREAM-pwm-th1520-Fix-clippy-warning-for-redundant.patch
@@ -1,7 +1,7 @@
 From f50a99fb3a07f055180fda03ac9963dbf21003ad Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:35 +0100
-Subject: [PATCH 067/450] UPSTREAM: pwm: th1520: Fix clippy warning for
+Subject: [PATCH 067/451] UPSTREAM: pwm: th1520: Fix clippy warning for
  redundant struct field init
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-UPSTREAM-pwm-th1520-Use-module_pwm_platform_driver-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-UPSTREAM-pwm-th1520-Use-module_pwm_platform_driver-m.patch
@@ -1,7 +1,7 @@
 From 88c2c1489998ce63603193f9f8a961a4d5867971 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:34 +0100
-Subject: [PATCH 068/450] UPSTREAM: pwm: th1520: Use
+Subject: [PATCH 068/451] UPSTREAM: pwm: th1520: Use
  module_pwm_platform_driver! macro
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-UPSTREAM-pwm-th1520-Fix-missing-Kconfig-dependencies.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-UPSTREAM-pwm-th1520-Fix-missing-Kconfig-dependencies.patch
@@ -1,7 +1,7 @@
 From bcc049896b3f8907e862584c5bd34fe4b1286499 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 9 Dec 2025 21:06:03 +0100
-Subject: [PATCH 069/450] UPSTREAM: pwm: th1520: Fix missing Kconfig
+Subject: [PATCH 069/451] UPSTREAM: pwm: th1520: Fix missing Kconfig
  dependencies
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-UPSTREAM-riscv-dts-thead-add-xtheadvector-to-the-th1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-UPSTREAM-riscv-dts-thead-add-xtheadvector-to-the-th1.patch
@@ -1,7 +1,7 @@
 From edc7686e3c7a5018421936c53511e9c6954fc4af Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:47 +0800
-Subject: [PATCH 070/450] UPSTREAM: riscv: dts: thead: add xtheadvector to the
+Subject: [PATCH 070/451] UPSTREAM: riscv: dts: thead: add xtheadvector to the
  th1520 devicetree
 
 The th1520 support xtheadvector [1] so it can be included in the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-UPSTREAM-riscv-dts-thead-add-ziccrse-for-th1520.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-UPSTREAM-riscv-dts-thead-add-ziccrse-for-th1520.patch
@@ -1,7 +1,7 @@
 From 1d72e4ff18fd861d029b52226b6abf52c1fa4b62 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:48 +0800
-Subject: [PATCH 071/450] UPSTREAM: riscv: dts: thead: add ziccrse for th1520
+Subject: [PATCH 071/451] UPSTREAM: riscv: dts: thead: add ziccrse for th1520
 
 Existing rv64 hardware conforms to the rva20 profile.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-UPSTREAM-riscv-dts-thead-add-zfh-for-th1520.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-UPSTREAM-riscv-dts-thead-add-zfh-for-th1520.patch
@@ -1,7 +1,7 @@
 From 433d766c056f127c4a2294619545a3dc766d8e81 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:49 +0800
-Subject: [PATCH 072/450] UPSTREAM: riscv: dts: thead: add zfh for th1520
+Subject: [PATCH 072/451] UPSTREAM: riscv: dts: thead: add zfh for th1520
 
 th1520 support Zfh ISA extension.
 It supports the same RISC-V extensions as SG2042.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-UPSTREAM-riscv-dts-thead-Add-PWM-controller-node.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-UPSTREAM-riscv-dts-thead-Add-PWM-controller-node.patch
@@ -1,7 +1,7 @@
 From 9526c2358f7cbefc5f52e9e82b61597dc3898a06 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:06 +0200
-Subject: [PATCH 073/450] UPSTREAM: riscv: dts: thead: Add PWM controller node
+Subject: [PATCH 073/451] UPSTREAM: riscv: dts: thead: Add PWM controller node
 
 Add the Device Tree node for the T-HEAD TH1520 SoC's PWM controller.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-UPSTREAM-riscv-dts-thead-Add-PWM-fan-and-thermal-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-UPSTREAM-riscv-dts-thead-Add-PWM-fan-and-thermal-con.patch
@@ -1,7 +1,7 @@
 From ee1fad0efff3a2ea0a260bff2a17957ed322d37e Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:07 +0200
-Subject: [PATCH 074/450] UPSTREAM: riscv: dts: thead: Add PWM fan and thermal
+Subject: [PATCH 074/451] UPSTREAM: riscv: dts: thead: Add PWM fan and thermal
  control
 
 Add Device Tree nodes to enable a PWM controlled fan and it's associated

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-UPSTREAM-MIPS-Loongson64-dts-fix-phy-related-definit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-UPSTREAM-MIPS-Loongson64-dts-fix-phy-related-definit.patch
@@ -1,7 +1,7 @@
 From de1a3779127ed39c665e52cd592cf73cd7723bce Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 2 Jan 2026 23:52:43 +0800
-Subject: [PATCH 075/450] UPSTREAM: MIPS: Loongson64: dts: fix phy-related
+Subject: [PATCH 075/451] UPSTREAM: MIPS: Loongson64: dts: fix phy-related
  definition of LS7A GMAC
 
 Currently the LS7A GMAC device tree node lacks a proper phy-handle

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From fbd6cd6675c70ae0e865286015099f99595515b0 Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 076/450] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 076/451] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
@@ -1,7 +1,7 @@
 From 052b38e42a5aecd079626b9e6fa96ed3848d112c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 077/450] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
+Subject: [PATCH 077/451] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
  before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From f2437302c95dbe9d290fbe2ea00851f032d12648 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 078/450] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 078/451] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From 98ef762d34220652904086947e0967cdaeca8421 Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 079/450] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 079/451] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
@@ -1,7 +1,7 @@
 From 0e74bdc49a3c441c25fec54ec984da7af575b894 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:47 +0800
-Subject: [PATCH 080/450] FROMLIST: dt-bindings: serial: 8250: Add Loongson
+Subject: [PATCH 080/451] FROMLIST: dt-bindings: serial: 8250: Add Loongson
  uart compatible
 
 The Loongson family have a mostly NS16550A-compatible UART and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
@@ -1,7 +1,7 @@
 From e25f9fc99cac1a19206c3d58998bc65da3404b7c Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:48 +0800
-Subject: [PATCH 081/450] FROMLIST: serial: 8250: Add Loongson uart driver
+Subject: [PATCH 081/451] FROMLIST: serial: 8250: Add Loongson uart driver
  support
 
 Add the driver for on-chip UART used on Loongson family chips.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
@@ -1,7 +1,7 @@
 From dbbf6e36a34b981865d162c9c894e2049dc74bde Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:49 +0800
-Subject: [PATCH 082/450] FROMLIST: LoongArch: dts: Add uart new compatible
+Subject: [PATCH 082/451] FROMLIST: LoongArch: dts: Add uart new compatible
  string
 
 Add loongson,ls2k*-uart compatible string on uarts.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From da05587fec58f284d969818d97f9287ee1ed5395 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 083/450] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 083/451] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 9056ff2a4090b30e75b749489c6d0a1c5d30f1e4 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 084/450] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 084/451] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From fca8682029dad9ea809138db5ff3765106425713 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 085/450] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 085/451] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
@@ -1,7 +1,7 @@
 From 679916a37ae544563108d0e5d4ede3b0782ae949 Mon Sep 17 00:00:00 2001
 From: WangYuli <wangyuli@uniontech.com>
 Date: Tue, 18 Mar 2025 14:11:25 +0800
-Subject: [PATCH 086/450] FROMLIST: scsi: Bypass certain SCSI commands on disks
+Subject: [PATCH 086/451] FROMLIST: scsi: Bypass certain SCSI commands on disks
  with "use_192_bytes_for_3f" attribute
 
 On some external USB hard drives, mounting can fail if "lshw" is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
@@ -1,7 +1,7 @@
 From 2faf7040118eb7b8f7ce2bb5fb8fbe279572c6fa Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Sun, 11 May 2025 16:34:12 +0800
-Subject: [PATCH 087/450] FROMLIST: PCI: Use local_pci_probe() when best
+Subject: [PATCH 087/451] FROMLIST: PCI: Use local_pci_probe() when best
  selected cpu is offline
 
 When the best selected CPU is offline, work_on_cpu() will stuck forever.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From a804cdefd0720a2d73bdea772cd68eb4fb081b9c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 11 May 2025 16:34:13 +0800
-Subject: [PATCH 088/450] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 088/451] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
@@ -1,7 +1,7 @@
 From e455150d704dd16420471c266115c06a2ae63f35 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 17 Aug 2025 22:19:09 +0800
-Subject: [PATCH 089/450] REVERT: Revert "Mark xe driver as BROKEN if kernel
+Subject: [PATCH 089/451] REVERT: Revert "Mark xe driver as BROKEN if kernel
  page size is not 4kB"
 
 This reverts commit 022906afdf90327bce33d52fb4fb41b6c7d618fb.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
@@ -1,7 +1,7 @@
 From 513cd78b6559d3b054dd73a5e7f5a07abd9bac4f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 090/450] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
+Subject: [PATCH 090/451] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
  non-4K kernel page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From 5e2f73d8d888a31d484b41a8e2e5488a212e1bdc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 091/450] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
+Subject: [PATCH 091/451] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
  alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
 From e11e221f2cf68b5a2c969f4b60da9850c2db1bd6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 092/450] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 092/451] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From 6ff85d95d3aefef8fcfcdb177cfb94b494ec2317 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 093/450] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 093/451] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From 228b6dc1626001fd0c75a82094d4c6c16e111345 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 094/450] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 094/451] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
@@ -1,7 +1,7 @@
 From 591d8077efe81d0d760e1a1ce49dd96e4a4c7712 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Aug 2025 11:21:36 +0800
-Subject: [PATCH 095/450] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
+Subject: [PATCH 095/451] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
  LoongArch and AArch64
 
 While testing my ROCm port for LoongArch and AArch64 (patches pending) on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
@@ -1,7 +1,7 @@
 From d3ca2f3573c013de0e3e17e9ff4a87e49e3e0f3d Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:46 +0800
-Subject: [PATCH 096/450] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
+Subject: [PATCH 096/451] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
  coherency status in ttm_device
 
 Currently TTM utilizes cached memory regardless of whether the device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
@@ -1,7 +1,7 @@
 From 1ef7ee5ba8e780741be70e598527bf84bfef1c87 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:47 +0800
-Subject: [PATCH 097/450] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
+Subject: [PATCH 097/451] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
  write_combined when snooping not available
 
 As we can now acquire the presence of the full DMA coherency (snooping

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
@@ -1,7 +1,7 @@
 From 87e02277fc664d0f3691238d9f6893ab2e9b155b Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:21 -0400
-Subject: [PATCH 098/450] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
+Subject: [PATCH 098/451] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
  fixup
 
 The early version of XuanTie C910 core has a store merge buffer

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
@@ -1,7 +1,7 @@
 From 8a098276a9fae647f67bc764ef711bb4aa031256 Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sat, 11 Oct 2025 11:57:46 -0400
-Subject: [PATCH 099/450] FROMLIST: riscv: Add pgprot_dmacoherent definition
+Subject: [PATCH 099/451] FROMLIST: riscv: Add pgprot_dmacoherent definition
 
 RISC-V Svpbmt Standard Extension for Page-Based Memory Types
 defines three modes:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
@@ -1,7 +1,7 @@
 From 96e4f510db0e3b87d76f4aaa83d8843e48417f70 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ilpo=20J=C3=A4rvinen?= <ilpo.jarvinen@linux.intel.com>
 Date: Thu, 18 Sep 2025 13:58:56 -0700
-Subject: [PATCH 100/450] FROMLIST: PCI: Release BAR0 of an integrated bridge
+Subject: [PATCH 100/451] FROMLIST: PCI: Release BAR0 of an integrated bridge
  to allow GPU BAR resize
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-FROMLIST-LoongArch-KVM-Get-VM-PMU-capability-from-HW.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-FROMLIST-LoongArch-KVM-Get-VM-PMU-capability-from-HW.patch
@@ -1,7 +1,7 @@
 From 90211967da65428a601c00d8008cf5df8bc4da67 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Sep 2025 17:37:41 +0800
-Subject: [PATCH 101/450] FROMLIST: LoongArch: KVM: Get VM PMU capability from
+Subject: [PATCH 101/451] FROMLIST: LoongArch: KVM: Get VM PMU capability from
  HW GCFG register
 
 Now VM PMU capability comes from host PMU capability directly, instead

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From 02ed553f2cd2f812df6b70564d51a8232b2f895f Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia.pukngae@linux.dev>
 Date: Wed, 22 Oct 2025 18:40:42 +0800
-Subject: [PATCH 102/450] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 102/451] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-FROMLIST-gpio-loongson-64bit-Switch-to-dynamic-alloc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-FROMLIST-gpio-loongson-64bit-Switch-to-dynamic-alloc.patch
@@ -1,7 +1,7 @@
 From ec27c591a61f9bc859803618f8cf5f4e834dfe43 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 23 Oct 2025 17:03:46 +0800
-Subject: [PATCH 103/450] FROMLIST: gpio: loongson-64bit: Switch to dynamic
+Subject: [PATCH 103/451] FROMLIST: gpio: loongson-64bit: Switch to dynamic
  allocate GPIO base in byte mode
 
 gpiolib want to get completely rid of static gpiobase allocation, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-FROMLIST-dt-bindings-clock-thead-th1520-clk-ap-Add-I.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-FROMLIST-dt-bindings-clock-thead-th1520-clk-ap-Add-I.patch
@@ -1,7 +1,7 @@
 From b8371572a497c9a791d816f4590988f439daab30 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:10 +0000
-Subject: [PATCH 104/450] FROMLIST: dt-bindings: clock: thead,th1520-clk-ap:
+Subject: [PATCH 104/451] FROMLIST: dt-bindings: clock: thead,th1520-clk-ap:
  Add ID for C910 bus clock
 
 Add binding ID for C910 bus clock, which takes CLK_C910 as parent and is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-FROMLIST-clk-thead-th1520-ap-Poll-for-PLL-lock-and-w.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-FROMLIST-clk-thead-th1520-ap-Poll-for-PLL-lock-and-w.patch
@@ -1,7 +1,7 @@
 From 7fee2a2bd283a7135e5a3505868fe1a74cc91642 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:11 +0000
-Subject: [PATCH 105/450] FROMLIST: clk: thead: th1520-ap: Poll for PLL lock
+Subject: [PATCH 105/451] FROMLIST: clk: thead: th1520-ap: Poll for PLL lock
  and wait for stability
 
 All PLLs found on TH1520 SoC take 21250ns at maximum to lock, and their

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-FROMLIST-clk-thead-th1520-ap-Add-C910-bus-clock.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-FROMLIST-clk-thead-th1520-ap-Add-C910-bus-clock.patch
@@ -1,7 +1,7 @@
 From a05f1a78c41d398ef72cf672711c93a4bdc556ab Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:12 +0000
-Subject: [PATCH 106/450] FROMLIST: clk: thead: th1520-ap: Add C910 bus clock
+Subject: [PATCH 106/451] FROMLIST: clk: thead: th1520-ap: Add C910 bus clock
 
 This divider takes c910_clk as parent and is essential for the C910
 cluster to operate, thus is marked as CLK_IS_CRITICAL.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-FROMLIST-clk-thead-th1520-ap-Support-setting-PLL-rat.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-FROMLIST-clk-thead-th1520-ap-Support-setting-PLL-rat.patch
@@ -1,7 +1,7 @@
 From 0f723c888f0b171307df6716103628104f2271c3 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:13 +0000
-Subject: [PATCH 107/450] FROMLIST: clk: thead: th1520-ap: Support setting PLL
+Subject: [PATCH 107/451] FROMLIST: clk: thead: th1520-ap: Support setting PLL
  rates
 
 TH1520 ships several PLLs that could operate in either integer or

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-FROMLIST-clk-thead-th1520-ap-Add-macro-to-define-mul.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-FROMLIST-clk-thead-th1520-ap-Add-macro-to-define-mul.patch
@@ -1,7 +1,7 @@
 From 0b95a2660669954b67f08cfd611698f3e06beeee Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:14 +0000
-Subject: [PATCH 108/450] FROMLIST: clk: thead: th1520-ap: Add macro to define
+Subject: [PATCH 108/451] FROMLIST: clk: thead: th1520-ap: Add macro to define
  multiplexers with flags
 
 The new macro, TH_CCU_MUX_FLAGS, extends TH_CCU_MUX macro by adding two

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-FROMLIST-clk-thead-th1520-ap-Support-CPU-frequency-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-FROMLIST-clk-thead-th1520-ap-Support-CPU-frequency-s.patch
@@ -1,7 +1,7 @@
 From ff112c41107b77b236a0f381aafc62816f750ef3 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:15 +0000
-Subject: [PATCH 109/450] FROMLIST: clk: thead: th1520-ap: Support CPU
+Subject: [PATCH 109/451] FROMLIST: clk: thead: th1520-ap: Support CPU
  frequency scaling
 
 On TH1520 SoC, c910_clk feeds the CPU cluster. It could be glitchlessly

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-FROMLIST-NFU-riscv-dts-thead-Add-CPU-clock-and-OPP-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-FROMLIST-NFU-riscv-dts-thead-Add-CPU-clock-and-OPP-t.patch
@@ -1,7 +1,7 @@
 From 69b39c7b6bb8ad8a2ee5976d64d179e26d1382b8 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:16 +0000
-Subject: [PATCH 110/450] FROMLIST: NFU: riscv: dts: thead: Add CPU clock and
+Subject: [PATCH 110/451] FROMLIST: NFU: riscv: dts: thead: Add CPU clock and
  OPP table for TH1520
 
 Add operating point table for CPU cores, and wire up clocks for CPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-FROMLIST-dt-bindings-vendor-prefixes-add-verisilicon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-FROMLIST-dt-bindings-vendor-prefixes-add-verisilicon.patch
@@ -1,7 +1,7 @@
 From 7e9b3638ee3f4443003944e2b60a7762b280ef2c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:18 +0800
-Subject: [PATCH 111/450] FROMLIST: dt-bindings: vendor-prefixes: add
+Subject: [PATCH 111/451] FROMLIST: dt-bindings: vendor-prefixes: add
  verisilicon
 
 VeriSilicon is a Silicon IP vendor, which is the current owner of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-FROMLIST-dt-bindings-display-add-verisilicon-dc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-FROMLIST-dt-bindings-display-add-verisilicon-dc.patch
@@ -1,7 +1,7 @@
 From 0175cfbd3f09b8b9bda82b079ec0c89352f39c75 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:19 +0800
-Subject: [PATCH 112/450] FROMLIST: dt-bindings: display: add verisilicon,dc
+Subject: [PATCH 112/451] FROMLIST: dt-bindings: display: add verisilicon,dc
 
 Verisilicon has a series of display controllers prefixed with DC and
 with self-identification facility like their GC series GPUs.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-FROMLIST-drm-verisilicon-add-a-driver-for-Verisilico.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-FROMLIST-drm-verisilicon-add-a-driver-for-Verisilico.patch
@@ -1,7 +1,7 @@
 From 65b91ca4b21629c94ce52c9c0da030b33c509b3c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:20 +0800
-Subject: [PATCH 113/450] FROMLIST: drm: verisilicon: add a driver for
+Subject: [PATCH 113/451] FROMLIST: drm: verisilicon: add a driver for
  Verisilicon display controllers
 
 This is a from-scratch driver targeting Verisilicon DC-series display

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-FROMLIST-dt-bindings-display-bridge-add-binding-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-FROMLIST-dt-bindings-display-bridge-add-binding-for-.patch
@@ -1,7 +1,7 @@
 From ac2f197af04472e10bd0d0edc43d1d2fb94b8e45 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:21 +0800
-Subject: [PATCH 114/450] FROMLIST: dt-bindings: display/bridge: add binding
+Subject: [PATCH 114/451] FROMLIST: dt-bindings: display/bridge: add binding
  for TH1520 HDMI controller
 
 T-Head TH1520 SoC contains a Synopsys DesignWare HDMI controller paired

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-FROMLIST-drm-bridge-add-a-driver-for-T-Head-TH1520-H.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-FROMLIST-drm-bridge-add-a-driver-for-T-Head-TH1520-H.patch
@@ -1,7 +1,7 @@
 From 64b97fa852097cfa11a97c07d7f240563cbb972b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:22 +0800
-Subject: [PATCH 115/450] FROMLIST: drm/bridge: add a driver for T-Head TH1520
+Subject: [PATCH 115/451] FROMLIST: drm/bridge: add a driver for T-Head TH1520
  HDMI controller
 
 T-Head TH1520 SoC contains a Synopsys DesignWare HDMI controller (paired

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-FROMLIST-riscv-dts-thead-add-DPU-and-HDMI-device-tre.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-FROMLIST-riscv-dts-thead-add-DPU-and-HDMI-device-tre.patch
@@ -1,7 +1,7 @@
 From faf2ed5e4769389fbf88258d5ebabd26bea1a9ba Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:23 +0800
-Subject: [PATCH 116/450] FROMLIST: riscv: dts: thead: add DPU and HDMI device
+Subject: [PATCH 116/451] FROMLIST: riscv: dts: thead: add DPU and HDMI device
  tree nodes
 
 T-Head TH1520 SoC contains a Verisilicon DC8200 display controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-FROMLIST-MAINTAINERS-assign-myself-as-maintainer-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-FROMLIST-MAINTAINERS-assign-myself-as-maintainer-for.patch
@@ -1,7 +1,7 @@
 From ce21e99a473cffa5a591a28a369b0ae4d6c8d4a1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:25 +0800
-Subject: [PATCH 117/450] FROMLIST: MAINTAINERS: assign myself as maintainer
+Subject: [PATCH 117/451] FROMLIST: MAINTAINERS: assign myself as maintainer
  for verisilicon DC driver
 
 As I am the author of this rewritten driver, it makes sense for me to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-FROMLIST-mailmap-map-all-Icenowy-Zheng-s-mail-addres.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-FROMLIST-mailmap-map-all-Icenowy-Zheng-s-mail-addres.patch
@@ -1,7 +1,7 @@
 From 4f57e7fcc635e3f73725fd253186d377ea4294a1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:26 +0800
-Subject: [PATCH 118/450] FROMLIST: mailmap: map all Icenowy Zheng's mail
+Subject: [PATCH 118/451] FROMLIST: mailmap: map all Icenowy Zheng's mail
  addresses
 
 Map all mail addresses Icenowy Zheng had used to the personal mailbox

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-FROMLIST-dt-bindings-usb-Add-T-HEAD-TH1520-USB-contr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-FROMLIST-dt-bindings-usb-Add-T-HEAD-TH1520-USB-contr.patch
@@ -1,7 +1,7 @@
 From 3e768fb40c50a6fb86c73828d7f0e547f744bce0 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 28 Sep 2023 00:42:21 +0800
-Subject: [PATCH 119/450] FROMLIST: dt-bindings: usb: Add T-HEAD TH1520 USB
+Subject: [PATCH 119/451] FROMLIST: dt-bindings: usb: Add T-HEAD TH1520 USB
  controller
 
 T-HEAD TH1520 platform's USB has a wrapper module around

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-FROMLIST-usb-dwc3-add-T-HEAD-TH1520-usb-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-FROMLIST-usb-dwc3-add-T-HEAD-TH1520-usb-driver.patch
@@ -1,7 +1,7 @@
 From 7253469d315fed880abf1cd8910d49e9f49066ed Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 28 Sep 2023 00:42:22 +0800
-Subject: [PATCH 120/450] FROMLIST: usb: dwc3: add T-HEAD TH1520 usb driver
+Subject: [PATCH 120/451] FROMLIST: usb: dwc3: add T-HEAD TH1520 usb driver
 
 Adds TH1520 Glue layer to support USB controller on T-HEAD TH1520 SoC.
 There is a DesignWare USB3 DRD core in TH1520 SoCs, the dwc3 core is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-FROMLIST-net-stmmac-Add-generic-suspend-resume-helpe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-FROMLIST-net-stmmac-Add-generic-suspend-resume-helpe.patch
@@ -1,7 +1,7 @@
 From 0ef207944a04e546ca84ca6e901fe57d8cd5f05b Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:15 +0000
-Subject: [PATCH 121/450] FROMLIST: net: stmmac: Add generic suspend/resume
+Subject: [PATCH 121/451] FROMLIST: net: stmmac: Add generic suspend/resume
  helper for PCI-based controllers
 
 Most glue driver for PCI-based DWMAC controllers utilize similar

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-FROMLIST-net-stmmac-loongson-Use-generic-PCI-suspend.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-FROMLIST-net-stmmac-loongson-Use-generic-PCI-suspend.patch
@@ -1,7 +1,7 @@
 From c073393c0bb3bb82409c9fca09478eeb5e60b9e5 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:16 +0000
-Subject: [PATCH 122/450] FROMLIST: net: stmmac: loongson: Use generic PCI
+Subject: [PATCH 122/451] FROMLIST: net: stmmac: loongson: Use generic PCI
  suspend/resume routines
 
 Convert glue driver for Loongson DWMAC controller to use the generic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-FROMLIST-net-stmmac-pci-Use-generic-PCI-suspend-resu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-FROMLIST-net-stmmac-pci-Use-generic-PCI-suspend-resu.patch
@@ -1,7 +1,7 @@
 From b82ebfd7c08eaa163ddf6c31624c3d74890f4388 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:17 +0000
-Subject: [PATCH 123/450] FROMLIST: net: stmmac: pci: Use generic PCI
+Subject: [PATCH 123/451] FROMLIST: net: stmmac: pci: Use generic PCI
  suspend/resume routines
 
 Convert STMMAC PCI glue driver to use the generic platform

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-FROMLIST-net-phy-motorcomm-Support-YT8531S-PHY-in-YT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-FROMLIST-net-phy-motorcomm-Support-YT8531S-PHY-in-YT.patch
@@ -1,7 +1,7 @@
 From ed60dcaa7c3019514c97afd96e95ae9e0fa7408a Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:09 +0000
-Subject: [PATCH 124/450] FROMLIST: net: phy: motorcomm: Support YT8531S PHY in
+Subject: [PATCH 124/451] FROMLIST: net: phy: motorcomm: Support YT8531S PHY in
  YT6801 Ethernet controller
 
 YT6801's internal PHY is confirmed as a GMII-capable variant of YT8531S

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-FROMLIST-net-stmmac-Add-glue-driver-for-Motorcomm-YT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-FROMLIST-net-stmmac-Add-glue-driver-for-Motorcomm-YT.patch
@@ -1,7 +1,7 @@
 From ad3d875db56827a1af03f2fca199586ac0cfcd7b Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:10 +0000
-Subject: [PATCH 125/450] FROMLIST: net: stmmac: Add glue driver for Motorcomm
+Subject: [PATCH 125/451] FROMLIST: net: stmmac: Add glue driver for Motorcomm
  YT6801 ethernet controller
 
 Motorcomm YT6801 is a PCIe ethernet controller based on DWMAC4 IP. It

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-FROMLIST-MAINTAINERS-Assign-myself-as-maintainer-of-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-FROMLIST-MAINTAINERS-Assign-myself-as-maintainer-of-.patch
@@ -1,7 +1,7 @@
 From 0a5c75cad2ae96a84df4bf9e8eaafbf828d00cf0 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:11 +0000
-Subject: [PATCH 126/450] FROMLIST: MAINTAINERS: Assign myself as maintainer of
+Subject: [PATCH 126/451] FROMLIST: MAINTAINERS: Assign myself as maintainer of
  Motorcomm DWMAC glue driver
 
 I volunteer to maintain the DWMAC glue driver for Motorcomm ethernet

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From b9cb765d60523e3875fada7eee54680509e155fa Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 27 Nov 2025 16:02:03 +0800
-Subject: [PATCH 127/450] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 127/451] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-FROMLIST-PCI-Add-Cix-Technology-Vendor-and-Device-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-FROMLIST-PCI-Add-Cix-Technology-Vendor-and-Device-ID.patch
@@ -1,7 +1,7 @@
 From 7aa51b44f9b660c7b9f7e5336d2085bf69f0fe0d Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Mon, 20 Oct 2025 12:28:53 +0800
-Subject: [PATCH 128/450] FROMLIST: PCI: Add Cix Technology Vendor and Device
+Subject: [PATCH 128/451] FROMLIST: PCI: Add Cix Technology Vendor and Device
  ID
 
 Add CIX P1 (internal name sky1) as a vendor and device ID for PCI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-FROMLIST-MAINTAINERS-add-entry-for-CIX-Sky1-PCIe-dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-FROMLIST-MAINTAINERS-add-entry-for-CIX-Sky1-PCIe-dri.patch
@@ -1,7 +1,7 @@
 From 9f991851bba47ca2fcfad40d40c59c6f972f21a6 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Mon, 20 Oct 2025 12:28:55 +0800
-Subject: [PATCH 129/450] FROMLIST: MAINTAINERS: add entry for CIX Sky1 PCIe
+Subject: [PATCH 129/451] FROMLIST: MAINTAINERS: add entry for CIX Sky1 PCIe
  driver
 
 Add myself as maintainer of Sky1 PCIe host driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-FROMLIST-dt-bindings-reset-add-sky1-reset-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-FROMLIST-dt-bindings-reset-add-sky1-reset-controller.patch
@@ -1,7 +1,7 @@
 From ef8d0e0f345136527388494e8a0f87269d710e6f Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Thu, 13 Nov 2025 15:59:33 +0800
-Subject: [PATCH 130/450] FROMLIST: dt-bindings: reset: add sky1 reset
+Subject: [PATCH 130/451] FROMLIST: dt-bindings: reset: add sky1 reset
  controller
 
 There are two reset controllers on Cix sky1 Soc.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-FROMLIST-reset-cix-add-support-for-cix-sky1-resets.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-FROMLIST-reset-cix-add-support-for-cix-sky1-resets.patch
@@ -1,7 +1,7 @@
 From ab08dd281302ac083443a1a70bdef4ed43cf9904 Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Thu, 13 Nov 2025 15:59:34 +0800
-Subject: [PATCH 131/450] FROMLIST: reset: cix: add support for cix sky1 resets
+Subject: [PATCH 131/451] FROMLIST: reset: cix: add support for cix sky1 resets
 
 There are two reset controllers on Cix Sky1 Soc.
 One is located in S0 domain, and the other is located

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-FROMLIST-arm64-dts-cix-add-support-for-cix-sky1-rese.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-FROMLIST-arm64-dts-cix-add-support-for-cix-sky1-rese.patch
@@ -1,7 +1,7 @@
 From 96d29dcb0cb21cecb00385cf10411fc3d834a3e8 Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 2 Dec 2025 19:29:22 +0800
-Subject: [PATCH 132/450] FROMLIST: arm64: dts: cix: add support for cix sky1
+Subject: [PATCH 132/451] FROMLIST: arm64: dts: cix: add support for cix sky1
  resets
 
 There are two reset conctrollers on Cix Sky1 Soc.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-FROMLIST-ALSA-hda-dt-bindings-add-CIX-IPBLOQ-HDA-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-FROMLIST-ALSA-hda-dt-bindings-add-CIX-IPBLOQ-HDA-con.patch
@@ -1,7 +1,7 @@
 From c04eaa0fa5895901c9d084d242f673c0877f35a3 Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:56:58 +0800
-Subject: [PATCH 133/450] FROMLIST: ALSA: hda: dt-bindings: add CIX IPBLOQ HDA
+Subject: [PATCH 133/451] FROMLIST: ALSA: hda: dt-bindings: add CIX IPBLOQ HDA
  controller support
 
 Add CIX IPBLOQ HDA controller support, which integrated in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-FROMLIST-ALSA-hda-core-add-addr_offset-field-for-bus.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-FROMLIST-ALSA-hda-core-add-addr_offset-field-for-bus.patch
@@ -1,7 +1,7 @@
 From ff1129d84b1c4cad05848f138f0a3bd8069de3ea Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:56:59 +0800
-Subject: [PATCH 134/450] FROMLIST: ALSA: hda/core: add addr_offset field for
+Subject: [PATCH 134/451] FROMLIST: ALSA: hda/core: add addr_offset field for
  bus address translation
 
 Add bus addr_offset field for dma address translation,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-FROMLIST-ALSA-hda-add-CIX-IPBLOQ-HDA-controller-supp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-FROMLIST-ALSA-hda-add-CIX-IPBLOQ-HDA-controller-supp.patch
@@ -1,7 +1,7 @@
 From ac30397d594177c80109d64f8fffdeb8ccd0e0c7 Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:57:00 +0800
-Subject: [PATCH 135/450] FROMLIST: ALSA: hda: add CIX IPBLOQ HDA controller
+Subject: [PATCH 135/451] FROMLIST: ALSA: hda: add CIX IPBLOQ HDA controller
  support
 
 Add CIX IPBLOQ HDA controller support, which integrated

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From 7e0c6a6bdc2c1f6cf840a672faa5395f8dc28752 Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia@aosc.io>
 Date: Wed, 22 Oct 2025 18:16:30 +0800
-Subject: [PATCH 136/450] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 136/451] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-FROMLIST-rust-export-BINDGEN_TARGET-from-a-separate-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-FROMLIST-rust-export-BINDGEN_TARGET-from-a-separate-.patch
@@ -1,7 +1,7 @@
 From 5ac1d783fff3ffbec61b8b72f4445b1087321f5e Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:51 +0100
-Subject: [PATCH 137/450] FROMLIST: rust: export BINDGEN_TARGET from a separate
+Subject: [PATCH 137/451] FROMLIST: rust: export BINDGEN_TARGET from a separate
  Makefile
 
 A subsequent commit will add a new function `bindgen-option` to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-FROMLIST-rust-generate-a-fatal-error-if-BINDGEN_TARG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-FROMLIST-rust-generate-a-fatal-error-if-BINDGEN_TARG.patch
@@ -1,7 +1,7 @@
 From 22aee263bee19ff7d5bb1c39c4b04562f061ff92 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:52 +0100
-Subject: [PATCH 138/450] FROMLIST: rust: generate a fatal error if
+Subject: [PATCH 138/451] FROMLIST: rust: generate a fatal error if
  BINDGEN_TARGET is undefined
 
 Generate a friendly fatal error if the target triplet is undefined for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-FROMLIST-rust-add-a-Kconfig-function-to-test-for-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-FROMLIST-rust-add-a-Kconfig-function-to-test-for-sup.patch
@@ -1,7 +1,7 @@
 From adf618fb04cf85f55a9658409e3cf356a26d75cd Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:53 +0100
-Subject: [PATCH 139/450] FROMLIST: rust: add a Kconfig function to test for
+Subject: [PATCH 139/451] FROMLIST: rust: add a Kconfig function to test for
  support of bindgen options
 
 Add a new `bindgen-backend-option` Kconfig function to test whether the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-FROMLIST-RISC-V-handle-extension-configs-for-bindgen.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-FROMLIST-RISC-V-handle-extension-configs-for-bindgen.patch
@@ -1,7 +1,7 @@
 From d4c8cc65227751a17f9bcccf5aa3f53c0efb8c0d Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:54 +0100
-Subject: [PATCH 140/450] FROMLIST: RISC-V: handle extension configs for
+Subject: [PATCH 140/451] FROMLIST: RISC-V: handle extension configs for
  bindgen, re-enable gcc + rust builds
 
 Commit 33549fcf37ec ("RISC-V: disallow gcc + rust builds") disabled GCC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-FROMLIST-riscv-dts-thead-lichee-pi-4a-enable-HDMI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-FROMLIST-riscv-dts-thead-lichee-pi-4a-enable-HDMI.patch
@@ -1,7 +1,7 @@
 From b82348c0747e349f482f43a5231f3a8a22a96529 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:24 +0800
-Subject: [PATCH 141/450] FROMLIST: riscv: dts: thead: lichee-pi-4a: enable
+Subject: [PATCH 141/451] FROMLIST: riscv: dts: thead: lichee-pi-4a: enable
  HDMI
 
 Lichee Pi 4A board features a HDMI Type-A connector connected to the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2042-PC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2042-PC.patch
@@ -1,7 +1,7 @@
 From 255de065d41e0c79818f0f5af8c456392fecd4ec Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 25 Dec 2025 18:05:28 +0800
-Subject: [PATCH 142/450] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2042
+Subject: [PATCH 142/451] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2042
  PCIe [1f1c:2042] Root Ports
 
 Since commit f3ac2ff14834 ("PCI/ASPM: Enable all ClockPM and ASPM

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2044-PC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2044-PC.patch
@@ -1,7 +1,7 @@
 From 7805f78759a269fbe387283d9e0c4614f80dc0b2 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 25 Dec 2025 18:05:29 +0800
-Subject: [PATCH 143/450] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2044
+Subject: [PATCH 143/451] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2044
  PCIe [1f1c:2044] Root Ports
 
 Since commit f3ac2ff14834 ("PCI/ASPM: Enable all ClockPM and ASPM

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-FROMLIST-PCI-loongson-Override-PCIe-bridge-supported.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-FROMLIST-PCI-loongson-Override-PCIe-bridge-supported.patch
@@ -1,7 +1,7 @@
 From 112970b4b7f64521af5155e6f2c8c9d85ecef5b2 Mon Sep 17 00:00:00 2001
 From: Ziyao Li <liziyao@uniontech.com>
 Date: Wed, 21 Jan 2026 16:22:40 +0800
-Subject: [PATCH 144/450] FROMLIST: PCI: loongson: Override PCIe bridge
+Subject: [PATCH 144/451] FROMLIST: PCI: loongson: Override PCIe bridge
  supported speeds for Loongson-3C6000 series
 
 Older steppings of the Loongson-3C6000 series incorrectly report the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-BACKPORT-FROMLIST-loongarch-wire-up-memfd_secret-sys.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-BACKPORT-FROMLIST-loongarch-wire-up-memfd_secret-sys.patch
@@ -1,7 +1,7 @@
 From 6a5fa9ee3023fc7e88db2ca920025a8c8d679200 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fearyncess@aosc.io>
 Date: Fri, 9 Jan 2026 13:10:51 +0800
-Subject: [PATCH 145/450] BACKPORT: FROMLIST: loongarch: wire up memfd_secret
+Subject: [PATCH 145/451] BACKPORT: FROMLIST: loongarch: wire up memfd_secret
  system call
 
 LoongArch supports ARCH_HAS_SET_DIRECT_MAP, therefore wire up the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-FROMLIST-loongarch-retrieve-CPU-package-ID-from-PPTT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-FROMLIST-loongarch-retrieve-CPU-package-ID-from-PPTT.patch
@@ -1,7 +1,7 @@
 From b3bf17d505ba1d992e3b5baa0e48739f6cd60db5 Mon Sep 17 00:00:00 2001
 From: Rong Bao <rong.bao@csmantle.top>
 Date: Fri, 23 Jan 2026 23:56:06 +0800
-Subject: [PATCH 146/450] FROMLIST: loongarch: retrieve CPU package ID from
+Subject: [PATCH 146/451] FROMLIST: loongarch: retrieve CPU package ID from
  PPTT when available
 
 Currently, the LoongArch CPU topology initialization code calculates

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-BACKPORT-FROMLIST-ACPI-PCI-check-if-the-root-io-spac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-BACKPORT-FROMLIST-ACPI-PCI-check-if-the-root-io-spac.patch
@@ -1,7 +1,7 @@
 From 152a47a9849907350ef41d668aed7ed714de61c8 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 20:09:15 +0800
-Subject: [PATCH 147/450] BACKPORT: FROMLIST: ACPI: PCI: check if the root io
+Subject: [PATCH 147/451] BACKPORT: FROMLIST: ACPI: PCI: check if the root io
  space is page aligned
 
 When the IO resource given by _CRS method is not page aligned, especially

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-FROMLIST-PCI-MSI-Conservatively-generalize-no_64bit_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-FROMLIST-PCI-MSI-Conservatively-generalize-no_64bit_.patch
@@ -1,7 +1,7 @@
 From f74db4cc5aeb2c80f992e6a80a56f60d9a51e0d4 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:28 +0800
-Subject: [PATCH 148/450] FROMLIST: PCI/MSI: Conservatively generalize
+Subject: [PATCH 148/451] FROMLIST: PCI/MSI: Conservatively generalize
  no_64bit_msi into msi_addr_mask
 
 Some PCI devices have PCI_MSI_FLAGS_64BIT in the MSI capability, but

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-FROMLIST-PCI-MSI-Check-msi_addr_mask-in-msi_verify_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-FROMLIST-PCI-MSI-Check-msi_addr_mask-in-msi_verify_e.patch
@@ -1,7 +1,7 @@
 From fea7c8fb4a3b234ed2089574264b2e2961b32c87 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:29 +0800
-Subject: [PATCH 149/450] FROMLIST: PCI/MSI: Check msi_addr_mask in
+Subject: [PATCH 149/451] FROMLIST: PCI/MSI: Check msi_addr_mask in
  msi_verify_entries()
 
 Instead of a 32-bit/64-bit dichotomy, check the MSI address against

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-FROMLIST-drm-radeon-Raise-msi_addr_mask-to-dma_bits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-FROMLIST-drm-radeon-Raise-msi_addr_mask-to-dma_bits.patch
@@ -1,7 +1,7 @@
 From 957cf429ac32406d489e65832651d37e0669f789 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:30 +0800
-Subject: [PATCH 150/450] FROMLIST: drm/radeon: Raise msi_addr_mask to dma_bits
+Subject: [PATCH 150/451] FROMLIST: drm/radeon: Raise msi_addr_mask to dma_bits
 
 The code was originally written using no_64bit_msi, which restricts the
 device to 32-bit MSI addresses.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-FROMLIST-ALSA-hda-intel-Raise-msi_addr_mask-to-dma_b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-FROMLIST-ALSA-hda-intel-Raise-msi_addr_mask-to-dma_b.patch
@@ -1,7 +1,7 @@
 From b35ffad95edcbc1d441a931f3a277cb5791a8583 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:31 +0800
-Subject: [PATCH 151/450] FROMLIST: ALSA: hda/intel: Raise msi_addr_mask to
+Subject: [PATCH 151/451] FROMLIST: ALSA: hda/intel: Raise msi_addr_mask to
  dma_bits
 
 The code was originally written using no_64bit_msi, which restricts the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-FROMLIST-genirq-reserve-NR_IRQS_LEGACY-IRQs-in-dynir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-FROMLIST-genirq-reserve-NR_IRQS_LEGACY-IRQs-in-dynir.patch
@@ -1,7 +1,7 @@
 From 72c65bc0d532a916a1aa621047445aa221f0cc92 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Sat, 31 Jan 2026 16:51:42 +0800
-Subject: [PATCH 152/450] FROMLIST: genirq: reserve NR_IRQS_LEGACY IRQs in
+Subject: [PATCH 152/451] FROMLIST: genirq: reserve NR_IRQS_LEGACY IRQs in
  dynirq by default
 
 Several architectures define NR_IRQS_LEGACY to reserve a low range of IRQ

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-FROMLIST-dt-bindings-interrupt-controller-add-LS7A-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-FROMLIST-dt-bindings-interrupt-controller-add-LS7A-P.patch
@@ -1,7 +1,7 @@
 From 532e5d158ee640c7b36fd5cf532aa4cae87c0ceb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:59:33 +0800
-Subject: [PATCH 153/450] FROMLIST: dt-bindings: interrupt-controller: add LS7A
+Subject: [PATCH 153/451] FROMLIST: dt-bindings: interrupt-controller: add LS7A
  PCH LPC
 
 Loongson 7A series PCH contains an LPC controller with an interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-BACKPORT-FROMLIST-irqchip-loongson-pch-lpc-extract-n.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-BACKPORT-FROMLIST-irqchip-loongson-pch-lpc-extract-n.patch
@@ -1,7 +1,7 @@
 From 670a2da923b3a1f6ef7618c213077ef534c41414 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:22:40 +0800
-Subject: [PATCH 154/450] BACKPORT: FROMLIST: irqchip/loongson-pch-lpc: extract
+Subject: [PATCH 154/451] BACKPORT: FROMLIST: irqchip/loongson-pch-lpc: extract
  non-ACPI-related code from ACPI init
 
 A lot of code could be shared between the current ACPI init flow with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-FROMLIST-irqchip-loongson-pch-lpc-guard-ACPI-init-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-FROMLIST-irqchip-loongson-pch-lpc-guard-ACPI-init-co.patch
@@ -1,7 +1,7 @@
 From 6564011320d665a4c818d7d34deea5c24adbf811 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:27:26 +0800
-Subject: [PATCH 155/450] FROMLIST: irqchip/loongson-pch-lpc: guard ACPI init
+Subject: [PATCH 155/451] FROMLIST: irqchip/loongson-pch-lpc: guard ACPI init
  code with CONFIG_ACPI
 
 As OF-based initialization is going to be added to the driver, guard the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-FROMLIST-irqchip-loongson-pch-lpc-add-OF-init-code.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-FROMLIST-irqchip-loongson-pch-lpc-add-OF-init-code.patch
@@ -1,7 +1,7 @@
 From 7d653b341796ca9f8a3d3f531d8b9a339f6c82e8 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:41:50 +0800
-Subject: [PATCH 156/450] FROMLIST: irqchip/loongson-pch-lpc: add OF init code
+Subject: [PATCH 156/451] FROMLIST: irqchip/loongson-pch-lpc: add OF init code
 
 As the (kernel-internally) OF-based MIPS Loongson-3 systems can also
 have PCH LPC interrupt controller, add OF-based initialization code for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-FROMLIST-irqchip-loongson-pch-lpc-enable-building-on.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-FROMLIST-irqchip-loongson-pch-lpc-enable-building-on.patch
@@ -1,7 +1,7 @@
 From 1fd696cc7db02ccf47462a0d70ce5b0dd4fb7f56 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:45:01 +0800
-Subject: [PATCH 157/450] FROMLIST: irqchip/loongson-pch-lpc: enable building
+Subject: [PATCH 157/451] FROMLIST: irqchip/loongson-pch-lpc: enable building
  on MIPS Loongson64
 
 As the driver can now support OF-based platforms, it's now possible to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-FROMLIST-MIPS-Loongson64-dts-sort-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-FROMLIST-MIPS-Loongson64-dts-sort-nodes.patch
@@ -1,7 +1,7 @@
 From a7ef1a86e3ff675c198fbcfaa81e4bcc0ca2f8d8 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Thu, 15 Jan 2026 12:03:45 +0800
-Subject: [PATCH 158/450] FROMLIST: MIPS: Loongson64: dts: sort nodes
+Subject: [PATCH 158/451] FROMLIST: MIPS: Loongson64: dts: sort nodes
 
 The RTC's address is after UARTs, however the node is currently before
 them.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-FROMLIST-MIPS-Loongson64-dts-add-node-for-LS7A-PCH-L.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-FROMLIST-MIPS-Loongson64-dts-add-node-for-LS7A-PCH-L.patch
@@ -1,7 +1,7 @@
 From 8cbfdc9d5ebb4e5e5b6956e0cb23489e9cf76839 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:48:34 +0800
-Subject: [PATCH 159/450] FROMLIST: MIPS: Loongson64: dts: add node for LS7A
+Subject: [PATCH 159/451] FROMLIST: MIPS: Loongson64: dts: add node for LS7A
  PCH LPC
 
 Loongson 7A series PCH contain a LPC IRQ controller.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-FROMLIST-kbuild-install-extmod-build-do-not-exclude-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-FROMLIST-kbuild-install-extmod-build-do-not-exclude-.patch
@@ -1,7 +1,7 @@
 From 8a72fece9e0bc4e2d3c9a82787cb5f83a4abe43f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Sun, 1 Feb 2026 20:39:30 +0800
-Subject: [PATCH 160/450] FROMLIST: kbuild: install-extmod-build: do not
+Subject: [PATCH 160/451] FROMLIST: kbuild: install-extmod-build: do not
  exclude scripts/dtc/libfdt/
 
 There exists a header file in include/linux/ called libfdt.h that is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From f56f015a090b0fa759f9d013d839304b661df320 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 161/450] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 161/451] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From e180ecccc7ecc3a60e36157da2bdc41fbef071db Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 162/450] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 162/451] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From b606bff2306fd7b5f87764c55db84d7ee57b5314 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 163/450] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 163/451] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 9f1fc74d28e6858658da1659f3c8e67a6ff62ba9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 164/450] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 164/451] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From 89f53106eba7c53d21acd5217c71eef0f14d4928 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 165/450] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 165/451] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 190398773de79a89b250b5ed80ff0dc1d47bfa4d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 166/450] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 166/451] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From 60294203b3f5009d09e7f0774a593ba97fd556f6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 167/450] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 167/451] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From 58dd6aa8be438b45e42f971e04adbdf50461f1da Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 168/450] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 168/451] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 95beb1656a27659a4789d549f372ec81b162fdbb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 169/450] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 169/451] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From eff3edf78151602738c0c46c9de6323852c88118 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 170/450] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 170/451] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From feba6c3d9cf22c9c231cfc005a34755f93d05428 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 171/450] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 171/451] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 4bb728650f23abe3a08864198fa6d425e8974314 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 172/450] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 172/451] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From 8e83184731fd9d7fb92815ff2bc4b2071a7ad842 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 173/450] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 173/451] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From e5117f1664179db2f0826df0ffd5252378fbe940 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 174/450] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 174/451] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From 4b6a21f9ef853c35126149bc8df2b8b064a2c46a Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 175/450] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 175/451] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 981bdebd7a0462afed81776ca46ff23c3ae1e933 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 176/450] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 176/451] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
@@ -1,7 +1,7 @@
 From b4ca767811a7566747495e7cb1c2ccb8a4a2fa37 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 May 2025 20:08:26 +0800
-Subject: [PATCH 177/450] LOONGSON: drm/ast: Restore vaddr field to struct
+Subject: [PATCH 177/451] LOONGSON: drm/ast: Restore vaddr field to struct
  ast_plane
 
 Revert "drm/ast: Remove vaddr field from struct ast_plane".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From ddfcfda1a6955252e8e104901b7fa80c38d08114 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 28 Feb 2025 20:28:08 +0800
-Subject: [PATCH 178/450] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 178/451] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
@@ -1,7 +1,7 @@
 From d6d5a5d0ef1d8d936c24bb9f8acc03f6b6bf2963 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 26 Aug 2025 19:01:09 +0800
-Subject: [PATCH 179/450] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
+Subject: [PATCH 179/451] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
 
 If I read the upstream commit 62e1e11a4916
 ("drm/client: Do not pin in drm_client_buffer_vmap()") correctly, we

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-LOONGSON-dt-bindings-dmaengine-Add-Loongson-Multi-Ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-LOONGSON-dt-bindings-dmaengine-Add-Loongson-Multi-Ch.patch
@@ -1,7 +1,7 @@
 From 15b49ff5154e423111d0ffa6a4dac0cbbb53f4c2 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 23 Oct 2025 20:27:08 +0800
-Subject: [PATCH 180/450] LOONGSON: dt-bindings: dmaengine: Add Loongson
+Subject: [PATCH 180/451] LOONGSON: dt-bindings: dmaengine: Add Loongson
  Multi-Channel DMA controller
 
 The Loongson-2K0300/Loongson-2K3000 have built-in multi-channel DMA

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-LOONGSON-dmaengine-loongson2-mcdma-New-driver-for-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-LOONGSON-dmaengine-loongson2-mcdma-New-driver-for-th.patch
@@ -1,7 +1,7 @@
 From e45f199e17191e156feaab408d925b11bb045239 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 18 Oct 2025 12:46:21 +0800
-Subject: [PATCH 181/450] LOONGSON: dmaengine: loongson2-mcdma: New driver for
+Subject: [PATCH 181/451] LOONGSON: dmaengine: loongson2-mcdma: New driver for
  the Loongson Multi-Channel DMA controller
 
 This DMA controller appears in Loongson-2K0300 and Loongson-2K3000.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-LOONGSON-LoongArch-Add-canfd-support-for-ls2k3000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-LOONGSON-LoongArch-Add-canfd-support-for-ls2k3000.patch
@@ -1,7 +1,7 @@
 From fdac8bc91b7ec28a340ea468d1664046bb0c7efa Mon Sep 17 00:00:00 2001
 From: libingxiong <libingxiong@loongson.cn>
 Date: Fri, 30 May 2025 14:22:46 +0800
-Subject: [PATCH 182/450] LOONGSON: LoongArch: Add canfd support for ls2k3000
+Subject: [PATCH 182/451] LOONGSON: LoongArch: Add canfd support for ls2k3000
 
 Add new canfd controller and dma controller driver support for ls2k3000
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From 956d739fc3839d56356550e94d11596a558b7c69 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 183/450] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 183/451] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From c578a5b90c0eddbd89c804c0a14b70b6576be167 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 184/450] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 184/451] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From 1a7d583d1be0b7fb5c7a3f2a8e197d38445f7f58 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 185/450] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 185/451] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From 782fdc735881fc2ac0fc1b81b14ec194bdb94e9e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 186/450] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 186/451] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From fc1812cb0555ff40e79a5ab07fe3ee26d71a7b37 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 187/450] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 187/451] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From b06c8aa22eafea76f32f4895a1e1fe80066dbef8 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 188/450] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 188/451] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From 5b99698545e8551f575dd66caceb579b33db635c Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 189/450] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 189/451] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From 8521a094782fb8fa364667e6874788366ed431b8 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 190/450] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 190/451] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From 1f650a632f3c5a6a2e4d905d410bc44bf57dad76 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 191/450] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 191/451] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From 2838d837fc47fbbf0892f259eddba49893073545 Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 192/450] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 192/451] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From 0c98c46bfc83265117180b427eabbaaf51343acc Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 193/450] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 193/451] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From 54563990d985b7e1c454236f7eddfe3ee1ee2b1c Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 194/450] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 194/451] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From 5af388d3b971eaae3fe51250fecd99665fbbb226 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 195/450] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 195/451] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From 2ff3e93627d9f2580d29f38a5b79d091f7eccb1a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 196/450] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 196/451] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From 9e30cb25506c15004713ef184705d6d3f670ccdb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 197/450] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 197/451] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From 626eb5744adc7b120a7f209fdca466661e15da2b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 198/450] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 198/451] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From 65daaa7907f97901485fc95a6a11dabeaeec2686 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 199/450] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 199/451] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From fd981af2921312571e6fe068d6d310ff22480d41 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 200/450] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 200/451] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From 7b3a3f5400c4f5c1fda8025782625e2f06d0fdc8 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 201/450] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 201/451] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From fe7481fe2293c9e55fe2dd761ec8c0097e73fc04 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 202/450] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 202/451] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From 5190cbf7180c59c169951cd497d999190cd9914e Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 203/450] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 203/451] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From ec54865f6f53a3dd70dbccaa33a8740d3a1f3da1 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 204/450] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 204/451] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From 3a639f61c152da209d517065ecf6cd848dce4e0a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 205/450] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 205/451] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From cd14679d780a5c392af77adcc312bf6fc35b41f0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 206/450] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 206/451] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 7f052dda92b8d2344662f9b6b6f5d4bda2fef361 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 207/450] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 207/451] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From 7fa8c05381965c8e25011c5601207398b872afa7 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 208/450] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 208/451] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From 844533432d3f419ad88183ad4028e199342391a3 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 209/450] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 209/451] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 5e62bed7d0f674856cf5bb35260db27c3ab02993 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 210/450] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 210/451] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 36d8ef5e56413de9ced0beb06f1d1a0ed486efb7 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 211/450] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 211/451] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
@@ -1,7 +1,7 @@
 From 59cce29d3d8829feb89c7f3d8e8689b143c24270 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 15 Aug 2024 17:06:59 +0800
-Subject: [PATCH 212/450] PHYTIUM: net/phytmac: Add support for phytmac v2.0
+Subject: [PATCH 212/451] PHYTIUM: net/phytmac: Add support for phytmac v2.0
 
 This patch Adds support for phtymac v2.0,including acpi description,
 rx tail pointer supporting, power management and other functions.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
@@ -1,7 +1,7 @@
 From 603607d0e187f1b21dacaa0a3bb3b92e5bade78d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 213/450] PHYTIUM: net/phytmac: Slove left-shift out of bound
+Subject: [PATCH 213/451] PHYTIUM: net/phytmac: Slove left-shift out of bound
  issue
 
 When the value of the bd_prefetch is equal to 0, subtracting 1 and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
@@ -1,7 +1,7 @@
 From 6caf1dd61235836258b5292b9559c5a25bfe7a3c Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:29:38 +0800
-Subject: [PATCH 214/450] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
+Subject: [PATCH 214/451] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
  PHY supports WOL"
 
 This reverts commit 94967211afe596a9e9c5d80ca9d54e915de3a335.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
@@ -1,7 +1,7 @@
 From 1125b71e76acd1979b6f3cd53498a992b73abbde Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:36:36 +0800
-Subject: [PATCH 215/450] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
+Subject: [PATCH 215/451] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
  issue"
 
 This reverts commit 3161ed880479e35c7759e127c62c37d2d722edee.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 7970539ee188d2ae1d37a662ca92ba6ad3b7312b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 216/450] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 216/451] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
  supports WOL feature
 
 Don't manage WoL on MAC, if PHY sets wol fails, So modify if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
@@ -1,7 +1,7 @@
 From 1b0c32fbf779080de4d9402b6e1e46eaa764f43a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 217/450] PHYTIUM: net/phytmac: Fixed the PTP test failure
+Subject: [PATCH 217/451] PHYTIUM: net/phytmac: Fixed the PTP test failure
  issue
 
 The bit of RX_TS_VALID should be retained in the process of zero RX

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
@@ -1,7 +1,7 @@
 From 34ba3185e3483af91e86f26830cdd6dc9254a1e5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 218/450] PHYTIUM: net/phytmac: Cancels the power-on/off
+Subject: [PATCH 218/451] PHYTIUM: net/phytmac: Cancels the power-on/off
  capability
 
 The MAC register is powered on by default in the firmware

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
@@ -1,7 +1,7 @@
 From 8a7d2f8e5db2a850a2138a94daf7274f7e5b50d2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 219/450] PHYTIUM: net/phytmac: Exit probe when MDIO times out
+Subject: [PATCH 219/451] PHYTIUM: net/phytmac: Exit probe when MDIO times out
 
 Exit early to avoid system stuck due to MDIO timeout.
 We have added a callback function for mdio_idle and improved

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
@@ -1,7 +1,7 @@
 From 6fb1a39b382c238353b5fbfb9cf4d9d71b28290d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 220/450] PHYTIUM: net/phytmac: Add XDP feature support
+Subject: [PATCH 220/451] PHYTIUM: net/phytmac: Add XDP feature support
 
 Add XDP feature support to the phytmac driver.XDP by optimizing
 the data processing flow provided significant performance improvements

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
@@ -1,7 +1,7 @@
 From 0c84512e2ebdb3122a247687ff723cef16ce5a75 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 221/450] PHYTIUM: net/phytmac: Clear RX descriptor address
+Subject: [PATCH 221/451] PHYTIUM: net/phytmac: Clear RX descriptor address
  after the skb construction
 
 If the skb build failed, the descriptor address has been cleared,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
@@ -1,7 +1,7 @@
 From a18addfb6f16941134dfc42bf35c3696663e8329 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 222/450] PHYTIUM: net/phytmac: Enable the tail pointer by the
+Subject: [PATCH 222/451] PHYTIUM: net/phytmac: Enable the tail pointer by the
  driver
 
 It is need to enable the RX/TX tail pointer to ensure the NIC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
@@ -1,7 +1,7 @@
 From cab2a4263ae2f25752ef0ac09909d4a9b58d3dea Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 223/450] PHYTIUM: net/phytmac: Modify cmd processing function
+Subject: [PATCH 223/451] PHYTIUM: net/phytmac: Modify cmd processing function
 
 Change the para size in the msg struct from 64 to 56
 and add mutux to avoid race.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 1b5581d6a1f66b44fd0be4c223b20e90aecad631 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 224/450] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 224/451] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
@@ -1,7 +1,7 @@
 From bc2c2c3c6b5df92b0a3a79a395e62845488e0935 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 225/450] PHYTIUM: net/phytmac: Bugfix invalid wait context
+Subject: [PATCH 225/451] PHYTIUM: net/phytmac: Bugfix invalid wait context
 
 After the spinlock is called, the mutex should no longer to be
 invoked, which will lead to unnecessary sleep.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
@@ -1,7 +1,7 @@
 From 02c3a9b899ab7315d4fe73112463faf244f7585a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 226/450] PHYTIUM: net/phytmac: Change the requested resource
+Subject: [PATCH 226/451] PHYTIUM: net/phytmac: Change the requested resource
  type from nRE to nRnE
 
 The resource type is changed from nRE to nRnE to avoid interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
@@ -1,7 +1,7 @@
 From 4f0c4782ef5e0344d570bc5dc7a71410b61b483f Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 227/450] PHYTIUM: net/phytmac: BugFix Memory leak when
+Subject: [PATCH 227/451] PHYTIUM: net/phytmac: BugFix Memory leak when
  releasing resource
 
 The size of the memory released in the dma_free_coherent is smaller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
@@ -1,7 +1,7 @@
 From f2c7862e3920a0d6907839b4cf229594153d5196 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 228/450] PHYTIUM: net/phytmac: Limit the number of retries to
+Subject: [PATCH 228/451] PHYTIUM: net/phytmac: Limit the number of retries to
  avoid deadlock
 
 It is need to limit retries that messages are processed

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-PHYTIUM-net-phytmac-update-to-1.0.47.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-PHYTIUM-net-phytmac-update-to-1.0.47.patch
@@ -1,7 +1,7 @@
 From ecb3395b4997b9c4ceb22c43465511c496e7170e Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 11:41:46 +0800
-Subject: [PATCH 229/450] PHYTIUM: net: phytmac: update to 1.0.47
+Subject: [PATCH 229/451] PHYTIUM: net: phytmac: update to 1.0.47
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From f12fa1866dc5b12a4985773c34f825b30e8cbb8a Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 230/450] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 230/451] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From ed84726eff72fbbfdb89c06bb5aca362edaecd74 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 231/450] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 231/451] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 178954e9a639ee378b47e0eba9b263338d808eba Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 232/450] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 232/451] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From bd203dc7090ea11faf85d64e4eee6404c474c2ad Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 233/450] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 233/451] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From 6bb0a7f9924af814698f5cccb00095df1988bc7f Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 234/450] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 234/451] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From 13d97d3962b7ff6ef9b802545705d71ed59c388d Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 235/450] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 235/451] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From 4aed0ffab31edb56946b69bd1aafd4295da841f6 Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 236/450] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 236/451] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
@@ -1,7 +1,7 @@
 From 8a6ee65b9e6cb027c3552fc63cc29d1df1b62c30 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 12 Aug 2024 14:28:31 +0800
-Subject: [PATCH 237/450] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 237/451] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for SKL integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2062951

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
@@ -1,7 +1,7 @@
 From 30fc1a61c8b060955c99ed20f30aa65401863e32 Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 18 Nov 2024 09:28:40 +0800
-Subject: [PATCH 238/450] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 238/451] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for KBL and CML integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2086587

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From 9f4d097ebae5290472f52ed1a15d0df44d392327 Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 239/450] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 239/451] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From f3beef76b290ed1eb04fa4a2d29e4652875bbc37 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 240/450] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 240/451] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From 1cd1b33c516dfe53dcf4a0196503f73fdaac94f9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 241/450] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 241/451] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
@@ -1,7 +1,7 @@
 From 8631a63a32d7874671e13497c9894e1a36057240 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 242/450] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
+Subject: [PATCH 242/451] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
  transition of devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From a6e86443539553f8117b250cc92908c8ba576d9f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 243/450] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 243/451] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 2f14ba2b31d1333e3c749d131553a5e840b36bde Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 244/450] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 244/451] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From da67ed71f28d7d44bdf5220c1b6547003e1891ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 245/450] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 245/451] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From 8b191f66cad2eb2d61a72ad0354727da57a29c4d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 246/450] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 246/451] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From fbdc12f1324fc34a6b6bf0378ecb485e01109e47 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 247/450] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 247/451] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From 42634954388f968639fb363768957b6a8dcff2e3 Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 248/450] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 248/451] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
@@ -1,7 +1,7 @@
 From 71d4600bb798353324ee4167643a282c2b6c7c4d Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
-Subject: [PATCH 249/450] SURFACE: (surface3-oemb) add DMI matches for Surface
+Subject: [PATCH 249/451] SURFACE: (surface3-oemb) add DMI matches for Surface
  3 with broken DMI table
 
 On some Surface 3, the DMI table gets corrupted for unknown reasons

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
@@ -1,7 +1,7 @@
 From 685a74e72ac14893f32958cd82f10aab14baa1f6 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
-Subject: [PATCH 250/450] SURFACE: surface3-spi: workaround: disable DMA mode
+Subject: [PATCH 250/451] SURFACE: surface3-spi: workaround: disable DMA mode
  to avoid crash by default
 
 On Arch Linux kernel at least after 4.19, touch input is broken after suspend

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From 935c832f70fd0748cd196aba664b9957d774ebfe Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 251/450] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 251/451] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 
 The most recent firmware of the 88W8897 card reports a hardcoded LTR

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From 69d7cbb4c77de51fb4612e4c27e757d9eb0b6476 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 252/450] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 252/451] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-BACKPORT-SURFACE-Bluetooth-btusb-Lower-passive-lesca.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-BACKPORT-SURFACE-Bluetooth-btusb-Lower-passive-lesca.patch
@@ -1,7 +1,7 @@
 From 8794862277d2aa479694024ecfdd2b1520a1c3b2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 253/450] BACKPORT: SURFACE: Bluetooth: btusb: Lower passive
+Subject: [PATCH 253/451] BACKPORT: SURFACE: Bluetooth: btusb: Lower passive
  lescan interval on Marvell 88W8897
 
 The Marvell 88W8897 combined wifi and bluetooth card (pcie+usb version)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
@@ -1,7 +1,7 @@
 From c9ffa1c987acbc32fba843d37fed5bb65796b4e1 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
-Subject: [PATCH 254/450] SURFACE: ath10k: Add module parameters to override
+Subject: [PATCH 254/451] SURFACE: ath10k: Add module parameters to override
  board files
 
 Some Surface devices, specifically the Surface Go and AMD version of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From c9749b4403d67e295cbf3986cc3220d0b25ae810 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 255/450] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 255/451] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
@@ -1,7 +1,7 @@
 From fe1065452d7cfc1badc0383b8c83ae45dbcf70ad Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 256/450] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
+Subject: [PATCH 256/451] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
  for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
@@ -1,7 +1,7 @@
 From 1d2e64e2eed3c465707baaff0e07fbde021dd90d Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 257/450] SURFACE: hid: Add support for Intel Precise Touch and
+Subject: [PATCH 257/451] SURFACE: hid: Add support for Intel Precise Touch and
  Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
@@ -1,7 +1,7 @@
 From 66b464163edc88f99750ed52174f6a1853bd9b61 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
-Subject: [PATCH 258/450] SURFACE: iommu: intel: Disable source id verification
+Subject: [PATCH 258/451] SURFACE: iommu: intel: Disable source id verification
  for ITHC
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
@@ -1,7 +1,7 @@
 From c8596adcbb3e9381ae2ecfaaba829ea21207acfb Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
-Subject: [PATCH 259/450] SURFACE: hid: Add support for Intel Touch Host
+Subject: [PATCH 259/451] SURFACE: hid: Add support for Intel Touch Host
  Controller
 
 Based on quo/ithc-linux@34539af4726d.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
@@ -1,7 +1,7 @@
 From 2c2613e8029a72870beac8ab15503c87d68e7d4a Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
-Subject: [PATCH 260/450] SURFACE: rtc: Add basic support for RTC via Surface
+Subject: [PATCH 260/451] SURFACE: rtc: Add basic support for RTC via Surface
  System Aggregator Module
 
 Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
@@ -1,7 +1,7 @@
 From 876c482dfc6333347d39d4e6b12110802c653274 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
-Subject: [PATCH 261/450] SURFACE: platform/surface: aggregator_registry: Add
+Subject: [PATCH 261/451] SURFACE: platform/surface: aggregator_registry: Add
  Surface Laptop 7 (ACPI)
 
 Patchset: surface-sam

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
@@ -1,7 +1,7 @@
 From 559371d5c7ff1971f72df3d7d3990ac94872f076 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
-Subject: [PATCH 262/450] SURFACE: i2c: acpi: Implement RawBytes read access
+Subject: [PATCH 262/451] SURFACE: i2c: acpi: Implement RawBytes read access
 
 Microsoft Surface Pro 4 and Book 1 devices access the MSHW0030 I2C
 device via a generic serial bus operation region and RawBytes read

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
@@ -1,7 +1,7 @@
 From a2decd4900474e1395c51f000f08b09a3439674e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
-Subject: [PATCH 263/450] SURFACE: platform/surface: Add driver for Surface
+Subject: [PATCH 263/451] SURFACE: platform/surface: Add driver for Surface
  Book 1 dGPU switch
 
 Add driver exposing the discrete GPU power-switch of the  Microsoft

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
@@ -1,7 +1,7 @@
 From a70dd9b2ed3f87d27d828321c819246db2e1442b Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
-Subject: [PATCH 264/450] SURFACE: Input: soc_button_array - support AMD
+Subject: [PATCH 264/451] SURFACE: Input: soc_button_array - support AMD
  variant Surface devices
 
 The power button on the AMD variant of the Surface Laptop uses the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
@@ -1,7 +1,7 @@
 From 94bdc074ab503654fcd3a551e81ce52ac71ed3ee Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
-Subject: [PATCH 265/450] SURFACE: platform/surface: surfacepro3_button: don't
+Subject: [PATCH 265/451] SURFACE: platform/surface: surfacepro3_button: don't
  load on amd variant
 
 The AMD variant of the Surface Laptop report 0 for their OEM platform

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
@@ -1,7 +1,7 @@
 From 07bd6ea5e533eb24fd5a2255cefb9fdaa9297731 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
-Subject: [PATCH 266/450] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
+Subject: [PATCH 266/451] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
  Surface Go 3 Type-Cover
 
 The touchpad on the Type-Cover of the Surface Go 3 is sometimes not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From f09636ea6a89d529eedfb6c334fc532ff33fce8a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 267/450] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 267/451] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 
 The Type Cover for Microsoft Surface devices supports a special usb

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-SURFACE-hid-multitouch-Add-support-for-surface-pro-t.patch
@@ -1,7 +1,7 @@
 From 8a5bf43f4668f69045d5dd3330261d42795f47b7 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 268/450] SURFACE: hid/multitouch: Add support for surface pro
+Subject: [PATCH 268/451] SURFACE: hid/multitouch: Add support for surface pro
  type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
@@ -1,7 +1,7 @@
 From 6e201774c0a542c7bb8571f53fe5e3da1b3c8e6a Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH 269/450] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
+Subject: [PATCH 269/451] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
  shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
@@ -1,7 +1,7 @@
 From 4993c086b1308c65da026fedc0d12c79aa8d6415 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
-Subject: [PATCH 270/450] SURFACE: platform/surface: gpe: Add support for
+Subject: [PATCH 270/451] SURFACE: platform/surface: gpe: Add support for
  Surface Pro 9
 
 Add the lid GPE used by the Surface Pro 9.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 333de266a133f4350d0d1187951223ed6638c80d Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 271/450] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 271/451] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
@@ -1,7 +1,7 @@
 From b88a55883e1dd74a13ac6dcb7a51b2b3a5edd37c Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 272/450] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
+Subject: [PATCH 272/451] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
  passthrough mode for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From 337a5829a9c00fbc26fcf6fb1baef43657d9e1bb Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 273/450] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 273/451] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From f62f03f5542af6b6eb478f38afc548afc8ace5f4 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 274/450] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 274/451] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From 629a58eafc7d0ed8526c3173158cfce051526e0b Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 275/450] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 275/451] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From f12619a134bb79663c82fe004083923ab2f84668 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 276/450] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 276/451] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From 536c25f7e1ea28822a9b31c8926c2da6191db522 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 277/450] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 277/451] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From a780efa60f20afb6af8e241703b53e16367715bf Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 278/450] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 278/451] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From facf6cb8706840139bfe49e862c3ede4a120b740 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 279/450] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 279/451] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
@@ -1,7 +1,7 @@
 From 35339847e5a53c271137562c8572b85a44b75a84 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
-Subject: [PATCH 280/450] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
+Subject: [PATCH 280/451] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
  missing irq 7 override
 
 This patch is the work of Thomas Gleixner <tglx@linutronix.de> and is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
@@ -1,7 +1,7 @@
 From 78e0c663d26b4d141312327c61b303338bb90f01 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
-Subject: [PATCH 281/450] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
+Subject: [PATCH 281/451] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
  irq 7 override quirk
 
 The 13" version of the Surface Laptop 4 has the same problem as the 15"

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
@@ -1,7 +1,7 @@
 From 668efe457b6bea93184c0a9a15c6b5b62b124537 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
-Subject: [PATCH 282/450] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
+Subject: [PATCH 282/451] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
  HW-reduced platforms
 
 The specification [1] allows so-called HW-reduced platforms,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-XUANTIE-riscv-dts-th1520-add-licheepi4a-16g-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-XUANTIE-riscv-dts-th1520-add-licheepi4a-16g-support.patch
@@ -1,7 +1,7 @@
 From 51e1b988a3398639bd9b43eeb87094c99731068d Mon Sep 17 00:00:00 2001
 From: Han Gao <gaohan@iscas.ac.cn>
 Date: Mon, 24 Nov 2025 20:38:44 +0800
-Subject: [PATCH 283/450] XUANTIE: riscv: dts: th1520: add licheepi4a 16g
+Subject: [PATCH 283/451] XUANTIE: riscv: dts: th1520: add licheepi4a 16g
  support
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/01a510898e41e704bee1fe58a2c0c0a29cb96548

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-XUANTIE-riscv-dts-thead-Add-TH1520-USB-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-XUANTIE-riscv-dts-thead-Add-TH1520-USB-nodes.patch
@@ -1,7 +1,7 @@
 From bb03bdaeea281156b00ab77f32a89ebec985fbd4 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:51:56 +0800
-Subject: [PATCH 284/450] XUANTIE: riscv: dts: thead: Add TH1520 USB nodes
+Subject: [PATCH 284/451] XUANTIE: riscv: dts: thead: Add TH1520 USB nodes
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/2bd78742752e4f0eb07b421c3b3fc662c953aff0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-XUANTIE-riscv-dts-thead-Add-TH1520-I2C-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-XUANTIE-riscv-dts-thead-Add-TH1520-I2C-nodes.patch
@@ -1,7 +1,7 @@
 From dd9c1058a68b5cfec17dd58f8620596d7e6d95dd Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:50:07 +0800
-Subject: [PATCH 285/450] XUANTIE: riscv: dts: thead: Add TH1520 I2C nodes
+Subject: [PATCH 285/451] XUANTIE: riscv: dts: thead: Add TH1520 I2C nodes
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/ef4ac920a874b013f7609fb1f88fa08bcd445a01
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-XUANTIE-riscv-dts-thead-Add-Lichee-Pi-4A-IO-expansio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-XUANTIE-riscv-dts-thead-Add-Lichee-Pi-4A-IO-expansio.patch
@@ -1,7 +1,7 @@
 From 257637b8148047e40ec755caeddc9266ab526a78 Mon Sep 17 00:00:00 2001
 From: Emil Renner Berthing <emil.renner.berthing@canonical.com>
 Date: Wed, 13 Dec 2023 01:58:00 +0100
-Subject: [PATCH 286/450] XUANTIE: riscv: dts: thead: Add Lichee Pi 4A IO
+Subject: [PATCH 286/451] XUANTIE: riscv: dts: thead: Add Lichee Pi 4A IO
  expansions
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/b41720b46f4b203f7935d7cf5613c1782949774b

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-XUANTIE-riscv-dts-thead-Enable-Lichee-Pi-4A-USB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-XUANTIE-riscv-dts-thead-Enable-Lichee-Pi-4A-USB.patch
@@ -1,7 +1,7 @@
 From 5d09c87b3f50896e3ccebbe8639825aa6446f07b Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:56:37 +0800
-Subject: [PATCH 287/450] XUANTIE: riscv: dts: thead: Enable Lichee Pi 4A USB
+Subject: [PATCH 287/451] XUANTIE: riscv: dts: thead: Enable Lichee Pi 4A USB
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/9f2a969ac4596062d55412ee6b7f25a6774b5358
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-REVYOS-HACK-riscv-dts-th1520-rename-thead-to-xuantie.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-REVYOS-HACK-riscv-dts-th1520-rename-thead-to-xuantie.patch
@@ -1,7 +1,7 @@
 From 9a186792f5735ca18eb07c07b30deeefdd24ce61 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 14 May 2025 08:16:15 +0800
-Subject: [PATCH 288/450] REVYOS: HACK: riscv: dts: th1520: rename thead to
+Subject: [PATCH 288/451] REVYOS: HACK: riscv: dts: th1520: rename thead to
  xuantie
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/fe55f7b77b81749bfd2a5eac9328e016f299d7a6

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-REVYOS-HACK-riscv-dts-th1520-add-xuantie-th1520-mbox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-REVYOS-HACK-riscv-dts-th1520-add-xuantie-th1520-mbox.patch
@@ -1,7 +1,7 @@
 From f10d3e66cb7876c9659420cc6d664e97d26756e9 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 14 May 2025 08:27:18 +0800
-Subject: [PATCH 289/450] REVYOS: HACK: riscv: dts: th1520: add
+Subject: [PATCH 289/451] REVYOS: HACK: riscv: dts: th1520: add
  xuantie,th1520-mbox-r
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/1e57185ba18320bb4fb747a6089f9404f970964c

--- a/runtime-kernel/linux-kernel/autobuild/patches/0290-FROMEXT-cjktty-6.16.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0290-FROMEXT-cjktty-6.16.patch.patch
@@ -1,7 +1,7 @@
 From 50f9765f40f52dadb38d621496d1069a748cfdba Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 3 Nov 2025 17:49:44 +0800
-Subject: [PATCH 290/450] FROMEXT: cjktty-6.16.patch
+Subject: [PATCH 290/451] FROMEXT: cjktty-6.16.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From 3874091026b801d18c2fa358a36201c1ec6465c3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 292/450] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 292/451] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 894addd0e3567428aa2070be4f513f1c40265a86 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 293/450] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 293/451] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From 1066c75063fff4f4ac20bafc5b1dc75295b35ec1 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 294/450] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 294/451] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From 2e90535da583c34e8f71f8b05f6b98d959e5851b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 295/450] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 295/451] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From 8cbc4f7b857438d659ad89c95bdad9eea1bf04d1 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 296/450] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 296/451] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-net-stmmac-dwmac-phytium-convert-to-use-phy_i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-net-stmmac-dwmac-phytium-convert-to-use-phy_i.patch
@@ -1,7 +1,7 @@
 From 62462fc5108153448f602f23319a42286d8ae89e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 15 Oct 2025 16:26:32 +0800
-Subject: [PATCH 297/450] AOSCOS: net: stmmac: dwmac-phytium: convert to use
+Subject: [PATCH 297/451] AOSCOS: net: stmmac: dwmac-phytium: convert to use
  phy_interface
 
 Follow upstream changes post-6.17 and replace mac_interface with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-stmmac-stmmac-phytium-fix-build-against-post-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-stmmac-stmmac-phytium-fix-build-against-post-.patch
@@ -1,7 +1,7 @@
 From a447434a940a6a60eee8ce1aec97b9682556dbcc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 5 Nov 2025 10:58:36 +0800
-Subject: [PATCH 298/450] AOSCOS: stmmac: stmmac-phytium: fix build against
+Subject: [PATCH 298/451] AOSCOS: stmmac: stmmac-phytium: fix build against
  post-6.18 net-next
 
 Since commit "net: stmmac: replace has_xxxx with core_type" from post-

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From 7e6542f1644d5bfdf9589aec566b865bb38b3127 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 299/450] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 299/451] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 79a51f1f9434dc9f16aeebdf755af9f3f2e76ab3 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 300/450] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 300/451] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-loongarch-re-introduce-add_numamem_region-ini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-loongarch-re-introduce-add_numamem_region-ini.patch
@@ -1,7 +1,7 @@
 From 86de26326fe6335dc72b07456bd18298d743c8a9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Nov 2025 22:21:05 +0800
-Subject: [PATCH 301/450] AOSCOS: loongarch: re-introduce add_numamem_region(),
+Subject: [PATCH 301/451] AOSCOS: loongarch: re-introduce add_numamem_region(),
  init_node_memblock()
 
 This is a partial revert for commit acf5de1b23b0 ("LoongArch: Fix NUMA

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From cb7c1418defd1d0a8c648854136c57f7ce98db65 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 302/450] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 302/451] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From d2e6b2fe5af8db869be80fa4ac71bd5ef1b02aaa Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 303/450] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 303/451] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From 9a8680def5f122e5366460948ebc81ed058af1c6 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 304/450] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 304/451] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From 50a8c5e6281604c0926d78316b0e027216d6f337 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 305/450] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 305/451] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From ddeb144aa1560caadee1b970200eb88fd35e60b7 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 306/450] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 306/451] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From 9548801bf2d2fde9439333b3cd0dddd96fa622f7 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 307/450] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 307/451] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From ad7edbe50715d14c3f021c1c03793cee4f135efa Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 308/450] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 308/451] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From affeec56028f127cf34dd096044353529363d4c3 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 309/450] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 309/451] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 36f7a930d96e25a68c9be1d54edb6806a9db32fa Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 310/450] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 310/451] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 [Xi Ruoyao: Select KALLSYMS and KPROBE]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From 25bd687371bb9dd48f5c65eb97829cabd282e983 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 311/450] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 311/451] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From a22043de4fddd2a3540f55fe820cde64e39566f9 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 312/450] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 312/451] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 0414f9e2cbb00eae7b994e05e80d3b0e2cac1540 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 313/450] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 313/451] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From 9bfb980f39856c2486ce5aef17cec3c8f47be097 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 314/450] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 314/451] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From 9d3a78ee1c02f8eba208f9a9e175961240f744d8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 315/450] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 315/451] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From 71138557a8fa12a73ff3fd076adbc2feef58ad84 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 316/450] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 316/451] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From 51f06755f2c2b23ea5b748688191974581fca464 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 317/450] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 317/451] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From d9252c80bfbbff2c88865904bca2c3052b2023dc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 318/450] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 318/451] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 6194b0e8e5ddbf29a1f8278e3792b4fb001612e5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 319/450] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 319/451] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 0b68532fa75a0fc9b50df85046e001c25ebf378b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 320/450] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 320/451] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From 919c2f66e00454e443ca57e116333a34ce6e6dbc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 321/450] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 321/451] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From 47b127a3d39eb445229b5d3b96e7f18e08895642 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 322/450] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 322/451] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 997d726d2088d84c3dbd7fc4947b1776f67a24ff Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 323/450] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 323/451] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From a54b1b34dbd60a9ff1080232358050592c699903 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 324/450] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 324/451] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From b225f11b3e30c65c3ac3c9c9ea6358f94ea0359e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 325/450] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 325/451] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
@@ -1,7 +1,7 @@
 From 05242001fd41fc5fce6af31fe8e25e127cdf21a2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 16:01:27 +0800
-Subject: [PATCH 326/450] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
+Subject: [PATCH 326/451] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
  support
 
 On IPASON NL38-N11 laptops, the touchpad device (a HID multitouch device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
@@ -1,7 +1,7 @@
 From 4f2d13bdbc234dae8f257df3e1a3aedcf85ff06b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:36:15 +0800
-Subject: [PATCH 327/450] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
+Subject: [PATCH 327/451] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
  xdp_do_flush()
 
 Per 7f04bd109d4c ("net: Tree wide: Replace xdp_do_flush_map() with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
@@ -1,7 +1,7 @@
 From 7cd06658a81ab84fce4d4bb2cf2ae88191cb5e68 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:38:09 +0800
-Subject: [PATCH 328/450] AOSCOS: net/phytmac: Remove unnecessary
+Subject: [PATCH 328/451] AOSCOS: net/phytmac: Remove unnecessary
  pcim_iounmap_regions() call
 
 pcim_iounmap_regions() is removed in commit 855c634930f0 ("PCI: Remove

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
@@ -1,7 +1,7 @@
 From afd18746a8fea4c2728ad71cbccec78f464dfd7f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 21:59:21 +0800
-Subject: [PATCH 329/450] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
+Subject: [PATCH 329/451] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
 
 The driver seems relying on ACPI to power up the device.  And the device
 is only available as a part of Phytium SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-AOSCOS-arm64-Disable-MPAM-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-AOSCOS-arm64-Disable-MPAM-by-default.patch
@@ -1,7 +1,7 @@
 From 277ed976f5cf31d03d7de68a3cacfed04a996229 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 14 Jul 2025 18:06:42 +0800
-Subject: [PATCH 330/450] AOSCOS: arm64: Disable MPAM by default
+Subject: [PATCH 330/451] AOSCOS: arm64: Disable MPAM by default
 
 We have to work OotB on W510, and ARM64 does not support extending the
 built-in command line with the one from the bootloader.  So only try

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 9a810af132378f39d49d0a88d7462451bebf8d8b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 331/450] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 331/451] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From ba1a5d8d2f53082fb76b6555328e06168633ca79 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 332/450] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 332/451] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk

--- a/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From 1a59490fa4864e9e18283aabe4dfdf3316622da0 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 333/450] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 333/451] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open

--- a/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From a6417b12dd92b0354b16f76cd253911861d378cc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 334/450] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 334/451] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").

--- a/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 4b1a431f9d3ec74ca4dad57062344ec820311ee7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 335/450] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 335/451] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From fc1b88faee48e20bb1b19e648cbe2060fefe2cee Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 336/450] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 336/451] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode

--- a/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 7481300d22bfc5f02eae1d3aff525eb692478cf6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 337/450] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 337/451] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From 02862a26d1ea9a7f614c7676ebf2104121b64093 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 338/450] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 338/451] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror

--- a/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 2daaa04e0857c5dc208aeb81e7ee63fd11204098 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 339/450] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 339/451] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 08bf61276cf62c0f454945ee645727717a912b46 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 340/450] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 340/451] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 56385690210721c053e74a6c52d283d405e369ee Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 341/450] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 341/451] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From 4992d29ae6fe2af01748075e1cb53f874b683173 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 342/450] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 342/451] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From eed860c7e60b65f47bb3df98df67f9340fbfaca2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 343/450] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 343/451] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From 94890cdc8226e3ce40e746950c460268b51e5a6f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 344/450] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 344/451] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From e1eb7d376addfec85634a216d3b6b3fef06e9f55 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 345/450] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 345/451] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From d84c0a50440077cf3d4f39a44a32d694e2af87dd Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 346/450] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 346/451] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From 3b6a70288b0f0c19c5f10663828623863a681325 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 347/450] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 347/451] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From a5db22c42bc64c848a8505a4d18d16352c08f02a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 348/450] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 348/451] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From c794c70313516b2726a86eaa4b2470374340bc06 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 349/450] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 349/451] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From e91287f227546979d38c7d3154f4086e335020c1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 350/450] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 350/451] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From c13cf6766f238d7854e89e2b5775ade2e2e14c37 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 351/450] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 351/451] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From cde4e9e0a565a2b9e9e0692f875de0be02fce550 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 352/450] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 352/451] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From 87b3691d1aa92152dd4bebc35c7cda1e17bd8531 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 353/450] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 353/451] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From 0856b00de07910d4b2c5f1b6868c60caba1da5be Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 354/450] AOSCOS: input: atkbd: disable
+Subject: [PATCH 354/451] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From ce1de00d5bf542690e0c1ad592cd4683cd96ee59 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 355/450] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 355/451] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From 917fcbeebc3635033ac1491d76b5d1448d60d478 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 356/450] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 356/451] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 19c33d0e09d206607d884f697ef8abf0352e8012 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 357/450] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 357/451] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 9db1db7830b661f1f04fae19da311815a6f8b937 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 358/450] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 358/451] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From 3f287c42fd83b45d022248c0525a44c5333a9e89 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 359/450] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 359/451] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From b3d682715820c5992b1ba71d9c0ca66dc65ed8f1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 360/450] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 360/451] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 6547ff6793d3aafa99553ac4849fc8e21f75f460 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 361/450] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 361/451] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3

--- a/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From a50d28b9adefb78752d383f400ed91e34c2eccba Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 362/450] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 362/451] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From def15cbd1730eb1a2539f912204e92dc87d2160f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 363/450] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 363/451] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From 1201e9962823929d142bf3396ce0a0ed7dec85df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 364/450] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 364/451] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference

--- a/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From 6d7ff2835c5d8c80a419135169eee5f3aa34c7e4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 365/450] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 365/451] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From 0973810394b6cbc283f6ef4150f834ba1c34061d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 366/450] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 366/451] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an

--- a/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 8db8f100f7e7ac2bad1e3b68530f62d57e50ebb6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 367/450] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 367/451] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0368-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0368-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From 065daf546ef3cac68770d80ac71879618f30d768 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 368/450] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 368/451] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From 17af8848216522f983c5113c5903601711f83a72 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 369/450] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 369/451] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From d54b100aa42cf59e501bbfbc78b2e6e129218300 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 370/450] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 370/451] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From c47960890298088369f74cbc8b9d6fadbd9211a7 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 371/450] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 371/451] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0372-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0372-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 64ab58d7d9fbdca51689e3ab46c012406d556a4e Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 372/450] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 372/451] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0373-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0373-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From 435366c203c7d24ff5d222a6de17192772f640ab Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 373/450] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 373/451] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0374-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0374-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From 9edf104c113cf223fb6bfe04f56946274760f497 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 374/450] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 374/451] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0375-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0375-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From 95416e688bf10e5852d3f93160c8294990c74a91 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 375/450] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 375/451] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0376-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0376-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From 436cb3a15cb157c90ad46593cf9ec726c6e21867 Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 376/450] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 376/451] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0377-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0377-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From e3bff38a11bc9d347cc59cabfef739eb14fe2074 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 377/450] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 377/451] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0378-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0378-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 37b67c770875d5afce9f2afccc71ec3fbc63b387 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 378/450] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 378/451] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0379-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0379-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From fd773cb181fa6a60ef1b62a91b5b35de4c7d40cd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 379/450] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 379/451] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0380-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0380-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From b9eeed9b08a1f38c5dc06c809aa74d8728f6a66d Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 380/450] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 380/451] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0381-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0381-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From 2ee71f37be32de710d9e025c5aad8e4bb3ab58f1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 381/450] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 381/451] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0382-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0382-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 01b7b28b718ff53424db42c9b94c45fa0918ec74 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 382/450] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 382/451] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`

--- a/runtime-kernel/linux-kernel/autobuild/patches/0383-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0383-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From efbf87c9f54b1f8739d33411ec59099f3c60fa81 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 383/450] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 383/451] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0384-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0384-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From 0d73d39f7f77e655b45f46b6971a7d5db4289144 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 384/450] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 384/451] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0385-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0385-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From 7f711ddb42d6c7b3a40c871eb3201f1786993c09 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 385/450] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 385/451] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0386-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0386-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 12d483848e6052bd70cb1690979a2e48889f0e4d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 386/450] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 386/451] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0387-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0387-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From a6155ef0bb5f51bd7bbb2b2c611483f1cec6b434 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 387/450] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 387/451] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0388-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0388-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 5b7cf3370616ee9b7c955c46fce1e0fd3a222c34 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 388/450] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 388/451] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0389-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0389-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From 348d3119af2faa974fbcbb8b0f85f68b77f33f00 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 389/450] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 389/451] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0390-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0390-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 16d6c53d919ac8bae9932bf31e735e24526fc9c8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 390/450] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 390/451] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0391-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0391-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From 54ca429517103a121e709a3f458dec604d897586 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 391/450] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 391/451] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0392-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0392-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From 6ab50a4868d0c210cf143c1bd36b2dbc9d832c5c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 392/450] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 392/451] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0393-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0393-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From 7779c27224a6e7514a1958a8c80dfbefbed030df Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 393/450] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 393/451] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do

--- a/runtime-kernel/linux-kernel/autobuild/patches/0394-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0394-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From 8388e307acd78a03e5232f5a71ed10bd2477d676 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 394/450] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 394/451] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART

--- a/runtime-kernel/linux-kernel/autobuild/patches/0395-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0395-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From ef738c045a51505a30e4a65454e2e49f467715b2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 395/450] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 395/451] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0396-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0396-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From 31c64c9c07053392e59e95ae37ef58f2ca49b4a8 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 396/450] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 396/451] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0397-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0397-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 40a872990a4282a1ed53dc5deb207036a3687a3c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 397/450] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 397/451] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0398-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0398-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From c48f45f56853ceb5db1e26622fc3bc5415ad94be Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 398/450] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 398/451] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0399-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0399-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From 52479edb70f8419a9f693ac54b506af0881791aa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 399/450] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 399/451] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!

--- a/runtime-kernel/linux-kernel/autobuild/patches/0400-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0400-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From de1c97464d254d7b2c0a7dd7c1afc7e470a0337d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 400/450] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 400/451] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h

--- a/runtime-kernel/linux-kernel/autobuild/patches/0401-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0401-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From cd19ae818b2acd11d0b6a6781d0f811082f6a98a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 401/450] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 401/451] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing

--- a/runtime-kernel/linux-kernel/autobuild/patches/0402-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0402-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From 813b240dcaef07a1cead7a71e98a8ef4e80c2a4e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 402/450] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 402/451] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under

--- a/runtime-kernel/linux-kernel/autobuild/patches/0403-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0403-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From 8437b510df67f3e7479dd79c37f2709a04100885 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 403/450] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 403/451] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0404-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0404-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From f50aa0cb5ebac9b6a435975f384f68350d864e2e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 404/450] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 404/451] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0405-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0405-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From e5ed3d8c89b9027228b1bd5ae463946ebfe1f3e5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 405/450] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 405/451] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all

--- a/runtime-kernel/linux-kernel/autobuild/patches/0406-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0406-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From d54113bcd311d0c85fc6ff44d187abdbc351cd98 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 406/450] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 406/451] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0407-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0407-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From 6a02f3a48ad51c65c7a1bd7dd3a0fa515596d769 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 407/450] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 407/451] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0408-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0408-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From 2ab912f800ec21f09f720dd7e5599eab99d1558f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 408/450] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 408/451] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0409-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0409-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 31f44350fa5f3280703d706d446f00f4e87e886e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 409/450] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 409/451] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number

--- a/runtime-kernel/linux-kernel/autobuild/patches/0410-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0410-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From 8037a9679ee9821d0216bda1017397fc9dcd0443 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 410/450] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 410/451] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0411-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0411-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From d57b5bfe177fbf778a29ab1ab022e296becc6fae Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 411/450] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 411/451] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count

--- a/runtime-kernel/linux-kernel/autobuild/patches/0412-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0412-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From 8fdeaa6a061c081722edc9c389fcac00779bb6a6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 412/450] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 412/451] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0413-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0413-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 5c955ab9b16f71850ae05517b61b4dcf322e5de1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 413/450] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 413/451] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0414-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0414-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 24eb0bb96777ef1a832ac5505eeba0c4d871a355 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 414/450] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 414/451] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0415-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0415-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From f857a550a7af71719ee21d8f9cd0a8cbfc322cdd Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 415/450] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 415/451] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as

--- a/runtime-kernel/linux-kernel/autobuild/patches/0416-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0416-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 94e5eba52ed54888c54290adf29ece818b52b678 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 416/450] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 416/451] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0417-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0417-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From affc58fc388545935e76600682945fde365f414e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 417/450] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 417/451] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0418-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0418-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From af737fa56d48fe19efab33dba409be96c93d15be Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 418/450] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 418/451] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0419-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0419-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From a2affbd8b913bffab16b2a391709a47d52c3c7ab Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 419/450] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 419/451] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0420-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0420-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From 6713255fd53e82a7d79dbccfb3c19468ae1d2648 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 420/450] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 420/451] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where

--- a/runtime-kernel/linux-kernel/autobuild/patches/0421-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0421-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From 3de9029ada76971e3b68bbb413086a316900afcb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 421/450] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 421/451] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0422-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0422-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From d02053ac5296da25f9f359bbeb3720063ed80b5b Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 422/450] AOSCOS: Optimize clear_page
+Subject: [PATCH 422/451] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0423-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0423-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 1c17feffbeee8662cd8e0e7fba20181d03005390 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 423/450] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 423/451] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0424-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0424-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 884381d3e40dbd9478cb6cc261e792a5036ca5b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 424/450] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 424/451] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0425-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0425-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 798930f4b1173009ac20bedd571dc223b2a9a4f6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 425/450] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 425/451] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0426-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0426-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From f568bc16f6ebcd03ae7a3f46b3a104186d0386ab Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 426/450] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 426/451] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific

--- a/runtime-kernel/linux-kernel/autobuild/patches/0427-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0427-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From ec3b2d25f91ce225ead50b756afd58a7f82f0435 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 427/450] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 427/451] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0428-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0428-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 99b0033681f47817ddcb180da512a8181528b679 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 428/450] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 428/451] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0429-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0429-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From bf2b636732dca15e99aa8ce1c57717da9142376e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 429/450] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 429/451] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0430-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0430-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From f2b7126f3551bfb8e0b0c77c30350a574bdebf54 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 430/450] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 430/451] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0431-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0431-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 61fa082211a516ad672d49a5c28eab37df0e6000 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 431/450] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 431/451] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0432-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0432-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From 3176c24a9b39650746da2d1956f1cc1000225952 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 432/450] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 432/451] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0433-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0433-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 6dbf830f363465cd33d20f7c434c9c3607eff94d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 433/450] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 433/451] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0434-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0434-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From dce7c655ca4d945ac75c03cf8b88fd17e4f98cfc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 434/450] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 434/451] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0435-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0435-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From 8bd29ccc2be06d58706e81aa0f3c2f89bb1baa00 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 435/450] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 435/451] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0436-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0436-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From 8e4900d87147331570c55d53f0080349bbfbe90f Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 436/450] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 436/451] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0437-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0437-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From 0db2fe89a37b49b0ee575b94cce6edb9d92b52fb Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 437/450] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 437/451] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper

--- a/runtime-kernel/linux-kernel/autobuild/patches/0438-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0438-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From a88f84743a634b7836e954130b5c1c65a55bde54 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 438/450] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 438/451] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In

--- a/runtime-kernel/linux-kernel/autobuild/patches/0439-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0439-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 86a7d0baf51fcb0716813a746ad317e2063ac31c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 439/450] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 439/451] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0440-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0440-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From 53aa6dbdb25b3a1dc6a9e92c068796688f371229 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 440/450] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 440/451] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes; Also move the struct domain_device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0441-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0441-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From af857c46dd7ff319e7a374a146fc88ccb50ccf39 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 441/450] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 441/451] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0442-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0442-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
@@ -1,7 +1,7 @@
 From 32f0358796a772b4b896a3a8d2a8d292c1e6b3ba Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 22:05:56 +0800
-Subject: [PATCH 442/450] AOSCOS: sb105x: Adapt for timer related function
+Subject: [PATCH 442/451] AOSCOS: sb105x: Adapt for timer related function
  renames
 
 The upstream has renamed the timer related functions to have a strict

--- a/runtime-kernel/linux-kernel/autobuild/patches/0443-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0443-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From bb25be9e2d76be6f94e457c9ad8cb587bd9661b9 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 443/450] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 443/451] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0444-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0444-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
@@ -1,7 +1,7 @@
 From 23ba7acd8de90b174d1b959aefe54189e0047111 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 09:50:44 +0800
-Subject: [PATCH 444/450] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
+Subject: [PATCH 444/451] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
  LS7A
 
 On LoongArch laptops using LG110 GPU for display, LS7A PWM3 is used for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0445-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0445-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
@@ -1,7 +1,7 @@
 From 1975dff083e510383709d3d27f977bf823935c62 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:32:58 +0800
-Subject: [PATCH 445/450] AOSCOS: gpio: aaeon: use new GPIO line value setter
+Subject: [PATCH 445/451] AOSCOS: gpio: aaeon: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0446-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0446-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
@@ -1,7 +1,7 @@
 From b72e83196b5f6f9ec1f6776b7f25b523e34eccf6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:36:16 +0800
-Subject: [PATCH 446/450] AOSCOS: gpio: nct6102: use new GPIO line value setter
+Subject: [PATCH 446/451] AOSCOS: gpio: nct6102: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0447-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0447-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
@@ -1,7 +1,7 @@
 From f3ddf5fc0e26f31ac05acfa6a1534ba6644241a8 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 10 Sep 2025 23:21:26 +0800
-Subject: [PATCH 447/450] AOSCOS: scsi: dc395x: correctly discard the return
+Subject: [PATCH 447/451] AOSCOS: scsi: dc395x: correctly discard the return
  value in certain reads
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0448-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0448-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
@@ -1,7 +1,7 @@
 From c27f6983cbad067c99af34abae7516ca6fbc1619 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 12 Nov 2025 11:41:05 +0800
-Subject: [PATCH 448/450] AOSCOS: crypto: padlock-sha: return -ENODEV on
+Subject: [PATCH 448/451] AOSCOS: crypto: padlock-sha: return -ENODEV on
  Zhaoxin KaiXian KX-6000/6000G
 
 On Zhaoxin KaiXian KX-6000/6000G series of processors, this crypto module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0449-AOSCOS-Revert-FROMLIST-rust-generate-a-fatal-error-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0449-AOSCOS-Revert-FROMLIST-rust-generate-a-fatal-error-i.patch
@@ -1,7 +1,7 @@
 From 1f3a08806b5c5b5a3dd0afbdf96fa8caa46003e7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 23 Dec 2025 20:08:10 +0800
-Subject: [PATCH 449/450] AOSCOS: Revert "FROMLIST: rust: generate a fatal
+Subject: [PATCH 449/451] AOSCOS: Revert "FROMLIST: rust: generate a fatal
  error if BINDGEN_TARGET is undefined"
 
 This reverts "FROMLIST: rust: generate a fatal error if BINDGEN_TARGET is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0450-AOSCOS-MIPS-Loongson-Salvage-the-full-count-from-the.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0450-AOSCOS-MIPS-Loongson-Salvage-the-full-count-from-the.patch
@@ -1,7 +1,7 @@
 From 20f8783fff293432197476226fb414569023dff6 Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Sun, 25 Jan 2026 00:54:35 +0800
-Subject: [PATCH 450/450] AOSCOS: MIPS: Loongson: Salvage the full count from
+Subject: [PATCH 450/451] AOSCOS: MIPS: Loongson: Salvage the full count from
  the constant timer
 
 HWR $30 (Loongson64 constant timer) is 64 bits wide. However, vDSO uses

--- a/runtime-kernel/linux-kernel/autobuild/patches/0451-Revert-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0451-Revert-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-.patch
@@ -1,0 +1,94 @@
+From 1d84c22352954ae9628cd73e54b308e41035fce9 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 18 Feb 2026 14:41:48 +0800
+Subject: [PATCH 451/451] Revert "AOSCOS: drm: amdgpu: radeon: disable cache
+ flush workaround for LoongArch and Loongson64"
+
+This reverts commit 894addd0e3567428aa2070be4f513f1c40265a86.
+---
+ drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c | 8 --------
+ drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c | 8 --------
+ drivers/gpu/drm/radeon/cik.c          | 8 --------
+ 3 files changed, 24 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
+index d455a752f3ff1..2b7aba22ecc19 100644
+--- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
+@@ -2125,13 +2125,6 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
+ 	bool int_sel = flags & AMDGPU_FENCE_FLAG_INT;
+ 	bool exec = flags & AMDGPU_FENCE_FLAG_EXEC;
+ 
+-/* This workaround causes instability for LoongArch/Loongson (MIPS)
+- * devices based on the 7A1000/2000 chipset under heavy I/O load.
+- *
+- * FIXME: Disable this workaround until we find a better fix (possibly in
+- * the platform-specific PCI code).
+- */
+-#ifndef CONFIG_MACH_LOONGSON64
+ 	/* Workaround for cache flush problems. First send a dummy EOP
+ 	 * event down the pipe with seq one below.
+ 	 */
+@@ -2145,7 +2138,6 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
+ 				DATA_SEL(1) | INT_SEL(0));
+ 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
+ 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
+-#endif
+ 
+ 	/* Then send the real EOP event down the pipe. */
+ 	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
+diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
+index 61b999f2e8c80..8a81713d97aac 100644
+--- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
+@@ -6113,13 +6113,6 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
+ 	bool int_sel = flags & AMDGPU_FENCE_FLAG_INT;
+ 	bool exec = flags & AMDGPU_FENCE_FLAG_EXEC;
+ 
+-/* This workaround causes instability for LoongArch/Loongson (MIPS)
+- * devices based on the 7A1000/2000 chipset under heavy I/O load.
+- *
+- * FIXME: Disable this workaround until we find a better fix (possibly in
+- * the platform-specific PCI code).
+- */
+-#ifndef CONFIG_MACH_LOONGSON64
+ 	/* Workaround for cache flush problems. First send a dummy EOP
+ 	 * event down the pipe with seq one below.
+ 	 */
+@@ -6134,7 +6127,6 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
+ 				DATA_SEL(1) | INT_SEL(0));
+ 	amdgpu_ring_write(ring, lower_32_bits(seq - 1));
+ 	amdgpu_ring_write(ring, upper_32_bits(seq - 1));
+-#endif
+ 
+ 	/* Then send the real EOP event down the pipe:
+ 	 * EVENT_WRITE_EOP - flush caches, send int */
+diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
+index 170d54c4b5eb5..e7b2108770dc9 100644
+--- a/drivers/gpu/drm/radeon/cik.c
++++ b/drivers/gpu/drm/radeon/cik.c
+@@ -3543,13 +3543,6 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
+ 	struct radeon_ring *ring = &rdev->ring[fence->ring];
+ 	u64 addr = rdev->fence_drv[fence->ring].gpu_addr;
+ 
+-/* This workaround causes instability for LoongArch/Loongson (MIPS)
+- * devices based on the 7A1000/2000 chipset under heavy I/O load.
+- *
+- * FIXME: Disable this workaround until we find a better fix (possibly in
+- * the platform-specific PCI code).
+- */
+-#ifndef CONFIG_MACH_LOONGSON64
+ 	/* Workaround for cache flush problems. First send a dummy EOP
+ 	 * event down the pipe with seq one below.
+ 	 */
+@@ -3563,7 +3556,6 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,
+ 				DATA_SEL(1) | INT_SEL(0));
+ 	radeon_ring_write(ring, fence->seq - 1);
+ 	radeon_ring_write(ring, 0);
+-#endif
+ 
+ 	/* Then send the real EOP event down the pipe. */
+ 	radeon_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.18.12
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=1.1
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] linux-kernel: drop workaround for workaround for AMDGPU cache flush

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.18.12-1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
