### PR TITLE
gnuchess: update to 6.3.0

### DIFF
--- a/app-games/gnuchess/spec
+++ b/app-games/gnuchess/spec
@@ -1,4 +1,4 @@
-VER=6.2.9
+VER=6.3.0
 SRCS="tbl::https://ftp.gnu.org/gnu/chess/gnuchess-$VER.tar.gz"
-CHKSUMS="sha256::ddfcc20bdd756900a9ab6c42c7daf90a2893bf7f19ce347420ce36baebc41890"
+CHKSUMS="sha256::0b37bec2098c2ad695b7443e5d7944dc6dc8284f8d01fcc30bdb94dd033ca23a"
 CHKUPDATE="anitya::id=1206"


### PR DESCRIPTION
Topic Description
-----------------

- gnuchess: update to 6.3.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gnuchess: 6.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnuchess
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
