### PR TITLE
uefi-manager: new, 26.02

### DIFF
--- a/app-admin/uefi-manager/autobuild/beyond
+++ b/app-admin/uefi-manager/autobuild/beyond
@@ -1,0 +1,25 @@
+abinfo "Installing license and man pages"
+install -dvm755 "$PKGDIR"/usr/share/doc/uefi-manager
+install -dvm755 "$PKGDIR"/usr/share/man/man1
+install -Dvm644 "$SRCDIR"/docs/license.html "$PKGDIR"/usr/share/doc/uefi-manager
+install -Dvm644 "$SRCDIR"/docs/uefi-manager.1 "$PKGDIR"/usr/share/man/man1
+
+abinfo "Installing polkit related files"
+install -dvm755 "$PKGDIR"/usr/share/polkit-1/actions
+install -dvm755 "$PKGDIR"/usr/lib/uefi-manager
+install -Dvm644 "$SRCDIR"/scripts/*.policy "$PKGDIR"/usr/share/polkit-1/actions
+install -Dvm755 "$SRCDIR"/scripts/helper "$PKGDIR"/usr/lib/uefi-manager
+install -Dvm755 "$SRCDIR"/scripts/uefimanager-lib "$PKGDIR"/usr/lib/uefi-manager
+
+abinfo "Installing translations"
+install -dvm755 "$PKGDIR"/usr/share/uefi-manager/locale
+install -Dvm644 "$BLDDIR"/*.qm "$PKGDIR"/usr/share/uefi-manager/locale
+
+abinfo "Installing desktop file"
+install -Dvm644 "$SRCDIR"/uefi-manager.desktop "$PKGDIR"/usr/share/applications/uefi-manager.desktop
+
+abinfo "Installing icons"
+install -Dvm644 "$SRCDIR"/uefi-manager.png "$PKGDIR"/usr/share/icons/hicolor/48x48/apps/uefi-manager.png
+install -Dvm644 "$SRCDIR"/uefi-manager.png "$PKGDIR"/usr/share/pixmaps/uefi-manager.png
+install -Dvm644 "$SRCDIR"/uefi-manager.svg "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/uefi-manager.svg
+

--- a/app-admin/uefi-manager/autobuild/defines
+++ b/app-admin/uefi-manager/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=uefi-manager
+PKGSEC=admin
+PKGDEP="efibootmgr glibc xdg-utils qt-6"
+BUILDDEP="qt-6"
+PKGDES="Graphical tool for managing UEFI boot entries"
+
+ABTYPE=cmake
+CMAKE_AFTER=(
+    "-DPROJECT_VERSION_OVERRIDE=$PKGVER"
+)

--- a/app-admin/uefi-manager/spec
+++ b/app-admin/uefi-manager/spec
@@ -1,0 +1,3 @@
+VER=26.02
+SRCS="git::commit=tags/$VER::https://github.com/MX-Linux/uefi-manager.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

Provided by MX Linux, UEFI Manager is a graphical tool for managing UEFI boot entries.

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

uefi-manager

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit uefi-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
