### PR TITLE
inetutils: backport a fix for CVE-2026-28372

### DIFF
--- a/app-utils/inetutils/autobuild/patches/0001-UPSTREAM-Fix-injection-bug-with-bogus-user-names.patch
+++ b/app-utils/inetutils/autobuild/patches/0001-UPSTREAM-Fix-injection-bug-with-bogus-user-names.patch
@@ -1,7 +1,7 @@
 From 8e72515a42703bad59438ba1b16afb3e92007d06 Mon Sep 17 00:00:00 2001
 From: Paul Eggert <eggert@cs.ucla.edu>
 Date: Tue, 20 Jan 2026 01:10:36 -0800
-Subject: [PATCH 1/7] UPSTREAM: Fix injection bug with bogus user names
+Subject: [PATCH 1/8] UPSTREAM: Fix injection bug with bogus user names
 
 Problem reported by Kyu Neushwaistein.
 * telnetd/utility.c (_var_short_name):

--- a/app-utils/inetutils/autobuild/patches/0002-UPSTREAM-telnetd-Sanitize-all-variable-expansions.patch
+++ b/app-utils/inetutils/autobuild/patches/0002-UPSTREAM-telnetd-Sanitize-all-variable-expansions.patch
@@ -1,7 +1,7 @@
 From f21604f97030656c19937e238962696a335d8070 Mon Sep 17 00:00:00 2001
 From: Simon Josefsson <simon@josefsson.org>
 Date: Tue, 20 Jan 2026 14:02:39 +0100
-Subject: [PATCH 2/7] UPSTREAM: telnetd: Sanitize all variable expansions
+Subject: [PATCH 2/8] UPSTREAM: telnetd: Sanitize all variable expansions
 
 * telnetd/utility.c (sanitize): New function.
 (_var_short_name): Use it for all variables.

--- a/app-utils/inetutils/autobuild/patches/0003-FROMLIST-telnet-telnetd-fix-build-with-GCC-14.patch
+++ b/app-utils/inetutils/autobuild/patches/0003-FROMLIST-telnet-telnetd-fix-build-with-GCC-14.patch
@@ -1,7 +1,7 @@
 From dd7be9916436b7f9b4247a5ca8ee2d8e6c002146 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 10 Feb 2025 18:04:09 +0800
-Subject: [PATCH 3/7] FROMLIST: telnet: telnetd: fix build with GCC >= 14
+Subject: [PATCH 3/8] FROMLIST: telnet: telnetd: fix build with GCC >= 14
 
 Link: https://savannah.gnu.org/bugs/?65263
 Signed-off-by: Jeffrey Cliff <themusicgod1>

--- a/app-utils/inetutils/autobuild/patches/0004-DEBIAN-build-Disable-GFDL-info-files-and-useless-man.patch
+++ b/app-utils/inetutils/autobuild/patches/0004-DEBIAN-build-Disable-GFDL-info-files-and-useless-man.patch
@@ -1,7 +1,7 @@
 From 7b2431d57b373e0c9bad4d5a670753abb7418675 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 9 Jun 2010 03:56:08 +0200
-Subject: [PATCH 4/7] DEBIAN: build: Disable GFDL info files and useless man
+Subject: [PATCH 4/8] DEBIAN: build: Disable GFDL info files and useless man
  pages
 
 We do not install the info file due to GFDL, and because it would

--- a/app-utils/inetutils/autobuild/patches/0005-DEBIAN-build-Use-runstatedir-for-run-directory.patch
+++ b/app-utils/inetutils/autobuild/patches/0005-DEBIAN-build-Use-runstatedir-for-run-directory.patch
@@ -1,7 +1,7 @@
 From 32dbd2bc3c98f0c150a422b5e822a358fb7d52a7 Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Sun, 5 Sep 2021 05:00:23 +0200
-Subject: [PATCH 5/7] DEBIAN: build: Use runstatedir for /run directory
+Subject: [PATCH 5/8] DEBIAN: build: Use runstatedir for /run directory
 
 ---
  paths | 10 +++++-----

--- a/app-utils/inetutils/autobuild/patches/0006-DEBIAN-inetd-Change-protocol-semantics-in-inetd.conf.patch
+++ b/app-utils/inetutils/autobuild/patches/0006-DEBIAN-inetd-Change-protocol-semantics-in-inetd.conf.patch
@@ -1,7 +1,7 @@
 From f76eede2c12c4d5e2e0a3c4b9870114a2ca7c7aa Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Mon, 6 Sep 2010 10:52:27 +0200
-Subject: [PATCH 6/7] DEBIAN: inetd: Change protocol semantics in inetd.conf
+Subject: [PATCH 6/8] DEBIAN: inetd: Change protocol semantics in inetd.conf
 
 Readd parts of the original patch that got botched when applied
 upstream.

