### PR TITLE
lxcfs: update to 6.0.6

### DIFF
--- a/app-admin/lxcfs/spec
+++ b/app-admin/lxcfs/spec
@@ -1,4 +1,4 @@
-VER=6.0.5
+VER=6.0.6
 SRCS="tbl::https://linuxcontainers.org/downloads/lxcfs/lxcfs-v$VER.tar.gz"
-CHKSUMS="sha256::91ce19087147791361115f3c8d3c647d5b0a36d386cd050ee0175bb75cc5d918"
+CHKSUMS="sha256::386339ba4cde289b0f6df4fe7a614caa1e45dd91bc0200b4aff6c51bf9d5ef9e"
 CHKUPDATE="anitya::id=17098"


### PR DESCRIPTION
Topic Description
-----------------

- lxcfs: update on 6.0.6

Package(s) Affected
-------------------

- lxcfs: 6.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxcfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
