### PR TITLE
simplejson: update to 3.20.2

### DIFF
--- a/lang-python/simplejson/spec
+++ b/lang-python/simplejson/spec
@@ -1,5 +1,4 @@
-VER=3.16.0
-REL="6"
+VER=3.20.2
 SRCS="tbl::https://pypi.io/packages/source/s/simplejson/simplejson-$VER.tar.gz"
-CHKSUMS="sha256::b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5"
+CHKSUMS="sha256::5fe7a6ce14d1c300d80d08695b7f7e633de6cd72c80644021874d985b3393649"
 CHKUPDATE="anitya::id=4026"


### PR DESCRIPTION
Topic Description
-----------------

- simplejson: update to 3.20.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- simplejson: 3.20.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit simplejson
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
