### PR TITLE
rustdesk-server: update to 1.1.15

### DIFF
--- a/app-network/rustdesk-server/autobuild/patches/0001-AOSCOS-bump-rustls-platform-verifier-to-fix-build-fo.patch.deferred.hbb_common
+++ b/app-network/rustdesk-server/autobuild/patches/0001-AOSCOS-bump-rustls-platform-verifier-to-fix-build-fo.patch.deferred.hbb_common
@@ -1,4 +1,4 @@
-From b8a200ae6496739c84cb21b4ccd7bbe3def5225a Mon Sep 17 00:00:00 2001
+From ca90c9720b676e7c2fff65f3c94a87eff737a0a8 Mon Sep 17 00:00:00 2001
 From: ilikara <3435193369@qq.com>
 Date: Thu, 16 Oct 2025 22:15:15 +0800
 Subject: [PATCH] AOSCOS: bump rustls-platform-verifier to fix build for
@@ -37,7 +37,7 @@ index 34d2c51..b2d432a 100644
      // `http::Uri`, in that it makes sense to use in a network request.
      fn into_url(self) -> Result<Url, ProxyError>;
 diff --git a/src/tcp.rs b/src/tcp.rs
-index 17f360f..000a862 100644
+index c85338d..9e12e73 100644
 --- a/src/tcp.rs
 +++ b/src/tcp.rs
 @@ -1,4 +1,4 @@
@@ -59,5 +59,5 @@ index 17f360f..000a862 100644
          std::net::SocketAddr::V4(..) => TcpSocket::new_v4()?,
          std::net::SocketAddr::V6(..) => TcpSocket::new_v6()?,
 -- 
-2.51.0
+2.52.0
 

--- a/app-network/rustdesk-server/autobuild/patches/0001-AOSCOS-bump-sqlx-and-jsonwebtoken-to-fix-build-for-l.patch
+++ b/app-network/rustdesk-server/autobuild/patches/0001-AOSCOS-bump-sqlx-and-jsonwebtoken-to-fix-build-for-l.patch
@@ -1,125 +1,35 @@
-From 0d5f0dcd1da44a8b07c482ad820b26910832cb84 Mon Sep 17 00:00:00 2001
+From 1990d67ba7a39445165ec4073539cbd8f883fd62 Mon Sep 17 00:00:00 2001
 From: ilikara <3435193369@qq.com>
 Date: Thu, 16 Oct 2025 22:06:08 +0800
 Subject: [PATCH] AOSCOS: bump sqlx and jsonwebtoken to fix build for loongarch
 
 Signed-off-by: ilikara <3435193369@qq.com>
 ---
