### PR TITLE
libpaper: update to 2.2.7

### DIFF
--- a/runtime-productivity/libpaper/autobuild/defines
+++ b/runtime-productivity/libpaper/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=libpaper
 PKGSEC=libs
 PKGDES="Library for handling paper characteristics"
-PKGDEP="bash"
+PKGDEP="glibc"
 
 PKGBREAK="cups<=2.4.2 html2ps<=1.0b7-1 texlive<=20220321-1 \
           libreoffice<=7.5.4.2-1 ghostscript<=9.54.0"
+
+ABTYPE=autotools

--- a/runtime-productivity/libpaper/spec
+++ b/runtime-productivity/libpaper/spec
@@ -1,4 +1,4 @@
-VER=2.2.5
+VER=2.2.7
 SRCS="tbl::https://github.com/rrthomas/libpaper/releases/download/v$VER/libpaper-$VER.tar.gz"
-CHKSUMS="sha256::7be50974ce0df0c74e7587f10b04272cd53fd675cb6a1273ae1cc5c9cc9cab09"
+CHKSUMS="sha256::3925401edf1eda596277bc2485e050b704fd7f364f257c874b0c40ac5aa627c0"
 CHKUPDATE="anitya::id=15136"


### PR DESCRIPTION
Topic Description
-----------------

- libpaper: update to 2.2.7

Package(s) Affected
-------------------

- libpaper: 2.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpaper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
