### PR TITLE
rocm: rebuild llvm rccl

### DIFF
--- a/runtime-rocm/rocm-llvm/autobuild/defines
+++ b/runtime-rocm/rocm-llvm/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=rocm-llvm
 PKGDES="LLVM customized for ROCm"
 PKGSEC=devel
 PKGDEP="gcc-runtime libxml2 libedit zlib rocm-core"
-BUILDDEP="cmake llvm llvm-20"
+BUILDDEP="cmake llvm llvm-21"
 
 USECLANG=1
 
@@ -16,8 +16,8 @@ ABTYPE=cmakeninja
 CMAKE_AFTER=(
     '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm/lib/llvm'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
-    '-DCMAKE_C_COMPILER=/usr/lib/llvm-20/bin/clang'
-    '-DCMAKE_CXX_COMPILER=/usr/lib/llvm-20/bin/clang++'
+    '-DCMAKE_C_COMPILER=/usr/lib/llvm-21/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/llvm-21/bin/clang++'
     '-DBUILD_SHARED_LIBS=ON'
     '-DLIBCXX_ENABLE_SHARED=OFF'
     '-DLIBCXX_ENABLE_STATIC=ON'

--- a/runtime-rocm/rocm-llvm/autobuild/patches/0003-rocm-llvm-loongarch64-feature-support.patch
+++ b/runtime-rocm/rocm-llvm/autobuild/patches/0003-rocm-llvm-loongarch64-feature-support.patch
@@ -1,12 +1,13 @@
 diff --git a/clang/lib/Basic/Targets/LoongArch.h b/clang/lib/Basic/Targets/LoongArch.h
-index 88dc433924d6..c829d7fad69c 100644
+index 88dc433924d6..d36cc1d8232a 100644
 --- a/clang/lib/Basic/Targets/LoongArch.h
 +++ b/clang/lib/Basic/Targets/LoongArch.h
-@@ -61,6 +61,7 @@ public:
+@@ -61,6 +61,8 @@ public:
      WCharType = SignedInt;
      WIntType = UnsignedInt;
      BitIntMaxAlign = 128;
 +    HasFloat128 = true;
++    HasBFloat16 = true;
    }
  
    bool setCPU(const std::string &Name) override {

--- a/runtime-rocm/rocm-llvm/spec
+++ b/runtime-rocm/rocm-llvm/spec
@@ -4,3 +4,4 @@ CHKSUMS="SKIP"
 SUBDIR="llvm-project/llvm"
 CHKUPDATE="anitya::id=231449"
 ENVREQ="total_mem_per_core=1"
+REL=1

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -5,3 +5,4 @@ CHKUPDATE="anitya::id=241714"
 ENVREQ="total_mem=70"
 # Note: Disable iGPU/CDNA on ARM64. Reduce build pressure.
 ENVREQ__ARM64="total_mem=50"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rccl: bump REL to trigger rebuild
- rocm-llvm: update to build against LLVM 21; add LoongArch BF16 feature support

Package(s) Affected
-------------------

- rocm-llvm: 7.2.0-1
- rocm-rccl: 7.2.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-llvm rocm-rccl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
