### PR TITLE
libodfgen: fix build with GCC15

### DIFF
--- a/runtime-productivity/libodfgen/autobuild/patches/0001-fix-build.patch
+++ b/runtime-productivity/libodfgen/autobuild/patches/0001-fix-build.patch
@@ -1,0 +1,10 @@
+--- libodfgen-0.1.8/src/OdfGenerator.cxx~	2021-01-06 04:16:44.000000000 -0600
++++ libodfgen-0.1.8/src/OdfGenerator.cxx	2025-02-25 13:44:24.275284629 -0600
+@@ -31,6 +31,7 @@
+ #include "OdfGenerator.hxx"
+ 
+ #include <math.h>
++#include <cstdint>
+ 
+ #include <cctype>
+ #include <limits>

--- a/runtime-productivity/libodfgen/autobuild/prepare
+++ b/runtime-productivity/libodfgen/autobuild/prepare
@@ -1,1 +1,0 @@
-export CXXFLAGS="${CXXFLAGS} -Wno-error=parentheses"


### PR DESCRIPTION
Topic Description
-----------------

- libodfgen: fix build with GCC15
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libodfgen: 0.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libodfgen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
