### PR TITLE
libinput: update to 1.31.0

### DIFF
--- a/runtime-devices/libinput/autobuild/defines
+++ b/runtime-devices/libinput/autobuild/defines
@@ -1,7 +1,18 @@
 PKGNAME=libinput
 PKGSEC=libs
-PKGDEP="mtdev systemd libevdev libwacom"
-BUILDDEP="check doxygen graphviz gtk-3 recommonmark"
+PKGDEP="mtdev systemd libevdev libwacom lua-5.4"
 PKGDES="Library that handles input devices for display servers and other applications"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Dlibwacom=true'
+    '-Dmtdev=true'
+    '-Ddebug-gui=false'
+    '-Dtests=false'
+    '-Dinstall-tests=false'
+    '-Ddocumentation=false'
+    '-Dcoverity=false'
+    '-Dinternal-event-debugging=false'
+    '-Dautoload-plugins=false'
+    '-Dlua-plugins=enabled'
+)

--- a/runtime-devices/libinput/autobuild/patches/0001-AOSCOS-fix-evdev-mt-touchpad-tap.c-enable-tap-to-cli.patch
+++ b/runtime-devices/libinput/autobuild/patches/0001-AOSCOS-fix-evdev-mt-touchpad-tap.c-enable-tap-to-cli.patch
@@ -1,7 +1,7 @@
-From d98739b3952af85cf4e01e1967f48d7c388b6375 Mon Sep 17 00:00:00 2001
+From 3df958e30fe37d6c63411f4b19da7becf21e4aa7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Sep 2024 00:10:11 +0800
-Subject: [PATCH 1/2] AOSCOS: fix(evdev-mt-touchpad-tap.c): enable tap-to-click
+Subject: [PATCH 1/7] AOSCOS: fix(evdev-mt-touchpad-tap.c): enable tap-to-click
  by default
 
 As we know, most touchpads these days come with no buttons *and*, more
@@ -38,25 +38,15 @@ This is a partial revert of:
     Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>
 
 [^1]: https://invent.kde.org/plasma/plasma-desktop/-/issues/97
-
----
-
-Patch submitted but NOT accepted by the upstream:
-
-https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1047
-
----
-
-Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  src/evdev-mt-touchpad-tap.c | 18 +-----------------
  1 file changed, 1 insertion(+), 17 deletions(-)
 
 diff --git a/src/evdev-mt-touchpad-tap.c b/src/evdev-mt-touchpad-tap.c
-index 3c76c3d6..7f912276 100644
+index 596ba944..9bb2c887 100644
 --- a/src/evdev-mt-touchpad-tap.c
 +++ b/src/evdev-mt-touchpad-tap.c
