### PR TITLE
pydantic: fix dependencies

### DIFF
--- a/lang-python/pydantic/autobuild/defines
+++ b/lang-python/pydantic/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=pydantic
 PKGSEC=python
 PKGDES="Data validation and settings management using Python type hinting"
-PKGDEP="python-3 pydantic-core annotated-types"
-BUILDDEP="python-build hatchling hatch-fancy-pypi-readme python-installer"
+PKGDEP="python-3 typing-extensions annotated-types pydantic-core typing-inspection"
+BUILDDEP="hatchling hatch-fancy-pypi-readme"
 
 ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/pydantic/spec
+++ b/lang-python/pydantic/spec
@@ -1,5 +1,5 @@
 VER=2.12.5
+REL=2
 SRCS="git::commit=v${VER}::https://github.com/pydantic/pydantic"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=39654"
-REL="1"

--- a/lang-python/typing-inspection/autobuild/defines
+++ b/lang-python/typing-inspection/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=typing-inspection
+PKGSEC=python
+PKGDES="Runtime typing introspection tools for Python"
+PKGDEP="python-3 typing-extensions"
+BUILDDEP="hatchling"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2=1

--- a/lang-python/typing-inspection/spec
+++ b/lang-python/typing-inspection/spec
@@ -1,0 +1,4 @@
+VER=0.4.2
+SRCS="pypi::version=$VER::typing-inspection"
+CHKSUMS="sha256::ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"
+CHKUPDATE="anitya::id=377682"


### PR DESCRIPTION
Topic Description
-----------------

- pydantic: fix dependencies
    Signed-off-by: stydxm <stydxm@outlook.com>
- typing-inspection: new, 0.4.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pydantic: 2.12.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pydantic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
