### PR TITLE
onnxruntime: update to 1.24.3

### DIFF
--- a/runtime-common/onnxruntime/spec
+++ b/runtime-common/onnxruntime/spec
@@ -1,4 +1,4 @@
-VER=1.23.2
+VER=1.24.3
 SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/microsoft/onnxruntime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=34845"


### PR DESCRIPTION
Topic Description
-----------------

- onnxruntime: update to 1.24.3
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- onnxruntime: 1.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit onnxruntime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
