### PR TITLE
fwupd: update to 2.1.1

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -2,21 +2,51 @@ PKGNAME=fwupd
 PKGSEC=admin
 PKGDES="Firmware update daemon and utilities"
 PKGDEP="bluez curl flashrom fwupd-efi gcc-runtime glib glibc gnutls \
-        hicolor-icon-theme json-glib libarchive libcbor libdrm libjcat \
-        libxmlb modemmanager passim polkit protobuf-c python-3 readline \
-        shared-mime-info sqlite systemd tpm2-tss udisks-2 xz zlib"
-BUILDDEP="cairo gi-docgen gobject-introspection vala valgrind"
+        libcbor libdrm libjcat libmbim libmnl libqmi libusb libxmlb \
+        modemmanager passim polkit readline sqlite systemd tpm2-tss \
+        udisks-2 util-linux-runtime xz zlib"
+BUILDDEP="cairo gobject-introspection jinja2 vala"
 # FIXME: Fwupd-efi is not yet available for ppc64el & loongson3.
 PKGDEP__LOONGSON3="${PKGDEP/fwupd-efi/}"
 PKGDEP__PPC64EL="${PKGDEP/fwupd-efi/}"
-# FIXME: Valgrind is not yet available for LoongArch.
-BUILDDEP__LOONGARCH64="${BUILDDEP/valgrind/}"
-BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP/valgrind/}"
 
 MESON_AFTER=(
-    "-Ddocs=disabled"
-    "-Defi_binary=false"
-    "-Dtests=false"
+    '-Dbash_completion=true'
+    '-Dblkid=enabled'
+    '-Dbluez=enabled'
+    '-Dbuild=all'
+    '-Dcbor=enabled'
+    '-Ddocs=disabled'
+    '-Defi_binary=false'
+    '-Dfirmware-packager=true'
+    '-Dfish_completion=true'
+    '-Dgnutls=enabled'
+    '-Dhsi=enabled'
+    '-Dintrospection=enabled'
+    '-Dlibdrm=enabled'
+    '-Dlibmnl=enabled'
+    '-Dlogind=enabled'
+    '-Dlvfs=true'
+    '-Dman=true'
+    '-Dmetainfo=true'
+    '-Dp2p_policy=metadata'
+    '-Dudev_hotplug=true'
+    '-Dpassim=enabled'
+    '-Dplugin_flashrom=enabled'
+    '-Dplugin_modem_manager=enabled'
+    '-Dplugin_uefi_capsule_splash=true'
+    '-Dpolkit=enabled'
+    '-Dpython=/usr/bin/python3'
+    '-Dqubes=false'
+    '-Dreadline=enabled'
+    '-Dstatic_analysis=false'
+    '-Dsupported_build=disabled'
+    '-Dsystemd=enabled'
+    '-Dsystemd_unit_user=fwupd-refresh'
+    '-Dtests=false'
+    '-Dumockdev_tests=disabled'
+    '-Dvalgrind=disabled'
+    '-Dvendor_metadata=false'
 )
 
 PKGBREAK="fwupdate<=12-2 discover<=5.27.12 gnome-software<=42.4-1"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=2.0.20
+VER=2.1.1
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 2.1.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- fwupd: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
