### PR TITLE
racket: update to 9.1

### DIFF
--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=9.0
+VER=9.1
 SRCS="tbl::https://download.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::a05f54103789477da8e6facabb777049477c4c3998c5865c0d7ce285d3577411"
+CHKSUMS="sha256::1062dce1826884a2a758b565318570440dfd06699f1b1c47cd27d805e4f6833e"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 9.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- racket: 9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
