### PR TITLE
wrapt: update to 2.1.1

### DIFF
--- a/lang-python/wrapt/spec
+++ b/lang-python/wrapt/spec
@@ -1,5 +1,4 @@
-VER=1.11.2
+VER=2.1.1
 SRCS="tbl::https://pypi.io/packages/source/w/wrapt/wrapt-$VER.tar.gz"
-CHKSUMS="sha256::565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
-REL="5"
+CHKSUMS="sha256::5fdcb09bf6db023d88f312bd0767594b414655d58090fc1c46b3414415f67fac"
 CHKUPDATE="anitya::id=75893"


### PR DESCRIPTION
Topic Description
-----------------

- wrapt: update to 2.1.1
    Co-authored-by: Xinmudotmoe \(@Xinmudotmoe\) <zhang1813023404@outlook.com>

Package(s) Affected
-------------------

- wrapt: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wrapt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
