### PR TITLE
pipewire: update to 1.6.0

### DIFF
--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -4,10 +4,16 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
-        webrtc-audio-processing libcamera wireplumber"
+        webrtc-audio-processing libcamera wireplumber x11-lib glib opus \
+        libebur128 fftw onnxruntime"
+PKGDEP__SNAPD="${PKGDEP} snapd-glib"
+PKGDEP__AMD64="${PKGDEP__SNAPD} libffado"
+PKGDEP__ARM64="${PKGDEP__SNAPD}"
+PKGDEP__PPC64EL="${PKGDEP__SNAPD}"
+PKGDEP__RISCV64="${PKGDEP__SNAPD}"
 PKGRECOM="pipewire-jack"
 
-BUILDDEP="avahi doxygen graphviz meson ninja pulseaudio sdl2"
+BUILDDEP="avahi doxygen graphviz meson ninja pulseaudio sdl2 gettext"
 
 # FIXME: Autobuild is not yet capable of generating Spiral markers for gstreamer1.0-* modules.
 PKGPROV="gstreamer1.0-pipewire_spiral"
@@ -16,21 +22,105 @@ PKGPROV="gstreamer1.0-pipewire_spiral"
 # to make building fairly straightforward as they say
 ABTYPE=meson
 MESON_AFTER=(
-    -Ddocs=disabled
-    -Dman=enabled
-    -Dgstreamer=enabled
-    -Dsystemd=enabled
-    -Dgstreamer-device-provider=enabled
-    -Djack-devel=false
-    -Dsdl2=disabled
-    -Daudiotestsrc=disabled
-    -Dvideotestsrc=disabled
-    -Dvolume=disabled
-    -Dbluez5-codec-aptx=enabled
-    -Droc=disabled
-    -Dsession-managers=/usr/bin/wireplumber
-    -Dvulkan=enabled
-    -Dffmpeg=enabled
-    -Dudevrulesdir="$LIBDIR"/udev/rules.d
-    -Drlimits-install=false
+    '-Ddocs=disabled'
+    '-Dman=enabled'
+    '-Dexamples=enabled'
+    '-Dtests=disabled'
+    '-Dinstalled_tests=disabled'
+    '-Dgstreamer=enabled'
+    '-Dgstreamer-device-provider=enabled'
+    '-Dlibsystemd=enabled'
+    '-Dlogind=enabled'
+    '-Dlogind-provider=libsystemd'
+    '-Dsystemd-system-service=disabled'
+    '-Dsystemd-user-service=enabled'
+    '-Dselinux=disabled'
+    '-Dpipewire-alsa=enabled'
+    '-Dpipewire-jack=enabled'
+    '-Dpipewire-v4l2=enabled'
+    '-Djack-devel=false'
+    '-Dspa-plugins=enabled'
+    '-Dalsa=enabled'
+    '-Daudiomixer=enabled'
+    '-Daudioconvert=enabled'
+    '-Dbluez5=enabled'
+    '-Dbluez5-backend-hsp-native=enabled'
+    '-Dbluez5-backend-hfp-native=enabled'
+    '-Dbluez5-backend-native-mm=disabled'
+    '-Dbluez5-backend-ofono=enabled'
+    '-Dbluez5-backend-hsphfpd=enabled'
+    '-Dbluez5-codec-aptx=enabled'
+    '-Dbluez5-codec-ldac=enabled'
+    '-Dbluez5-codec-ldac-dec=disabled'
+    '-Dbluez5-codec-aac=enabled'
+    '-Dbluez5-codec-lc3plus=disabled'
+    '-Dbluez5-codec-opus=enabled'
+    '-Dbluez5-codec-lc3=disabled'
+    '-Dbluez5-codec-g722=enabled'
+    '-Dbluez5-plc-spandsp=enabled'
+    '-Dcontrol=enabled'
+    '-Daudiotestsrc=enabled'
+    '-Dffmpeg=enabled'
+    '-Djack=enabled'
+    '-Dsupport=enabled'
+    '-Devl=disabled'
+    '-Dtest=disabled'
+    '-Dv4l2=enabled'
+    '-Ddbus=enabled'
+    '-Dlibcamera=enabled'
+    '-Daudiotestsrc=disabled'
+    '-Dvideotestsrc=disabled'
+    '-Dvolume=disabled'
+    '-Dvulkan=enabled'
+    '-Dpw-cat=enabled'
+    '-Dpw-cat-ffmpeg=enabled'
+    '-Dudev=enabled'
+    '-Dsdl2=enabled'
+    '-Dsndfile=enabled'
+    '-Dlibmysofa=disabled'
+    '-Dlibpulse=enabled'
+    '-Droc=disabled'
+    '-Davahi=enabled'
+    '-Dsession-managers=/usr/bin/wireplumber'
+    '-Draop=enabled'
+    '-Dlv2=enabled'
+    '-Dx11=enabled'
+    '-Dx11-xfixes=enabled'
+    '-Dlibcanberra=enabled'
+    '-Dlegacy-rtkit=true'
+    '-Davb=enabled'
+    '-Dflatpak=enabled'
+    '-Dreadline=enabled'
+    '-Dgsettings=enabled'
+    '-Dcompress-offload=enabled'
+    '-Dpam-defaults-install=false'
+    '-Drlimits-install=false'
+    '-Dopus=enabled'
+    '-Dlibffado=disabled'
+    '-Dgsettings-pulse-schema=enabled'
+    '-Dsnap=disabled'
+    '-Debur128=enabled'
+    '-Dfftw=enabled'
+    '-Donnxruntime=enabled'
+    "-Dudevrulesdir=${LIBDIR}/udev/rules.d"
+)
+MESON_AFTER__SNAPD=(
+    '-Dsnap=enabled'
+)
+MESON_AFTER__AMD64=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
+    '-Dlibffado=enabled'
+)
+MESON_AFTER__ARM64=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
+)
+MESON_AFTER__PPC64EL=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
+)
+MESON_AFTER__RISCV64=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
 )

