### PR TITLE
vscode: update to 1.110.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.109.5
+VER=1.110.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::1c3837928eb11e52a53abf096ae5159619642668f0d88f86fb6b812610af580a"
-CHKSUMS__ARM64="sha256::f989b2896cca4af7acfc83252b61e1ca08ae5bcbaa9a065193380926502105cc"
+CHKSUMS__AMD64="sha256::aafe94571d90fba6a1ccbde889ff371e5b56bbead738f9aa028570712d9b71fd"
+CHKSUMS__ARM64="sha256::e16d634a5ba98b0b96a5479bc2931e62bf04a79ab0747ae151973080f7d88a1e"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.110.0

Package(s) Affected
-------------------

- vscode: 1.110.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
