### PR TITLE
shh: update to 2026.3.8

### DIFF
--- a/app-utils/shh/autobuild/beyond
+++ b/app-utils/shh/autobuild/beyond
@@ -2,7 +2,7 @@ abinfo "Building manpages ..."
 install -dvm755 "$SRCDIR"/target/man
 cargo run \
     --locked \
-    --features generate-extra \
+    --features generate-extras \
     -- gen-man-pages \
     "$SRCDIR"/target/man/
 
@@ -14,8 +14,8 @@ abinfo "Building completion files ..."
 install -dvm755 "$SRCDIR"/target/shellcompletions
 cargo run \
     --locked \
-    --features generate-extra \
-    -- gen-shell-complete \
+    --features generate-extras \
+    -- gen-shell-completions \
     "$SRCDIR"/target/shellcompletions/
 
 abinfo "Installing completion files ..."

--- a/app-utils/shh/spec
+++ b/app-utils/shh/spec
@@ -1,4 +1,4 @@
-VER=2026.1.27
+VER=2026.3.8
 SRCS="git::commit=tags/v$VER::https://github.com/desbma/shh.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377910"


### PR DESCRIPTION
Topic Description
-----------------

- shh: update to 2026.3.8

Package(s) Affected
-------------------

- shh: 2026.3.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit shh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
