### PR TITLE
ppsspp: update to 1.20.1

### DIFF
--- a/app-games/ppsspp/autobuild/beyond
+++ b/app-games/ppsspp/autobuild/beyond
@@ -1,17 +1,6 @@
-abinfo 'Building PPSSPP (SDL) ...'
-ninja clean \
-    -C "$SRCDIR"/abbuild
-cmake "$SRCDIR" \
-    -B "$SRCDIR"/abbuild \
-    -DUSING_QT_UI=OFF \
-    -DHEADLESS=ON
-ninja \
-    -C "$SRCDIR"/abbuild \
-    -v
-DESTDIR="$PKGDIR" \
-ninja install \
-    -C "$SRCDIR"/abbuild
+abinfo 'Creating a symlink to /usr/bin/ppsspp for our default frontend (SDL) ...'
+ln -sv PPSSPPSDL \
+    "$PKGDIR"/usr/bin/ppsspp
 
-abinfo 'Installing PPSSPP (SDL) ...'
-install -Dvm755 "$SRCDIR"/abbuild/PPSSPPHeadless \
-    "$PKGDIR"/usr/bin/PPSSPPHeadless
+abinfo 'Removing unused .desktop entry ...'
+rm -v "$PKGDIR"/usr/share/applications/PPSSPP*.desktop

--- a/app-games/ppsspp/autobuild/defines
+++ b/app-games/ppsspp/autobuild/defines
@@ -1,21 +1,77 @@
 PKGNAME=ppsspp
 PKGSEC=games
-PKGDEP="ffmpeg libzip sdl2 snappy libuv libpng glew qt-5"
-BUILDDEP="cmake glu llvm"
-PKGDES="A PSP (PlayStation® Portable) emulator"
+PKGDEP="ffmpeg glew libpng libuv libzip miniupnpc sdl2 sdl2-ttf snappy"
+BUILDDEP="glu llvm"
+PKGDES="Emulator for PlayStation® Portable (PSP)"
 
-# Note: Use bundled FFmpeg as it has no chance in supporting FFmpeg >= 5.0 and
-# the upstream has already started removing FFmpeg support from key
-# multimedia components.
-CMAKE_AFTER="-DPNG_LIBRARY=/usr/lib/libpng.so \
-             -DPNG_PNG_INCLUDE_DIR=/usr/include/libpng16 \
-             -DUSING_QT_UI=ON \
-             -DHEADLESS=OFF \
-             -DCMAKE_SKIP_RPATH=ON \
-             -DUSE_SYSTEM_FFMPEG=OFF \
-             -DUSE_SYSTEM_LIBZIP=ON \
-             -DUSE_SYSTEM_SNAPPY=ON \
-             -DOpenGL_GL_PREFERENCE=GLVND"
+CMAKE_AFTER=(
+    '-DBUILD_EXTERNAL=OFF'
+    # Note: Pointless.
+    '-DBUILD_SHARED_LIBS=OFF'
+    '-DBUILD_TESTING=OFF'
+    '-DENABLE_CTEST=OFF'
+    '-DENABLE_EXCEPTIONS=OFF'
+    '-DENABLE_GLSLANG_BINARIES=OFF'
+    '-DENABLE_GLSLANG_JS=OFF'
+    '-DENABLE_HLSL=ON'
+    '-DENABLE_OPT=ON'
+    '-DENABLE_PCH=ON'
+    '-DENABLE_RTTI=OFF'
+    '-DENABLE_SPVREMAPPER=OFF'
+    '-DGOLD=OFF'
+    '-DHEADLESS=OFF'
+    '-DLIBRETRO=OFF'
+    '-DMOBILE_DEVICE=OFF'
+    '-DSIMULATOR=OFF'
+    '-DSKIP_GLSLANG_INSTALL=ON'
+    '-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=OFF'
+    '-DUNITTEST=OFF'
+    '-DUSE_ASAN=OFF'
+    '-DUSE_CCACHE=OFF'
+    '-DUSE_DISCORD=ON'
+    '-DUSE_FFMPEG=ON'
+    '-DUSE_IAP=OFF'
+    '-DUSE_LIBNX=OFF'
+    '-DUSE_MINIUPNPC=ON'
+    '-DUSE_NO_MMAP=OFF'
+    '-DUSE_SYSTEM_FFMPEG=ON'
+    '-DUSE_SYSTEM_LIBPNG=ON'
+    '-DUSE_SYSTEM_LIBSDL2=ON'
+    '-DUSE_SYSTEM_LIBZIP=ON'
+    '-DUSE_SYSTEM_MINIUPNPC=ON'
+    '-DUSE_SYSTEM_SNAPPY=ON'
+    '-DUSE_SYSTEM_ZSTD=ON'
+    '-DUSE_UBSAN=OFF'
+    # Note: Experimental.
+    '-DUSE_VULKAN_DISPLAY_KHR=OFF'
+    '-DUSE_WAYLAND_WSI=ON'
+    '-DUSING_EGL=ON'
+    '-DUSING_FBDEV=ON'
+    '-DUSING_GLES2=ON'
+    '-DUSING_QT_UI=OFF'
+    '-DUSING_X11_VULKAN=ON'
+    '-DZLIB_BUILD_EXAMPLES=OFF'
+)
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER[@]}"
+    '-DX86_64=ON'
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    '-DARM=ON'
+)
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER[@]}"
+    '-DLOONGARCH64=ON'
+)
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER[@]}"
+    '-DLOONGARCH64=OFF'
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER[@]}"
+    '-DRISCV64=ON'
+)
 
 AB_FLAGS_O3=1
 