- Cargo.lock      | 3051 ++++++++++++++++++++++++++++++++---------------
- Cargo.toml      |    4 +-
- src/common.rs   |   15 +-
- src/database.rs |    2 +-
- 4 files changed, 2075 insertions(+), 997 deletions(-)
+ Cargo.lock               | 1118 +++++++++++++++++++++++++++++---------
+ Cargo.toml               |    4 +-
+ src/common.rs            |   15 +-
+ src/database.rs          |    2 +-
+ src/rendezvous_server.rs |   57 +-
+ 5 files changed, 907 insertions(+), 289 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index a87da66..6245ce3 100644
+index bf7b850..7e22569 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -4,26 +4,26 @@ version = 4
- 
- [[package]]
- name = "addr2line"
--version = "0.24.2"
-+version = "0.25.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
- dependencies = [
-  "gimli",
+@@ -37,6 +37,12 @@ dependencies = [
+  "memchr",
  ]
  
- [[package]]
- name = "adler2"
--version = "2.0.0"
-+version = "2.0.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
- 
- [[package]]
- name = "ahash"
--version = "0.7.6"
-+version = "0.7.8"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
- dependencies = [
-- "getrandom",
-+ "getrandom 0.2.16",
-  "once_cell",
-  "version_check",
- ]
-@@ -38,10 +38,10 @@ dependencies = [
- ]
- 
- [[package]]
--name = "android-tzdata"
--version = "0.1.1"
++[[package]]
 +name = "allocator-api2"
 +version = "0.2.21"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
- 
++
  [[package]]
- name = "android_system_properties"
-@@ -63,9 +63,9 @@ dependencies = [
- 
- [[package]]
- name = "anyhow"
--version = "1.0.57"
-+version = "1.0.100"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
-+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
- 
- [[package]]
- name = "arrayvec"
-@@ -75,21 +75,21 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
- 
- [[package]]
- name = "async-compression"
--version = "0.4.18"
-+version = "0.4.32"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
-+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
- dependencies = [
-- "flate2",
-+ "compression-codecs",
-+ "compression-core",
-  "futures-core",
-- "memchr",
-  "pin-project-lite",
-  "tokio",
- ]
- 
- [[package]]
- name = "async-speed-limit"
--version = "0.3.1"
--source = "git+https://github.com/open-trade/async-speed-limit#f89f702ae01d4016429543d2f0dda1086157e420"
-+version = "0.3.1-1"
-+source = "git+https://github.com/open-trade/async-speed-limit#8d1851d967b1014eb263bae23053a0e513431a9f"
- dependencies = [
-  "futures-core",
-  "futures-io",
-@@ -99,24 +99,30 @@ dependencies = [
- 
- [[package]]
- name = "async-trait"
--version = "0.1.53"
-+version = "0.1.89"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
-+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 1.0.93",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
+ name = "android-tzdata"
+ version = "0.1.1"
+@@ -110,9 +116,9 @@ dependencies = [
  
  [[package]]
  name = "atoi"
@@ -131,99 +41,8 @@ index a87da66..6245ce3 100644
  dependencies = [
   "num-traits",
  ]
- 
-+[[package]]
-+name = "atomic-waker"
-+version = "1.1.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-+
- [[package]]
- name = "atty"
- version = "0.2.14"
-@@ -130,15 +136,15 @@ dependencies = [
- 
- [[package]]
- name = "autocfg"
--version = "1.1.0"
-+version = "1.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
- 
- [[package]]
- name = "axum"
--version = "0.5.5"
-+version = "0.5.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "00f1e8a972137fad81e2a1a60b86ff17ce0338f8017264e45a9723d0083c39a1"
-+checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
- dependencies = [
-  "async-trait",
-  "axum-core",
-@@ -146,9 +152,9 @@ dependencies = [
-  "bytes",
-  "futures-util",
-  "headers",
-- "http",
-- "http-body",
-- "hyper",
-+ "http 0.2.12",
-+ "http-body 0.4.6",
-+ "hyper 0.14.32",
-  "itoa",
-  "matchit",
-  "memchr",
-@@ -158,9 +164,9 @@ dependencies = [
-  "serde",
-  "serde_json",
-  "serde_urlencoded",
-- "sync_wrapper",
-+ "sync_wrapper 0.1.2",
-  "tokio",
-- "tower",
-+ "tower 0.4.13",
-  "tower-http",
-  "tower-layer",
-  "tower-service",
-@@ -168,23 +174,25 @@ dependencies = [
- 
- [[package]]
- name = "axum-core"
--version = "0.2.4"
-+version = "0.2.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
-+checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
- dependencies = [
-  "async-trait",
-  "bytes",
-  "futures-util",
-- "http",
-- "http-body",
-+ "http 0.2.12",
-+ "http-body 0.4.6",
-  "mime",
-+ "tower-layer",
-+ "tower-service",
- ]
- 
- [[package]]
- name = "backtrace"
--version = "0.3.74"
-+version = "0.3.76"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
- dependencies = [
-  "addr2line",
-  "cfg-if",
-@@ -192,14 +200,20 @@ dependencies = [
-  "miniz_oxide",
-  "object",
-  "rustc-demangle",
-- "windows-targets 0.52.6",
-+ "windows-link",
+@@ -195,6 +201,12 @@ dependencies = [
+  "windows-targets 0.52.6",
  ]
  
 +[[package]]
@@ -234,192 +53,39 @@ index a87da66..6245ce3 100644
 +
  [[package]]
  name = "base64"
--version = "0.13.0"
-+version = "0.13.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
- 
- [[package]]
- name = "base64"
-@@ -213,15 +227,21 @@ version = "0.22.1"
+ version = "0.13.0"
+@@ -213,6 +225,12 @@ version = "0.22.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
  
 +[[package]]
 +name = "base64ct"
-+version = "1.8.0"
++version = "1.8.3"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
++checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 +
  [[package]]
  name = "bcrypt"
  version = "0.13.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "a7e7c93a3fb23b2fdde989b2c9ec4dd153063ec81f408507f84c090cd91c6641"
- dependencies = [
-- "base64 0.13.0",
-+ "base64 0.13.1",
-  "blowfish",
-- "getrandom",
-+ "getrandom 0.2.16",
-  "zeroize",
- ]
- 
-@@ -235,15 +255,15 @@ dependencies = [
-  "cexpr",
-  "clang-sys",
-  "clap",
-- "env_logger 0.9.0",
-+ "env_logger 0.9.3",
-  "lazy_static",
-  "lazycell",
-  "log",
-  "peeking_take_while",
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-  "regex",
-- "rustc-hash",
-+ "rustc-hash 1.1.0",
-  "shlex",
-  "which",
- ]
-@@ -256,15 +276,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+@@ -256,9 +274,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
  
  [[package]]
  name = "bitflags"
 -version = "2.7.0"
-+version = "2.9.4"
++version = "2.11.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
-+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
++checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 +dependencies = [
-+ "serde",
++ "serde_core",
 +]
  
  [[package]]
  name = "block-buffer"
--version = "0.10.2"
-+version = "0.10.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
-+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
- dependencies = [
-  "generic-array",
- ]
-@@ -281,31 +304,32 @@ dependencies = [
- 
- [[package]]
- name = "bumpalo"
--version = "3.9.1"
-+version = "3.19.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
-+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
- 
- [[package]]
- name = "byteorder"
--version = "1.4.3"
-+version = "1.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
- 
- [[package]]
- name = "bytes"
--version = "1.9.0"
-+version = "1.10.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
-+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
- dependencies = [
-  "serde",
- ]
- 
- [[package]]
- name = "cc"
--version = "1.2.9"
-+version = "1.2.41"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
-+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
- dependencies = [
-+ "find-msvc-tools",
-  "jobserver",
-  "libc",
-  "shlex",
-@@ -323,34 +347,39 @@ version = "0.6.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
- dependencies = [
-- "nom 7.1.1",
-+ "nom 7.1.3",
- ]
- 
- [[package]]
- name = "cfg-if"
--version = "1.0.0"
-+version = "1.0.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-+
-+[[package]]
-+name = "cfg_aliases"
-+version = "0.2.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
- 
- [[package]]
- name = "chrono"
--version = "0.4.39"
-+version = "0.4.42"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
-+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
- dependencies = [
-- "android-tzdata",
-  "iana-time-zone",
-  "js-sys",
-  "num-traits",
-  "wasm-bindgen",
-- "windows-targets 0.52.6",
-+ "windows-link",
- ]
- 
- [[package]]
- name = "cipher"
--version = "0.4.3"
-+version = "0.4.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
- dependencies = [
-  "crypto-common",
-  "inout",
-@@ -392,6 +421,32 @@ dependencies = [
+@@ -392,6 +413,15 @@ dependencies = [
   "memchr",
  ]
  
-+[[package]]
-+name = "compression-codecs"
-+version = "0.4.31"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
-+dependencies = [
-+ "compression-core",
-+ "flate2",
-+ "memchr",
-+]
-+
-+[[package]]
-+name = "compression-core"
-+version = "0.4.29"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
-+
 +[[package]]
 +name = "concurrent-queue"
 +version = "2.5.0"
@@ -432,23 +98,13 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "config"
  version = "0.11.0"
-@@ -399,7 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
- dependencies = [
-  "lazy_static",
-- "nom 5.1.2",
-+ "nom 5.1.3",
-  "serde",
- ]
- 
-@@ -410,10 +465,16 @@ source = "git+https://github.com/rustdesk-org/confy#83db9ec19a2f97e9718aef69e4fc
+@@ -410,10 +440,16 @@ source = "git+https://github.com/rustdesk-org/confy#83db9ec19a2f97e9718aef69e4fc
  dependencies = [
   "directories-next",
   "serde",
 - "thiserror",
-- "toml 0.5.9",
-+ "thiserror 1.0.69",
-+ "toml 0.5.11",
++ "thiserror 1.0.31",
+  "toml 0.5.9",
  ]
  
 +[[package]]
@@ -460,7 +116,7 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "core-foundation"
  version = "0.9.4"
-@@ -424,6 +485,16 @@ dependencies = [
+@@ -424,6 +460,16 @@ dependencies = [
   "libc",
  ]
  
@@ -477,7 +133,7 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "core-foundation-sys"
  version = "0.8.7"
-@@ -432,116 +503,129 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+@@ -432,9 +478,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
  
  [[package]]
  name = "cpufeatures"
@@ -489,135 +145,32 @@ index a87da66..6245ce3 100644
  dependencies = [
   "libc",
  ]
- 
- [[package]]
- name = "crc"
--version = "3.0.0"
-+version = "3.3.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
-+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
- dependencies = [
-  "crc-catalog",
- ]
- 
- [[package]]
- name = "crc-catalog"
--version = "2.1.0"
-+version = "2.4.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
-+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
- 
- [[package]]
- name = "crc32fast"
--version = "1.4.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
--dependencies = [
-- "cfg-if",
--]
--
--[[package]]
--name = "crossbeam"
--version = "0.8.1"
-+version = "1.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
- dependencies = [
-  "cfg-if",
-- "crossbeam-channel",
-- "crossbeam-deque",
-- "crossbeam-epoch",
-- "crossbeam-queue",
-- "crossbeam-utils",
- ]
- 
- [[package]]
- name = "crossbeam-channel"
--version = "0.5.4"
-+version = "0.5.15"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
-+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
- dependencies = [
-- "cfg-if",
-  "crossbeam-utils",
- ]
- 
- [[package]]
- name = "crossbeam-deque"
--version = "0.8.1"
-+version = "0.8.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
- dependencies = [
-- "cfg-if",
-  "crossbeam-epoch",
-  "crossbeam-utils",
- ]
- 
- [[package]]
- name = "crossbeam-epoch"
--version = "0.9.8"
-+version = "0.9.18"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
-+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
- dependencies = [
-- "autocfg",
-- "cfg-if",
-  "crossbeam-utils",
-- "lazy_static",
-- "memoffset",
-- "scopeguard",
- ]
- 
- [[package]]
- name = "crossbeam-queue"
--version = "0.3.5"
-+version = "0.3.12"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
-+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
- dependencies = [
-- "cfg-if",
-  "crossbeam-utils",
- ]
+@@ -524,12 +570,20 @@ dependencies = [
  
  [[package]]
  name = "crossbeam-utils"
 -version = "0.8.8"
 +version = "0.8.21"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 +
 +[[package]]
 +name = "crypto-bigint"
 +version = "0.5.5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 +checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
  dependencies = [
 - "cfg-if",
 - "lazy_static",
 + "generic-array",
-+ "rand_core 0.6.4",
++ "rand_core",
 + "subtle",
 + "zeroize",
  ]
  
  [[package]]
- name = "crypto-common"
--version = "0.1.3"
-+version = "0.1.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
-+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
- dependencies = [
-  "generic-array",
+@@ -542,6 +596,33 @@ dependencies = [
   "typenum",
  ]
  
@@ -643,15 +196,15 @@ index a87da66..6245ce3 100644
 +source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 +dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
++ "proc-macro2 1.0.93",
++ "quote 1.0.38",
++ "syn 2.0.96",
 +]
 +
  [[package]]
  name = "deadpool"
  version = "0.8.2"
-@@ -565,14 +649,27 @@ dependencies = [
+@@ -565,14 +646,27 @@ dependencies = [
   "winapi",
  ]
  
@@ -681,31 +234,7 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
-@@ -606,6 +703,17 @@ dependencies = [
-  "winapi",
- ]
- 
-+[[package]]
-+name = "displaydoc"
-+version = "0.2.5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+]
-+
- [[package]]
- name = "dlopen"
- version = "0.1.8"
-@@ -643,45 +751,98 @@ checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
- dependencies = [
-  "cfg-if",
-  "libc",
-- "socket2 0.4.4",
-+ "socket2 0.4.10",
-  "winapi",
+@@ -648,10 +742,24 @@ dependencies = [
  ]
  
  [[package]]
@@ -733,12 +262,12 @@ index a87da66..6245ce3 100644
  
  [[package]]
  name = "ed25519"
--version = "1.5.0"
-+version = "1.5.3"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-+dependencies = [
-+ "signature 1.6.4",
+@@ -659,7 +767,31 @@ version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
+ dependencies = [
+- "signature",
++ "signature 1.5.0",
 +]
 +
 +[[package]]
@@ -754,11 +283,9 @@ index a87da66..6245ce3 100644
 +[[package]]
 +name = "ed25519-dalek"
 +version = "2.2.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
- dependencies = [
-- "signature",
++dependencies = [
 + "curve25519-dalek",
 + "ed25519 2.2.3",
 + "serde",
@@ -768,26 +295,20 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
- name = "either"
--version = "1.13.0"
-+version = "1.15.0"
+@@ -667,6 +799,30 @@ name = "either"
+ version = "1.13.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 +dependencies = [
 + "serde",
 +]
- 
- [[package]]
--name = "encoding_rs"
--version = "0.8.35"
++
++[[package]]
 +name = "elliptic-curve"
 +version = "0.13.8"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
- dependencies = [
-- "cfg-if",
++dependencies = [
 + "base16ct",
 + "crypto-bigint",
 + "digest",
@@ -797,53 +318,29 @@ index a87da66..6245ce3 100644
 + "hkdf",
 + "pem-rfc7468",
 + "pkcs8",
-+ "rand_core 0.6.4",
++ "rand_core",
 + "sec1",
 + "subtle",
 + "zeroize",
- ]
- 
- [[package]]
- name = "env_logger"
--version = "0.9.0"
-+version = "0.9.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
- dependencies = [
-  "atty",
-  "humantime",
-@@ -705,42 +866,87 @@ dependencies = [
- 
- [[package]]
- name = "equivalent"
--version = "1.0.1"
-+version = "1.0.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-+
-+[[package]]
-+name = "errno"
-+version = "0.3.14"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-+dependencies = [
-+ "libc",
-+ "windows-sys 0.61.2",
 +]
-+
+ 
+ [[package]]
+ name = "encoding_rs"
+@@ -709,11 +865,27 @@ version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+ 
 +[[package]]
 +name = "etcetera"
 +version = "0.8.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 +dependencies = [
 + "cfg-if",
 + "home",
 + "windows-sys 0.48.0",
 +]
- 
++
  [[package]]
  name = "event-listener"
 -version = "2.5.2"
@@ -859,23 +356,20 @@ index a87da66..6245ce3 100644
  
  [[package]]
  name = "fastrand"
--version = "1.7.0"
-+version = "2.3.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-+
+@@ -724,6 +896,22 @@ dependencies = [
+  "instant",
+ ]
+ 
 +[[package]]
 +name = "ff"
 +version = "0.13.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
- dependencies = [
-- "instant",
-+ "rand_core 0.6.4",
++dependencies = [
++ "rand_core",
 + "subtle",
- ]
- 
++]
++
 +[[package]]
 +name = "fiat-crypto"
 +version = "0.2.9"
@@ -884,68 +378,22 @@ index a87da66..6245ce3 100644
 +
  [[package]]
  name = "filetime"
--version = "0.2.16"
-+version = "0.2.26"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
-+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
- dependencies = [
-  "cfg-if",
-  "libc",
-- "redox_syscall",
-- "winapi",
-+ "libredox",
-+ "windows-sys 0.60.2",
- ]
- 
-+[[package]]
-+name = "find-msvc-tools"
-+version = "0.1.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
-+
- [[package]]
- name = "flate2"
--version = "1.0.35"
-+version = "1.1.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
-+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
- dependencies = [
-  "crc32fast",
-  "miniz_oxide",
-@@ -748,20 +954,21 @@ dependencies = [
- 
- [[package]]
- name = "flexi_logger"
--version = "0.22.3"
-+version = "0.22.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "969940c39bc718475391e53a3a59b0157e64929c80cf83ad5dde5f770ecdc423"
-+checksum = "0c76a80dd14a27fc3d8bc696502132cb52b3f227256fd8601166c3a35e45f409"
- dependencies = [
-  "ansi_term",
-  "atty",
-  "chrono",
-- "crossbeam",
-+ "crossbeam-channel",
-+ "crossbeam-queue",
-  "glob",
-  "lazy_static",
+ version = "0.2.16"
+@@ -761,7 +949,7 @@ dependencies = [
   "log",
   "regex",
   "rustversion",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "time",
  ]
  
-@@ -780,19 +987,18 @@ dependencies = [
+@@ -780,19 +968,18 @@ dependencies = [
   "log",
   "nu-ansi-term",
   "regex",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
  ]
  
  [[package]]
@@ -960,11 +408,11 @@ index a87da66..6245ce3 100644
   "futures-sink",
 - "pin-project",
 - "spin 0.9.3",
-+ "spin",
++ "spin 0.9.8",
  ]
  
  [[package]]
-@@ -801,6 +1007,12 @@ version = "1.0.7"
+@@ -801,6 +988,12 @@ version = "1.0.7"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
  
@@ -977,63 +425,7 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "foreign-types"
  version = "0.3.2"
-@@ -818,19 +1030,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
- 
- [[package]]
- name = "form_urlencoded"
--version = "1.0.1"
-+version = "1.2.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
- dependencies = [
-- "matches",
-  "percent-encoding",
- ]
- 
- [[package]]
- name = "futures"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
-+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
- dependencies = [
-  "futures-channel",
-  "futures-core",
-@@ -843,9 +1054,9 @@ dependencies = [
- 
- [[package]]
- name = "futures-channel"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
-+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
- dependencies = [
-  "futures-core",
-  "futures-sink",
-@@ -853,15 +1064,15 @@ dependencies = [
- 
- [[package]]
- name = "futures-core"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
-+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
- 
- [[package]]
- name = "futures-executor"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
- dependencies = [
-  "futures-core",
-  "futures-task",
-@@ -870,55 +1081,55 @@ dependencies = [
+@@ -870,20 +1063,20 @@ dependencies = [
  
  [[package]]
  name = "futures-intrusive"
@@ -1052,62 +444,14 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "futures-io"
 -version = "0.3.21"
-+version = "0.3.31"
++version = "0.3.32"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
-+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
++checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
  
  [[package]]
  name = "futures-macro"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
-+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 1.0.93",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
- 
- [[package]]
- name = "futures-sink"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
-+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
- 
- [[package]]
- name = "futures-task"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
-+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
- 
- [[package]]
- name = "futures-timer"
--version = "3.0.2"
-+version = "3.0.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
- 
- [[package]]
- name = "futures-util"
--version = "0.3.21"
-+version = "0.3.31"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
-+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
- dependencies = [
-  "futures-channel",
-  "futures-core",
-@@ -934,84 +1145,98 @@ dependencies = [
+@@ -934,12 +1127,13 @@ dependencies = [
  
  [[package]]
  name = "generic-array"
@@ -1123,107 +467,54 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
- name = "getrandom"
--version = "0.2.15"
-+version = "0.2.16"
+@@ -965,6 +1159,17 @@ version = "0.3.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
- dependencies = [
-  "cfg-if",
-+ "js-sys",
-  "libc",
-  "wasi",
-+ "wasm-bindgen",
-+]
-+
+ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+ 
 +[[package]]
-+name = "getrandom"
-+version = "0.3.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-+dependencies = [
-+ "cfg-if",
-+ "js-sys",
-+ "libc",
-+ "r-efi",
-+ "wasip2",
-+ "wasm-bindgen",
- ]
- 
- [[package]]
- name = "gimli"
--version = "0.31.1"
-+version = "0.32.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
- 
- [[package]]
- name = "glob"
--version = "0.3.0"
-+version = "0.3.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
- 
- [[package]]
--name = "h2"
--version = "0.3.26"
 +name = "group"
 +version = "0.13.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
- dependencies = [
-- "bytes",
-- "fnv",
-- "futures-core",
-- "futures-sink",
-- "futures-util",
-- "http",
-- "indexmap 2.7.0",
-- "slab",
-- "tokio",
-- "tokio-util",
-- "tracing",
++dependencies = [
 + "ff",
-+ "rand_core 0.6.4",
++ "rand_core",
 + "subtle",
++]
++
+ [[package]]
+ name = "h2"
+ version = "0.3.26"
+@@ -977,19 +1182,13 @@ dependencies = [
+  "futures-sink",
+  "futures-util",
+  "http",
+- "indexmap 2.7.0",
++ "indexmap",
+  "slab",
+  "tokio",
+  "tokio-util",
+  "tracing",
  ]
  
- [[package]]
- name = "hashbrown"
+-[[package]]
+-name = "hashbrown"
 -version = "0.11.2"
-+version = "0.12.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-+dependencies = [
-+ "ahash",
-+]
- 
+-
  [[package]]
  name = "hashbrown"
--version = "0.12.1"
-+version = "0.15.5"
+ version = "0.12.1"
+@@ -1004,14 +1203,19 @@ name = "hashbrown"
+ version = "0.15.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
-+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
- dependencies = [
-- "ahash",
+ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
++dependencies = [
 + "allocator-api2",
 + "equivalent",
 + "foldhash",
- ]
- 
- [[package]]
- name = "hashbrown"
--version = "0.15.2"
-+version = "0.16.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
++]
  
  [[package]]
  name = "hashlink"
@@ -1234,85 +525,20 @@ index a87da66..6245ce3 100644
 +checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
  dependencies = [
 - "hashbrown 0.12.1",
-+ "hashbrown 0.15.5",
++ "hashbrown 0.15.2",
  ]
  
  [[package]]
-@@ -1042,7 +1267,7 @@ dependencies = [
-  "osascript",
-  "protobuf",
-  "protobuf-codegen",
-- "rand",
-+ "rand 0.8.5",
-  "regex",
-  "rustls-pki-types",
-  "rustls-platform-verifier",
-@@ -1053,11 +1278,11 @@ dependencies = [
+@@ -1053,7 +1257,7 @@ dependencies = [
   "socket2 0.3.19",
   "sodiumoxide",
   "sysinfo",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "tokio",
   "tokio-native-tls",
-- "tokio-rustls 0.26.1",
-- "tokio-socks 0.5.2-1",
-+ "tokio-rustls",
-+ "tokio-socks 0.5.2-3",
-  "tokio-util",
-  "toml 0.7.8",
-  "url",
-@@ -1073,16 +1298,16 @@ dependencies = [
-  "async-speed-limit",
-  "async-trait",
-  "axum",
-- "base64 0.13.0",
-+ "base64 0.13.1",
-  "bcrypt",
-  "chrono",
-  "clap",
-  "deadpool",
-  "dns-lookup",
-- "flexi_logger 0.22.3",
-+ "flexi_logger 0.22.6",
-  "hbb_common",
-  "headers",
-- "http",
-+ "http 0.2.12",
-  "ipnetwork",
-  "jsonwebtoken",
-  "lazy_static",
-@@ -1109,18 +1334,17 @@ dependencies = [
- 
- [[package]]
- name = "headers"
--version = "0.3.7"
-+version = "0.3.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
-+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
- dependencies = [
-- "base64 0.13.0",
-- "bitflags 1.3.2",
-+ "base64 0.21.7",
-  "bytes",
-  "headers-core",
-- "http",
-+ "http 0.2.12",
-  "httpdate",
-  "mime",
-- "sha-1",
-+ "sha1",
- ]
- 
- [[package]]
-@@ -1129,17 +1353,14 @@ version = "0.2.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
- dependencies = [
-- "http",
-+ "http 0.2.12",
- ]
+  "tokio-rustls 0.26.1",
+@@ -1135,12 +1339,9 @@ dependencies = [
  
  [[package]]
  name = "heck"
@@ -1327,19 +553,7 @@ index a87da66..6245ce3 100644
  
  [[package]]
  name = "hermit-abi"
-@@ -1152,9 +1373,9 @@ dependencies = [
- 
- [[package]]
- name = "hermit-abi"
--version = "0.4.0"
-+version = "0.5.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
- 
- [[package]]
- name = "hex"
-@@ -1162,11 +1383,49 @@ version = "0.4.3"
+@@ -1163,6 +1364,33 @@ version = "0.4.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
  
@@ -1363,415 +577,37 @@ index a87da66..6245ce3 100644
 +
 +[[package]]
 +name = "home"
-+version = "0.5.11"
++version = "0.5.12"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
++checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 +dependencies = [
-+ "windows-sys 0.59.0",
++ "windows-sys 0.61.2",
 +]
 +
  [[package]]
  name = "http"
--version = "0.2.7"
-+version = "0.2.12"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-+dependencies = [
-+ "bytes",
-+ "fnv",
-+ "itoa",
-+]
-+
-+[[package]]
-+name = "http"
-+version = "1.3.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
-+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
- dependencies = [
-  "bytes",
-  "fnv",
-@@ -1175,38 +1434,61 @@ dependencies = [
- 
- [[package]]
- name = "http-body"
--version = "0.4.4"
-+version = "0.4.6"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-+dependencies = [
-+ "bytes",
-+ "http 0.2.12",
-+ "pin-project-lite",
-+]
-+
-+[[package]]
-+name = "http-body"
-+version = "1.0.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-+dependencies = [
-+ "bytes",
-+ "http 1.3.1",
-+]
-+
-+[[package]]
-+name = "http-body-util"
-+version = "0.1.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
-+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
- dependencies = [
-  "bytes",
-- "http",
-+ "futures-core",
-+ "http 1.3.1",
-+ "http-body 1.0.1",
-  "pin-project-lite",
+ version = "0.2.7"
+@@ -1294,16 +1522,6 @@ dependencies = [
+  "unicode-normalization",
  ]
  
- [[package]]
- name = "http-range-header"
--version = "0.3.0"
-+version = "0.3.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
-+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
- 
- [[package]]
- name = "httparse"
--version = "1.9.5"
-+version = "1.10.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
-+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
- 
- [[package]]
- name = "httpdate"
--version = "1.0.2"
-+version = "1.0.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
- 
- [[package]]
- name = "humantime"
--version = "2.1.0"
-+version = "2.3.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
- 
- [[package]]
- name = "hyper"
-@@ -1218,59 +1500,111 @@ dependencies = [
-  "futures-channel",
-  "futures-core",
-  "futures-util",
-- "h2",
-- "http",
-- "http-body",
-+ "http 0.2.12",
-+ "http-body 0.4.6",
-  "httparse",
-  "httpdate",
-  "itoa",
-  "pin-project-lite",
-- "socket2 0.5.8",
-+ "socket2 0.5.10",
-  "tokio",
-  "tower-service",
-  "tracing",
-  "want",
- ]
- 
-+[[package]]
-+name = "hyper"
-+version = "1.7.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
-+dependencies = [
-+ "atomic-waker",
-+ "bytes",
-+ "futures-channel",
-+ "futures-core",
-+ "http 1.3.1",
-+ "http-body 1.0.1",
-+ "httparse",
-+ "itoa",
-+ "pin-project-lite",
-+ "pin-utils",
-+ "smallvec",
-+ "tokio",
-+ "want",
-+]
-+
- [[package]]
- name = "hyper-rustls"
--version = "0.24.2"
-+version = "0.27.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
- dependencies = [
-- "futures-util",
-- "http",
-- "hyper",
-- "rustls 0.21.12",
-+ "http 1.3.1",
-+ "hyper 1.7.0",
-+ "hyper-util",
-+ "rustls",
-+ "rustls-native-certs",
-+ "rustls-pki-types",
-  "tokio",
-- "tokio-rustls 0.24.1",
-+ "tokio-rustls",
-+ "tower-service",
-+ "webpki-roots 1.0.3",
- ]
- 
- [[package]]
- name = "hyper-tls"
--version = "0.5.0"
-+version = "0.6.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
- dependencies = [
-  "bytes",
-- "hyper",
-+ "http-body-util",
-+ "hyper 1.7.0",
-+ "hyper-util",
-  "native-tls",
-  "tokio",
-  "tokio-native-tls",
-+ "tower-service",
-+]
-+
-+[[package]]
-+name = "hyper-util"
-+version = "0.1.17"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
-+dependencies = [
-+ "base64 0.22.1",
-+ "bytes",
-+ "futures-channel",
-+ "futures-core",
-+ "futures-util",
-+ "http 1.3.1",
-+ "http-body 1.0.1",
-+ "hyper 1.7.0",
-+ "ipnet",
-+ "libc",
-+ "percent-encoding",
-+ "pin-project-lite",
-+ "socket2 0.6.1",
-+ "tokio",
-+ "tower-service",
-+ "tracing",
- ]
- 
- [[package]]
- name = "iana-time-zone"
--version = "0.1.61"
-+version = "0.1.64"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
- dependencies = [
-  "android_system_properties",
-  "core-foundation-sys",
-  "iana-time-zone-haiku",
-  "js-sys",
-+ "log",
-  "wasm-bindgen",
-- "windows-core 0.52.0",
-+ "windows-core 0.62.2",
- ]
- 
- [[package]]
-@@ -1283,59 +1617,136 @@ dependencies = [
- ]
- 
- [[package]]
--name = "idna"
--version = "0.2.3"
-+name = "icu_collections"
-+version = "2.0.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
- dependencies = [
-- "matches",
-- "unicode-bidi",
-- "unicode-normalization",
-+ "displaydoc",
-+ "potential_utf",
-+ "yoke",
-+ "zerofrom",
-+ "zerovec",
- ]
- 
- [[package]]
+-[[package]]
 -name = "indexmap"
 -version = "1.8.1"
-+name = "icu_locale_core"
-+version = "2.0.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
-+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
- dependencies = [
+-dependencies = [
 - "autocfg",
 - "hashbrown 0.11.2",
-+ "displaydoc",
-+ "litemap",
-+ "tinystr",
-+ "writeable",
-+ "zerovec",
- ]
- 
- [[package]]
--name = "indexmap"
--version = "2.7.0"
-+name = "icu_normalizer"
-+version = "2.0.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
-+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
- dependencies = [
-- "equivalent",
-- "hashbrown 0.15.2",
-+ "displaydoc",
-+ "icu_collections",
-+ "icu_normalizer_data",
-+ "icu_properties",
-+ "icu_provider",
-+ "smallvec",
-+ "zerovec",
- ]
- 
- [[package]]
--name = "inout"
--version = "0.1.3"
-+name = "icu_normalizer_data"
-+version = "2.0.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
-+
-+[[package]]
-+name = "icu_properties"
-+version = "2.0.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
- dependencies = [
-- "generic-array",
-+ "displaydoc",
-+ "icu_collections",
-+ "icu_locale_core",
-+ "icu_properties_data",
-+ "icu_provider",
-+ "potential_utf",
-+ "zerotrie",
-+ "zerovec",
- ]
- 
- [[package]]
--name = "instant"
--version = "0.1.12"
-+name = "icu_properties_data"
-+version = "2.0.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
-+
-+[[package]]
-+name = "icu_provider"
-+version = "2.0.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
- dependencies = [
-- "cfg-if",
-+ "displaydoc",
-+ "icu_locale_core",
-+ "stable_deref_trait",
-+ "tinystr",
-+ "writeable",
-+ "yoke",
-+ "zerofrom",
-+ "zerotrie",
-+ "zerovec",
-+]
-+
-+[[package]]
-+name = "idna"
-+version = "1.1.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-+dependencies = [
-+ "idna_adapter",
-+ "smallvec",
-+ "utf8_iter",
-+]
-+
-+[[package]]
-+name = "idna_adapter"
-+version = "1.2.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-+dependencies = [
-+ "icu_normalizer",
-+ "icu_properties",
-+]
-+
-+[[package]]
-+name = "indexmap"
-+version = "2.11.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
-+dependencies = [
-+ "equivalent",
-+ "hashbrown 0.16.0",
-+]
-+
-+[[package]]
-+name = "inout"
-+version = "0.1.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-+dependencies = [
-+ "generic-array",
- ]
- 
- [[package]]
- name = "ipnet"
--version = "2.10.1"
-+version = "2.11.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
- 
- [[package]]
- name = "ipnetwork"
-@@ -1348,42 +1759,35 @@ dependencies = [
- 
- [[package]]
- name = "is-terminal"
--version = "0.4.13"
-+version = "0.4.16"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
- dependencies = [
-- "hermit-abi 0.4.0",
-+ "hermit-abi 0.5.2",
-  "libc",
-- "windows-sys 0.52.0",
 -]
 -
+ [[package]]
+ name = "indexmap"
+ version = "2.7.0"
+@@ -1358,15 +1576,6 @@ dependencies = [
+  "windows-sys 0.52.0",
+ ]
+ 
 -[[package]]
 -name = "itertools"
 -version = "0.10.3"
@@ -1779,16 +615,12 @@ index a87da66..6245ce3 100644
 -checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 -dependencies = [
 - "either",
-+ "windows-sys 0.59.0",
- ]
- 
+-]
+-
  [[package]]
  name = "itoa"
--version = "1.0.1"
-+version = "1.0.15"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
-+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+ version = "1.0.1"
+@@ -1375,16 +1584,18 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
  
  [[package]]
  name = "jni"
@@ -1804,57 +636,33 @@ index a87da66..6245ce3 100644
   "jni-sys",
   "log",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "walkdir",
 + "windows-sys 0.45.0",
  ]
  
  [[package]]
-@@ -1394,18 +1798,19 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
- 
- [[package]]
- name = "jobserver"
--version = "0.1.32"
-+version = "0.1.34"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
- dependencies = [
-+ "getrandom 0.3.4",
-  "libc",
- ]
- 
- [[package]]
- name = "js-sys"
--version = "0.3.77"
-+version = "0.3.81"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
- dependencies = [
-  "once_cell",
-  "wasm-bindgen",
-@@ -1413,23 +1818,35 @@ dependencies = [
+@@ -1414,15 +1625,24 @@ dependencies = [
  
  [[package]]
  name = "jsonwebtoken"
 -version = "8.1.0"
-+version = "10.0.0"
++version = "10.3.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "cc9051c17f81bae79440afa041b3a278e1de71bfb96d32454b477fd4703ccb6f"
-+checksum = "f1417155a38e99d7704ddb3ea7445fe57fdbd5d756d727740a9ed8b9ebaed6e1"
++checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
  dependencies = [
 - "base64 0.13.0",
 + "base64 0.22.1",
 + "ed25519-dalek",
-+ "getrandom 0.2.16",
++ "getrandom",
 + "hmac",
 + "js-sys",
 + "p256",
 + "p384",
   "pem",
 - "ring 0.16.20",
-+ "rand 0.8.5",
++ "rand",
 + "rsa",
   "serde",
   "serde_json",
@@ -1863,61 +671,30 @@ index a87da66..6245ce3 100644
   "simple_asn1",
  ]
  
- [[package]]
- name = "lazy_static"
--version = "1.4.0"
-+version = "1.5.0"
+@@ -1431,6 +1651,9 @@ name = "lazy_static"
+ version = "1.4.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 +dependencies = [
-+ "spin",
++ "spin 0.5.2",
 +]
  
  [[package]]
  name = "lazycell"
-@@ -1452,18 +1869,35 @@ dependencies = [
- 
- [[package]]
- name = "libc"
--version = "0.2.169"
-+version = "0.2.177"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
- 
- [[package]]
- name = "libloading"
--version = "0.8.6"
-+version = "0.8.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
- dependencies = [
-  "cfg-if",
-- "windows-targets 0.52.6",
-+ "windows-link",
-+]
-+
-+[[package]]
-+name = "libm"
-+version = "0.2.15"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-+
-+[[package]]
-+name = "libredox"
-+version = "0.1.10"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-+dependencies = [
-+ "bitflags 2.9.4",
-+ "libc",
-+ "redox_syscall",
+@@ -1467,6 +1690,12 @@ dependencies = [
+  "windows-targets 0.52.6",
  ]
  
++[[package]]
++name = "libm"
++version = "0.2.16"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
++
  [[package]]
-@@ -1480,51 +1914,71 @@ dependencies = [
+ name = "libsodium-sys"
+ version = "0.2.7"
+@@ -1481,9 +1710,9 @@ dependencies = [
  
  [[package]]
  name = "libsqlite3-sys"
@@ -1929,94 +706,31 @@ index a87da66..6245ce3 100644
  dependencies = [
   "cc",
   "pkg-config",
-  "vcpkg",
- ]
- 
-+[[package]]
-+name = "linux-raw-sys"
-+version = "0.4.15"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-+
-+[[package]]
-+name = "linux-raw-sys"
-+version = "0.11.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-+
-+[[package]]
-+name = "litemap"
-+version = "0.8.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
-+
- [[package]]
- name = "local-ip-address"
--version = "0.5.3"
-+version = "0.5.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2815836665de176ba66deaa449ada98fdf208d84730d1a84a22cbeed6151a6fa"
-+checksum = "612ed4ea9ce5acfb5d26339302528a5e1e59dfed95e9e11af3c083236ff1d15d"
+@@ -1498,7 +1727,7 @@ checksum = "2815836665de176ba66deaa449ada98fdf208d84730d1a84a22cbeed6151a6fa"
  dependencies = [
   "libc",
   "neli",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "windows-sys 0.48.0",
  ]
  
- [[package]]
- name = "lock_api"
--version = "0.4.7"
-+version = "0.4.14"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
- dependencies = [
-- "autocfg",
-  "scopeguard",
- ]
+@@ -1514,12 +1743,9 @@ dependencies = [
  
  [[package]]
  name = "log"
 -version = "0.4.17"
-+version = "0.4.28"
++version = "0.4.29"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 -dependencies = [
 - "cfg-if",
 -]
-+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-+
-+[[package]]
-+name = "lru-slab"
-+version = "0.1.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
++checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
  
  [[package]]
  name = "mac_address"
--version = "1.1.5"
-+version = "1.1.8"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4863ee94f19ed315bf3bc00299338d857d4b5bc856af375cc97d237382ad3856"
-+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
- dependencies = [
-  "nix",
-  "winapi",
-@@ -1549,44 +2003,48 @@ dependencies = [
-  "winreg 0.11.0",
- ]
- 
--[[package]]
--name = "matches"
--version = "0.1.9"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
--
- [[package]]
- name = "matchit"
- version = "0.5.0"
+@@ -1562,6 +1788,16 @@ version = "0.5.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
  
@@ -2032,93 +746,13 @@ index a87da66..6245ce3 100644
 +
  [[package]]
  name = "memchr"
--version = "2.7.4"
-+version = "2.7.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
- 
- [[package]]
- name = "memoffset"
--version = "0.6.5"
-+version = "0.9.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
- dependencies = [
-  "autocfg",
- ]
- 
- [[package]]
- name = "mime"
--version = "0.3.16"
-+version = "0.3.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
- 
- [[package]]
- name = "mime_guess"
--version = "2.0.4"
-+version = "2.0.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
- dependencies = [
-  "mime",
-  "unicase",
-@@ -1600,39 +2058,39 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
- 
- [[package]]
- name = "miniz_oxide"
--version = "0.8.3"
-+version = "0.8.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
-+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
- dependencies = [
-  "adler2",
-+ "simd-adler32",
- ]
- 
- [[package]]
- name = "minreq"
--version = "2.6.0"
-+version = "2.14.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4c785bc6027fd359756e538541c8624012ba3776d3d3fe123885643092ed4132"
-+checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
- dependencies = [
-- "log",
-  "punycode",
- ]
- 
- [[package]]
- name = "mio"
--version = "1.0.3"
-+version = "1.0.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
- dependencies = [
-  "libc",
-  "wasi",
-- "windows-sys 0.52.0",
-+ "windows-sys 0.59.0",
- ]
- 
- [[package]]
- name = "native-tls"
--version = "0.2.12"
-+version = "0.2.14"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
- dependencies = [
+ version = "2.7.4"
+@@ -1638,10 +1874,10 @@ dependencies = [
   "libc",
   "log",
-@@ -1640,16 +2098,16 @@ dependencies = [
-  "openssl-probe",
+  "openssl",
+- "openssl-probe",
++ "openssl-probe 0.1.5",
   "openssl-sys",
   "schannel",
 - "security-framework",
@@ -2126,93 +760,22 @@ index a87da66..6245ce3 100644
   "security-framework-sys",
   "tempfile",
  ]
- 
- [[package]]
- name = "neli"
--version = "0.6.4"
-+version = "0.6.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
-+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
- dependencies = [
-  "byteorder",
-  "libc",
-@@ -1659,35 +2117,35 @@ dependencies = [
- 
- [[package]]
- name = "neli-proc-macros"
--version = "0.1.3"
-+version = "0.1.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
-+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
- dependencies = [
-  "either",
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-  "serde",
-- "syn 1.0.93",
-+ "syn 1.0.109",
- ]
- 
- [[package]]
- name = "nix"
--version = "0.23.1"
-+version = "0.29.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
- dependencies = [
-- "bitflags 1.3.2",
-- "cc",
-+ "bitflags 2.9.4",
-  "cfg-if",
-+ "cfg_aliases",
-  "libc",
-  "memoffset",
- ]
- 
- [[package]]
- name = "nom"
--version = "5.1.2"
-+version = "5.1.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
- dependencies = [
-  "lexical-core",
-  "memchr",
-@@ -1696,9 +2154,9 @@ dependencies = [
- 
- [[package]]
- name = "nom"
--version = "7.1.1"
-+version = "7.1.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
- dependencies = [
-  "memchr",
-  "minimal-lexical",
-@@ -1732,6 +2190,23 @@ dependencies = [
+@@ -1733,6 +1969,22 @@ dependencies = [
   "num-traits",
  ]
  
 +[[package]]
 +name = "num-bigint-dig"
-+version = "0.8.4"
++version = "0.8.6"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
++checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 +dependencies = [
-+ "byteorder",
 + "lazy_static",
 + "libm",
 + "num-integer",
 + "num-iter",
 + "num-traits",
-+ "rand 0.8.5",
++ "rand",
 + "smallvec",
 + "zeroize",
 +]
@@ -2220,7 +783,7 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "num-integer"
  version = "0.1.46"
-@@ -1741,6 +2216,17 @@ dependencies = [
+@@ -1742,6 +1994,17 @@ dependencies = [
   "num-traits",
  ]
  
@@ -2238,7 +801,7 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "num-traits"
  version = "0.2.19"
-@@ -1748,49 +2234,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1749,6 +2012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
  dependencies = [
   "autocfg",
@@ -2246,101 +809,29 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
- name = "num_cpus"
--version = "1.13.1"
-+version = "1.17.0"
+@@ -1791,7 +2055,7 @@ version = "0.10.68"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
- dependencies = [
-- "hermit-abi 0.1.19",
-+ "hermit-abi 0.5.2",
-  "libc",
- ]
- 
- [[package]]
- name = "num_threads"
--version = "0.1.6"
-+version = "0.1.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
- dependencies = [
-  "libc",
- ]
- 
- [[package]]
- name = "object"
--version = "0.36.7"
-+version = "0.37.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
- dependencies = [
-  "memchr",
- ]
- 
- [[package]]
- name = "once_cell"
--version = "1.20.2"
-+version = "1.21.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
- 
- [[package]]
- name = "openssl"
--version = "0.10.68"
-+version = "0.10.74"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+ checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
  dependencies = [
 - "bitflags 2.7.0",
-+ "bitflags 2.9.4",
++ "bitflags 2.11.0",
   "cfg-if",
   "foreign-types",
   "libc",
-@@ -1805,22 +2292,22 @@ version = "0.1.1"
+@@ -1817,6 +2081,12 @@ version = "0.1.5"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
+ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
  
- [[package]]
- name = "openssl-probe"
--version = "0.1.5"
-+version = "0.1.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
- 
++[[package]]
++name = "openssl-probe"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
++
  [[package]]
  name = "openssl-sys"
--version = "0.9.104"
-+version = "0.9.110"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
- dependencies = [
-  "cc",
-  "libc",
-@@ -1835,7 +2322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
- dependencies = [
-  "dlv-list",
-- "hashbrown 0.12.1",
-+ "hashbrown 0.12.3",
- ]
- 
- [[package]]
-@@ -1850,59 +2337,58 @@ dependencies = [
+ version = "0.9.104"
+@@ -1851,16 +2121,35 @@ dependencies = [
  ]
  
  [[package]]
@@ -2359,64 +850,63 @@ index a87da66..6245ce3 100644
 + "elliptic-curve",
 + "primeorder",
 + "sha2",
- ]
- 
- [[package]]
--name = "parking_lot"
--version = "0.12.0"
++]
++
++[[package]]
 +name = "p384"
 +version = "0.13.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
- dependencies = [
-- "lock_api",
-- "parking_lot_core 0.9.3",
++dependencies = [
 + "ecdsa",
 + "elliptic-curve",
 + "primeorder",
 + "sha2",
  ]
  
- [[package]]
--name = "parking_lot_core"
--version = "0.8.5"
++[[package]]
 +name = "parking"
 +version = "2.2.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 +
-+[[package]]
-+name = "parking_lot"
-+version = "0.12.5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+ [[package]]
+ name = "parking_lot"
+ version = "0.12.0"
+@@ -1868,28 +2157,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
  dependencies = [
+  "lock_api",
+- "parking_lot_core 0.9.3",
++ "parking_lot_core",
+ ]
+ 
+ [[package]]
+ name = "parking_lot_core"
+-version = "0.8.5"
++version = "0.9.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+-dependencies = [
 - "cfg-if",
 - "instant",
 - "libc",
 - "redox_syscall",
 - "smallvec",
 - "winapi",
-+ "lock_api",
-+ "parking_lot_core",
- ]
- 
- [[package]]
- name = "parking_lot_core"
+-]
+-
+-[[package]]
+-name = "parking_lot_core"
 -version = "0.9.3"
-+version = "0.9.12"
- source = "registry+https://github.com/rust-lang/crates.io-index"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
-+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
++checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
  dependencies = [
   "cfg-if",
   "libc",
-  "redox_syscall",
-  "smallvec",
-- "windows-sys 0.36.1",
-+ "windows-link",
+@@ -1898,12 +2173,6 @@ dependencies = [
+  "windows-sys 0.36.1",
  ]
  
 -[[package]]
@@ -2428,7 +918,7 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "peeking_take_while"
  version = "0.1.2"
-@@ -1911,37 +2397,47 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+@@ -1912,11 +2181,21 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
  
  [[package]]
  name = "pem"
@@ -2453,65 +943,20 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
- name = "percent-encoding"
--version = "2.1.0"
-+version = "2.3.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
- 
- [[package]]
- name = "pin-project"
--version = "1.1.8"
-+version = "1.1.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
-+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+@@ -1965,7 +2244,28 @@ checksum = "69044d1c00894fc1f43d9485aadb6ab6e68df90608fa52cf1074cda6420c6b76"
  dependencies = [
-  "pin-project-internal",
- ]
- 
- [[package]]
- name = "pin-project-internal"
--version = "1.1.8"
-+version = "1.1.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
-+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
- 
- [[package]]
-@@ -1958,26 +2454,68 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
- 
- [[package]]
- name = "ping"
--version = "0.4.0"
-+version = "0.4.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6370a87a1a5bacec2eb80fa24ff3b7f47a1d47404a96611230d3b0d2e0f51141"
-+dependencies = [
-+ "rand 0.8.5",
-+ "socket2 0.4.10",
-+ "thiserror 1.0.69",
+  "rand",
+  "socket2 0.4.4",
+- "thiserror",
++ "thiserror 1.0.31",
 +]
 +
 +[[package]]
 +name = "pkcs1"
 +version = "0.7.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "69044d1c00894fc1f43d9485aadb6ab6e68df90608fa52cf1074cda6420c6b76"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
- dependencies = [
-- "rand",
-- "socket2 0.4.4",
-- "thiserror",
++dependencies = [
 + "der",
 + "pkcs8",
 + "spki",
@@ -2528,33 +973,10 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
- name = "pkg-config"
--version = "0.3.25"
-+version = "0.3.32"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-+
-+[[package]]
-+name = "potential_utf"
-+version = "0.1.3"
+@@ -1980,6 +2280,15 @@ version = "0.2.16"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
-+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
-+dependencies = [
-+ "zerovec",
-+]
+ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
  
- [[package]]
- name = "ppv-lite86"
--version = "0.2.16"
-+version = "0.2.21"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-+dependencies = [
-+ "zerocopy",
-+]
-+
 +[[package]]
 +name = "primeorder"
 +version = "0.13.6"
@@ -2563,68 +985,30 @@ index a87da66..6245ce3 100644
 +dependencies = [
 + "elliptic-curve",
 +]
- 
++
  [[package]]
  name = "proc-macro2"
-@@ -1985,35 +2523,35 @@ version = "0.4.30"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
- dependencies = [
-- "unicode-xid 0.1.0",
-+ "unicode-xid",
- ]
- 
- [[package]]
- name = "proc-macro2"
--version = "1.0.93"
-+version = "1.0.101"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
-+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
- dependencies = [
-  "unicode-ident",
- ]
- 
- [[package]]
- name = "protobuf"
--version = "3.7.1"
-+version = "3.7.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
-+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
- dependencies = [
+ version = "0.4.30"
+@@ -2007,7 +2316,7 @@ dependencies = [
   "bytes",
   "once_cell",
   "protobuf-support",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
  ]
  
  [[package]]
- name = "protobuf-codegen"
--version = "3.7.1"
-+version = "3.7.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
-+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
- dependencies = [
-  "anyhow",
-  "once_cell",
-@@ -2021,32 +2559,32 @@ dependencies = [
+@@ -2022,7 +2331,7 @@ dependencies = [
   "protobuf-parse",
   "regex",
   "tempfile",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
  ]
  
  [[package]]
- name = "protobuf-parse"
--version = "3.7.1"
-+version = "3.7.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
-+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+@@ -2032,12 +2341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
  dependencies = [
   "anyhow",
 - "indexmap 2.7.0",
@@ -2634,147 +1018,20 @@ index a87da66..6245ce3 100644
   "protobuf-support",
   "tempfile",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "which",
  ]
  
- [[package]]
- name = "protobuf-support"
--version = "3.7.1"
-+version = "3.7.2"
+@@ -2047,7 +2356,7 @@ version = "3.7.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
-+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+ checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
  dependencies = [
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
  ]
  
  [[package]]
-@@ -2056,12 +2594,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "e9e1dcb320d6839f6edb64f7a4a59d39b30480d4d1765b56873f7c858538a5fe"
- 
- [[package]]
--name = "quickcheck"
--version = "1.0.3"
-+name = "quinn"
-+version = "0.11.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
- dependencies = [
-- "rand",
-+ "bytes",
-+ "cfg_aliases",
-+ "pin-project-lite",
-+ "quinn-proto",
-+ "quinn-udp",
-+ "rustc-hash 2.1.1",
-+ "rustls",
-+ "socket2 0.6.1",
-+ "thiserror 2.0.17",
-+ "tokio",
-+ "tracing",
-+ "web-time",
-+]
-+
-+[[package]]
-+name = "quinn-proto"
-+version = "0.11.13"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
-+dependencies = [
-+ "bytes",
-+ "getrandom 0.3.4",
-+ "lru-slab",
-+ "rand 0.9.2",
-+ "ring",
-+ "rustc-hash 2.1.1",
-+ "rustls",
-+ "rustls-pki-types",
-+ "slab",
-+ "thiserror 2.0.17",
-+ "tinyvec",
-+ "tracing",
-+ "web-time",
-+]
-+
-+[[package]]
-+name = "quinn-udp"
-+version = "0.5.14"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-+dependencies = [
-+ "cfg_aliases",
-+ "libc",
-+ "once_cell",
-+ "socket2 0.6.1",
-+ "tracing",
-+ "windows-sys 0.60.2",
- ]
- 
- [[package]]
-@@ -2075,13 +2659,19 @@ dependencies = [
- 
- [[package]]
- name = "quote"
--version = "1.0.38"
-+version = "1.0.41"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
-+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
- dependencies = [
-- "proc-macro2 1.0.93",
-+ "proc-macro2 1.0.101",
- ]
- 
-+[[package]]
-+name = "r-efi"
-+version = "5.3.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-+
- [[package]]
- name = "rand"
- version = "0.8.5"
-@@ -2089,8 +2679,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
- dependencies = [
-  "libc",
-- "rand_chacha",
-- "rand_core",
-+ "rand_chacha 0.3.1",
-+ "rand_core 0.6.4",
-+]
-+
-+[[package]]
-+name = "rand"
-+version = "0.9.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-+dependencies = [
-+ "rand_chacha 0.9.0",
-+ "rand_core 0.9.3",
- ]
- 
- [[package]]
-@@ -2100,23 +2700,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
- dependencies = [
-  "ppv-lite86",
-- "rand_core",
-+ "rand_core 0.6.4",
-+]
-+
-+[[package]]
-+name = "rand_chacha"
-+version = "0.9.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-+dependencies = [
-+ "ppv-lite86",
-+ "rand_core 0.9.3",
- ]
+@@ -2106,9 +2415,9 @@ dependencies = [
  
  [[package]]
  name = "rand_core"
@@ -2784,220 +1041,58 @@ index a87da66..6245ce3 100644
 -checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 +checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
  dependencies = [
-- "getrandom",
-+ "getrandom 0.2.16",
-+]
-+
-+[[package]]
-+name = "rand_core"
-+version = "0.9.3"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-+dependencies = [
-+ "getrandom 0.3.4",
+  "getrandom",
  ]
- 
- [[package]]
- name = "rayon"
--version = "1.10.0"
-+version = "1.11.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+@@ -2150,7 +2459,7 @@ checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
  dependencies = [
-  "either",
-  "rayon-core",
-@@ -2124,9 +2743,9 @@ dependencies = [
- 
- [[package]]
- name = "rayon-core"
--version = "1.12.1"
-+version = "1.13.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
- dependencies = [
-  "crossbeam-deque",
-  "crossbeam-utils",
-@@ -2134,29 +2753,29 @@ dependencies = [
- 
- [[package]]
- name = "redox_syscall"
--version = "0.2.13"
-+version = "0.5.18"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
-+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
- dependencies = [
-- "bitflags 1.3.2",
-+ "bitflags 2.9.4",
- ]
- 
- [[package]]
- name = "redox_users"
--version = "0.4.3"
-+version = "0.4.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
- dependencies = [
-- "getrandom",
-- "redox_syscall",
+  "getrandom",
+  "redox_syscall",
 - "thiserror",
-+ "getrandom 0.2.16",
-+ "libredox",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
  ]
  
  [[package]]
- name = "regex"
--version = "1.11.1"
-+version = "1.12.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
- dependencies = [
-  "aho-corasick",
-  "memchr",
-@@ -2166,9 +2785,9 @@ dependencies = [
- 
- [[package]]
- name = "regex-automata"
--version = "0.4.9"
-+version = "0.4.13"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
- dependencies = [
-  "aho-corasick",
-  "memchr",
-@@ -2177,36 +2796,28 @@ dependencies = [
- 
- [[package]]
- name = "regex-syntax"
--version = "0.8.5"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
--
--[[package]]
--name = "remove_dir_all"
--version = "0.5.3"
-+version = "0.8.8"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
--dependencies = [
-- "winapi",
--]
-+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
- 
- [[package]]
- name = "reqwest"
--version = "0.11.23"
--source = "git+https://github.com/rustdesk-org/reqwest#9cb758c9fb2f4edc62eb790acfd45a6a3da21ed3"
-+version = "0.12.15"
-+source = "git+https://github.com/rustdesk-org/reqwest#32db1b0b05c4991ee34a65f08338755c4434f54e"
- dependencies = [
-  "async-compression",
-- "base64 0.21.7",
-+ "base64 0.22.1",
-  "bytes",
-- "encoding_rs",
-+ "futures-channel",
-  "futures-core",
-  "futures-util",
-- "h2",
-- "http",
-- "http-body",
-- "hyper",
-+ "http 1.3.1",
-+ "http-body 1.0.1",
-+ "http-body-util",
-+ "hyper 1.7.0",
-  "hyper-rustls",
-  "hyper-tls",
-+ "hyper-util",
-  "ipnet",
-  "js-sys",
-  "log",
-@@ -2215,55 +2826,70 @@ dependencies = [
-  "once_cell",
-  "percent-encoding",
+@@ -2218,7 +2527,7 @@ dependencies = [
   "pin-project-lite",
-- "rustls 0.21.12",
-- "rustls-native-certs 0.6.2",
+  "rustls 0.21.12",
+  "rustls-native-certs 0.6.2",
 - "rustls-pemfile 1.0.0",
-+ "quinn",
-+ "rustls",
-+ "rustls-native-certs",
-+ "rustls-pki-types",
++ "rustls-pemfile",
   "serde",
   "serde_json",
   "serde_urlencoded",
-- "sync_wrapper",
-- "system-configuration",
-+ "sync_wrapper 1.0.2",
-  "tokio",
-  "tokio-native-tls",
-- "tokio-rustls 0.24.1",
-+ "tokio-rustls",
-  "tokio-socks 0.5.2",
-  "tokio-util",
-+ "tower 0.5.2",
-  "tower-service",
-  "url",
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "web-sys",
-- "webpki-roots 0.25.4",
-- "winreg 0.50.0",
-+ "webpki-roots 1.0.3",
+@@ -2238,6 +2547,16 @@ dependencies = [
+  "winreg 0.50.0",
  ]
  
- [[package]]
--name = "ring"
--version = "0.16.20"
++[[package]]
 +name = "rfc6979"
 +version = "0.4.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
- dependencies = [
-- "cc",
-- "libc",
-- "once_cell",
-- "spin 0.5.2",
-- "untrusted 0.7.1",
-- "web-sys",
-- "winapi",
++dependencies = [
 + "hmac",
 + "subtle",
- ]
- 
- [[package]]
- name = "ring"
--version = "0.17.3"
-+version = "0.17.14"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
-+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
- dependencies = [
-  "cc",
-- "getrandom",
-+ "cfg-if",
-+ "getrandom 0.2.16",
-  "libc",
-- "spin 0.9.3",
-- "untrusted 0.9.0",
-- "windows-sys 0.48.0",
-+ "untrusted",
-+ "windows-sys 0.52.0",
 +]
 +
+ [[package]]
+ name = "ring"
+ version = "0.16.20"
+@@ -2262,11 +2581,31 @@ dependencies = [
+  "cc",
+  "getrandom",
+  "libc",
+- "spin 0.9.3",
++ "spin 0.9.8",
+  "untrusted 0.9.0",
+  "windows-sys 0.48.0",
+ ]
+ 
 +[[package]]
 +name = "rsa"
-+version = "0.9.8"
++version = "0.9.10"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
++checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 +dependencies = [
 + "const-oid",
 + "digest",
@@ -3006,38 +1101,22 @@ index a87da66..6245ce3 100644
 + "num-traits",
 + "pkcs1",
 + "pkcs8",
-+ "rand_core 0.6.4",
++ "rand_core",
 + "signature 2.2.0",
 + "spki",
 + "subtle",
 + "zeroize",
- ]
- 
++]
++
  [[package]]
-@@ -2278,9 +2904,9 @@ dependencies = [
- 
- [[package]]
- name = "rustc-demangle"
--version = "0.1.24"
-+version = "0.1.26"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
- 
- [[package]]
- name = "rustc-hash"
-@@ -2289,112 +2915,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ name = "rust-ini"
+ version = "0.18.0"
+@@ -2290,15 +2629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
  
  [[package]]
 -name = "rustls"
 -version = "0.20.4"
-+name = "rustc-hash"
-+version = "2.1.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-+
-+[[package]]
 +name = "rustc_version"
 +version = "0.4.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,105 +1131,69 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
--name = "rustls"
--version = "0.21.12"
-+name = "rustix"
-+version = "0.38.44"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
- dependencies = [
-- "log",
-- "ring 0.17.3",
-- "rustls-webpki 0.101.7",
-- "sct",
-+ "bitflags 2.9.4",
-+ "errno",
-+ "libc",
-+ "linux-raw-sys 0.4.15",
-+ "windows-sys 0.59.0",
-+]
-+
-+[[package]]
-+name = "rustix"
-+version = "1.1.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
-+dependencies = [
-+ "bitflags 2.9.4",
-+ "errno",
-+ "libc",
-+ "linux-raw-sys 0.11.0",
-+ "windows-sys 0.61.2",
- ]
+@@ -2315,15 +2651,15 @@ dependencies = [
  
  [[package]]
  name = "rustls"
 -version = "0.23.21"
-+version = "0.23.32"
++version = "0.23.37"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
-+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
++checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
  dependencies = [
   "log",
   "once_cell",
-- "ring 0.17.3",
-+ "ring",
+  "ring 0.17.3",
   "rustls-pki-types",
 - "rustls-webpki 0.102.8",
-+ "rustls-webpki",
++ "rustls-webpki 0.103.9",
   "subtle",
   "zeroize",
+ ]
+@@ -2334,23 +2670,22 @@ version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+ dependencies = [
+- "openssl-probe",
+- "rustls-pemfile 1.0.0",
++ "openssl-probe 0.1.5",
++ "rustls-pemfile",
+  "schannel",
+- "security-framework",
++ "security-framework 2.11.1",
  ]
  
  [[package]]
  name = "rustls-native-certs"
--version = "0.6.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
--dependencies = [
-- "openssl-probe",
-- "rustls-pemfile 1.0.0",
-- "schannel",
-- "security-framework",
--]
--
--[[package]]
--name = "rustls-native-certs"
 -version = "0.7.3"
-+version = "0.8.2"
++version = "0.8.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
++checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
  dependencies = [
-  "openssl-probe",
+- "openssl-probe",
 - "rustls-pemfile 2.2.0",
++ "openssl-probe 0.2.1",
   "rustls-pki-types",
   "schannel",
 - "security-framework",
--]
--
--[[package]]
--name = "rustls-pemfile"
--version = "1.0.0"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
--dependencies = [
-- "base64 0.13.0",
-+ "security-framework 3.5.1",
++ "security-framework 3.7.0",
+ ]
+ 
+ [[package]]
+@@ -2363,39 +2698,33 @@ dependencies = [
  ]
  
  [[package]]
 -name = "rustls-pemfile"
 -version = "2.2.0"
 +name = "rustls-pki-types"
-+version = "1.12.0"
++version = "1.14.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
++checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
  dependencies = [
 - "rustls-pki-types",
-+ "web-time",
 + "zeroize",
  ]
  
@@ -3176,13 +1219,13 @@ index a87da66..6245ce3 100644
   "once_cell",
 - "rustls 0.23.21",
 - "rustls-native-certs 0.7.3",
-+ "rustls",
-+ "rustls-native-certs",
++ "rustls 0.23.37",
++ "rustls-native-certs 0.8.3",
   "rustls-platform-verifier-android",
 - "rustls-webpki 0.102.8",
 - "security-framework",
-+ "rustls-webpki",
-+ "security-framework 3.5.1",
++ "rustls-webpki 0.103.9",
++ "security-framework 3.7.0",
   "security-framework-sys",
 - "webpki-roots 0.26.7",
 - "winapi",
@@ -3191,100 +1234,45 @@ index a87da66..6245ce3 100644
  ]
  
  [[package]]
-@@ -2405,36 +3021,26 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+@@ -2416,9 +2745,9 @@ dependencies = [
  
  [[package]]
  name = "rustls-webpki"
--version = "0.101.7"
-+version = "0.103.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
- dependencies = [
-- "ring 0.17.3",
-- "untrusted 0.9.0",
--]
--
--[[package]]
--name = "rustls-webpki"
 -version = "0.102.8"
--source = "registry+https://github.com/rust-lang/crates.io-index"
++version = "0.103.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
--dependencies = [
-- "ring 0.17.3",
-+ "ring",
-  "rustls-pki-types",
-- "untrusted 0.9.0",
-+ "untrusted",
- ]
- 
- [[package]]
- name = "rustversion"
--version = "1.0.6"
-+version = "1.0.22"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
- 
- [[package]]
- name = "ryu"
--version = "1.0.9"
-+version = "1.0.20"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
- 
- [[package]]
- name = "same-file"
-@@ -2447,27 +3053,31 @@ dependencies = [
- 
- [[package]]
- name = "schannel"
--version = "0.1.27"
-+version = "0.1.28"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
++checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
  dependencies = [
-- "windows-sys 0.59.0",
-+ "windows-sys 0.61.2",
+  "ring 0.17.3",
+  "rustls-pki-types",
+@@ -2471,44 +2800,86 @@ dependencies = [
+  "untrusted 0.7.1",
  ]
  
- [[package]]
- name = "scopeguard"
--version = "1.1.0"
-+version = "1.2.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
- 
- [[package]]
--name = "sct"
--version = "0.7.0"
++[[package]]
 +name = "sec1"
 +version = "0.7.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
- dependencies = [
-- "ring 0.16.20",
-- "untrusted 0.7.1",
++dependencies = [
 + "base16ct",
 + "der",
 + "generic-array",
 + "pkcs8",
 + "subtle",
 + "zeroize",
- ]
- 
++]
++
  [[package]]
-@@ -2476,60 +3086,90 @@ version = "2.11.1"
+ name = "security-framework"
+ version = "2.11.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
  dependencies = [
 - "bitflags 2.7.0",
 - "core-foundation",
-+ "bitflags 2.9.4",
++ "bitflags 2.11.0",
 + "core-foundation 0.9.4",
 + "core-foundation-sys",
 + "libc",
@@ -3293,11 +1281,11 @@ index a87da66..6245ce3 100644
 +
 +[[package]]
 +name = "security-framework"
-+version = "3.5.1"
++version = "3.7.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
++checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 +dependencies = [
-+ "bitflags 2.9.4",
++ "bitflags 2.11.0",
 + "core-foundation 0.10.1",
   "core-foundation-sys",
   "libc",
@@ -3308,10 +1296,10 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "security-framework-sys"
 -version = "2.14.0"
-+version = "2.15.0"
++version = "2.17.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
++checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
  dependencies = [
   "core-foundation-sys",
   "libc",
@@ -3319,15 +1307,16 @@ index a87da66..6245ce3 100644
  
 +[[package]]
 +name = "semver"
-+version = "1.0.26"
++version = "1.0.27"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
++checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 +
  [[package]]
  name = "serde"
 -version = "1.0.217"
 +version = "1.0.228"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 +checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 +dependencies = [
 + "serde_core",
@@ -3337,8 +1326,7 @@ index a87da66..6245ce3 100644
 +[[package]]
 +name = "serde_core"
 +version = "1.0.228"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
  dependencies = [
   "serde_derive",
@@ -3352,64 +1340,42 @@ index a87da66..6245ce3 100644
 -checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 +checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
  dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
+  "proc-macro2 1.0.93",
+  "quote 1.0.38",
+@@ -2517,13 +2888,15 @@ dependencies = [
  
  [[package]]
  name = "serde_json"
 -version = "1.0.81"
-+version = "1.0.145"
++version = "1.0.149"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
-+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
++checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
  dependencies = [
   "itoa",
+- "ryu",
 + "memchr",
-  "ryu",
   "serde",
 + "serde_core",
++ "zmij",
  ]
  
  [[package]]
- name = "serde_spanned"
--version = "0.6.8"
-+version = "0.6.9"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
- dependencies = [
-  "serde",
+@@ -2558,11 +2931,22 @@ dependencies = [
+  "digest",
  ]
-@@ -2548,9 +3188,20 @@ dependencies = [
  
- [[package]]
- name = "sha-1"
--version = "0.10.0"
-+version = "0.10.1"
++[[package]]
++name = "sha1"
++version = "0.10.6"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
++checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 +dependencies = [
 + "cfg-if",
 + "cpufeatures",
 + "digest",
 +]
 +
-+[[package]]
-+name = "sha1"
-+version = "0.10.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
- dependencies = [
-  "cfg-if",
-  "cpufeatures",
-@@ -2559,9 +3210,9 @@ dependencies = [
- 
  [[package]]
  name = "sha2"
 -version = "0.10.2"
@@ -3420,26 +1386,10 @@ index a87da66..6245ce3 100644
  dependencies = [
   "cfg-if",
   "cpufeatures",
-@@ -2576,42 +3227,61 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
- 
- [[package]]
- name = "signal-hook-registry"
--version = "1.4.0"
-+version = "1.4.6"
+@@ -2590,6 +2974,16 @@ version = "1.5.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
- dependencies = [
-  "libc",
- ]
+ checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
  
- [[package]]
- name = "signature"
--version = "1.5.0"
-+version = "1.6.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-+
 +[[package]]
 +name = "signature"
 +version = "2.2.0"
@@ -3447,38 +1397,22 @@ index a87da66..6245ce3 100644
 +checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 +dependencies = [
 + "digest",
-+ "rand_core 0.6.4",
++ "rand_core",
 +]
 +
-+[[package]]
-+name = "simd-adler32"
-+version = "0.3.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
-+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
- 
  [[package]]
  name = "simple_asn1"
--version = "0.6.1"
-+version = "0.6.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
-+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+ version = "0.6.1"
+@@ -2598,7 +2992,7 @@ checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
  dependencies = [
   "num-bigint",
   "num-traits",
 - "thiserror",
-+ "thiserror 2.0.17",
++ "thiserror 1.0.31",
   "time",
  ]
  
- [[package]]
- name = "slab"
--version = "0.4.6"
-+version = "0.4.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
-+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+@@ -2610,9 +3004,12 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
  
  [[package]]
  name = "smallvec"
@@ -3493,63 +1427,19 @@ index a87da66..6245ce3 100644
  
  [[package]]
  name = "socket2"
-@@ -2626,9 +3296,9 @@ dependencies = [
- 
- [[package]]
- name = "socket2"
--version = "0.4.4"
-+version = "0.4.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
-+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
- dependencies = [
-  "libc",
-  "winapi",
-@@ -2636,21 +3306,31 @@ dependencies = [
- 
- [[package]]
- name = "socket2"
--version = "0.5.8"
-+version = "0.5.10"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
- dependencies = [
-  "libc",
-  "windows-sys 0.52.0",
- ]
- 
-+[[package]]
-+name = "socket2"
-+version = "0.6.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-+dependencies = [
-+ "libc",
-+ "windows-sys 0.60.2",
-+]
-+
- [[package]]
- name = "sodiumoxide"
- version = "0.2.7"
+@@ -2651,7 +3048,7 @@ version = "0.2.7"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
  dependencies = [
 - "ed25519",
-+ "ed25519 1.5.3",
++ "ed25519 1.5.0",
   "libc",
   "libsodium-sys",
   "serde",
-@@ -2658,119 +3338,223 @@ dependencies = [
+@@ -2665,111 +3062,215 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
  
  [[package]]
  name = "spin"
--version = "0.5.2"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
--
--[[package]]
--name = "spin"
 -version = "0.9.3"
 +version = "0.9.8"
  source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3616,7 +1506,7 @@ index a87da66..6245ce3 100644
   "futures-intrusive",
 + "futures-io",
   "futures-util",
-+ "hashbrown 0.15.5",
++ "hashbrown 0.15.2",
   "hashlink",
 - "hex",
 - "indexmap 1.8.1",
@@ -3631,7 +1521,7 @@ index a87da66..6245ce3 100644
   "percent-encoding",
 - "rustls 0.20.4",
 - "rustls-pemfile 1.0.0",
-+ "rustls",
++ "rustls 0.23.37",
   "serde",
   "serde_json",
   "sha2",
@@ -3640,46 +1530,44 @@ index a87da66..6245ce3 100644
 - "sqlx-rt",
 - "stringprep",
 - "thiserror",
-+ "thiserror 2.0.17",
++ "thiserror 2.0.18",
 + "tokio",
   "tokio-stream",
 + "tracing",
   "url",
 - "webpki-roots 0.22.4",
-+ "webpki-roots 0.26.11",
++ "webpki-roots 0.26.7",
  ]
  
  [[package]]
  name = "sqlx-macros"
 -version = "0.6.0"
 +version = "0.8.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "f40c63177cf23d356b159b60acd27c54af7423f1736988502e36bae9a712118f"
++source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
- dependencies = [
-- "dotenv",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
++dependencies = [
++ "proc-macro2 1.0.93",
++ "quote 1.0.38",
 + "sqlx-core",
 + "sqlx-macros-core",
-+ "syn 2.0.106",
++ "syn 2.0.96",
 +]
 +
 +[[package]]
 +name = "sqlx-macros-core"
 +version = "0.8.6"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f40c63177cf23d356b159b60acd27c54af7423f1736988502e36bae9a712118f"
 +checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-+dependencies = [
+ dependencies = [
+- "dotenv",
 + "dotenvy",
   "either",
   "heck",
 + "hex",
   "once_cell",
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
+  "proc-macro2 1.0.93",
+  "quote 1.0.38",
 + "serde",
   "serde_json",
   "sha2",
@@ -3689,7 +1577,7 @@ index a87da66..6245ce3 100644
 + "sqlx-mysql",
 + "sqlx-postgres",
 + "sqlx-sqlite",
-+ "syn 2.0.106",
++ "syn 2.0.96",
 + "tokio",
   "url",
  ]
@@ -3705,7 +1593,7 @@ index a87da66..6245ce3 100644
  dependencies = [
 + "atoi",
 + "base64 0.22.1",
-+ "bitflags 2.9.4",
++ "bitflags 2.11.0",
 + "byteorder",
 + "bytes",
 + "chrono",
@@ -3729,7 +1617,7 @@ index a87da66..6245ce3 100644
 - "tokio",
 - "tokio-rustls 0.23.4",
 + "percent-encoding",
-+ "rand 0.8.5",
++ "rand",
 + "rsa",
 + "serde",
 + "sha1",
@@ -3737,11 +1625,11 @@ index a87da66..6245ce3 100644
 + "smallvec",
 + "sqlx-core",
 + "stringprep",
-+ "thiserror 2.0.17",
++ "thiserror 2.0.18",
 + "tracing",
 + "whoami",
- ]
- 
++]
++
 +[[package]]
 +name = "sqlx-postgres"
 +version = "0.8.6"
@@ -3750,7 +1638,7 @@ index a87da66..6245ce3 100644
 +dependencies = [
 + "atoi",
 + "base64 0.22.1",
-+ "bitflags 2.9.4",
++ "bitflags 2.11.0",
 + "byteorder",
 + "chrono",
 + "crc",
@@ -3768,14 +1656,14 @@ index a87da66..6245ce3 100644
 + "md-5",
 + "memchr",
 + "once_cell",
-+ "rand 0.8.5",
++ "rand",
 + "serde",
 + "serde_json",
 + "sha2",
 + "smallvec",
 + "sqlx-core",
 + "stringprep",
-+ "thiserror 2.0.17",
++ "thiserror 2.0.18",
 + "tracing",
 + "whoami",
 +]
@@ -3800,439 +1688,112 @@ index a87da66..6245ce3 100644
 + "serde",
 + "serde_urlencoded",
 + "sqlx-core",
-+ "thiserror 2.0.17",
++ "thiserror 2.0.18",
 + "tracing",
 + "url",
-+]
-+
-+[[package]]
-+name = "stable_deref_trait"
-+version = "1.2.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-+
- [[package]]
- name = "static_assertions"
- version = "1.1.0"
-@@ -2779,12 +3563,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
- 
- [[package]]
- name = "stringprep"
--version = "0.1.2"
-+version = "0.1.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
-+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
- dependencies = [
-  "unicode-bidi",
-  "unicode-normalization",
-+ "unicode-properties",
  ]
  
  [[package]]
-@@ -2807,28 +3592,28 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+@@ -2860,7 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
  dependencies = [
-  "proc-macro2 0.4.30",
-  "quote 0.6.13",
-- "unicode-xid 0.1.0",
-+ "unicode-xid",
- ]
- 
- [[package]]
- name = "syn"
--version = "1.0.93"
-+version = "1.0.109"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
-+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "unicode-xid 0.2.3",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "unicode-ident",
- ]
- 
- [[package]]
- name = "syn"
--version = "2.0.96"
-+version = "2.0.106"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
-+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-  "unicode-ident",
- ]
- 
-@@ -2839,59 +3624,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
- 
- [[package]]
--name = "sysinfo"
--version = "0.29.10"
--source = "git+https://github.com/rustdesk-org/sysinfo?branch=rlim_max#90b1705d909a4902dbbbdea37ee64db17841077d"
-+name = "sync_wrapper"
-+version = "1.0.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
- dependencies = [
-- "cfg-if",
-- "core-foundation-sys",
-- "libc",
-- "ntapi",
-- "once_cell",
-- "rayon",
-- "windows",
-+ "futures-core",
- ]
- 
- [[package]]
--name = "system-configuration"
--version = "0.5.1"
-+name = "synstructure"
-+version = "0.13.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
- dependencies = [
-- "bitflags 1.3.2",
+  "bitflags 1.3.2",
 - "core-foundation",
-- "system-configuration-sys",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
++ "core-foundation 0.9.4",
+  "system-configuration-sys",
  ]
  
- [[package]]
--name = "system-configuration-sys"
--version = "0.5.0"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-+name = "sysinfo"
-+version = "0.29.10"
-+source = "git+https://github.com/rustdesk-org/sysinfo?branch=rlim_max#90b1705d909a4902dbbbdea37ee64db17841077d"
- dependencies = [
-+ "cfg-if",
-  "core-foundation-sys",
-  "libc",
-+ "ntapi",
-+ "once_cell",
-+ "rayon",
-+ "windows",
- ]
- 
- [[package]]
- name = "tempfile"
--version = "3.3.0"
-+version = "3.23.0"
+@@ -2912,7 +3413,16 @@ version = "1.0.31"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+ checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
  dependencies = [
-- "cfg-if",
-  "fastrand",
-- "libc",
-- "redox_syscall",
-- "remove_dir_all",
-- "winapi",
-+ "getrandom 0.3.4",
-+ "once_cell",
-+ "rustix 1.1.2",
-+ "windows-sys 0.61.2",
- ]
- 
- [[package]]
- name = "termcolor"
--version = "1.1.3"
-+version = "1.4.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
- dependencies = [
-  "winapi-util",
- ]
-@@ -2907,22 +3690,42 @@ dependencies = [
- 
- [[package]]
- name = "thiserror"
--version = "1.0.31"
-+version = "1.0.69"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-+dependencies = [
-+ "thiserror-impl 1.0.69",
+- "thiserror-impl",
++ "thiserror-impl 1.0.31",
 +]
 +
 +[[package]]
 +name = "thiserror"
-+version = "2.0.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
-+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
- dependencies = [
-- "thiserror-impl",
-+ "thiserror-impl 2.0.17",
++version = "2.0.18"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
++dependencies = [
++ "thiserror-impl 2.0.18",
  ]
  
  [[package]]
- name = "thiserror-impl"
--version = "1.0.31"
-+version = "1.0.69"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
-+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 1.0.93",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+]
-+
+@@ -2926,6 +3436,17 @@ dependencies = [
+  "syn 1.0.93",
+ ]
+ 
 +[[package]]
 +name = "thiserror-impl"
-+version = "2.0.17"
++version = "2.0.18"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
++checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 +dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
- 
- [[package]]
-@@ -2934,7 +3737,6 @@ dependencies = [
-  "itoa",
-  "libc",
-  "num_threads",
-- "quickcheck",
-  "time-macros",
- ]
- 
-@@ -2944,95 +3746,83 @@ version = "0.2.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
- 
-+[[package]]
-+name = "tinystr"
-+version = "0.8.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
-+dependencies = [
-+ "displaydoc",
-+ "zerovec",
++ "proc-macro2 1.0.93",
++ "quote 1.0.38",
++ "syn 2.0.96",
 +]
 +
  [[package]]
- name = "tinyvec"
--version = "1.6.0"
-+version = "1.10.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
- dependencies = [
-  "tinyvec_macros",
- ]
- 
- [[package]]
- name = "tinyvec_macros"
--version = "0.1.0"
-+version = "0.1.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
- 
- [[package]]
- name = "tokio"
--version = "1.43.0"
-+version = "1.48.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
-+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
- dependencies = [
-- "backtrace",
+ name = "time"
+ version = "0.3.9"
+@@ -2970,7 +3491,7 @@ dependencies = [
   "bytes",
   "libc",
   "mio",
 - "parking_lot 0.12.0",
-- "pin-project-lite",
-- "signal-hook-registry",
-- "socket2 0.5.8",
-- "tokio-macros",
-- "windows-sys 0.52.0",
--]
--
--[[package]]
--name = "tokio-macros"
--version = "2.5.0"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
--dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
--]
--
--[[package]]
--name = "tokio-native-tls"
--version = "0.3.1"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
--dependencies = [
-- "native-tls",
-- "tokio",
 + "parking_lot",
-+ "pin-project-lite",
-+ "signal-hook-registry",
-+ "socket2 0.6.1",
-+ "tokio-macros",
-+ "windows-sys 0.61.2",
+  "pin-project-lite",
+  "signal-hook-registry",
+  "socket2 0.5.8",
+@@ -2999,17 +3520,6 @@ dependencies = [
+  "tokio",
  ]
  
- [[package]]
+-[[package]]
 -name = "tokio-rustls"
 -version = "0.23.4"
-+name = "tokio-macros"
-+version = "2.6.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
- dependencies = [
+-dependencies = [
 - "rustls 0.20.4",
 - "tokio",
 - "webpki",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
- 
- [[package]]
--name = "tokio-rustls"
--version = "0.24.1"
-+name = "tokio-native-tls"
-+version = "0.3.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
- dependencies = [
-- "rustls 0.21.12",
-+ "native-tls",
-  "tokio",
- ]
- 
+-]
+-
  [[package]]
  name = "tokio-rustls"
--version = "0.26.1"
-+version = "0.26.4"
+ version = "0.24.1"
+@@ -3026,7 +3536,7 @@ version = "0.26.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
-+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+ checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
  dependencies = [
 - "rustls 0.23.21",
-+ "rustls",
++ "rustls 0.23.37",
   "tokio",
  ]
  
- [[package]]
- name = "tokio-socks"
--version = "0.5.2-1"
--source = "git+https://github.com/rustdesk-org/tokio-socks#94e97c6d7c93b0bcbfa54f2dc397c1da0a6e43d3"
-+version = "0.5.2-3"
-+source = "git+https://github.com/rustdesk-org/tokio-socks#bdb9aa3de5bac41602d0742b8ef6bbc6bfebd127"
- dependencies = [
-  "bytes",
-  "either",
-@@ -3040,7 +3830,7 @@ dependencies = [
+@@ -3041,7 +3551,7 @@ dependencies = [
   "futures-sink",
   "futures-util",
   "pin-project",
 - "thiserror",
-+ "thiserror 2.0.17",
++ "thiserror 1.0.31",
   "tokio",
   "tokio-util",
  ]
-@@ -3053,15 +3843,15 @@ checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+@@ -3054,7 +3564,7 @@ checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
  dependencies = [
   "either",
   "futures-util",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "tokio",
  ]
  
- [[package]]
- name = "tokio-stream"
--version = "0.1.8"
-+version = "0.1.17"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
-+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
- dependencies = [
-  "futures-core",
-  "pin-project-lite",
-@@ -3070,9 +3860,9 @@ dependencies = [
- 
- [[package]]
- name = "tokio-tungstenite"
--version = "0.17.1"
-+version = "0.17.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
-+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
- dependencies = [
-  "futures-util",
-  "log",
-@@ -3082,26 +3872,26 @@ dependencies = [
- 
- [[package]]
- name = "tokio-util"
--version = "0.7.1"
-+version = "0.7.16"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
-+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
- dependencies = [
-  "bytes",
-  "futures-core",
-  "futures-io",
-  "futures-sink",
-  "futures-util",
-+ "hashbrown 0.15.5",
-  "pin-project-lite",
-  "slab",
-  "tokio",
-- "tracing",
- ]
- 
- [[package]]
- name = "toml"
--version = "0.5.9"
-+version = "0.5.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
-+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
- dependencies = [
-  "serde",
- ]
-@@ -3120,9 +3910,9 @@ dependencies = [
- 
- [[package]]
- name = "toml_datetime"
--version = "0.6.8"
-+version = "0.6.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
- dependencies = [
-  "serde",
- ]
-@@ -3133,7 +3923,7 @@ version = "0.19.15"
+@@ -3134,7 +3644,7 @@ version = "0.19.15"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
  dependencies = [
@@ -4241,451 +1802,42 @@ index a87da66..6245ce3 100644
   "serde",
   "serde_spanned",
   "toml_datetime",
-@@ -3142,33 +3932,47 @@ dependencies = [
- 
- [[package]]
- name = "tower"
--version = "0.4.12"
-+version = "0.4.13"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
-+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
- dependencies = [
-  "futures-core",
-  "futures-util",
-  "pin-project",
-  "pin-project-lite",
-  "tokio",
-- "tokio-util",
-  "tower-layer",
-  "tower-service",
-  "tracing",
- ]
- 
-+[[package]]
-+name = "tower"
-+version = "0.5.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
-+dependencies = [
-+ "futures-core",
-+ "futures-util",
-+ "pin-project-lite",
-+ "sync_wrapper 1.0.2",
-+ "tokio",
-+ "tower-layer",
-+ "tower-service",
-+]
-+
- [[package]]
- name = "tower-http"
--version = "0.3.3"
-+version = "0.3.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7d342c6d58709c0a6d48d48dabbb62d4ef955cf5f0f3bbfd845838e7ae88dbae"
-+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
- dependencies = [
-  "bitflags 1.3.2",
-  "bytes",
-  "futures-core",
-  "futures-util",
-- "http",
-- "http-body",
-+ "http 0.2.12",
-+ "http-body 0.4.6",
-  "http-range-header",
-  "httpdate",
-  "mime",
-@@ -3177,7 +3981,7 @@ dependencies = [
-  "pin-project-lite",
-  "tokio",
-  "tokio-util",
-- "tower",
-+ "tower 0.4.13",
-  "tower-layer",
-  "tower-service",
-  "tracing",
-@@ -3185,15 +3989,15 @@ dependencies = [
- 
- [[package]]
- name = "tower-layer"
--version = "0.3.1"
-+version = "0.3.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
-+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
- 
- [[package]]
- name = "tower-service"
--version = "0.3.1"
-+version = "0.3.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
-+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
- 
- [[package]]
- name = "tracing"
-@@ -3209,96 +4013,93 @@ dependencies = [
- 
- [[package]]
- name = "tracing-attributes"
--version = "0.1.28"
-+version = "0.1.30"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
-+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
- ]
- 
- [[package]]
- name = "tracing-core"
--version = "0.1.33"
-+version = "0.1.34"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
- dependencies = [
-  "once_cell",
- ]
- 
- [[package]]
- name = "try-lock"
--version = "0.2.3"
-+version = "0.2.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
- 
- [[package]]
- name = "tungstenite"
--version = "0.17.2"
-+version = "0.17.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
-+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
- dependencies = [
-- "base64 0.13.0",
-+ "base64 0.13.1",
-  "byteorder",
-  "bytes",
-- "http",
-+ "http 0.2.12",
-  "httparse",
+@@ -3248,7 +3758,7 @@ dependencies = [
   "log",
-- "rand",
-+ "rand 0.8.5",
+  "rand",
   "sha-1",
 - "thiserror",
-+ "thiserror 1.0.69",
++ "thiserror 1.0.31",
   "url",
   "utf-8",
  ]
- 
- [[package]]
- name = "typenum"
--version = "1.15.0"
-+version = "1.19.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
- 
- [[package]]
- name = "unicase"
--version = "2.6.0"
-+version = "2.8.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
--dependencies = [
-- "version_check",
--]
-+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
- 
- [[package]]
- name = "unicode-bidi"
--version = "0.3.8"
-+version = "0.3.18"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
-+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
- 
- [[package]]
- name = "unicode-ident"
--version = "1.0.14"
-+version = "1.0.19"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
- 
- [[package]]
- name = "unicode-normalization"
--version = "0.1.19"
-+version = "0.1.24"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
-+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
- dependencies = [
+@@ -3289,12 +3799,6 @@ dependencies = [
   "tinyvec",
  ]
  
- [[package]]
+-[[package]]
 -name = "unicode-segmentation"
 -version = "1.9.0"
-+name = "unicode-properties"
-+version = "0.1.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
- 
+-
  [[package]]
  name = "unicode-width"
--version = "0.1.9"
-+version = "0.1.14"
+ version = "0.1.9"
+@@ -3313,12 +3817,6 @@ version = "0.2.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
  
- [[package]]
- name = "unicode-xid"
-@@ -3306,24 +4107,6 @@ version = "0.1.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
- 
--[[package]]
--name = "unicode-xid"
--version = "0.2.3"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
--
 -[[package]]
 -name = "unicode_categories"
 -version = "0.1.1"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 -
--[[package]]
--name = "untrusted"
--version = "0.7.1"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
--
  [[package]]
  name = "untrusted"
- version = "0.9.0"
-@@ -3332,14 +4115,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
- 
- [[package]]
- name = "url"
--version = "2.2.2"
-+version = "2.5.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
-+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
- dependencies = [
-  "form_urlencoded",
-  "idna",
-- "matches",
-  "percent-encoding",
-+ "serde",
- ]
- 
- [[package]]
-@@ -3348,13 +4131,21 @@ version = "0.7.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
- 
-+[[package]]
-+name = "utf8_iter"
-+version = "1.0.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-+
- [[package]]
- name = "uuid"
--version = "1.12.0"
-+version = "1.18.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
-+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
- dependencies = [
-- "getrandom",
-+ "getrandom 0.3.4",
-+ "js-sys",
-+ "wasm-bindgen",
- ]
- 
- [[package]]
-@@ -3371,68 +4162,82 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
- 
- [[package]]
- name = "version_check"
--version = "0.9.4"
-+version = "0.9.5"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
- 
- [[package]]
- name = "walkdir"
--version = "2.3.2"
-+version = "2.5.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
- dependencies = [
-  "same-file",
-- "winapi",
-  "winapi-util",
- ]
- 
- [[package]]
- name = "want"
--version = "0.3.0"
-+version = "0.3.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
- dependencies = [
-- "log",
-  "try-lock",
- ]
- 
- [[package]]
- name = "wasi"
--version = "0.11.0+wasi-snapshot-preview1"
-+version = "0.11.1+wasi-snapshot-preview1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-+
-+[[package]]
-+name = "wasip2"
-+version = "1.0.1+wasi-0.2.4"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-+dependencies = [
-+ "wit-bindgen",
-+]
-+
-+[[package]]
-+name = "wasite"
-+version = "0.1.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
- 
- [[package]]
- name = "wasm-bindgen"
--version = "0.2.100"
-+version = "0.2.104"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
-+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
- dependencies = [
-  "cfg-if",
-  "once_cell",
-  "rustversion",
-  "wasm-bindgen-macro",
-+ "wasm-bindgen-shared",
- ]
- 
- [[package]]
- name = "wasm-bindgen-backend"
--version = "0.2.100"
-+version = "0.2.104"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
- dependencies = [
-  "bumpalo",
-  "log",
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-  "wasm-bindgen-shared",
- ]
- 
- [[package]]
- name = "wasm-bindgen-futures"
--version = "0.4.50"
-+version = "0.4.54"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
- dependencies = [
-  "cfg-if",
-  "js-sys",
-@@ -3443,98 +4248,112 @@ dependencies = [
- 
- [[package]]
- name = "wasm-bindgen-macro"
--version = "0.2.100"
-+version = "0.2.104"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
-+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
- dependencies = [
-- "quote 1.0.38",
-+ "quote 1.0.41",
-  "wasm-bindgen-macro-support",
- ]
- 
- [[package]]
- name = "wasm-bindgen-macro-support"
--version = "0.2.100"
-+version = "0.2.104"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
-+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
- dependencies = [
-- "proc-macro2 1.0.93",
-- "quote 1.0.38",
-- "syn 2.0.96",
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-  "wasm-bindgen-backend",
-  "wasm-bindgen-shared",
- ]
- 
- [[package]]
- name = "wasm-bindgen-shared"
--version = "0.2.100"
-+version = "0.2.104"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
- dependencies = [
-  "unicode-ident",
- ]
- 
- [[package]]
- name = "web-sys"
--version = "0.3.77"
-+version = "0.3.81"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
-+dependencies = [
-+ "js-sys",
-+ "wasm-bindgen",
-+]
-+
-+[[package]]
-+name = "web-time"
-+version = "1.1.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
- dependencies = [
-  "js-sys",
-  "wasm-bindgen",
+ version = "0.7.1"
+@@ -3485,22 +3983,21 @@ dependencies = [
  ]
  
  [[package]]
@@ -4699,183 +1851,56 @@ index a87da66..6245ce3 100644
  dependencies = [
 - "ring 0.16.20",
 - "untrusted 0.7.1",
-+ "webpki-root-certs 1.0.3",
++ "webpki-root-certs 1.0.6",
  ]
  
  [[package]]
 -name = "webpki-roots"
 -version = "0.22.4"
 +name = "webpki-root-certs"
-+version = "1.0.3"
++version = "1.0.6"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
-+checksum = "05d651ec480de84b762e7be71e6efa7461699c19d9e2c272c8d93455f567786e"
++checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
  dependencies = [
 - "webpki",
 + "rustls-pki-types",
  ]
  
  [[package]]
- name = "webpki-roots"
--version = "0.25.4"
-+version = "0.26.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-+dependencies = [
-+ "webpki-roots 1.0.3",
-+]
- 
- [[package]]
- name = "webpki-roots"
--version = "0.26.7"
-+version = "1.0.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
-+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
- dependencies = [
-  "rustls-pki-types",
+@@ -3598,6 +4095,12 @@ dependencies = [
+  "windows-targets 0.52.6",
  ]
  
- [[package]]
- name = "which"
--version = "4.2.5"
-+version = "4.4.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
-+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
- dependencies = [
-  "either",
-- "lazy_static",
-- "libc",
-+ "home",
-+ "once_cell",
-+ "rustix 0.38.44",
- ]
- 
- [[package]]
- name = "whoami"
--version = "1.2.1"
-+version = "1.6.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
-+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
- dependencies = [
-- "wasm-bindgen",
-+ "libredox",
-+ "wasite",
-  "web-sys",
- ]
- 
-@@ -3556,11 +4375,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
- 
- [[package]]
- name = "winapi-util"
--version = "0.1.5"
-+version = "0.1.11"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
- dependencies = [
-- "winapi",
-+ "windows-sys 0.61.2",
- ]
- 
- [[package]]
-@@ -3590,24 +4409,70 @@ dependencies = [
- 
- [[package]]
- name = "windows-core"
--version = "0.52.0"
-+version = "0.62.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
- dependencies = [
-- "windows-targets 0.52.6",
-+ "windows-implement",
-+ "windows-interface",
-+ "windows-link",
-+ "windows-result",
-+ "windows-strings",
-+]
-+
-+[[package]]
-+name = "windows-implement"
-+version = "0.60.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+]
-+
-+[[package]]
-+name = "windows-interface"
-+version = "0.59.3"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+]
-+
 +[[package]]
 +name = "windows-link"
 +version = "0.2.1"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
 +checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 +
-+[[package]]
-+name = "windows-result"
-+version = "0.4.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-+dependencies = [
-+ "windows-link",
-+]
-+
-+[[package]]
-+name = "windows-strings"
-+version = "0.5.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-+dependencies = [
-+ "windows-link",
- ]
- 
  [[package]]
  name = "windows-sys"
--version = "0.36.1"
-+version = "0.45.0"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
- dependencies = [
-- "windows_aarch64_msvc 0.36.1",
-- "windows_i686_gnu 0.36.1",
-- "windows_i686_msvc 0.36.1",
-- "windows_x86_64_gnu 0.36.1",
-- "windows_x86_64_msvc 0.36.1",
-+ "windows-targets 0.42.2",
- ]
- 
- [[package]]
-@@ -3637,6 +4502,39 @@ dependencies = [
-  "windows-targets 0.52.6",
+ version = "0.36.1"
+@@ -3611,6 +4114,15 @@ dependencies = [
+  "windows_x86_64_msvc 0.36.1",
  ]
  
 +[[package]]
 +name = "windows-sys"
-+version = "0.60.2"
++version = "0.45.0"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
++checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 +dependencies = [
-+ "windows-targets 0.53.5",
++ "windows-targets 0.42.2",
 +]
 +
+ [[package]]
+ name = "windows-sys"
+ version = "0.48.0"
+@@ -3638,6 +4150,30 @@ dependencies = [
+  "windows-targets 0.52.6",
+ ]
+ 
 +[[package]]
 +name = "windows-sys"
 +version = "0.61.2"
@@ -4903,35 +1928,10 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "windows-targets"
  version = "0.48.5"
-@@ -3661,13 +4559,36 @@ dependencies = [
-  "windows_aarch64_gnullvm 0.52.6",
-  "windows_aarch64_msvc 0.52.6",
-  "windows_i686_gnu 0.52.6",
-- "windows_i686_gnullvm",
-+ "windows_i686_gnullvm 0.52.6",
-  "windows_i686_msvc 0.52.6",
-  "windows_x86_64_gnu 0.52.6",
-  "windows_x86_64_gnullvm 0.52.6",
+@@ -3669,6 +4205,12 @@ dependencies = [
   "windows_x86_64_msvc 0.52.6",
  ]
  
-+[[package]]
-+name = "windows-targets"
-+version = "0.53.5"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-+dependencies = [
-+ "windows-link",
-+ "windows_aarch64_gnullvm 0.53.1",
-+ "windows_aarch64_msvc 0.53.1",
-+ "windows_i686_gnu 0.53.1",
-+ "windows_i686_gnullvm 0.53.1",
-+ "windows_i686_msvc 0.53.1",
-+ "windows_x86_64_gnu 0.53.1",
-+ "windows_x86_64_gnullvm 0.53.1",
-+ "windows_x86_64_msvc 0.53.1",
-+]
-+
 +[[package]]
 +name = "windows_aarch64_gnullvm"
 +version = "0.42.2"
@@ -4941,108 +1941,62 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "windows_aarch64_gnullvm"
  version = "0.48.5"
-@@ -3680,11 +4601,17 @@ version = "0.52.6"
+@@ -3687,6 +4229,12 @@ version = "0.36.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
- 
-+[[package]]
-+name = "windows_aarch64_gnullvm"
-+version = "0.53.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-+
- [[package]]
- name = "windows_aarch64_msvc"
--version = "0.36.1"
-+version = "0.42.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
- 
- [[package]]
- name = "windows_aarch64_msvc"
-@@ -3698,11 +4625,17 @@ version = "0.52.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
  
 +[[package]]
 +name = "windows_aarch64_msvc"
-+version = "0.53.1"
++version = "0.42.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
++checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 +
  [[package]]
- name = "windows_i686_gnu"
--version = "0.36.1"
-+version = "0.42.2"
+ name = "windows_aarch64_msvc"
+ version = "0.48.5"
+@@ -3705,6 +4253,12 @@ version = "0.36.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
- 
- [[package]]
- name = "windows_i686_gnu"
-@@ -3716,17 +4649,29 @@ version = "0.52.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
  
 +[[package]]
 +name = "windows_i686_gnu"
-+version = "0.53.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-+
- [[package]]
- name = "windows_i686_gnullvm"
- version = "0.52.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
- 
-+[[package]]
-+name = "windows_i686_gnullvm"
-+version = "0.53.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-+
- [[package]]
- name = "windows_i686_msvc"
--version = "0.36.1"
 +version = "0.42.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
- 
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
++
  [[package]]
- name = "windows_i686_msvc"
-@@ -3740,11 +4685,17 @@ version = "0.52.6"
+ name = "windows_i686_gnu"
+ version = "0.48.5"
+@@ -3729,6 +4283,12 @@ version = "0.36.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
  
 +[[package]]
 +name = "windows_i686_msvc"
-+version = "0.53.1"
++version = "0.42.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
++checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 +
  [[package]]
- name = "windows_x86_64_gnu"
--version = "0.36.1"
-+version = "0.42.2"
+ name = "windows_i686_msvc"
+ version = "0.48.5"
+@@ -3747,6 +4307,12 @@ version = "0.36.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
- 
- [[package]]
- name = "windows_x86_64_gnu"
-@@ -3758,6 +4709,18 @@ version = "0.52.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
  
 +[[package]]
 +name = "windows_x86_64_gnu"
-+version = "0.53.1"
++version = "0.42.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
++checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 +
+ [[package]]
+ name = "windows_x86_64_gnu"
+ version = "0.48.5"
+@@ -3759,6 +4325,12 @@ version = "0.52.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+ 
 +[[package]]
 +name = "windows_x86_64_gnullvm"
 +version = "0.42.2"
@@ -5052,199 +2006,34 @@ index a87da66..6245ce3 100644
  [[package]]
  name = "windows_x86_64_gnullvm"
  version = "0.48.5"
-@@ -3770,11 +4733,17 @@ version = "0.52.6"
+@@ -3777,6 +4349,12 @@ version = "0.36.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
- 
-+[[package]]
-+name = "windows_x86_64_gnullvm"
-+version = "0.53.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-+
- [[package]]
- name = "windows_x86_64_msvc"
--version = "0.36.1"
-+version = "0.42.2"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
- 
- [[package]]
- name = "windows_x86_64_msvc"
-@@ -3788,6 +4757,12 @@ version = "0.52.6"
- source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
  
 +[[package]]
 +name = "windows_x86_64_msvc"
-+version = "0.53.1"
++version = "0.42.2"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
++checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 +
  [[package]]
- name = "winnow"
- version = "0.5.40"
-@@ -3817,44 +4792,144 @@ dependencies = [
- ]
- 
- [[package]]
--name = "winreg"
--version = "0.50.0"
-+name = "wit-bindgen"
-+version = "0.46.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-+
-+[[package]]
-+name = "writeable"
-+version = "0.6.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-+
-+[[package]]
-+name = "yoke"
-+version = "0.8.0"
+ name = "windows_x86_64_msvc"
+ version = "0.48.5"
+@@ -3833,6 +4411,12 @@ version = "1.8.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
- dependencies = [
-- "cfg-if",
-- "windows-sys 0.48.0",
-+ "serde",
-+ "stable_deref_trait",
-+ "yoke-derive",
-+ "zerofrom",
-+]
-+
-+[[package]]
-+name = "yoke-derive"
-+version = "0.8.0"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+ "synstructure",
-+]
-+
-+[[package]]
-+name = "zerocopy"
-+version = "0.8.27"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-+dependencies = [
-+ "zerocopy-derive",
-+]
-+
-+[[package]]
-+name = "zerocopy-derive"
-+version = "0.8.27"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+]
-+
-+[[package]]
-+name = "zerofrom"
-+version = "0.1.6"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-+dependencies = [
-+ "zerofrom-derive",
-+]
-+
-+[[package]]
-+name = "zerofrom-derive"
-+version = "0.1.6"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+ "synstructure",
- ]
+ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
  
- [[package]]
- name = "zeroize"
--version = "1.8.1"
-+version = "1.8.2"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-+
 +[[package]]
-+name = "zerotrie"
-+version = "0.2.2"
++name = "zmij"
++version = "1.0.21"
 +source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-+dependencies = [
-+ "displaydoc",
-+ "yoke",
-+ "zerofrom",
-+]
++checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 +
-+[[package]]
-+name = "zerovec"
-+version = "0.11.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
-+dependencies = [
-+ "yoke",
-+ "zerofrom",
-+ "zerovec-derive",
-+]
-+
-+[[package]]
-+name = "zerovec-derive"
-+version = "0.11.1"
-+source = "registry+https://github.com/rust-lang/crates.io-index"
-+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
-+dependencies = [
-+ "proc-macro2 1.0.101",
-+ "quote 1.0.41",
-+ "syn 2.0.106",
-+]
- 
  [[package]]
  name = "zstd"
--version = "0.13.2"
-+version = "0.13.3"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
-+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
- dependencies = [
-  "zstd-safe",
- ]
- 
- [[package]]
- name = "zstd-safe"
--version = "7.2.1"
-+version = "7.2.4"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
-+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
- dependencies = [
-  "zstd-sys",
- ]
- 
- [[package]]
- name = "zstd-sys"
--version = "2.0.13+zstd.1.5.6"
-+version = "2.0.16+zstd.1.5.7"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
-+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
- dependencies = [
-  "cc",
-  "pkg-config",
+ version = "0.13.2"
 diff --git a/Cargo.toml b/Cargo.toml
-index 4ca6d74..cc4bb13 100644
+index ac0a63c..094a119 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -30,14 +30,14 @@ mac_address = "1.1.5"
@@ -5323,6 +2112,113 @@ index fa1b6ed..9a19c30 100644
          SqliteConnection::connect_with(&opt).await
      }
      async fn recycle(
+diff --git a/src/rendezvous_server.rs b/src/rendezvous_server.rs
+index efe6330..b3f32df 100644
+--- a/src/rendezvous_server.rs
++++ b/src/rendezvous_server.rs
+@@ -65,7 +65,12 @@ static ALWAYS_USE_RELAY: AtomicBool = AtomicBool::new(false);
+ use once_cell::sync::Lazy;
+ use tokio::sync::Mutex as TokioMutex; // differentiate if needed
+ #[derive(Clone)]
+-struct PunchReqEntry { tm: Instant, from_ip: String, to_ip: String, to_id: String }
++struct PunchReqEntry {
++    tm: Instant,
++    from_ip: String,
++    to_ip: String,
++    to_id: String,
++}
+ static PUNCH_REQS: Lazy<TokioMutex<Vec<PunchReqEntry>>> = Lazy::new(|| TokioMutex::new(Vec::new()));
+ const PUNCH_REQ_DEDUPE_SEC: u64 = 60;
+ 
+@@ -688,7 +693,11 @@ impl RendezvousServer {
+     ) -> ResultType<(RendezvousMessage, Option<SocketAddr>)> {
+         let mut ph = ph;
+         if !key.is_empty() && ph.licence_key != key {
+-            log::warn!("Authentication failed from {} for peer {} - invalid key", addr, ph.id);
++            log::warn!(
++                "Authentication failed from {} for peer {} - invalid key",
++                addr,
++                ph.id
++            );
+             let mut msg_out = RendezvousMessage::new();
+             msg_out.set_punch_hole_response(PunchHoleResponse {
+                 failure: punch_hole_response::Failure::LICENSE_MISMATCH.into(),
+@@ -715,7 +724,7 @@ impl RendezvousServer {
+                 });
+                 return Ok((msg_out, None));
+             }
+-            
++
+             // record punch hole request (from addr -> peer id/peer_addr)
+             {
+                 let from_ip = try_into_v4(addr).ip().to_string();
+@@ -723,13 +732,23 @@ impl RendezvousServer {
+                 let to_id_clone = id.clone();
+                 let mut lock = PUNCH_REQS.lock().await;
+                 let mut dup = false;
+-                for e in lock.iter().rev().take(30) { // only check recent tail subset for speed
++                for e in lock.iter().rev().take(30) {
++                    // only check recent tail subset for speed
+                     if e.from_ip == from_ip && e.to_id == to_id_clone {
+-                        if e.tm.elapsed().as_secs() < PUNCH_REQ_DEDUPE_SEC { dup = true; }
++                        if e.tm.elapsed().as_secs() < PUNCH_REQ_DEDUPE_SEC {
++                            dup = true;
++                        }
+                         break;
+                     }
+                 }
+-                if !dup { lock.push(PunchReqEntry { tm: Instant::now(), from_ip, to_ip, to_id: to_id_clone }); }
++                if !dup {
++                    lock.push(PunchReqEntry {
++                        tm: Instant::now(),
++                        from_ip,
++                        to_ip,
++                        to_id: to_id_clone,
++                    });
++                }
+             }
+ 
+             let mut msg_out = RendezvousMessage::new();
+@@ -1051,20 +1070,32 @@ impl RendezvousServer {
+                 use std::fmt::Write as _;
+                 let mut lock = PUNCH_REQS.lock().await;
+                 // retain only recent (optional cleanup older than a day)
+-                lock.retain(|e| e.tm.elapsed().as_secs() < 24*3600);
++                lock.retain(|e| e.tm.elapsed().as_secs() < 24 * 3600);
+                 let arg = fds.next();
+-                if let Some("-") = arg { lock.clear(); }
+-                else {
++                if let Some("-") = arg {
++                    lock.clear();
++                } else {
+                     let mut start = arg.and_then(|x| x.parse::<usize>().ok()).unwrap_or(0);
+-                    let mut page_size = fds.next().and_then(|x| x.parse::<usize>().ok()).unwrap_or(10);
+-                    if page_size == 0 { page_size = 10; }
+-                    if start >= lock.len() { start = 0; }
++                    let mut page_size = fds
++                        .next()
++                        .and_then(|x| x.parse::<usize>().ok())
++                        .unwrap_or(10);
++                    if page_size == 0 {
++                        page_size = 10;
++                    }
++                    if start >= lock.len() {
++                        start = 0;
++                    }
+                     for (_, e) in lock.iter().enumerate().skip(start).take(page_size) {
+                         let age = e.tm.elapsed();
+                         let event_system = std::time::SystemTime::now() - age;
+                         let event_iso = chrono::DateTime::<chrono::Utc>::from(event_system)
+                             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+-                        let _ = writeln!(res, "{} {} -> {}@{}", event_iso, e.from_ip, e.to_id, e.to_ip);
++                        let _ = writeln!(
++                            res,
++                            "{} {} -> {}@{}",
++                            event_iso, e.from_ip, e.to_id, e.to_ip
++                        );
+                     }
+                 }
+             }
 -- 
-2.51.0
+2.52.0
 

--- a/app-network/rustdesk-server/spec
+++ b/app-network/rustdesk-server/spec
@@ -1,4 +1,4 @@
-VER=1.1.14
+VER=1.1.15
 SRCS="git::commit=tags/${VER}::https://github.com/rustdesk/rustdesk-server"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=rustdesk/rustdesk-server"


### PR DESCRIPTION
Topic Description
-----------------

- rustdesk-server: update to 1.1.15
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- rustdesk-server: 1.1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustdesk-server
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
