### PR TITLE
oma: update to 1.24.1

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.23.5
+VER=1.24.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.24.1.toml
+++ b/topics/oma-1.24.1.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.24"
+zh_CN = "小熊猫包管理 (oma) 1.24"
+
+[caution]
+default = "Improves compatibility with APT's cryptography policies and enhances logging performance with spdlog-rs"
+zh_CN = "增强对 APT 密码学算法策略的兼容性并通过引入 spdlog-rs 改善日志性能"
+
+[packages-v2]
+"oma" = "< 1.24.1"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.24.1

Package(s) Affected
-------------------

- oma: 1.24.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



