### PR TITLE
kubernetes: update to 1.35.1

### DIFF
--- a/app-containers/kubernetes/01-kubectl/build
+++ b/app-containers/kubernetes/01-kubectl/build
@@ -1,5 +1,7 @@
 abinfo "Building kubectl ..."
-make kubectl
+# Without "FORCE_HOST_GO=1" the build scripts will attempt to download a whole Go toolchain
+# when our Go does not match version from '.go-version'.
+FORCE_HOST_GO=1 make kubectl
 
 abinfo "Installing kubectl ..."
 install -Dvm755 "$SRCDIR"/_output/bin/kubectl -t "$PKGDIR"/usr/bin

--- a/app-containers/kubernetes/01-kubectl/defines
+++ b/app-containers/kubernetes/01-kubectl/defines
@@ -4,4 +4,4 @@ PKGDEP="glibc"
 BUILDDEP="go"
 PKGSEC="admin"
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el)"

--- a/app-containers/kubernetes/02-kubeadm/build
+++ b/app-containers/kubernetes/02-kubeadm/build
@@ -1,5 +1,5 @@
 abinfo "Building kubeadm ..."
-make kubeadm
+FORCE_HOST_GO=1 make kubeadm
 
 abinfo "Installing kubeadm ..."
 install -Dvm755 "$SRCDIR"/_output/bin/kubeadm -t "$PKGDIR"/usr/bin

--- a/app-containers/kubernetes/02-kubeadm/defines
+++ b/app-containers/kubernetes/02-kubeadm/defines
@@ -4,4 +4,4 @@ PKGDEP="glibc"
 BUILDDEP="go"
 PKGSEC="admin"
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el)"

--- a/app-containers/kubernetes/03-kubelet/build
+++ b/app-containers/kubernetes/03-kubelet/build
@@ -1,5 +1,5 @@
 abinfo "Building kubelet ..."
-make kubelet
+FORCE_HOST_GO=1 make kubelet
 
 abinfo "Installing kubelet ..."
 install -Dvm755 "$SRCDIR"/_output/bin/kubelet -t "$PKGDIR"/usr/bin

--- a/app-containers/kubernetes/03-kubelet/defines
+++ b/app-containers/kubernetes/03-kubelet/defines
@@ -4,4 +4,4 @@ PKGDEP="containerd cni-plugins"
 BUILDDEP="go"
 PKGSEC="admin"
 
-FAIL_ARCH="!(amd64|arm64|loongarch64|ppc64el)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el)"

--- a/app-containers/kubernetes/spec
+++ b/app-containers/kubernetes/spec
@@ -1,5 +1,4 @@
-VER=1.34.1
-REL=2
+VER=1.35.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/kubernetes/kubernetes"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10954"


### PR DESCRIPTION
Topic Description
-----------------

- kubernetes: update to 1.35.1
    - Build using the system's Go.
    - Support loongarch64_nosimd.

Package(s) Affected
-------------------

- kubeadm: 1.35.1
- kubectl: 1.35.1
- kubelet: 1.35.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kubernetes
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
