### PR TITLE
grub: fix initrd command oom failure on loongson3

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From e88970e73fd8f08a10fd13483ac2ee49586c1746 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/73] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/75] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.
@@ -71,5 +71,5 @@ index 5d8d75292..d7693913b 100644
  
  osx_entry() {
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From 4ff98b915f5603b206ca9cccf0553814c57a02d9 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/73] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/75] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---
@@ -69,5 +69,5 @@ index d7693913b..e749dba35 100644
  
  osx_entry() {
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 3e6574ea506f9d1aceda508e156d1b2cd04333a1 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/73] Don't add '*' to highlighted row
+Subject: [PATCH 03/75] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---
@@ -22,5 +22,5 @@ index 9c383e64a..40f352d38 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From 6df62e9e0bf85ae25fa59efbc29059a64dac71b7 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/73] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/75] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---
@@ -28,5 +28,5 @@ index 40f352d38..cd6a5af02 100644
    geo->timeout_lines = 2;
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 5c7235bde4bb48e21e974fb1c3801d4e08b1552a Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/73] Indent menu entries
+Subject: [PATCH 05/75] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-
@@ -22,5 +22,5 @@ index cd6a5af02..f71435371 100644
    grub_print_ucs4_menu (unicode_title,
  			unicode_title + len,
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From 2f4a261e8342d96ba4fdda30e6330f5de2283eb7 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/73] Fix margins
+Subject: [PATCH 06/75] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----
@@ -33,5 +33,5 @@ index f71435371..0aaff9a19 100644
      - geo->timeout_lines /* timeout */
      - 1 /* empty final line  */;
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 7cdbcd176a51a5112dfb8657cdb6ec7f01d34b64 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/73] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/75] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>
@@ -23,5 +23,5 @@ index 0aaff9a19..4f0a10160 100644
    geo->first_entry_y = 3; /* three empty lines*/
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From eb7eb307f0eb845ee95293cf0eeab2489c3ae70f Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/73] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/75] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--
@@ -41,5 +41,5 @@ index 27bff00a8..ee6a60529 100644
  fi
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 14cb218fc9d996e928d7e1cf4392018bbd0bcf26 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/73] Don't draw a border around the menu
+Subject: [PATCH 09/75] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---
@@ -70,5 +70,5 @@ index 4f0a10160..90329af7b 100644
    grub_term_highlight_color = old_color_highlight;
    geo->timeout_y = geo->first_entry_y + geo->num_entries
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 9165cb00c269609c823b7bba36667663dad8fe83 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/73] Use the standard margin for the timeout string
+Subject: [PATCH 10/75] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---
@@ -39,5 +39,5 @@ index 90329af7b..83573099d 100644
      }
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 353077b372583fd82bd9175fbdb12ec3949f68df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/73] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/75] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---
@@ -22,5 +22,5 @@ index e7b9078ab..299b8c3cc 100644
    iso9660_dir = grub_util_make_temporary_dir ();
    grub_util_info ("temporary iso9660 dir is `%s'", iso9660_dir);
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From 66751206633925a70d0cb7ea32c89e28a9cfaad9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/73] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/75] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---
@@ -23,5 +23,5 @@ index 74be91f5f..8327dc494 100644
      # no initrd or builtin initramfs, it can't work here.
      if [ "x${GRUB_DEVICE_PARTUUID}" = "x" ] \
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From b64b7e0a816b2163263b90ff85ae8daa8022fcbc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/73] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/75] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++
@@ -41,5 +41,5 @@ index 77834cfaf..48253206f 100644
  gfxterm=0;
  for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 3602577caef6826c20f48cb9f5f6588af1e333fc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/73] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/75] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.
@@ -23,5 +23,5 @@ index de9a3f961..0d544bf53 100644
      return;
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 19a18e7dddb513ec52dfa1bd5071543dc1194a45 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/73] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/75] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---
@@ -29,5 +29,5 @@ index 060246589..f85be18f0 100644
  	    The EFI System Partition may have been given directly using
  	    --root-directory.
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From c0f948f451f969336100e1f4a9b6a79c5691de99 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/73] commands: add new command memsize
+Subject: [PATCH 16/75] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory
@@ -374,5 +374,5 @@ index 000000000..b5ab52f4b
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0a3f263585d911faa0d60e2c8750d5db81a9b15e Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/73] commands: add new command 'pause'
+Subject: [PATCH 17/75] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.
@@ -88,5 +88,5 @@ index 000000000..7b7fc185b
 +  grub_unregister_extcmd (cmd);
 +}
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From 16cd91ff2672c9935b691c93ebe4f01e2bb9ad80 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/73] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/75] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---
@@ -23,5 +23,5 @@ index 83573099d..b2168a356 100644
    if (data->timeout_msg == TIMEOUT_TERSE
        || data->timeout_msg == TIMEOUT_TERSE_NO_MARGIN)
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From c5404d39a01bacf22fb1a563079b885f82180504 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/73] po: add patch to disable parallel execution
+Subject: [PATCH 19/75] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.
@@ -76,5 +76,5 @@ index 000000000..0cef9fafe
 +2.39.1
 +
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0020-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From bd4d8f29ee747e32c3be7da1b862f1e48dd01c48 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 20/73] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 20/75] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:
@@ -93,5 +93,5 @@ index 299b8c3cc..372af496b 100644
        free (imgname);
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0021-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0021-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 0ef18b6fc26076e00b9deb864931f0b225c289bd Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 21/73] loongarch64: able to start on legacy firmware
+Subject: [PATCH 21/75] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.
@@ -44,5 +44,5 @@ index d460267be..534ba4b32 100644
  
  #endif /* ! GRUB_MEMORY_CPU_HEADER */
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0022-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0022-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,7 +1,7 @@
 From 866070c34b3f9d67e5374567182667923171bcca Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 19:29:21 +0800
