### PR TITLE
sing-box: use upstream build tags and ldflags

### DIFF
--- a/app-proxy/sing-box/autobuild/prepare
+++ b/app-proxy/sing-box/autobuild/prepare
@@ -1,24 +1,17 @@
-abinfo "Setting build tags ..."
-TAGS=(
-    "with_quic"
-    "with_grpc"
-    "with_dhcp"
-    "with_wireguard"
-    "with_utls"
-    "with_acme"
-    "with_clash_api"
-    "with_v2ray_api"
-    "with_gvisor"
-    "with_tailscale"
-)
-# FIXME: For `with_naive_outbound`, though it does not support ppc64el.
+abinfo "Reading build tags from release/ ..."
 if ! ab_match_arch ppc64el; then
-    export CGO_LDFLAGS="${LDFLAGS} -fuse-ld=lld"
-    TAGS=(
-        "${TAGS[@]}"
-        "with_naive_outbound"
-    )
+    _CGO_LDFLAGS="-fuse-ld=lld"
+    if ab_match_arch armv6hf || ab_match_arch armv7hf || \
+       ab_match_arch loongson3 || ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
+        _CGO_LDFLAGS="${_CGO_LDFLAGS} -Wl,-no-pie"
+    fi
+    export CGO_LDFLAGS="${LDFLAGS} ${_CGO_LDFLAGS}"
+    _TAGS=$(cat release/DEFAULT_BUILD_TAGS)
+else
+    _TAGS=$(cat release/DEFAULT_BUILD_TAGS_OTHERS)
 fi
+_EXTRA_LDFLAGS=$(cat release/LDFLAGS)
 GO_BUILD_AFTER=(
-    -tags "${TAGS[*]}"
+    -tags "${_TAGS}"
 )
+GO_LDFLAGS+=("${_EXTRA_LDFLAGS}")

--- a/app-proxy/sing-box/spec
+++ b/app-proxy/sing-box/spec
@@ -1,4 +1,5 @@
 VER=1.13.2
+REL=1
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
- Read build tags and ldflags from `release/` files instead of hardcoding
- Add `-Wl,-no-pie` for architectures where Go does not support PIE (386, arm, loong64, mipsle, mips64le): when linking with cronet's static library (which triggers external linkmode), the linker must not produce a PIE executable