-@@ -1420,23 +1420,7 @@ tp_tap_config_is_enabled(struct libinput_device *device)
+@@ -1424,23 +1424,7 @@ tp_tap_config_is_enabled(struct libinput_device *device)
  static enum libinput_config_tap_state
  tp_tap_default(struct evdev_device *evdev)
  {
@@ -82,5 +72,5 @@ index 3c76c3d6..7f912276 100644
  
  static enum libinput_config_tap_state
 -- 
-2.48.1
+2.52.0
 

--- a/runtime-devices/libinput/autobuild/patches/0002-UPSTREAM-quirks-microsoft-surface-keyboard-event-BTN.patch
+++ b/runtime-devices/libinput/autobuild/patches/0002-UPSTREAM-quirks-microsoft-surface-keyboard-event-BTN.patch
@@ -1,0 +1,45 @@
+From fa6429816326ce6c996f02d90268b35a74cc3203 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Santamar=C3=ADa=20Rogado?= <howl.nsp@gmail.com>
+Date: Fri, 20 Feb 2026 03:27:44 +0100
+Subject: [PATCH 2/7] UPSTREAM: quirks: microsoft surface keyboard event BTN_0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Apply AttrEventCode=-BTN_0 to all surface keyboards.
+
+Fixes: #1251.
+
+Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1431>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/30-vendor-microsoft.quirks | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/quirks/30-vendor-microsoft.quirks b/quirks/30-vendor-microsoft.quirks
+index dc3a1382..96d1dbf7 100644
+--- a/quirks/30-vendor-microsoft.quirks
++++ b/quirks/30-vendor-microsoft.quirks
+@@ -11,15 +11,10 @@ AttrLidSwitchReliability=write_open
+ # - Surface Laptop 3: Microsoft Surface 045E:09AE Keyboard
+ # - Surface Book 2: Microsoft Surface Keyboard
+ [Microsoft Surface Keyboard]
+-MatchName=*Microsoft Surface *Keyboard*
++MatchName=Microsoft Surface *Keyboard
+ MatchDMIModalias=dmi:*:svnMicrosoftCorporation:*
+-AttrKeyboardIntegration=internal
+-
+-[Microsoft Surface Cover]
+-MatchName=*Microsoft Surface *Cover*
+-MatchDMIModalias=dmi:*:svnMicrosoftCorporation:*
+-AttrKeyboardIntegration=internal
+ AttrEventCode=-BTN_0;
++AttrKeyboardIntegration=internal
+ 
+ [Microsoft Surface Laptop Studio Touchpad]
+ MatchVendor=0x045E
+-- 
+2.52.0
+

--- a/runtime-devices/libinput/autobuild/patches/0003-UPSTREAM-quirks-apple-Add-AttrSizeHint-to-Magic-Trac.patch
+++ b/runtime-devices/libinput/autobuild/patches/0003-UPSTREAM-quirks-apple-Add-AttrSizeHint-to-Magic-Trac.patch
@@ -1,0 +1,28 @@
+From 521675e69890cc557c09da4aed5a3a80164ea3e2 Mon Sep 17 00:00:00 2001
+From: BBaoVanC <bbaovanc@bbaovanc.com>
+Date: Wed, 4 Mar 2026 04:53:28 +0000
+Subject: [PATCH 3/7] UPSTREAM: quirks/apple: Add AttrSizeHint to Magic
+ Trackpad USB-C
+
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1437>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/50-system-apple.quirks | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/quirks/50-system-apple.quirks b/quirks/50-system-apple.quirks
+index b287daf9..98572e5a 100644
+--- a/quirks/50-system-apple.quirks
++++ b/quirks/50-system-apple.quirks
+@@ -88,6 +88,7 @@ AttrThumbSizeThreshold=700
+ MatchBus=usb
+ MatchVendor=0x05AC
+ MatchProduct=0x0324
++AttrSizeHint=162x115
+ AttrTouchSizeRange=20:10
+ AttrPressureRange=3:0
+ AttrPalmSizeThreshold=900
+-- 
+2.52.0
+

--- a/runtime-devices/libinput/autobuild/patches/0004-UPSTREAM-quirks-hp-omnibook-ultra-flip-14-improve-ru.patch
+++ b/runtime-devices/libinput/autobuild/patches/0004-UPSTREAM-quirks-hp-omnibook-ultra-flip-14-improve-ru.patch
@@ -1,0 +1,72 @@
+From 765670cdadab8a9e849aa3d4360774a2c5950d87 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Santamar=C3=ADa=20Rogado?= <howl.nsp@gmail.com>
+Date: Thu, 19 Feb 2026 17:10:11 +0100
+Subject: [PATCH 4/7] UPSTREAM: quirks: hp omnibook ultra flip 14 improve rule
+ set
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some initial units had 14t-fh000 instead 14-fh0xxx in their product name
+but they are exactly the same model.
+
+We could match both in product version SBKPF or in board product name
+8CDE. Match board as seems the way hp-wmi kernel module uses to match.
+
+While at it rewrite the entire huge comment to a little less huge
+comment but with more really interesting info.
+
+Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1430>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/50-system-hp.quirks | 26 +++++++++++---------------
+ 1 file changed, 11 insertions(+), 15 deletions(-)
+
+diff --git a/quirks/50-system-hp.quirks b/quirks/50-system-hp.quirks
+index 31502552..d607d679 100644
+--- a/quirks/50-system-hp.quirks
++++ b/quirks/50-system-hp.quirks
+@@ -24,27 +24,23 @@ MatchName=*Intel Virtual Button*
+ MatchDMIModalias=dmi:*:svnHP:pnHPElitex21013G3:*
+ ModelTabletModeSwitchUnreliable=1
+ 
+-# The HP OmniBook Ultra Flip Laptop 14-fh0xxx's custom Intel ISH firmware
+-# filters out events from its builtin keyboard and touchpad when the hinge is
+-# opened little more than 180 degrees but toggles tablet-mode when it's opened
+-# little less than 180 degrees.
+-# Do not suspend the keyboard and touchpad to let use the device in flat
+-# position and also give consistency with some keyboard keys controlled by the
+-# Video Bus device (brightness down/up), the HP WMI hotkeys device (mic mute and
+-# hp hubs launcher key) and the backlight getting on and off by the firmware at
+-# the same time it enables disables the input.
+-# This one is for the keyboard and...
+-[HP OmniBook Ultra Flip Laptop 14-fh0xxx Keyboard]
++# The HP OmniBook Ultra Flip 14 toggles tablet mode at a little less than 180
++# degrees and hardware switches off inputs at a little more than 180 degrees.
++# We don't suspend ourselves to allow using them in flat position. It is
++# possible that HP fixes this in the future (i.e. so tablet mode toggles
++# after 180 degrees) so check before removing these rules.
++# This rule is for the keyboard and...
++[HP OmniBook Ultra Flip Laptop 14-fh0xxx and 14t-fh000 Keyboard]
+ MatchBus=ps2
+ MatchUdevType=keyboard
+-MatchDMIModalias=dmi:*:svnHP:pnHPOmniBookUltraFlipLaptop14-fh0xxx:*
++MatchDMIModalias=dmi:*:svnHP:*:rn8CDE:*
+ ModelTabletModeNoSuspend=1
+ 
+-# ...this one is for the touchpad.
+-[HP OmniBook Ultra Flip Laptop 14-fh0xxx Touchpad]
++# ...this rule is for the touchpad.
++[HP OmniBook Ultra Flip Laptop 14-fh0xxx and 14t-fh000 Touchpad]
+ MatchBus=i2c
+ MatchUdevType=touchpad
+-MatchDMIModalias=dmi:*:svnHP:pnHPOmniBookUltraFlipLaptop14-fh0xxx:*
++MatchDMIModalias=dmi:*:svnHP:*:rn8CDE:*
+ ModelTabletModeNoSuspend=1
+ 
+ [HP Pavilion dm4]
+-- 
+2.52.0
+

--- a/runtime-devices/libinput/autobuild/patches/0005-UPSTREAM-quirks-hp-omnibook-ultra-flip-14-touch-pres.patch
+++ b/runtime-devices/libinput/autobuild/patches/0005-UPSTREAM-quirks-hp-omnibook-ultra-flip-14-touch-pres.patch
@@ -1,0 +1,37 @@
+From 44af0e8cf641e36032f9d89fa30bb57d762e00f7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Santamar=C3=ADa=20Rogado?= <howl.nsp@gmail.com>
+Date: Tue, 3 Mar 2026 01:12:12 +0100
+Subject: [PATCH 5/7] UPSTREAM: quirks: hp omnibook ultra flip 14 touch
+ pressure
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add pressure attributes to make libinput measure touchpad-pressure
+behave right.
+
+Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1430>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/50-system-hp.quirks | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/quirks/50-system-hp.quirks b/quirks/50-system-hp.quirks
+index d607d679..e4d1e4cc 100644
+--- a/quirks/50-system-hp.quirks
++++ b/quirks/50-system-hp.quirks
+@@ -42,6 +42,9 @@ MatchBus=i2c
+ MatchUdevType=touchpad
+ MatchDMIModalias=dmi:*:svnHP:*:rn8CDE:*
+ ModelTabletModeNoSuspend=1
++AttrPressureRange=15:5
++AttrThumbPressureThreshold=80
++AttrPalmPressureThreshold=125
+ 
+ [HP Pavilion dm4]
+ MatchName=*SynPS/2 Synaptics TouchPad
+-- 
+2.52.0
+

--- a/runtime-devices/libinput/autobuild/patches/0006-UPSTREAM-quirks-add-some-more-goodix-haptic-touchpad.patch
+++ b/runtime-devices/libinput/autobuild/patches/0006-UPSTREAM-quirks-add-some-more-goodix-haptic-touchpad.patch
@@ -1,0 +1,57 @@
+From 18d23d156fde113b7fb9f1d7e2ae17d28898f9df Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?David=20Santamar=C3=ADa=20Rogado?= <howl.nsp@gmail.com>
+Date: Mon, 9 Mar 2026 09:36:25 +0100
+Subject: [PATCH 6/7] UPSTREAM: quirks: add some more goodix haptic touchpads
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1440>
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/30-vendor-goodix.quirks | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/quirks/30-vendor-goodix.quirks b/quirks/30-vendor-goodix.quirks
+index b7aab62b..0f849981 100644
+--- a/quirks/30-vendor-goodix.quirks
++++ b/quirks/30-vendor-goodix.quirks
+@@ -9,6 +9,33 @@ MatchProduct=0x01E8
+ MatchUdevType=touchpad
+ AttrInputProp=+INPUT_PROP_PRESSUREPAD
+ 
++# "GXTP5100 Touchpad": pressure touchpad mostly used in Lenovo laptops.
++# GXTP5100:00 27C6:01E9 Touchpad
++[Goodix Haptic Touchpad (27C6:01E9)]
++MatchBus=i2c
++MatchVendor=0x27C6
++MatchProduct=0x01E9
++MatchUdevType=touchpad
++AttrInputProp=+INPUT_PROP_PRESSUREPAD
++
++# "GXTP5100 Touchpad": pressure touchpad mostly used in Lenovo laptops.
++# GXTP5100:00 27C6:01EA Touchpad
++[Goodix Haptic Touchpad (27C6:01EA)]
++MatchBus=i2c
++MatchVendor=0x27C6
++MatchProduct=0x01EA
++MatchUdevType=touchpad
++AttrInputProp=+INPUT_PROP_PRESSUREPAD
++
++# "GXTP5100 Touchpad": pressure touchpad mostly used in Lenovo laptops.
++# GXTP5100:00 27C6:01EB Touchpad
++[Goodix Haptic Touchpad (27C6:01EB)]
++MatchBus=i2c
++MatchVendor=0x27C6
++MatchProduct=0x01EB
++MatchUdevType=touchpad
++AttrInputProp=+INPUT_PROP_PRESSUREPAD
++
+ # "GXTP5420 Touchpad": pressure touchpad mostly used in Lenovo laptops.
+ # GXTP5420:00 27C6:0F95 Touchpad
+ [Goodix Haptic Touchpad (27C6:0F95)]
+-- 
+2.52.0
+

--- a/runtime-devices/libinput/autobuild/patches/0007-FROMLIST-quirks-add-Goodix-pressure-pad-quirk-for-27.patch
+++ b/runtime-devices/libinput/autobuild/patches/0007-FROMLIST-quirks-add-Goodix-pressure-pad-quirk-for-27.patch
@@ -1,0 +1,37 @@
+From 6e68deb22b9afbd6f3aac55214549f16b186ac63 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 10 Mar 2026 11:37:14 +0800
+Subject: [PATCH 7/7] FROMLIST: quirks: add Goodix pressure pad quirk for
+ 27C6:01E7
+
+This touchpad is found on the newly released Lenovo ThinkBook G8+ IPH.
+
+Link: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1442
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ quirks/30-vendor-goodix.quirks | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/quirks/30-vendor-goodix.quirks b/quirks/30-vendor-goodix.quirks
+index 0f849981..94c3637b 100644
+--- a/quirks/30-vendor-goodix.quirks
++++ b/quirks/30-vendor-goodix.quirks
+@@ -2,6 +2,15 @@
+ 
+ # "GXTP5100 Touchpad": pressure touchpad mostly used in Lenovo laptops.
+ # Match vid and pid as it can have other names.
++[Goodix Haptic Touchpad (27C6:01E7)]
++MatchBus=i2c
++MatchVendor=0x27C6
++MatchProduct=0x01E7
++MatchUdevType=touchpad
++AttrInputProp=+INPUT_PROP_PRESSUREPAD
++
++# "GXTP5100 Touchpad": pressure touchpad mostly used in Lenovo laptops.
++# GXTP5100:00 27C6:01E8 Touchpad
+ [Goodix Haptic Touchpad (27C6:01E8)]
+ MatchBus=i2c
+ MatchVendor=0x27C6
+-- 
+2.52.0
+

--- a/runtime-devices/libinput/spec
+++ b/runtime-devices/libinput/spec
@@ -1,4 +1,4 @@
-VER=1.29.2
+VER=1.31.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/libinput/libinput"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5781"


### PR DESCRIPTION
Topic Description
-----------------

- libinput: update to 1.31.0
    - Specify options explicitly where applicable.
    - Track patches at AOSC-Tracking/libinput @ aosc/1.31.0
    \(HEAD: 3df958e30fe37d6c63411f4b19da7becf21e4aa7\).

Package(s) Affected
-------------------

- libinput: 1.31.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
