### PR TITLE
zen-browser: update to 1.19.2~beta

### DIFF
--- a/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
+++ b/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
@@ -1,4 +1,4 @@
-From 3c52b4da1edd11bb1837a5127704d399954162f7 Mon Sep 17 00:00:00 2001
+From f50394f225b04e89e1e35f8602f9467be2504f3a Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:14:20 -0800
 Subject: [PATCH 1/7] AOSCOS: Disable LASX by default for libyuv

--- a/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
+++ b/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
@@ -1,4 +1,4 @@
-From 722e455045ed341c620fe9d5e63d8b8424707e0d Mon Sep 17 00:00:00 2001
+From e9c7bfff603ea0fded5925ef5c7493f93029af6a Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:17:48 -0800
 Subject: [PATCH 2/7] Enable GLES on riscv64

--- a/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
+++ b/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
@@ -1,4 +1,4 @@
-From e33ee6b06100ba607b26f0e5f87b0e4dee481502 Mon Sep 17 00:00:00 2001
+From ff67756af9ff0638020fc6ec002bc0120923c4fc Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:20:35 -0800
 Subject: [PATCH 3/7] Disable BROTLI_MODEL macro for some targets

--- a/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
+++ b/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
@@ -1,4 +1,4 @@
-From a9ac6228ebc2c4280c8c940cd025e49ce7153dc4 Mon Sep 17 00:00:00 2001
+From 224a6a469db08dd3a3bd0b7f5f11c3e00c25e961 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:23:13 -0800
 Subject: [PATCH 4/7] AOSCOS: Fix unistd.h header inclusion in libwebrtc

--- a/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
+++ b/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
@@ -1,4 +1,4 @@
-From 9eec59623877838f8e08affe7ee152a1312418ed Mon Sep 17 00:00:00 2001
+From 3f113e46b8a6830c25812bc424e8a987cf7cbdaf Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 23:32:26 -0800
 Subject: [PATCH 5/7] AOSCOS: Update Google API keyfile path

--- a/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
+++ b/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
@@ -1,4 +1,4 @@
-From 97fdb7b9d4e771e0570ba6e7b980214e05bd93f8 Mon Sep 17 00:00:00 2001
+From a17e48caa2bb7496c2591a15b8cc04bbce09b6a0 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <the@salted.fish>
 Date: Sat, 21 Feb 2026 20:28:31 -0500
 Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
@@ -8,7 +8,7 @@ Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/surfer.json b/surfer.json
-index 2af778af8d09f..2cf8a80b5b650 100644
+index c2d36b089c0b2..cdfb7cabb4082 100644
 --- a/surfer.json
 +++ b/surfer.json
 @@ -2,7 +2,7 @@
@@ -19,7 +19,7 @@ index 2af778af8d09f..2cf8a80b5b650 100644
 +  "binaryName": "zen-browser",
    "version": {
      "product": "firefox",
-     "version": "148.0",
+     "version": "148.0.2",
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
+++ b/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
@@ -1,4 +1,4 @@
-From 70929f185cec40b73d45d777148f11757b0092ce Mon Sep 17 00:00:00 2001
+From 6a3d3c571018edf9e21a0c11fa162a283b2e4d24 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 3 Feb 2026 05:56:14 -0500
 Subject: [PATCH 7/7] AOSCOS: Adjust mozconfig

--- a/app-web/zen-browser/spec
+++ b/app-web/zen-browser/spec
@@ -1,4 +1,4 @@
-__VER="1.19.1"
+__VER="1.19.2"
 VER="${__VER}~beta"
 SRCS="git::commit=tags/${__VER}b;copy-repo=true::https://github.com/zen-browser/desktop"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- zen-browser: update to 1.19.2\~beta

Package(s) Affected
-------------------

- zen-browser: 1.19.2~beta

Security Update?
----------------

No

Build Order
-----------

```
#buildit zen-browser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
