### PR TITLE
parsedatetime: update to 2.6

### DIFF
--- a/lang-python/parsedatetime/autobuild/defines
+++ b/lang-python/parsedatetime/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="python-3"
 BUILDDEP="setuptools-python3"
 PKGDES="Parses human-readable date-and-time strings"
 
-ABTYPE=python
+ABTYPE=pep517
 ABHOST=noarch
 
 NOPYTHON2=1

--- a/lang-python/parsedatetime/spec
+++ b/lang-python/parsedatetime/spec
@@ -1,5 +1,4 @@
-VER=2.4
-REL="6"
-SRCS="tbl::https://pypi.io/packages/source/p/parsedatetime/parsedatetime-$VER.tar.gz"
-CHKSUMS="sha256::3d817c58fb9570d1eec1dd46fa9448cd644eeed4fb612684b02dfda3a79cb84b"
+VER=2.6
+SRCS="pypi::version=${VER}::parsedatetime"
+CHKSUMS="sha256::4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455"
 CHKUPDATE="anitya::id=6853"


### PR DESCRIPTION
Topic Description
-----------------

- parsedatetime: update to 2.6
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- parsedatetime: 2.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit parsedatetime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
