### PR TITLE
MATE Desktop Survey (March, 2026)

### DIFF
--- a/desktop-mate/atril/spec
+++ b/desktop-mate/atril/spec
@@ -1,5 +1,4 @@
-VER=1.28.1
-REL=2
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/atril-$VER.tar.xz"
-CHKSUMS="sha256::74c4f42979f3ead52def23767448d06ad7f715421e03c9b509404b096de8193e"
+VER=1.28.3
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/atril"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198706"

--- a/desktop-mate/eom/autobuild/patch
+++ b/desktop-mate/eom/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i -E 's/（(_.)）/(\1)/g' po/zh_CN.po

--- a/desktop-mate/eom/autobuild/patches/0001-UPSTREAM-configure-Only-use-girepository-2.0-if-libp.patch
+++ b/desktop-mate/eom/autobuild/patches/0001-UPSTREAM-configure-Only-use-girepository-2.0-if-libp.patch
@@ -1,0 +1,49 @@
+From cbdc703e419bbad93724c61229cbe8468f56a89e Mon Sep 17 00:00:00 2001
+From: Victor Kareh <vkareh@redhat.com>
+Date: Mon, 26 Jan 2026 15:15:05 -0500
+Subject: [PATCH] UPSTREAM: configure: Only use girepository-2.0 if libpeas
+ uses it too
+
+Fixes header conflicts on systems where glib has girepository-2.0 but
+libpeas still uses the old gobject-introspection-1.0 headers.
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ configure.ac | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index f3d0316..fb5b4be 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -118,9 +118,16 @@ if test "$found_introspection" = "yes"; then
+ 	AC_DEFINE([HAVE_INTROSPECTION], [1], [Define to enable GObject Introspection])
+ 
+ 	# Check for girepository-2.0 API (moved to glib in version 1.80+)
+-	PKG_CHECK_EXISTS([girepository-2.0],
+-		[AC_DEFINE([HAVE_GIREPOSITORY_2], [1], [Using girepository-2.0 API])],
+-		[])
++	# We can only use girepository-2.0 if libpeas also uses it, otherwise we get conflicts
++	PKG_CHECK_EXISTS([girepository-2.0], [
++		# Check if libpeas requires girepository-2.0
++		if pkg-config --print-requires libpeas-1.0 | grep -q "girepository-2.0"; then
++			AC_DEFINE([HAVE_GIREPOSITORY_2], [1], [Using girepository-2.0 API])
++			have_girepository_2=yes
++		else
++			have_girepository_2=no
++		fi
++	], [have_girepository_2=no])
+ else
+ 	have_introspection=no
+ fi
+@@ -434,6 +441,7 @@ Configure summary:
+ 	RSVG support ...............:  ${have_rsvg}
+ 	Colour management support ..:  ${have_lcms}
+ 	GObject Introspection.......:  ${have_introspection}
++	GIRepository 2.0............:  ${have_girepository_2:-no}
+ 	Native Language support.....:  ${USE_NLS}
+ 	Thumbnailer.................:  ${eom_thumbnailer}
+ "
+-- 
+2.52.0
+

--- a/desktop-mate/eom/spec
+++ b/desktop-mate/eom/spec
@@ -1,4 +1,4 @@
-VER=1.28.0
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/eom-$VER.tar.xz"
-CHKSUMS="sha256::9a01cab2995a1a8c7258c865eae5f182ed4730c44672afdc3a07e423edd53abc"
+VER=1.28.1
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/eom"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198704"

--- a/desktop-mate/libmateweather/spec
+++ b/desktop-mate/libmateweather/spec
@@ -1,4 +1,4 @@
-VER=1.28.0
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/libmateweather-$VER.tar.xz"
-CHKSUMS="sha256::554373deb5b393b9d84b275dd2ca66c9a4a2d0e6ec92044fab8aa53e3032d2b5"
+VER=1.28.2
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/libmateweather"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230605"

--- a/desktop-mate/marco/spec
+++ b/desktop-mate/marco/spec
@@ -1,4 +1,4 @@
-VER=1.28.1
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/marco-$VER.tar.xz"
-CHKSUMS="sha256::2496e5e40ee980cd6849493ac3e0f8fd0dec8b81c674da8d9ba19a577f0ac2e1"
+VER=1.28.2
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/marco"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230606"

--- a/desktop-mate/mate-menus/spec
+++ b/desktop-mate/mate-menus/spec
@@ -1,5 +1,4 @@
-VER=1.28.0
-REL=1
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-menus-$VER.tar.xz"
-CHKSUMS="sha256::cf40c75c7d6f0aad1d4969828fc62025c6222bc6a84f0bb9d6ead7e45970508d"
+VER=1.28.1
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/mate-menus"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230616"

