### PR TITLE
libsecret: break older version of bash-completion

### DIFF
--- a/runtime-desktop/libsecret/autobuild/defines
+++ b/runtime-desktop/libsecret/autobuild/defines
@@ -36,5 +36,5 @@ MESON_AFTER__RETRO=(
 PKGPROV="libsecret-1-0_spiral"
 
 # Note: GNOME Keyring PAM module is now shipped with this package.
-PKGBREAK="gnome-keyring<=48.0"
+PKGBREAK="gnome-keyring<=48.0 bash-completion<=1:2.16.0"
 PKGREP="gnome-keyring<=48.0"

--- a/runtime-desktop/libsecret/spec
+++ b/runtime-desktop/libsecret/spec
@@ -1,4 +1,5 @@
 VER=0.21.7
+REL=1
 SRCS="https://download.gnome.org/sources/libsecret/${VER:0:4}/libsecret-$VER.tar.xz"
 CHKSUMS="sha256::6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e"
 CHKUPDATE="anitya::id=13150"


### PR DESCRIPTION
Topic Description
-----------------

- libsecret: break older version of bash-completion
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libsecret: 0.21.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsecret
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
