### PR TITLE
gnome-online-accounts: adjust dependency

### DIFF
--- a/desktop-gnome/gnome-online-accounts/autobuild/defines
+++ b/desktop-gnome/gnome-online-accounts/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=gnome-online-accounts
 PKGSEC=gnome
 PKGDEP="gcr-4 json-glib krb5 libaccounts-glib libnotify libsecret rest \
-        telepathy-glib webkit2gtk"
+        telepathy-glib webkit2gtk libadwaita"
 BUILDDEP="gobject-introspection vala"
 PKGDES="GNOME service to access online accounts"
 

--- a/desktop-gnome/gnome-online-accounts/spec
+++ b/desktop-gnome/gnome-online-accounts/spec
@@ -1,4 +1,5 @@
 VER=3.56.4
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/GNOME/gnome-online-accounts"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10943"


### PR DESCRIPTION
Topic Description
-----------------

- gnome-online-accounts: adjust dependency
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
