### PR TITLE
loonggl: only create the egl vendor symlink for the GPU model in use

### DIFF
--- a/runtime-display/loonggl/autobuild/overrides/usr/libexec/loonggl-hack
+++ b/runtime-display/loonggl/autobuild/overrides/usr/libexec/loonggl-hack
@@ -12,7 +12,7 @@ for i in /sys/class/drm/card[0-9]/device/driver; do
 	driver="$(basename $(readlink $i))"
 
 	if [ "$driver" = "loonggpu-dc" ]; then
-		has_loonggpu=1
+		has_loonggpu="$(<$(dirname $i)/device)"
 	elif [ "$driver" != "hantro" ]; then
 		# If any drm device(s) with a different driver (except a hantro VPU)
 		# are loaded, don't even try LoongGPU EGL implementations.
@@ -56,13 +56,17 @@ for i in /sys/class/drm/card[0-9]/device/driver; do
 	fi
 done
 
+# Well, even LG1xx driver causes a segfault running PPSSPP on LG2xx...
+# So only active the driver we really need.
+DIR=/usr/share/glvnd/egl_vendor.d
+case $has_loonggpu in
+	0x7a36 ) TARGET=$DIR/40_gsgpu.json ;;
+	0x7a46 ) TARGET=$DIR/40_loonggpu.json ;;
+	* ) ;;
+esac
+
 # Note that "$V" is only for debugging purpose (set V=-v).
-for TARGET in /usr/share/glvnd/egl_vendor.d/40_{gs,loong}gpu.json; do
-	if [[ "$has_loonggpu" = 1 ]]; then
-		ln $V -sf "${TARGET/40/60}" "$TARGET"
-	else
-		rm $V -f "$TARGET"
-	fi
-done
+rm $V -f /usr/share/glvnd/egl_vendor.d/40_{gs,loong}gpu.json
+[ -z "$TARGET" ] || ln $V -sf "${TARGET/40/60}" "$TARGET"
 
 # vim: ts=4

--- a/runtime-display/loonggl/spec
+++ b/runtime-display/loonggl/spec
@@ -7,3 +7,4 @@ SRCS="file::use-url-name=true::https://repo.aosc.io/aosc-repacks/loonggpu/loongg
 CHKSUMS="sha256::2952db5f143c848172fa79e4c236e36e1f718978520b4206699f779cb20f8aeb"
 SUBDIR=.
 CHKUPDATE="anitya::id=376483"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

We found if both 40_gsgpu.json and 40_loonggpu.json exist, on LG200 PPSSPP will segfault in libEGL_gsgpu.so.  This is need to fix the issue.

Package(s) Affected
-------------------

- loonggl: `1:1.0.2+0ky11.1~0.10-1`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggl
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] LoongArch 64-bit `loongarch64`
