### PR TITLE
q: update to 0.19.12

### DIFF
--- a/app-network/q/spec
+++ b/app-network/q/spec
@@ -1,5 +1,4 @@
-VER=0.19.11
-REL=1
+VER=0.19.12
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/natesales/q.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376437"


### PR DESCRIPTION
Topic Description
-----------------

- q: update to 0.19.12
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- q: 0.19.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit q
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
