### PR TITLE
cryptography: fix openssl backend

### DIFF
--- a/lang-python/cryptography/autobuild/defines
+++ b/lang-python/cryptography/autobuild/defines
@@ -6,3 +6,4 @@ BUILDDEP="setuptools-python3 setuptools-rust appdirs wheel rustc llvm typing-ext
 
 NOPYTHON2=1
 ABTYPE=pep517
+USECLANG=1

--- a/lang-python/cryptography/spec
+++ b/lang-python/cryptography/spec
@@ -1,4 +1,5 @@
 VER=46.0.5
+REL=1
 SRCS="pypi::version=$VER::cryptography"
 CHKSUMS="sha256::abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"
 CHKUPDATE="anitya::id=5532"


### PR DESCRIPTION
Topic Description
-----------------

- cryptography: fix openssl backend
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cryptography: 46.0.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cryptography
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
