### PR TITLE
grub: add installation quirk for Lenovo KaiTian HG4M-X7 Laptop

### DIFF
--- a/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-asus-xc-kx700m-d4.bash
+++ b/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-asus-xc-kx700m-d4.bash
@@ -1,1 +1,1 @@
-match_arch amd64 && regex_match_modalias "dmi:.*pnZXECRB:.*rnXC-KX700MD4:.*" && install_efi_extra_removable
+match_arch amd64 && regex_match_modalias "dmi:.*pnZXECRB:.*rnXC-KX700MD4:.*" && install_efi_extra_removable x86_64-efi

--- a/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-ho-z6000g.bash
+++ b/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-ho-z6000g.bash
@@ -1,1 +1,1 @@
-match_arch amd64 && regex_match_modalias "dmi:.*pnZGO31:.*rnZGO31:.*" && install_efi_extra_removable
+match_arch amd64 && regex_match_modalias "dmi:.*pnZGO31:.*rnZGO31:.*" && install_efi_extra_removable x86_64-efi

--- a/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-huawei-qingyun-w510.bash
+++ b/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-huawei-qingyun-w510.bash
@@ -1,1 +1,1 @@
-match_arch arm64 && regex_match_modalias "dmi:.*svnHUAWEI:.*pnHUAWEIPGU-WBY0:.*" && install_efi_extra_removable --bootloader-id="ubuntu"
+match_arch arm64 && regex_match_modalias "dmi:.*svnHUAWEI:.*pnHUAWEIPGU-WBY0:.*" && install_efi_extra_removable arm64-efi --bootloader-id="ubuntu"

--- a/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-lenovo-kaitian-hg4m-x7.bash
+++ b/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-lenovo-kaitian-hg4m-x7.bash
@@ -1,0 +1,1 @@
+match_arch amd64 && match_efi && regex_match_modalias "dmi:.*:svnKaiTian:pnX7hG1e:.*" && install_efi_removable x86_64-efi

--- a/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-unis-l3891-g2.bash
+++ b/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/10-unis-l3891-g2.bash
@@ -1,1 +1,1 @@
-match_arch amd64 && regex_match_modalias "dmi:.*pnUNISL3891G2x006:.*rnEM_KX819_V2.0_DC:.*" && install_efi_extra_removable
+match_arch amd64 && regex_match_modalias "dmi:.*pnUNISL3891G2x006:.*rnEM_KX819_V2.0_DC:.*" && install_efi_extra_removable x86_64-efi

--- a/app-admin/grub/autobuild/postinst
+++ b/app-admin/grub/autobuild/postinst
@@ -231,11 +231,15 @@ install_efi() {
 }
 
 install_efi_removable() {
-	install_efi "$1" --removable
+	local efitgt="$1"
+	shift
+	install_efi "$efitgt" --removable "$@"
 }
 
 install_efi_extra_removable() {
-	install_efi "$1" --force-extra-removable
+	local efitgt="$1"
+	shift
+	install_efi "$efitgt" --force-extra-removable "$@"
 }
 
 # Run grub-install for PCs with BIOS.
@@ -252,7 +256,7 @@ install_pc() {
 # Run grub-install for OpenFirmware compatible PPC machines.
 install_ppc_ieee1275() {
 	echo $"-- Installing GRUB for powerpc-ieee1275 ..."
-	grub-install --target=powerpc-ieee1275
+	grub-install --target=powerpc-ieee1275 "$@"
 }
 
 

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=17.0.02
 RETROFONTVER=20200402
 
 VER=${GRUBVER}+unifont${__UNIFONTVER}
-REL=3
+REL=4
 SRCS="git::commit=tags/grub-${__UPSTREAM_VER};rename=grub-${__UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::rename=grub-fonts-$RETROFONTVER.tar.xz::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: add removable quirk for Lenovo KaiTian HG4M-X7 laptop
- grub: support additional grub-install arguments in quirk shortcuts
- grub: explicitly specify target when handling quriks

Package(s) Affected
-------------------

- grub: 2:2.14+unifont17.0.02-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
