### PR TITLE
freerdp: fix connection aborts with drive redirection enabled

### DIFF
--- a/app-network/freerdp/autobuild/patches/0001-BACKPORT-UPSTREAM-core-gateway-ignore-incomplete-rpc.patch
+++ b/app-network/freerdp/autobuild/patches/0001-BACKPORT-UPSTREAM-core-gateway-ignore-incomplete-rpc.patch
@@ -1,0 +1,30 @@
+From 5cd792a71f02a995dec513c4066d37a817454205 Mon Sep 17 00:00:00 2001
+From: Armin Novak <armin.novak@thincast.com>
+Date: Wed, 25 Feb 2026 22:52:06 +0100
+Subject: [PATCH 1/3] BACKPORT: UPSTREAM: [core,gateway] ignore incomplete rpc
+ header
+
+[Mingcong Bai: Fixed a minor post-3.23.0 merge conflict in
+ libfreerdp/core/gateway/rpc_client.c]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libfreerdp/core/gateway/rpc_client.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libfreerdp/core/gateway/rpc_client.c b/libfreerdp/core/gateway/rpc_client.c
+index 1f85820cc..93d874923 100644
+--- a/libfreerdp/core/gateway/rpc_client.c
++++ b/libfreerdp/core/gateway/rpc_client.c
+@@ -691,7 +691,7 @@ static SSIZE_T rpc_client_default_out_channel_recv(rdpRpc* rpc)
+ 			Stream_SetPosition(fragment, 0);
+ 
+ 			/* Ignore errors, the PDU might not be complete. */
+-			rts_read_common_pdu_header(fragment, &header, TRUE);
++			(void)rts_read_common_pdu_header(fragment, &header, TRUE);
+ 			Stream_SetPosition(fragment, pos);
+ 
+ 			if (header.frag_length > rpc->max_recv_frag)
+-- 
+2.52.0
+

