### PR TITLE
navidrome: update to 0.60.3

### DIFF
--- a/app-multimedia/navidrome/autobuild/defines
+++ b/app-multimedia/navidrome/autobuild/defines
@@ -5,13 +5,8 @@ PKGDEP="ffmpeg gcc-runtime glibc taglib zlib"
 BUILDDEP="nodejs go"
 
 ABTYPE=gomod
-
 GO_BUILD_AFTER=(
     "-tags=netgo"
-)
-GO_LDFLAGS=(
-    "-X github.com/navidrome/navidrome/consts.gitSha=$(git rev-parse HEAD)"
-    "-X github.com/navidrome/navidrome/consts.gitTag=$PKGVER"
 )
 
 # FIXME: Vite not supported on loongson3, riscv64.

--- a/app-multimedia/navidrome/autobuild/patches/0001-disable-anonymous-data-collection-by-default.patch
+++ b/app-multimedia/navidrome/autobuild/patches/0001-disable-anonymous-data-collection-by-default.patch
@@ -1,4 +1,4 @@
-From ec57831fc9adcbf96849ccf3ee55bac9778ef4e0 Mon Sep 17 00:00:00 2001
+From 5e71cd4d958f2a4d739f978f46eb7a7e811de8e0 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 4 Jun 2025 10:45:50 +0800
 Subject: [PATCH] disable anonymous data collection by default
@@ -8,10 +8,10 @@ Subject: [PATCH] disable anonymous data collection by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/conf/configuration.go b/conf/configuration.go
-index c3a08bb..9f08fd2 100644
+index e2aca6c1..046bc5a6 100644
 --- a/conf/configuration.go
 +++ b/conf/configuration.go
-@@ -496,7 +496,7 @@ func setViperDefaults() {
+@@ -612,7 +612,7 @@ func setViperDefaults() {
  	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)
  	viper.SetDefault("defaultdownloadableshare", false)
  	viper.SetDefault("gatrackingid", "")
@@ -21,5 +21,5 @@ index c3a08bb..9f08fd2 100644
  	viper.SetDefault("authrequestlimit", 5)
  	viper.SetDefault("authwindowlength", 20*time.Second)
 -- 
-2.49.0
+2.53.0
 

--- a/app-multimedia/navidrome/autobuild/prepare
+++ b/app-multimedia/navidrome/autobuild/prepare
@@ -1,5 +1,18 @@
+abinfo "Setting GO_LDFLAGS..."
+GO_LDFLAGS=(
+    "-X github.com/navidrome/navidrome/consts.gitSha=$(git rev-parse HEAD)"
+    "-X github.com/navidrome/navidrome/consts.gitTag=$PKGVER"
+)
+
 abinfo "Building UI ..."
 pushd "$SRCDIR"/ui
 npm install
-npm run build
+
+# FIXME: Build error with nodejs-24 on loongarch64.
+# https://issues.chromium.org/issues/429974680
+if ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
+    node --no-liftoff "$SRCDIR"/ui/node_modules/.bin/vite build
+else
+    npm run build
+fi
 popd

--- a/app-multimedia/navidrome/spec
+++ b/app-multimedia/navidrome/spec
@@ -1,5 +1,4 @@
-VER=0.59.0
-REL=1
+VER=0.60.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/navidrome/navidrome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326646"


### PR DESCRIPTION
Topic Description
-----------------

- navidrome: update to 0.60.3
    - Fix build on loongarch64.
    - Refresh patch.

Package(s) Affected
-------------------

- navidrome: 0.60.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit navidrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