-Subject: [PATCH 22/73] Add support for forcing EFI installation to the
+Subject: [PATCH 22/75] Add support for forcing EFI installation to the
  removable media path
 
 Add an extra option to grub-install "--force-extra-removable". On EFI
@@ -222,5 +222,5 @@ index f85be18f0..03b29327e 100644
  
  	free (dst);
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0023-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0023-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,7 +1,7 @@
 From bb89bcfbe59b26096a987c65824b9b7d1c7262ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 14 Aug 2024 19:34:26 +0800
-Subject: [PATCH 23/73] grub-install: (loongarch64-efi) also install
+Subject: [PATCH 23/75] grub-install: (loongarch64-efi) also install
  BOOTLOONGARCH.EFI
 
 Some old-world firmware (especially that of the BPI01000 revision) does not
@@ -72,5 +72,5 @@ index 03b29327e..9d8b9693d 100644
  	grub_set_install_backup_ponr ();
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0024-mips64-Add-support-for-64-bit-MIPS.patch
+++ b/app-admin/grub/autobuild/patches/0024-mips64-Add-support-for-64-bit-MIPS.patch
@@ -1,7 +1,7 @@
 From b339138392f98ff0e341d8eb423defa05d06ec6a Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Mon, 9 Jan 2017 14:42:41 +0800
-Subject: [PATCH 24/73] mips64: Add support for 64-bit MIPS.
+Subject: [PATCH 24/75] mips64: Add support for 64-bit MIPS.
 
 ---
  configure.ac                         |  21 +-
@@ -2461,5 +2461,5 @@ index 2920c0249..5bd3356bd 100644
        .dirname = "loongarch64-efi",
        .names = { "loongarch64-efi", NULL },
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0025-mips64-Add-support-for-Loongson.patch
+++ b/app-admin/grub/autobuild/patches/0025-mips64-Add-support-for-Loongson.patch
@@ -1,7 +1,7 @@
 From 9407164f6fceff0ffa7992eb337b8ab3cad1db92 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Fri, 13 Jan 2017 16:02:41 +0800
-Subject: [PATCH 25/73] mips64: Add support for Loongson.
+Subject: [PATCH 25/75] mips64: Add support for Loongson.
 
 ---
  configure.ac                            |   6 +-
@@ -1402,5 +1402,5 @@ index 52e6ae6eb..e4063783f 100644
  
  #endif /* ! GRUB_MEMORY_CPU_HEADER */
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0026-loader-mips64-linux-fix-missing-type-args-while-load.patch
+++ b/app-admin/grub/autobuild/patches/0026-loader-mips64-linux-fix-missing-type-args-while-load.patch
@@ -1,7 +1,7 @@
 From 54811b85302fb0d2bfa3a84755538ef7e53b47f4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:59:42 +0800
-Subject: [PATCH 26/73] loader/mips64/linux: fix missing type args while
+Subject: [PATCH 26/75] loader/mips64/linux: fix missing type args while
  loading kernel
 
 ---
@@ -30,5 +30,5 @@ index afa508f81..226207303 100644
      return grub_errno;
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0027-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
+++ b/app-admin/grub/autobuild/patches/0027-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
@@ -1,7 +1,7 @@
 From f4bef0a70b24da1594b2957988578e01caaea3a1 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:33:13 +0800
-Subject: [PATCH 27/73] util/grub-mkimagexx: fix uncorrect section var in
+Subject: [PATCH 27/75] util/grub-mkimagexx: fix uncorrect section var in
  `make_reloc_section`
 
 ---
@@ -23,5 +23,5 @@ index 535fc9bb4..1ba5389db 100644
  	grub_util_info ("translating the relocation section %s",
  			smd->strtab + grub_le_to_cpu32 (s->sh_name));
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
+++ b/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
@@ -1,7 +1,7 @@
 From 3639cb8468b0ffada495a1c0e38375eae8266567 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:03:46 +0800
-Subject: [PATCH 28/73] loader/mips64/linux: drop argv[] args when calling
+Subject: [PATCH 28/75] loader/mips64/linux: drop argv[] args when calling
  grub_initrd_load()
 
 ---
@@ -22,5 +22,5 @@ index 226207303..514335e47 100644
  
    grub_snprintf ((char *) linux_args_addr + rd_addr_arg_off,
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0029-lib-mips64-drop-all-efi_call-wrappers.patch
+++ b/app-admin/grub/autobuild/patches/0029-lib-mips64-drop-all-efi_call-wrappers.patch
@@ -1,7 +1,7 @@
 From 1f6f20c3eae695beb15fa94655996cd43fb495cc Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:20:57 +0800
-Subject: [PATCH 29/73] lib/mips64: drop all efi_call wrappers
+Subject: [PATCH 29/75] lib/mips64: drop all efi_call wrappers
 
 ---
  grub-core/kern/mips64/efi/init.c    | 8 ++++----
@@ -49,5 +49,5 @@ index 19eefeb4a..f06f9ae4b 100644
      grub_fatal ("cannot allocate Loongson boot parameters!");
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0030-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
+++ b/app-admin/grub/autobuild/patches/0030-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
@@ -1,7 +1,7 @@
 From 0bd483beeeab454f9553777e5323008e2791e4ff Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:27:17 +0800
-Subject: [PATCH 30/73] lib/mips64: use a common GUID impl in GRUB
+Subject: [PATCH 30/75] lib/mips64: use a common GUID impl in GRUB
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 2 +-
@@ -21,5 +21,5 @@ index f06f9ae4b..e8acb6965 100644
  
    if (boot_params)
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0031-kern-mips64-fix-error-catch-output-type-mismatch.patch
+++ b/app-admin/grub/autobuild/patches/0031-kern-mips64-fix-error-catch-output-type-mismatch.patch
@@ -1,7 +1,7 @@
 From 18cf5c51b3866f269cfd920cd78f982b1377a7ee Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:46:18 +0800
-Subject: [PATCH 31/73] kern/mips64: fix error catch output type mismatch
+Subject: [PATCH 31/75] kern/mips64: fix error catch output type mismatch
 
 ---
  grub-core/kern/mips64/dl.c | 2 +-
@@ -21,5 +21,5 @@ index 049d3187c..6d518b537 100644
  	  }
  	  break;
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0032-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
+++ b/app-admin/grub/autobuild/patches/0032-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
@@ -1,7 +1,7 @@
 From 99b3e5bac2803600e9a29703d4b3b144571dd502 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:01 +0800
