### PR TITLE
xwayland-satellite: update to 0.8.1

### DIFF
--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -1,4 +1,4 @@
-VER=0.8
+VER=0.8.1
 SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377600"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland-satellite: update to 0.8.1
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- xwayland-satellite: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
