### PR TITLE
clash-verge-rev: update to 2.4.6

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -4,8 +4,8 @@ PKGDEP="bzip2 cairo gcc-runtime gdk-pixbuf glib \
         glibc gtk-3 libsoup-3 openssl pango webkit2gtk \
         libayatana-appindicator libappindicator \
         xz mihomo clash-verge-service-ipc mihomo-rules-dat"
-BUILDDEP="nodejs rustc llvm-20 tauri-cli"
-PKGDES="A GUI configuration manager for the Clash rule-based proxy"
+BUILDDEP="nodejs rustc llvm tauri-cli"
+PKGDES="GUI configuration manager for the Clash rule-based proxy"
 PKGPROV="clash-verge"
 PKGEPOCH=1
 
@@ -14,3 +14,7 @@ FAIL_ARCH="(loongson3|riscv64)"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_0_17_8_LIMBS_are_zero
 NOLTO=1
+
+# FIXME: got Segmentation fault from pnpm with nodejs-24
+BUILDDEP__LOONGARCH64="${BUILDDEP/nodejs/nodejs-22}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP/nodejs/nodejs-22}"

--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From 55569ddb97af6b11c0c3e154aa7ca7462c5fe5a0 Mon Sep 17 00:00:00 2001
+From d1f99a1fe94060f4271ed67f5d0941fd99ed11dd Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
@@ -9,11 +9,11 @@ Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
  2 files changed, 2 insertions(+), 32 deletions(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 4a50c259..bbb69bc6 100755
+index 3b74293b..d05b350f 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -2,7 +2,7 @@
-   "version": "2.4.4",
+   "version": "2.4.6",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,
@@ -22,7 +22,7 @@ index 4a50c259..bbb69bc6 100755
      "icon": [
        "icons/32x32.png",
 diff --git a/src-tauri/tauri.linux.conf.json b/src-tauri/tauri.linux.conf.json
-index 0d5c0de3..318d0af8 100644
+index eea413dd..318d0af8 100644
 --- a/src-tauri/tauri.linux.conf.json
 +++ b/src-tauri/tauri.linux.conf.json
 @@ -1,34 +1,4 @@
@@ -33,7 +33,7 @@ index 0d5c0de3..318d0af8 100644
 -    "targets": ["deb", "rpm"],
 -    "linux": {
 -      "deb": {
--        "depends": ["openssl"],
+-        "depends": ["openssl", "libayatana-appindicator3-1"],
 -        "desktopTemplate": "./packages/linux/clash-verge.desktop",
 -        "provides": ["clash-verge"],
 -        "conflicts": ["clash-verge"],
@@ -42,7 +42,7 @@ index 0d5c0de3..318d0af8 100644
 -        "preRemoveScript": "./packages/linux/pre-remove.sh"
 -      },
 -      "rpm": {
--        "depends": ["openssl"],
+-        "depends": ["openssl", "libayatana-appindicator-gtk3"],
 -        "desktopTemplate": "./packages/linux/clash-verge.desktop",
 -        "provides": ["clash-verge"],
 -        "conflicts": ["clash-verge"],
@@ -52,9 +52,9 @@ index 0d5c0de3..318d0af8 100644
 -      }
 -    },
 -    "externalBin": [
--      "./resources/clash-verge-service",
--      "./resources/clash-verge-service-install",
--      "./resources/clash-verge-service-uninstall",
+-      "./sidecar/clash-verge-service",
+-      "./sidecar/clash-verge-service-install",
+-      "./sidecar/clash-verge-service-uninstall",
 -      "./sidecar/verge-mihomo",
 -      "./sidecar/verge-mihomo-alpha"
 -    ]

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
@@ -1,4 +1,4 @@
-From 9804bdd9269a621be9ebf19a22aa4cd9e019efc9 Mon Sep 17 00:00:00 2001
+From e1a5e9142e8def2abf4f5b9cce5bafea44319ffd Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 02/13] feat: drop mihomo-alpha support

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
@@ -1,4 +1,4 @@
-From dde41ed035887d30b66ea24e118efbfe4460dce4 Mon Sep 17 00:00:00 2001
+From b818e49e651fc9ac2983c78243737af7a1ca8094 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
@@ -9,10 +9,10 @@ Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
  2 files changed, 13 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 7325d571..a3c5e775 100644
+index abf93456..4f6acebd 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -640,18 +640,6 @@ const resolveUnSetDnsScript = () =>
+@@ -646,18 +646,6 @@ const resolveUnSetDnsScript = () =>
  // Tasks
  // =======================
  const tasks = [
@@ -32,7 +32,7 @@ index 7325d571..a3c5e775 100644
    { name: "service", func: resolveService, retry: 5 },
    { name: "install", func: resolveInstall, retry: 5 },
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index bbb69bc6..e8be2209 100755
+index d05b350f..4b3363c9 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -13,7 +13,6 @@

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
@@ -1,4 +1,4 @@
-From 0648361722d5475980b8c54614fb27a5a96e5498 Mon Sep 17 00:00:00 2001
+From 39cb3a9f3104809e1be625f9d06e44432b15a09b Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 04/13] Drop check update feature and update checker component
@@ -7,20 +7,20 @@ Co-authored-by: eatradish <sakiiily@aosc.io>
 Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  src/components/home/system-info-card.tsx      |  65 -------
- src/components/layout/update-button.tsx       |  49 -----
- src/components/setting/mods/update-viewer.tsx | 170 ------------------
+ src/components/layout/update-button.tsx       |  36 ----
+ src/components/setting/mods/update-viewer.tsx | 167 ------------------
  .../setting/setting-verge-advanced.tsx        |  27 +--
  .../setting/setting-verge-basic.tsx           |   3 -
- src/pages/_layout.tsx                         |   2 -
- 6 files changed, 1 insertion(+), 315 deletions(-)
+ src/pages/_layout.tsx                         |   1 -
+ 6 files changed, 1 insertion(+), 298 deletions(-)
  delete mode 100644 src/components/layout/update-button.tsx
  delete mode 100644 src/components/setting/mods/update-viewer.tsx
 
 diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
-index 4ec5f3b1..90689f9f 100644
+index 11fcdf91..365128f6 100644
 --- a/src/components/home/system-info-card.tsx
 +++ b/src/components/home/system-info-card.tsx
-@@ -91,36 +91,6 @@ export const SystemInfoCard = () => {
+@@ -94,36 +94,6 @@ export const SystemInfoCard = () => {
          }
        })
        .catch(console.error);
