### PR TITLE
depthcharge-tools: add two unmerged upstream PRs for Py3.14 compat

### DIFF
--- a/app-admin/depthcharge-tools/autobuild/patches/0001-FROMLIST-Port-away-from-pkg_resources.patch
+++ b/app-admin/depthcharge-tools/autobuild/patches/0001-FROMLIST-Port-away-from-pkg_resources.patch
@@ -1,0 +1,130 @@
+From f55ce8ed7869f2dfebe7a70d1204cddb2fef9748 Mon Sep 17 00:00:00 2001
+From: Colin Watson <cjwatson@debian.org>
+Date: Thu, 29 Jan 2026 14:55:35 +0000
+Subject: [PATCH 1/2] Port away from pkg_resources
+
+This requires Python >= 3.9, but that's older than the oldest version
+still in support.
+---
+ README.rst                    |  3 +--
+ depthcharge_tools/__init__.py | 50 ++++++++++++++++++++---------------
+ setup.py                      |  3 ++-
+ 3 files changed, 31 insertions(+), 25 deletions(-)
+
+diff --git a/README.rst b/README.rst
+index 3df6785..51972fb 100644
+--- a/README.rst
++++ b/README.rst
+@@ -73,8 +73,7 @@ the work::
+ 
+ Installation
+ ============
+-This depends on the ``pkg_resources`` Python package which is usually
+-distributed with ``setuptools``. The tools can run a number of programs
++The tools can run a number of programs
+ when necessary, which should be considered dependencies:
+ 
+ - ``futility`` (``vbutil_kernel``), ``cgpt``, ``crossystem``
+diff --git a/depthcharge_tools/__init__.py b/depthcharge_tools/__init__.py
+index 960da0a..1a809cd 100644
+--- a/depthcharge_tools/__init__.py
++++ b/depthcharge_tools/__init__.py
+@@ -8,9 +8,11 @@
+ import glob
+ import logging
+ import pathlib
+-import pkg_resources
+ import re
+ import subprocess
++from importlib import metadata, resources
++
++from packaging.version import InvalidVersion, Version
+ 
+ logger = logging.getLogger(__name__)
+ logger.addHandler(logging.NullHandler())
+@@ -18,22 +20,24 @@ logger.addHandler(logging.NullHandler())
+ 
+ def get_version():
+     version = None
+-    pkg_path = pkg_resources.resource_filename(__name__, '')
+-    pkg_path = pathlib.Path(pkg_path).resolve()
++    pkg_path = resources.files(__name__)
+ 
+     try:
+-        self = pkg_resources.require(__name__)[0]
+-        version = self.version
+-
+-    except pkg_resources.DistributionNotFound:
+-        setup_py = pkg_path.parent / "setup.py"
+-        if setup_py.exists():
+-            version = re.findall(
+-                'version=(\'.+\'|".+"),',
+-                setup_py.read_text(),
+-            )[0].strip('"\'')
+-
+-    if (pkg_path.parent / ".git").exists():
++        version = metadata.version(__name__)
++
++    except metadata.PackageNotFoundError:
++        if isinstance(pkg_path, pathlib.Path):
++            setup_py = pkg_path.parent / "setup.py"
++            if setup_py.exists():
++                version = re.findall(
++                    'version=(\'.+\'|".+"),',
++                    setup_py.read_text(),
++                )[0].strip('"\'')
++
++    if (
++        isinstance(pkg_path, pathlib.Path)
++        and (pkg_path.parent / ".git").exists()
++    ):
+         proc = subprocess.run(
+             ["git", "-C", pkg_path, "describe"],
+             stdout=subprocess.PIPE,
+@@ -44,20 +48,22 @@ def get_version():
+             tag, *local = proc.stdout.split("-")
+ 
+             if local:
+-                version = "{}+{}".format(tag, ".".join(local))
++                git_version = "{}+{}".format(tag, ".".join(local))
+             else:
+-                version = tag
++                git_version = tag
++            try:
++                return Version(git_version)
++            except InvalidVersion:
++                pass
+ 
+     if version is not None:
+-        return pkg_resources.parse_version(version)
++        return Version(version)
+ 
+ __version__ = get_version()
+ 
+-config_ini = pkg_resources.resource_string(__name__, "config.ini")
+-config_ini = config_ini.decode("utf-8")
++config_ini = resources.files(__name__).joinpath("config.ini").read_text()
+ 
+-boards_ini = pkg_resources.resource_string(__name__, "boards.ini")
+-boards_ini = boards_ini.decode("utf-8")
++boards_ini = resources.files(__name__).joinpath("boards.ini").read_text()
+ 
+ config_files = [
+     *glob.glob("/etc/depthcharge-tools/config"),
+diff --git a/setup.py b/setup.py
+index 1be4589..a27ea59 100644
+--- a/setup.py
++++ b/setup.py
+@@ -43,7 +43,8 @@ setuptools.setup(
+     package_data={
+         "depthcharge_tools": ["config.ini", "boards.ini"],
+     },
++    python_requires=">=3.9",
+     install_requires=[
+-        'setuptools',
++        'packaging',
+     ],
+ )
+-- 
+2.52.0
+

--- a/app-admin/depthcharge-tools/autobuild/patches/0002-FROMLIST-utils-argparse-suppress-some-arguments-from-Python-a.patch
+++ b/app-admin/depthcharge-tools/autobuild/patches/0002-FROMLIST-utils-argparse-suppress-some-arguments-from-Python-a.patch
@@ -1,0 +1,41 @@
+From 9c58e93c075ace7d4ef599d741984906f807bce2 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Wed, 11 Mar 2026 15:42:33 +0800
+Subject: [PATCH 2/2] utils: argparse: suppress some arguments from Python
+ argparse
+
+The diskinfo parameter is abusing the @Argument decorator, and the way
+optional positional arguments are implemented (nargs=0 positional) is
+weird. Both situations are rejected by Python 3.14 argparse, which will
+complain positional arguments shouldn't have nargs=0.
+
+Prevent these arguments from being passed to Python argparse, but run
+other code in the decorator.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ depthcharge_tools/utils/argparse.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/depthcharge_tools/utils/argparse.py b/depthcharge_tools/utils/argparse.py
+index 078c9ea..29002cd 100644
+--- a/depthcharge_tools/utils/argparse.py
++++ b/depthcharge_tools/utils/argparse.py
+@@ -436,6 +436,14 @@ class Argument(_MethodDecorator):
+         option_strings = self._args
+         kwargs = self.__kwargs
+ 
++        if kwargs["dest"] == argparse.SUPPRESS and kwargs["help"] == argparse.SUPPRESS:
++            # Hack to suppress diskinfo being passed to Python argparse
++            return
++
++        if "nargs" in kwargs and kwargs["nargs"] == 0 and not option_strings:
++            # Hack to suppress optional positional arguments being passed to Python argparse
++            return
++
+         return parent.add_argument(*option_strings, **kwargs)
+ 
+     def __property_from_kwargs(name):
+-- 
+2.52.0
+

--- a/app-admin/depthcharge-tools/spec
+++ b/app-admin/depthcharge-tools/spec
@@ -1,4 +1,5 @@
 VER=0.6.2
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/alpernebbi/depthcharge-tools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198825"


### PR DESCRIPTION
Topic Description
-----------------

- depthcharge-tools: add two unmerged upstream PRs for Py3.14 compat
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- depthcharge-tools: 0.6.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit depthcharge-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