-Subject: [PATCH 32/73] kern/mips64: fix missing grub_install_get_time_ms
+Subject: [PATCH 32/75] kern/mips64: fix missing grub_install_get_time_ms
  prototype
 
 ---
@@ -21,5 +21,5 @@ index 7fd508c54..ab225cb98 100644
  #include <grub/efi/efi.h>
  #include <grub/loader.h>
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0033-lib-mips64-silence-werror.patch
+++ b/app-admin/grub/autobuild/patches/0033-lib-mips64-silence-werror.patch
@@ -1,7 +1,7 @@
 From 454af77cba4390bb8031b252d8c03b906e525346 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:28 +0800
-Subject: [PATCH 33/73] lib/mips64: silence werror
+Subject: [PATCH 33/75] lib/mips64: silence werror
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 5 ++++-
@@ -31,5 +31,5 @@ index e8acb6965..a283b41b1 100644
  		   bpmem->map[index].memtype,
  		   bpmem->map[index].memstart,
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0034-loader-mips64-fix-warnings-and-style.patch
+++ b/app-admin/grub/autobuild/patches/0034-loader-mips64-fix-warnings-and-style.patch
@@ -1,7 +1,7 @@
 From 2a5822c78d6f8b15759b5774b4dcc2d71d0b080d Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:32:14 +0800
-Subject: [PATCH 34/73] loader/mips64: fix warnings and style
+Subject: [PATCH 34/75] loader/mips64: fix warnings and style
 
 ---
  grub-core/loader/mips64/linux.c | 82 ++++++++++++++++++---------------
@@ -141,5 +141,5 @@ index 514335e47..6b6cac273 100644
    if (linux_size == 0)
      return grub_errno;
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0035-util-grub-install-mips64el-efi-rename-removable-exec.patch
+++ b/app-admin/grub/autobuild/patches/0035-util-grub-install-mips64el-efi-rename-removable-exec.patch
@@ -1,7 +1,7 @@
 From 3074c0c30e22e96461a682617c228e92dfae7075 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 9 Oct 2024 15:26:25 +0800
-Subject: [PATCH 35/73] util/grub-install: mips64el-efi: rename removable
+Subject: [PATCH 35/75] util/grub-install: mips64el-efi: rename removable
  executable
 
 as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI
@@ -23,5 +23,5 @@ index 0076eb07d..b6cd8bb44 100644
  	    default:
  	      grub_util_error ("%s", _("You've found a bug"));
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0036-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
+++ b/app-admin/grub/autobuild/patches/0036-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
@@ -1,7 +1,7 @@
 From b5ebf83b167df51ed8889deefa1991c831fac572 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 10 Oct 2024 14:40:32 +0800
-Subject: [PATCH 36/73] fix(util/grub-mkrescue): fix EFI executable name for
+Subject: [PATCH 36/75] fix(util/grub-mkrescue): fix EFI executable name for
  mips64el-efi
 
 Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.
@@ -23,5 +23,5 @@ index eaa6d48a3..246d397ef 100644
        free (imgname);
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0037-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
+++ b/app-admin/grub/autobuild/patches/0037-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
@@ -1,7 +1,7 @@
 From 609826867aadffa129d06dbadc2981baad9399f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:53:43 +0800
-Subject: [PATCH 37/73] grub.d: 00-header: disable graphical output for
+Subject: [PATCH 37/75] grub.d: 00-header: disable graphical output for
  MacBook6,2
 
 MacBook Pro 15'' (Mid-2010, MacBookPro6,2) are known to have broken
@@ -35,5 +35,5 @@ index 48253206f..84223a85f 100644
      if [ "x$GRUB_THEME" != x ] && [ -f "$GRUB_THEME" ] \
  	&& is_path_readable_by_grub "$GRUB_THEME"; then
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0038-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
+++ b/app-admin/grub/autobuild/patches/0038-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
@@ -1,7 +1,7 @@
 From 2fd913924369bf463e6671757202c169ce231327 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:33:38 +0800
