### PR TITLE
pycountry: update to 26.2.16

### DIFF
--- a/lang-python/pycountry/autobuild/defines
+++ b/lang-python/pycountry/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=pycountry
 PKGSEC=python
-PKGDEP="python-3 lxml"
-BUILDDEP="python-build python-installer wheel"
+PKGDEP="python-3"
+BUILDDEP="python-build python-installer wheel poetry"
 PKGDES="ISO country, subdivision, language, currency and script definitions and their translations"
 
 ABHOST=noarch

--- a/lang-python/pycountry/spec
+++ b/lang-python/pycountry/spec
@@ -1,5 +1,4 @@
-VER=18.12.8
-REL="5"
-SRCS="tbl::https://pypi.io/packages/source/p/pycountry/pycountry-$VER.tar.gz"
-CHKSUMS="sha256::8ec4020b2b15cd410893d573820d42ee12fe50365332e58c0975c953b60a16de"
+VER=26.2.16
+SRCS="pypi::version=$VER::pycountry"
+CHKSUMS="sha256::5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801"
 CHKUPDATE="anitya::id=11989"


### PR DESCRIPTION
Topic Description
-----------------

- pycountry: update to 26.2.16
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- pycountry: 26.2.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit pycountry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
