### PR TITLE
gst-plugins-rs: update to 0.15.1

### DIFF
--- a/runtime-multimedia/gst-plugins-rs/autobuild/defines
+++ b/runtime-multimedia/gst-plugins-rs/autobuild/defines
@@ -15,27 +15,40 @@ MESON_AFTER=(
 )
 
 MESON_AFTER__NO_SKIA=(
-    "${MESON_AFTER[@]}"
     '-Dskia=disabled'
+)
+
+MESON_AFTER__NO_VALIDATE=(
+    '-Dvalidate=disabled'
 )
 
 # FIXME: skia-bindings missing fetch_gn support on loongarch64, loongson3,
 # ppc64el, riscv64
+# FIXME: gstreamer-validate-1-0 is unavailable on loongarch64, loongarch64_nosimd,
+# due to missing devtools in gstreamer. Check out gstreamer defines for more 
+# information
 MESON_AFTER__LOONGARCH64=(
+    "${MESON_AFTER[@]}"
     "${MESON_AFTER__NO_SKIA[@]}"
+    "${MESON_AFTER__NO_VALIDATE[@]}"
 )
 MESON_AFTER__LOONGARCH64_NOSIMD=(
+    "${MESON_AFTER[@]}"
     "${MESON_AFTER__NO_SKIA[@]}"
+    "${MESON_AFTER__NO_VALIDATE[@]}"
 )
 MESON_AFTER__LOONGSON3=(
+    "${MESON_AFTER[@]}"
     "${MESON_AFTER__NO_SKIA[@]}"
 )
 MESON_AFTER__PPC64EL=(
+    "${MESON_AFTER[@]}"
     "${MESON_AFTER__NO_SKIA[@]}"
 )
 # FIXME: libsodium-sys Invalid configuration `riscv64gc-unknown-linux-gnu':
 # machine `riscv64gc-unknown' not recognized
 MESON_AFTER__RISCV64=(
+    "${MESON_AFTER[@]}"
     "${MESON_AFTER__NO_SKIA[@]}"
     '-Dsodium=disabled'
 )

--- a/runtime-multimedia/gst-plugins-rs/spec
+++ b/runtime-multimedia/gst-plugins-rs/spec
@@ -1,4 +1,4 @@
-VER=0.14.4
+VER=0.15.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328366"


### PR DESCRIPTION
Topic Description
-----------------

- gst-plugins-rs: update to 0.15.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gst-plugins-rs: 0.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gst-plugins-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
