### PR TITLE
crush: update to 0.49.0

### DIFF
--- a/app-utils/crush/autobuild/defines
+++ b/app-utils/crush/autobuild/defines
@@ -3,5 +3,8 @@ PKGSEC=utils
 PKGDES="CLI-based AI coding agent"
 PKGDEP="glibc"
 BUILDDEP="go"
+
 ABTYPE=gomod
 GO_LDFLAGS=("-X 'github.com/charmbracelet/crush/internal/version.Version=${PKGVER}'")
+# FIXME: purego does not support mips
+FAIL_ARCH="loongson3"

--- a/app-utils/crush/spec
+++ b/app-utils/crush/spec
@@ -1,5 +1,4 @@
-VER=0.29.1
-REL=2
+VER=0.49.0
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/crush"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=382294"


### PR DESCRIPTION
Topic Description
-----------------

- crush: update to 0.49.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- crush: 0.49.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit crush
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
