### PR TITLE
coturn: update to 4.9.0

### DIFF
--- a/app-network/coturn/autobuild/beyond
+++ b/app-network/coturn/autobuild/beyond
@@ -5,3 +5,7 @@ mv -v "$PKGDIR"/usr/share/examples "$PKGDIR"/usr/share/doc/turnserver/examples
 
 abinfo "Setting executable bits for all binary executables ..."
 chmod -v +x "$PKGDIR"/usr/bin/*
+
+abinfo "Correcting symlinks ..."
+rm -v "$PKGDIR"/usr/bin/turnadmin
+ln -sv turnserver "$PKGDIR"/usr/bin/turnadmin

--- a/app-network/coturn/spec
+++ b/app-network/coturn/spec
@@ -1,4 +1,4 @@
-VER=4.7.0
+VER=4.9.0
 SRCS="git::commit=tags/$VER::https://github.com/coturn/coturn.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=105341"

--- a/topics/coturn-4.9.0.toml
+++ b/topics/coturn-4.9.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Coturn 4.9.0"
+
+[caution]
+default = "Fixes a vulnerability that can bypass `denied-peer-ip` and loopback restrictions with IPv4-mapped IPv6 - CVE-2026-27624 (Severity: High)"
+zh_CN = "修复一处可以通过 IPv4 映射 IPv6 绕过 `denied-peer-ip` 和本地回环限制的漏洞，漏洞编号 CVE-2026-27624（严重性：高）"
+
+[packages-v2]
+"coturn" = "< 4.9.0"


### PR DESCRIPTION
Topic Description
-----------------

- coturn: update to 4.9.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- coturn: 4.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit coturn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
