### PR TITLE
grub: Fix prefix detection with iso9660 on ieee1275

### DIFF
--- a/app-admin/grub/autobuild/patches/0073-ieee1275-don-t-return-NULL-if-there-is-no-partition.patch
+++ b/app-admin/grub/autobuild/patches/0073-ieee1275-don-t-return-NULL-if-there-is-no-partition.patch
@@ -1,0 +1,69 @@
+From 04358635d191dcb577e0da65dfd5dec64baaf984 Mon Sep 17 00:00:00 2001
+From: AOSC Maintainers <maintainers@aosc.io>
+Date: Wed, 4 Mar 2026 10:28:44 +0000
+Subject: [PATCH 73/73] ieee1275: don't return NULL if there is no partition
+
+ISOs generated using grub-mkrescue does not contain "partitions", as seen
+in the SLOF firmware which is used in the QEMU pseries machines.
+
+Returning NULL causes the machine cease to boot.
+---
+ grub-core/kern/ieee1275/openfw.c | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/grub-core/kern/ieee1275/openfw.c b/grub-core/kern/ieee1275/openfw.c
+index 06757f5d8..1687b6165 100644
+--- a/grub-core/kern/ieee1275/openfw.c
++++ b/grub-core/kern/ieee1275/openfw.c
+@@ -489,6 +489,7 @@ grub_ieee1275_encode_devname (const char *path)
+   char *encoding;
+   char *optr;
+   const char *iptr;
++  int error = 0;
+ 
+   if (! device)
+     return 0;
+@@ -520,11 +521,21 @@ grub_ieee1275_encode_devname (const char *path)
+       if (*endptr != '\0' || partno > 65535 ||
+           (partno == 0 && ! grub_ieee1275_test_flag (GRUB_IEEE1275_FLAG_0_BASED_PARTITIONS)))
+         {
+-          grub_free (partition);
+-          grub_free (device);
+-          grub_free (encoding);
++          /*
++           * On iso9660 there will be no partition as seen in the SLOF
++           * firmware.
++           * In this case partition contains the path to the booted file.
++           * This can't be treated as an error, the device name must be
++           * returned, otherwise image files created using grub-mkrescue
++           * will fail to boot.
++           */
++          error = 1;
++          if (grub_strstr (path, partition) != NULL) {
++            error = 0;
++          }
+           grub_error (GRUB_ERR_BAD_ARGUMENT, N_("invalid partition number"));
+-          return NULL;
++          *optr = '\0';
++          goto out;
+         }
+ 
+       *optr++ = ',';
+@@ -538,9 +549,13 @@ grub_ieee1275_encode_devname (const char *path)
+   else
+     *optr = '\0';
+ 
++out:
+   grub_free (partition);
+   grub_free (device);
+-
++  if (error) {
++    grub_free (encoding);
++    return NULL;
++  }
+   return encoding;
+ }
+ 
+-- 
+2.52.0
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=17.0.02
 RETROFONTVER=20200402
 
 VER=${GRUBVER}+unifont${__UNIFONTVER}
-REL=2
+REL=3
 SRCS="git::commit=tags/grub-${__UPSTREAM_VER};rename=grub-${__UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::rename=grub-fonts-$RETROFONTVER.tar.xz::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: fix prefix path when booted with iso9660 on ieee1275

Package(s) Affected
-------------------

- grub: 2:2.14+unifont17.0.02-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
