### PR TITLE
tzdata: update to 2026a

### DIFF
--- a/runtime-data/tzdata/spec
+++ b/runtime-data/tzdata/spec
@@ -1,4 +1,4 @@
-VER=2025c
+VER=2026a
 SRCS="https://data.iana.org/time-zones/releases/tzdata$VER.tar.gz"
-CHKSUMS="sha256::4aa79e4effee53fc4029ffe5f6ebe97937282ebcdf386d5d2da91ce84142f957"
+CHKSUMS="sha256::77b541725937bb53bd92bd484c0b43bec8545e2d3431ee01f04ef8f2203ba2b7"
 CHKUPDATE="anitya::id=5021"


### PR DESCRIPTION
Topic Description
-----------------

- tzdata: update to 2026a
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- tzdata: 2026a

Security Update?
----------------

No

Build Order
-----------

```
#buildit tzdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
