### PR TITLE
winetricks, winetricks-zh: decouple LATX on loongarch64

### DIFF
--- a/app-emulation/winetricks-zh/autobuild/defines
+++ b/app-emulation/winetricks-zh/autobuild/defines
@@ -1,9 +1,7 @@
 PKGNAME=winetricks-zh
 PKGSEC=utils
 PKGDEP="wine cabextract"
-# Note: Wine is provided by LATX on LoongArch.
-PKGDEP__LOONGARCH64="${PKGDEP/wine/latx}"
-PKGDES="A windows applications setup wizard for Chinese wine users"
+PKGDES="Applications setup wizard for Chinese users"
 
 ABSPLITDBG=0
 

--- a/app-emulation/winetricks-zh/spec
+++ b/app-emulation/winetricks-zh/spec
@@ -1,4 +1,5 @@
 VER=20240105.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/hillwoodroc/winetricks-zh"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227369"

--- a/app-emulation/winetricks/autobuild/defines
+++ b/app-emulation/winetricks/autobuild/defines
@@ -1,8 +1,6 @@
 PKGNAME=winetricks
 PKGSEC=utils
 PKGDEP="cabextract unzip wine x11-app"
-# Note: Wine is provided by LATX on LoongArch.
-PKGDEP__LOONGARCH64="${PKGDEP/wine/latx}"
 PKGSUG="zenity"
 PKGDES="Script to install various redistributable runtime libraries in Wine"
 

--- a/app-emulation/winetricks/spec
+++ b/app-emulation/winetricks/spec
@@ -1,4 +1,5 @@
 VER=20260125
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/Winetricks/winetricks"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7258"


### PR DESCRIPTION
Topic Description
-----------------

- winetricks-zh: decouple LATX on loongarch64
- winetricks: decouple LATX on loongarch64

Package(s) Affected
-------------------

- winetricks: 20260125-1
- winetricks-zh: 20240105.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit winetricks winetricks-zh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
