### PR TITLE
httpcore: update to 1.0.9

### DIFF
--- a/lang-python/httpcore/autobuild/defines
+++ b/lang-python/httpcore/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=httpcore
 PKGSEC=python
 PKGDEP="hyper-h11 hyper-h2 sniffio"
 BUILDDEP="python-build tomli hatchling hatch-fancy-pypi-readme python-installer"
-PKGDES="A minimal HTTP client library"
+PKGDES="HTTP client library for Python"
 
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/httpcore/spec
+++ b/lang-python/httpcore/spec
@@ -1,5 +1,4 @@
-VER=1.0.5
-SRCS="tbl::https://github.com/encode/httpcore/archive/${VER}.tar.gz"
-CHKSUMS="sha256::5058e39e0ee755aa894f8faacb052f3174df3ba5ca8b5102a327fec3bfa39e09"
+VER=1.0.9
+SRCS="pypi::version=$VER::httpcore"
+CHKSUMS="sha256::6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
 CHKUPDATE="anitya::id=79947"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- httpcore: update to 1.0.9
    This version fixes AttributeError when importing with Python 3.14.
    Link: https://github.com/encode/httpcore/pull/1005

Package(s) Affected
-------------------

- httpcore: 1.0.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit httpcore
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