--- a/desktop-mate/mate-notification-daemon/spec
+++ b/desktop-mate/mate-notification-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.28.3
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-notification-daemon-$VER.tar.xz"
-CHKSUMS="sha256::e00cecb1ff9f75b9ccc2644558e44343b80941edb40377dd8100ed3922adf413"
+VER=1.28.5
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/mate-notification-daemon"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230618"

--- a/desktop-mate/mate-panel/autobuild/defines
+++ b/desktop-mate/mate-panel/autobuild/defines
@@ -4,8 +4,18 @@ PKGDEP="caja dbus-glib dconf dconf-editor gtk-3 libwnck-3 libcanberra \
 	libmateweather librsvg libsoup marco mate-menus mate-desktop \
 	mate-session-manager yelp"
 BUILDDEP="gobject-introspection mate-common yelp-tools"
-PKGDES="A highly customizable panel for the MATE desktop"
+PKGDES="Customizable panel for the MATE desktop"
 
-AUTOTOOLS_AFTER="--enable-introspection --enable-gtk-doc \
-                 --with-in-process-applets=all"
-PKGEPOCH=1
+AUTOTOOLS_AFTER=(
+    '--enable-introspection'
+    '--disable-gtk-doc'
+    '--with-in-process-applets=all'
+)
+
+# FIXME: Shadow build fails.
+#
+# [...]/mate-panel/applets/notification_area/status-notifier/sn-host-v0.h:22:10: fatal error: sn-host-v0-gen.h: No such file or directory
+#    22 | #include "sn-host-v0-gen.h"
+#       |          ^~~~~~~~~~~~~~~~~~
+# compilation terminated.
+ABSHADOW=0

--- a/desktop-mate/mate-panel/spec
+++ b/desktop-mate/mate-panel/spec
@@ -1,4 +1,4 @@
-VER=1.28.4
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-panel-$VER.tar.xz"
-CHKSUMS="sha256::02f09eb0314c2ac197b6f089950a571cdba39bfd03d6c3a0b8fd77252a968874"
+VER=1.28.7
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/mate-panel"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230619"

--- a/desktop-mate/mate-terminal/spec
+++ b/desktop-mate/mate-terminal/spec
@@ -1,6 +1,5 @@
-VER=1.28.1
-REL=3
+VER=1.28.2
 EPOCH=1
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/mate-terminal-$VER.tar.xz"
-CHKSUMS="sha256::f135eb1a9e2ae22798ecb2dc1914fdb4cfd774e6bb65c0152be37cc6c9469e92"
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/mate-terminal"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198702"

--- a/desktop-mate/pluma/autobuild/patches/0001-UPSTREAM-configure-Only-use-girepository-2.0-if-libp.patch
+++ b/desktop-mate/pluma/autobuild/patches/0001-UPSTREAM-configure-Only-use-girepository-2.0-if-libp.patch
@@ -1,0 +1,51 @@
+From 57e3aaadb16d392c92edbd6aa06e692cc76f3d7d Mon Sep 17 00:00:00 2001
+From: Victor Kareh <vkareh@redhat.com>
+Date: Mon, 26 Jan 2026 10:14:14 -0500
+Subject: [PATCH] UPSTREAM: configure: Only use girepository-2.0 if libpeas
+ uses it too
+
+Fixes header conflicts on systems where glib has girepository-2.0 but
+libpeas still uses the old gobject-introspection-1.0 headers.
+
+Fixes https://github.com/mate-desktop/pluma/issues/729
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ configure.ac | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index b35b55e..5f9a848 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -197,9 +197,16 @@ if test "$found_introspection" = "yes"; then
+ 	AC_DEFINE([HAVE_INTROSPECTION], [1], [Define to enable GObject Introspection])
+ 
+ 	# Check for girepository-2.0 API (moved to glib in version 1.80+)
+-	PKG_CHECK_EXISTS([girepository-2.0],
+-		[AC_DEFINE([HAVE_GIREPOSITORY_2], [1], [Using girepository-2.0 API])],
+-		[])
++	# We can only use girepository-2.0 if libpeas also uses it, otherwise we get conflicts
++	PKG_CHECK_EXISTS([girepository-2.0], [
++		# Check if libpeas requires girepository-2.0
++		if pkg-config --print-requires libpeas-1.0 | grep -q "girepository-2.0"; then
++			AC_DEFINE([HAVE_GIREPOSITORY_2], [1], [Using girepository-2.0 API])
++			have_girepository_2=yes
++		else
++			have_girepository_2=no
++		fi
++	], [have_girepository_2=no])
+ else
+ 	have_introspection=no
+ fi
+@@ -308,6 +315,7 @@ Configure summary:
+ 	Spell Plugin enabled:	$enable_enchant
+ 	Gvfs metadata enabled:	$enable_gvfs_metadata
+ 	GObject Introspection:	${have_introspection}
++	GIRepository 2.0:	${have_girepository_2:-no}
+ 	Tests enabled:		$enable_tests
+ "
+ 
+-- 
+2.52.0
+

