### PR TITLE
cpufetch: add loongarch64 support

### DIFF
--- a/app-utils/cpufetch/autobuild/defines
+++ b/app-utils/cpufetch/autobuild/defines
@@ -4,4 +4,4 @@ PKGDES="A command-line tool displays the CPU information"
 PKGDEP="bash"
 
 # FIXME: These architectures are not supported by upstream.
-FAIL_ARCH="(loongarch64|loongson3)"
+FAIL_ARCH="(loongson3)"

--- a/app-utils/cpufetch/autobuild/patches/0001-v1.07-PPC-Fix-build-since-40374121b8b1.patch
+++ b/app-utils/cpufetch/autobuild/patches/0001-v1.07-PPC-Fix-build-since-40374121b8b1.patch
@@ -1,7 +1,7 @@
 From e347b9c3c7715ffbd550bc595c62d8659ce4aac9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 2 Nov 2025 18:11:47 +0800
-Subject: [PATCH] [v1.07][PPC] Fix build since 40374121b8b1
+Subject: [PATCH 1/2] [v1.07][PPC] Fix build since 40374121b8b1
 
 Since commit 40374121b8b1 ("[v1.06] Replace emalloc+memset with ecalloc
 when possible. Refactor some memory allocation code"), variable `path' was
@@ -30,5 +30,5 @@ index ffa26d2..254f286 100644
    for(int i=0; i < total_cores; i++) {
      sprintf(path, "%s%s/cpu%d/%s", _PATH_SYS_SYSTEM, _PATH_SYS_CPU, i, SYS_PATH);
 -- 
-2.51.1
+2.52.0
 

--- a/app-utils/cpufetch/autobuild/patches/0002-AOSCOS-support-loongarch64.patch
+++ b/app-utils/cpufetch/autobuild/patches/0002-AOSCOS-support-loongarch64.patch
@@ -1,0 +1,1115 @@
+From 9eea20a32b3252802653956c36be20b4b23801a0 Mon Sep 17 00:00:00 2001
+From: Ilikara <3435193369@qq.com>
+Date: Sat, 7 Mar 2026 22:13:10 +0800
+Subject: [PATCH 2/2] AOSCOS: support loongarch64
+
+Signed-off-by: Ilikara <3435193369@qq.com>
+---
+ Makefile                  |   5 +
+ src/common/ascii.h        |  81 +++++++++
+ src/common/cpu.c          |   6 +-
+ src/common/cpu.h          |  28 ++-
+ src/common/global.c       |   3 +
+ src/common/printer.c      | 179 ++++++++++++++++++-
+ src/common/printer.h      |   2 +
+ src/loongarch/loongarch.c | 357 ++++++++++++++++++++++++++++++++++++++
+ src/loongarch/loongarch.h |  12 ++
+ src/loongarch/uarch.c     |  92 ++++++++++
+ src/loongarch/uarch.h     |  14 ++
+ src/loongarch/udev.c      |  51 ++++++
+ src/loongarch/udev.h      |  12 ++
+ 13 files changed, 830 insertions(+), 12 deletions(-)
+ create mode 100644 src/loongarch/loongarch.c
+ create mode 100644 src/loongarch/loongarch.h
+ create mode 100644 src/loongarch/uarch.c
+ create mode 100644 src/loongarch/uarch.h
+ create mode 100644 src/loongarch/udev.c
+ create mode 100644 src/loongarch/udev.h
+
+diff --git a/Makefile b/Makefile
+index d07f036..32cba74 100644
+--- a/Makefile
++++ b/Makefile
+@@ -61,6 +61,11 @@ ifneq ($(OS),Windows_NT)
+ 		SOURCE += $(COMMON_SRC) $(SRC_DIR)riscv.c $(SRC_DIR)uarch.c $(SRC_COMMON)soc.c $(SRC_DIR)soc.c $(SRC_DIR)udev.c
+ 		HEADERS += $(COMMON_HDR) $(SRC_DIR)riscv.h $(SRC_DIR)uarch.h $(SRC_COMMON)soc.h $(SRC_DIR)soc.h $(SRC_DIR)udev.h $(SRC_DIR)socs.h
+ 		CFLAGS += -DARCH_RISCV -Wno-unused-parameter -std=c99 -fstack-protector-all
++	else ifeq ($(arch), $(filter $(arch), loongarch64))
++		SRC_DIR=src/loongarch/
++		SOURCE += $(COMMON_SRC) $(SRC_DIR)loongarch.c $(SRC_DIR)uarch.c $(SRC_DIR)udev.c
++		HEADERS += $(COMMON_HDR) $(SRC_DIR)loongarch.h $(SRC_DIR)uarch.h $(SRC_DIR)udev.h
++		CFLAGS += -DARCH_LOONGARCH -Wno-unused-parameter -std=c99 -fstack-protector-all
+ 	else
+ 		# Error lines should not be tabulated because Makefile complains about it
+ $(warning Unsupported arch detected: $(arch). See https://github.com/Dr-Noob/cpufetch#1-support)
+diff --git a/src/common/ascii.h b/src/common/ascii.h
+index f92ec25..8feda3a 100644
+--- a/src/common/ascii.h
++++ b/src/common/ascii.h
+@@ -465,6 +465,45 @@ $C1    :#######:              \
+ $C1       :####:              \
+ $C1         :##:              "
+ 
++#define ASCII_LOONGSON \
++"$C1 ########################################################################### \
++$C1 ########################################################################### \
++$C1 ##########################@@@@@############################################ \
++$C1 #####################@@@@@@@@@@@@@@######################################## \
++$C1 #################@@@@@@@@@@@@@@@@@@@@###################################### \
++$C1 ################@@@@@@@@@@@@@@@@@@@@@###################################### \
++$C1 ################@@@@@@@@@@@@@@@@@@@@@###################################### \
++$C1 #################@@@@@@@@@@@@@@@@@@@######################@@@@@############ \
++$C1 ##################@@@@@@@@@@@@@@@@@#####################@@@@@@@@@########## \
++$C1 ####################@@@@@@@@@@@@@#######################@@@@@@@@@@######### \
++$C1 ###################@@@@@@@@@@##########################@@@@@@@@@@@######### \
++$C1 ################@@@@@@@@@##############################@@@@@############### \
++$C1 ##############@@@@@@@@@####################@@@#########@@@@@############### \
++$C1 ############@@@@@@@@@###@@@@@@###########@@@@@@@@@######@@@@@############## \
++$C1 ##########@@@@@@@@####@@@@@@@@@@@#######@@@@@@@@@@@@####@@@@@@############# \
++$C1 ########@@@@@@@@####@@@@@@@@@@@@@@@#####@@@@@@@@@@@@@####@@@@@@############ \
++$C1 #######@@@@@@@@##@@@@@@@@@@@@@@@@@@####@@@@@@#@@@@@@@@####@@@@@@########### \
++$C1 #######@@@@@@@@@@@@@@@@@@@@@@@@@@@#####@@@@@@@@@@@@@@@######@@@@@########## \
++$C1 ########@@@@@@@@@@@@@#@@@@@@@@@@@######@@@@@@@@@@@@@@########@@@@@######### \
++$C1 ###########@@@@@@####@@@@@@@@@@@####@@@@@@@@@@@@@@@###########@@@@@######## \
++$C1 ####################@@@@@@@@@@###@@@@@@@@@@@@@#################@@@@@####### \
++$C1 ####################@@@@@@@@@#@@@@@@@@@@@@@@@@@@@###############@@@@@###### \
++$C1 ###################@@@@@@@@@@@@@@@@@###@@@@@@@@@@@@##############@@@@@##### \
++$C1 ###################@@@@@@@@@@@@##########@@@@@@@@@@@##############@@@@##### \
++$C1 #################@@@@@@@@@@@@@#############@@@@@@@@@@#############@@@@@#### \
++$C1 ##############@@@@@@@@@@@@@@@@#########@@@####@@@@@@@#############@@@@@#### \
++$C1 ############@@@@@@@@@@@@@@@@@@####@@@##@@@###@@@@@@@@##############@@@@#### \
++$C1 #########@@@@@@@@@@####@@@@@@@@#@@###########@@@@@@@##############@@@@@#### \
++$C1 #######@@@@@@@@@#######@@@@@@@@#############@@@@@@@###############@@@@@#### \
++$C1 ######@@@@@@@#########@@@@@@@@@#############@@@@@@###############@@@@@##### \
++$C1 ######@@@@@@#######@@@@@@@@@@@##############@@@@@@#############@@@@@@###### \
++$C1 #####@@@@@@@@@@@@@@@@@@@@@@@@###############@@@@@@@@########@@@@@@@@####### \
++$C1 ######@@@@@@@@@@@@@@@@@@@@###################@@@@@@@@@@@@@@@@@@@@@@######## \
++$C1 #######@@@@@@@@@@@@@@@@########################@@@@@@@@@@@@@@@@@@########## \
++$C1 ###########@@@@@@@################################@@@@@@@@@@@@############# \
++$C1 ########################################################################### \
++$C1 ########################################################################### "
++
+ // --------------------- LONG LOGOS ------------------------- //
+ #define ASCII_AMD_L \
+ "$C1                                                              \
+@@ -614,6 +653,46 @@ $C1            olcc::;              ,:ccloMMMMMMMMM  \
+ $C1                  :......oMMMMMMMMMMMMMMMMMMMMMM  \
+ $C1                  :lllMMMMMMMMMMMMMMMMMMMMMMMMMM  "
+ 
++#define ASCII_LOONGSON_L \
++"$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ############@@@@@@@##########@@@@@@@###########@@@@@@@#########@@@@@@@########## \
++$C1 ###########@@@@@@@@#########@@@@@@@@#####@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@##### \
++$C1 #####@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@###@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@##### \
++$C1 #####@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@#########@@@@@@###########@@@@@########### \
++$C1 ##########@@@@@@@####@@@@@@@@################################################### \
++$C1 ##########@@@@@@@####@@@@@@@@####@@@@@@#####@@@@@@#@@@@@@##@@@@@@##@@@@@@####### \
++$C1 #########@@@@@@@#####@@@@@@@@@@@@@@@@@@####@@@@@@@#@@@@@@@#@@@@@@##@@@@@@####### \
++$C1 #########@@@@@@@#####@@@@@@@@@@@@@@@@@#####@@@@@@@#@@@@@@@##@@@@@@#@@@@@@@###### \
++$C1 ########@@@@@@@##@@@@@@@@@@@@@@@###########@@@@@@##@@@@@@@##@@@@@@#@@@@@@@###### \
++$C1 ########@@@@@@@##@@@@@@@@@@@@#############@@@@@@@##@@@@@@@##@@@@@@##@@@@@@###### \
++$C1 #######@@@@@@@##@@@@#@@@@@@@@#############@@@@@@@##@@@@@@@###@@@@@@#@@@@@@###### \
++$C1 #######@@@@@@@#######@@@@@@@@#############@@@@@@###@@@@@@####@@@@@##@@@@@@@##### \
++$C1 ######@@@@@@@########@@@@@@@@@@@@@@@@@####@@@@@@###@@@@@@@@@@@@@@@##@@@@@@@##### \
++$C1 ######@@@@@@@#########@@@@@@@@@@@@@@@@@##@@@@@@@####@@@@@@@@@@@@@@@##@@@@@@##### \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ \
++$C1 ################################################################################ "
++
+ typedef struct ascii_logo asciiL;
+ 
+ //                        +-----------------------------------------------------------------------------------------------------------------+
+@@ -645,6 +724,7 @@ asciiL logo_nxp         = { ASCII_NXP,         55,  8, false, {C_FG_YELLOW, C_FG
+ asciiL logo_amlogic     = { ASCII_AMLOGIC,     58,  8, false, {C_FG_BLUE},                                    {C_FG_BLUE,    C_FG_B_WHITE} };
+ asciiL logo_marvell     = { ASCII_MARVELL,     56, 10, false, {C_FG_B_BLACK},                                 {C_FG_B_BLACK, C_FG_B_WHITE} };
+ asciiL logo_spacemit    = { ASCII_SPACEMIT,    27, 18, false, {C_FG_B_GREEN},                                 {C_FG_B_GREEN, C_FG_B_WHITE} };
++asciiL logo_loongson    = { ASCII_LOONGSON,    77, 37, true,  {C_BG_RED, C_BG_WHITE},                         {C_FG_RED,     C_FG_WHITE}   };
+ 
+ // Long variants          | ----------------------------------------------------------------------------------------------------------------|
+ asciiL logo_amd_l       = { ASCII_AMD_L,       62, 19, true,  {C_BG_WHITE, C_BG_GREEN},                       {C_FG_WHITE, C_FG_GREEN}     };
+@@ -655,6 +735,7 @@ asciiL logo_ibm_l       = { ASCII_IBM_L,       62, 13, true,  {C_BG_CYAN, C_FG_W
+ asciiL logo_starfive_l  = { ASCII_STARFIVE_L,  50, 22, false, {C_FG_WHITE},                                   {C_FG_WHITE, C_FG_BLUE}      };
+ asciiL logo_sifive_l    = { ASCII_SIFIVE_L,    53, 21, true,  {C_BG_WHITE, C_BG_BLACK},                       {C_FG_WHITE, C_FG_CYAN}      };
+ asciiL logo_nvidia_l    = { ASCII_NVIDIA_L,    50, 15, false, {C_FG_GREEN, C_FG_WHITE},                       {C_FG_WHITE, C_FG_GREEN}     };
++asciiL logo_loongson_l  = { ASCII_LOONGSON_L,  82, 38, true,  {C_BG_RED, C_BG_WHITE},                         {C_FG_RED,     C_FG_WHITE}   };
+ asciiL logo_unknown     = { NULL,               0,  0, false, {COLOR_NONE},                                   {COLOR_NONE, COLOR_NONE}     };
+ 
+ #endif
+diff --git a/src/common/cpu.c b/src/common/cpu.c
+index e3f6bcb..efa84ac 100644
+--- a/src/common/cpu.c
++++ b/src/common/cpu.c
+@@ -16,6 +16,8 @@
+   #include "../arm/uarch.h"
+ #elif ARCH_RISCV
+   #include "../riscv/uarch.h"
++#elif ARCH_LOONGARCH
++  #include "../loongarch/uarch.h"
+ #endif
+ 
+ #define STRING_YES        "Yes"
+@@ -40,7 +42,7 @@ int64_t get_freq_pp(struct frequency* freq) {
+ }
+ #endif
+ 
+-#if defined(ARCH_X86) || defined(ARCH_PPC)
++#if defined(ARCH_X86) || defined(ARCH_PPC) || defined(ARCH_LOONGARCH)
+ char* get_str_cpu_name(struct cpuInfo* cpu, bool fcpuname) {
+   #ifdef ARCH_X86
+   if(!fcpuname) {
+@@ -48,6 +50,8 @@ char* get_str_cpu_name(struct cpuInfo* cpu, bool fcpuname) {
+   }
+   #elif ARCH_PPC
+   UNUSED(fcpuname);
++  #elif ARCH_LOONGARCH
++  UNUSED(fcpuname);
+   #endif
+   return cpu->cpu_name;
+ }
+diff --git a/src/common/cpu.h b/src/common/cpu.h
+index fbfb108..ad90499 100644
+--- a/src/common/cpu.h
++++ b/src/common/cpu.h
+@@ -26,6 +26,8 @@ enum {
+   CPU_VENDOR_SIFIVE,
+   CPU_VENDOR_THEAD,
+   CPU_VENDOR_SPACEMIT,
++// ARCH_LOONGARCH
++  CPU_VENDOR_LOONGSON,
+ // OTHERS
+   CPU_VENDOR_UNKNOWN,
+   CPU_VENDOR_INVALID
+@@ -94,7 +96,7 @@ struct cache {
+ struct topology {
+   int32_t total_cores;  
+   struct cache* cach;
+-#if defined(ARCH_X86) || defined(ARCH_PPC)
++#if defined(ARCH_X86) || defined(ARCH_PPC) || defined(ARCH_LOONGARCH)
+   int32_t physical_cores;
+   int32_t logical_cores;
+   uint32_t sockets;
+@@ -126,14 +128,30 @@ struct features {
+ #elif ARCH_PPC
+   bool altivec;
+ #elif ARCH_ARM
+-  bool NEON;  
++  bool NEON;
+   bool SHA1;
+   bool SHA2;
+   bool CRC32;
+   bool SVE;
+   bool SVE2;
+   uint64_t cntb;
+-#endif  
++#elif ARCH_LOONGARCH
++  bool CPUCFG;
++  bool LAM;
++  bool UAL;
++  bool FPU;
++  bool LSX;
++  bool LASX;
++  bool CRC32;
++  bool COMPLEX;
++  bool CRYPTO;
++  bool LVZ;
++  bool LBT_X86;
++  bool LBT_ARM;
++  bool LBT_MIPS;
++  bool PTW;
++  bool LSPW;
++#endif
+ };
+ 
+ struct extensions {
+@@ -158,7 +176,7 @@ struct cpuInfo {
+   struct features* feat;
+ #endif
+ 
+-#if defined(ARCH_X86) || defined(ARCH_PPC)
++#if defined(ARCH_X86) || defined(ARCH_PPC) || defined(ARCH_LOONGARCH)
+   // CPU name from model
+   char* cpu_name;
+ #endif
+@@ -200,7 +218,7 @@ struct cpuInfo {
+ #endif
+ };
+ 
+-#if defined(ARCH_X86) || defined(ARCH_PPC)
++#if defined(ARCH_X86) || defined(ARCH_PPC) || defined(ARCH_LOONGARCH)
+ char* get_str_cpu_name(struct cpuInfo* cpu, bool fcpuname);
+ char* get_str_sockets(struct topology* topo);
+ uint32_t get_nsockets(struct topology* topo);
+diff --git a/src/common/global.c b/src/common/global.c
+index 1400b97..d8ff8f0 100644
+--- a/src/common/global.c
++++ b/src/common/global.c
+@@ -43,6 +43,9 @@
+ #elif ARCH_RISCV
+   static const char* ARCH_STR = "RISC-V build";
+   #include "../riscv/riscv.h"
++#elif ARCH_LOONGARCH
++  static const char* ARCH_STR = "LoongArch build";
++  #include "../loongarch/loongarch.h"
+ #endif
+ 
+ #ifdef __linux__
+diff --git a/src/common/printer.c b/src/common/printer.c
+index 617a2f4..134b89c 100644
+--- a/src/common/printer.c
++++ b/src/common/printer.c
+@@ -26,6 +26,9 @@
+   #include "../riscv/riscv.h"
+   #include "../riscv/uarch.h"
+   #include "../riscv/soc.h"
++#elif ARCH_LOONGARCH
++  #include "../loongarch/loongarch.h"
++  #include "../loongarch/uarch.h"
+ #endif
+ 
+ #ifdef _WIN32
+@@ -52,14 +55,14 @@ typedef struct {
+ } AttributeField;
+ 
+ enum {
+-#if defined(ARCH_X86)
++#if defined(ARCH_X86) || defined(ARCH_LOONGARCH)
+   ATTRIBUTE_NAME,
+ #elif defined(ARCH_PPC)
+   ATTRIBUTE_PART_NUMBER,
+ #elif defined(ARCH_ARM) || defined(ARCH_RISCV)
+   ATTRIBUTE_SOC,
+ #endif
+-#if defined(ARCH_X86) || defined(ARCH_ARM)
++#if defined(ARCH_X86) || defined(ARCH_ARM) || defined(ARCH_LOONGARCH)
+   ATTRIBUTE_CPU_NUM,
+ #endif
+   ATTRIBUTE_HYPERVISOR,
+@@ -75,7 +78,7 @@ enum {
+   ATTRIBUTE_FMA,
+ #elif ARCH_PPC
+   ATTRIBUTE_ALTIVEC,
+-#elif ARCH_ARM
++#elif defined(ARCH_ARM) || defined(ARCH_LOONGARCH)
+   ATTRIBUTE_FEATURES,
+ #elif ARCH_RISCV
+   ATTRIBUTE_EXTENSIONS,
+@@ -88,14 +91,14 @@ enum {
+ };
+ 
+ static const AttributeField ATTRIBUTE_INFO[] = {
+-#if defined(ARCH_X86)
++#if defined(ARCH_X86) || defined(ARCH_LOONGARCH)
+   { ATTRIBUTE_NAME,        "Name:",              "Name:"          },
+ #elif defined(ARCH_PPC)
+   { ATTRIBUTE_PART_NUMBER, "Part Number:",       "P/N:"           },
+ #elif defined(ARCH_ARM) || defined(ARCH_RISCV)
+   { ATTRIBUTE_SOC,         "SoC:",               "SoC:"           },
+ #endif
+-#if defined(ARCH_X86) || defined(ARCH_ARM)
++#if defined(ARCH_X86) || defined(ARCH_ARM) || defined(ARCH_LOONGARCH)
+   { ATTRIBUTE_CPU_NUM,     "",                   ""               },     
+ #endif
+   { ATTRIBUTE_HYPERVISOR,  "Hypervisor:",        "Hypervisor:"    },
+@@ -111,7 +114,7 @@ static const AttributeField ATTRIBUTE_INFO[] = {
+   { ATTRIBUTE_FMA,         "FMA:",               "FMA:"           },
+ #elif ARCH_PPC
+   { ATTRIBUTE_ALTIVEC,     "Altivec: ",          "Altivec: "      },
+-#elif ARCH_ARM
++#elif defined(ARCH_ARM) || defined(ARCH_LOONGARCH)
+   { ATTRIBUTE_FEATURES,    "Features: ",         "Features: "     },
+ #elif ARCH_RISCV
+   { ATTRIBUTE_EXTENSIONS,  "Extensions: ",       "Extensions: "   },
+@@ -388,6 +391,8 @@ void choose_ascii_art(struct ascii* art, struct color** cs, struct terminal* ter
+     art->art = &logo_spacemit;
+   else
+     art->art = &logo_riscv;
++#elif ARCH_LOONGARCH
++  art->art = choose_ascii_art_aux(&logo_loongson_l, &logo_loongson, term, lf);
+ #endif
+ 
+   // 2. Choose colors
+@@ -1079,6 +1084,166 @@ bool print_cpufetch_riscv(struct cpuInfo* cpu, STYLE s, struct color** cs, struc
+ }
+ #endif
+ 
++#ifdef ARCH_LOONGARCH
++void print_ascii_loongarch(struct ascii *art, uint32_t la, int32_t termw,
++                           bool use_short) {
++  struct ascii_logo *logo = art->art;
++  int attr_to_print = 0;
++  int attr_type;
++  char *attr_value;
++  int32_t beg_space;
++  int32_t limit_up;
++  int32_t limit_down;
++  uint32_t logo_pos = 0;
++  int32_t space_right;
++  int32_t space_up = ((int)logo->height - (int)(art->n_attributes_set)) / 2;
++  int32_t space_down =
++      (int)logo->height - (int)(art->n_attributes_set) - (int)space_up;
++
++  struct line_buffer *lbuf = emalloc(sizeof(struct line_buffer));
++  lbuf->buf = emalloc(sizeof(char) * LINE_BUFFER_SIZE);
++  lbuf->pos = 0;
++  lbuf->chars = 0;
++
++  if (art->n_attributes_set > logo->height) {
++    limit_up = 0;
++    limit_down = art->n_attributes_set;
++  } else {
++    limit_up = space_up;
++    limit_down = logo->height - space_down;
++  }
++
++  bool add_space = false;
++  int32_t iters = max(logo->height, art->n_attributes_set);
++
++  printf("\n");
++  for (int32_t n = 0; n < iters; n++) {
++    // 1. Print logo
++    if (n >= (int)art->additional_spaces &&
++        n < (int)logo->height + (int)art->additional_spaces) {
++      for (uint32_t i = 0; i < logo->width; i++) {
++        if (logo->art[logo_pos] == '$') {
++          if (logo->replace_blocks)
++            logo_pos += 3;
++          else
++            parse_print_color(art, lbuf, &logo_pos);
++        }
++        if (logo->replace_blocks && logo->art[logo_pos] != ' ') {
++          if (logo->art[logo_pos] == '#')
++            printOut(lbuf, 1, "%s%c%s", logo->color_ascii[0], ' ', art->reset);
++          else if (logo->art[logo_pos] == '@')
++            printOut(lbuf, 1, "%s%c%s", logo->color_ascii[1], ' ', art->reset);
++          else if (logo->art[logo_pos] == '%')
++            printOut(lbuf, 1, "%s%c%s", logo->color_ascii[2], ' ', art->reset);
++          else
++            printOut(lbuf, 1, "%c", logo->art[logo_pos]);
++        } else
++          printOut(lbuf, 1, "%c", logo->art[logo_pos]);
++
++        logo_pos++;
++      }
++      printOut(lbuf, 0, "%s", art->reset);
++    } else {
++      // If logo should not be printed, fill with spaces
++      printOut(lbuf, logo->width, "%*c", logo->width, ' ');
++    }
++
++    // 2. Print text
++    if (n >= limit_up && n < limit_down) {
++      attr_type = art->attributes[attr_to_print]->type;
++      attr_value = art->attributes[attr_to_print]->value;
++      attr_to_print++;
++
++      if (attr_type == ATTRIBUTE_PEAK) {
++        add_space = false;
++      }
++      if (attr_type == ATTRIBUTE_CPU_NUM) {
++        printOut(lbuf, strlen(attr_value), "%s%s%s", logo->color_text[0],
++                 attr_value, art->reset);
++        add_space = true;
++      } else {
++        beg_space = 0;
++        const char *attr_str = use_short ? ATTRIBUTE_INFO[attr_type].shortname
++                                         : ATTRIBUTE_INFO[attr_type].name;
++        space_right = 2 + 1 + (la - strlen(attr_str));
++        if (add_space) {
++          beg_space = 2;
++          space_right -= 2;
++        }
++
++        printOut(lbuf,
++                 beg_space + strlen(attr_str) + space_right +
++                     strlen(attr_value),
++                 "%*s%s%s%s%*s%s%s%s", beg_space, "", logo->color_text[0],
++                 attr_str, art->reset, space_right, "", logo->color_text[1],
++                 attr_value, art->reset);
++      }
++    }
++    printOutLine(lbuf, art, termw);
++    printf("\n");
++  }
++  printf("\n");
++
++  free(lbuf->buf);
++  free(lbuf);
++}
++
++bool print_cpufetch_loongarch(struct cpuInfo *cpu, STYLE s, struct color **cs,
++                              struct terminal *term, bool fcpuname) {
++  struct ascii *art = set_ascii(get_cpu_vendor(cpu), s);
++  if (art == NULL)
++    return false;
++
++  // Step 1. Retrieve attributes
++  char *cpu_name = get_str_cpu_name(cpu, fcpuname);
++  char *uarch = get_str_uarch(cpu);
++  char *max_frequency = get_str_freq(cpu->freq);
++  char *n_cores = get_str_topology(cpu, cpu->topo, false);
++  char *pp = get_str_peak_performance(cpu->peak_performance);
++  char *features = get_str_features(cpu);
++  char *l1i = get_str_l1i(cpu->cach);
++  char *l1d = get_str_l1d(cpu->cach);
++  char *l2 = get_str_l2(cpu->cach);
++  char *l3 = get_str_l3(cpu->cach);
++
++  // Step 2. Set attributes
++  setAttribute(art, ATTRIBUTE_NAME, cpu_name);
++  if (cpu->hv->present) {
++    setAttribute(art, ATTRIBUTE_HYPERVISOR, cpu->hv->hv_name);
++  }
++  setAttribute(art, ATTRIBUTE_UARCH, uarch);
++  setAttribute(art, ATTRIBUTE_NCORES, n_cores);
++  setAttribute(art, ATTRIBUTE_FREQUENCY, max_frequency);
++  if (features != NULL) {
++    setAttribute(art, ATTRIBUTE_FEATURES, features);
++  }
++  setAttribute(art, ATTRIBUTE_L1i, l1i);
++  setAttribute(art, ATTRIBUTE_L1d, l1d);
++  setAttribute(art, ATTRIBUTE_L2, l2);
++  if(l3 != NULL) {
++    setAttribute(art, ATTRIBUTE_L3, l3);
++  }
++  setAttribute(art, ATTRIBUTE_PEAK, pp);
++
++  // Step 3. Print output
++  bool use_short = false;
++  uint32_t longest_attribute = longest_attribute_length(art, use_short);
++  uint32_t longest_field = longest_field_length(art, longest_attribute);
++  choose_ascii_art(art, cs, term, longest_field);
++
++  if (!ascii_fits_screen(term->w, *art->art, longest_field)) {
++    // Despite of choosing the smallest logo, the output does not fit
++    // Choose the shorter field names and recalculate the longest attr
++    use_short = true;
++    longest_attribute = longest_attribute_length(art, use_short);
++  }
++
++  print_ascii_loongarch(art, longest_attribute, term->w, use_short);
++
++  return true;
++}
++#endif
++
+ struct terminal* get_terminal_size(void) {
+   struct terminal* term = emalloc(sizeof(struct terminal));
+ 
+@@ -1118,5 +1283,7 @@ bool print_cpufetch(struct cpuInfo* cpu, STYLE s, struct color** cs, bool show_f
+   return print_cpufetch_arm(cpu, s, cs, term);
+ #elif ARCH_RISCV
+   return print_cpufetch_riscv(cpu, s, cs, term);
++#elif ARCH_LOONGARCH
++  return print_cpufetch_loongarch(cpu, s, cs, term, show_full_cpu_name);
+ #endif
+ }
+diff --git a/src/common/printer.h b/src/common/printer.h
+index 26a1fa3..a3f21a0 100644
+--- a/src/common/printer.h
++++ b/src/common/printer.h
+@@ -13,6 +13,8 @@ typedef int STYLE;
+   #include "../arm/midr.h"
+ #elif ARCH_RISCV
+   #include "../riscv/riscv.h"
++#elif ARCH_LOONGARCH
++  #include "../loongarch/loongarch.h"
+ #endif
+ 
+ //                              +-----------------------------------+-----------------------+
+diff --git a/src/loongarch/loongarch.c b/src/loongarch/loongarch.c
+new file mode 100644
+index 0000000..e4a26eb
+--- /dev/null
++++ b/src/loongarch/loongarch.c
+@@ -0,0 +1,357 @@
++#include <assert.h>
++#include <errno.h>
++#include <stdbool.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <stdint.h>
++
++#include <asm/hwcap.h>
++#include <sys/auxv.h>
++
++#include "../common/global.h"
++#include "../common/udev.h"
++#include "loongarch.h"
++#include "uarch.h"
++#include "udev.h"
++
++unsigned long parse_cpu_cores(void) {
++  int filelen;
++  char *buf;
++
++  // 读取核心列表文件
++  if ((buf =
++           read_file("/sys/devices/system/cpu/cpu0/topology/core_siblings_list",
++                     &filelen)) == NULL) {
++    printWarn("read_file: %s: %s",
++              "/sys/devices/system/cpu/cpu0/topology/core_siblings_list",
++              strerror(errno));
++    return 0;
++  }
++
++  char *dash = strchr(buf, '-');
++  if (dash == NULL) {
++    free(buf);
++    return 1;
++  }
++
++  char *end;
++  errno = 0;
++  unsigned long start = strtoul(buf, NULL, 10);
++  if (errno != 0) {
++    free(buf);
++    return 0;
++  }
++
++  unsigned long end_num = strtoul(dash + 1, &end, 10);
++  if (errno != 0 || dash + 1 == end) {
++    free(buf);
++    return 0;
++  }
++
++  free(buf);
++  return end_num - start + 1;
++}
++
++unsigned long parse_cpu_threads(void) {
++  int filelen;
++  char *buf;
++
++  // 读取线程列表文件
++  if ((buf = read_file(
++           "/sys/devices/system/cpu/cpu0/topology/thread_siblings_list",
++           &filelen)) == NULL) {
++    printWarn("read_file: %s: %s",
++              "/sys/devices/system/cpu/cpu0/topology/thread_siblings_list",
++              strerror(errno));
++    return 0;
++  }
++
++  char *dash = strchr(buf, '-');
++  if (dash == NULL) {
++    free(buf);
++    return 1;
++  }
++
++  char *end;
++  errno = 0;
++  unsigned long start = strtoul(buf, NULL, 10);
++  if (errno != 0) {
++    free(buf);
++    return 0;
++  }
++
++  unsigned long end_num = strtoul(dash + 1, &end, 10);
++  if (errno != 0 || dash + 1 == end) {
++    free(buf);
++    return 0;
++  }
++
++  free(buf);
++  return end_num - start + 1;
++}
++
++float parse_cpuinfo_field_float(char *field_str) {
++  int filelen;
++  char *buf;
++  if ((buf = read_file(_PATH_CPUINFO, &filelen)) == NULL) {
++    printWarn("read_file: %s: %s", _PATH_CPUINFO, strerror(errno));
++    return 0.0f;
++  }
++
++  char *tmp = strstr(buf, field_str);
++  if (tmp == NULL)
++    return 0.0f;
++  tmp += strlen(field_str);
++
++  char *end;
++  errno = 0;
++  float ret = strtof(tmp, &end);
++  if (errno != 0) {
++    printWarn("strtof: %s: %s", strerror(errno), tmp);
++    return 0.0f;
++  }
++
++  return ret;
++}
++
++struct cache *get_cache_info(struct cpuInfo *cpu) {
++  struct cache *cach = emalloc(sizeof(struct cache));
++  init_cache_struct(cach);
++
++  cach->L1i->size = get_l1i_cache_size(0);
++  cach->L1d->size = get_l1d_cache_size(0);
++  cach->L2->size = get_l2_cache_size(0);
++  cach->L3->size = get_l3_cache_size(0);
++
++  if (cach->L1i->size > 0) {
++    cach->L1i->exists = true;
++    cach->L1i->num_caches = get_num_caches_by_level(cpu, 0);
++    cach->max_cache_level = 1;
++  }
++  if (cach->L1d->size > 0) {
++    cach->L1d->exists = true;
++    cach->L1d->num_caches = get_num_caches_by_level(cpu, 1);
++    cach->max_cache_level = 2;
++  }
++  if (cach->L2->size > 0) {
++    cach->L2->exists = true;
++    cach->L2->num_caches = get_num_caches_by_level(cpu, 2);
++    cach->max_cache_level = 3;
++  }
++  if (cach->L3->size > 0) {
++    cach->L3->exists = true;
++    cach->L3->num_caches = get_num_caches_by_level(cpu, 3);
++    cach->max_cache_level = 4;
++  }
++
++  return cach;
++}
++
++struct frequency *get_frequency_info(uint32_t core) {
++  struct frequency *freq = emalloc(sizeof(struct frequency));
++
++  freq->measured = false;
++  freq->base = UNKNOWN_DATA;
++  freq->max = parse_cpuinfo_field_float("CPU MHz\t\t\t:");
++
++  return freq;
++}
++
++int64_t get_peak_performance(struct cpuInfo *cpu) {
++  // First check we have consistent data
++  if (get_freq(cpu->freq) == UNKNOWN_DATA) {
++    return -1;
++  }
++
++  struct features *feat = cpu->feat;
++  int64_t flops = cpu->topo->total_cores * (get_freq(cpu->freq) * 1000000);
++
++  if (feat->LASX)
++    flops = flops * 8;
++  else if (feat->LSX)
++    flops = flops * 4;
++
++  if (1)
++    flops = flops * 2; // We assume FMA is always supported, which is the case
++                       // for all LoongArch 64-bit CPUs
++
++  return flops;
++}
++
++struct features *get_features_info(void) {
++  struct features *feat = emalloc(sizeof(struct features));
++  bool *ptr = &(feat->AES);
++  for (uint32_t i = 0; i < sizeof(struct features) / sizeof(bool); i++, ptr++) {
++    *ptr = false;
++  }
++
++  errno = 0;
++  long hwcaps = getauxval(AT_HWCAP);
++
++  if (errno == ENOENT) {
++    printWarn("Unable to retrieve AT_HWCAP using getauxval");
++  } else {
++    feat->CPUCFG = hwcaps & HWCAP_LOONGARCH_CPUCFG;
++    feat->LAM = hwcaps & HWCAP_LOONGARCH_LAM;
++    feat->UAL = hwcaps & HWCAP_LOONGARCH_UAL;
++    feat->FPU = hwcaps & HWCAP_LOONGARCH_FPU;
++    feat->LSX = hwcaps & HWCAP_LOONGARCH_LSX;
++    feat->LASX = hwcaps & HWCAP_LOONGARCH_LASX;
++    feat->CRC32 = hwcaps & HWCAP_LOONGARCH_CRC32;
++    feat->COMPLEX = hwcaps & HWCAP_LOONGARCH_COMPLEX;
++    feat->CRYPTO = hwcaps & HWCAP_LOONGARCH_CRYPTO;
++    feat->LVZ = hwcaps & HWCAP_LOONGARCH_LVZ;
++    feat->LBT_X86 = hwcaps & HWCAP_LOONGARCH_LBT_X86;
++    feat->LBT_ARM = hwcaps & HWCAP_LOONGARCH_LBT_ARM;
++    feat->LBT_MIPS = hwcaps & HWCAP_LOONGARCH_LBT_MIPS;
++    feat->PTW = hwcaps & HWCAP_LOONGARCH_PTW;
++    feat->LSPW = hwcaps & HWCAP_LOONGARCH_LSPW;
++  }
++
++  return feat;
++}
++
++struct cpuInfo *get_cpu_info(void) {
++  struct cpuInfo *cpu = malloc(sizeof(struct cpuInfo));
++  struct topology *topo = emalloc(sizeof(struct topology));
++  topo->logical_cores = topo->total_cores = get_ncores_from_cpuinfo();
++  unsigned long smt = parse_cpu_threads();
++  topo->smt_supported = smt;
++  topo->physical_cores = topo->logical_cores / smt;
++  topo->cach = NULL;
++  cpu->topo = topo;
++  cpu->cpu_name = get_field_from_cpuinfo("Model Name\t\t: ");
++  cpu->feat = get_features_info();
++
++  cpu->hv = emalloc(sizeof(struct hypervisor));
++  cpu->hv->present = false;
++  cpu->arch = get_uarch(cpu);
++  cpu->cach = get_cache_info(cpu);
++  cpu->freq = get_frequency_info(0);
++  cpu->peak_performance = get_peak_performance(cpu);
++
++  return cpu;
++}
++
++char *get_str_features(struct cpuInfo *cpu) {
++  struct features *feat = cpu->feat;
++  uint32_t max_len = strlen("CPUCFG,LAM,UAL,FPU,LSX,LASX,CRC32,COMPLEX,CRYPTO,"
++                            "LVZ,LBT_X86,LBT_ARM,LBT_MIPS,PTW,LSPW") +
++                     1;
++  uint32_t len = 0;
++  char *string = ecalloc(max_len, sizeof(char));
++
++  if (feat->CPUCFG) {
++    strcat(string, "CPUCFG,");
++    len += 7;
++  }
++  if (feat->LAM) {
++    strcat(string, "LAM,");
++    len += 4;
++  }
++  if (feat->UAL) {
++    strcat(string, "UAL,");
++    len += 4;
++  }
++  if (feat->FPU) {
++    strcat(string, "FPU,");
++    len += 4;
++  }
++  if (feat->LSX) {
++    strcat(string, "LSX,");
++    len += 4;
++  }
++  if (feat->LASX) {
++    strcat(string, "LASX,");
++    len += 5;
++  }
++  if (feat->CRC32) {
++    strcat(string, "CRC32,");
++    len += 6;
++  }
++  if (feat->COMPLEX) {
++    strcat(string, "COMPLEX,");
++    len += 8;
++  }
++  if (feat->CRYPTO) {
++    strcat(string, "CRYPTO,");
++    len += 6;
++  }
++  if (feat->LVZ) {
++    strcat(string, "LVZ,");
++    len += 4;
++  }
++  if (feat->LBT_X86) {
++    strcat(string, "LBT_X86,");
++    len += 8;
++  }
++  if (feat->LBT_ARM) {
++    strcat(string, "LBT_ARM,");
++    len += 8;
++  }
++  if (feat->LBT_MIPS) {
++    strcat(string, "LBT_MIPS,");
++    len += 9;
++  }
++  if (feat->PTW) {
++    strcat(string, "PTW,");
++    len += 4;
++  }
++  if (feat->LSPW) {
++    strcat(string, "LSPW,");
++    len += 5;
++  }
++
++  if (len > 0) {
++    string[len - 1] = '\0';
++    return string;
++  } else
++    return NULL;
++}
++
++char *get_str_topology(struct cpuInfo *cpu, struct topology *topo,
++                       bool dual_socket) {
++  int topo_sockets = dual_socket ? topo->sockets : 1;
++  char *string;
++
++  if (topo->logical_cores == UNKNOWN_DATA) {
++    string = emalloc(sizeof(char) * (strlen(STRING_UNKNOWN) + 1));
++    strcpy(string, STRING_UNKNOWN);
++  } else {
++    char cores_str[6];
++    memset(cores_str, 0, sizeof(char) * 6);
++    if (topo->physical_cores * topo_sockets > 1)
++      strcpy(cores_str, "cores");
++    else
++      strcpy(cores_str, "core");
++
++    if (topo->smt_supported > 1) {
++      // 4 for digits, 21 for ' cores (SMT disabled)' which is the longest
++      // possible output
++      uint32_t max_size = 4 + 21 + 1;
++      string = emalloc(sizeof(char) * max_size);
++
++      snprintf(string, max_size, "%d %s (%d threads)",
++               topo->physical_cores * topo_sockets, cores_str,
++               topo->logical_cores * topo_sockets);
++    } else {
++      uint32_t max_size = 4 + 7 + 1;
++      string = emalloc(sizeof(char) * max_size);
++      snprintf(string, max_size, "%d %s", topo->physical_cores * topo_sockets,
++               cores_str);
++    }
++  }
++
++  return string;
++}
++
++void print_debug(struct cpuInfo *cpu) {
++  printf("- uarch: ");
++  char *arch_cpuinfo_str = get_arch_cpuinfo_str(cpu);
++  if (arch_cpuinfo_str == NULL) {
++    printf("NULL\n");
++  } else {
++    printf("'%s'\n", arch_cpuinfo_str);
++  }
++}
+diff --git a/src/loongarch/loongarch.h b/src/loongarch/loongarch.h
+new file mode 100644
+index 0000000..95efd80
+--- /dev/null
++++ b/src/loongarch/loongarch.h
+@@ -0,0 +1,12 @@
++#ifndef __LOONGARCH__
++#define __LOONGARCH__
++
++#include "../common/cpu.h"
++
++struct cpuInfo *get_cpu_info(void);
++char *get_str_topology(struct cpuInfo *cpu, struct topology *topo,
++                       bool dual_socket);
++char *get_str_features(struct cpuInfo *cpu);
++void print_debug(struct cpuInfo *cpu);
++
++#endif
+diff --git a/src/loongarch/uarch.c b/src/loongarch/uarch.c
+new file mode 100644
+index 0000000..7209edf
+--- /dev/null
++++ b/src/loongarch/uarch.c
+@@ -0,0 +1,92 @@
++#include <stdbool.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include "../common/global.h"
++#include "uarch.h"
++#include "udev.h"
++
++typedef uint32_t MICROARCH;
++
++struct uarch {
++  MICROARCH uarch;
++  char *uarch_str;
++  char *cpuinfo_str;
++  struct loongarch_cpuinfo *ci;
++};
++
++enum {
++  UARCH_UNKNOWN,
++  // Loongson
++  UARCH_LA132,
++  UARCH_LA264,
++  UARCH_LA364,
++  UARCH_LA464,
++  UARCH_LA664,
++};
++
++#define PRID_SERIES_START                                                      \
++  if (false) {                                                                 \
++  }
++#define CHECK_PRID_SERIES(arch, prid_val, str, uarch, vendor)                  \
++  else if ((arch->ci->prid & 0xf000) == (unsigned long)prid_val)               \
++      fill_uarch(arch, cpu, str, uarch, vendor);
++#define PRID_SERIES_END                                                        \
++  else {                                                                       \
++    printWarn("Unknown microarchitecture detected: prid=0x%.8X",               \
++              arch->ci->prid);                                                 \
++    fill_uarch(arch, cpu, "Unknown", UARCH_UNKNOWN, CPU_VENDOR_UNKNOWN);       \
++  }
++
++void fill_uarch(struct uarch *arch, struct cpuInfo *cpu, char *str, MICROARCH u,
++                VENDOR vendor) {
++  arch->uarch = u;
++  cpu->cpu_vendor = vendor;
++  arch->uarch_str = emalloc(sizeof(char) * (strlen(str) + 1));
++  strcpy(arch->uarch_str, str);
++}
++
++// Use prid to get the microarchitecture
++// linux kernel arch/loongarch/include/asm/cpu.h
++struct uarch *get_uarch_from_loongarch_cpuinfo(struct cpuInfo *cpu,
++                                               struct uarch *arch) {
++
++  PRID_SERIES_START
++  CHECK_PRID_SERIES(arch, 0x8000, "LA132", UARCH_LA132, CPU_VENDOR_LOONGSON)
++  CHECK_PRID_SERIES(arch, 0xa000, "LA264", UARCH_LA264, CPU_VENDOR_LOONGSON)
++  CHECK_PRID_SERIES(arch, 0xb000, "LA364", UARCH_LA364, CPU_VENDOR_LOONGSON)
++  CHECK_PRID_SERIES(arch, 0xc000, "LA464", UARCH_LA464, CPU_VENDOR_LOONGSON)
++  CHECK_PRID_SERIES(arch, 0xd000, "LA664", UARCH_LA664, CPU_VENDOR_LOONGSON)
++  PRID_SERIES_END
++
++  return arch;
++}
++
++struct uarch *get_uarch(struct cpuInfo *cpu) {
++  struct uarch *arch = emalloc(sizeof(struct uarch));
++  arch->uarch = UARCH_UNKNOWN;
++  arch->ci = get_loongarch_cpuinfo();
++
++  if (arch->ci == NULL || arch->ci->prid == 0)
++    printWarn("get_loongarch_cpuinfo: Unable to get prid from udev");
++  else
++    arch = get_uarch_from_loongarch_cpuinfo(cpu, arch);
++
++  if (arch->uarch == UARCH_UNKNOWN)
++    fill_uarch(arch, cpu, "Unknown", UARCH_UNKNOWN, CPU_VENDOR_UNKNOWN);
++
++  return arch;
++}
++
++char *get_str_uarch(struct cpuInfo *cpu) { return cpu->arch->uarch_str; }
++
++char *get_arch_cpuinfo_str(struct cpuInfo *cpu) {
++  return cpu->arch->cpuinfo_str;
++}
++
++void free_uarch_struct(struct uarch *arch) {
++  free(arch->uarch_str);
++  free(arch->cpuinfo_str);
++  free(arch);
++}
+diff --git a/src/loongarch/uarch.h b/src/loongarch/uarch.h
+new file mode 100644
+index 0000000..0ad3874
+--- /dev/null
++++ b/src/loongarch/uarch.h
+@@ -0,0 +1,14 @@
++#ifndef __UARCH_LOONGARCH__
++#define __UARCH_LOONGARCH__
++
++#include "loongarch.h"
++#include <stdint.h>
++
++struct uarch;
++
++char *get_arch_cpuinfo_str(struct cpuInfo *cpu);
++char *get_str_uarch(struct cpuInfo *cpu);
++void free_uarch_struct(struct uarch *arch);
++struct uarch *get_uarch(struct cpuInfo *cpu);
++
++#endif
+diff --git a/src/loongarch/udev.c b/src/loongarch/udev.c
+new file mode 100644
+index 0000000..890cefd
+--- /dev/null
++++ b/src/loongarch/udev.c
+@@ -0,0 +1,51 @@
++#include <errno.h>
++#include <string.h>
++
++#include "../common/global.h"
++#include "udev.h"
++
++#define CPUINFO_LOONGARCH_PRID "PRID\t\t\t:"
++
++unsigned long parse_cpuinfo_prid(char *field_str) {
++  int filelen;
++  char *buf;
++  if ((buf = read_file(_PATH_CPUINFO, &filelen)) == NULL) {
++    printWarn("read_file: %s: %s", _PATH_CPUINFO, strerror(errno));
++    return 0;
++  }
++
++  char *tmp = strstr(buf, field_str);
++  if (tmp == NULL) {
++    free(buf);
++    return 0;
++  }
++
++  char *paren = strchr(tmp, '(');
++  if (paren != NULL) {
++    tmp = paren + 1;
++  } else {
++    tmp += strlen(field_str);
++  }
++
++  char *end;
++  errno = 0;
++  unsigned long ret = strtoul(tmp, &end, 16);
++  if (errno != 0 || tmp == end) {
++    free(buf);
++    return 0;
++  }
++
++  free(buf);
++  return ret;
++}
++
++struct loongarch_cpuinfo *get_loongarch_cpuinfo(void) {
++  struct loongarch_cpuinfo *ci = emalloc(sizeof(struct loongarch_cpuinfo));
++
++  ci->prid = parse_cpuinfo_prid(CPUINFO_LOONGARCH_PRID);
++
++  if (ci->prid == 0)
++    return NULL;
++
++  return ci;
++}
+diff --git a/src/loongarch/udev.h b/src/loongarch/udev.h
+new file mode 100644
+index 0000000..dcd16a4
+--- /dev/null
++++ b/src/loongarch/udev.h
+@@ -0,0 +1,12 @@
++#ifndef __UDEV_LOONGARCH__
++#define __UDEV_LOONGARCH__
++
++#include "../common/udev.h"
++
++struct loongarch_cpuinfo {
++  unsigned long prid;
++};
++
++struct loongarch_cpuinfo *get_loongarch_cpuinfo(void);
++
++#endif
+-- 
+2.52.0
+

--- a/app-utils/cpufetch/spec
+++ b/app-utils/cpufetch/spec
@@ -1,4 +1,5 @@
 VER=1.07
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/Dr-Noob/cpufetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=187771"


### PR DESCRIPTION
Topic Description
-----------------

- cpufetch: add loongarch64 support
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- cpufetch: 1.07-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cpufetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