@@ -50,21 +50,21 @@ index 4ec5f3b1..90689f9f 100644
 -
 -      timeoutId = window.setTimeout(() => {
 -        if (verge?.auto_check_update) {
--          checkUpdate().catch(console.error);
+-          triggerCheckUpdate().catch(console.error);
 -        }
 -      }, 5000);
 -    }
      return () => {
        if (timeoutId !== undefined) {
          window.clearTimeout(timeoutId);
-@@ -169,23 +139,6 @@ export const SystemInfoCard = () => {
+@@ -153,23 +123,6 @@ export const SystemInfoCard = () => {
      }
    }, [isSidecarMode, isAdminMode, installServiceAndRestartCore]);
  
 -  // 检查更新
 -  const onCheckUpdate = useLockFn(async () => {
 -    try {
--      const info = await checkUpdate();
+-      const info = await triggerCheckUpdate();
 -      if (!info?.available) {
 -        showNotice.success(
 -          "settings.components.verge.advanced.notifications.latestVersion",
@@ -81,7 +81,7 @@ index 4ec5f3b1..90689f9f 100644
    // 是否启用自启动
    const autoLaunchEnabled = useMemo(
      () => verge?.enable_auto_launch || false,
-@@ -344,24 +297,6 @@ export const SystemInfoCard = () => {
+@@ -321,24 +274,6 @@ export const SystemInfoCard = () => {
            </Typography>
          </Stack>
          <Divider />
@@ -108,18 +108,16 @@ index 4ec5f3b1..90689f9f 100644
              {t("home.components.systemInfo.fields.vergeVersion")}
 diff --git a/src/components/layout/update-button.tsx b/src/components/layout/update-button.tsx
 deleted file mode 100644
-index d5c8b4ff..00000000
+index 53dba06f..00000000
 --- a/src/components/layout/update-button.tsx
 +++ /dev/null
-@@ -1,49 +0,0 @@
+@@ -1,36 +0,0 @@
 -import { Button } from "@mui/material";
 -import { useRef } from "react";
--import useSWR from "swr";
 -
--import { useVerge } from "@/hooks/use-verge";
--import { checkUpdateSafe } from "@/services/update";
+-import { DialogRef } from "@/components/base";
+-import { useUpdate } from "@/hooks/use-update";
 -
--import { DialogRef } from "../base";
 -import { UpdateViewer } from "../setting/mods/update-viewer";
 -
 -interface Props {
@@ -128,20 +126,9 @@ index d5c8b4ff..00000000
 -
 -export const UpdateButton = (props: Props) => {
 -  const { className } = props;
--  const { verge } = useVerge();
--  const { auto_check_update } = verge || {};
--
 -  const viewerRef = useRef<DialogRef>(null);
 -
--  const { data: updateInfo } = useSWR(
--    auto_check_update || auto_check_update === null ? "checkUpdate" : null,
--    checkUpdateSafe,
--    {
--      errorRetryCount: 2,
--      revalidateIfStale: false,
--      focusThrottleInterval: 36e5, // 1 hour
--    },
--  );
+-  const { updateInfo } = useUpdate();
 -
 -  if (!updateInfo?.available) return null;
 -
@@ -163,10 +150,10 @@ index d5c8b4ff..00000000
 -};
 diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
 deleted file mode 100644
-index 95e22c4f..00000000
+index 69ed5396..00000000
 --- a/src/components/setting/mods/update-viewer.tsx
 +++ /dev/null
-@@ -1,170 +0,0 @@
+@@ -1,167 +0,0 @@
 -import { Box, Button, LinearProgress } from "@mui/material";
 -import { relaunch } from "@tauri-apps/plugin-process";
 -import { open as openUrl } from "@tauri-apps/plugin-shell";
@@ -176,13 +163,13 @@ index 95e22c4f..00000000
 -import { useImperativeHandle, useMemo, useRef, useState } from "react";
 -import { useTranslation } from "react-i18next";
 -import ReactMarkdown from "react-markdown";
--import useSWR from "swr";
+-import rehypeRaw from "rehype-raw";
 -
 -import { BaseDialog, DialogRef } from "@/components/base";
+-import { useUpdate } from "@/hooks/use-update";
 -import { portableFlag } from "@/pages/_layout";
 -import { showNotice } from "@/services/notice-service";
 -import { useSetUpdateState, useUpdateState } from "@/services/states";
--import { checkUpdateSafe as checkUpdate } from "@/services/update";
 -
 -export function UpdateViewer({ ref }: { ref?: Ref<DialogRef> }) {
 -  const { t } = useTranslation();
@@ -191,11 +178,7 @@ index 95e22c4f..00000000
 -  const updateState = useUpdateState();
 -  const setUpdateState = useSetUpdateState();
 -
--  const { data: updateInfo } = useSWR("checkUpdate", checkUpdate, {
--    errorRetryCount: 2,
--    revalidateIfStale: false,
--    focusThrottleInterval: 36e5, // 1 hour
--  });
+-  const { updateInfo } = useUpdate();
 -
 -  const [downloaded, setDownloaded] = useState(0);
 -  const [total, setTotal] = useState(0);
@@ -313,6 +296,7 @@ index 95e22c4f..00000000
 -    >
 -      <Box sx={{ height: "calc(100% - 10px)", overflow: "auto" }}>
 -        <ReactMarkdown
+-          rehypePlugins={[rehypeRaw]}
 -          components={{
 -            a: ({ ...props }) => {
 -              const { children } = props;
@@ -338,10 +322,10 @@ index 95e22c4f..00000000
 -  );
 -}
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index fa214677..4f851077 100644
+index 43f95e32..42df5263 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -25,7 +25,6 @@ import { LiteModeViewer } from "./mods/lite-mode-viewer";
+@@ -24,7 +24,6 @@ import { LiteModeViewer } from "./mods/lite-mode-viewer";
  import { MiscViewer } from "./mods/misc-viewer";
  import { SettingItem, SettingList } from "./mods/setting-comp";
  import { ThemeViewer } from "./mods/theme-viewer";
@@ -349,7 +333,7 @@ index fa214677..4f851077 100644
  
  interface Props {
    onError?: (err: Error) => void;
-@@ -39,24 +38,9 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -38,24 +37,9 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
@@ -374,7 +358,7 @@ index fa214677..4f851077 100644
  
    const onExportDiagnosticInfo = useCallback(async () => {
      await exportDiagnosticInfo();
-@@ -82,7 +66,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -81,7 +65,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -382,7 +366,7 @@ index fa214677..4f851077 100644
        <BackupViewer ref={backupRef} />
        <LiteModeViewer ref={liteModeRef} />
  
-@@ -118,15 +101,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -117,15 +100,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          label={t("settings.components.verge.advanced.fields.openCoreDir")}
        />
  
@@ -400,10 +384,10 @@ index fa214677..4f851077 100644
        <SettingItem
          onClick={openDevTools}
 diff --git a/src/components/setting/setting-verge-basic.tsx b/src/components/setting/setting-verge-basic.tsx
-index b298548d..1a7621bb 100644
+index ab516d31..7a0d52d3 100644
 --- a/src/components/setting/setting-verge-basic.tsx
 +++ b/src/components/setting/setting-verge-basic.tsx
-@@ -22,7 +22,6 @@ import { MiscViewer } from "./mods/misc-viewer";
+@@ -21,7 +21,6 @@ import { MiscViewer } from "./mods/misc-viewer";
  import { SettingItem, SettingList } from "./mods/setting-comp";
  import { ThemeModeSwitch } from "./mods/theme-mode-switch";
  import { ThemeViewer } from "./mods/theme-viewer";
@@ -411,7 +395,7 @@ index b298548d..1a7621bb 100644
  
  interface Props {
    onError?: (err: Error) => void;
-@@ -67,7 +66,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
+@@ -66,7 +65,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
    const miscRef = useRef<DialogRef>(null);
    const themeRef = useRef<DialogRef>(null);
    const layoutRef = useRef<DialogRef>(null);
@@ -419,7 +403,7 @@ index b298548d..1a7621bb 100644
    const backupRef = useRef<DialogRef>(null);
  
    const onChangeData = (patch: any) => {
-@@ -89,7 +87,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
+@@ -88,7 +86,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -428,18 +412,10 @@ index b298548d..1a7621bb 100644
  
        <SettingItem label={t("settings.components.verge.basic.fields.language")}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index a5ea23cc..2c5d20d0 100644
+index 9ba2576f..ddbeab0a 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -37,7 +37,6 @@ import { NoticeManager } from "@/components/base/NoticeManager";
- import { WindowControls } from "@/components/controller/window-controller";
- import { LayoutItem } from "@/components/layout/layout-item";
- import { LayoutTraffic } from "@/components/layout/layout-traffic";
--import { UpdateButton } from "@/components/layout/update-button";
- import { useCustomTheme } from "@/components/layout/use-custom-theme";
- import { useI18n } from "@/hooks/use-i18n";
- import { useVerge } from "@/hooks/use-verge";
-@@ -335,7 +334,6 @@ const Layout = () => {
+@@ -353,7 +353,6 @@ const Layout = () => {
                    />
                    <LogoSvg fill={isDark ? "white" : "black"} />
                  </div>

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From afa1cfab6fb7316e0ddd4bfd2c14eafce522269b Mon Sep 17 00:00:00 2001
+From 7d7fe513e60c4ce50c47e022e8710f4dbca511c1 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 05/13] Set core binary name as mihomo
@@ -9,10 +9,10 @@ Co-authored-by: eatradish <sakiiily@aosc.io>
  scripts/portable.mjs                          |  7 +++---
  scripts/prebuild.mjs                          |  8 +++----
  src-tauri/packages/windows/installer.nsi      | 24 +++++++++----------
- src-tauri/src/config/verge.rs                 | 14 +++++------
+ src-tauri/src/config/verge.rs                 | 12 +++++-----
  src-tauri/src/enhance/chain.rs                |  2 +-
  .../setting/mods/clash-core-viewer.tsx        |  4 ++--
- 7 files changed, 32 insertions(+), 31 deletions(-)
+ 7 files changed, 31 insertions(+), 30 deletions(-)
 
 diff --git a/scripts/portable-fixed-webview2.mjs b/scripts/portable-fixed-webview2.mjs
 index 1a62be3f..911befb1 100644
@@ -48,10 +48,10 @@ index e1918971..ff6bf2ca 100644
    zip.addLocalFolder(configDir, ".config");
  
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index a3c5e775..7ab56423 100644
+index 4f6acebd..090cffc3 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -294,8 +294,8 @@ function clashMetaAlpha() {
+@@ -299,8 +299,8 @@ function clashMetaAlpha() {
    const isWin = platform === "win32";
    const urlExt = isWin ? "zip" : "gz";
    return {
@@ -62,7 +62,7 @@ index a3c5e775..7ab56423 100644
      exeFile: `${name}${isWin ? ".exe" : ""}`,
      zipFile: `${name}-${META_ALPHA_VERSION}.${urlExt}`,
      downloadURL: `${META_ALPHA_URL_PREFIX}/${name}-${META_ALPHA_VERSION}.${urlExt}`,
-@@ -307,8 +307,8 @@ function clashMeta() {
+@@ -312,8 +312,8 @@ function clashMeta() {
    const isWin = platform === "win32";
    const urlExt = isWin ? "zip" : "gz";
    return {
@@ -126,10 +126,10 @@ index e6fc4940..f2469ee6 100644
    ${EndIf}
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index ad43af33..84bb4bd4 100644
+index 7f9bcd9e..2821b8ec 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
-@@ -266,7 +266,7 @@ pub struct IVergeTheme {
+@@ -282,7 +282,7 @@ pub struct IVergeTheme {
  
  impl IVerge {
      /// 有效的clash核心名称
@@ -138,7 +138,7 @@ index ad43af33..84bb4bd4 100644
  
      /// 验证并修正配置文件中的clash_core值
      pub async fn validate_and_fix_config() -> Result<()> {
-@@ -284,19 +284,19 @@ impl IVerge {
+@@ -300,19 +300,19 @@ impl IVerge {
                  logging!(
                      warn,
                      Type::Config,
@@ -162,22 +162,13 @@ index ad43af33..84bb4bd4 100644
              needs_fix = true;
          }
  
-@@ -333,7 +333,7 @@ impl IVerge {
-     }
- 
-     pub fn get_valid_clash_core(&self) -> String {
--        self.clash_core.clone().unwrap_or_else(|| "verge-mihomo".into())
-+        self.clash_core.clone().unwrap_or_else(|| "mihomo".into())
-     }
- 
-     fn get_system_language() -> String {
-@@ -377,7 +377,7 @@ impl IVerge {
+@@ -380,7 +380,7 @@ impl IVerge {
          Self {
              app_log_max_size: Some(128),
              app_log_max_count: Some(8),
 -            clash_core: Some("verge-mihomo".into()),
 +            clash_core: Some("mihomo".into()),
-             language: Some(Self::get_system_language()),
+             language: Some(clash_verge_i18n::system_language().into()),
              theme_mode: Some("system".into()),
              #[cfg(not(target_os = "windows"))]
 diff --git a/src-tauri/src/enhance/chain.rs b/src-tauri/src/enhance/chain.rs

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From 744a6dd979b90148fac7db9168a190354b496ec9 Mon Sep 17 00:00:00 2001
+From a0a33c9797fc31dc14cb1268827adc51cf18b769 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 06/13] feat: always not portable

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,23 +1,20 @@
-From ceaf3e36d3f108307e876230ef60312722cd5b26 Mon Sep 17 00:00:00 2001
+From d503bf44075362c29f137f2847961f854de545e8 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 07/13] Set service install/uninstall script path to
  /usr/libexec
 
 ---
- src-tauri/src/core/service.rs | 13 ++++++++-----
- 1 file changed, 8 insertions(+), 5 deletions(-)
+ src-tauri/src/core/service.rs | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 1974473d..8dd9cea4 100644
+index 23cf8c73..a323aac4 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -113,10 +113,12 @@ async fn reinstall_service() -> Result<()> {
- 
- #[allow(clippy::unused_async)]
+@@ -113,8 +113,10 @@ fn install_service() -> Result<()> {
  #[cfg(target_os = "linux")]
--async fn uninstall_service() -> Result<()> {
-+pub async fn uninstall_service() -> Result<()> {
+ fn uninstall_service() -> Result<()> {
      logging!(info, Type::Service, "uninstall service");
 +    use std::path::Path;
  
@@ -27,13 +24,9 @@ index 1974473d..8dd9cea4 100644
  
      if !uninstall_path.exists() {
          bail!(format!("uninstaller not found: {uninstall_path:?}"));
-@@ -169,11 +171,12 @@ async fn uninstall_service() -> Result<()> {
- }
- 
+@@ -169,8 +171,10 @@ fn uninstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
--#[allow(clippy::unused_async)]
--async fn install_service() -> Result<()> {
-+pub async fn install_service() -> Result<()> {
+ fn install_service() -> Result<()> {
      logging!(info, Type::Service, "install service");
 +    use std::path::Path;
  

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From 06362ad70d01a7886ffa42ced3577d5a5819731f Mon Sep 17 00:00:00 2001
+From 1c8330b7c73218a35c48c4b96dd56c3f97bb8502 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 08/13] Do not use gcc

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
@@ -1,4 +1,4 @@
-From 45ececffcabebb68d1bd762f14e5b836d153b8a0 Mon Sep 17 00:00:00 2001
+From 5d8fe2f85b7d6c2790ed8b4527040b8f1ec98e59 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 09/13] Drop "Upgrade core" button
@@ -6,7 +6,8 @@ Subject: [PATCH 09/13] Drop "Upgrade core" button
 ---
  .../setting/mods/clash-core-viewer.tsx        | 30 -------------------
  .../setting/setting-verge-advanced.tsx        |  2 +-
- 2 files changed, 1 insertion(+), 31 deletions(-)
+ src/pages/_layout.tsx                         |  1 -
+ 3 files changed, 1 insertion(+), 32 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
 index ba6d6fb5..14e5b148 100644
@@ -57,10 +58,10 @@ index ba6d6fb5..14e5b148 100644
                variant="contained"
                size="small"
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 4f851077..ced5b782 100644
+index 42df5263..42bd9c8c 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -101,7 +101,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -100,7 +100,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          label={t("settings.components.verge.advanced.fields.openCoreDir")}
        />
  
@@ -69,6 +70,18 @@ index 4f851077..ced5b782 100644
  
        <SettingItem
          onClick={openDevTools}
+diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
+index ddbeab0a..6ef43b3c 100644
+--- a/src/pages/_layout.tsx
++++ b/src/pages/_layout.tsx
+@@ -36,7 +36,6 @@ import { BaseErrorBoundary } from "@/components/base";
+ import { LayoutItem } from "@/components/layout/layout-item";
+ import { LayoutTraffic } from "@/components/layout/layout-traffic";
+ import { NoticeManager } from "@/components/layout/notice-manager";
+-import { UpdateButton } from "@/components/layout/update-button";
+ import { WindowControls } from "@/components/layout/window-controller";
+ import { useI18n } from "@/hooks/use-i18n";
+ import { useVerge } from "@/hooks/use-verge";
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
@@ -1,4 +1,4 @@
-From 6f8b70699941da1fc543b4f99344a3e8ce329a89 Mon Sep 17 00:00:00 2001
+From e6384fcc33305446c527365894cc026dbcc76c04 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 10/13] fix: drop Open Core Dir function
@@ -14,7 +14,7 @@ This is useless for our users as it would just open /usr/bin.
  6 files changed, 1 insertion(+), 26 deletions(-)
 
 diff --git a/src-tauri/src/cmd/app.rs b/src-tauri/src/cmd/app.rs
-index 9a2fe39a..b60f95aa 100644
+index 77a98ab6..18b9678e 100644
 --- a/src-tauri/src/cmd/app.rs
 +++ b/src-tauri/src/cmd/app.rs
 @@ -20,14 +20,6 @@ pub async fn open_app_dir() -> CmdResult<()> {
@@ -33,10 +33,10 @@ index 9a2fe39a..b60f95aa 100644
  #[tauri::command]
  pub async fn open_logs_dir() -> CmdResult<()> {
 diff --git a/src-tauri/src/core/tray/menu_def.rs b/src-tauri/src/core/tray/menu_def.rs
-index 24a488fd..0f10b63e 100644
+index 7012ce21..2fd3de09 100644
 --- a/src-tauri/src/core/tray/menu_def.rs
 +++ b/src-tauri/src/core/tray/menu_def.rs
-@@ -45,7 +45,6 @@ define_menu! {
+@@ -38,7 +38,6 @@ define_menu! {
      lightweight_mode => LIGHTWEIGHT_MODE, "tray_lightweight_mode", "tray.lightweightMode",
      copy_env => COPY_ENV, "tray_copy_env", "tray.copyEnv",
      conf_dir => CONF_DIR, "tray_conf_dir", "tray.confDir",
@@ -45,10 +45,10 @@ index 24a488fd..0f10b63e 100644
      open_dir => OPEN_DIR, "tray_open_dir", "tray.openDir",
      app_log => APP_LOG, "tray_app_log", "tray.appLog",
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index ea289117..e92c94a5 100644
+index e13abd39..7377547e 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
-@@ -893,8 +893,6 @@ async fn create_tray_menu(
+@@ -786,8 +786,6 @@ async fn create_tray_menu(
  
      let open_app_dir = &MenuItem::with_id(app_handle, MenuIds::CONF_DIR, &texts.conf_dir, true, None::<&str>)?;
  
@@ -57,7 +57,7 @@ index ea289117..e92c94a5 100644
      let open_logs_dir = &MenuItem::with_id(app_handle, MenuIds::LOGS_DIR, &texts.logs_dir, true, None::<&str>)?;
  
      let open_app_log = &MenuItem::with_id(app_handle, MenuIds::APP_LOG, &texts.app_log, true, None::<&str>)?;
-@@ -906,7 +904,7 @@ async fn create_tray_menu(
+@@ -799,7 +797,7 @@ async fn create_tray_menu(
          MenuIds::OPEN_DIR,
          &texts.open_dir,
          true,
@@ -66,8 +66,8 @@ index ea289117..e92c94a5 100644
      )?;
  
      let restart_clash = &MenuItem::with_id(
-@@ -1008,9 +1006,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
-                 println!("Open directory submenu clicked");
+@@ -964,9 +962,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+             MenuIds::CONF_DIR => {
                  let _ = cmd::open_app_dir().await;
              }
 -            MenuIds::CORE_DIR => {
@@ -77,10 +77,10 @@ index ea289117..e92c94a5 100644
                  let _ = cmd::open_logs_dir().await;
              }
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 42d33c9e..4107cb9a 100644
+index bd3fa20c..bde67c87 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -142,7 +142,6 @@ mod app_init {
+@@ -139,7 +139,6 @@ mod app_init {
              cmd::open_app_dir,
              cmd::open_logs_dir,
              cmd::open_web_url,
@@ -89,10 +89,10 @@ index 42d33c9e..4107cb9a 100644
              cmd::open_core_log,
              cmd::get_portable_flag,
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index ced5b782..7333681d 100644
+index 42bd9c8c..c2f420f1 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -9,7 +9,6 @@ import {
+@@ -8,7 +8,6 @@ import {
    exitApp,
    exportDiagnosticInfo,
    openAppDir,
@@ -100,7 +100,7 @@ index ced5b782..7333681d 100644
    openDevTools,
    openLogsDir,
  } from "@/services/cmds";
-@@ -96,11 +95,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+@@ -95,11 +94,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          }
        />
  
@@ -113,7 +113,7 @@ index ced5b782..7333681d 100644
  
        <SettingItem
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index 1c227acf..5ea754a7 100644
+index d2a959e2..f5780678 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
 @@ -318,10 +318,6 @@ export async function openAppDir() {

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
@@ -1,27 +1,22 @@
-From 0252651095dfd22479c0810b863d744b4b97dcf7 Mon Sep 17 00:00:00 2001
+From d0a7b328b76b9f047f1c994dacb859a3e9b93cd8 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 11/13] fix: disable GeoData update
 
 We handle this via mihomo-rules-dat.
 ---
- scripts/prebuild.mjs                     | 19 -------------------
- src/components/setting/setting-clash.tsx | 13 +------------
- 2 files changed, 1 insertion(+), 31 deletions(-)
+ scripts/prebuild.mjs                     | 12 ------------
+ src/components/setting/setting-clash.tsx | 14 +-------------
+ 2 files changed, 1 insertion(+), 25 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 7ab56423..b0e945e4 100644
+index 090cffc3..217e7dd3 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -604,21 +604,6 @@ const resolveUninstall = () => {
+@@ -615,16 +615,6 @@ const resolveMmdb = () =>
+     file: "Country.mmdb",
+     downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb`,
    });
- };
- 
--const resolveMmdb = () =>
--  resolveResource({
--    file: "Country.mmdb",
--    downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb`,
--  });
 -const resolveGeosite = () =>
 -  resolveResource({
 -    file: "geosite.dat",
@@ -35,24 +30,20 @@ index 7ab56423..b0e945e4 100644
  const resolveEnableLoopback = () =>
    resolveResource({
      file: "enableLoopback.exe",
-@@ -641,12 +626,8 @@ const resolveUnSetDnsScript = () =>
- // =======================
- const tasks = [
-   { name: "plugin", func: resolvePlugin, retry: 5, winOnly: true },
--  { name: "service", func: resolveService, retry: 5 },
+@@ -651,8 +641,6 @@ const tasks = [
    { name: "install", func: resolveInstall, retry: 5 },
    { name: "uninstall", func: resolveUninstall, retry: 5 },
--  { name: "mmdb", func: resolveMmdb, retry: 5 },
+   { name: "mmdb", func: resolveMmdb, retry: 5 },
 -  { name: "geosite", func: resolveGeosite, retry: 5 },
 -  { name: "geoip", func: resolveGeoIP, retry: 5 },
    {
      name: "enableLoopback",
      func: resolveEnableLoopback,
 diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
-index ff182f72..666511e9 100644
+index 50d336b7..3463fd94 100644
 --- a/src/components/setting/setting-clash.tsx
 +++ b/src/components/setting/setting-clash.tsx
-@@ -65,14 +65,7 @@ const SettingClash = ({ onError }: Props) => {
+@@ -66,14 +66,7 @@ const SettingClash = ({ onError }: Props) => {
      mutateClash((old) => ({ ...old!, ...patch }), false);
    };
    const onUpdateGeo = async () => {
@@ -68,7 +59,7 @@ index ff182f72..666511e9 100644
    };
  
    // 实现DNS设置开关处理函数
-@@ -279,10 +272,6 @@ const SettingClash = ({ onError }: Props) => {
+@@ -280,11 +273,6 @@ const SettingClash = ({ onError }: Props) => {
          />
        )}
  
@@ -76,9 +67,10 @@ index ff182f72..666511e9 100644
 -        onClick={onUpdateGeo}
 -        label={t("settings.sections.clash.form.fields.updateGeoData")}
 -      />
-     </SettingList>
-   );
- };
+-
+       <SettingItem
+         label={t("settings.sections.clash.form.fields.tunnels.title")}
+         onClick={() => tunnelRef.current?.open()}
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From 7acb0dd210b748be99b85216469cc50667ed2dc4 Mon Sep 17 00:00:00 2001
+From 913fa12814d65915ff971f9215357500f053c6b2 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 12/13] Do not sidecar mihomo program
@@ -9,11 +9,11 @@ Subject: [PATCH 12/13] Do not sidecar mihomo program
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/manager/state.rs b/src-tauri/src/core/manager/state.rs
-index e2c9e230..5b88ae69 100644
+index eb4ad960..c63ff275 100644
 --- a/src-tauri/src/core/manager/state.rs
 +++ b/src-tauri/src/core/manager/state.rs
-@@ -33,7 +33,7 @@ impl CoreManager {
- 
+@@ -34,7 +34,7 @@ impl CoreManager {
+         let previous_mask = unsafe { tauri_plugin_clash_verge_sysinfo::libc::umask(0o007) };
          let (mut rx, child) = app_handle
              .shell()
 -            .sidecar(clash_core.as_str())?

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
@@ -1,4 +1,4 @@
-From cbabddaf1cae3a6cbda11244ffb68e73478748ee Mon Sep 17 00:00:00 2001
+From 5e95df22591dd8aca70448f47b5324718d4ff697 Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Sun, 9 Nov 2025 19:15:18 +0800
 Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
@@ -6,17 +6,17 @@ Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
 Signed-off-by: stydxm <stydxm@outlook.com>
 ---
  Cargo.lock           | 11 -----------
- package.json         | 15 +++++----------
+ package.json         | 13 ++++---------
  scripts/prebuild.mjs |  6 ++++--
  src-tauri/Cargo.toml |  2 +-
  vite.config.mts      |  2 +-
- 5 files changed, 11 insertions(+), 25 deletions(-)
+ 5 files changed, 10 insertions(+), 24 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 7581e385..e9b8ab6f 100644
+index d5895c0b..15f393aa 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -783,7 +783,6 @@ dependencies = [
+@@ -706,7 +706,6 @@ dependencies = [
   "dashmap 6.1.0",
   "dynify",
   "fast-float2",
@@ -24,8 +24,8 @@ index 7581e385..e9b8ab6f 100644
   "futures-channel",
   "futures-concurrency",
   "futures-lite 2.6.1",
-@@ -2519,16 +2518,6 @@ dependencies = [
-  "thiserror 2.0.17",
+@@ -2474,16 +2473,6 @@ dependencies = [
+  "thiserror 2.0.18",
  ]
  
 -[[package]]
@@ -42,24 +42,21 @@ index 7581e385..e9b8ab6f 100644
  name = "fnv"
  version = "1.0.7"
 diff --git a/package.json b/package.json
-index 09318b7a..21000939 100644
+index 083f590a..b409b093 100644
 --- a/package.json
 +++ b/package.json
-@@ -86,7 +86,7 @@
-     "@types/react": "19.2.7",
+@@ -90,7 +90,7 @@
+     "@types/react": "19.2.14",
      "@types/react-dom": "19.2.3",
      "@vitejs/plugin-legacy": "^7.2.1",
--    "@vitejs/plugin-react-swc": "^4.2.2",
-+    "@vitejs/plugin-react": "^5.1.0",
+-    "@vitejs/plugin-react-swc": "^4.2.3",
++    "@vitejs/plugin-react": "^5.1.4",
      "adm-zip": "^0.5.16",
      "cli-color": "^2.0.4",
-     "commander": "^14.0.2",
-@@ -125,15 +125,10 @@
-     ]
-   },
+     "commander": "^14.0.3",
+@@ -132,13 +132,8 @@
    "type": "module",
--  "packageManager": "pnpm@10.26.1",
-+  "packageManager": "pnpm@9.13.2",
+   "packageManager": "pnpm@10.29.2",
    "pnpm": {
 -    "onlyBuiltDependencies": [
 -      "@parcel/watcher",
@@ -75,10 +72,10 @@ index 09318b7a..21000939 100644
    }
  }
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index b0e945e4..e63da21a 100644
+index 217e7dd3..47905141 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -186,7 +186,8 @@ const META_ALPHA_MAP = {
+@@ -191,7 +191,8 @@ const META_ALPHA_MAP = {
    "linux-arm64": "mihomo-linux-arm64",
    "linux-arm": "mihomo-linux-armv7",
    "linux-riscv64": "mihomo-linux-riscv64",
@@ -88,7 +85,7 @@ index b0e945e4..e63da21a 100644
  };
  
  const META_MAP = {
-@@ -200,7 +201,8 @@ const META_MAP = {
+@@ -205,7 +206,8 @@ const META_MAP = {
    "linux-arm64": "mihomo-linux-arm64",
    "linux-arm": "mihomo-linux-armv7",
    "linux-riscv64": "mihomo-linux-riscv64",
@@ -99,18 +96,18 @@ index b0e945e4..e63da21a 100644
  
  // =======================
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index f49420a4..00c1e573 100755
+index f2273b21..3407db5e 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -59,7 +59,7 @@ open = "5.3.3"
+@@ -60,7 +60,7 @@ open = "5.3.3"
  dunce = "1.0.5"
  nanoid = "0.4"
- chrono = "0.4.42"
+ chrono = "0.4.43"
 -boa_engine = "0.21.0"
 +boa_engine = { version = "0.21.0", features = ["xsum"], default-features = false }
  once_cell = { version = "1.21.3", features = ["parking_lot"] }
- port_scanner = "0.1.5"
  delay_timer = "0.11.6"
+ percent-encoding = "2.3.2"
 diff --git a/vite.config.mts b/vite.config.mts
 index a5ef33af..3fc10b22 100644
 --- a/vite.config.mts

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=2.4.4
+VER=2.4.6
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"

--- a/app-proxy/clash-verge-service-ipc/autobuild/postinst
+++ b/app-proxy/clash-verge-service-ipc/autobuild/postinst
@@ -3,5 +3,5 @@ if systemctl is-active --quiet clash-verge-service; then
     echo "Restarting service..."
     systemctl try-restart clash-verge-service
 else
-    echo "Service is not running."
+    echo "Service is not running, skip restart."
 fi

--- a/app-proxy/clash-verge-service-ipc/autobuild/postrm
+++ b/app-proxy/clash-verge-service-ipc/autobuild/postrm
@@ -1,0 +1,8 @@
+if systemctl is-active --quiet clash-verge-service; then
+    echo "Stopping service ..."
+    systemctl stop clash-verge-service
+fi
+
+echo "Uninstalling service ..."
+sudo /usr/libexec/clash-verge-uninstall-service
+systemctl daemon-reload

--- a/app-proxy/clash-verge-service-ipc/autobuild/preinst
+++ b/app-proxy/clash-verge-service-ipc/autobuild/preinst
@@ -1,0 +1,10 @@
+if systemctl is-active --quiet clash-verge-service; then
+    echo "Stopping service ..."
+    systemctl stop clash-verge-service
+fi
+
+if [ -f "/usr/libexec/clash-verge-uninstall-service" ]; then
+    echo "Uninstalling service ..."
+    sudo /usr/libexec/clash-verge-uninstall-service
+fi
+systemctl daemon-reload

--- a/app-proxy/clash-verge-service-ipc/spec
+++ b/app-proxy/clash-verge-service-ipc/spec
@@ -1,3 +1,3 @@
-VER=2.0.26
-SRCS="git::commit=tags/v"$VER"::https://github.com/clash-verge-rev/clash-verge-service-ipc"
+VER=2.1.3
+SRCS="git::commit=v$VER::https://github.com/clash-verge-rev/clash-verge-service-ipc"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.4.6
- clash-verge-service-ipc: update to 2.1.3

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-service-ipc clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
