### PR TITLE
libva-nvidia-driver: update to 0.0.16

### DIFF
--- a/runtime-multimedia/libva-nvidia-driver/spec
+++ b/runtime-multimedia/libva-nvidia-driver/spec
@@ -1,4 +1,4 @@
-VER=0.0.15
+VER=0.0.16
 SRCS="git::commit=tags/v$VER::https://github.com/elFarto/nvidia-vaapi-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242346"


### PR DESCRIPTION
Topic Description
-----------------

- libva-nvidia-driver: update to 0.0.16
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libva-nvidia-driver: 0.0.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit libva-nvidia-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
