### PR TITLE
vice: update to 3.10

### DIFF
--- a/app-emulation/vice/spec
+++ b/app-emulation/vice/spec
@@ -1,5 +1,4 @@
-VER=3.9
-REL=1
+VER=3.10
 SRCS="tbl::https://downloads.sourceforge.net/project/vice-emu/releases/vice-$VER.tar.gz"
-CHKSUMS="sha256::40202b63455e26b87ecc63eb5a52322c6fa3f57cab12acf0c227cf9f4daec370"
+CHKSUMS="sha256::8e5bac18cbcb9f192380ad3ef881f8790f5b75c41d7b3da65d831985d864d6d1"
 CHKUPDATE="anitya::id=16029"


### PR DESCRIPTION
Topic Description
-----------------

- vice: update to 3.10
    Co-authored-by: Henry Chen \(@chenx97\)

Package(s) Affected
-------------------

- vice: 3.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit vice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
