### PR TITLE
libavif: update to 1.4.0

### DIFF
--- a/runtime-multimedia/libavif/spec
+++ b/runtime-multimedia/libavif/spec
@@ -1,4 +1,4 @@
-VER=1.2.1
+VER=1.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOMediaCodec/libavif.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=178015"


### PR DESCRIPTION
Topic Description
-----------------

- libavif: update to 1.4.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libavif: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libavif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
