### PR TITLE
groff: update to 1.24.1

### DIFF
--- a/app-utils/groff/autobuild/beyond
+++ b/app-utils/groff/autobuild/beyond
@@ -1,2 +1,8 @@
-ln -sv eqn $PKGDIR/usr/bin/geqn
-ln -sv tbl $PKGDIR/usr/bin/gtbl
+abinfo "Creating compatibility wrappers/symlinks for eqn and tbl ..."
+ln -sv eqn \
+    "$PKGDIR"/usr/bin/geqn
+ln -sv tbl \
+    "$PKGDIR"/usr/bin/gtbl
+
+abinfo "Dropping local documentation per the Styling Manual ..."
+rm -rv "$PKGDIR"/usr/share/doc/groff-$PKGVER

--- a/app-utils/groff/autobuild/defines
+++ b/app-utils/groff/autobuild/defines
@@ -1,27 +1,29 @@
 PKGNAME=groff
 PKGDES="GNU Nroff alternative"
 PKGSEC=utils
-PKGDEP="glibc ncurses perl"
+PKGDEP="glibc ncurses perl uchardet"
 
-PAPER=A4
-ABSHADOW=0
+ABTYPE=autotools
+
+# FIXME: Re-configure with autoreconf(1).
+#
+# '[...]/groff-1.24.1/autogen.sh' -> '[...]/groff-1.24.1/bootstrap'
+# [...]/groff-1.24.1/bootstrap: Bootstrapping from a non-checked-out distribution is risky.
+ABNOBOOTSTRAP=1
+ABNOAUTOGEN=1
+
+# FIXME: Installation fails with parallelism with many-core systems.
 NOPARALLEL=1
 
-PKGDEP__RETRO="glibc ncurses"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP__RETRO="perl"
-BUILDDEP__ARMV4="${BUIDLDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUIDLDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUIDLDEP__RETRO}"
-BUILDDEP__PPC64="${BUIDLDEP__RETRO}"
+AUTOTOOLS_AFTER=(
+    '--enable-threads'
+    '--disable-rpath'
+    '--disable-groff-allocator'
+    '--enable-year2038'
+    '--with-x'
+    '--with-uchardet=yes'
+    '--with-urw-fonts'
+    '--with-urw-fonts-dir=/usr/share/fonts/Type1'
+    '--with-compatibility-wrappers=check'
+    '--with-gs=/usr/bin/gs'
+)

--- a/app-utils/groff/autobuild/prepare
+++ b/app-utils/groff/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting default page size to A4 ..."
+export PAGE=A4

--- a/app-utils/groff/spec
+++ b/app-utils/groff/spec
@@ -1,5 +1,4 @@
-VER=1.23.0
-REL=1
+VER=1.24.1
 SRCS="tbl::https://ftp.gnu.org/gnu/groff/groff-$VER.tar.gz"
-CHKSUMS="sha256::6b9757f592b7518b4902eb6af7e54570bdccba37a871fddb2d30ae3863511c13"
+CHKSUMS="sha256::74e2819795b6aff431aeac983d63a9c8968eeaba2a2eba7df8ba4c7b41e7cfd8"
 CHKUPDATE="anitya::id=1253"


### PR DESCRIPTION
Topic Description
-----------------

- groff: update to 1.24.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- groff: 1.24.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit groff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