--- a/desktop-mate/pluma/spec
+++ b/desktop-mate/pluma/spec
@@ -1,5 +1,4 @@
-VER=1.28.0
-SRCS="tbl::https://pub.mate-desktop.org/releases/${VER:0:4}/pluma-$VER.tar.xz"
-CHKSUMS="sha256::aa8adf9589345093a50e30b27ede4a78a2421d1727c27f465fc87c435965a1d4"
+VER=1.28.1
+SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/pluma"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198621"
-REL="1"

--- a/runtime-desktop/libwnck-3/autobuild/defines
+++ b/runtime-desktop/libwnck-3/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=libwnck-3
 PKGSEC=libs
 PKGDEP="gtk-3 startup-notification x11-lib"
-BUILDDEP="gobject-introspection gtk-doc vim"
-PKGDES="Window navigator construction kit (GTK+3)"
+BUILDDEP="gobject-introspection"
+PKGDES="Window Navigator Construction Kit (GTK 3)"
 
-MESON_AFTER="-Dinstall_tools=true \
-             -Dstartup_notification=enabled \
-             -Dintrospection=enabled \
-             -Dgtk_doc=true"
+ABTYPE=meson
+MESON_AFTER=(
+    '-Ddeprecation_flags=false'
+    '-Dinstall_tools=true'
+    '-Dintrospection=enabled'
+    '-Dgtk_doc=false'
+)

--- a/runtime-desktop/libwnck-3/spec
+++ b/runtime-desktop/libwnck-3/spec
@@ -1,4 +1,4 @@
-VER=40.1
+VER=43.3
 SRCS="https://download.gnome.org/sources/libwnck/${VER%%.*}/libwnck-$VER.tar.xz"
-CHKSUMS="sha256::03134fa114ef3fbe34075aa83678f58aa2debe9fcef4ea23c0779e28601d6611"
+CHKSUMS="sha256::6af8ac41a8f067ade1d3caaed254a83423b5f61ad3f7a460fcacbac2e192bdf7"
 CHKUPDATE="anitya::id=11006"


### PR DESCRIPTION
Topic Description
-----------------

- libwnck-3: update to 43.3
- pluma: update to 1.28.1
    Backport an upstream patch to fix build with libpeas built against
    gobject-introspection-1.0 headers.
    Track patches at AOSC-Tracking/pluma @ aosc/v1.28.1
    \(HEAD: 57e3aaadb16d392c92edbd6aa06e692cc76f3d7d\).
    Link: https://github.com/mate-desktop/pluma/issues/729
    Link: https://github.com/mate-desktop/pluma/pull/731
- mate-terminal: update to 1.28.2
- mate-panel: update to 1.28.7
- mate-notification-daemon: update to 1.28.5
- mate-menus: update to 1.28.1
- marco: update to 1.28.2
- libmateweather: update to 1.28.2
- eom: update to 1.28.1
    - Backport an upstream patch to fix build with libpeas built against
    gobject-introspection-1.0 headers.
    - Drop unused patch script.
    - Track patches at AOSC-Tracking/eom @ aosc/v1.28.1
    \(HEAD: cbdc703e419bbad93724c61229cbe8468f56a89e\).
    Link: https://github.com/mate-desktop/eom/pull/372
- atril: update to 1.28.3

Package(s) Affected
-------------------

- atril: 1.28.3
- eom: 1:1.28.1
- libmateweather: 1:1.28.2
- libwnck-3: 43.3
- marco: 1:1.28.2
- mate-menus: 1:1.28.1
- mate-notification-daemon: 1:1.28.5
- mate-panel: 1:1.28.7
- mate-terminal: 1.28.2
- pluma: 1.28.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit atril eom libmateweather marco mate-menus libwnck-3 mate-panel mate-notification-daemon mate-terminal pluma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
