### PR TITLE
rime-ice: update to 2025.12.08

### DIFF
--- a/app-i18n/rime-ice/spec
+++ b/app-i18n/rime-ice/spec
@@ -1,5 +1,4 @@
-VER=2025.04.06
-REL=1
+VER=2025.12.08
 SRCS="git::commit=tags/$VER::https://github.com/iDvel/rime-ice.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377230"


### PR DESCRIPTION
Topic Description
-----------------

- rime-ice: update to 2025.12.08
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- rime-ice: 2025.12.08

Security Update?
----------------

No

Build Order
-----------

```
#buildit rime-ice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
