### PR TITLE
opentabletdriver: add loongarch64 support

### DIFF
--- a/runtime-devices/opentabletdriver/autobuild/defines
+++ b/runtime-devices/opentabletdriver/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=opentabletdriver
 PKGSEC=libs
-BUILDDEP="x11-lib libev dotnet-sdk-8.0 jq"
-PKGDEP="debconf libevdev gtk-3 dotnet-runtime-8.0 glibc gcc-runtime"
-PKGDES="A user-mode graphics tablet driver"
-FAIL_ARCH="!(arm64|amd64|armv7hf)" 
+BUILDDEP="x11-lib libev dotnet-sdk-10.0 jq"
+PKGDEP="debconf libevdev gtk-3 dotnet-runtime-10.0 glibc gcc-runtime"
+PKGDES="User-mode graphics tablet driver"
+FAIL_ARCH="!(arm64|amd64|armv7hf|loongarch64)"
 
 # .NET binary releases break when stripped
 # See https://github.com/dotnet/runtime/issues/37334

--- a/runtime-devices/opentabletdriver/autobuild/patches/0001-Remove-architecture-limitation-in-package.sh.patch
+++ b/runtime-devices/opentabletdriver/autobuild/patches/0001-Remove-architecture-limitation-in-package.sh.patch
@@ -1,0 +1,29 @@
+From b86fe5c0b7f8e8756eb0c0204f4ee1bd57405924 Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Sat, 7 Mar 2026 17:33:18 +0800
+Subject: [PATCH 1/3] Remove architecture limitation in package.sh
+
+---
+ eng/linux/package.sh | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/eng/linux/package.sh b/eng/linux/package.sh
+index 82a3c295..63432578 100755
+--- a/eng/linux/package.sh
++++ b/eng/linux/package.sh
+@@ -3,11 +3,7 @@
+ set -eu
+ . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+ 
+-if is_musl_based_distro; then
+-  NET_RUNTIME="linux-musl-x64"
+-else
+-  NET_RUNTIME="linux-x64"
+-fi
++NET_RUNTIME=$(dotnet --info | perl -ne '/RID:\s+(.+)/ && print "$1"')
+ 
+ PACKAGE_GEN=""
+ PROJECTS=(
+-- 
+2.52.0
+

--- a/runtime-devices/opentabletdriver/autobuild/patches/0002-Use-.NET-10.0.patch
+++ b/runtime-devices/opentabletdriver/autobuild/patches/0002-Use-.NET-10.0.patch
@@ -1,0 +1,39 @@
+From cf65c90f06138ece85a446c83c2be42c6d7286e5 Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Wed, 4 Mar 2026 20:27:14 +0800
+Subject: [PATCH 2/3] Use .NET 10.0
+
+---
+ Directory.Build.props | 2 +-
+ eng/lib.sh            | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index e6beb67a..956b2c45 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -2,7 +2,7 @@
+ 
+   <PropertyGroup>
+     <VersionBase>0.6.6.2</VersionBase>
+-    <FrameworkBase>net8.0</FrameworkBase>
++    <FrameworkBase>net10.0</FrameworkBase>
+     <VersionPrefix>$(VersionBase)</VersionPrefix>
+     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+   </PropertyGroup>
+diff --git a/eng/lib.sh b/eng/lib.sh
+index 450cd57b..ba333f6a 100755
+--- a/eng/lib.sh
++++ b/eng/lib.sh
+@@ -17,7 +17,7 @@ REPO_ROOT="$(readlink -f "${ENG_SCRIPT_ROOT}/../")"
+ 
+ ### Build Requirements
+ 
+-DOTNET_VERSION="8.0"
++DOTNET_VERSION="10.0"
+ 
+ # could do away with declare -g, but did it anyway for all of them for consistency
+ # with NET_RUNTIME (a global variable without initial value in lib.sh)
+-- 
+2.52.0
+

--- a/runtime-devices/opentabletdriver/autobuild/patches/0003-Switch-to-no-self-contained-over-self-contained-fals.patch
+++ b/runtime-devices/opentabletdriver/autobuild/patches/0003-Switch-to-no-self-contained-over-self-contained-fals.patch
@@ -1,0 +1,38 @@
+From 2e113e3f258bbbb8aa7008cb68dac8473a3cde7b Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Sat, 7 Mar 2026 20:32:49 +0800
+Subject: [PATCH 3/3] Switch to --no-self-contained over --self-contained false
+
+`--self-contained false` doesn't work anymore:
+https://github.com/OpenTabletDriver/OpenTabletDriver/pull/4623
+---
+ eng/lib.sh | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/eng/lib.sh b/eng/lib.sh
+index ba333f6a..e451808a 100755
+--- a/eng/lib.sh
++++ b/eng/lib.sh
+@@ -219,7 +219,6 @@ build() {
+     --configuration "${CONFIG}"
+     --runtime "${NET_RUNTIME}"
+     --framework "${FRAMEWORK}"
+-    --self-contained "${SELF_CONTAINED}"
+     --output "${OUTPUT}"
+     /p:PublishTrimmed=false
+     /p:DebugType=embedded
+@@ -233,6 +232,11 @@ build() {
+   if [ "${SINGLE_FILE}" == "true" ]; then
+     options+=( /p:PublishSingleFile=true )
+   fi
++  if [ "${SELF_CONTAINED}" == "true" ]; then
++    options+=( --self-contained "${SELF_CONTAINED}" )
++  else
++    options+=( --no-self-contained )
++  fi
+ 
+   if [ ${#extra_options[@]} -gt 0 ]; then
+     options+=("${extra_options[@]}")
+-- 
+2.52.0
+

--- a/runtime-devices/opentabletdriver/spec
+++ b/runtime-devices/opentabletdriver/spec
@@ -1,4 +1,5 @@
 VER=0.6.6.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/OpenTabletDriver/OpenTabletDriver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241822"


### PR DESCRIPTION
Topic Description
-----------------

- opentabletdriver: add loongarch64

Package(s) Affected
-------------------

- opentabletdriver: 0.6.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentabletdriver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
