### PR TITLE
linux-firmware: update to 20260221+debian20260110+1

### DIFF
--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,5 +1,5 @@
-UPSTREAM_VER=20260110
-DEBIANVER=20251125-1
+UPSTREAM_VER=20260221
+DEBIANVER=20260110-1
 VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
 SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
@@ -12,6 +12,6 @@ CHKSUMS="SKIP \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::a78d0ca0c92fd8cee3dfd50cb552e730896216bd0137d5697c3cebcaaa9760cc"
+         sha256::2deee6a63255e3a8e8ab1530e36064fd85c77b3e1db7ede89dc1484b4e0bf63c"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"

--- a/topics/linux-firmware-20260221.toml
+++ b/topics/linux-firmware-20260221.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "Device Driver Firmware and Microcode Update (February 21, 2026)"
+zh_CN = "设备驱动固件及微码更新（2026 年 2 月 21 日）"
+
+[caution]
+default = "With enhancements for various audio, graphics, networking, and SoC devices and platforms, notably firmware for Intel Image Processing Unit 7, enabling webcam support for Intel Panther Lake-based devices"
+zh_CN = "包含对数款音频、图形和网络设备，以及 SoC 平台的支持增强，新增 Intel Image Processing Unit 7 的固件，可用于启用 Intel Panther Lake 设备摄像头的支持"
+
+[packages-v2]
+"firmware-nonfree" = "< 20260221+debian20260110+1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add linux-firmware-20260221.toml
- linux-firmware: update to 20260221+debian20260110+1

Package(s) Affected
-------------------

- firmware-free: 20260221+debian20260110+1
- firmware-nonfree: 20260221+debian20260110+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
