### PR TITLE
virt-viewer: bump REL due to rest update to 0.10.2

### DIFF
--- a/app-virtualization/virt-viewer/spec
+++ b/app-virtualization/virt-viewer/spec
@@ -2,3 +2,4 @@ VER=11.0
 SRCS="tbl::https://releases.pagure.org/virt-viewer/virt-viewer-$VER.tar.xz"
 CHKSUMS="sha256::a43fa2325c4c1c77a5c8c98065ac30ef0511a21ac98e590f22340869bad9abd0"
 CHKUPDATE="anitya::id=15273"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- virt-viewer: bump REL due to rest update to 0.10.2

Package(s) Affected
-------------------

- virt-viewer: 11.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit virt-viewer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
