### PR TITLE
ca-certs: rebuild with Autobuild 4.16.0

### DIFF
--- a/runtime-data/ca-certs/spec
+++ b/runtime-data/ca-certs/spec
@@ -1,4 +1,5 @@
 VER=20260206
+REL=1
 CHANGESET=24ffdb17f470c11d3c20509aa5e2028a0a911494
 SRCS="file::rename=certdata.txt::https://github.com/nss-dev/nss/raw/${CHANGESET}/lib/ckfw/builtins/certdata.txt"
 CHKSUMS="sha256::3b98d4e3ff57a326d9587c33633039c8c3a9cf0b55f7ca581d7598ff329eb1f3"


### PR DESCRIPTION
Topic Description
-----------------

- ca-certs: rebuild with Autobuild 4.16.0

Package(s) Affected
-------------------

- ca-certs: 20260206-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ca-certs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
