### PR TITLE
qtcreator: update to 19.0.0

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,5 +1,4 @@
-VER=18.0.0
-REL=2
+VER=19.0.0
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
-CHKSUMS="sha256::c773b74114d1fbca66c81b8fb799892827e7e1542491ed459aaad279e0253973"
+CHKSUMS="sha256::f7f69bd007462a4606787c130e83583db4416df627bf777d33944f23caeacf6d"
 CHKUPDATE="anitya::id=4136"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: update to 19.0.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- qtcreator: 19.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
