### PR TITLE
yq: update to 4.52.4

### DIFF
--- a/app-devel/yq/autobuild/defines
+++ b/app-devel/yq/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=yq
 PKGSEC=devel
 PKGDEP="glibc"
-PKGDES="A command-line YAML, JSON, XML, CSV, TOML and properties processor"
+PKGDES="Command-line YAML, JSON, XML, CSV, TOML and properties processor"
 BUILDDEP="go"
 
 # FIXME: Autobuild does not yet support splitting out debug symbol from Go executables

--- a/app-devel/yq/spec
+++ b/app-devel/yq/spec
@@ -1,5 +1,4 @@
-VER=4.50.1
-REL=2
+VER=4.52.4
 SRCS="git::commit=tags/v${VER}::https://github.com/mikefarah/yq.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=303696"


### PR DESCRIPTION
Topic Description
-----------------

- yq: update to 4.52.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- yq: 4.52.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit yq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
