### PR TITLE
MinGW-w64 Survey 20260309

### DIFF
--- a/runtime-optenvw64/binutils+w64/spec
+++ b/runtime-optenvw64/binutils+w64/spec
@@ -1,4 +1,4 @@
-VER=2.43.1
-SRCS="git::commit=binutils-${VER//./_}::https://sourceware.org/git/binutils-gdb.git"
-CHKSUMS="SKIP"
+VER=2.46.0
+SRCS="https://ftp.gnu.org/gnu/binutils/binutils-$VER.tar.xz"
+CHKSUMS="sha256::d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2"
 CHKUPDATE="anitya::id=7981"

--- a/runtime-optenvw64/gcc+w64/spec
+++ b/runtime-optenvw64/gcc+w64/spec
@@ -1,4 +1,4 @@
-VER=14.2.0
-SRCS="git::commit=tags/releases/gcc-${VER}::https://github.com/gcc-mirror/gcc"
-CHKSUMS="SKIP"
+VER=15.2.0
+SRCS="https://ftp.gnu.org/gnu/gcc/gcc-$VER/gcc-$VER.tar.xz"
+CHKSUMS="sha256::438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
 CHKUPDATE="anitya::id=6502"

--- a/runtime-optenvw64/mingw+w64/spec
+++ b/runtime-optenvw64/mingw+w64/spec
@@ -1,4 +1,4 @@
-VER=12.0.0
+VER=13.0.0
 SRCS="https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v$VER.tar.bz2"
-CHKSUMS="sha256::cc41898aac4b6e8dd5cffd7331b9d9515b912df4420a3a612b5ea2955bbeed2f"
-CHKUPDATE="anitya::id=231062"
+CHKSUMS="sha256::5afe822af5c4edbf67daaf45eec61d538f49eef6b19524de64897c6b95828caf"
+CHKUPDATE="anitya::id=141402"


### PR DESCRIPTION
Topic Description
-----------------

- gcc: update to 15.2.0
  - update SRCS
- binutils+w64: update to 2.46.0
  - update SRCS
- mingw+w64: update to 13.0.0
  - update CHKUPDATE

Package(s) Affected
-------------------

- binutils+w64: 2.46.0
- gcc+w64: 15.2.0
- mingw+w64: 13.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mingw+w64 binutils+w64 gcc+w64
```

Test Build(s) Done
------------------

