### PR TITLE
scribus: fix duplicated rel

### DIFF
--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -3,4 +3,3 @@ REL=2
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::09bdb736a8ff8a437191458a36d847cc0adeca0fc059cf696474e0ba6f59ac6a"
 CHKUPDATE="anitya::id=4773"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- scribus: fix duplicated REL
    Two different mass rebuild actions ejected REL at different position of
    the spec file.
    Only leave the bigger one \(2\) in the file now.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- scribus: 1.6.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit scribus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
