### PR TITLE
chardet Survey 20260221

### DIFF
--- a/app-doc/pdfminer/autobuild/defines
+++ b/app-doc/pdfminer/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=pdfminer
 PKGSEC=doc
-PKGDEP="chardet six sortedcontainers"
-BUILDDEP="setuptools"
+PKGDEP="charset-normalizer cryptography"
+BUILDDEP="setuptools-scm"
 PKGDES="Python PDF Parser"
 
 NOPYTHON2=1
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517

--- a/app-doc/pdfminer/spec
+++ b/app-doc/pdfminer/spec
@@ -1,5 +1,4 @@
-VER=20240706
-SRCS="git::commit=tags/$VER::https://github.com/pdfminer/pdfminer.six"
+VER=20260107
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/pdfminer/pdfminer.six"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9483"
-REL="1"

--- a/app-editors/retext/autobuild/beyond
+++ b/app-editors/retext/autobuild/beyond
@@ -1,14 +1,11 @@
 abinfo "Creating data directories ..."
 mkdir -pv "$PKGDIR"/usr/share/{applications,mime/packages}
 
-for size in 16 22 24 32 48 128; do
-    abinfo "Installing ${size}x${size} icons ..."
-    mkdir -pv "$PKGDIR"/usr/share/icons/hicolor/${size}x${size}/apps
-    convert -resize $size "$SRCDIR"/icons/retext.png \
-        "$PKGDIR"/usr/share/icons/hicolor/${size}x${size}/apps/retext.png
-done
-
 abinfo "Installing scalable icon ..."
 mkdir -pv "$PKGDIR"/usr/share/icons/hicolor/scalable/apps
-cp -v "$SRCDIR"/icons/retext.svg \
+cp -v "$SRCDIR"/retext_src/ReText/icons/retext.svg \
     "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/retext.svg
+
+abinfo "Installing .desktop entry ..."
+install -Dvm644 "$SRCDIR"/retext_src/data/me.mitya57.ReText.desktop \
+    "$PKGDIR"/usr/share/applications/retext.desktop

--- a/app-editors/retext/autobuild/defines
+++ b/app-editors/retext/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=retext
 PKGSEC=editors
-PKGDEP="chardet desktop-file-utils docutils gconf markdown pyenchant \
-        pymarkups pyqt5 xdg-utils"
+PKGDEP="pymarkups pygments pyqt6"
+PKGSUG="chardet pyenchant pyqt6-webengine"
 BUILDDEP="imagemagick"
-PKGDES="A simple editor for Markdown and ReStructuredText markup languages"
+PKGDES="Editor for Markdown and reStructuredText"
 
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch
 
 NOPYTHON2=1

--- a/app-editors/retext/spec
+++ b/app-editors/retext/spec
@@ -1,5 +1,4 @@
-VER=7.2.2
-SRCS="tbl::https://github.com/retext-project/retext/archive/$VER.tar.gz"
-CHKSUMS="sha256::91345b130eb55c09aae454de821ade9b1437b4614576cbb71ad9c77cde8e1c64"
+VER=8.1.0
+SRCS="git::commit=tags/$VER::https://github.com/retext-project/retext"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8915"
-REL="1"

--- a/app-multimedia/gaupol/autobuild/build
+++ b/app-multimedia/gaupol/autobuild/build
@@ -1,1 +1,0 @@
-python3 setup.py --without-iso-codes install --root="$PKGDIR" -O1

--- a/app-multimedia/gaupol/autobuild/defines
+++ b/app-multimedia/gaupol/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=gaupol
 PKGSEC=video
-PKGDEP="desktop-file-utils gst-plugins-good-1-0 iso-codes gtkspell3 chardet pyenchant"
-BUILDDEP="intltool"
+PKGDEP="desktop-file-utils gst-plugins-good-1-0 iso-codes gspell gstreamer charset-normalizer"
 PKGDES="Editor for text-based subtitle files"
 
+ABTYPE=python
 NOPYTHON2=1
 ABHOST=noarch

