### PR TITLE
cool-retro-term: new, 2.0.0-beta1

### DIFF
--- a/app-utils/cool-retro-term/autobuild/build
+++ b/app-utils/cool-retro-term/autobuild/build
@@ -1,0 +1,10 @@
+abinfo "Building cool-retro-term ..."
+qmake-qt6
+make -j$ABTHREADS
+
+abinfo "Installing cool-retro-term ..."
+make -C app install INSTALL_ROOT="$PKGDIR"
+make -C qmltermwidget install INSTALL_ROOT="$PKGDIR"
+make install INSTALL_ROOT="$PKGDIR"
+
+install -Dvm644 gpl-3.0.txt "$PKGDIR"/usr/share/doc/cool-retro-term/COPYING

--- a/app-utils/cool-retro-term/autobuild/defines
+++ b/app-utils/cool-retro-term/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=cool-retro-term
+PKGSEC=utils
+# this would require significant version bump of the deps
+# PKGDEP="kdsingleapplication qmltermwidget"
+# may conflict if qmltermwidget updates to Qt 6?
+# PKGCONFL="qmltermwidget"
+PKGDEP="qt-6"
+PKGDES="A good looking terminal emulator which mimics the old cathode display"
+# cannot be used for Qt 6 currently; cool-retro-term requires subproject installs
+# ABTYPE=qtproj
+ABTYPE=self
+
+NOPARALLEL=1
+# QT_SELECT=6

--- a/app-utils/cool-retro-term/spec
+++ b/app-utils/cool-retro-term/spec
@@ -1,0 +1,5 @@
+VER=2.0.0-beta1
+# repo with submodules that are not included in the release tar
+SRCS="git::commit=fe92fa73307a5e77d2852df70d33fb6b93a6efe1::https://github.com/Swordfish90/cool-retro-term"
+CHKSUMS="SKIP"
+# CHKUPDATE=


### PR DESCRIPTION
This also installs `/usr/lib/qt6/qml/QMLTermWidget` which may be not we want. Bump `runtime-desktop/qmltermwidget` to Qt 6 instead?

Topic Description
-----------------

cool-retro-term 2.0.0-beta1
A good looking terminal emulator which mimics the old cathode display.

Package(s) Affected
-------------------

cool-retro-term

Security Update?
----------------

No

Build Order
-----------

```
#buildit cool-retro-term
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`