### PR TITLE
nvtop: update to 3.3.2

### DIFF
--- a/app-admin/nvtop/spec
+++ b/app-admin/nvtop/spec
@@ -1,4 +1,4 @@
-VER=3.3.1
+VER=3.3.2
 SRCS="git::commit=tags/$VER::https://github.com/Syllo/nvtop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226779"


### PR DESCRIPTION
Topic Description
-----------------

- nvtop: update to 3.3.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- nvtop: 3.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvtop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
