### PR TITLE
systemd: rework triggers

### DIFF
--- a/app-admin/systemd/autobuild/postinst
+++ b/app-admin/systemd/autobuild/postinst
@@ -7,7 +7,7 @@ _systemctl() {
 
 _update_binfmt() {
     if [ "$(_systemctl show -P LoadState systemd-binfmt.service)" != "masked" ]; then
-        #Note: try-restart doesn't restart inactive services
+        # Note: try-restart doesn't restart inactive services
         echo "Reloading binfmt ..."
         _systemctl restart systemd-binfmt.service || true
     fi
@@ -58,15 +58,25 @@ getent passwd systemd-nobody > /dev/null || \
 
 if [ "$1" = "triggered" ]; then
     shift
+
+    # Note: avoid duplicate trigger actions.
+    # e.g. postinst triggered /usr/lib/binfmt.d systemd-binfmt
+    update_binfmt=0
+    reload_daemon=0
+
     for trigger in $@; do
         case $trigger in
             /etc/binfmt.d|/usr/lib/binfmt.d|systemd-binfmt)
-                _update_binfmt
+                update_binfmt=1
                 ;;
             /etc/systemd/system|/usr/lib/systemd/system|daemon-reload)
-                _reload_daemon
+                reload_daemon=1
                 ;;
         esac
     done
+
+    [ "$update_binfmt" = 1 ] && _update_binfmt
+    [ "$reload_daemon" = 1 ] && _reload_daemon
+
     exit 0
 fi

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=259
 
 # Use this for stable/main branch releases.
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- systemd: rework triggers

Package(s) Affected
-------------------

- systemd: 1:259-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
