### PR TITLE
lxc: update to 6.0.6

### DIFF
--- a/app-admin/lxc/spec
+++ b/app-admin/lxc/spec
@@ -1,5 +1,4 @@
-VER=6.0.5
+VER=6.0.6
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/lxc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1860"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- lxc: update to 6.0.6

Package(s) Affected
-------------------

- lxc: 6.0.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
