### PR TITLE
xfsprogs: update to 6.18.0

### DIFF
--- a/app-admin/xfsprogs/spec
+++ b/app-admin/xfsprogs/spec
@@ -1,4 +1,4 @@
-VER=6.17.0
+VER=6.18.0
 SRCS="https://www.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-$VER.tar.xz"
-CHKSUMS="sha256::5b0f56a81f641326266f762ae8a563b29d95cdbcda83bc7938f68ce122f1edd9"
+CHKSUMS="sha256::3a6dc7b1245ce9bccd197bab00691f1b190bd3694d3ccc301d21b83afc133199"
 CHKUPDATE="anitya::id=5188"


### PR DESCRIPTION
Topic Description
-----------------

- xfsprogs: update to 6.18.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- xfsprogs: 6.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
