### PR TITLE
adguardhome: update to 0.107.72

### DIFF
--- a/app-web/adguardhome/autobuild/defines
+++ b/app-web/adguardhome/autobuild/defines
@@ -2,11 +2,9 @@ PKGNAME=adguardhome
 PKGSEC=web
 PKGDES="Network-level advertisement and tracker blocking DNS server"
 PKGDEP="glibc"
-BUILDDEP="go nodejs"
+BUILDDEP="go"
 ABTYPE=gomod
-GO_LDFLAGS=("-X github.com/AdguardTeam/AdGuardHome/internal/version.version=${PKGVER}"
-            "-X github.com/AdguardTeam/AdGuardHome/internal/version.channel=release")
-# FIXME: Build fails due to SV39 limitation on SG2042 build hosts.
-#
-# RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
-FAIL_ARCH="riscv64"
+GO_LDFLAGS=(
+    "-X 'github.com/AdguardTeam/AdGuardHome/internal/version.version=${PKGVER}'"
+    "-X 'github.com/AdguardTeam/AdGuardHome/internal/version.channel=release'"
+)

--- a/app-web/adguardhome/autobuild/prepare
+++ b/app-web/adguardhome/autobuild/prepare
@@ -1,4 +1,2 @@
-abinfo "Installing NPM dependencies ..."
-npm --prefix client ci
-abinfo "Building static assets ..."
-npm --prefix client run build-prod
+abinfo "Placing pre-built frontend resource ..."
+cp -rv "${SRCDIR}/../build" "${SRCDIR}"

--- a/app-web/adguardhome/spec
+++ b/app-web/adguardhome/spec
@@ -1,5 +1,7 @@
-VER=0.107.69
-REL=1
-SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome"
-CHKSUMS="SKIP"
+VER=0.107.72
+SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome \
+      tbl::https://github.com/AdguardTeam/AdGuardHome/releases/download/v${VER}/AdGuardHome_frontend.tar.gz"
+CHKSUMS="SKIP \
+         sha256::bfdedb78b10269d2b263fcea658b24ee7597770be1ca635d56f6419f825dfecc"
 CHKUPDATE="anitya::id=301521"
+SUBDIR="adguardhome"


### PR DESCRIPTION
Topic Description
-----------------

- adguardhome: update to 0.107.72
    - Use pre-built frontend tarball.

Package(s) Affected
-------------------

- adguardhome: 0.107.72

Security Update?
----------------

No

Build Order
-----------

```
#buildit adguardhome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
