### PR TITLE
remmina: update to 1.4.43

### DIFF
--- a/app-network/remmina/autobuild/defines
+++ b/app-network/remmina/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="gtk-3 zlib libjpeg-turbo libssh libunique avahi libgcrypt \
         libspice-gtk cups vte libsecret"
 BUILDDEP="gnome-keyring kwallet spice-protocol"
 PKGSUG="gnome-keyring kwallet"
-PKGDES="A remote desktop client written in GTK+"
+PKGDES="Remote desktop client"
 
 # Note: -DWITH_ICON_CACHE, Generate the icon cache during install target.
 # Note: -DWITH_UPDATE_DESKTOP_DB, Generate desktop files cache database.
@@ -26,7 +26,7 @@ __CMAKE_AFTER=(
     '-DWITH_GVNC=ON'
     '-DWITH_ICON_CACHE=OFF'
     '-DWITH_KF5WALLET=ON'
-    '-DWITH_KIOSK_SESSION=ON'
+    '-DWITH_KIOSK_SESSION=OFF'
     '-DWITH_LIBSECRET=ON'
     '-DWITH_LIBSSH=ON'
     '-DWITH_LIBVNCSERVER=ON'

--- a/app-network/remmina/spec
+++ b/app-network/remmina/spec
@@ -1,4 +1,4 @@
-VER=1.4.40
+VER=1.4.43
 SRCS="tbl::https://gitlab.com/Remmina/Remmina/-/archive/v${VER}/Remmina-v{VER}.tar.gz"
-CHKSUMS="sha256::a1881003474211368fa18ec2a46f29ce55458932faedc6dca02a28e713470b73"
+CHKSUMS="sha256::dc27bed5ce6fe9eff5cfbbcb6583535d4ba4f3e7f5a993df8877a58b9504125d"
 CHKUPDATE="anitya::id=4188"


### PR DESCRIPTION
Topic Description
-----------------

- remmina: update to 1.4.43
    Drop useless GNOME Kiosk session.

Package(s) Affected
-------------------

- remmina: 1.4.43

Security Update?
----------------

No

Build Order
-----------

```
#buildit remmina
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
