### PR TITLE
uv: update to 0.10.7

### DIFF
--- a/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
+++ b/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
@@ -1,0 +1,48 @@
+From 588f908c973cdefa3be17469a6f9744ba1a50ab6 Mon Sep 17 00:00:00 2001
+From: Rong Bao <rong.bao@csmantle.top>
+Date: Sat, 28 Feb 2026 13:11:54 +0800
+Subject: [PATCH] AOSCOS: Relax ELF parsing mode
+
+uv finds the libc version on the current platform by looking at the
+name of dynamic linker (ld). It finds ld by parsing several well-known
+ELF executables. This process can be problematic when the underlying ELF
+parsing library, i.e. goblin, has trouble on a particular platform.
+
+For example, goblin does not handle MIPS64's non-standard relocation
+layout well. This is causing commands like `uv python list` to fail on
+Loongson3 (MIPS64).
+
+This patch works around this problem by lowering the strictness when
+parsing ELFs to prevent goblin from giving up continuing.
+
+Link: https://github.com/m4b/goblin/issues/274 ("MIPS64 parse error:
+ "type is too big (1236271128) for 137416")
+Signed-off-by: Rong Bao <rong.bao@csmantle.top>
+---
+ crates/uv-platform/src/libc.rs | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/crates/uv-platform/src/libc.rs b/crates/uv-platform/src/libc.rs
+index edf05255e..015be4b1f 100644
+--- a/crates/uv-platform/src/libc.rs
++++ b/crates/uv-platform/src/libc.rs
+@@ -6,6 +6,7 @@
+ use crate::cpuinfo::detect_hardware_floating_point_support;
+ use fs_err as fs;
+ use goblin::elf::Elf;
++use goblin::options::ParseOptions as ElfParseOptions;
+ use regex::Regex;
+ use std::fmt::Display;
+ use std::io;
+@@ -319,7 +320,7 @@ fn find_ld_path_at(path: impl AsRef<Path>) -> Option<PathBuf> {
+     let path = path.as_ref();
+     // Not all linux distributions have all of these paths.
+     let buffer = fs::read(path).ok()?;
+-    let elf = match Elf::parse(&buffer) {
++    let elf = match Elf::parse_with_opts(&buffer, &ElfParseOptions::permissive()) {
+         Ok(elf) => elf,
+         Err(err) => {
+             trace!(
+-- 
+2.53.0.windows.1
+

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,5 +1,4 @@
-VER=0.10.6
-REL=1
+VER=0.10.7
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,5 @@
 VER=0.10.6
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.10.7
- uv: add workaround for arch detection on Loongson3

Package(s) Affected
-------------------

- uv: 0.10.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
