### PR TITLE
osu-lazer: update to 2026.305.0+lazer & add non-x86 support

### DIFF
--- a/app-games/osu-lazer/autobuild/beyond
+++ b/app-games/osu-lazer/autobuild/beyond
@@ -1,2 +1,0 @@
-abinfo "Removing PDB files..."
-find "$PKGDIR"/usr/lib/osu-lazer/ -name "*.pdb" -delete -print

--- a/app-games/osu-lazer/autobuild/build
+++ b/app-games/osu-lazer/autobuild/build
@@ -34,7 +34,7 @@ if ab_match_arch loongarch64; then
     cmake . \
         "${CMAKE_DEF[@]}" \
         -GNinja
-    ninja
+    ninja libveldrid-spirv.so
 
     # FIXME: It seems that osu! would only accept native runtime under the
     # same path as the main executable.
@@ -54,11 +54,7 @@ if ab_match_arch loongarch64; then
         -DREALM_USE_SYSTEM_OPENSSL=YES \
         -DREALM_USE_SYSTEM_OPENSSL_PATHS=YES \
         -GNinja
-    # FIXME: ld.lld fails on LoongArch.
-    #
-    # ld.lld: error: undefined symbol: sqlite3_finalize
-    # 	>>> referenced by raw_statement.rs:194 (/root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rusqlite-0.31.0/src/raw_statement.rs:194)
-    mold -run ninja
+    ninja src/librealm-wrappers.so
 
     # FIXME: It seems that osu! would only accept native runtime under the
     # same path as the main executable.
@@ -73,7 +69,7 @@ if ab_match_arch loongarch64; then
     cmake . \
         "${CMAKE_DEF[@]}" \
         -GNinja
-    ninja
+    ninja libstbi.so
 
     # FIXME: It seems that osu! would only accept native runtime under the
     # same path as the main executable.

--- a/app-games/osu-lazer/autobuild/build
+++ b/app-games/osu-lazer/autobuild/build
@@ -1,8 +1,127 @@
-abinfo "Build osu.Desktop"
-dotnet publish "$SRCDIR"/osu.Desktop/osu.Desktop.csproj -c Release \
-    -o "$PKGDIR"/usr/lib/osu-lazer \
-    -r linux-x64 --no-self-contained
+abinfo "Setting DOTNET_ARCH variable for later ..."
+case $ARCH in
+    amd64)
+        DOTNET_ARCH="x64"
+        ;;
+    arm64)
+        DOTNET_ARCH="arm64"
+        ;;
+    loongarch64)
+        DOTNET_ARCH="loongarch64"
+        ;;
+esac
+abinfo "DOTNET_ARCH: $DOTNET_ARCH ..."
 
