### PR TITLE
grub: fix i386-pc matching in quirks script

### DIFF
--- a/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/99-catchall.bash
+++ b/app-admin/grub/autobuild/overrides/etc/grub.d/quirks-install/99-catchall.bash
@@ -5,7 +5,7 @@ match_arch amd64 && match_efi_64 && match_writable_efivars && install_efi x86_64
 match_arch amd64 && match_efi_64 && install_efi_removable x86_64-efi
 match_arch amd64 && match_efi_32 && match_writable_efivars && install_efi i386-efi
 match_arch amd64 && match_efi_32 && install_efi_removable i386-efi
-match_arch amd64 && ! match_efi && install_pc
+match_arch amd64 && ! match_efi && matched && install_pc
 
 match_arch arm64 && match_writable_efivars && install_efi_extra_removable arm64-efi
 match_arch arm64 && install_efi_removable arm64-efi

--- a/app-admin/grub/autobuild/overrides/usr/share/grub/quirks-lib.bash
+++ b/app-admin/grub/autobuild/overrides/usr/share/grub/quirks-lib.bash
@@ -30,6 +30,11 @@ else
 	}
 fi
 
+# Force the match result to be true.
+matched() {
+	QUIRK_MATCH="1"
+}
+
 # Check if a string matches one of the generic strings above.
 is_generic() {
 	local in="$1" str

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=17.0.02
 RETROFONTVER=20200402
 
 VER=${GRUBVER}+unifont${__UNIFONTVER}
-REL=4
+REL=5
 SRCS="git::commit=tags/grub-${__UPSTREAM_VER};rename=grub-${__UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::rename=grub-fonts-$RETROFONTVER.tar.xz::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: fix i386-pc matching in quirks
    \* \`&& ! match_efi\` does not update the MATCHED flag to true, so
    install-grub will treat the catchall script as no match, leaving user
    with an error.

Package(s) Affected
-------------------

- grub: 2:2.14+unifont17.0.02-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