-Subject: [PATCH 38/73] menu: add GRUB_RIGHT_TO_SELECT to toggle
+Subject: [PATCH 38/75] menu: add GRUB_RIGHT_TO_SELECT to toggle
  select-by-right-arrow-key
 
 Normally, GRUB allows using a combination of the Return/Enter (`\n' and
@@ -123,5 +123,5 @@ index 84223a85f..0de7101d1 100644
 +set right_to_select=${GRUB_RIGHT_TO_SELECT}
 +EOF
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0039-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
+++ b/app-admin/grub/autobuild/patches/0039-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
@@ -1,7 +1,7 @@
 From 56573b2b4fd0933d6f15a67d892cc3c04850d72a Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Fri, 15 Nov 2024 16:49:55 +0800
-Subject: [PATCH 39/73] templates: make UEFI fwsetup menu entry label
+Subject: [PATCH 39/75] templates: make UEFI fwsetup menu entry label
  translatable
 
 When the "UEFI Firmware Settings" entries was added in commit 46d76f8fe
@@ -28,5 +28,5 @@ index 1c2365ddb..9cbeac6cc 100644
  gettext_printf "Adding boot menu entry for UEFI Firmware Settings ...\n" >&2
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0040-gitignore-reconsider-PO-files-and-grub.pot-template.patch
+++ b/app-admin/grub/autobuild/patches/0040-gitignore-reconsider-PO-files-and-grub.pot-template.patch
@@ -1,7 +1,7 @@
 From c06dea59cf9c10387c7fccd2fae532376d0ad414 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:12 +0800
-Subject: [PATCH 40/73] gitignore: reconsider PO files and grub.pot template
+Subject: [PATCH 40/75] gitignore: reconsider PO files and grub.pot template
 
 ---
  .gitignore | 1 -
@@ -20,5 +20,5 @@ index db16295ad..f586577f9 100644
  /po/stamp-po
  /printf_test
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0041-po-add-PO-files-from-translationproject.org.patch
+++ b/app-admin/grub/autobuild/patches/0041-po-add-PO-files-from-translationproject.org.patch
@@ -1,7 +1,7 @@
 From 855d756f9cd4cbd610dde1492235f97201b7f89c Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:48 +0800
-Subject: [PATCH 41/73] po: add PO files from translationproject.org
+Subject: [PATCH 41/75] po: add PO files from translationproject.org
 
 To generate grub.pot, you can run the following command:
 
@@ -248570,5 +248570,5 @@ index 000000000..8713a1ac1
 +msgid "Loading Xen %s ..."
 +msgstr "正在載入 Xen %s ..."
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0042-po-update-zh_CN-translation.patch
+++ b/app-admin/grub/autobuild/patches/0042-po-update-zh_CN-translation.patch
@@ -1,7 +1,7 @@
 From 9f8fe461e420566dfbdbec23ae27758e72e0ce24 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 22:38:48 +0800
-Subject: [PATCH 42/73] po: update zh_CN translation
+Subject: [PATCH 42/75] po: update zh_CN translation
 
 ---
  po/zh_CN.po | 1314 +++++++++++++++++++++++++++++++++------------------
@@ -2689,5 +2689,5 @@ index 468f6368f..64fe257e6 100644
  
  #~ msgid "Predicted = %d, written = %llu\n"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0043-po-update-zh_TW-translations.patch
+++ b/app-admin/grub/autobuild/patches/0043-po-update-zh_TW-translations.patch
@@ -1,7 +1,7 @@
 From 4d449abb28a4957a9e90de13007ff867b160ebf1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 16 Nov 2024 22:46:05 +0800
-Subject: [PATCH 43/73] po: update zh_TW translations
+Subject: [PATCH 43/75] po: update zh_TW translations
 
 Add translation for UEFI Settings.
 ---
@@ -9687,5 +9687,5 @@ index 8713a1ac1..6e863c161 100644
 +#~ msgid "cannot guess the root device. Specify the option `--root-device'"
 +#~ msgstr "無法猜測根裝置。請指定「--root-device」選項"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0044-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
+++ b/app-admin/grub/autobuild/patches/0044-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
@@ -1,7 +1,7 @@
 From 32211360b1a52f724aaa51f308d79d4e10ca8814 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sun, 19 Jan 2025 23:18:56 +0800
-Subject: [PATCH 44/73] grub.d/30_uefi-firmware: disable fwsetup menu for
+Subject: [PATCH 44/75] grub.d/30_uefi-firmware: disable fwsetup menu for
  mips64el-efi
 
 ---
@@ -22,5 +22,5 @@ index 9cbeac6cc..4ff256a20 100644
  	if [ "\$?" = 0 ]; then
  		menuentry '$LABEL' \$menuentry_id_option 'uefi-firmware' {
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0045-loader-mips64-linux-properly-prepare-memory-for-init.patch
+++ b/app-admin/grub/autobuild/patches/0045-loader-mips64-linux-properly-prepare-memory-for-init.patch
@@ -1,7 +1,7 @@
 From 14c355fefcb8d1474b7b1301753b743f0b08e0ad Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Wed, 22 Jan 2025 21:13:13 +0800
-Subject: [PATCH 45/73] loader/mips64/linux: properly prepare memory for initrd
+Subject: [PATCH 45/75] loader/mips64/linux: properly prepare memory for initrd
 
 ... instead of allocating a fixed amount at initialization
 ---
@@ -44,5 +44,5 @@ index 6b6cac273..9ac371352 100644
      grub_relocator_chunk_t ch;
      err = grub_relocator_alloc_chunk_align (relocator, &ch,
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0046-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
+++ b/app-admin/grub/autobuild/patches/0046-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
@@ -1,7 +1,7 @@
 From bff9800b71ea5353bc03694272c9695e102462bf Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Fri, 14 Feb 2025 15:23:20 +0800
-Subject: [PATCH 46/73] fix(util/grub-mkimagexx): unconditionaly use 64-bit
+Subject: [PATCH 46/75] fix(util/grub-mkimagexx): unconditionaly use 64-bit
  addresses for mips64el-efi
 
 grub_addr_t uses host pointer size, which becomes undesirable if the host
@@ -133,5 +133,5 @@ index 1ba5389db..10783a1b1 100644
  				 image_target);
  	  }
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0047-grub.d-10_linux-Use-an-in-house-script-to-generate-l.patch
+++ b/app-admin/grub/autobuild/patches/0047-grub.d-10_linux-Use-an-in-house-script-to-generate-l.patch
@@ -1,7 +1,7 @@
 From fe80c1e44d0913c931447e0da8972df8b94fbe94 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 11 Aug 2025 10:42:41 +0800
-Subject: [PATCH 47/73] grub.d/10_linux: Use an in-house script to generate
+Subject: [PATCH 47/75] grub.d/10_linux: Use an in-house script to generate
  linux menu entries
 
 Now we have to deal with different kernel configurations for each kernel
@@ -1213,5 +1213,5 @@ index 8327dc494..76ea145fb 100644
 +process_kernels
 +info "$(gettext_printf "Done generating entries for %s." "$OS")"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0048-po-update-PO-files.patch
+++ b/app-admin/grub/autobuild/patches/0048-po-update-PO-files.patch
@@ -1,7 +1,7 @@
 From a38a4dc4a654398c9a5b3f3697d056d27c3b25e8 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 3 Sep 2025 12:17:03 +0800
-Subject: [PATCH 48/73] po: update PO files
+Subject: [PATCH 48/75] po: update PO files
 
 ---
  po/ast.po   | 4785 ++++++++++++++++++++++-----------
@@ -191032,5 +191032,5 @@ index 6e863c161..606783c6a 100644
  #~ msgstr "顯露 v1 表。"
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0049-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0049-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From 6c63aa2014a88726e6334398f9517319da8edd33 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2?= <jeffbai@aosc.io>
 Date: Thu, 4 Sep 2025 01:36:34 +0000
-Subject: [PATCH 49/73] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 49/75] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1558 of 1558 strings)
@@ -137,5 +137,5 @@ index f5da04cfd..3124218b6 100644
  #: util/grub.d/10_netbsd.in:105
  #, c-format, sh-printf-format
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0050-10_linux-show-the-latest-kernel-for-each-variant-on-.patch
+++ b/app-admin/grub/autobuild/patches/0050-10_linux-show-the-latest-kernel-for-each-variant-on-.patch
@@ -1,7 +1,7 @@
 From 3ec5dd0d04f422f2e101acce31cff6d1769baccc Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 5 Sep 2025 14:55:45 +0800
