### PR TITLE
forgejo: update to 14.0.2

### DIFF
--- a/app-web/forgejo/autobuild/build
+++ b/app-web/forgejo/autobuild/build
@@ -1,7 +1,7 @@
 abinfo "Building Forgejo ..."
 # FIXME: flag provided but not defined: -Wl,-O1,--sort-common,--as-needed
 unset LDFLAGS
-TAGS="bindata timetzdata sqlite sqlite_unlock_notify" make build
+TAGS="bindata timetzdata sqlite sqlite_unlock_notify" make backend
 
 abinfo "Installing Forgejo ..."
 install -Dvm755 "$SRCDIR"/gitea "$PKGDIR"/usr/bin/forgejo

--- a/app-web/forgejo/autobuild/defines
+++ b/app-web/forgejo/autobuild/defines
@@ -1,15 +1,7 @@
 PKGNAME=forgejo
 PKGSEC=web
-PKGDES="A code hosting platform for collaborative development"
+PKGDES="Code hosting platform for collaborative development"
 PKGDEP="glibc git"
 PKGRECOM="openssh"
-
-BUILDDEP="go nodejs"
-
-# FIXME: Autobuild does not yet support splitting out debug symbol from Go executables.
-ABSPLITDBG=0
-
-# FIXME: riscv: runtime.cgo_yield: relocation target _cgo_yield not defined
-# FIXME: loongson3: nodejs broken
-#        https://github.com/nodejs/node/issues/56973
-FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64)"
+BUILDDEP="go"
+ABTYPE=self

--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,6 +1,4 @@
-VER=11.0.0
-REL=3
-# Note: copy-repo required by auto version detection
-SRCS="git::commit=tags/v$VER;copy-repo=true::https://codeberg.org/forgejo/forgejo"
-CHKSUMS="SKIP"
+VER=14.0.2
+SRCS="tbl::https://codeberg.org/forgejo/forgejo/releases/download/v$VER/forgejo-src-$VER.tar.gz"
+CHKSUMS="sha256::422f04bfa0f615e4d686cfae9012693f821eaaf7efae8eb4905416c5633440af"
 CHKUPDATE="anitya::id=370527"


### PR DESCRIPTION
Topic Description
-----------------

- forgejo: update to 14.0.2
    - Use tarball to build, as it contains pre-built frontend files.

Package(s) Affected
-------------------

- forgejo: 14.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit forgejo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
