### PR TITLE
certbot-dns-cloudflare: rework for dependencies

### DIFF
--- a/app-web/certbot-dns-cloudflare/autobuild/defines
+++ b/app-web/certbot-dns-cloudflare/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=certbot-dns-cloudflare
 PKGSEC=python
-PKGDEP="certbot"
+PKGDEP="certbot python-cloudflare"
 PKGDES="Cloudflare DNS challenge plugin for Certbot"
 
 NOPYTHON2=1

--- a/app-web/certbot-dns-cloudflare/spec
+++ b/app-web/certbot-dns-cloudflare/spec
@@ -1,4 +1,5 @@
 VER=5.3.1
+REL=1
 SRCS="pypi::version=$VER::certbot-dns-cloudflare"
 CHKSUMS="sha256::5239e6f0834b76f6e5bc096248cad3d5bcee0ee3ad2d31ed406ba6429a32b308"
 CHKUPDATE="anitya::id=17035"


### PR DESCRIPTION
Topic Description
-----------------

- certbot-dns-cloudflare: rework for dependencies
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit certbot-dns-cloudflare
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
