### PR TITLE
discord: update to 0.0.126

### DIFF
--- a/app-web/discord/spec
+++ b/app-web/discord/spec
@@ -1,5 +1,5 @@
-VER=0.0.125
+VER=0.0.126
 SRCS="tbl::https://dl.discordapp.net/apps/linux/$VER/discord-$VER.tar.gz"
-CHKSUMS="sha256::032294ab61898cc6a6dabee842375006106c4d86e156d9d469378b3f87a64481"
+CHKSUMS="sha256::6bad72589183702e65e92cfb00b989424cbe3c278216ceb0094f084aa0df972d"
 SUBDIR=.
 CHKUPDATE="anitya::id=372593"


### PR DESCRIPTION
Topic Description
-----------------

- discord: update to 0.0.126
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- discord: 0.0.126

Security Update?
----------------

No

Build Order
-----------

```
#buildit discord
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
