### PR TITLE
freerdp: update to 3.24.0

### DIFF
--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=3.23.0
+VER=3.24.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::929273003f35b0b4f211e48d5abed4ebcef99da94784a50b6dc85cd0b7e257b1"
+CHKSUMS="sha256::168011bd58eae8d898842ef39c6c9bf5761ab617a68ccad80d623a3e535d0367"
 CHKUPDATE="anitya::id=10442"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.24.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- freerdp: 2:3.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
