### PR TITLE
fuse: bump REL for spiral markers

### DIFF
--- a/app-admin/fuse/autobuild/defines
+++ b/app-admin/fuse/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=fuse
 PKGSEC=admin
 PKGDES="Filesystem in userspace"
 PKGDEP="fuse-common glibc"
+PKGPROV="libfuse2_spiral"
 
 AUTOTOOLS_AFTER=(
     '--enable-lib'

--- a/app-admin/fuse/spec
+++ b/app-admin/fuse/spec
@@ -1,5 +1,5 @@
 VER=2.9.9
-REL=3
+REL=4
 SRCS="tbl::https://github.com/libfuse/libfuse/releases/download/fuse-$VER/fuse-$VER.tar.gz"
 CHKSUMS="sha256::d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
 CHKUPDATE="anitya::id=229381"


### PR DESCRIPTION
Topic Description
-----------------

- fuse: bump REL for spiral markers
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fuse: 2.9.9-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