--- a/app-multimedia/gaupol/spec
+++ b/app-multimedia/gaupol/spec
@@ -1,5 +1,4 @@
-VER=1.7
-SRCS="tbl::https://github.com/otsaloma/gaupol/archive/$VER.tar.gz"
-CHKSUMS="sha256::250b0d929e635eec89656dc9672f5dba3bc0324325008f17155b3e54ac560788"
-REL="4"
+VER=1.15
+SRCS="git::commit=tags/$VER::https://github.com/otsaloma/gaupol"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=874"

--- a/lang-python/beautifulsoup4/autobuild/defines
+++ b/lang-python/beautifulsoup4/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=beautifulsoup4
 PKGSEC=python
-PKGDEP="chardet soupsieve"
-BUILDDEP="setuptools"
-PKGDES="A Python library designed for quick turnaround projects like screen-scraping"
+PKGDEP="soupsieve typing-extensions"
+BUILDDEP="setuptools hatchling"
+PKGDES="Library to scrape information from web pages"
 
+ABTYPE=pep517
 ABHOST=noarch
 
 NOPYTHON2=1

--- a/lang-python/beautifulsoup4/spec
+++ b/lang-python/beautifulsoup4/spec
@@ -1,5 +1,4 @@
-VER=4.10.0
-SRCS="tbl::https://pypi.io/packages/source/b/beautifulsoup4/beautifulsoup4-$VER.tar.gz"
-CHKSUMS="sha256::c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"
+VER=4.14.3
+SRCS="pypi::version=$VER::beautifulsoup4"
+CHKSUMS="sha256::6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"
 CHKUPDATE="anitya::id=3779"
-REL="1"

--- a/lang-python/chardet/autobuild/defines
+++ b/lang-python/chardet/autobuild/defines
@@ -5,6 +5,6 @@ BUILDDEP="setuptools-python3"
 PKGDES="Python module for character encoding autodetection"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/chardet/spec
+++ b/lang-python/chardet/spec
@@ -1,5 +1,4 @@
-VER=3.0.4
-REL="7"
+VER=5.2.0
 SRCS="pypi::version=$VER::chardet"
-CHKSUMS="sha256::84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+CHKSUMS="sha256::1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"
 CHKUPDATE="anitya::id=3798"

--- a/lang-python/pyenchant/spec
+++ b/lang-python/pyenchant/spec
@@ -1,5 +1,4 @@
-VER=3.2.2
-SRCS="tbl::https://pypi.io/packages/source/p/pyenchant/pyenchant-$VER.tar.gz"
-CHKSUMS="sha256::1cf830c6614362a78aab78d50eaf7c6c93831369c52e1bb64ffae1df0341e637"
+VER=3.3.0
+SRCS="pypi::version=$VER::pyenchant"
+CHKSUMS="sha256::825288246b5debc9436f91967650974ef0d5636458502619e322c476f1283891"
 CHKUPDATE="anitya::id=3857"
-REL="1"

--- a/lang-python/pymarkups/autobuild/defines
+++ b/lang-python/pymarkups/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=pymarkups
 PKGSEC=python
-PKGDEP="docutils pygments python-markdown-math python-3"
+PKGDEP="docutils pygments python-markdown-math pyyaml asciidoc lxml"
 BUILDDEP="setuptools-python3"
 PKGDES="Wrapper around various text markups"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/pymarkups/spec
+++ b/lang-python/pymarkups/spec
@@ -1,5 +1,4 @@
-VER=3.0.0
-REL="7"
-SRCS="tbl::https://github.com/retext-project/pymarkups/archive/$VER.tar.gz"
-CHKSUMS="sha256::5edc73ceed7d5ee207c481cc67852b5e54c731d65a32cb06afc27c455d5e70f4"
+VER=4.1.1
+SRCS="git::commit=tags/$VER::https://github.com/retext-project/pymarkups"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=174580"


### PR DESCRIPTION
Topic Description
-----------------

- retext: update to 8.1.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- pymarkups: update to 4.1.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- pdfminer: update to 20260107
    Signed-off-by: stydxm <stydxm@outlook.com>
- gaupol: update to 1.15
    Signed-off-by: stydxm <stydxm@outlook.com>
- beautifulsoup4: update to 4.14.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- chardet: update to 5.2.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit chardet beautifulsoup4 gaupol pdfminer pymarkups pyenchant retext
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
