### PR TITLE
ciel: update to 3.10.1

### DIFF
--- a/app-devel/ciel/spec
+++ b/app-devel/ciel/spec
@@ -1,4 +1,4 @@
-VER=3.10.0
+VER=3.10.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/ciel-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227000"


### PR DESCRIPTION
Topic Description
-----------------

- ciel: update to 3.10.1
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- ciel: 3.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ciel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
