### PR TITLE
unifont: update to 17.0.04

### DIFF
--- a/desktop-fonts/unifont/autobuild/defines
+++ b/desktop-fonts/unifont/autobuild/defines
@@ -4,3 +4,5 @@ PKGDEP="fontconfig"
 PKGDES="Font for every printable code point in the Unicode Multilingual Plane"
 
 ABHOST=noarch
+
+ABTYPE=self

--- a/desktop-fonts/unifont/spec
+++ b/desktop-fonts/unifont/spec
@@ -1,4 +1,4 @@
-VER=17.0.03
+VER=17.0.04
 SRCS="tbl::https://ftp.gnu.org/gnu/unifont/unifont-$VER/unifont-$VER.tar.gz"
-CHKSUMS="sha256::9a26aa9adfa8eb1f91b0cd9b83e7f95ea9e14c6e85be71aa3ab0df5cb4e69c35"
+CHKSUMS="sha256::5c52c5d56ef98089ddbca62e68560ceccc57ea88940b9d38cc3c888fe3b59a34"
 CHKUPDATE="anitya::id=14916"


### PR DESCRIPTION
Topic Description
-----------------

- unifont: update to 17.0.04
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- unifont: 17.0.04

Security Update?
----------------

No

Build Order
-----------

```
#buildit unifont
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
