### PR TITLE
sing-box: update to 1.13.0

### DIFF
--- a/app-proxy/sing-box/autobuild/defines
+++ b/app-proxy/sing-box/autobuild/defines
@@ -2,8 +2,12 @@ PKGNAME=sing-box
 PKGSEC=net
 PKGDES="A universal proxy platform"
 PKGDEP="glibc"
-BUILDDEP="go"
+BUILDDEP="go llvm"
 
 ABTYPE=gomod
 GO_LDFLAGS=("-X github.com/sagernet/sing-box/constant.Version=$PKGVER")
 GO_PACKAGES=("cmd/sing-box")
+
+# FIXME: For `with_naive_outbound`, though it does not support ppc64el.
+USECLANG=1
+USECLANG__PPC64EL=0

--- a/app-proxy/sing-box/autobuild/prepare
+++ b/app-proxy/sing-box/autobuild/prepare
@@ -11,6 +11,14 @@ TAGS=(
     "with_gvisor"
     "with_tailscale"
 )
+# FIXME: For `with_naive_outbound`, though it does not support ppc64el.
+if ! ab_match_arch ppc64el; then
+    export CGO_LDFLAGS="${LDFLAGS} -fuse-ld=lld"
+    TAGS=(
+        "${TAGS[@]}"
+        "with_naive_outbound"
+    )
+fi
 GO_BUILD_AFTER=(
     -tags "${TAGS[*]}"
 )

--- a/app-proxy/sing-box/spec
+++ b/app-proxy/sing-box/spec
@@ -1,5 +1,4 @@
-VER=1.12.20
-REL=1
+VER=1.13.0
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.13.0

Package(s) Affected
-------------------

- sing-box: 1.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
