### PR TITLE
python-markdown-math: update to 0.9

### DIFF
--- a/lang-python/python-markdown-math/autobuild/defines
+++ b/lang-python/python-markdown-math/autobuild/defines
@@ -4,8 +4,6 @@ PKGDEP="markdown python-3"
 BUILDDEP="setuptools-python3"
 PKGDES="Math extension for Python-Markdown"
 
+ABTYPE=pep517
 ABHOST=noarch
-
-ABTYPE=python
-
 NOPYTHON2=1

--- a/lang-python/python-markdown-math/spec
+++ b/lang-python/python-markdown-math/spec
@@ -1,5 +1,4 @@
-VER=0.6
-SRCS="tbl::https://pypi.io/packages/source/p/python-markdown-math/python-markdown-math-$VER.tar.gz"
-CHKSUMS="sha256::c68d8cb9695cb7b435484403dc18941d1bad0ff148e4166d9417046a0d5d3022"
-REL="5"
+VER=0.9
+SRCS="pypi::version=$VER::python-markdown-math"
+CHKSUMS="sha256::567395553dc4941e79b3789a1096dcabb3fda9539d150d558ef3507948b264a3"
 CHKUPDATE="anitya::id=141583"


### PR DESCRIPTION
Topic Description
-----------------

- python-markdown-math: update to 0.9
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- python-markdown-math: 0.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-markdown-math
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
