### PR TITLE
gi-docgen: update to 2026.1

### DIFF
--- a/app-doc/gi-docgen/autobuild/defines
+++ b/app-doc/gi-docgen/autobuild/defines
@@ -2,12 +2,10 @@ PKGNAME=gi-docgen
 PKGSEC=doc
 PKGDEP="jinja2 markdown markupsafe pygments toml typogrify tomli"
 BUILDDEP="setuptools-python3"
-PKGDES="A documentation generator for GObject-based libraries"
+PKGDES="Documentation generator for GObject-based libraries"
 
 ABHOST=noarch
-ABTYPE=pep517
-NOPYTHON2=1
-
+ABTYPE=meson
 MESON_AFTER=(
     '-Ddevelopment_tests=false'
 )

--- a/app-doc/gi-docgen/spec
+++ b/app-doc/gi-docgen/spec
@@ -1,5 +1,4 @@
-VER=2025.4
-REL="2"
+VER=2026.1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/gi-docgen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=178582"


### PR DESCRIPTION
Topic Description
-----------------

- gi-docgen: update to 2026.1
    - Correct ABTYPE.

Package(s) Affected
-------------------

- gi-docgen: 2026.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gi-docgen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
