### PR TITLE
pyproject-metadata: update to 0.11.0

### DIFF
--- a/lang-python/pyproject-metadata/spec
+++ b/lang-python/pyproject-metadata/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
+VER=0.11.0
 SRCS="pypi::version=$VER::pyproject_metadata"
-CHKSUMS="sha256::b8b2253dd1b7062b78cf949a115f02ba7fa4114aabe63fa10528e9e1a954a816"
+CHKSUMS="sha256::c72fa49418bb7c5a10f25e050c418009898d1c051721d19f98a6fb6da59a66cf"
 CHKUPDATE="anitya::id=255630"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pyproject-metadata: update to 0.11.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- pyproject-metadata: 0.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyproject-metadata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
