### PR TITLE
cairocffi: update to 1.7.1

### DIFF
--- a/lang-python/cairocffi/autobuild/defines
+++ b/lang-python/cairocffi/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=cairocffi
 PKGSEC=python
-PKGDEP="cffi gdk-pixbuf xcffib cairo"
-BUILDDEP="pip setuptools"
-PKGDES="A CFFI-based drop-in replacement for PyCairo"
+PKGDEP="cairo cffi"
+PKGSUG="xcffib"
+PKGDES="CFFI-based Cairo bindings for Python"
 
+ABTYPE=pep517
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/cairocffi/spec
+++ b/lang-python/cairocffi/spec
@@ -1,5 +1,4 @@
-VER=1.0.2
-REL="5"
-SRCS="tbl::https://pypi.io/packages/source/c/cairocffi/cairocffi-$VER.tar.gz"
-CHKSUMS="sha256::01ac51ae12c4324ca5809ce270f9dd1b67f5166fe63bd3e497e9ea3ca91946ff"
+VER=1.7.1
+SRCS="pypi::version=$VER::cairocffi"
+CHKSUMS="sha256::2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b"
 CHKUPDATE="anitya::id=9297"

--- a/lang-python/xcffib/autobuild/defines
+++ b/lang-python/xcffib/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=xcffib
 PKGSEC=python
-PKGDEP="libxcb cffi six"
+PKGDEP="libxcb cffi"
 BUILDDEP="setuptools"
 PKGDES="Python drop-in replacement for xpyb, an XCB python binding"
 
+ABTYPE=pep517
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/xcffib/spec
+++ b/lang-python/xcffib/spec
@@ -1,5 +1,4 @@
-VER=0.7.0
-REL="5"
-SRCS="tbl::https://pypi.io/packages/source/x/xcffib/xcffib-$VER.tar.gz"
-CHKSUMS="sha256::68ed1204a3162766fe44bd215f84c2e7a765b85e34e024d0b4131e935016cc8b"
+VER=1.12.0
+SRCS="pypi::version=$VER::xcffib"
+CHKSUMS="sha256::43452de509c1264d5bcea4bc025ca1bf68272d240ef26d3340b46e11f63d3d4a"
 CHKUPDATE="anitya::id=231402"


### PR DESCRIPTION
Topic Description
-----------------

- cairocffi: update to 1.7.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- xcffib: update to 1.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit xcffib cairocffi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
