### PR TITLE
box64: update to 0.4.1+2

### DIFF
--- a/app-emulation/box64/autobuild/defines
+++ b/app-emulation/box64/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=box64
 PKGSEC=utils
-PKGDEP="glibc gcc-runtime"
+PKGDEP="gcc-runtime glibc ncurses"
 PKGDES="Userspace emulator for running x86-64 applications on non-x86 systems"
 ABTYPE="cmakeninja"
 
@@ -26,6 +26,7 @@ CMAKE_AFTER__LOONGARCH64=(
 CMAKE_AFTER__PPC64EL=(
     "${CMAKE_AFTER[@]}"
     "-DPPC64LE=ON"
+    "-DPPC64LE_DYNAREC=ON"
 )
 
 CMAKE_AFTER__RISCV64=(

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=0.4.1-1
+UPSTREAM_VER=0.4.1-2
 VER=${UPSTREAM_VER//\-/+}
 # Note: copy-repo is required for "box64 -v" to show the commit hash
 SRCS="git::commit=tags/v${UPSTREAM_VER};copy-repo=true::https://github.com/ptitSeb/box64.git"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.4.1+2
    - Add missing ncurses PKGDEP.
    - Enable dynarec on ppc64el.

Package(s) Affected
-------------------

- box64: 0.4.1+2

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
