### PR TITLE
 gssproxy: update to 0.9.2

### DIFF
--- a/app-network/gssproxy/autobuild/beyond
+++ b/app-network/gssproxy/autobuild/beyond
@@ -4,11 +4,10 @@ rm -rf "$PKGDIR"/usr/share/doc
 install -m644 examples/gssproxy.conf "$PKGDIR"/etc/gssproxy/gssproxy.conf
 
 install -m644 examples/24-nfs-server.conf "$PKGDIR"/etc/gssproxy/24-nfs-server.conf
-install -m644 examples/99-nfs-client.conf "$PKGDIR"/etc/gssproxy/99-nfs-client.conf
+install -m644 examples/99-network-fs-clients.conf "$PKGDIR"/etc/gssproxy/99-network-fs-clients.conf
 install -m644 examples/80-httpd.conf "$PKGDIR"/etc/gssproxy/80-httpd.conf
 sed -i -e "s:euid = apache:euid = http:" "$PKGDIR"/etc/gssproxy/80-httpd.conf
 
-install -Dm644 examples/mech "$PKGDIR"/etc/gss/mech.d/gssproxy.conf
-  
+install -m700 -d "$PKGDIR"/var/lib/gssproxy/rcache
 install -m755 -d "$PKGDIR"/usr/share/licenses/$pkgname
 install -m644 COPYING "$PKGDIR"/usr/share/licenses/$pkgname/

--- a/app-network/gssproxy/autobuild/conffiles
+++ b/app-network/gssproxy/autobuild/conffiles
@@ -1,5 +1,4 @@
 /etc/gssproxy/gssproxy.conf
 /etc/gssproxy/24-nfs-server.conf
 /etc/gssproxy/80-httpd.conf
-/etc/gssproxy/99-nfs-client.conf
-/etc/gss/mech.d/gssproxy.conf
+/etc/gssproxy/99-network-fs-clients.conf

--- a/app-network/gssproxy/autobuild/defines
+++ b/app-network/gssproxy/autobuild/defines
@@ -2,9 +2,12 @@ PKGNAME=gssproxy
 PKGSEC=net
 PKGDEP="ding-libs krb5 popt systemd"
 BUILDDEP="docbook-xsl doxygen po4a"
-PKGDES="A gss-proxy protocol to allow proxying of GSSAPI context establishment and channel handling"
+PKGDES="GSS-API proxy with standardizable protocol and a reference client and server implementation"
 
-AUTOTOOLS_AFTER="--with-pubconf-path=/etc/gssproxy \
-                 --without-selinux \
-                 --with-initscript=systemd"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--with-pubconf-path=/etc/gssproxy'
+    '--without-selinux'
+    '--with-initscript=systemd'
+)
 ABSHADOW=no

--- a/app-network/gssproxy/autobuild/patch
+++ b/app-network/gssproxy/autobuild/patch
@@ -1,6 +1,0 @@
-sed -i "/# GSSPROXY will not be started until syslog is/d" systemd/gssproxy.service.in
-sed -i "/^After=syslog.target/d" systemd/gssproxy.service.in
-sed -i "s/nfs-secure.service/rpc-gssd.service/" systemd/gssproxy.service.in
-sed -i "s/nfs-secure-server.service/rpc-svcgssd.service/" systemd/gssproxy.service.in
-
-sed -i 's@^\#include <sys\/un\.h>@&\n#include <sys/uio.h>@g' src/gp_socket.c

--- a/app-network/gssproxy/autobuild/preinst
+++ b/app-network/gssproxy/autobuild/preinst
@@ -1,0 +1,3 @@
+if [ -e /etc/gssproxy/99-nfs-client.conf ]; then
+    rm -f /etc/gssproxy/99-nfs-client.conf
+fi

--- a/app-network/gssproxy/spec
+++ b/app-network/gssproxy/spec
@@ -1,4 +1,4 @@
-VER=0.8.2
-SRCS="tbl::https://releases.pagure.org/gssproxy/gssproxy-$VER.tar.gz"
-CHKSUMS="sha256::35b4039eb61399506e5e64e4d707dcfd79d4c0ca336c900bda3967b7a4ec5303"
+VER=0.9.2
+SRCS="git::commit=tags/v$VER::https://github.com/gssapi/gssproxy"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138133"


### PR DESCRIPTION
Topic Description
-----------------

- gssproxy: update to 0.9.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gssproxy: 0.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gssproxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
