### PR TITLE
firefox: fix detection of default browser

### DIFF
--- a/app-web/firefox/autobuild/overrides/usr/share/applications/firefox.desktop
+++ b/app-web/firefox/autobuild/overrides/usr/share/applications/firefox.desktop
@@ -42,7 +42,7 @@ Comment[pt]=Navegue na Internet
 Comment[pt_BR]=Navegue na Internet
 Comment[sk]=Prehliadanie internetu
 Comment[sv]=Surfa på webben
-Exec=firefox %u
+Exec=/usr/lib/firefox/firefox %u
 Icon=firefox
 Terminal=false
 Type=Application
@@ -158,7 +158,7 @@ Name[wo]=Palanteer bu bees
 Name[xh]=Ifestile entsha
 Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
-Exec=firefox --new-window %u
+Exec=/usr/lib/firefox/firefox --new-window %u
 
 [Desktop Action new-private-window]
 Name=Open a New Private Window
@@ -266,7 +266,7 @@ Name[wo]=Panlanteeru biir bu bees
 Name[xh]=Ifestile yangasese entsha
 Name[zh_CN]=新建隐私浏览窗口
 Name[zh_TW]=新增隱私視窗
-Exec=firefox --private-window %u
+Exec=/usr/lib/firefox/firefox --private-window %u
 
 [Desktop Action profile-manager-window]
 Name=Open the Profile Manager
@@ -274,4 +274,4 @@ Name[cs]=Správa profilů
 Name[de]=Profilverwaltung öffnen
 Name[fr]=Ouvrir le gestionnaire de profils
 Name[zh_CN]=打开用户配置管理器
-Exec=firefox --ProfileManager
+Exec=/usr/lib/firefox/firefox --ProfileManager

--- a/app-web/firefox/spec
+++ b/app-web/firefox/spec
@@ -1,5 +1,5 @@
 VER=147.0.3
-REL=1
+REL=2
 CHKUPDATE="anitya::id=5506"
 SRCS="tbl::https://archive.mozilla.org/pub/firefox/releases/$VER/source/firefox-$VER.source.tar.xz \
       file::rename=ach.xpi::https://archive.mozilla.org/pub/firefox/releases/$VER/linux-x86_64/xpi/ach.xpi \


### PR DESCRIPTION
Topic Description
-----------------

- firefox: use realpath of the executable for the desktop entry
    Based on code found in \`nsGIOService\` and \`nsGNOMEShellService\`,
    a valid default browser entry for Firefox should have the real path
    to the executable in the Exec field, or Firefox will believe that it
    isn't the default browser. Let's use \`/usr/lib/firefox/firefox\` for
    the Exec field, as that's what the generated entries use.

Package(s) Affected
-------------------

- firefox: 147.0.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit firefox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
