### PR TITLE
0ad: update to 0.28.0

### DIFF
--- a/app-games/0ad/autobuild/build
+++ b/app-games/0ad/autobuild/build
@@ -49,10 +49,5 @@ install -Dvm644 "$SRCDIR"/build/resources/0ad.appdata.xml \
     "$PKGDIR"/usr/share/appdata/0ad.appdata.xml
 
 abinfo "Installing game data ..."
-tar xvf "$SRCDIR"/../data.tar.xz
-cp -rv "$SRCDIR"/0ad-$PKGVER/binaries/data \
+cp -rv "$SRCDIR"/binaries/data \
     "$PKGDIR"/usr/share/0ad/
-
-abinfo "Installing zh-lang mod ..."
-cp -v "$SRCDIR"/../zh-lang.zip \
-    "$PKGDIR"/usr/share/0ad/data/mods/public/

--- a/app-games/0ad/autobuild/defines
+++ b/app-games/0ad/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=0ad
 PKGSEC=games
 PKGDEP="binutils boost curl enet libogg libpng libvorbis libxml2 openal-soft \
         sdl wxgtk3 zlib mesa glu gloox miniupnpc icu nspr fmt"
-BUILDDEP="rustc llvm"
+BUILDDEP="rustc llvm cbindgen"
 PKGDES="RTS (Real Time Strategy) Game of Ancient Warfare"
 
 ABTYPE=self
@@ -10,6 +10,11 @@ ABTYPE=self
 # ld: undefined reference to `RustMozCrash'
 # Setting USECLANG=1 does not fix this problem.
 NOLTO=1
+
+# FIXME: Fails to build with exceptions.
+#
+# Link: https://bugzilla.redhat.com/show_bug.cgi?id=2304756
+AB_FLAGS_EXC=0
 
 # FIXME: No premake support.
 FAIL_ARCH="(loongson3|ppc64el)"

--- a/app-games/0ad/autobuild/patches/0003-fix-missing-fonts.patch
+++ b/app-games/0ad/autobuild/patches/0003-fix-missing-fonts.patch
@@ -1,0 +1,16 @@
+upstream project has a typo, accidentally wrote `zh` instead of `zh_CN`
+which leads to missing fonts
+https://gitea.wildfiregames.com/0ad/0ad/issues/8847
+diff --git a/binaries/data/config/default.cfg b/binaries/data/config/default.cfg
+index 77bd195033..2b2e7fb387 100644
+--- a/binaries/data/config/default.cfg
++++ b/binaries/data/config/default.cfg
+@@ -670,7 +670,7 @@ regular = "DejaVuSansMono.ttf", "FreeMono.ttf"
+ regular = "SourceHanSansJP-Regular.otf"
+ bold = "SourceHanSansJP-Bold.otf"
+ 
+-[fonts.zh.sans]
++[fonts.zh_CN.sans]
+ regular = "SourceHanSansCN-Regular.otf"
+ bold = "SourceHanSansCN-Bold.otf"
+ 

--- a/app-games/0ad/autobuild/prepare
+++ b/app-games/0ad/autobuild/prepare
@@ -1,5 +1,4 @@
-# FIXME: Whilst configuring the bundled JS 115:
-#
-#   0:01.62 mozbuild.configure.options.InvalidOptionError: RUSTFLAGS takes 1 value
+# FIXME: Whilst configuring the bundled JS 128:
+# mozbuild.configure.options.InvalidOptionError: RUSTFLAGS takes 1 value
 abinfo "Unsetting RUSTFLAGS ..."
 unset RUSTFLAGS

--- a/app-games/0ad/spec
+++ b/app-games/0ad/spec
@@ -1,9 +1,7 @@
-VER=0.27.1
-REL=2
+VER=0.28.0
 SRCS="tbl::https://sourceforge.net/projects/zero-ad/files/releases/0ad-${VER}-unix-build.tar.xz \
-      file::rename=data.tar.xz::https://sourceforge.net/projects/zero-ad/files/releases/0ad-${VER}-unix-data.tar.xz \
-      file::rename=zh-lang.zip::https://releases.wildfiregames.com/locales/zh-lang-0.27.0.pyromod"
-CHKSUMS="sha256::a0a5355eeb5968d24f283770736150d974dafecba07754d4662707dc17016bfb \
-         sha256::837e2d6ddf138b025fc02017245d7581a4bb84fd94b42c0e605d321b7017a998 \
-         sha256::a4c03d34857949c04574108ccedc672c4d45401e12d9b231731bdecedb0748aa"
+      tbl::https://sourceforge.net/projects/zero-ad/files/releases/0ad-${VER}-unix-data.tar.xz"
+CHKSUMS="sha256::27e217755ef76a922fe58dbf593d96e54b6ed2375d23f548c35619aa6bd5a42a \
+         sha256::e844b30ae2102c47e0a4fff2f0e0ef05ba0cebb1890aa72276fa12457c39526f"
+SUBDIR="0ad-$VER"
 CHKUPDATE="anitya::id=5830"


### PR DESCRIPTION
Topic Description
-----------------

- 0ad: update to 0.28.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- 0ad: 0.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit 0ad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
