### PR TITLE
waydroid: update to 1.6.2

### DIFF
--- a/app-emulation/waydroid/spec
+++ b/app-emulation/waydroid/spec
@@ -1,5 +1,4 @@
-VER=1.6.1
+VER=1.6.2
 SRCS="git::commit=tags/$VER::https://github.com/waydroid/waydroid"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=314286"
-REL="1"

--- a/lang-python/gbinder-python/spec
+++ b/lang-python/gbinder-python/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
+VER=1.3.1
 SRCS="git::commit=tags/$VER::https://github.com/erfanoabdi/gbinder-python"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=312572"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- waydroid: update to 1.6.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- waydroid: 1.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gbinder-python waydroid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
