### PR TITLE
fcitx-libpinyin: rebuild for libpinyin update

### DIFF
--- a/app-i18n/fcitx-libpinyin/spec
+++ b/app-i18n/fcitx-libpinyin/spec
@@ -1,4 +1,5 @@
 VER=0.5.4
+REL=1
 SRCS="tbl::https://download.fcitx-im.org/fcitx-libpinyin/fcitx-libpinyin-$VER.tar.xz"
 CHKSUMS="sha256::650a846f59a50af5e0ce2e493957885bac59995784bb4e211bf8ad1a83607af3"
 CHKUPDATE="anitya::id=8011"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx-libpinyin: rebuild for libpinyin update
    A recent libpinyin update bumped SONAME to version 15 and this package
    lacked rebuild.

Package(s) Affected
-------------------

- fcitx-libpinyin: 0.5.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx-libpinyin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
