### PR TITLE
rosegarden: update to 25.12

### DIFF
--- a/app-creativity/rosegarden/spec
+++ b/app-creativity/rosegarden/spec
@@ -1,4 +1,4 @@
-VER=24.12
+VER=25.12
 SRCS="tbl::https://downloads.sourceforge.net/project/rosegarden/rosegarden/$VER/rosegarden-${VER}.tar.xz"
-CHKSUMS="sha256::7f3f66136b09af14bd9998e4ade4d6204d458afd1694788fd6dcb3a96ebf15cc"
+CHKSUMS="sha256::970bcd4cc33e4a7d7b3d1cc6d8c09bffbaa5f00a487b965c12f6e8dca8cafa6d"
 CHKUPDATE="anitya::id=8939"


### PR DESCRIPTION
Topic Description
-----------------

- rosegarden: update to 25.12
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- rosegarden: 25.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit rosegarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
