### PR TITLE
texinfo: update to 7.3

### DIFF
--- a/app-utils/texinfo/spec
+++ b/app-utils/texinfo/spec
@@ -1,4 +1,4 @@
-VER=7.2
+VER=7.3
 SRCS="tbl::https://ftp.gnu.org/gnu/texinfo/texinfo-$VER.tar.xz"
-CHKSUMS="sha256::0329d7788fbef113fa82cb80889ca197a344ce0df7646fe000974c5d714363a6"
+CHKSUMS="sha256::51f74eb0f51cfa9873b85264dfdd5d46e8957ec95b88f0fb762f63d9e164c72e"
 CHKUPDATE="anitya::id=4958"


### PR DESCRIPTION
Topic Description
-----------------

- texinfo: update to 7.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- texinfo: 7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit texinfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
