### PR TITLE
vscode: update to 1.111.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.110.0
+VER=1.111.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::aafe94571d90fba6a1ccbde889ff371e5b56bbead738f9aa028570712d9b71fd"
-CHKSUMS__ARM64="sha256::e16d634a5ba98b0b96a5479bc2931e62bf04a79ab0747ae151973080f7d88a1e"
+CHKSUMS__AMD64="sha256::2b8b1a5b9c6fc14bd49920ce45c1b65798ab01dc3abab7aefd31102286e50ac4"
+CHKSUMS__ARM64="sha256::4803404f163f2f13c5fff1d49dd6dc0d0e61a524fb128b559ca8b9b61c98983c"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.111.0
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- vscode: 1.111.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
