### PR TITLE
abseil-cpp: update to 20260107.1

### DIFF
--- a/app-network/grpc/spec
+++ b/app-network/grpc/spec
@@ -1,5 +1,4 @@
-VER=1.72.0
-REL="3"
+VER=1.78.1
 SRCS="git::commit=tags/v$VER::https://github.com/grpc/grpc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19117"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,5 +1,5 @@
 VER=6.3.6
-REL=3
+REL=4
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=d888bc3f79b4aa80333d8903410fa439db5f6696
 TDLIBVER=889bdf06029f98f3d04cac874dafab6f4f847c47

--- a/runtime-common/abseil-cpp/spec
+++ b/runtime-common/abseil-cpp/spec
@@ -1,4 +1,4 @@
-VER=20240722.0
+VER=20260107.1
 SRCS="git::commit=tags/$VER::https://github.com/abseil/abseil-cpp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=115295"

--- a/runtime-common/protobuf-c/spec
+++ b/runtime-common/protobuf-c/spec
@@ -1,4 +1,5 @@
 VER=1.5.2
+REL=1
 SRCS="https://github.com/protobuf-c/protobuf-c/releases/download/v$VER/protobuf-c-$VER.tar.gz"
 CHKSUMS="sha256::e2c86271873a79c92b58fef7ebf8de1aa0df4738347a8bd5d4e65a80a16d0d24"
 CHKUPDATE="anitya::id=3716"

--- a/runtime-common/protobuf/spec
+++ b/runtime-common/protobuf/spec
@@ -1,6 +1,5 @@
-VER=32.0
+VER=34.1
 EPOCH=1
-REL="2"
 SRCS="git::commit=tags/v$VER::https://github.com/protocolbuffers/protobuf.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3715"

--- a/runtime-common/re2/spec
+++ b/runtime-common/re2/spec
@@ -1,5 +1,6 @@
 UPSTREAM_VER=2025-11-05
 VER=${UPSTREAM_VER//-/}
+REL=1
 SRCS="tbl::https://github.com/google/re2/releases/download/$UPSTREAM_VER/re2-$UPSTREAM_VER.tar.gz"
 CHKSUMS="sha256::87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67"
 CHKUPDATE="anitya::id=10500"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: bump REL for abseil-cpp update
- re2: bump REL for abseil-cpp update
- grpc: update to 1.78.1
- protobuf-c: bump REL for abseil-cpp update
- protobuf: update to 34.1
- abseil-cpp: update to 20260107.1

Package(s) Affected
-------------------

- abseil-cpp: 20260107.1
- protobuf: 34.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit abseil-cpp protobuf  protobuf-c   re2  grpc  telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
