### PR TITLE
vscode: update to 1.109.5

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.109.2
+VER=1.109.5
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::a428d744fc227cfd8bc32696db113102eb781eb7ae47bf81ef3f3278cd389694"
-CHKSUMS__ARM64="sha256::f90c30ce1578ec43d23116667e4195e36cff0129adf36d33777e09b9cf9cb046"
+CHKSUMS__AMD64="sha256::1c3837928eb11e52a53abf096ae5159619642668f0d88f86fb6b812610af580a"
+CHKSUMS__ARM64="sha256::f989b2896cca4af7acfc83252b61e1ca08ae5bcbaa9a065193380926502105cc"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.109.5
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- vscode: 1.109.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
