### PR TITLE
cinny-desktop: update to 4.10.5

### DIFF
--- a/app-web/cinny-desktop/autobuild/defines
+++ b/app-web/cinny-desktop/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=cinny-desktop
 PKGSEC=web
 PKGDEP="webkit2gtk openssl gtk-3"
 BUILDDEP="nodejs rustc llvm-20"
-PKGDES="A Matrix client for desktop"
+PKGDES="Matrix client for desktop"
 
 USECLANG=1
 ABTYPE=rust
@@ -15,4 +15,6 @@ ABTYPE=rust
 #
 # FIXME: swc_ecma_codegen: index out of bounds: the len is 1 but the index is 1
 # on riscv64.
-FAIL_ARCH="(loongarch64|loongson3|riscv64)"
+#
+# FIXME: stuck at `vite v5.4.19 building for production...` on ppc64el
+FAIL_ARCH="(loongarch64|loongarch64_nosimd|loongson3|riscv64|ppc64el)"

--- a/app-web/cinny-desktop/spec
+++ b/app-web/cinny-desktop/spec
@@ -1,4 +1,4 @@
-VER=4.10.2
+VER=4.10.5
 SRCS="git::commit=tags/v$VER::https://github.com/cinnyapp/cinny-desktop"
 CHKSUMS="SKIP"
 SUBDIR="cinny-desktop/src-tauri"


### PR DESCRIPTION
Topic Description
-----------------

- cinny-desktop: update to 4.10.5
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- cinny-desktop: 4.10.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinny-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