--- a/app-network/freerdp/autobuild/patches/0002-BACKPORT-UPSTREAM-core-gateway-fix-rts_read_common_p.patch
+++ b/app-network/freerdp/autobuild/patches/0002-BACKPORT-UPSTREAM-core-gateway-fix-rts_read_common_p.patch
@@ -1,0 +1,153 @@
+From 5dddd4c0f051247f211d4ab5d82c4456a3b9e1ad Mon Sep 17 00:00:00 2001
+From: Armin Novak <armin.novak@thincast.com>
+Date: Thu, 26 Feb 2026 08:49:42 +0100
+Subject: [PATCH 2/3] BACKPORT: UPSTREAM: [core,gateway] fix
+ rts_read_common_pdu_header
+
+The function does not return BOOL but 3 possible conditions, so use a
+proper enum type for this.
+
+[Mingcong Bai: Fixed minor post-3.23.0 merge conflicts in...
+ libfreerdp/core/gateway/rpc_client.c
+ libfreerdp/core/gateway/rts.h]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libfreerdp/core/gateway/rpc_client.c | 15 +++++++++------
+ libfreerdp/core/gateway/rts.c        | 18 ++++++++++--------
+ libfreerdp/core/gateway/rts.h        | 11 +++++++++--
+ 3 files changed, 28 insertions(+), 16 deletions(-)
+
+diff --git a/libfreerdp/core/gateway/rpc_client.c b/libfreerdp/core/gateway/rpc_client.c
+index 93d874923..6ac606ead 100644
+--- a/libfreerdp/core/gateway/rpc_client.c
++++ b/libfreerdp/core/gateway/rpc_client.c
+@@ -691,7 +691,10 @@ static SSIZE_T rpc_client_default_out_channel_recv(rdpRpc* rpc)
+ 			Stream_SetPosition(fragment, 0);
+ 
+ 			/* Ignore errors, the PDU might not be complete. */
+-			(void)rts_read_common_pdu_header(fragment, &header, TRUE);
++			const rts_pdu_status_t rc = rts_read_common_pdu_header(fragment, &header, TRUE);
++			if (rc == RTS_PDU_FAIL)
++				return -1;
++
+ 			Stream_SetPosition(fragment, pos);
+ 
+ 			if (header.frag_length > rpc->max_recv_frag)
+@@ -978,19 +981,19 @@ static void rpc_array_client_call_free(void* call)
+ 
+ int rpc_in_channel_send_pdu(RpcInChannel* inChannel, const BYTE* buffer, size_t length)
+ {
+-	SSIZE_T status = 0;
+ 	RpcClientCall* clientCall = NULL;
+-	wStream s;
++	wStream s = Stream_Init();
+ 	rpcconn_common_hdr_t header = { 0 };
+ 
+-	status = rpc_channel_write(&inChannel->common, buffer, length);
++	SSIZE_T status = rpc_channel_write(&inChannel->common, buffer, length);
+ 
+ 	if (status <= 0)
+ 		return -1;
+ 
+ 	Stream_StaticConstInit(&s, buffer, length);
+-	if (!rts_read_common_pdu_header(&s, &header, FALSE))
+-		return -1;
++	const rts_pdu_status_t rc = rts_read_common_pdu_header(&s, &header, FALSE);
++	if (rc != RTS_PDU_VALID)
++		return FALSE;
+ 
+ 	clientCall = rpc_client_call_find_by_id(inChannel->common.client, header.call_id);
+ 	if (!clientCall)
+diff --git a/libfreerdp/core/gateway/rts.c b/libfreerdp/core/gateway/rts.c
+index 592348d27..a4e9eec13 100644
+--- a/libfreerdp/core/gateway/rts.c
++++ b/libfreerdp/core/gateway/rts.c
+@@ -221,7 +221,8 @@ static BOOL rts_write_common_pdu_header(wStream* s, const rpcconn_common_hdr_t*
+ 	return TRUE;
+ }
+ 
+-BOOL rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* header, BOOL ignoreErrors)
++rts_pdu_status_t rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* header,
++                                            BOOL ignoreErrors)
+ {
+ 	WINPR_ASSERT(s);
+ 	WINPR_ASSERT(header);
+@@ -229,13 +230,13 @@ BOOL rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* header, BOOL i
+ 	if (!ignoreErrors)
+ 	{
+ 		if (!Stream_CheckAndLogRequiredLength(TAG, s, sizeof(rpcconn_common_hdr_t)))
+-			return FALSE;
++			return RTS_PDU_INCOMPLETE;
+ 	}
+ 	else
+ 	{
+ 		const size_t sz = Stream_GetRemainingLength(s);
+ 		if (sz < sizeof(rpcconn_common_hdr_t))
+-			return FALSE;
++			return RTS_PDU_INCOMPLETE;
+ 	}
+ 
+ 	Stream_Read_UINT8(s, header->rpc_vers);
+@@ -252,22 +253,22 @@ BOOL rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* header, BOOL i
+ 		if (!ignoreErrors)
+ 			WLog_WARN(TAG, "Invalid header->frag_length of %" PRIu16 ", expected %" PRIuz,
+ 			          header->frag_length, sizeof(rpcconn_common_hdr_t));
+-		return FALSE;
++		return RTS_PDU_FAIL;
+ 	}
+ 
+ 	if (!ignoreErrors)
+ 	{
+ 		if (!Stream_CheckAndLogRequiredLength(TAG, s,
+ 		                                      header->frag_length - sizeof(rpcconn_common_hdr_t)))
+-			return FALSE;
++			return RTS_PDU_INCOMPLETE;
+ 	}
+ 	else
+ 	{
+ 		const size_t sz2 = Stream_GetRemainingLength(s);
+ 		if (sz2 < header->frag_length - sizeof(rpcconn_common_hdr_t))
+-			return FALSE;
++			return RTS_PDU_INCOMPLETE;
+ 	}
+-	return TRUE;
++	return RTS_PDU_VALID;
+ }
+ 
+ static BOOL rts_read_auth_verifier_no_checks(wStream* s, auth_verifier_co_t* auth,
+@@ -1189,7 +1190,8 @@ BOOL rts_read_pdu_header_ex(wStream* s, rpcconn_hdr_t* header, BOOL silent)
+ 	WINPR_ASSERT(s);
+ 	WINPR_ASSERT(header);
+ 
+-	if (!rts_read_common_pdu_header(s, &header->common, silent))
++	const rts_pdu_status_t status = rts_read_common_pdu_header(s, &header->common, silent);
++	if (status != RTS_PDU_VALID)
+ 		return FALSE;
+ 
+ 	WLog_DBG(TAG, "Reading PDU type %s", rts_pdu_ptype_to_string(header->common.ptype));
+diff --git a/libfreerdp/core/gateway/rts.h b/libfreerdp/core/gateway/rts.h
+index 40535cbf5..a601ea543 100644
+--- a/libfreerdp/core/gateway/rts.h
++++ b/libfreerdp/core/gateway/rts.h
+@@ -86,8 +86,15 @@ FREERDP_LOCAL BOOL rts_read_pdu_header(wStream* s, rpcconn_hdr_t* header);
+ FREERDP_LOCAL BOOL rts_read_pdu_header_ex(wStream* s, rpcconn_hdr_t* header, BOOL silent);
+ FREERDP_LOCAL void rts_free_pdu_header(rpcconn_hdr_t* header, BOOL allocated);
+ 
+-FREERDP_LOCAL BOOL rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* header,
+-                                              BOOL ignoreErrors);
++typedef enum
++{
++	RTS_PDU_FAIL = -1,
++	RTS_PDU_INCOMPLETE = 0,
++	RTS_PDU_VALID = 1
++} rts_pdu_status_t;
++
++FREERDP_LOCAL rts_pdu_status_t rts_read_common_pdu_header(wStream* s, rpcconn_common_hdr_t* header,
++                                                          BOOL ignoreErrors);
+ 
+ FREERDP_LOCAL BOOL rts_command_length(UINT32 CommandType, wStream* s, size_t* length, BOOL silent);
+ 
+-- 
+2.52.0
+

