### PR TITLE
charset-normalizer: update to 3.4.4

### DIFF
--- a/lang-python/charset-normalizer/autobuild/defines
+++ b/lang-python/charset-normalizer/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=charset-normalizer
 PKGSEC=python
 PKGDEP="python-3"
 BUILDDEP="setuptools"
-PKGDES="A Python module for detecting character sets"
+PKGDES="Python module for detecting character sets"
 
 ABHOST=noarch
 ABTYPE=python

--- a/lang-python/charset-normalizer/spec
+++ b/lang-python/charset-normalizer/spec
@@ -1,5 +1,4 @@
-VER=2.0.9
-REL="2"
-SRCS="tbl::https://files.pythonhosted.org/packages/source/c/charset-normalizer/charset-normalizer-$VER.tar.gz"
-CHKSUMS="sha256::b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
+VER=3.4.4
+SRCS="pypi::version=$VER::charset-normalizer"
+CHKSUMS="sha256::94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"
 CHKUPDATE="anitya::id=55366"


### PR DESCRIPTION
Topic Description
-----------------

- charset-normalizer: update to 3.4.4
    Signed-off-by: stydxm <stydxm@outlook.com>
- topics: rework for exiv2-0.28.7.toml
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- charset-normalizer: 3.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit charset-normalizer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
