### PR TITLE
fcitx5-pinyin-moegirl: update to 20260310

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260209
+VER=20260310
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::669b80712e8a81544bf2bbbe53ffff662ee38972c621b4b1e9d3c5d0a58bbf04\
-         sha256::9b3bf1156fe5c2b027a014d0b1f0757277d4be7d03f7aeba8968140e9698adc2\
+CHKSUMS="sha256::03e5df3029aeda5df5ff30ec4c570f7c1c7d2b1e0b80acbf5792ea76507813cc \
+         sha256::14debd8bef41a970a2a0b93b83c6a2f5beeffb0da993d4c5afced7bf732a36e2 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260310

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260310
- rime-pinyin-moegirl: 20260310

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
