### PR TITLE
systemd: improve triggers handling

### DIFF
--- a/app-admin/systemd/autobuild/postinst
+++ b/app-admin/systemd/autobuild/postinst
@@ -5,6 +5,19 @@ _systemctl() {
 	fi
 }
 
+_update_binfmt() {
+    if [ "$(_systemctl show -P LoadState systemd-binfmt.service)" != "masked" ]; then
+        #Note: try-restart doesn't restart inactive services
+        echo "Reloading binfmt ..."
+        _systemctl restart systemd-binfmt.service || true
+    fi
+}
+
+_reload_daemon() {
+    echo "Reloading systemd manager configuration ..."
+    _systemctl --system daemon-reload || true
+}
+
 # Add `|| true' just to be safe, but this shouldn't be needed unless
 # the package upgrade sequence is messed up (i.e., whilst updating
 # OpenSSL, breaking systemd programs).
@@ -43,5 +56,17 @@ getent passwd systemd-nobody > /dev/null || \
 	useradd -u 65534 -g systemd-nogroup -d /dev/null -s /bin/false \
 		-c 'Unprivileged User (systemd)' systemd-nobody > /dev/null
 
-echo "Reloading binfmt ..."
-_systemctl try-restart systemd-binfmt.service
+if [ "$1" = "triggered" ]; then
+    shift
+    for trigger in $@; do
+        case $trigger in
+            /etc/binfmt.d|/usr/lib/binfmt.d|systemd-binfmt)
+                _update_binfmt
+                ;;
+            /etc/systemd/system|/usr/lib/systemd/system|daemon-reload)
+                _reload_daemon
+                ;;
+        esac
+    done
+    exit 0
+fi

--- a/app-admin/systemd/autobuild/triggers
+++ b/app-admin/systemd/autobuild/triggers
@@ -1,3 +1,6 @@
 interest /etc/binfmt.d
 interest /usr/lib/binfmt.d
 interest systemd-binfmt
+interest /etc/systemd/system
+interest /usr/lib/systemd/system
+interest daemon-reload

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=259
 
 # Use this for stable/main branch releases.
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- systemd: improve triggers handling
    - Add check for "$1" = "triggered" to avoid running full postinst.
    - Use restart instead of try-restart when reloading binfmt,
    as try-restart doesn't restart inactive services.
    - Add a trigger to reload systemd manager configuration.

Package(s) Affected
-------------------

- systemd: 1:259-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
