### PR TITLE
nodejs-24: disable AB_FLAGS_EXC to align with upstream

### DIFF
--- a/lang-js/nodejs-24/autobuild/defines
+++ b/lang-js/nodejs-24/autobuild/defines
@@ -1,12 +1,11 @@
 PKGNAME=nodejs-24
 PKGSEC=devel
 PKGDEP="python-3 icu zlib brotli libuv openssl ca-certs nghttp2 nghttp3 ngtcp2 sqlite zstd ada"
-BUILDDEP="chrpath unzip jq llvm"
+BUILDDEP="chrpath unzip jq"
 PKGDES="JavaScript runtime built on the V8 JavaScript engine (LTS branch 24.x)"
 
 # https://github.com/nodejs/node/issues/44195#issuecomment-1545966528
 NOLTO=1
 
-# FIXME: nodejs-24 compiled with GCC segfaults on loongarch64 when running Wasm code
-USECLANG__LOONGARCH64=1
-USECLANG__LOONGARCH64_NOSIMD=1
+# https://github.com/nodejs/node/blob/9027f29e6d5de49842905d0ed082ad5907e80d78/common.gypi#L503
+AB_FLAGS_EXC=0

--- a/lang-js/nodejs-24/spec
+++ b/lang-js/nodejs-24/spec
@@ -1,5 +1,5 @@
 VER=24.13.1
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/nodejs/node"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379150"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-24: disable AB_FLAGS_EXC to align with upstream
    https://github.com/nodejs/node/blob/9027f29e6d5de49842905d0ed082ad5907e80d78/common.gypi#L503

Package(s) Affected
-------------------

- nodejs-24: 24.13.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-24
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
