### PR TITLE
noctalia-qs: new, 0.0.4

### DIFF
--- a/runtime-desktop/noctalia-qs/autobuild/defines
+++ b/runtime-desktop/noctalia-qs/autobuild/defines
@@ -1,9 +1,9 @@
-PKGNAME=quickshell
+PKGNAME=noctalia-qs
 PKGSEC=libs
-PKGDES="Toolkit for making desktop shells"
+PKGDES="Fork of Quickshell for Noctalia Shell"
 PKGDEP="gcc-runtime glibc jemalloc libdrm libxcb linux-pam mesa pipewire qt-6 wayland"
 BUILDDEP="cli11 cmake ninja pkgconf spirv-tools wayland-protocols"
-PKGCONFL="noctalia-qs"
+PKGCONFL="quickshell"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(

--- a/runtime-desktop/noctalia-qs/spec
+++ b/runtime-desktop/noctalia-qs/spec
@@ -1,0 +1,4 @@
+VER=0.0.4
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/noctalia-dev/noctalia-qs"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=388550"

--- a/runtime-desktop/quickshell/spec
+++ b/runtime-desktop/quickshell/spec
@@ -2,4 +2,4 @@ VER=0.2.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/quickshell-mirror/quickshell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378649"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- noctalia-qs: new, 0.0.4

Package(s) Affected
-------------------

- noctalia-qs: 0.0.4
- quickshell: 0.2.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit quickshell noctalia-qs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
