### PR TITLE
qtcreator: update to 18.0.2

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,5 +1,4 @@
-VER=18.0.0
-REL=2
+VER=18.0.2
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
-CHKSUMS="sha256::c773b74114d1fbca66c81b8fb799892827e7e1542491ed459aaad279e0253973"
+CHKSUMS="sha256::1cff642233234b6ddd40389d05e4905808f98fd44342187fe9109290a0492c88"
 CHKUPDATE="anitya::id=4136"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: update to 18.0.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qtcreator: 18.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