-Subject: [PATCH 50/73] 10_linux: show the latest kernel for each variant on
+Subject: [PATCH 50/75] 10_linux: show the latest kernel for each variant on
  toplevel menu
 
 Previously, this script just place the latest kernel in the top level
@@ -212,5 +212,5 @@ index 76ea145fb..46d8b9980 100644
  	printf "}\n"
  }
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0051-po-process-transliterated-line-breaks-n.patch
+++ b/app-admin/grub/autobuild/patches/0051-po-process-transliterated-line-breaks-n.patch
@@ -1,7 +1,7 @@
 From 697b93a6caf5685ea86bb03d2a6acaca20980bfc Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 5 Sep 2025 18:03:12 +0800
-Subject: [PATCH 51/73] =?UTF-8?q?po:=20process=20transliterated=20line=20b?=
+Subject: [PATCH 51/75] =?UTF-8?q?po:=20process=20transliterated=20line=20b?=
  =?UTF-8?q?reaks:=20\=D0=BD=20->=20\n?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -63,5 +63,5 @@ index ce59e576e..c7fd69026 100644
  s,%\([0-9]*\)צ,%\1c,g
  s,%\([0-9]*\)ד,%\1d,g
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0052-10_linux-show-all-kernels-in-the-submenu.patch
+++ b/app-admin/grub/autobuild/patches/0052-10_linux-show-all-kernels-in-the-submenu.patch
@@ -1,7 +1,7 @@
 From 0eb104c0e22760c382b380c462fb000c7ebb12ce Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 6 Sep 2025 00:17:44 +0800
-Subject: [PATCH 52/73] 10_linux: show all kernels in the submenu
+Subject: [PATCH 52/75] 10_linux: show all kernels in the submenu
 
 ---
  util/grub.d/10_linux.in | 3 +--
@@ -28,5 +28,5 @@ index 46d8b9980..c3b5497ff 100644
  	# mess up the order.
  	printf "submenu '%s' {\n" "$submenu_title"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0053-10_linux-skip-showing-Processing-for-kernels-in-the-.patch
+++ b/app-admin/grub/autobuild/patches/0053-10_linux-skip-showing-Processing-for-kernels-in-the-.patch
@@ -1,7 +1,7 @@
 From dd3ee9626a2de856f6f82e2bc9a584057088e0e7 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 6 Sep 2025 00:17:44 +0800
-Subject: [PATCH 53/73] 10_linux: skip showing 'Processing' for kernels in the
+Subject: [PATCH 53/75] 10_linux: skip showing 'Processing' for kernels in the
  toplevel menu
 
 ---
@@ -50,5 +50,5 @@ index c3b5497ff..648c2d21d 100644
  		comments="$(gettext_printf "With kernel %s" "$uname_r")"
  		comments=" ($(echo "$comments" | grub_quote))"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0054-po-update-PO-template-and-translation-files.patch
+++ b/app-admin/grub/autobuild/patches/0054-po-update-PO-template-and-translation-files.patch
@@ -1,7 +1,7 @@
 From 4abfd5f2e159de7957d01e4e38b85577b203bfbb Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 15:45:24 +0800
-Subject: [PATCH 54/73] po: update PO template and translation files
+Subject: [PATCH 54/75] po: update PO template and translation files
 
 ---
  po/ast.po   | 36 ++++++++++++++++++------------------
@@ -4156,5 +4156,5 @@ index 606783c6a..dd2c0167d 100644
  msgid "Done generating entries for %s."
  msgstr ""
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0055-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0055-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From a41769ef3edd86634eaa89504c1c17c438ff2bd9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2?= <jeffbai@aosc.io>
 Date: Mon, 8 Sep 2025 07:57:32 +0000
-Subject: [PATCH 55/73] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 55/75] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1558 of 1558 strings)
@@ -47,5 +47,5 @@ index 36aeab91d..1b560cdd2 100644
  #: util/grub.d/10_linux.in:431
  #, c-format, sh-printf-format
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0056-10_linux-fix-the-formatting-of-Booting-and-Loading-K.patch
+++ b/app-admin/grub/autobuild/patches/0056-10_linux-fix-the-formatting-of-Booting-and-Loading-K.patch
@@ -1,7 +1,7 @@
 From 8339cf221d0e9829aeb0ef17090321ca4a29a6cc Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 16:44:12 +0800