--- a/app-network/freerdp/autobuild/patches/0003-BACKPORT-UPSTREAM-winpr-Add-initializer-functions.patch
+++ b/app-network/freerdp/autobuild/patches/0003-BACKPORT-UPSTREAM-winpr-Add-initializer-functions.patch
@@ -1,0 +1,374 @@
+From 6141bbee8890e6ef8e854ac9310b3c520f62dfe8 Mon Sep 17 00:00:00 2001
+From: Armin Novak <armin.novak@thincast.com>
+Date: Tue, 24 Feb 2026 21:23:47 +0100
+Subject: [PATCH 3/3] BACKPORT: UPSTREAM: [winpr] Add initializer functions
+
+* Add initializer for wStream
+* Add initializer for ASN1 decoder
+
+[Mingcong Bai: Fixed minor post-3.23.0 merge conflicts in...
+ channels/rdpear/client/rdpear_main.c
+ libfreerdp/core/nla.c
+ winpr/libwinpr/sspi/Negotiate/negotiate.c
+ winpr/libwinpr/utils/test/TestASN1.c]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ channels/rdpear/client/rdpear_main.c      | 18 +++++++++---------
+ libfreerdp/core/nla.c                     | 20 ++++++++++----------
+ winpr/include/winpr/asn1.h                | 12 ++++++++++++
+ winpr/include/winpr/stream.h              | 11 +++++++++++
+ winpr/libwinpr/ncrypt/ncrypt_pkcs11.c     |  4 ++--
+ winpr/libwinpr/sspi/Kerberos/kerberos.c   | 10 +++++-----
+ winpr/libwinpr/sspi/Negotiate/negotiate.c | 12 ++++++------
+ winpr/libwinpr/sspi/sspi_gss.c            |  4 ++--
+ winpr/libwinpr/utils/asn1/asn1.c          | 10 +++++-----
+ winpr/libwinpr/utils/test/TestASN1.c      |  6 +++---
+ 10 files changed, 65 insertions(+), 42 deletions(-)
+
+diff --git a/channels/rdpear/client/rdpear_main.c b/channels/rdpear/client/rdpear_main.c
+index e7c8792f0..2670397a3 100644
+--- a/channels/rdpear/client/rdpear_main.c
++++ b/channels/rdpear/client/rdpear_main.c
+@@ -394,9 +394,9 @@ static char* KERB_RPC_UNICODESTR_to_charptr(const RPC_UNICODE_STRING* src)
+ 
+ static BOOL extractAuthData(const KERB_ASN1_DATA* src, krb5_authdata* authData, BOOL* haveData)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec3 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec3 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1Decoder_InitMem(&dec, WINPR_ASN1_DER, src->Asn1Buffer, src->Asn1BufferHints.count);
+ 	BOOL error = FALSE;
+ 	WinPrAsn1_INTEGER adType = 0;
+@@ -429,8 +429,8 @@ static BOOL extractAuthData(const KERB_ASN1_DATA* src, krb5_authdata* authData,
+ 
+ static BOOL extractChecksum(const KERB_ASN1_DATA* src, krb5_checksum* dst)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1Decoder_InitMem(&dec, WINPR_ASN1_DER, src->Asn1Buffer, src->Asn1BufferHints.count);
+ 	BOOL error = FALSE;
+ 	WinPrAsn1_OctetString os;
+@@ -626,8 +626,8 @@ out:
+ 
+ static BOOL rdpear_findEncryptedData(const KERB_ASN1_DATA* src, int* penctype, krb5_data* data)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1Decoder_InitMem(&dec, WINPR_ASN1_DER, src->Asn1Buffer, src->Asn1BufferHints.count);
+ 	BOOL error = FALSE;
+ 	WinPrAsn1_INTEGER encType = 0;
+@@ -974,8 +974,8 @@ static UINT rdpear_on_data_received(IWTSVirtualChannelCallback* pChannelCallback
+ 	if (!freerdp_nla_decrypt(rdpear->rdp_context, &inBuffer, &decrypted))
+ 		goto out;
+ 
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	wStream decodedStream = { 0 };
+ 	Stream_StaticInit(&decodedStream, decrypted.pvBuffer, decrypted.cbBuffer);
+ 	WinPrAsn1Decoder_Init(&dec, WINPR_ASN1_DER, &decodedStream);
+diff --git a/libfreerdp/core/nla.c b/libfreerdp/core/nla.c
+index a34bef682..6be7ce0af 100644
+--- a/libfreerdp/core/nla.c
++++ b/libfreerdp/core/nla.c
+@@ -1355,9 +1355,9 @@ typedef enum
+ 
+ static BOOL nla_read_ts_credentials(rdpNla* nla, SecBuffer* data)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1_OctetString credentials = { 0 };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
++        WinPrAsn1_OctetString credentials = { 0 };
+ 	BOOL error = FALSE;
+ 	WinPrAsn1_INTEGER credType = -1;
+ 	BOOL ret = TRUE;
+@@ -1423,7 +1423,7 @@ static BOOL nla_read_ts_credentials(rdpNla* nla, SecBuffer* data)
+ 			settings->PasswordIsSmartcardPin = TRUE;
+ 
+ 			/* cspData [1] TSCspDataDetail */
+-			WinPrAsn1Decoder cspDetails = { .encoding = WINPR_ASN1_BER, { 0 } };
++			WinPrAsn1Decoder cspDetails = WinPrAsn1Decoder_init();
+ 			if (!WinPrAsn1DecReadContextualSequence(&dec, 1, &error, &cspDetails) && error)
+ 				return FALSE;
+ 			if (!nla_read_TSCspDataDetail(&cspDetails, settings))
+@@ -1450,7 +1450,7 @@ static BOOL nla_read_ts_credentials(rdpNla* nla, SecBuffer* data)
+ 				                            .ServiceTicket = NULL,
+ 				                            .TicketGrantingTicket = NULL };
+ 
+-			WinPrAsn1Decoder logonCredsSeq = { .encoding = WINPR_ASN1_BER, { 0 } };
++			WinPrAsn1Decoder logonCredsSeq = WinPrAsn1Decoder_init();
+ 
+ 			if (!WinPrAsn1DecReadContextualSequence(&dec2, 0, &error, &logonCredsSeq) || error)
+ 				return FALSE;
+@@ -1474,12 +1474,12 @@ static BOOL nla_read_ts_credentials(rdpNla* nla, SecBuffer* data)
+ 
+ 			/* supplementalCreds [1] SEQUENCE OF TSRemoteGuardPackageCred OPTIONAL, */
+ 			MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL* suppCreds = NULL;
+-			WinPrAsn1Decoder suppCredsSeq = { .encoding = WINPR_ASN1_BER, { 0 } };
++			WinPrAsn1Decoder suppCredsSeq = WinPrAsn1Decoder_init();
+ 
+ 			if (WinPrAsn1DecReadContextualSequence(&dec2, 1, &error, &suppCredsSeq) &&
+ 			    Stream_GetRemainingLength(&suppCredsSeq.source))
+ 			{
+-				WinPrAsn1Decoder ntlmCredsSeq = { .encoding = WINPR_ASN1_BER, { 0 } };
++				WinPrAsn1Decoder ntlmCredsSeq = WinPrAsn1Decoder_init();
+ 				if (!WinPrAsn1DecReadSequence(&suppCredsSeq, &ntlmCredsSeq))
+ 					return FALSE;
+ 
+@@ -2065,8 +2065,8 @@ fail:
+ 
+ static int nla_decode_ts_request(rdpNla* nla, wStream* s)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	BOOL error = FALSE;
+ 	WinPrAsn1_tagId tag = { 0 };
+ 	WinPrAsn1_INTEGER val = { 0 };
+@@ -2108,7 +2108,7 @@ static int nla_decode_ts_request(rdpNla* nla, wStream* s)
+ 
+ 	while (WinPrAsn1DecReadContextualTag(&dec, &tag, &dec2) != 0)
+ 	{
+-		WinPrAsn1Decoder dec3 = { .encoding = WINPR_ASN1_BER, { 0 } };
++		WinPrAsn1Decoder dec3 = WinPrAsn1Decoder_init();
+ 		WinPrAsn1_OctetString octet_string = { 0 };
+ 
+ 		switch (tag)
+diff --git a/winpr/include/winpr/asn1.h b/winpr/include/winpr/asn1.h
+index 75556eb3d..84ed76f79 100644
+--- a/winpr/include/winpr/asn1.h
++++ b/winpr/include/winpr/asn1.h
+@@ -68,6 +68,18 @@ struct WinPrAsn1Decoder
+ 
+ typedef struct WinPrAsn1Decoder WinPrAsn1Decoder;
+ 
++/** @brief helper initializing a \b WinPrAsn1Decoder context
++ *
++ * @return The initialized context
++ * @since version 3.24.0
++ */
++static inline WinPrAsn1Decoder WinPrAsn1Decoder_init(void)
++{
++	const wStream stream = Stream_Init();
++	const WinPrAsn1Decoder empty = { WINPR_ASN1_BER, stream };
++	return empty;
++}
++
+ typedef BYTE WinPrAsn1_tag;
+ typedef BYTE WinPrAsn1_tagId;
+ typedef BOOL WinPrAsn1_BOOL;
+diff --git a/winpr/include/winpr/stream.h b/winpr/include/winpr/stream.h
+index b3cd0c55f..b6833ad69 100644
+--- a/winpr/include/winpr/stream.h
++++ b/winpr/include/winpr/stream.h
+@@ -51,6 +51,17 @@ extern "C"
+ 		BOOL isOwner;
+ 	} wStream;
+ 
++	/** @brief helper initializing a \b wStream context
++	 *
++	 * @return The initialized context
++	 * @since version 3.24.0
++	 */
++	static inline wStream Stream_Init(void)
++	{
++		const wStream empty = { NULL, NULL, 0, 0, 0, NULL, FALSE, FALSE };
++		return empty;
++	}
++
+ 	static inline size_t Stream_Capacity(const wStream* _s);
+ 	WINPR_API size_t Stream_GetRemainingCapacity(const wStream* _s);
+ 	WINPR_API size_t Stream_GetRemainingLength(const wStream* _s);
+diff --git a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+index bc31616ca..b620e57cd 100644
+--- a/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
++++ b/winpr/libwinpr/ncrypt/ncrypt_pkcs11.c
+@@ -875,8 +875,8 @@ static SECURITY_STATUS get_piv_container_name(NCryptP11KeyHandle* key, const BYT
+ 	char container_name[PIV_CONTAINER_NAME_LEN + 1] = { 0 };
+ 	DWORD buf_len = 0;
+ 	SECURITY_STATUS ret = NTE_BAD_KEY;
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	size_t len = 0;
+ 	BYTE tag = 0;
+ 	BYTE* p = NULL;
+diff --git a/winpr/libwinpr/sspi/Kerberos/kerberos.c b/winpr/libwinpr/sspi/Kerberos/kerberos.c
+index da142b4f2..d0b68d1bd 100644
+--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
++++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
+@@ -725,7 +725,7 @@ static BOOL append(char* dst, size_t dstSize, const char* src)
+ static BOOL kerberos_rd_tgt_req_tag2(WinPrAsn1Decoder* dec, char* buf, size_t len)
+ {
+ 	BOOL rc = FALSE;
+-	WinPrAsn1Decoder seq = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder seq = WinPrAsn1Decoder_init();
+ 
+ 	/* server-name [2] PrincipalName (SEQUENCE) */
+ 	if (!WinPrAsn1DecReadSequence(dec, &seq))
+@@ -810,7 +810,7 @@ static BOOL kerberos_rd_tgt_req(WinPrAsn1Decoder* dec, char** target)
+ 	if (len == 0)
+ 		return TRUE;
+ 
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1_tagId tag = 0;
+ 	if (WinPrAsn1DecReadContextualTag(dec, &tag, &dec2) == 0)
+ 		return FALSE;
+@@ -856,7 +856,7 @@ static BOOL kerberos_rd_tgt_rep(WinPrAsn1Decoder* dec, krb5_data* ticket)
+ 		return FALSE;
+ 
+ 	/* ticket [2] Ticket */
+-	WinPrAsn1Decoder asnTicket = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder asnTicket = WinPrAsn1Decoder_init();
+ 	WinPrAsn1_tagId tag = 0;
+ 	if (WinPrAsn1DecReadContextualTag(dec, &tag, &asnTicket) == 0)
+ 		return FALSE;
+@@ -884,11 +884,11 @@ static BOOL kerberos_rd_tgt_token(const sspi_gss_data* token, char** target, krb
+ 	if (target)
+ 		*target = NULL;
+ 
+-	WinPrAsn1Decoder der = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder der = WinPrAsn1Decoder_init();
+ 	WinPrAsn1Decoder_InitMem(&der, WINPR_ASN1_DER, (BYTE*)token->data, token->length);
+ 
+ 	/* KERB-TGT-REQUEST (SEQUENCE) */
+-	WinPrAsn1Decoder seq = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder seq = WinPrAsn1Decoder_init();
+ 	if (!WinPrAsn1DecReadSequence(&der, &seq))
+ 		return FALSE;
+ 
+diff --git a/winpr/libwinpr/sspi/Negotiate/negotiate.c b/winpr/libwinpr/sspi/Negotiate/negotiate.c
+index caaaea76c..0ecd0bd97 100644
+--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
++++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
+@@ -477,8 +477,8 @@ cleanup:
+ 
+ static BOOL negotiate_read_neg_token(PSecBuffer input, NegToken* token)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1_OID oid = { 0 };
+ 	WinPrAsn1_tagId contextual = 0;
+ 	WinPrAsn1_tag tag = 0;
+@@ -990,8 +990,8 @@ static SECURITY_STATUS SEC_ENTRY negotiate_InitializeSecurityContextA(
+ 
+ static const Mech* guessMech(PSecBuffer input_buffer, BOOL* spNego, WinPrAsn1_OID* oid)
+ {
+-	WinPrAsn1Decoder decoder = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder appDecoder = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder decoder = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder appDecoder = WinPrAsn1Decoder_init();
+ 	WinPrAsn1_tagId tag = 0;
+ 	const char ssp[] = "NTLMSSP";
+ 
+@@ -1039,8 +1039,8 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcceptSecurityContext(
+ 	SecBufferDesc mech_input = { SECBUFFER_VERSION, 1, &input_token.mechToken };
+ 	SecBufferDesc mech_output = { SECBUFFER_VERSION, 1, &output_token.mechToken };
+ 	SECURITY_STATUS status = SEC_E_INTERNAL_ERROR;
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1_tagId tag = 0;
+ 	WinPrAsn1_OID oid = { 0 };
+ 	const Mech* first_mech = NULL;
+diff --git a/winpr/libwinpr/sspi/sspi_gss.c b/winpr/libwinpr/sspi/sspi_gss.c
+index 9fc9340c2..6e4e8a46f 100644
+--- a/winpr/libwinpr/sspi/sspi_gss.c
++++ b/winpr/libwinpr/sspi/sspi_gss.c
+@@ -86,8 +86,8 @@ cleanup:
+ BOOL sspi_gss_unwrap_token(const SecBuffer* buf, WinPrAsn1_OID* oid, uint16_t* tok_id,
+                            sspi_gss_data* token)
+ {
+-	WinPrAsn1Decoder dec = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder dec2 = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder dec = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder dec2 = WinPrAsn1Decoder_init();
+ 	WinPrAsn1_tagId tag = 0;
+ 	wStream sbuffer = { 0 };
+ 	wStream* s = NULL;
+diff --git a/winpr/libwinpr/utils/asn1/asn1.c b/winpr/libwinpr/utils/asn1/asn1.c
+index e8b503d1b..2b0bbbfdb 100644
+--- a/winpr/libwinpr/utils/asn1/asn1.c
++++ b/winpr/libwinpr/utils/asn1/asn1.c
+@@ -1388,7 +1388,7 @@ size_t WinPrAsn1DecReadContextualBool(WinPrAsn1Decoder* dec, WinPrAsn1_tagId tag
+ {
+ 	size_t ret = 0;
+ 	size_t ret2 = 0;
+-	WinPrAsn1Decoder content = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder content = WinPrAsn1Decoder_init();
+ 
+ 	ret = readContextualHeader(dec, tagId, error, &content);
+ 	if (!ret)
+@@ -1410,7 +1410,7 @@ size_t WinPrAsn1DecReadContextualInteger(WinPrAsn1Decoder* dec, WinPrAsn1_tagId
+ {
+ 	size_t ret = 0;
+ 	size_t ret2 = 0;
+-	WinPrAsn1Decoder content = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder content = WinPrAsn1Decoder_init();
+ 
+ 	ret = readContextualHeader(dec, tagId, error, &content);
+ 	if (!ret)
+@@ -1432,7 +1432,7 @@ size_t WinPrAsn1DecReadContextualOID(WinPrAsn1Decoder* dec, WinPrAsn1_tagId tagI
+ {
+ 	size_t ret = 0;
+ 	size_t ret2 = 0;
+-	WinPrAsn1Decoder content = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder content = WinPrAsn1Decoder_init();
+ 
+ 	ret = readContextualHeader(dec, tagId, error, &content);
+ 	if (!ret)
+@@ -1455,7 +1455,7 @@ size_t WinPrAsn1DecReadContextualOctetString(WinPrAsn1Decoder* dec, WinPrAsn1_ta
+ {
+ 	size_t ret = 0;
+ 	size_t ret2 = 0;
+-	WinPrAsn1Decoder content = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder content = WinPrAsn1Decoder_init();
+ 
+ 	ret = readContextualHeader(dec, tagId, error, &content);
+ 	if (!ret)
+@@ -1477,7 +1477,7 @@ size_t WinPrAsn1DecReadContextualSequence(WinPrAsn1Decoder* dec, WinPrAsn1_tagId
+ {
+ 	size_t ret = 0;
+ 	size_t ret2 = 0;
+-	WinPrAsn1Decoder content = { .encoding = WINPR_ASN1_BER, { 0 } };
++	WinPrAsn1Decoder content = WinPrAsn1Decoder_init();
+ 
+ 	ret = readContextualHeader(dec, tagId, error, &content);
+ 	if (!ret)
+diff --git a/winpr/libwinpr/utils/test/TestASN1.c b/winpr/libwinpr/utils/test/TestASN1.c
+index 79d5b82b3..8a3aa9b3c 100644
+--- a/winpr/libwinpr/utils/test/TestASN1.c
++++ b/winpr/libwinpr/utils/test/TestASN1.c
+@@ -30,9 +30,9 @@ static const BYTE utctimeContent[] = { 0x17, 0x0D, 0x32, 0x31, 0x30, 0x33, 0x31,
+ 
+ int TestASN1Read(int argc, char* argv[])
+ {
+-	WinPrAsn1Decoder decoder = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	WinPrAsn1Decoder seqDecoder = { .encoding = WINPR_ASN1_BER, { 0 } };
+-	wStream staticS = { 0 };
++	WinPrAsn1Decoder decoder = WinPrAsn1Decoder_init();
++	WinPrAsn1Decoder seqDecoder = WinPrAsn1Decoder_init();
++        wStream staticS = { 0 };
+ 	WinPrAsn1_BOOL boolV = 0;
+ 	WinPrAsn1_INTEGER integerV = 0;
+ 	WinPrAsn1_OID oidV = { 0 };
+-- 
+2.52.0
+

--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,5 @@
 VER=3.23.0
+REL=1
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
 CHKSUMS="sha256::929273003f35b0b4f211e48d5abed4ebcef99da94784a50b6dc85cd0b7e257b1"
 CHKUPDATE="anitya::id=10442"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: fix connection aborts with drive redirection enabled
    Track patches at AOSC-Tracking/FreeRDP @ aosc/3.23.0
    \(HEAD: 5dddd4c0f051247f211d4ab5d82c4456a3b9e1ad\).
    Link: https://github.com/FreeRDP/FreeRDP/issues/12388
    Link: https://github.com/FreeRDP/FreeRDP/pull/12376 \(backported fix\)

Package(s) Affected
-------------------

- freerdp: 2:3.23.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
