### PR TITLE
spdylay: drop, orphaned

### DIFF
--- a/groups/openssl-rebuilds
+++ b/groups/openssl-rebuilds
@@ -15,7 +15,6 @@ runtime-network/libssh
 app-admin/cryptsetup
 runtime-network/libssh2
 runtime-common/libevent
-runtime-web/spdylay
 runtime-web/nghttp2
 app-network/rtmpdump
 app-web/curl

--- a/groups/stage1-to-apt
+++ b/groups/stage1-to-apt
@@ -45,7 +45,6 @@ jemalloc
 libev
 libevent
 libxml2
-spdylay
 nghttp2
 curl
 nettle

--- a/runtime-web/nghttp2/autobuild/defines
+++ b/runtime-web/nghttp2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=nghttp2
 PKGSEC=libs
-PKGDEP="c-ares jansson jemalloc libbpf libev spdylay"
+PKGDEP="c-ares jansson jemalloc libbpf libev"
 BUILDDEP="cython llvm"
 PKGDES="Library to implement the HTTP/2 protocol and the HPACK header compression algorithm"
 

--- a/runtime-web/nghttp2/autobuild/defines.stage2
+++ b/runtime-web/nghttp2/autobuild/defines.stage2
@@ -1,6 +1,6 @@
 PKGNAME=nghttp2
 PKGSEC=libs
-PKGDEP="c-ares jansson jemalloc libev spdylay"
+PKGDEP="c-ares jansson jemalloc libev"
 PKGDES="Library to implement the HTTP/2 protocol and the HPACK header compression algorithm"
 
 # FIXME: --disable-examples to skip broken examples (event.h incompatibility).

--- a/runtime-web/nghttp2/spec
+++ b/runtime-web/nghttp2/spec
@@ -1,4 +1,5 @@
 VER=1.65.0
+REL=1
 SRCS="tbl::https://github.com/nghttp2/nghttp2/releases/download/v$VER/nghttp2-$VER.tar.xz"
 CHKSUMS="sha256::f1b9df5f02e9942b31247e3d415483553bc4ac501c87aa39340b6d19c92a9331"
 CHKUPDATE="anitya::id=8651"

--- a/runtime-web/spdylay/autobuild/defines
+++ b/runtime-web/spdylay/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=spdylay
-PKGSEC=libs
-PKGDEP="zlib libevent libxml2"
-PKGDES="The experimental SPDY protocol version 2, 3 and 3.1 implementation in C"

--- a/runtime-web/spdylay/spec
+++ b/runtime-web/spdylay/spec
@@ -1,5 +1,0 @@
-VER=1.4.0
-REL=5
-SRCS="tbl::https://github.com/tatsuhiro-t/spdylay/releases/download/v$VER/spdylay-$VER.tar.xz"
-CHKSUMS="sha256::1a133578dd330f5ff3b1c25798c0594e39858e6a050513e5d7ec31eda6e89341"
-CHKUPDATE="anitya::id=230540"


### PR DESCRIPTION
Topic Description
-----------------

- nghttp2: drop unused spdylay dependency
- spdylay: drop, orphaned

Package(s) Affected
-------------------

- nghttp2: 1.65.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nghttp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
