### PR TITLE
nvchecker: update to 2.20

### DIFF
--- a/app-utils/nvchecker/autobuild/defines
+++ b/app-utils/nvchecker/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=nvchecker
 PKGSEC=utils
-PKGDEP="pycurl tornado structlog"
+PKGDEP="pycurl tornado structlog platformdirs"
 BUILDDEP="setuptools python-installer python-build wheel"
 PKGDES="New version checker for software releases"
 

--- a/app-utils/nvchecker/spec
+++ b/app-utils/nvchecker/spec
@@ -1,5 +1,4 @@
-VER=2.15.1
+VER=2.20
 SRCS="git::commit=tags/v$VER::https://github.com/lilydjwg/nvchecker"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=37582"
-REL="1"

--- a/lang-python/backports-abc/autobuild/defines
+++ b/lang-python/backports-abc/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=backports-abc
-PKGSEC=python
-PKGDEP="python-3"
-BUILDDEP="setuptools"
-PKGDES="A backport of recent additions to the collections.abc module"
-
-ABHOST=noarch

--- a/lang-python/backports-abc/spec
+++ b/lang-python/backports-abc/spec
@@ -1,5 +1,0 @@
-VER=0.5
-REL="6"
-SRCS="tbl::https://pypi.python.org/packages/source/b/backports_abc/backports_abc-$VER.tar.gz"
-CHKSUMS="sha256::033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde"
-CHKUPDATE="anitya::id=10420"

--- a/lang-python/pycurl/spec
+++ b/lang-python/pycurl/spec
@@ -1,5 +1,4 @@
-VER=7.45.3
+VER=7.45.7
 SRCS="git::commit=tags/REL_${VER//./_}::https://github.com/pycurl/pycurl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7973"
-REL="1"

--- a/lang-python/structlog/autobuild/defines
+++ b/lang-python/structlog/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=structlog
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
+BUILDDEP="hatchling hatch-vcs hatch-fancy-pypi-readme"
 PKGDES="Structured Logging for Python"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/structlog/spec
+++ b/lang-python/structlog/spec
@@ -1,5 +1,4 @@
-VER=19.1.0
-REL="6"
-SRCS="tbl::https://github.com/hynek/structlog/archive/$VER.tar.gz"
-CHKSUMS="sha256::9116b6be372290dc9538a6af434d3e954dc901bf39b5423a4fdcb5f5c86c8f93"
+VER=25.5.0
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/hynek/structlog"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6901"

--- a/lang-python/tornado/autobuild/defines
+++ b/lang-python/tornado/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=tornado
 PKGSEC=python
-PKGDEP="backports-abc python-3"
+PKGDEP="python-3"
 BUILDDEP="python-installer python-build wheel"
-PKGDES="A Python web framework and asynchronous networking library"
+PKGDES="Python web framework and asynchronous networking library"
 
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/tornado/spec
+++ b/lang-python/tornado/spec
@@ -1,5 +1,4 @@
-VER=6.4.1
-SRCS="tbl::https://pypi.io/packages/source/t/tornado/tornado-$VER.tar.gz"
-CHKSUMS="sha256::92d3ab53183d8c50f8204a51e6f91d18a15d5ef261e84d452800d4ff6fc504e9"
+VER=6.5.4
+SRCS="pypi::version=${VER}::tornado"
+CHKSUMS="sha256::a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7"
 CHKUPDATE="anitya::id=7498"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- nvchecker: update to 2.20
    Signed-off-by: stydxm <stydxm@outlook.com>
- pycurl: update to 7.45.7
    Signed-off-by: stydxm <stydxm@outlook.com>
- tornado: update to 6.5.4
    Signed-off-by: stydxm <stydxm@outlook.com>
- collections-abc: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>
- structlog: update to 25.5.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit structlog tornado pycurl nvchecker
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
