### PR TITLE
sympy: update to 1.14.0

### DIFF
--- a/lang-python/pyglet/autobuild/defines
+++ b/lang-python/pyglet/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=pyglet
 PKGSEC=python
 PKGDEP="glu python-3"
 BUILDDEP="setuptools-python3"
-PKGDES="A cross-platform windowing and multimedia library for Python"
+PKGDES="Cross-platform windowing and multimedia library for Python"
 
 ABHOST=noarch
 ABTYPE=python

--- a/lang-python/pyglet/spec
+++ b/lang-python/pyglet/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
-REL="6"
-SRCS="tbl::https://pypi.io/packages/source/p/pyglet/pyglet-$VER.tar.gz"
-CHKSUMS="sha256::b00570e7cdf6971af8953b6ece50d83d13272afa5d1f1197c58c0f478dd17743"
+VER=2.1.13
+SRCS="pypi::version=$VER::pyglet"
+CHKSUMS="sha256::37a31c212b51658f7c125613f93818a199e8808f86e9b1abe7bfe5395661eee3"
 CHKUPDATE="anitya::id=20084"

--- a/lang-python/sympy/spec
+++ b/lang-python/sympy/spec
@@ -1,5 +1,4 @@
-VER=1.12
-SRCS="tbl::https://pypi.io/packages/source/s/sympy/sympy-$VER.tar.gz"
-CHKSUMS="sha256::ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"
+VER=1.14.0
+SRCS="pypi::version=$VER::sympy"
+CHKSUMS="sha256::d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"
 CHKUPDATE="anitya::id=4923"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- sympy: update to 1.14.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- pyglet: update to 2.1.13
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit pyglet sympy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
