### PR TITLE
tzdata: use fat TZif format for time transitions

### DIFF
--- a/runtime-data/tzdata/autobuild/build
+++ b/runtime-data/tzdata/autobuild/build
@@ -5,14 +5,14 @@ mkdir -pv "$ZONEINFO"/{posix,right}
 for tz in etcetera southamerica northamerica europe africa antarctica  \
           asia australasia backward; do
     abinfo "Building and installing timezone $tz ..."
-    zic -L /dev/null   -d "$ZONEINFO"       "$SRCDIR/$tz"
-    zic -L /dev/null   -d "$ZONEINFO"/posix "$SRCDIR/$tz"
-    zic -L leapseconds -d "$ZONEINFO"/right "$SRCDIR/$tz"
+    zic -b fat -L /dev/null -d "$ZONEINFO" "$SRCDIR/$tz"
+    zic -b fat -L /dev/null -d "$ZONEINFO"/posix "$SRCDIR/$tz"
+    zic -b fat -L leapseconds -d "$ZONEINFO"/right "$SRCDIR/$tz"
 done
 
 abinfo "Installing extra zoneinfo files ..."
 cp -v "$SRCDIR"/{zone.tab,zone1970.tab,iso3166.tab} \
     "$ZONEINFO"
-zic -d "$ZONEINFO" -p America/New_York
+zic -b fat -d "$ZONEINFO" -p America/New_York
 
 unset ZONEINFO

--- a/runtime-data/tzdata/spec
+++ b/runtime-data/tzdata/spec
@@ -1,4 +1,5 @@
 VER=2026a
+REL=1
 SRCS="https://data.iana.org/time-zones/releases/tzdata$VER.tar.gz"
 CHKSUMS="sha256::77b541725937bb53bd92bd484c0b43bec8545e2d3431ee01f04ef8f2203ba2b7"
 CHKUPDATE="anitya::id=5021"


### PR DESCRIPTION
Topic Description
-----------------

- tzdata: use fat TZif format for time transitions
    Since 2024a, zic\(8\) generates "slim" TZif data. This seems to have caused
    an issue where transition data were not generated after 2007, whereas
    "fat" TZif data would generate them up to 2037 - causing issue with the
    following test program:
    #define _GNU_SOURCE
    #include <stdio.h>
    #include <stdlib.h>
    #include <string.h>
    #include <time.h>
    int
    main\(void\)
    {
    setenv\("TZ", "IST-2IDT", 1\);
    tzset\(\);
    struct tm tm;
    memset\(&tm, 0, sizeof\(tm\)\);
    tm.tm_sec  = 0;
    tm.tm_min  = 0;
    tm.tm_hour  = 12;
    tm.tm_mday  = 15;
    tm.tm_mon  = 0;
    tm.tm_year  = 123;
    tm.tm_isdst  = -1;
    time_t epoch = mktime\(&tm\);
    printf\("Offset from UTC time in minutes: %ld\\n", tm.tm_gmtoff / 60\);
    printf\("Timezone name: %s\\n", tm.tm_zone\);
    memset\(&tm, 0, sizeof\(tm\)\);
    localtime_r\(&epoch, &tm\);
    printf\("Offset from UTC time in minutes: %ld\\n", tm.tm_gmtoff / 60\);
    printf\("Timezone name: %s\\n", tm.tm_zone\);
    memset\(&tm, 0, sizeof\(tm\)\);
    tm = \*localtime\(&epoch\);
    printf\("Offset from UTC time in minutes: %ld\\n", tm.tm_gmtoff / 60\);
    printf\("Timezone name: %s\\n", tm.tm_zone\);
    return 0;
    }
    Where it generates unexpected output, to quote:
    On a system where /usr/share/zoneinfo/posixrules is present and identical to EST5EDT provided by tzcode, the attached test program results in weird output,
    Offset from UTC time in minutes: -300
    Timezone name: EST
    Offset from UTC time in minutes: -300
    Timezone name: EST
    Offset from UTC time in minutes: -300
    Timezone name: EST
    while TZ is setting to "IST-2IDT". With posixrules file removed, the same program gives out expected output,
    Offset from UTC time in minutes: 120
    Timezone name: IST
    Offset from UTC time in minutes: 120
    Timezone name: IST
    Offset from UTC time in minutes: 120
    Timezone name: IST
    Generate "fat" TZif for better compatibility.
    Link: https://sourceware.org/bugzilla/show_bug.cgi?id=33971
    Suggested-by: Yao Zi <ziyao@disroot.org>

Package(s) Affected
-------------------

- tzdata: 2026a-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tzdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
