### PR TITLE
perl-image-exiftool: update to 13.52

### DIFF
--- a/lang-perl/perl-image-exiftool/autobuild/defines
+++ b/lang-perl/perl-image-exiftool/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=perl
 PKGDEP="perl"
 PKGDES="Reader and rewriter of EXIF informations that supports raw files"
 
+ABTYPE=perl
 ABHOST=noarch

--- a/lang-perl/perl-image-exiftool/spec
+++ b/lang-perl/perl-image-exiftool/spec
@@ -1,4 +1,4 @@
-VER=13.30
-SRCS="tbl::https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-${VER}.tar.gz"
-CHKSUMS="sha256::885afd06c4efcc60d1df703cc88ba7ddc3bb6fed854cfbaa9e6cd72adfbe8da9"
+VER=13.52
+SRCS="git::commit=tags/$VER::https://github.com/exiftool/exiftool"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6175"

--- a/topics/perl-image-exiftool-13.52.toml
+++ b/topics/perl-image-exiftool-13.52.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "perl-image-exiftool 13.52"
+
+[caution]
+default = "Fixes an OS command injection vulnerability - CVE-2026-3102 (Severity: High)"
+zh_CN = "修复一个操作系统命令注入漏洞，漏洞编号 CVE-2026-3102（严重性：高）"
+
+[packages-v2]
+"perl-image-exiftool" = "< 13.52"


### PR DESCRIPTION
Topic Description
-----------------

- perl-image-exiftool: update to 13.52

Package(s) Affected
-------------------

- perl-image-exiftool: 13.52

Security Update?
----------------

No

Build Order
-----------

```
#buildit perl-image-exiftool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