-abinfo "Deploy files"
-chmod 0755 "$PKGDIR"/usr/lib/osu-lazer/'osu!'
-install -Dm644 "$SRCDIR"/assets/lazer.png "$PKGDIR"/usr/share/pixmaps/osu-lazer.png
+abinfo "Building osu-lazer (osu.Desktop) ..."
+dotnet publish \
+    "$SRCDIR"/osu/osu.Desktop/osu.Desktop.csproj \
+    -c Release \
+    -o "$PKGDIR"/usr/lib/osu-lazer \
+    --no-self-contained
+
+# FIXME: No upstream runtime bundle available for LoongArch.
+if ab_match_arch loongarch64; then
+    abinfo "Preparing to build runtime libraries ..."
+    mkdir -pv "$SRCDIR"/libs-prepared
+
+    abinfo "Building libveldrid-spirv: entry ..."
+    cd "$SRCDIR"/veldrid-spirv/
+
+    abinfo "Building libveldrid-spirv: synching shaderc sources ..."
+    ./ext/sync-shaderc.sh
+
+    abinfo "Building libveldrid-spirv: configuring and building ..."
+    cmake . \
+        "${CMAKE_DEF[@]}" \
+        -GNinja
+    ninja
+
+    # FIXME: It seems that osu! would only accept native runtime under the
+    # same path as the main executable.
+    abinfo "Building libveldrid-spirv: installing ..."
+    install -Dvm744 ./libveldrid-spirv.so \
+        "$PKGDIR"/usr/lib/osu-lazer/libveldrid-spirv.so
+
+    abinfo "Building librealm-wrappers: entry ..."
+    cd "$SRCDIR"/realm-dotnet/wrappers/
+
+    abinfo "Building librealm-wrappers: configuring and building ..."
+    mkdir -pv build
+    cd build
+
+    cmake .. \
+        "${CMAKE_DEF[@]}" \
+        -DREALM_USE_SYSTEM_OPENSSL=YES \
+        -DREALM_USE_SYSTEM_OPENSSL_PATHS=YES \
+        -GNinja
+    # FIXME: ld.lld fails on LoongArch.
+    #
+    # ld.lld: error: undefined symbol: sqlite3_finalize
+    # 	>>> referenced by raw_statement.rs:194 (/root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rusqlite-0.31.0/src/raw_statement.rs:194)
+    mold -run ninja
+
+    # FIXME: It seems that osu! would only accept native runtime under the
+    # same path as the main executable.
+    abinfo "Building librealm-wrappers: moving built library to libs-prepared ..."
+    install -Dvm755 ./src/librealm-wrappers.so \
+        "$PKGDIR"/usr/lib/osu-lazer/librealm-wrappers.so
+
+    abinfo "Building stbi-sharp: entry ..."
+    cd "$SRCDIR"/stbi-sharp/libstbi
+
+    abinfo "Building stbi-sharp: configuring and building ..."
+    cmake . \
+        "${CMAKE_DEF[@]}" \
+        -GNinja
+    ninja
+
+    # FIXME: It seems that osu! would only accept native runtime under the
+    # same path as the main executable.
+    abinfo "Building stbi-sharp: moving built library to libs-prepared ..."
+    install -Dvm755 ./libstbi.so \
+        "$PKGDIR"/usr/lib/osu-lazer/libstbi.so
+
+    # FIXME: It seems that osu! would only accept libbass*.so under the
+    # same path of the main executable.
+    abinfo "Installing libbass..."
+    install -Dvm755 "$SRCDIR"/libbass*.so \
+        -t "$PKGDIR"/usr/lib/osu-lazer/
+
+    # FIXME: SourceGear.sqlite3 does not contain libe_sqlite3.so for loongarch64.
+    #
+    # Link: https://github.com/ericsink/cb/pull/29
+    #
+    # FIXME: It seems that osu! would only accept native runtime under the
+    # same path as the main executable.
+    abinfo "Creating a symlink to system SQLite ..."
+    ln -sv ../libsqlite3.so \
+        "$PKGDIR"/usr/lib/osu-lazer/libe_sqlite3.so
+fi
+
+abinfo "Setting executable bit on the main executable ..."
+chmod -v +x "$PKGDIR"/usr/lib/osu-lazer/'osu!'
+
+abinfo "Installing application icon ..."
+install -Dvm644 "$SRCDIR"/osu/assets/lazer.png \
+    "$PKGDIR"/usr/share/pixmaps/osu-lazer.png
+
+abinfo "Removing unneeded static libraries ..."
+find "$PKGDIR"/usr/lib/osu-lazer/ -name "*.a" -delete -print
+
+abinfo "Enabling extglob ..."
+shopt -s extglob
+
+abinfo "Removing unused runtimes ..."
+rm -rv "$PKGDIR"/usr/lib/osu-lazer/runtimes/!(linux-${DOTNET_ARCH})/
+
+# Note: We built this runtime directory ourselves for loongarch64, so
+# there is nothing to remove.
+if ! ab_match_arch loongarch64; then
+    abinfo "Removing unused vendored libraries ..."
+    rm -v "$PKGDIR"/usr/lib/osu-lazer/runtimes/linux-${DOTNET_ARCH}/native/!(libbass*.so|libe_sqlite3.so|libstbi.so|librealm-wrappers.so|libveldrid-spirv.so)
+fi
+
+abinfo "Moving PDB (program database) files to -dbg ..."
+install -Dvm644 "$PKGDIR"/usr/lib/osu-lazer/*.pdb \
+    -t "$SYMDIR"/usr/lib/osu-lazer/
+rm -v "$PKGDIR"/usr/lib/osu-lazer/*.pdb

--- a/app-games/osu-lazer/autobuild/build
+++ b/app-games/osu-lazer/autobuild/build
@@ -12,6 +12,11 @@ case $ARCH in
 esac
 abinfo "DOTNET_ARCH: $DOTNET_ARCH ..."
 
+abinfo "Switching osu-framework to a local copy ..."
+cd "$SRCDIR"/osu
+./UseLocalFramework.sh
+cd ..
+
 abinfo "Building osu-lazer (osu.Desktop) ..."
 dotnet publish \
     "$SRCDIR"/osu/osu.Desktop/osu.Desktop.csproj \
@@ -92,6 +97,11 @@ if ab_match_arch loongarch64; then
     abinfo "Creating a symlink to system SQLite ..."
     ln -sv ../libsqlite3.so \
         "$PKGDIR"/usr/lib/osu-lazer/libe_sqlite3.so
+
+    abinfo "Creating symlinks to ffmpeg ..."
+    for i in libavutil.so.59 libavcodec.so.61 libavformat.so.61 libswscale.so.8; do
+        ln -sv ../"$i" "$PKGDIR"/usr/lib/osu-lazer/"$i"
+    done
 fi
 
 abinfo "Setting executable bit on the main executable ..."

--- a/app-games/osu-lazer/autobuild/defines
+++ b/app-games/osu-lazer/autobuild/defines
@@ -1,10 +1,19 @@
 PKGNAME=osu-lazer
 PKGSEC=games
-PKGDES="Rhythm is just a click away!"
-PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-8.0"
-BUILDDEP="dotnet-sdk-8.0"
+PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-10.0"
+PKGDEP__ARM64="${PKGDEP} sqlite"
+PKGDEP__LOONGARCH64="${PKGDEP} sqlite"
+BUILDDEP="dotnet-sdk-10.0"
+# FIXME: Whilst building librealm-wrapper:
+#
+# ld.lld: error: undefined symbol: sqlite3_finalize
+#       >>> referenced by raw_statement.rs:194 (/root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rusqlite-0.31.0/src/raw_statement.rs:194)
+BUILDDEP__LOONGARCH64="${BUILDDEP} mold"
+PKGDES="Community-driven rhythm game"
 
-FAIL_ARCH="!(amd64)"
-NOSTATIC=0
-ABSTRIP=0
-ABSPLITDBG=0
+# Note: Limit to architectures with working .NET runtime and
+# libbass{,_fx,mix} (only binaries are available for the latter).
+#
+# FIXME: No CoreCLR runtime available for Power.
+# FIXME: .NET builds current gets stuck on RISC-V.
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/app-games/osu-lazer/autobuild/defines
+++ b/app-games/osu-lazer/autobuild/defines
@@ -4,11 +4,6 @@ PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-10.0"
 PKGDEP__ARM64="${PKGDEP} sqlite"
 PKGDEP__LOONGARCH64="${PKGDEP} sqlite"
 BUILDDEP="dotnet-sdk-10.0"
-# FIXME: Whilst building librealm-wrapper:
-#
-# ld.lld: error: undefined symbol: sqlite3_finalize
-#       >>> referenced by raw_statement.rs:194 (/root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rusqlite-0.31.0/src/raw_statement.rs:194)
-BUILDDEP__LOONGARCH64="${BUILDDEP} mold"
 PKGDES="Community-driven rhythm game"
 
 # Note: Limit to architectures with working .NET runtime and

--- a/app-games/osu-lazer/autobuild/defines
+++ b/app-games/osu-lazer/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=osu-lazer
 PKGSEC=games
-PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-10.0"
+PKGDEP="alsa-lib desktop-file-utils libgdiplus dotnet-runtime-10.0 ffmpeg"
 PKGDEP__ARM64="${PKGDEP} sqlite"
 PKGDEP__LOONGARCH64="${PKGDEP} sqlite"
-BUILDDEP="dotnet-sdk-10.0"
+BUILDDEP="dotnet-sdk-10.0 jq"
 PKGDES="Community-driven rhythm game"
 
 # Note: Limit to architectures with working .NET runtime and

--- a/app-games/osu-lazer/autobuild/overrides/usr/bin/osu-lazer
+++ b/app-games/osu-lazer/autobuild/overrides/usr/bin/osu-lazer
@@ -1,6 +1,2 @@
 #!/bin/bash
-PREFIX="/usr/lib/osu-lazer"
-LD_PRELOAD="${LD_PRELOAD} ${PREFIX}/libbass.so"
-export LD_PRELOAD
-export DOTNET_ROOT="/usr/lib/dotnet"
-exec "${PREFIX}"/osu\!
+exec /usr/lib/osu-lazer/osu\!

--- a/app-games/osu-lazer/autobuild/overrides/usr/share/applications/osu.desktop
+++ b/app-games/osu-lazer/autobuild/overrides/usr/share/applications/osu.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=osu!lazer
+Name=osu!
 Comment=Rhythm is just a *click* away!
 Exec=/usr/bin/osu-lazer %U
-Icon=osu-lazer
+Icon=/usr/share/pixmaps/osu-lazer.png
 Type=Application
 StartupNotify=true
 StartupWMClass=osu!

--- a/app-games/osu-lazer/autobuild/patch
+++ b/app-games/osu-lazer/autobuild/patch
@@ -9,3 +9,9 @@ for i in "$SRCDIR"/autobuild/patches/*.patch.osu; do
         -d "$SRCDIR"/osu \
         -i "$i"
 done
+for i in "$SRCDIR"/autobuild/patches/*.patch.osu-framework; do
+    abinfo "Applying $i ..."
+    patch -Np1 --binary \
+        -d "$SRCDIR"/osu-framework \
+        -i "$i"
+done

--- a/app-games/osu-lazer/autobuild/patch
+++ b/app-games/osu-lazer/autobuild/patch
@@ -1,0 +1,11 @@
+# Note: .osu-suffixed patches are for osu! sources.
+#
+# Note: Patch 0001 is converted to DOS line endings, whereas 0002 uses
+# UNIX line endings.
+abinfo "Patching osu! ..."
+for i in "$SRCDIR"/autobuild/patches/*.patch.osu; do
+    abinfo "Applying $i ..."
+    patch -Np1 --binary \
+        -d "$SRCDIR"/osu \
+        -i "$i"
+done

--- a/app-games/osu-lazer/autobuild/patches/0001-AOSCOS-Update-.NET-version-to-10.0.patch.osu
+++ b/app-games/osu-lazer/autobuild/patches/0001-AOSCOS-Update-.NET-version-to-10.0.patch.osu
@@ -1,0 +1,480 @@
+From a38c52e07e1b08fe8e41e96b384312c6c06f1dbc Mon Sep 17 00:00:00 2001
+From: gray <3059305632@qq.com>
+Date: Tue, 3 Mar 2026 17:21:18 +0800
+Subject: [PATCH 1/2] AOSCOS: Update .NET version to 10.0
+
+Our source build routine uses .NET 10, so change upstream's .NET 8.0 to
+10.0 as needed.
+
+Signed-off-by: gray <3059305632@qq.com>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ .../osu.Game.Rulesets.EmptyFreeform.Tests.csproj                | 2 +-
+ .../osu.Game.Rulesets.EmptyFreeform.csproj                      | 2 +-
+ .../osu.Game.Rulesets.Pippidon.Tests.csproj                     | 2 +-
+ .../osu.Game.Rulesets.Pippidon.csproj                           | 2 +-
+ .../osu.Game.Rulesets.EmptyScrolling.Tests.csproj               | 2 +-
+ .../osu.Game.Rulesets.EmptyScrolling.csproj                     | 2 +-
+ .../osu.Game.Rulesets.Pippidon.Tests.csproj                     | 2 +-
+ .../osu.Game.Rulesets.Pippidon.csproj                           | 2 +-
+ osu.Android/osu.Android.csproj                                  | 2 +-
+ osu.Desktop/osu.Desktop.csproj                                  | 2 +-
+ osu.Game.Benchmarks/osu.Game.Benchmarks.csproj                  | 2 +-
+ .../osu.Game.Rulesets.Catch.Tests.Android.csproj                | 2 +-
+ .../osu.Game.Rulesets.Catch.Tests.iOS.csproj                    | 2 +-
+ .../osu.Game.Rulesets.Catch.Tests.csproj                        | 2 +-
+ osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj          | 2 +-
+ .../osu.Game.Rulesets.Mania.Tests.Android.csproj                | 2 +-
+ .../osu.Game.Rulesets.Mania.Tests.iOS.csproj                    | 2 +-
+ .../osu.Game.Rulesets.Mania.Tests.csproj                        | 2 +-
+ osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj          | 2 +-
+ .../osu.Game.Rulesets.Osu.Tests.Android.csproj                  | 2 +-
+ .../osu.Game.Rulesets.Osu.Tests.iOS.csproj                      | 2 +-
+ osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj  | 2 +-
+ osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj              | 2 +-
+ .../osu.Game.Rulesets.Taiko.Tests.Android.csproj                | 2 +-
+ .../osu.Game.Rulesets.Taiko.Tests.iOS.csproj                    | 2 +-
+ .../osu.Game.Rulesets.Taiko.Tests.csproj                        | 2 +-
+ osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj          | 2 +-
+ osu.Game.Tests.Android/osu.Game.Tests.Android.csproj            | 2 +-
+ osu.Game.Tests.iOS/osu.Game.Tests.iOS.csproj                    | 2 +-
+ osu.Game.Tests/osu.Game.Tests.csproj                            | 2 +-
+ osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj      | 2 +-
+ osu.Game.Tournament/osu.Game.Tournament.csproj                  | 2 +-
+ osu.Game/osu.Game.csproj                                        | 2 +-
+ osu.iOS/osu.iOS.csproj                                          | 2 +-
+ 34 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
+index 86f73a37d4..a9bfa2fd4e 100644
+--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
++++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
+@@ -18,7 +18,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <RootNamespace>osu.Game.Rulesets.EmptyFreeform.Tests</RootNamespace>
+   </PropertyGroup>
+ </Project>
+diff --git a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/osu.Game.Rulesets.EmptyFreeform.csproj b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/osu.Game.Rulesets.EmptyFreeform.csproj
+index 89abd5665c..dc426146da 100644
+--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/osu.Game.Rulesets.EmptyFreeform.csproj
++++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/osu.Game.Rulesets.EmptyFreeform.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <AssemblyTitle>osu.Game.Rulesets.EmptyFreeform</AssemblyTitle>
+     <OutputType>Library</OutputType>
+     <PlatformTarget>AnyCPU</PlatformTarget>
+diff --git a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+index 51c0233942..d4093ee88f 100644
+--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
++++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+@@ -18,7 +18,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <RootNamespace>osu.Game.Rulesets.Pippidon.Tests</RootNamespace>
+   </PropertyGroup>
+ </Project>
+diff --git a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
+index 165b6b6c6b..23a5a46c2c 100644
+--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
++++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <AssemblyTitle>osu.Game.Rulesets.Pippidon</AssemblyTitle>
+     <OutputType>Library</OutputType>
+     <PlatformTarget>AnyCPU</PlatformTarget>
+diff --git a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
+index ed4e8631ea..53da478def 100644
+--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
++++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
+@@ -18,7 +18,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <RootNamespace>osu.Game.Rulesets.EmptyScrolling.Tests</RootNamespace>
+   </PropertyGroup>
+ </Project>
+diff --git a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/osu.Game.Rulesets.EmptyScrolling.csproj b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/osu.Game.Rulesets.EmptyScrolling.csproj
+index 6d9565a6f2..544abba0c0 100644
+--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/osu.Game.Rulesets.EmptyScrolling.csproj
++++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/osu.Game.Rulesets.EmptyScrolling.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <AssemblyTitle>osu.Game.Rulesets.EmptyScrolling</AssemblyTitle>
+     <OutputType>Library</OutputType>
+     <PlatformTarget>AnyCPU</PlatformTarget>
+diff --git a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+index 51c0233942..d4093ee88f 100644
+--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
++++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+@@ -18,7 +18,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <RootNamespace>osu.Game.Rulesets.Pippidon.Tests</RootNamespace>
+   </PropertyGroup>
+ </Project>
+diff --git a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
+index 165b6b6c6b..23a5a46c2c 100644
+--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
++++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <AssemblyTitle>osu.Game.Rulesets.Pippidon</AssemblyTitle>
+     <OutputType>Library</OutputType>
+     <PlatformTarget>AnyCPU</PlatformTarget>
+diff --git a/osu.Android/osu.Android.csproj b/osu.Android/osu.Android.csproj
+index be2e669728..1fe19b466d 100644
+--- a/osu.Android/osu.Android.csproj
++++ b/osu.Android/osu.Android.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <Import Project="..\osu.Android.props" />
+   <PropertyGroup>
+-    <TargetFramework>net8.0-android</TargetFramework>
++    <TargetFramework>net10.0-android</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Android</RootNamespace>
+     <AssemblyName>osu.Android</AssemblyName>
+diff --git a/osu.Desktop/osu.Desktop.csproj b/osu.Desktop/osu.Desktop.csproj
+index b0c5c953d4..b0a9c9b34f 100644
+--- a/osu.Desktop/osu.Desktop.csproj
++++ b/osu.Desktop/osu.Desktop.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>WinExe</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <Description>A free-to-win rhythm game. Rhythm is just a *click* away!</Description>
+diff --git a/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj b/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
+index 8a353eb2f5..f8d950c635 100644
+--- a/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
++++ b/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
+@@ -1,7 +1,7 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+ 
+   <PropertyGroup>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <IsPackable>false</IsPackable>
+   </PropertyGroup>
+diff --git a/osu.Game.Rulesets.Catch.Tests.Android/osu.Game.Rulesets.Catch.Tests.Android.csproj b/osu.Game.Rulesets.Catch.Tests.Android/osu.Game.Rulesets.Catch.Tests.Android.csproj
+index 4b2e54be67..093172fb19 100644
+--- a/osu.Game.Rulesets.Catch.Tests.Android/osu.Game.Rulesets.Catch.Tests.Android.csproj
++++ b/osu.Game.Rulesets.Catch.Tests.Android/osu.Game.Rulesets.Catch.Tests.Android.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <Import Project="..\osu.Android.props" />
+   <PropertyGroup>
+-    <TargetFramework>net8.0-android</TargetFramework>
++    <TargetFramework>net10.0-android</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Game.Rulesets.Catch.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Catch.Tests.Android</AssemblyName>
+diff --git a/osu.Game.Rulesets.Catch.Tests.iOS/osu.Game.Rulesets.Catch.Tests.iOS.csproj b/osu.Game.Rulesets.Catch.Tests.iOS/osu.Game.Rulesets.Catch.Tests.iOS.csproj
+index 9c262a752a..eda288b1d9 100644
+--- a/osu.Game.Rulesets.Catch.Tests.iOS/osu.Game.Rulesets.Catch.Tests.iOS.csproj
++++ b/osu.Game.Rulesets.Catch.Tests.iOS/osu.Game.Rulesets.Catch.Tests.iOS.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+-    <TargetFramework>net8.0-ios</TargetFramework>
++    <TargetFramework>net10.0-ios</TargetFramework>
+     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
+     <RootNamespace>osu.Game.Rulesets.Catch.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Catch.Tests.iOS</AssemblyName>
+diff --git a/osu.Game.Rulesets.Catch.Tests/osu.Game.Rulesets.Catch.Tests.csproj b/osu.Game.Rulesets.Catch.Tests/osu.Game.Rulesets.Catch.Tests.csproj
+index fc1b13f3ad..d619629b70 100644
+--- a/osu.Game.Rulesets.Catch.Tests/osu.Game.Rulesets.Catch.Tests.csproj
++++ b/osu.Game.Rulesets.Catch.Tests/osu.Game.Rulesets.Catch.Tests.csproj
+@@ -7,7 +7,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup Label="Project References">
+     <ProjectReference Include="..\osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj" />
+diff --git a/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj b/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
+index a5138ffb39..fbd7369412 100644
+--- a/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
++++ b/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Library</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <Description>catch the fruit. to the beat.</Description>
+diff --git a/osu.Game.Rulesets.Mania.Tests.Android/osu.Game.Rulesets.Mania.Tests.Android.csproj b/osu.Game.Rulesets.Mania.Tests.Android/osu.Game.Rulesets.Mania.Tests.Android.csproj
+index 2866508a02..7329bf8ec2 100644
+--- a/osu.Game.Rulesets.Mania.Tests.Android/osu.Game.Rulesets.Mania.Tests.Android.csproj
++++ b/osu.Game.Rulesets.Mania.Tests.Android/osu.Game.Rulesets.Mania.Tests.Android.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <Import Project="..\osu.Android.props" />
+   <PropertyGroup>
+-    <TargetFramework>net8.0-android</TargetFramework>
++    <TargetFramework>net10.0-android</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Game.Rulesets.Mania.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Mania.Tests.Android</AssemblyName>
+diff --git a/osu.Game.Rulesets.Mania.Tests.iOS/osu.Game.Rulesets.Mania.Tests.iOS.csproj b/osu.Game.Rulesets.Mania.Tests.iOS/osu.Game.Rulesets.Mania.Tests.iOS.csproj
+index d51e541e95..29c7c9ff55 100644
+--- a/osu.Game.Rulesets.Mania.Tests.iOS/osu.Game.Rulesets.Mania.Tests.iOS.csproj
++++ b/osu.Game.Rulesets.Mania.Tests.iOS/osu.Game.Rulesets.Mania.Tests.iOS.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+-    <TargetFramework>net8.0-ios</TargetFramework>
++    <TargetFramework>net10.0-ios</TargetFramework>
+     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
+     <RootNamespace>osu.Game.Rulesets.Mania.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Mania.Tests.iOS</AssemblyName>
+diff --git a/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj b/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
+index edb01b044e..18c019023a 100644
+--- a/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
++++ b/osu.Game.Rulesets.Mania.Tests/osu.Game.Rulesets.Mania.Tests.csproj
+@@ -7,7 +7,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup Label="Project References">
+     <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj" />
+diff --git a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+index 3bca938450..61caec5f96 100644
+--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
++++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Library</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <Description>smash the keys. to the beat.</Description>
+diff --git a/osu.Game.Rulesets.Osu.Tests.Android/osu.Game.Rulesets.Osu.Tests.Android.csproj b/osu.Game.Rulesets.Osu.Tests.Android/osu.Game.Rulesets.Osu.Tests.Android.csproj
+index b79de6d40b..e7df544852 100644
+--- a/osu.Game.Rulesets.Osu.Tests.Android/osu.Game.Rulesets.Osu.Tests.Android.csproj
++++ b/osu.Game.Rulesets.Osu.Tests.Android/osu.Game.Rulesets.Osu.Tests.Android.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <Import Project="..\osu.Android.props" />
+   <PropertyGroup>
+-    <TargetFramework>net8.0-android</TargetFramework>
++    <TargetFramework>net10.0-android</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Game.Rulesets.Osu.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Osu.Tests.Android</AssemblyName>
+diff --git a/osu.Game.Rulesets.Osu.Tests.iOS/osu.Game.Rulesets.Osu.Tests.iOS.csproj b/osu.Game.Rulesets.Osu.Tests.iOS/osu.Game.Rulesets.Osu.Tests.iOS.csproj
+index cd4fbcc00e..afa1b87cd7 100644
+--- a/osu.Game.Rulesets.Osu.Tests.iOS/osu.Game.Rulesets.Osu.Tests.iOS.csproj
++++ b/osu.Game.Rulesets.Osu.Tests.iOS/osu.Game.Rulesets.Osu.Tests.iOS.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+-    <TargetFramework>net8.0-ios</TargetFramework>
++    <TargetFramework>net10.0-ios</TargetFramework>
+     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Game.Rulesets.Osu.Tests</RootNamespace>
+diff --git a/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj b/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
+index 6510568555..f8d3e003f1 100644
+--- a/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
++++ b/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
+@@ -8,7 +8,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup Label="Project References">
+     <ProjectReference Include="..\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj" />
+diff --git a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+index 7817d55f57..a9362e980a 100644
+--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
++++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Library</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <Description>click the circles. to the beat.</Description>
+diff --git a/osu.Game.Rulesets.Taiko.Tests.Android/osu.Game.Rulesets.Taiko.Tests.Android.csproj b/osu.Game.Rulesets.Taiko.Tests.Android/osu.Game.Rulesets.Taiko.Tests.Android.csproj
+index 88aa137797..15f7b7c887 100644
+--- a/osu.Game.Rulesets.Taiko.Tests.Android/osu.Game.Rulesets.Taiko.Tests.Android.csproj
++++ b/osu.Game.Rulesets.Taiko.Tests.Android/osu.Game.Rulesets.Taiko.Tests.Android.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <Import Project="..\osu.Android.props" />
+   <PropertyGroup>
+-    <TargetFramework>net8.0-android</TargetFramework>
++    <TargetFramework>net10.0-android</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Game.Rulesets.Taiko.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Taiko.Tests.Android</AssemblyName>
+diff --git a/osu.Game.Rulesets.Taiko.Tests.iOS/osu.Game.Rulesets.Taiko.Tests.iOS.csproj b/osu.Game.Rulesets.Taiko.Tests.iOS/osu.Game.Rulesets.Taiko.Tests.iOS.csproj
+index 46ac59a1e7..4449c47848 100644
+--- a/osu.Game.Rulesets.Taiko.Tests.iOS/osu.Game.Rulesets.Taiko.Tests.iOS.csproj
++++ b/osu.Game.Rulesets.Taiko.Tests.iOS/osu.Game.Rulesets.Taiko.Tests.iOS.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+-    <TargetFramework>net8.0-ios</TargetFramework>
++    <TargetFramework>net10.0-ios</TargetFramework>
+     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
+     <RootNamespace>osu.Game.Rulesets.Taiko.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Rulesets.Taiko.Tests.iOS</AssemblyName>
+diff --git a/osu.Game.Rulesets.Taiko.Tests/osu.Game.Rulesets.Taiko.Tests.csproj b/osu.Game.Rulesets.Taiko.Tests/osu.Game.Rulesets.Taiko.Tests.csproj
+index e498989a79..eaff0ae95d 100644
+--- a/osu.Game.Rulesets.Taiko.Tests/osu.Game.Rulesets.Taiko.Tests.csproj
++++ b/osu.Game.Rulesets.Taiko.Tests/osu.Game.Rulesets.Taiko.Tests.csproj
+@@ -7,7 +7,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup Label="Project References">
+     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
+diff --git a/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj b/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+index cacba55c2a..da4b0cbc7a 100644
+--- a/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
++++ b/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Library</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <Description>bash the drum. to the beat.</Description>
+diff --git a/osu.Game.Tests.Android/osu.Game.Tests.Android.csproj b/osu.Game.Tests.Android/osu.Game.Tests.Android.csproj
+index a8fc9536b9..a11ffb65e6 100644
+--- a/osu.Game.Tests.Android/osu.Game.Tests.Android.csproj
++++ b/osu.Game.Tests.Android/osu.Game.Tests.Android.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <Import Project="..\osu.Android.props" />
+   <PropertyGroup>
+-    <TargetFramework>net8.0-android</TargetFramework>
++    <TargetFramework>net10.0-android</TargetFramework>
+     <OutputType>Exe</OutputType>
+     <RootNamespace>osu.Game.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Tests.Android</AssemblyName>
+diff --git a/osu.Game.Tests.iOS/osu.Game.Tests.iOS.csproj b/osu.Game.Tests.iOS/osu.Game.Tests.iOS.csproj
+index 9f13b0587b..0b58923ded 100644
+--- a/osu.Game.Tests.iOS/osu.Game.Tests.iOS.csproj
++++ b/osu.Game.Tests.iOS/osu.Game.Tests.iOS.csproj
+@@ -2,7 +2,7 @@
+   <Import Project="..\osu.iOS.props" />
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+-    <TargetFramework>net8.0-ios</TargetFramework>
++    <TargetFramework>net10.0-ios</TargetFramework>
+     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
+     <RootNamespace>osu.Game.Tests</RootNamespace>
+     <AssemblyName>osu.Game.Tests.iOS</AssemblyName>
+diff --git a/osu.Game.Tests/osu.Game.Tests.csproj b/osu.Game.Tests/osu.Game.Tests.csproj
+index c86f05c257..97286532d2 100644
+--- a/osu.Game.Tests/osu.Game.Tests.csproj
++++ b/osu.Game.Tests/osu.Game.Tests.csproj
+@@ -11,7 +11,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup Label="Code Analysis">
+     <GlobalAnalyzerConfigFiles Include="CodeAnalysis.tests.globalconfig" />
+diff --git a/osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj b/osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj
+index 8437a1bc4e..58845ba9c6 100644
+--- a/osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj
++++ b/osu.Game.Tournament.Tests/osu.Game.Tournament.Tests.csproj
+@@ -10,7 +10,7 @@
+   </ItemGroup>
+   <PropertyGroup Label="Project">
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup Label="Project References">
+     <ProjectReference Include="..\osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj" />
+diff --git a/osu.Game.Tournament/osu.Game.Tournament.csproj b/osu.Game.Tournament/osu.Game.Tournament.csproj
+index c8578ac464..a6e0cc5122 100644
+--- a/osu.Game.Tournament/osu.Game.Tournament.csproj
++++ b/osu.Game.Tournament/osu.Game.Tournament.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Library</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <Description>tools for tournaments.</Description>
+diff --git a/osu.Game/osu.Game.csproj b/osu.Game/osu.Game.csproj
+index 4e0138afd1..d85c343b15 100644
+--- a/osu.Game/osu.Game.csproj
++++ b/osu.Game/osu.Game.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net10.0</TargetFramework>
+     <OutputType>Library</OutputType>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+   </PropertyGroup>
+diff --git a/osu.iOS/osu.iOS.csproj b/osu.iOS/osu.iOS.csproj
+index 3e8beddaa4..525429e113 100644
+--- a/osu.iOS/osu.iOS.csproj
++++ b/osu.iOS/osu.iOS.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup Label="Project">
+-    <TargetFramework>net8.0-ios</TargetFramework>
++    <TargetFramework>net10.0-ios</TargetFramework>
+     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
+     <OutputType>Exe</OutputType>
+     <Version>0.1.0</Version>
+-- 
+2.52.0
+

--- a/app-games/osu-lazer/autobuild/patches/0002-AOSCOS-global.json-Update-.NET-version-to-10.0.patch.osu
+++ b/app-games/osu-lazer/autobuild/patches/0002-AOSCOS-global.json-Update-.NET-version-to-10.0.patch.osu
@@ -1,0 +1,34 @@
+From cb9ca2cbdf355f0cb9b547386cfcb488e40ea890 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 3 Mar 2026 17:21:38 +0800
+Subject: [PATCH 2/2] AOSCOS: global.json: Update .NET version to 10.0
+
+(Patch split as this file is the only one that uses UNIX line endings...)
+
+Our source build routine uses .NET 10, so change upstream's .NET 8.0 to
+10.0 as needed.
+
+Signed-off-by: gray <3059305632@qq.com>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ global.json | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/global.json b/global.json
+index 789bff3bd0..53b4c27791 100644
+--- a/global.json
++++ b/global.json
+@@ -1,7 +1,7 @@
+ {
+   "sdk": {
+-    "version": "8.0.100",
++    "version": "10.0.103",
+     "rollForward": "latestFeature",
+     "allowPrerelease": false
+   }
+-}
+\ No newline at end of file
++}
+-- 
+2.52.0
+

--- a/app-games/osu-lazer/autobuild/patches/0003-FROMLIST-ffmpeg-7.1.patch.osu-framework
+++ b/app-games/osu-lazer/autobuild/patches/0003-FROMLIST-ffmpeg-7.1.patch.osu-framework
@@ -191,15 +191,15 @@ diff --git a/osu.Framework/osu.Framework.csproj b/osu.Framework/osu.Framework.cs
 index 32f6ff8134..7a927b4377 100644
 --- a/osu.Framework/osu.Framework.csproj
 +++ b/osu.Framework/osu.Framework.csproj
-@@ -20,7 +20,7 @@
+@@ -19,7 +19,7 @@
+     <PackageTags>osu game framework</PackageTags>
    </PropertyGroup>
    <ItemGroup Label="Package References">
-     <PackageReference Include="managed-midi" Version="1.10.1" />
 -    <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
 +    <PackageReference Include="FFmpeg.AutoGen" Version="7.1.1" />
      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
+     <PackageReference Include="ppy.managed-midi" Version="1.10.2" />
      <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
-     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
 From 5b908a21e766c63e9d91e9a4c83a930b91d52306 Mon Sep 17 00:00:00 2001
 From: FreezyLemon <contact@freezylemon.com>
 Date: Wed, 3 Apr 2024 21:06:07 +0200

--- a/app-games/osu-lazer/autobuild/patches/0003-FROMLIST-ffmpeg-7.1.patch.osu-framework
+++ b/app-games/osu-lazer/autobuild/patches/0003-FROMLIST-ffmpeg-7.1.patch.osu-framework
@@ -1,0 +1,296 @@
+From 34d4eac49d8e6b48a93f5cc06638fb36f1f28daa Mon Sep 17 00:00:00 2001
+From: FreezyLemon <contact@freezylemon.com>
+Date: Wed, 3 Apr 2024 20:55:23 +0200
+Subject: [PATCH 1/4] Update FFmpeg.AutoGen to 7.0.0
+
+---
+ .../Graphics/Video/FFmpegExtensions.cs        |  3 -
+ .../Graphics/Video/FFmpegFunctionResolver.cs  | 72 +++++++++++++++++++
+ osu.Framework/Graphics/Video/VideoDecoder.cs  | 52 +-------------
+ osu.Framework/osu.Framework.csproj            |  2 +-
+ 4 files changed, 74 insertions(+), 55 deletions(-)
+ create mode 100644 osu.Framework/Graphics/Video/FFmpegFunctionResolver.cs
+
+diff --git a/osu.Framework/Graphics/Video/FFmpegExtensions.cs b/osu.Framework/Graphics/Video/FFmpegExtensions.cs
+index 778af3f2b3..89608ce18a 100644
+--- a/osu.Framework/Graphics/Video/FFmpegExtensions.cs
++++ b/osu.Framework/Graphics/Video/FFmpegExtensions.cs
+@@ -16,8 +16,6 @@ internal static bool IsHardwarePixelFormat(this AVPixelFormat pixFmt)
+                 case AVPixelFormat.AV_PIX_FMT_VDPAU:
+                 case AVPixelFormat.AV_PIX_FMT_CUDA:
+                 case AVPixelFormat.AV_PIX_FMT_VAAPI:
+-                case AVPixelFormat.AV_PIX_FMT_VAAPI_IDCT:
+-                case AVPixelFormat.AV_PIX_FMT_VAAPI_MOCO:
+                 case AVPixelFormat.AV_PIX_FMT_DXVA2_VLD:
+                 case AVPixelFormat.AV_PIX_FMT_QSV:
+                 case AVPixelFormat.AV_PIX_FMT_VIDEOTOOLBOX:
+@@ -28,7 +26,6 @@ internal static bool IsHardwarePixelFormat(this AVPixelFormat pixFmt)
+                 case AVPixelFormat.AV_PIX_FMT_MEDIACODEC:
+                 case AVPixelFormat.AV_PIX_FMT_VULKAN:
+                 case AVPixelFormat.AV_PIX_FMT_MMAL:
+-                case AVPixelFormat.AV_PIX_FMT_XVMC:
+                     return true;
+ 
+                 default:
+diff --git a/osu.Framework/Graphics/Video/FFmpegFunctionResolver.cs b/osu.Framework/Graphics/Video/FFmpegFunctionResolver.cs
+new file mode 100644
+index 0000000000..998cb74cfd
+--- /dev/null
++++ b/osu.Framework/Graphics/Video/FFmpegFunctionResolver.cs
+@@ -0,0 +1,72 @@
++// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
++// See the LICENCE file in the repository root for full licence text.
++
++using System;
++using System.Collections.Generic;
++using System.Runtime.InteropServices;
++using FFmpeg.AutoGen;
++
++namespace osu.Framework.Graphics.Video
++{
++    /// <summary>
++    /// Resolves the FFmpeg native functions required for video playback.
++    ///
++    /// If you want to support a different set of libraries, consider implementing the <see cref="IFunctionResolver"/> interface yourself.
++    /// </summary>
++    public sealed class FFmpegFunctionResolver : IFunctionResolver
++    {
++        // The order here matters because of inter-library dependencies.
++        // avcodec and swscale depend on avutil, avformat depends on avcodec.
++        private static readonly string[] libraries = ["avutil", "avcodec", "swscale", "avformat"];
++
++        private readonly Dictionary<string, IntPtr> loadedLibraries = new Dictionary<string, IntPtr>(libraries.Length);
++
++        /// <summary>
++        /// Load the default set of FFmpeg libraries.
++        /// </summary>
++        /// <exception cref="DllNotFoundException">If one of the libraries cannot be found in the DLL directory.</exception>
++        /// <exception cref="BadImageFormatException">If one of the library files is invalid.</exception>
++        public FFmpegFunctionResolver()
++        {
++            foreach (string library in libraries)
++                loadLibrary(library);
++        }
++
++        private void loadLibrary(string libraryName)
++        {
++            string libraryFileName = getLibraryFileName(libraryName);
++            IntPtr handle = NativeLibrary.Load(libraryFileName, RuntimeInfo.EntryAssembly, DllImportSearchPath.UseDllDirectoryForDependencies);
++
++            loadedLibraries.Add(libraryName, handle);
++        }
++
++        public T GetFunctionDelegate<T>(string libraryName, string functionName, bool throwOnError = true)
++        {
++            if (!loadedLibraries.TryGetValue(libraryName, out IntPtr libraryHandle))
++                throw new InvalidOperationException($"Required library {getLibraryFileName(libraryName)} was not loaded on initialization.");
++
++            IntPtr funcPtr = NativeLibrary.GetExport(libraryHandle, functionName);
++            return Marshal.GetDelegateForFunctionPointer<T>(funcPtr);
++        }
++
++        private string getLibraryFileName(string libraryName)
++        {
++            int version = ffmpeg.LibraryVersionMap[libraryName];
++
++            switch (RuntimeInfo.OS)
++            {
++                case RuntimeInfo.Platform.Windows:
++                    return $"{libraryName}-{version}.dll";
++
++                case RuntimeInfo.Platform.Linux:
++                    return $"lib{libraryName}.so.{version}";
++
++                case RuntimeInfo.Platform.macOS:
++                    return $"lib{libraryName}.{version}.dylib";
++
++                default:
++                    throw new PlatformNotSupportedException();
++            }
++        }
++    }
++}
+diff --git a/osu.Framework/Graphics/Video/VideoDecoder.cs b/osu.Framework/Graphics/Video/VideoDecoder.cs
+index 6b8638a805..a96b8d100c 100644
+--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
++++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
+@@ -22,7 +22,6 @@
+ using osu.Framework.Graphics.Rendering;
+ using osu.Framework.Logging;
+ using osu.Framework.Platform;
+-using osu.Framework.Platform.Linux.Native;
+ 
+ namespace osu.Framework.Graphics.Video
+ {
+@@ -109,25 +108,6 @@ public unsafe class VideoDecoder : IDisposable
+ 
+         internal bool Looping;
+ 
+-        static VideoDecoder()
+-        {
+-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
+-            {
+-                void loadVersionedLibraryGlobally(string name)
+-                {
+-                    int version = FFmpeg.AutoGen.ffmpeg.LibraryVersionMap[name];
+-                    Library.Load($"lib{name}.so.{version}", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
+-                }
+-
+-                // FFmpeg.AutoGen doesn't load libraries as RTLD_GLOBAL, so we must load them ourselves to fix inter-library dependencies
+-                // otherwise they would fallback to the system-installed libraries that can differ in version installed.
+-                loadVersionedLibraryGlobally("avutil");
+-                loadVersionedLibraryGlobally("avcodec");
+-                loadVersionedLibraryGlobally("avformat");
+-                loadVersionedLibraryGlobally("swscale");
+-            }
+-        }
+-
+         /// <summary>
+         /// Creates a new video decoder that decodes the given video file.
+         /// </summary>
+@@ -817,37 +797,7 @@ HardwareVideoDecoder targetHwDecoders
+ 
+         protected virtual FFmpegFuncs CreateFuncs()
+         {
+-            // other frameworks should handle native libraries themselves
+-            FFmpeg.AutoGen.ffmpeg.GetOrLoadLibrary = name =>
+-            {
+-                int version = FFmpeg.AutoGen.ffmpeg.LibraryVersionMap[name];
+-
+-                // "lib" prefix and extensions are resolved by .net core
+-                string libraryName;
+-
+-                switch (RuntimeInfo.OS)
+-                {
+-                    case RuntimeInfo.Platform.macOS:
+-                        libraryName = $"{name}.{version}";
+-                        break;
+-
+-                    case RuntimeInfo.Platform.Windows:
+-                        libraryName = $"{name}-{version}";
+-                        break;
+-
+-                    // To handle versioning in Linux, we have to specify the entire file name
+-                    // because Linux uses a version suffix after the file extension (e.g. libavutil.so.56)
+-                    // More info: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/native-library-loading?view=net-6.0
+-                    case RuntimeInfo.Platform.Linux:
+-                        libraryName = $"lib{name}.so.{version}";
+-                        break;
+-
+-                    default:
+-                        throw new ArgumentOutOfRangeException(nameof(RuntimeInfo.OS), RuntimeInfo.OS, null);
+-                }
+-
+-                return NativeLibrary.Load(libraryName, RuntimeInfo.EntryAssembly, DllImportSearchPath.UseDllDirectoryForDependencies | DllImportSearchPath.SafeDirectories);
+-            };
++            DynamicallyLoadedBindings.FunctionResolver ??= new FFmpegFunctionResolver();
+ 
+             return new FFmpegFuncs
+             {
+diff --git a/osu.Framework/osu.Framework.csproj b/osu.Framework/osu.Framework.csproj
+index 32f6ff8134..7a927b4377 100644
+--- a/osu.Framework/osu.Framework.csproj
++++ b/osu.Framework/osu.Framework.csproj
+@@ -20,7 +20,7 @@
+   </PropertyGroup>
+   <ItemGroup Label="Package References">
+     <PackageReference Include="managed-midi" Version="1.10.1" />
+-    <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
++    <PackageReference Include="FFmpeg.AutoGen" Version="7.1.1" />
+     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
+     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
+     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
+From 5b908a21e766c63e9d91e9a4c83a930b91d52306 Mon Sep 17 00:00:00 2001
+From: FreezyLemon <contact@freezylemon.com>
+Date: Wed, 3 Apr 2024 21:06:07 +0200
+Subject: [PATCH 2/4] Add workaround for VP9 hwdec bug
+
+---
+ osu.Framework/Graphics/Video/VideoDecoder.cs | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/osu.Framework/Graphics/Video/VideoDecoder.cs b/osu.Framework/Graphics/Video/VideoDecoder.cs
+index a96b8d100c..7f06aeac1b 100644
+--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
++++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
+@@ -783,6 +783,15 @@ HardwareVideoDecoder targetHwDecoders
+                     if (!hwVideoDecoder.HasValue || !targetHwDecoders.HasFlagFast(hwVideoDecoder.Value))
+                         continue;
+ 
++                    // VP9 Hardware decoding hangs on macOS on x64 platforms: https://trac.ffmpeg.org/ticket/9599
++                    if (codec.Id == AVCodecID.AV_CODEC_ID_VP9
++                        && hwVideoDecoder == HardwareVideoDecoder.VideoToolbox
++                        && RuntimeInfo.OS == RuntimeInfo.Platform.macOS
++                        && RuntimeInformation.OSArchitecture == Architecture.X64)
++                    {
++                        continue;
++                    }
++
+                     codecs.Add((codec, hwDeviceType));
+                 }
+             }
+
+From d2f847a99c308e496eba84432ba676d2d4df1144 Mon Sep 17 00:00:00 2001
+From: FreezyLemon <contact@freezylemon.com>
+Date: Tue, 23 Apr 2024 17:51:01 +0200
+Subject: [PATCH 3/4] Move FunctionResolver creation to static FFmpegFuncs ctor
+
+---
+ osu.Framework/Graphics/Video/FFmpegFuncs.cs  | 5 +++++
+ osu.Framework/Graphics/Video/VideoDecoder.cs | 2 --
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/osu.Framework/Graphics/Video/FFmpegFuncs.cs b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+index ccdc8de6ad..6154dfb867 100644
+--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
++++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+@@ -14,6 +14,11 @@ namespace osu.Framework.Graphics.Video
+ {
+     public unsafe class FFmpegFuncs
+     {
++        static FFmpegFuncs()
++        {
++            DynamicallyLoadedBindings.FunctionResolver = new FFmpegFunctionResolver();
++        }
++
+         #region Delegates
+ 
+         public delegate int AvDictSetDelegate(AVDictionary** pm, [MarshalAs(UnmanagedType.LPUTF8Str)] string key, [MarshalAs(UnmanagedType.LPUTF8Str)] string value, int flags);
+diff --git a/osu.Framework/Graphics/Video/VideoDecoder.cs b/osu.Framework/Graphics/Video/VideoDecoder.cs
+index 7f06aeac1b..9260c0edae 100644
+--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
++++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
+@@ -806,8 +806,6 @@ HardwareVideoDecoder targetHwDecoders
+ 
+         protected virtual FFmpegFuncs CreateFuncs()
+         {
+-            DynamicallyLoadedBindings.FunctionResolver ??= new FFmpegFunctionResolver();
+-
+             return new FFmpegFuncs
+             {
+                 av_dict_set = FFmpeg.AutoGen.ffmpeg.av_dict_set,
+
+From 9cb705d48addb5b8a866f7cf5b65e0fbc7894c07 Mon Sep 17 00:00:00 2001
+From: FreezyLemon <contact@freezylemon.com>
+Date: Wed, 15 May 2024 13:31:43 +0200
+Subject: [PATCH 4/4] Only use `FFmpegFunctionResolver` on desktop platforms
+
+Co-authored-by: Salman Ahmed <frenzibyte@gmail.com>
+---
+ osu.Framework/Graphics/Video/FFmpegFuncs.cs | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/osu.Framework/Graphics/Video/FFmpegFuncs.cs b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+index 6154dfb867..3cbbf7504a 100644
+--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
++++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+@@ -16,7 +16,8 @@ public unsafe class FFmpegFuncs
+     {
+         static FFmpegFuncs()
+         {
+-            DynamicallyLoadedBindings.FunctionResolver = new FFmpegFunctionResolver();
++            if (RuntimeInfo.IsDesktop)
++                DynamicallyLoadedBindings.FunctionResolver = new FFmpegFunctionResolver();
+         }
+ 
+         #region Delegates

--- a/app-games/osu-lazer/autobuild/patches/0004-AOSC-OS-deprioritize-vdpau.patch.osu-framework
+++ b/app-games/osu-lazer/autobuild/patches/0004-AOSC-OS-deprioritize-vdpau.patch.osu-framework
@@ -1,0 +1,13 @@
+diff --git a/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs b/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
+index e33c9edb3..dd1806b54 100644
+--- a/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
++++ b/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
+@@ -18,7 +18,7 @@ internal class AVHWDeviceTypePerformanceComparer : Comparer<AVHWDeviceType>
+             { AVHWDeviceType.AV_HWDEVICE_TYPE_D3D11VA, 8 },
+             { AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2, 7 },
+             // Linux
+-            { AVHWDeviceType.AV_HWDEVICE_TYPE_VDPAU, 10 },
++            { AVHWDeviceType.AV_HWDEVICE_TYPE_VDPAU, 8 },
+             { AVHWDeviceType.AV_HWDEVICE_TYPE_VAAPI, 9 },
+             // Android
+             { AVHWDeviceType.AV_HWDEVICE_TYPE_MEDIACODEC, 10 },

--- a/app-games/osu-lazer/autobuild/prepare
+++ b/app-games/osu-lazer/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Work around the environment variable VERSION"
-unset VERSION

--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,13 +1,16 @@
 # Note: Only -lazer-suffixed tags are considered stable.
 UPSTREAM_VER=2026.119.0-lazer
+FRAMEWORK_VER=2026.108.0
 VER="${UPSTREAM_VER/\-/+}"
 # Note: For components below, use latest versions.
 SRCS="git::commit=tags/${UPSTREAM_VER};rename=osu::https://github.com/ppy/osu \
+      git::commit=tags/${FRAMEWORK_VER};rename=osu-framework::https://github.com/ppy/osu-framework \
       git::commit=tags/v1.0.15-1;rename=veldrid-spirv::https://github.com/AOSC-Tracking/veldrid-spirv \
       git::commit=20.1.0;copy-git=true;copy-repo=true;rename=realm-dotnet::https://github.com/realm/realm-dotnet \
       git::commit=tags/v1.2.1;rename=stbi-sharp::https://github.com/Tom94/stbi-sharp.git \
       tbl::rename=libbass-loongarch64.zip::https://www.un4seen.com/stuff/bass24-linux-loongarch64.zip"
 CHKSUMS="SKIP \
+         SKIP \
          SKIP \
          SKIP \
          SKIP \

--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,6 +1,6 @@
 # Note: Only -lazer-suffixed tags are considered stable.
-UPSTREAM_VER=2026.119.0-lazer
-FRAMEWORK_VER=2026.108.0
+UPSTREAM_VER=2026.305.0-lazer
+FRAMEWORK_VER=2026.303.0
 VER="${UPSTREAM_VER/\-/+}"
 # Note: For components below, use latest versions.
 SRCS="git::commit=tags/${UPSTREAM_VER};rename=osu::https://github.com/ppy/osu \

--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,5 +1,16 @@
-UPSTREAM_VER=2025.1029.1-lazer
-VER=${UPSTREAM_VER/-lazer/}
-SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/ppy/osu"
-CHKSUMS="SKIP"
+# Note: Only -lazer-suffixed tags are considered stable.
+UPSTREAM_VER=2026.119.0-lazer
+VER="${UPSTREAM_VER/\-/+}"
+# Note: For components below, use latest versions.
+SRCS="git::commit=tags/${UPSTREAM_VER};rename=osu::https://github.com/ppy/osu \
+      git::commit=tags/v1.0.15-1;rename=veldrid-spirv::https://github.com/AOSC-Tracking/veldrid-spirv \
+      git::commit=20.1.0;copy-git=true;copy-repo=true;rename=realm-dotnet::https://github.com/realm/realm-dotnet \
+      git::commit=tags/v1.2.1;rename=stbi-sharp::https://github.com/Tom94/stbi-sharp.git \
+      tbl::rename=libbass-loongarch64.zip::https://www.un4seen.com/stuff/bass24-linux-loongarch64.zip"
+CHKSUMS="SKIP \
+         SKIP \
+         SKIP \
+         SKIP \
+         sha256::48f8c6019408a1fc51a035cd4d7c682cc5a65bfb4b861ae257909b97abd94c7d"
+SUBDIR="."
 CHKUPDATE="anitya::id=227666"


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2026.305.0+lazer & add non-x86 support

Package(s) Affected
-------------------

- osu-lazer: 2026.305.0+lazer

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
