### PR TITLE
feh: update to 3.11.3

### DIFF
--- a/app-imaging/feh/spec
+++ b/app-imaging/feh/spec
@@ -1,4 +1,4 @@
-VER=3.11.2
+VER=3.11.3
 SRCS="tbl::https://feh.finalrewind.org/feh-$VER.tar.bz2"
-CHKSUMS="sha256::020f8bce84c709333dcc6ec5fff36313782e0b50662754947c6585d922a7a7b2"
+CHKSUMS="sha256::f2cca3592a433922c0db7a9365fd63e5402c121d932a9327e279c71be6501063"
 CHKUPDATE="anitya::id=790"


### PR DESCRIPTION
Topic Description
-----------------

- feh: update to 3.11.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- feh: 3.11.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit feh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