--- a/app-multimedia/pipewire/autobuild/defines.stage2
+++ b/app-multimedia/pipewire/autobuild/defines.stage2
@@ -4,29 +4,123 @@ PKGDES="Server and user space API to deal with multimedia pipelines"
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
-        webrtc-audio-processing libcamera"
+        webrtc-audio-processing libcamera x11-lib glib opus \
+        libebur128 fftw onnxruntime"
+PKGDEP__SNAPD="${PKGDEP} snapd-glib"
+PKGDEP__AMD64="${PKGDEP__SNAPD} libffado"
+PKGDEP__ARM64="${PKGDEP__SNAPD}"
+PKGDEP__PPC64EL="${PKGDEP__SNAPD}"
+PKGDEP__RISCV64="${PKGDEP__SNAPD}"
+PKGRECOM="pipewire-jack"
 
-BUILDDEP="avahi doxygen graphviz meson ninja pulseaudio sdl2"
+BUILDDEP="avahi doxygen graphviz meson ninja pulseaudio sdl2 gettext"
+
+# FIXME: Autobuild is not yet capable of generating Spiral markers for gstreamer1.0-* modules.
+PKGPROV="gstreamer1.0-pipewire_spiral"
 
 # Must specify ABTYPE here because PipeWire owns Makefiles in the source root
 # to make building fairly straightforward as they say
 ABTYPE=meson
 MESON_AFTER=(
-    -Ddocs=disabled
-    -Dman=enabled
-    -Dgstreamer=enabled
-    -Dsystemd=enabled
-    -Dgstreamer-device-provider=enabled
-    -Djack-devel=false
-    -Dsdl2=disabled
-    -Daudiotestsrc=disabled
-    -Dvideotestsrc=disabled
-    -Dvolume=disabled
-    -Dbluez5-codec-aptx=enabled
-    -Droc=disabled
+    '-Ddocs=disabled'
+    '-Dman=enabled'
+    '-Dexamples=enabled'
+    '-Dtests=disabled'
+    '-Dinstalled_tests=disabled'
+    '-Dgstreamer=enabled'
+    '-Dgstreamer-device-provider=enabled'
+    '-Dlibsystemd=enabled'
+    '-Dlogind=enabled'
+    '-Dlogind-provider=libsystemd'
+    '-Dsystemd-system-service=disabled'
+    '-Dsystemd-user-service=enabled'
+    '-Dselinux=disabled'
+    '-Dpipewire-alsa=enabled'
+    '-Dpipewire-jack=enabled'
+    '-Dpipewire-v4l2=enabled'
+    '-Djack-devel=false'
+    '-Dspa-plugins=enabled'
+    '-Dalsa=enabled'
+    '-Daudiomixer=enabled'
+    '-Daudioconvert=enabled'
+    '-Dbluez5=enabled'
+    '-Dbluez5-backend-hsp-native=enabled'
+    '-Dbluez5-backend-hfp-native=enabled'
+    '-Dbluez5-backend-native-mm=disabled'
+    '-Dbluez5-backend-ofono=enabled'
+    '-Dbluez5-backend-hsphfpd=enabled'
+    '-Dbluez5-codec-aptx=enabled'
+    '-Dbluez5-codec-ldac=enabled'
+    '-Dbluez5-codec-ldac-dec=disabled'
+    '-Dbluez5-codec-aac=enabled'
+    '-Dbluez5-codec-lc3plus=disabled'
+    '-Dbluez5-codec-opus=enabled'
+    '-Dbluez5-codec-lc3=disabled'
+    '-Dbluez5-codec-g722=enabled'
+    '-Dbluez5-plc-spandsp=enabled'
+    '-Dcontrol=enabled'
+    '-Daudiotestsrc=enabled'
+    '-Dffmpeg=enabled'
+    '-Djack=enabled'
+    '-Dsupport=enabled'
+    '-Devl=disabled'
+    '-Dtest=disabled'
+    '-Dv4l2=enabled'
+    '-Ddbus=enabled'
+    '-Dlibcamera=enabled'
+    '-Daudiotestsrc=disabled'
+    '-Dvideotestsrc=disabled'
+    '-Dvolume=disabled'
+    '-Dvulkan=enabled'
+    '-Dpw-cat=enabled'
+    '-Dpw-cat-ffmpeg=enabled'
+    '-Dudev=enabled'
+    '-Dsdl2=enabled'
+    '-Dsndfile=enabled'
+    '-Dlibmysofa=disabled'
+    '-Dlibpulse=enabled'
+    '-Droc=disabled'
+    '-Davahi=enabled'
     '-Dsession-managers=[]'
-    -Dvulkan=enabled
-    -Dffmpeg=enabled
-    -Dudevrulesdir="$LIBDIR"/udev/rules.d
-    -Drlimits-install=false
+    '-Draop=enabled'
+    '-Dlv2=enabled'
+    '-Dx11=enabled'
+    '-Dx11-xfixes=enabled'
+    '-Dlibcanberra=enabled'
+    '-Dlegacy-rtkit=true'
+    '-Davb=enabled'
+    '-Dflatpak=enabled'
+    '-Dreadline=enabled'
+    '-Dgsettings=enabled'
+    '-Dcompress-offload=enabled'
+    '-Dpam-defaults-install=false'
+    '-Drlimits-install=false'
+    '-Dopus=enabled'
+    '-Dlibffado=disabled'
+    '-Dgsettings-pulse-schema=enabled'
+    '-Dsnap=disabled'
+    '-Debur128=enabled'
+    '-Dfftw=enabled'
+    '-Donnxruntime=enabled'
+    "-Dudevrulesdir=${LIBDIR}/udev/rules.d"
+)
+MESON_AFTER__SNAPD=(
+    '-Dsnap=enabled'
+)
+MESON_AFTER__AMD64=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
+    '-Dlibffado=enabled'
+)
+MESON_AFTER__ARM64=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
+)
+MESON_AFTER__PPC64EL=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
+)
+MESON_AFTER__RISCV64=(
+    "${MESON_AFTER[@]}"
+    "${MESON_AFTER__SNAPD[@]}"
 )

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,4 @@
-VER=1.4.10
-REL=1
+VER=1.6.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: update to 1.6.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- pipewire: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
