### PR TITLE
freerdp: update to 3.23.0

### DIFF
--- a/app-network/freerdp/autobuild/defines
+++ b/app-network/freerdp/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=freerdp
 PKGSEC=net
 PKGDEP="alsa-lib cups faac faad2 ffmpeg fuse-3 gsm krb5 lame libcl libusb \
-        linux-pam openh264 openssl pcsclite pulseaudio sdl2-ttf soxr wayland \
-        x11-lib libxkbcommon"
+        linux-pam openh264 openssl pcsclite pulseaudio soxr wayland \
+        x11-lib libxkbcommon sdl3 sdl-ttf sdl-image"
 BUILDDEP="docbook-xsl opencl-registry-api"
 PKGDES="Implementation of the Remote Desktop Protocol (RDP)"
 

--- a/app-network/freerdp/autobuild/defines
+++ b/app-network/freerdp/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=freerdp
 PKGSEC=net
 PKGDEP="alsa-lib cups faac faad2 ffmpeg fuse-3 gsm krb5 lame libcl libusb \
-        linux-pam openh264 openssl pcsclite pulseaudio soxr wayland \
-        x11-lib libxkbcommon sdl3 sdl-ttf sdl-image"
+        linux-pam openh264 openssl pcsclite pulseaudio soxr wayland opus \
+        x11-lib libxkbcommon sdl3 sdl3-ttf sdl3-image webkit2gtk"
 BUILDDEP="docbook-xsl opencl-registry-api"
 PKGDES="Implementation of the Remote Desktop Protocol (RDP)"
 
@@ -14,11 +14,13 @@ CMAKE_AFTER=(
     '-DWITH_CLIEN_CHANNELS=ON'
     '-DWITH_CLIENT_COMMON=ON'
     '-DWITH_CLIENT_INTERFACE=ON'
+    '-DWITH_CLIENT_SDL2=OFF'
     '-DWITH_CUPS=ON'
     '-DWITH_DSP_FFMPEG=ON'
     '-DWITH_FAAC=ON'
     '-DWITH_FAAD2=ON'
     '-DWITH_FFMPEG=ON'
+    '-DWITH_OPUS=ON'
     '-DWITH_GSM=ON'
     '-DWITH_GSSAPI=ON'
     '-DWITH_ICU=ON'
@@ -34,6 +36,8 @@ CMAKE_AFTER=(
     '-DWITH_OSS=OFF'
     '-DWITH_PAM=ON'
     '-DWITH_PCSC=ON'
+    '-DWITH_PKCS11=ON'
+    '-DWITH_WEBVIEW=ON'
     '-DWITH_PROXY=ON'
     '-DWITH_PROXY_MODULES=ON'
     '-DWITH_PULSE=ON'
@@ -47,6 +51,7 @@ CMAKE_AFTER=(
     '-DWITH_VAAPI=ON'
     '-DWITH_WAYLAND=ON'
     '-DWITH_WINPR_TOOLS=ON'
+    '-DWITH_VERBOSE_WINPR_ASSERT=OFF'
     '-DWITH_X11=ON'
     '-DWITH_XCURSOR=ON'
     '-DWITH_XDAMAGE=ON'

--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=3.17.2
+VER=3.23.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::c42c712ad879bf06607b78b8c3fad98e08c82f73f4e0bc1693552900041e692a"
+CHKSUMS="sha256::929273003f35b0b4f211e48d5abed4ebcef99da94784a50b6dc85cd0b7e257b1"
 CHKUPDATE="anitya::id=10442"

--- a/runtime-multimedia/sdl3-image/autobuild/defines
+++ b/runtime-multimedia/sdl3-image/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=sdl3-image
+PKGSEC=x11
+PKGDEP="libpng libjpeg-turbo libtiff libwebp sdl3"
+PKGDES="Image loader for the Simple Directmedia Layer (version 3)"

--- a/runtime-multimedia/sdl3-image/spec
+++ b/runtime-multimedia/sdl3-image/spec
@@ -1,0 +1,4 @@
+VER=3.4.0
+SRCS="tbl::https://www.libsdl.org/projects/SDL_image/release/SDL3_image-$VER.tar.gz"
+CHKSUMS="sha256::2ceb75eab4235c2c7e93dafc3ef3268ad368ca5de40892bf8cffdd510f29d9d8"
+CHKUPDATE="anitya::id=4781"

--- a/runtime-multimedia/sdl3-ttf/autobuild/defines
+++ b/runtime-multimedia/sdl3-ttf/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=sdl3-ttf
+PKGSEC=libs
+PKGDEP="sdl3 freetype"
+PKGDES="TrueType (.ttf) font support for the Simple Directmedia Layer (version 3)"

--- a/runtime-multimedia/sdl3-ttf/spec
+++ b/runtime-multimedia/sdl3-ttf/spec
@@ -1,0 +1,4 @@
+VER=3.2.2
+SRCS="tbl::https://www.libsdl.org/projects/SDL_ttf/release/SDL3_ttf-$VER.tar.gz"
+CHKSUMS="sha256::63547d58d0185c833213885b635a2c0548201cc8f301e6587c0be1a67e1e045d"
+CHKUPDATE="anitya::id=7988"

--- a/topics/freerdp-3.22.0.toml
+++ b/topics/freerdp-3.22.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "FreeRDP 3.23.0"
+
+[caution]
+default = "Fixes 44 security vulnerabilities disclosed by FreeRDP Security Team since January 24, 2026 (2 of high severity)"
+zh_CN = "修复 FreeRDP 安全团队自 2026 年 1 月 24 日以来披露的 44 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+freerdp = "< 3.23.0"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.23.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>
- sdl3-image: new, 3.4.0
- sdl3-ttf: new, 3.2.2
- freerdp: switch to sdl3

Package(s) Affected
-------------------

- freerdp: 2:3.23.0
- sdl3-image: 3.4.0
- sdl3-ttf: 3.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl3-ttf sdl3-image freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