-Subject: [PATCH 56/73] 10_linux: fix the formatting of "Booting" and "Loading
+Subject: [PATCH 56/75] 10_linux: fix the formatting of "Booting" and "Loading
  Kernel" prompt
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -1369,5 +1369,5 @@ index 648c2d21d..bda28b435 100644
  }
  
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0057-10_linux-add-an-arrow-to-the-submenu-entry.patch
+++ b/app-admin/grub/autobuild/patches/0057-10_linux-add-an-arrow-to-the-submenu-entry.patch
@@ -1,7 +1,7 @@
 From f18e95d1f7d690797035619772d39cfebec4c063 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 16:53:09 +0800
-Subject: [PATCH 57/73] 10_linux: add an arrow to the submenu entry
+Subject: [PATCH 57/75] 10_linux: add an arrow to the submenu entry
 
 ---
  util/grub.d/10_linux.in | 2 +-
@@ -21,5 +21,5 @@ index bda28b435..704abcbaa 100644
  	for kernel in "${KERNELS[@]}" ; do
  		uname_r=${kernel/#@(vmlinu?|kernel)-/}
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0058-10_linux-fix-initrd-detection-when-generating-submen.patch
+++ b/app-admin/grub/autobuild/patches/0058-10_linux-fix-initrd-detection-when-generating-submen.patch
@@ -1,7 +1,7 @@
 From e3df9aa4292985880e9b47459f31b3fa6e591e8c Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 12:06:33 +0800
-Subject: [PATCH 58/73] 10_linux: fix initrd detection when generating submenu
+Subject: [PATCH 58/75] 10_linux: fix initrd detection when generating submenu
  entries
 
 The condition that controls the initrd message is awfully wrong. It
@@ -61,5 +61,5 @@ index 704abcbaa..00c6fe529 100644
  			args="$ARGS"
  		fi
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0059-10_linux-support-btrfs-subvolumes-for-kernel-initrd-.patch
+++ b/app-admin/grub/autobuild/patches/0059-10_linux-support-btrfs-subvolumes-for-kernel-initrd-.patch
@@ -1,7 +1,7 @@
 From 0fe1e4e53122f71c874695c9af8a4401ddc1fd66 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 15:35:46 +0800
-Subject: [PATCH 59/73] 10_linux: support btrfs subvolumes for kernel/initrd
+Subject: [PATCH 59/75] 10_linux: support btrfs subvolumes for kernel/initrd
  paths
 
 ---
@@ -32,5 +32,5 @@ index 00c6fe529..d46b835ab 100644
  	INITRD_EARLY="${INITRD_EARLY##[ 	]}"
  done
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0060-10_linux-sort-submenu-entries-by-versions.patch
+++ b/app-admin/grub/autobuild/patches/0060-10_linux-sort-submenu-entries-by-versions.patch
@@ -1,7 +1,7 @@
 From e33aae4dcbcb70a531548ee1af6ac1c79b9edce6 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 17:15:15 +0800
-Subject: [PATCH 60/73] 10_linux: sort submenu entries by versions
+Subject: [PATCH 60/75] 10_linux: sort submenu entries by versions
 
 ---
  util/grub.d/10_linux.in | 38 ++++++++++++++++++++++----------------
@@ -57,5 +57,5 @@ index d46b835ab..aa908e973 100644
  	printf "}\n"
  }
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0061-10_linux-strip-leading-whitespaces-when-printing-ker.patch
+++ b/app-admin/grub/autobuild/patches/0061-10_linux-strip-leading-whitespaces-when-printing-ker.patch
@@ -1,7 +1,7 @@
 From 5d3f04591b123613c9ecdb7e4a2fa99d417faf3d Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Sep 2025 00:04:34 +0800
-Subject: [PATCH 61/73] 10_linux: strip leading whitespaces when printing
+Subject: [PATCH 61/75] 10_linux: strip leading whitespaces when printing
  kernel and initrd path
 
 ---
@@ -26,5 +26,5 @@ index aa908e973..86feda685 100644
  	printf "${indent}\techo	'%s'\n" "$(gettext_printf "Starting %s ..." "$OS")"
  	printf "${indent}}\n\n"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0062-10_linux-rework-prioritization-logic.patch
+++ b/app-admin/grub/autobuild/patches/0062-10_linux-rework-prioritization-logic.patch
@@ -1,7 +1,7 @@
 From 878d1f621f06276482fefcf3161ac56fb3b45000 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 2 Oct 2025 23:56:42 +0800
-Subject: [PATCH 62/73] 10_linux: rework prioritization logic
+Subject: [PATCH 62/75] 10_linux: rework prioritization logic
 
 Previously the kernel with default configuration (e.g. -16k for
 LoongArch) will always be on top regardless of its variant, i.e. a 16k
@@ -70,5 +70,5 @@ index 86feda685..29edc26e1 100644
  	OLDIFS="$IFS"
  	IFS=$'\n'
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0063-10_linux.in-read-etc-os-release-to-specify-OS-class.patch
+++ b/app-admin/grub/autobuild/patches/0063-10_linux.in-read-etc-os-release-to-specify-OS-class.patch
@@ -1,7 +1,7 @@
 From 540bacdb1012366052d7f7c9297bccec0b02ba82 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 3 Oct 2025 00:07:52 +0800
-Subject: [PATCH 63/73] 10_linux.in: read /etc/os-release to specify OS class
+Subject: [PATCH 63/75] 10_linux.in: read /etc/os-release to specify OS class
 
 Some theme uses OS classes to determine OS type. We missed that in the
 initial rewrite.
@@ -47,5 +47,5 @@ index 29edc26e1..560098f2a 100644
  	local scanned
  	IFS=$'\n'
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0064-10_linux-fix-GRUB_KERNEL_DIR-when-using-separate-boo.patch
+++ b/app-admin/grub/autobuild/patches/0064-10_linux-fix-GRUB_KERNEL_DIR-when-using-separate-boo.patch
@@ -1,7 +1,7 @@
 From 63a39dc574e5c9eaaf95a68ee2316dda9052d153 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 11 Oct 2025 17:21:59 +0800