--- a/app-utils/inetutils/autobuild/patches/0007-DEBIAN-Use-krb5_auth_con_getsendsubkey-instead-of-kr.patch
+++ b/app-utils/inetutils/autobuild/patches/0007-DEBIAN-Use-krb5_auth_con_getsendsubkey-instead-of-kr.patch
@@ -1,7 +1,7 @@
 From d92a614f8e5b5e18675b09e5991529f2d0b5b9cf Mon Sep 17 00:00:00 2001
 From: Guillem Jover <guillem@hadrons.org>
 Date: Wed, 10 Aug 2022 01:57:24 +0200
-Subject: [PATCH 7/7] DEBIAN: Use krb5_auth_con_getsendsubkey() instead of
+Subject: [PATCH 7/8] DEBIAN: Use krb5_auth_con_getsendsubkey() instead of
  krb5_auth_con_getlocalsubkey()
 
 The latter is not exposed in the headers anymore.

--- a/app-utils/inetutils/autobuild/patches/0008-BACKPORT-UPSTREAM-telnetd-don-t-allow-systemd-servic.patch
+++ b/app-utils/inetutils/autobuild/patches/0008-BACKPORT-UPSTREAM-telnetd-don-t-allow-systemd-servic.patch
@@ -1,0 +1,61 @@
+From d997d020549026a3312ece19f51c510f787cf639 Mon Sep 17 00:00:00 2001
+From: Erik Auerswald <auerswal@unix-ag.uni-kl.de>
+Date: Sun, 15 Feb 2026 15:38:50 +0100
+Subject: [PATCH 8/8] BACKPORT: UPSTREAM: telnetd: don't allow systemd service
+ credentials
+
+The login(1) implementation of util-linux added support for
+systemd service credentials in release 2.40.  This allows to
+bypass authentication by specifying a directory name in the
+environment variable CREDENTIALS_DIRECTORY.  If this directory
+contains a file named 'login.noauth' with the content of 'yes',
+login(1) skips authentication.
+
+GNU Inetutils telnetd supports to set arbitrary environment
+variables using the 'Environment' and 'New Environment'
+Telnet options.  This allows specifying a directory containing
+'login.noauth'.  A local user can create such a directory
+and file, and, e.g., specify the user name 'root' to escalate
+privileges.
+
+This problem was reported by Ron Ben Yizhak in
+<https://lists.gnu.org/archive/html/bug-inetutils/2026-02/msg00000.html>.
+
+This commit clears CREDENTIALS_DIRECTORY from the environment
+before executing login(1) to implement a simple fix that can
+be backported easily.
+
+* NEWS.md: Mention fix.
+* THANKS: Mention Ron Ben Yizhak.
+* telnetd/pty.c: Clear CREDENTIALS_DIRECTORY from the environment
+before executing 'login'.
+
+[Mingcong Bai: Drop changes in NEWS.md and THANKS]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ telnetd/pty.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/telnetd/pty.c b/telnetd/pty.c
+index 4d41e7c2..db1e8902 100644
+--- a/telnetd/pty.c
++++ b/telnetd/pty.c
+@@ -129,6 +129,14 @@ start_login (char *host, int autologin, char *name)
+   if (!cmd)
+     fatal (net, "can't expand login command line");
+   argcv_get (cmd, "", &argc, &argv);
++
++  /* util-linux's "login" introduced an authentication bypass method
++   * via environment variable "CREDENTIALS_DIRECTORY" in version 2.40.
++   * Clear it from the environment before executing "login" to prevent
++   * abuse via Telnet.
++   */
++  unsetenv ("CREDENTIALS_DIRECTORY");
++
+   execv (argv[0], argv);
+   syslog (LOG_ERR, "%s: %m\n", cmd);
+   fatalperror (net, cmd);
+-- 
+2.52.0
+

--- a/app-utils/inetutils/spec
+++ b/app-utils/inetutils/spec
@@ -1,4 +1,5 @@
 VER=2.7
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/inetutils/inetutils-$VER.tar.gz"
 CHKSUMS="sha256::a156be1cde3c5c0ffefc262180d9369a60484087907aa554c62787d2f40ec086"
 CHKUPDATE="anitya::id=13805"

--- a/topics/inetutils-2.7-cve-2026-28372.toml
+++ b/topics/inetutils-2.7-cve-2026-28372.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "GNU InetUtils 2.7-1"
+
+[caution]
+default = "Fixes a Remote Authentication Bypass vulnerability in telnetd - CVE-2026-28372 (Severity: High)"
+zh_CN = "修复一处远程鉴权绕过 (Remote Authentication Bypass) 漏洞，漏洞编号 CVE-2026-28372（严重性：高）"
+
+[packages-v2]
+"inetutils" = "< 2.7-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add inetutils-2.7-cve-2026-28372.toml
- inetutils: backport a fix for CVE-2026-28372
    Track patches at AOSC-Tracking/inetutils @ aosc/v2.7
    \(HEAD: d997d020549026a3312ece19f51c510f787cf639\).

Package(s) Affected
-------------------

- inetutils: 2.7-1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit inetutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
