### PR TITLE
freetype: update to 2.14.2

### DIFF
--- a/runtime-desktop/freetype/spec
+++ b/runtime-desktop/freetype/spec
@@ -1,4 +1,4 @@
-VER=2.13.3
+VER=2.14.2
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/freetype/freetype-$VER.tar.xz"
-CHKSUMS="sha256::0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
+CHKSUMS="sha256::4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1"
 CHKUPDATE="anitya::id=854"

--- a/runtime-optenv32/freetype+32/spec
+++ b/runtime-optenv32/freetype+32/spec
@@ -1,4 +1,4 @@
-VER=2.13.3
+VER=2.14.2
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/freetype/freetype-$VER.tar.xz"
-CHKSUMS="sha256::0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
+CHKSUMS="sha256::4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1"
 CHKUPDATE="anitya::id=854"

--- a/topics/freetype-2.14.2.toml
+++ b/topics/freetype-2.14.2.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Freetype 2.14.2"
+
+[caution]
+default = "Fixes an integer overflow vulnerability (CVE-2026-23865, Severity: Medium)"
+zh_CN = "修复了一个整型溢出漏洞（CVE-2026-23865，严重性：中等）"
+
+[packages-v2]
+"freetype" = "< 2.14.2"
+"freetype+32" = "< 2.14.2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add freetype-2.14.2.toml
    Signed-off-by: stydxm <stydxm@outlook.com>
- freetype+32: update to 2.14.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- freetype: update to 2.14.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- freetype: 2.14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit freetype
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
