### PR TITLE
unixbench: disable lto to prevent dhry Run_Index from being optimized away

### DIFF
--- a/app-benchmarks/unixbench/autobuild/build
+++ b/app-benchmarks/unixbench/autobuild/build
@@ -1,4 +1,4 @@
-make -C UnixBench/ OPTON="${CPPFLAGS} ${CFLAGS} -std=gnu17 ${LDFLAGS}"
+make -C UnixBench/ OPTON="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
 
 mkdir -p "$PKGDIR"/usr/{bin,lib/unixbench}
 cp -av "$SRCDIR"/UnixBench/{pgms,results,testdir,tmp,Run} "$PKGDIR"/usr/lib/unixbench

--- a/app-benchmarks/unixbench/autobuild/defines
+++ b/app-benchmarks/unixbench/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=unixbench
 PKGSEC=utils
 PKGDEP="perl"
 PKGDES="Open-Source Unix Benchmarking"
+
+NOLTO=1

--- a/app-benchmarks/unixbench/spec
+++ b/app-benchmarks/unixbench/spec
@@ -1,5 +1,5 @@
 VER=6.0.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/kdlucas/byte-unixbench/archive/v$VER.tar.gz"
 CHKSUMS="sha256::c151d28b6f4f3f40faad19e877c1ab06fbd4b3da006ccfa26b36200c741fc3ba"
 CHKUPDATE="anitya::id=226943"


### PR DESCRIPTION
Topic Description
-----------------

- unixbench: disable lto to prevent dhry Run_Index from being optimized away
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- unixbench: 6.0.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit unixbench
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
