### PR TITLE
gwenview: rebuild for exiv2

### DIFF
--- a/desktop-kde/gwenview/spec
+++ b/desktop-kde/gwenview/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/gwenview-$VER.tar.xz"
 CHKSUMS="sha256::a4fcd1c053b750d26ea8a9183208ecb5ed1d9b281625de3393e14f8bdc169038"
 CHKUPDATE="anitya::id=8763"

--- a/runtime-imaging/exiv2/autobuild/defines
+++ b/runtime-imaging/exiv2/autobuild/defines
@@ -13,6 +13,6 @@ CMAKE_AFTER=(
 )
 
 PKGBREAK="darktable<=1:5.4.0 digikam<=8.8.0 gexiv2<=0.14.6 \
-          gwenview<=23.08.5-1 gwenview-trinity<=14.1.5 hugin<=2024.0.1-"1" \
+          gwenview<=23.08.5-2 gwenview-trinity<=14.1.5 hugin<=2024.0.1-"1" \
           kfilemetadata<=5.115.0-3 koko<=23.08.5 krita<=5.2.14-"2" \
           libkexiv2<=23.08.5 libkexiv2-trinity<=14.1.5 qgis<=3.44.6"

--- a/runtime-imaging/exiv2/spec
+++ b/runtime-imaging/exiv2/spec
@@ -1,4 +1,5 @@
 VER=0.28.7
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/Exiv2/exiv2"
 CHKSUMS=SKIP
 CHKUPDATE="anitya::id=769"


### PR DESCRIPTION
Topic Description
-----------------

- gwenview: rebuild for exiv2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gwenview: 23.08.5-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gwenview exiv2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