-Subject: [PATCH 64/73] 10_linux: fix GRUB_KERNEL_DIR when using separate /boot
+Subject: [PATCH 64/75] 10_linux: fix GRUB_KERNEL_DIR when using separate /boot
  w/ btrfs
 
 If /boot is on a separate partition, we should use / for
@@ -34,5 +34,5 @@ index 560098f2a..78e38d01a 100644
  # search --fs-uuid commands.
  MENUENTRY_PREP="$(prepare_grub_to_access_device "$GRUB_DEVICE_BOOT")"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0065-Translated-using-Weblate-Esperanto.patch
+++ b/app-admin/grub/autobuild/patches/0065-Translated-using-Weblate-Esperanto.patch
@@ -1,7 +1,7 @@
 From bc8eb71f9826be1cff4b4711c6814a81c11832ad Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 17:42:49 +0800
-Subject: [PATCH 65/73] Translated using Weblate (Esperanto)
+Subject: [PATCH 65/75] Translated using Weblate (Esperanto)
 
 Currently translated at 97.6% (1522 of 1559 strings)
 
@@ -51,5 +51,5 @@ index 1d7b014ca..1e274185d 100644
  #: grub-core/commands/memsize.c:46
  msgid "Print and export the value as kibibytes."
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0066-10_linux-add-comment-string-for-Asahi-kernel.patch
+++ b/app-admin/grub/autobuild/patches/0066-10_linux-add-comment-string-for-Asahi-kernel.patch
@@ -1,7 +1,7 @@
 From 7e624543e95d8e789a7ead88d3d5b911dd37e974 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 18:21:07 +0800
-Subject: [PATCH 66/73] 10_linux: add comment string for Asahi kernel
+Subject: [PATCH 66/75] 10_linux: add comment string for Asahi kernel
 
 * Update PO Template.
 * Merge translations with the PO Template.
@@ -4322,5 +4322,5 @@ index 78e38d01a..f27a09b1b 100644
  			gettext_printf "Kernel variant '%s'" "$1"
  			;;
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0067-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0067-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From 8d2ff292c074446d7e424098e2aac4157e9c714e Mon Sep 17 00:00:00 2001
 From: Old Dodo <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 10:30:39 +0000
-Subject: [PATCH 67/73] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 67/75] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1561 of 1561 strings)
@@ -37,5 +37,5 @@ index d9b2f9851..4fbbf377b 100644
  #: util/grub.d/10_linux.in:163
  #, c-format, sh-printf-format
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0068-Translated-using-Weblate-Chinese-Traditional-Han-scr.patch
+++ b/app-admin/grub/autobuild/patches/0068-Translated-using-Weblate-Chinese-Traditional-Han-scr.patch
@@ -1,7 +1,7 @@
 From 5782e7560c0c44590e5aa263f04d3c360e8daf0c Mon Sep 17 00:00:00 2001
 From: Old Dodo <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 10:31:57 +0000
