### PR TITLE
Vulkan sdk 1.4.341.0

### DIFF
--- a/app-utils/vulkan-tools/spec
+++ b/app-utils/vulkan-tools/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"

--- a/runtime-display/spirv-headers/spec
+++ b/runtime-display/spirv-headers/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230542"

--- a/runtime-display/spirv-tools/spec
+++ b/runtime-display/spirv-tools/spec
@@ -1,5 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14894"
-REL="1"

--- a/runtime-display/volk-meta-loader/spec
+++ b/runtime-display/volk-meta-loader/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-display/vulkan-extensionlayer/spec
+++ b/runtime-display/vulkan-extensionlayer/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ExtensionLayer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-display/vulkan-headers/spec
+++ b/runtime-display/vulkan-headers/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-display/vulkan-loader/spec
+++ b/runtime-display/vulkan-loader/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-display/vulkan-utility-libraries/spec
+++ b/runtime-display/vulkan-utility-libraries/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370173"

--- a/runtime-display/vulkan-validationlayers/spec
+++ b/runtime-display/vulkan-validationlayers/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-ValidationLayers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230558"

--- a/runtime-optenv32/spirv-tools+32/spec
+++ b/runtime-optenv32/spirv-tools+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/SPIRV-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14894"

--- a/runtime-optenv32/volk-meta-loader+32/spec
+++ b/runtime-optenv32/volk-meta-loader+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/zeux/volk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370476"

--- a/runtime-optenv32/vulkan-headers+32/spec
+++ b/runtime-optenv32/vulkan-headers+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Headers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88835"

--- a/runtime-optenv32/vulkan-loader+32/spec
+++ b/runtime-optenv32/vulkan-loader+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Loader"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230557"

--- a/runtime-optenv32/vulkan-tools+32/spec
+++ b/runtime-optenv32/vulkan-tools+32/spec
@@ -1,4 +1,4 @@
-VER=1.4.335.0
+VER=1.4.341.0
 SRCS="git::commit=tags/vulkan-sdk-$VER::https://github.com/KhronosGroup/Vulkan-Tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15953"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- spirv-headers: update to 1.4.341.0
- spirv-tools: update to 1.4.341.0
- vulkan-headers: update to 1.4.341.0
- vulkan-loader: update to 1.4.341.0
- vulkan-utility-libraries: update to 1.4.341.0
- vulkan-validationlayers: update to 1.4.341.0
- volk-meta-loader: update to 1.4.341.0
- vulkan-tools: update to 1.4.341.0
- vulkan-extensionlayer: update to 1.4.341.0
- spirv-tools+32: update to 1.4.341.0
- vulkan-headers+32: update to 1.4.341.0
- vulkan-loader+32: update to 1.4.341.0
- volk-meta-loader+32: update to 1.4.341.0
- vulkan-tools+32: update to 1.4.341.0
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- spirv-headers: 1.4.341.0
- spirv-tools: 1.4.341.0
- vulkan-headers: 1.4.341.0
- vulkan-loader: 1.4.341.0
- vulkan-utility-libraries: 1.4.341.0
- vulkan-validationlayers: 1.4.341.0
- volk-meta-loader: 1.4.341.0
- vulkan-tools: 1.4.341.0
- vulkan-extensionlayer: 1.4.341.0
- spirv-tools+32: 1.4.341.0
- vulkan-headers+32: 1.4.341.0
- vulkan-loader+32: 1.4.341.0
- volk-meta-loader+32: 1.4.341.0
- vulkan-tools+32: 1.4.341.0
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit spirv-headers spirv-tools vulkan-headers vulkan-loader vulkan-utility-libraries vulkan-validationlayers volk-meta-loader vulkan-tools vulkan-extensionlayer
```

For optenv32:

```
/build vulkan-sdk-1.4.341.0 vulkan-headers,spirv-headers,spirv-tools+32,vulkan-headers+32,vulkan-loader+32,volk-meta-loader+32,vulkan-tools+32 amd64
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
