### PR TITLE
Configuration/Runtime Data Survey (March, 2026)

### DIFF
--- a/app-network/wireless-regdb/spec
+++ b/app-network/wireless-regdb/spec
@@ -1,4 +1,4 @@
-VER=2025.10.07
+VER=2026.02.04
 SRCS="tbl::https://www.kernel.org/pub/software/network/wireless-regdb/wireless-regdb-$VER.tar.xz"
-CHKSUMS="sha256::d4c872a44154604c869f5851f7d21d818d492835d370af7f58de8847973801c3"
+CHKSUMS="sha256::0ff48a5cd9e9cfe8e815a24e023734919e9a3b7ad2f039243ad121cf5aabf6c6"
 CHKUPDATE="anitya::id=15257"

--- a/runtime-data/hwdata/spec
+++ b/runtime-data/hwdata/spec
@@ -1,4 +1,4 @@
-VER=0.403
+VER=0.405
 SRCS="git::commit=tags/v$VER::https://github.com/vcrhonek/hwdata"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=13577"
+CHKUPDATE="anitya::id=5387"

--- a/runtime-data/iana-etc/spec
+++ b/runtime-data/iana-etc/spec
@@ -1,4 +1,4 @@
-VER=20251122
+VER=20260310
 SRCS="git::commit=tags/iana-etc-${VER}::https://github.com/AOSC-Dev/misc-files.git"
 CHKSUMS="SKIP"
-CHKUPDATE="anitya:id=383652"
+CHKUPDATE="anitya::id=383652"

--- a/runtime-data/unicode-ucd/spec
+++ b/runtime-data/unicode-ucd/spec
@@ -1,14 +1,14 @@
-VER=17.0.0
+VER=18.0.0
 SRCS="file::rename=UCD.zip::https://www.unicode.org/Public/$VER/ucd/UCD.zip \
       file::rename=Unihan.zip::https://www.unicode.org/Public/$VER/ucd/Unihan.zip \
       file::rename=ReadMe.txt::https://www.unicode.org/Public/$VER/ucd/ReadMe.txt \
       file::rename=emoji-sequences.txt::https://www.unicode.org/Public/$VER/emoji/emoji-sequences.txt \
       file::rename=emoji-tests.txt::https://www.unicode.org/Public/$VER/emoji/emoji-test.txt \
       file::rename=emoji-zwj-sequences.txt::https://www.unicode.org/Public/$VER/emoji/emoji-zwj-sequences.txt"
-CHKSUMS="sha256::2066d1909b2ea93916ce092da1c0ee4808ea3ef8407c94b4f14f5b7eb263d28e \
-         sha256::f7a48b2b545acfaa77b2d607ae28747404ce02baefee16396c5d2d7a8ef34b5e \
-         sha256::9fe1a90bd32659d7953616283dc2bffaa165518aae9ace026040c42c559ba606 \
-         sha256::12cc8267dc33cbd11ed32bcf6fc5dc2ad9c7a77bae1bdfba2f41b1b9b3ead8dd \
-         sha256::1d8a944f88d7952f7ef7c5167fef3c67995bcae24543949710231b03a201acda \
-         sha256::5b25441daed2322b068c5e70cda522946a4f0274df864445a1965a92e5fc5cad"
+CHKSUMS="sha256::c961d4405edd144b5052cfaf8bf7db54af44ebc5db7181f83c6c52df99e9363a \
+         sha256::835593ec1ca206486cdef6860a41930343ac014d7d61f7f7ef2b25084fadbdd4 \
+         sha256::95843c0254c4c580a3ff6752a31d459d08bcad2899ffa225268774d4c0fc14d1 \
+         sha256::e9820c591cff8781f5d617ac90d36ad7db88c5f4a885986c7ddfdfa2a96f83f4 \
+         sha256::b9b098068ecd7278d956dd0c6af554e87793dc086d850993e1711f5da8815cc4 \
+         sha256::f61b5213bdf85a57741a9f903cb38d0f39a3d13be6ff4aca3b39857e859a9191"
 CHKUPDATE="anitya::id=5045"


### PR DESCRIPTION
Topic Description
-----------------

- hwdata: update to 0.405
- unicode-ucd: update to 18.0.0
- iana-etc: update to 20260310
- wireless-regdb: update to 2026.02.04

Package(s) Affected
-------------------

- hwdata: 0.405
- iana-etc: 20260310
- unicode-ucd: 18.0.0
- wireless-regdb: 2026.02.04

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireless-regdb iana-etc unicode-ucd hwdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