-Subject: [PATCH 68/73] Translated using Weblate (Chinese (Traditional Han
+Subject: [PATCH 68/75] Translated using Weblate (Chinese (Traditional Han
  script))
 
 Currently translated at 22.2% (347 of 1561 strings)
@@ -48,5 +48,5 @@ index 20cf4bf05..d87db7054 100644
  #: util/grub.d/10_linux.in:163
  #, c-format, sh-printf-format
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0069-po-update-translation-catalogs.patch
+++ b/app-admin/grub/autobuild/patches/0069-po-update-translation-catalogs.patch
@@ -1,7 +1,7 @@
 From 9a69f5e02be993c4ac1ce5f3092c4d4c9a9f7b97 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 19 Jan 2026 10:47:57 +0800
-Subject: [PATCH 69/73] po: update translation catalogs
+Subject: [PATCH 69/75] po: update translation catalogs
 
 ---
  po/de.po    |  925 ++++++++++++++++++++++++++++++++++++++++++++-
@@ -9881,5 +9881,5 @@ index d87db7054..abf0f2c9d 100644
 +#~ msgid "%s, with Linux %s"
 +#~ msgstr "%s，採用 Linux %s"
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0070-mips64-relocator-add-some-dummy-func-and-var.patch
+++ b/app-admin/grub/autobuild/patches/0070-mips64-relocator-add-some-dummy-func-and-var.patch
@@ -1,7 +1,7 @@
 From 7c462e0800326ed0a5d5eb99e8eff146026b6cf9 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 31 Oct 2025 15:56:48 +0800
-Subject: [PATCH 70/73] mips64/relocator: add some dummy func and var
+Subject: [PATCH 70/75] mips64/relocator: add some dummy func and var
 
 fix grub_cpu_relocator_preamble and grub_relocator_preamble_size not defined,
 introduced in 6898fcf74d134d7220c533e476585370f25bc378
@@ -34,5 +34,5 @@ index 9712b6f73..3d6cad68d 100644
  write_reg (int regn, grub_uint64_t val, void **target)
  {
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0071-Revert-configure-Check-linker-for-image-base-support.patch
+++ b/app-admin/grub/autobuild/patches/0071-Revert-configure-Check-linker-for-image-base-support.patch
@@ -1,7 +1,7 @@
 From d4fb7a49f7ca0e2eda68ea75dbc769f73eb407fe Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Tue, 17 Feb 2026 03:58:36 +0800
-Subject: [PATCH 71/73] Revert "configure: Check linker for --image-base
+Subject: [PATCH 71/75] Revert "configure: Check linker for --image-base
  support"
 
 This reverts commit 1a5417f39a0ccefcdd5440f2a67f84d2d2e26960 and should
@@ -70,5 +70,5 @@ index cdea8c17a..a84e088a2 100644
  fi
  grub_PROG_LD_BUILD_ID_NONE
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0072-Revert-configure-Print-a-more-helpful-error-if-autoc.patch
+++ b/app-admin/grub/autobuild/patches/0072-Revert-configure-Print-a-more-helpful-error-if-autoc.patch
@@ -1,7 +1,7 @@
 From 43bfd901e87d8ea182dbc9bc684882ba708570a3 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Tue, 17 Feb 2026 23:39:20 +0800
-Subject: [PATCH 72/73] Revert "configure: Print a more helpful error if
+Subject: [PATCH 72/75] Revert "configure: Print a more helpful error if
  autoconf-archive is not installed"
 
 This reverts commit ac042f3f58d33ce9cd5ff61750f06da1a1d7b0eb.
@@ -28,5 +28,5 @@ index a84e088a2..a48c8b908 100644
  grub_PROG_OBJCOPY_ABSOLUTE
  fi
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/autobuild/patches/0073-ieee1275-don-t-return-NULL-if-there-is-no-partition.patch
+++ b/app-admin/grub/autobuild/patches/0073-ieee1275-don-t-return-NULL-if-there-is-no-partition.patch
@@ -1,7 +1,7 @@
 From 04358635d191dcb577e0da65dfd5dec64baaf984 Mon Sep 17 00:00:00 2001
 From: AOSC Maintainers <maintainers@aosc.io>
 Date: Wed, 4 Mar 2026 10:28:44 +0000
-Subject: [PATCH 73/73] ieee1275: don't return NULL if there is no partition
+Subject: [PATCH 73/75] ieee1275: don't return NULL if there is no partition
 
 ISOs generated using grub-mkrescue does not contain "partitions", as seen
 in the SLOF firmware which is used in the QEMU pseries machines.

--- a/app-admin/grub/autobuild/patches/0074-loader-mips64-linux-directly-ask-EFI-to-allocate-ini.patch
+++ b/app-admin/grub/autobuild/patches/0074-loader-mips64-linux-directly-ask-EFI-to-allocate-ini.patch
@@ -1,0 +1,61 @@
+From 8c22693055cee21b3ab4af582e921fb71babc422 Mon Sep 17 00:00:00 2001
+From: Henry Chen <henry.chen@oss.cipunited.com>
+Date: Fri, 13 Mar 2026 22:17:39 +0800
+Subject: [PATCH 74/75] loader/mips64/linux: directly ask EFI to allocate
+ initrd memory
+
+Why work around issues of `malloc_in_range` on EFI if we can just
+avoid using this function? It is over 700 lines of code.
+
+I thought I could work around its problems using `grub_memalign`.
+Now I consider myself wrong.
+---
+ grub-core/loader/mips64/linux.c | 23 ++++-------------------
+ 1 file changed, 4 insertions(+), 19 deletions(-)
+
+diff --git a/grub-core/loader/mips64/linux.c b/grub-core/loader/mips64/linux.c
+index 9ac371352..de5532cda 100644
+--- a/grub-core/loader/mips64/linux.c
++++ b/grub-core/loader/mips64/linux.c
+@@ -501,8 +501,7 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
+ {
+   grub_size_t size = 0;
+   void *initrd_dest;
+-  void *balloon = NULL;
+-  grub_err_t err;
++  void *initrd_page_base = NULL;
+   struct grub_linux_initrd_context initrd_ctx = { 0, 0, 0 };
+ 
+   if (argc == 0)
+@@ -519,25 +518,11 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
+ 
+   size = grub_get_initrd_size (&initrd_ctx);
+ 
+-  // make sure we can allocate sufficient memory for the initrd
+-  balloon = grub_memalign (0x10000, size);
+-  if (!balloon)
++  initrd_page_base = grub_efi_allocate_any_pages((size + 0x10000) >> 12);
++  if (!initrd_page_base)
+     goto fail;
+-  else
+-    // free this region for the relocator
+-    grub_free(balloon);
+ 
+-  {
+-    grub_relocator_chunk_t ch;
+-    err = grub_relocator_alloc_chunk_align (relocator, &ch,
+-					    0, (0xffffffff - size) + 1,
+-					    size, 0x10000,
+-					    GRUB_RELOCATOR_PREFERENCE_LOW, 0);
+-
+-    if (err)
+-      goto fail;
+-    initrd_dest = get_virtual_current_address (ch);
+-  }
++  initrd_dest = (void *)ALIGN_UP((grub_size_t)initrd_page_base, 0x10000);
+ 
+   if (grub_initrd_load (&initrd_ctx, initrd_dest))
+     goto fail;
+-- 
+2.52.0
+

--- a/app-admin/grub/autobuild/patches/0075-10_linux.in-Handle-vanilla_rc-kernel-variant.patch
+++ b/app-admin/grub/autobuild/patches/0075-10_linux.in-Handle-vanilla_rc-kernel-variant.patch
@@ -1,7 +1,7 @@
-From fbfa84d00644edab99b49ee85b16b0dd8e81bc6f Mon Sep 17 00:00:00 2001
+From 5476bfcd4a954ae5fd369a41a63b4c70323a8a0d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 15:24:19 +0800
-Subject: [PATCH 73/73] 10_linux.in: Handle vanilla_rc kernel variant
+Subject: [PATCH 75/75] 10_linux.in: Handle vanilla_rc kernel variant
 
 ---
  util/grub.d/10_linux.in | 7 +++++--
@@ -40,5 +40,5 @@ index f27a09b1b..ba393094b 100644
  			continue
  		fi
 -- 
-2.53.0
+2.52.0
 

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=17.0.02
 RETROFONTVER=20200402
 
 VER=${GRUBVER}+unifont${__UNIFONTVER}
-REL=5
+REL=6
 SRCS="git::commit=tags/grub-${__UPSTREAM_VER};rename=grub-${__UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::rename=grub-fonts-$RETROFONTVER.tar.xz::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: fix initrd command oom failure on loongson3
    Imagine failing to load a 15MiB initrd while the 30MiB one works.
    Now it's fixed.

Package(s) Affected
-------------------

- grub: 2:2.14+unifont17.0.02-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
