### PR TITLE
ptyprocess: update to 0.7.0

### DIFF
--- a/lang-python/pexpect/autobuild/defines
+++ b/lang-python/pexpect/autobuild/defines
@@ -3,5 +3,6 @@ PKGSEC=python
 PKGDEP="ptyprocess"
 PKGDES="Make Python a better tool for controlling and automating other programs"
 
+ABTYPE=pep517
 PKGREP=pyexpect
 ABHOST=noarch

--- a/lang-python/pexpect/spec
+++ b/lang-python/pexpect/spec
@@ -1,5 +1,4 @@
-VER=4.8.0
-SRCS="https://pypi.io/packages/source/p/pexpect/pexpect-$VER.tar.gz"
-CHKSUMS="sha256::fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+VER=4.9.0
+SRCS="pypi::version=$VER::pexpect"
+CHKSUMS="sha256::ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"
 CHKUPDATE="anitya::id=7654"
-REL="2"

--- a/lang-python/ptyprocess/autobuild/defines
+++ b/lang-python/ptyprocess/autobuild/defines
@@ -5,6 +5,5 @@ BUILDDEP="setuptools"
 PKGDES="Run a subprocess in a pseudo-terminal"
 
 ABHOST=noarch
-
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/ptyprocess/spec
+++ b/lang-python/ptyprocess/spec
@@ -1,5 +1,4 @@
-VER=0.6.0
-REL="7"
-SRCS="tbl::https://pypi.python.org/packages/source/p/ptyprocess/ptyprocess-$VER.tar.gz"
-CHKSUMS="sha256::923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"
+VER=0.7.0
+SRCS="pypi::version=$VER::ptyprocess"
+CHKSUMS="sha256::5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
 CHKUPDATE="anitya::id=6447"


### PR DESCRIPTION
Topic Description
-----------------

- pexpect: update to 4.9.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- ptyprocess: update to 0.7.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit ptyprocess pexpect
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
