### PR TITLE
pidgin: rebuild for evolution-data-server 3.58.3

### DIFF
--- a/app-web/pidgin/spec
+++ b/app-web/pidgin/spec
@@ -1,4 +1,5 @@
 VER=2.14.14
+REL=1
 SRCS="https://downloads.sourceforge.net/project/pidgin/Pidgin/$VER/pidgin-$VER.tar.bz2"
 CHKSUMS="sha256::0ffc9994def10260f98a55cd132deefa8dc4a9835451cc0e982747bd458e2356"
 CHKUPDATE="anitya::id=3636"


### PR DESCRIPTION
Topic Description
-----------------

- pidgin: rebuild for evolution-data-server 3.58.3
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- finch: 2.14.14-1
- libpurple: 2.14.14-1
- pidgin: 2.14.14-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pidgin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
