### PR TITLE
skopeo: update to 1.22.0

### DIFF
--- a/app-containers/skopeo/spec
+++ b/app-containers/skopeo/spec
@@ -1,5 +1,4 @@
-VER=1.19.0
-REL=4
+VER=1.22.0
 SRCS="git::commit=tags/v$VER::https://github.com/containers/skopeo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9216"


### PR DESCRIPTION
Topic Description
-----------------

- skopeo: update to 1.22.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- skopeo: 1.22.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit skopeo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
