### PR TITLE
pypkgconfig: update to 1.6.0

### DIFF
--- a/lang-python/pypkgconfig/autobuild/defines
+++ b/lang-python/pypkgconfig/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=pypkgconfig
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
+BUILDDEP="poetry"
 PKGDES="Python module to interface with the pkg-config command line tool"
 
+ABTYPE=pep517
 ABHOST=noarch
-ABTYPE=python
-
 NOPYTHON2=1

--- a/lang-python/pypkgconfig/spec
+++ b/lang-python/pypkgconfig/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
-REL="6"
-SRCS="tbl::https://github.com/matze/pkgconfig/archive/v$VER.tar.gz"
-CHKSUMS="sha256::38c5de8392f4acfe7f36b25d113c496d68f534e983afdbd0ba7240c8c475b161"
+VER=1.6.0
+SRCS="git::commit=tags/v$VER::https://github.com/matze/pkgconfig.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=209128"


### PR DESCRIPTION
Topic Description
-----------------

- pypkgconfig: update to 1.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pypkgconfig: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pypkgconfig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
