### PR TITLE
ppsspp: copy Git metadata to fix version display

### DIFF
--- a/app-games/ppsspp/spec
+++ b/app-games/ppsspp/spec
@@ -1,4 +1,5 @@
 VER=1.20.1
-SRCS="git::commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
+REL=1
+SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12295"


### PR DESCRIPTION
Topic Description
-----------------

- ppsspp: copy Git metadata to fix version display

Package(s) Affected
-------------------

- ppsspp: 1.20.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppsspp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
