### PR TITLE
zathura: update to 2026.02.22

### DIFF
--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=2026.02.03
+VER=2026.02.22
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"


### PR DESCRIPTION
Topic Description
-----------------

- zathura: update to 2026.02.22
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- zathura: 2026.02.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
