### PR TITLE
e2fsprogs: update to 1.47.4

### DIFF
--- a/app-admin/e2fsprogs/spec
+++ b/app-admin/e2fsprogs/spec
@@ -1,5 +1,4 @@
-VER=1.47.2
-REL=2
+VER=1.47.4
 SRCS="git::commit=tags/v${VER}::https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=646"


### PR DESCRIPTION
Topic Description
-----------------

- e2fsprogs: update to 1.47.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- e2fsprogs: 1.47.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit e2fsprogs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
