### PR TITLE
gn: update to 0+git20260226

### DIFF
--- a/app-devel/gn/autobuild/build
+++ b/app-devel/gn/autobuild/build
@@ -1,6 +1,6 @@
 abinfo "Generating build rules ..."
 python3 \
-    "$SRCDIR"/build/gen.py
+    "$SRCDIR"/build/gen.py --allow-warnings
 
 abinfo "Building gn ..."
 ninja \

--- a/app-devel/gn/spec
+++ b/app-devel/gn/spec
@@ -1,3 +1,3 @@
-VER=0+git20250718
-SRCS="git::commit=85f62c164c829442fb662f6aa1243c02bcc47155;copy-repo=true::https://gn.googlesource.com/gn"
+VER=0+git20260226
+SRCS="git::commit=1a310e88443018837759c952b113846b0096f65b;copy-repo=true::https://gn.googlesource.com/gn"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- gn: update to 0+git20260226
    Add a workaround for -Werror=comment.
    Link: https://gn.issues.chromium.org/issues/488456166 \("Compilation
    failure: ../src/gn/header_checker.h:109:3: error: multi-line comment"\)

Package(s) Affected
-------------------

- gn: 1:0+git20260226

Security Update?
----------------

No

Build Order
-----------

```
#buildit gn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