--- a/app-games/ppsspp/autobuild/overrides/usr/share/applications/ppsspp.desktop
+++ b/app-games/ppsspp/autobuild/overrides/usr/share/applications/ppsspp.desktop
@@ -3,7 +3,10 @@ Version=1.0
 Type=Application
 Name=PPSSPP
 GenericName=PSP Emulator
-Comment=PlayStation® Portable Simulator Suitable for Playing Portably (PPSSPP)
+GenericName[zh_CN]=PSP 模拟器
+Comment=Fast and portable PSP emulator
+Comment[zh_CN]=高性能、跨平台的 PSP 模拟器
+
 Exec=PPSSPPSDL %f
 Icon=ppsspp
 Categories=Game

--- a/app-games/ppsspp/autobuild/patches/0001-AOSCOS-ext-do-not-bundle-FreeType.patch
+++ b/app-games/ppsspp/autobuild/patches/0001-AOSCOS-ext-do-not-bundle-FreeType.patch
@@ -1,0 +1,30 @@
+From 738d55b65a0a709b5039d8e4721ca94ebf7968d0 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Fri, 6 Mar 2026 19:49:14 +0800
+Subject: [PATCH] AOSCOS: ext: do not bundle FreeType
+
+By enabling FreeType in ext/, PPSSPP installs libfreetype (along with
+development files) unconditionally.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ ext/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/ext/CMakeLists.txt b/ext/CMakeLists.txt
+index 32e5c4ce92..71923bc06f 100644
+--- a/ext/CMakeLists.txt
++++ b/ext/CMakeLists.txt
+@@ -42,9 +42,6 @@ set(FT_REQUIRE_BZIP2 OFF CACHE BOOL "" FORCE)
+ set(FT_REQUIRE_PNG OFF CACHE BOOL "" FORCE)
+ set(FT_REQUIRE_HARFBUZZ OFF CACHE BOOL "" FORCE)
+ set(FT_REQUIRE_BROTLI OFF CACHE BOOL "" FORCE)
+-if(NOT LIBRETRO)
+-    add_subdirectory(freetype)
+-endif()
+ 
+ if(NOT LIBRETRO)
+     add_subdirectory(imgui)
+-- 
+2.52.0
+

--- a/app-games/ppsspp/autobuild/prepare
+++ b/app-games/ppsspp/autobuild/prepare
@@ -1,6 +1,0 @@
-acbs_copy_git
-
-if [[ "${CROSS:-$ARCH}" = "loongson3" ]]; then
-    abinfo "Undefining mips to fix build ..."
-    export CXXFLAGS="${CXXFLAGS} -Umips"
-fi

--- a/app-games/ppsspp/spec
+++ b/app-games/ppsspp/spec
@@ -1,4 +1,4 @@
-VER=1.19.3
+VER=1.20.1
 SRCS="git::commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12295"


### PR DESCRIPTION
Topic Description
-----------------

- ppsspp: update to 1.20.1
    - Drop unused Qt and headless frontends.
    - Set options explicitly where applicable.
    - Drop unused prepare script.
    - Track patches at AOSC-Tracking/ppsspp @ aosc/v1.20.1
    \(HEAD: 738d55b65a0a709b5039d8e4721ca94ebf7968d0\).

Package(s) Affected
-------------------

- ppsspp: 1.20.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppsspp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
