### PR TITLE
gawk: update to 5.4.0

### DIFF
--- a/app-utils/gawk/spec
+++ b/app-utils/gawk/spec
@@ -1,4 +1,4 @@
-VER=5.3.2
+VER=5.4.0
 SRCS="tbl::https://ftp.gnu.org/gnu/gawk/gawk-$VER.tar.xz"
-CHKSUMS="sha256::f8c3486509de705192138b00ef2c00bbbdd0e84c30d5c07d23fc73a9dc4cc9cc"
+CHKSUMS="sha256::3dd430f0cd3b4428c6c3f6afc021b9cd3c1f8c93f7a688dc268ca428a90b4ac1"
 CHKUPDATE="anitya::id=868"


### PR DESCRIPTION
Topic Description
-----------------

- gawk: update to 5.4.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gawk: 5.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gawk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
