### PR TITLE
.NET SDK 10.0.104

### DIFF
--- a/lang-dotnet/dotnet10/spec
+++ b/lang-dotnet/dotnet10/spec
@@ -1,3 +1,4 @@
-VER=10.0.103
+VER=10.0.104
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/dotnet/dotnet.git"
 CHKSUMS="SKIP"
+CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(10\.0\.1.+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- dotnet10: update to 10.0.104

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-sdk-10.0-source-built-artifacts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
