### PR TITLE
asciinema: update to 3.2.0

### DIFF
--- a/app-multimedia/asciinema/spec
+++ b/app-multimedia/asciinema/spec
@@ -1,4 +1,4 @@
-VER=3.1.0
+VER=3.2.0
 SRCS="git::commit=tags/v${VER}::https://github.com/asciinema/asciinema"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=116"


### PR DESCRIPTION
Topic Description
-----------------

- asciinema: update to 3.2.0
    Co-authored-by: Lumiere \(@atlarator\) <vzstless@qq.com>

Package(s) Affected
-------------------

- asciinema: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit asciinema
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
