### PR TITLE
squashfs-tools: update to 4.7.5

### DIFF
--- a/app-admin/squashfs-tools/spec
+++ b/app-admin/squashfs-tools/spec
@@ -1,4 +1,4 @@
-VER=4.7.4
+VER=4.7.5
 SRCS="git::commit=tags/$VER::https://github.com/plougher/squashfs-tools.git"
 CHKSUMS="SKIP"
 SUBDIR="squashfs-tools/squashfs-tools"


### PR DESCRIPTION
Topic Description
-----------------

- squashfs-tools: update to 4.7.5

Package(s) Affected
-------------------

- squashfs-tools: 4.7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit squashfs-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`
