### PR TITLE
dracut-ng: add missing dependency libnvme

### DIFF
--- a/app-admin/dracut-ng/autobuild/defines
+++ b/app-admin/dracut-ng/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=dracut-ng
 PKGSEC=utils
-PKGDEP="arping coreutils cpio gawk kbd kmod nfs-utils util-linux systemd bash \
-        parallel isomd5sum tpm2-tools"
+PKGDEP="arping coreutils cpio gawk kbd kmod libnvme nfs-utils util-linux \
+        systemd bash parallel isomd5sum tpm2-tools"
 PKGDEP__RETRO=" \
         coreutils cpio gawk kbd kmod util-linux systemd bash parallel \
         isomd5sum tpm2-tools"

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,5 @@
 VER=108
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: add missing dependency libnvme
    Signed-off-by: Ilikara <3435193369@qq.com>
- topics: rework for freerdp-3.23.0.toml

Package(s) Affected
-------------------

- dracut-ng: 108-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
