### PR TITLE
pipewire: update to 1.6.1

### DIFF
--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,4 +1,4 @@
-VER=1.6.0
+VER=1.6.1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: update to 1.6.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pipewire: 1.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
