### PR TITLE
mupdf: update to 1.27.2

### DIFF
--- a/app-doc/mupdf/spec
+++ b/app-doc/mupdf/spec
@@ -1,4 +1,4 @@
-VER=1.27.0
+VER=1.27.2
 EPOCH=1
 SRCS="git::commit=tags/$VER::https://github.com/ArtifexSoftware/mupdf"
 CHKSUMS="SKIP"

--- a/topics/mupdf-1.27.2.toml
+++ b/topics/mupdf-1.27.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "MuPDF 1.27.2"
+
+[caution]
+default = "Fixes a double-free vulnerability - CVE-2026-25556 (Severity: High)"
+zh_CN = "修复一个双重释放漏洞，漏洞编号 CVE-2026-25556（严重性：高）"
+
+[packages-v2]
+"mupdf" = "< 1:1.27.2"


### PR DESCRIPTION
Topic Description
-----------------

- mupdf: update to 1.27.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- mupdf: 1.27.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mupdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
