### PR TITLE
keepassxc: update to 2.7.12

### DIFF
--- a/app-utils/keepassxc/autobuild/patches/0001-Fedora-fix-GNOME-quirks-on-Wayland-sessions.patch
+++ b/app-utils/keepassxc/autobuild/patches/0001-Fedora-fix-GNOME-quirks-on-Wayland-sessions.patch
@@ -1,6 +1,7 @@
---- a/src/main.cpp
-+++ b/src/main.cpp
-@@ -49,8 +49,26 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+diff -urNr keepassxc-2.7.12-orig/src/main.cpp keepassxc-2.7.12/src/main.cpp
+--- keepassxc-2.7.12-orig/src/main.cpp	2026-03-10 01:27:46.000000000 +0100
++++ keepassxc-2.7.12/src/main.cpp	2026-03-12 17:00:05.780444169 +0100
+@@ -49,8 +49,24 @@
  #include <windows.h>
  #endif
  
@@ -10,7 +11,7 @@
 +    QByteArray currentDesktop = qgetenv("XDG_CURRENT_DESKTOP").toLower();
 +    QByteArray sessionDesktop = qgetenv("XDG_SESSION_DESKTOP").toLower();
 +    QByteArray sessionType = qgetenv("XDG_SESSION_TYPE").toLower();
-+    if (sessionType.contains("wayland") && (currentDesktop.contains("gnome") || sessionDesktop.contains("gnome")))
++    if ((sessionType.contains("wayland") && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) && (currentDesktop.contains("gnome") || sessionDesktop.contains("gnome")))
 +    {
 +        qputenv("QT_QPA_PLATFORM", "xcb");
 +    }
@@ -19,11 +20,9 @@
 +
  int main(int argc, char** argv)
  {
-+
 +#ifdef Q_OS_LINUX
-+wayland_hacks();
++    wayland_hacks();
 +#endif
-+
      QT_REQUIRE_VERSION(argc, argv, QT_VERSION_STR)
  
-     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+ #ifdef Q_OS_WIN

--- a/app-utils/keepassxc/spec
+++ b/app-utils/keepassxc/spec
@@ -1,4 +1,4 @@
-VER=2.7.11
+VER=2.7.12
 SRCS="https://github.com/keepassxreboot/keepassxc/releases/download/${VER}/keepassxc-${VER}-src.tar.xz"
-CHKSUMS="sha256::ce76b02d396369726aaf695bb46b79c0cc41a0c4f9ec806bde1233cb22e6ef62"
+CHKSUMS="sha256::be34eeb297881adea4f894c7c6e4a1835bd7927f8043ddea495040df4792a7de"
 CHKUPDATE="anitya::id=15656"


### PR DESCRIPTION
Topic Description
-----------------

- keepassxc: update to 2.7.12
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- keepassxc: 2.7.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit keepassxc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
