### PR TITLE
libfprint: update to 1.94.10

### DIFF
--- a/runtime-devices/libfprint/spec
+++ b/runtime-devices/libfprint/spec
@@ -1,4 +1,4 @@
-VER=1.94.9
+VER=1.94.10
 SRCS="https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v$VER/libfprint-v$VER.tar.gz"
-CHKSUMS="sha256::6398e7a28c91b3a16ff17e6a577c7a03692a5de509e8def817396f1120823ecf"
+CHKSUMS="sha256::8d5b202e836f69076c90ead0a654b0ee275788922359ebc9d7706bb5cde7ca54"
 CHKUPDATE="anitya::id=1615"


### PR DESCRIPTION
Topic Description
-----------------

- libfprint: update to 1.94.10
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libfprint: 1.94.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfprint
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
