### PR TITLE
onedrive: update to 2.5.10

### DIFF
--- a/app-web/onedrive/spec
+++ b/app-web/onedrive/spec
@@ -1,5 +1,4 @@
-VER=2.5.5
-REL=1
+VER=2.5.10
 SRCS="git::commit=tags/v$VER::https://github.com/abraunegg/onedrive"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16974"


### PR DESCRIPTION
Topic Description
-----------------

- onedrive: update to 2.5.10
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- onedrive: 2.5.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit onedrive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
