### PR TITLE
topics/perl-image-exiftool-13.52.toml: rework title against CPAN naming convention

### DIFF
--- a/topics/perl-image-exiftool-13.52.toml
+++ b/topics/perl-image-exiftool-13.52.toml
@@ -1,7 +1,7 @@
 security = true
 
 [name]
-default = "perl-image-exiftool 13.52"
+default = "Perl Image::ExifTool 13.52"
 
 [caution]
 default = "Fixes an OS command injection vulnerability - CVE-2026-3102 (Severity: High)"


### PR DESCRIPTION
Topic Description
-----------------

- topics/perl-image-exiftool-13.52.toml: rework title against CPAN naming convention

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
