### PR TITLE
Cinnamon Survey (March, 2026)

### DIFF
--- a/desktop-cinnamon/cinnamon-session/spec
+++ b/desktop-cinnamon/cinnamon-session/spec
@@ -1,4 +1,4 @@
-VER=6.6.1
+VER=6.6.3
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/cinnamon-session"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6386"

--- a/desktop-cinnamon/cinnamon/spec
+++ b/desktop-cinnamon/cinnamon/spec
@@ -1,4 +1,4 @@
-VER=6.6.6
+VER=6.6.7
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/Cinnamon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6265"

--- a/desktop-cinnamon/nemo/spec
+++ b/desktop-cinnamon/nemo/spec
@@ -1,5 +1,4 @@
-VER=6.6.3
+VER=6.6.4
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/nemo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6391"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- nemo: update to 6.6.4
- cinnamon: update to 6.6.7
- cinnamon-session: update to 6.6.3

Package(s) Affected
-------------------

- cinnamon: 6.6.7
- cinnamon-session: 6.6.3
- nemo: 6.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinnamon-session cinnamon nemo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
