### PR TITLE
wireshark: update to 4.6.4

### DIFF
--- a/app-network/wireshark/autobuild/beyond
+++ b/app-network/wireshark/autobuild/beyond
@@ -1,8 +1,2 @@
-abinfo "Post-build hack: Fixing permissions and stripping unneeded file ..."
-chgrp -v 86 "$PKGDIR"/usr/bin/dumpcap
-chmod -v 754 "$PKGDIR"/usr/bin/dumpcap
-
-rm -vf "$PKGDIR"/usr/share/applications/wireshark-gtk.desktop
-
 abinfo "Installing development headers ..."
 DESTDIR="$PKGDIR" ninja -C "$SRCDIR"/abbuild install-headers

--- a/app-network/wireshark/autobuild/config
+++ b/app-network/wireshark/autobuild/config
@@ -1,0 +1,4 @@
+. /usr/share/debconf/confmodule
+
+db_input high wireshark/add_user_to_group || true
+db_go

--- a/app-network/wireshark/autobuild/defines
+++ b/app-network/wireshark/autobuild/defines
@@ -1,11 +1,15 @@
 PKGNAME=wireshark
 PKGDES="Network traffic and protocol analyzer"
 PKGSEC=net
-PKGDEP="brotli c-ares desktop-file-utils glib gnutls krb5 libcap libgcrypt libnl \
-        libpcap libssh lua minizip qt-6 sbc shared-mime-info xdg-utils portaudio geoip-api-c \
-        speex snappy systemd libilbc bcg729"
-BUILDDEP="docbook-xsl doxygen lynx w3m asciidoctor"
+PKGDEP="bcg729 brotli c-ares desktop-file-utils gcc-runtime glib \
+        glibc gnutls krb5 libcap libgcrypt libilbc libmaxminddb \
+        libnl libpcap libssh libxml2 lua-5.4 lz4 minizip nghttp2 \
+        nghttp3 opencore-amr opus pcre2 qt-6 sbc shared-mime-info \
+        snappy spandsp speex systemd xxhash zlib zstd"
+PKGPRDEP="debconf"
+BUILDDEP="asciidoctor doxygen"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
         "-DDISABLE_WERROR=ON"
         "-DUSE_qt6=ON"

--- a/app-network/wireshark/autobuild/overrides/usr/lib/sysusers.d/wireshark.conf
+++ b/app-network/wireshark/autobuild/overrides/usr/lib/sysusers.d/wireshark.conf
@@ -1,1 +1,1 @@
-g    netdev  86
+g wireshark - -

--- a/app-network/wireshark/autobuild/postinst
+++ b/app-network/wireshark/autobuild/postinst
@@ -1,5 +1,4 @@
-echo "Setting up netdev group ..."
 systemd-sysusers wireshark.conf
+setcap cap_net_raw,cap_net_admin+eip /usr/bin/dumpcap
 
-echo "Configuring capability of /usr/bin/dumpcap ..."
-setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
+. /usr/share/debconf/confmodule

--- a/app-network/wireshark/autobuild/postrm
+++ b/app-network/wireshark/autobuild/postrm
@@ -1,0 +1,4 @@
+if [ "$1" = "purge" -a -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/app-network/wireshark/autobuild/prepare
+++ b/app-network/wireshark/autobuild/prepare
@@ -1,1 +1,0 @@
-export PATH="$PATH:/usr/lib/qt5/bin"

--- a/app-network/wireshark/autobuild/templates
+++ b/app-network/wireshark/autobuild/templates
@@ -1,0 +1,14 @@
+Template: wireshark/add_user_to_group
+Type: note
+Description: Wireshark Configuration
+ To use Wireshark as a normal user, add your user to the `wireshark' group with the following command:
+ .
+ sudo usermod -aG wireshark $(whoami)
+ .
+ After adding your user to the group, please re-login for the changes to take effect.
+Description-zh_CN.UTF-8: Wireshark 配置贴士
+ 在普通用户下正常运行 Wireshark，请使用如下命令将您的用户添加到 `wireshark' 用户组：
+ .
+ sudo usermod -aG wireshark $(whoami)
+ .
+ 完成后，请重新登录以使更改生效。

--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,4 +1,4 @@
-VER=4.6.2
+VER=4.6.4
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::e218e3b3899e5d6e35a5fe95eeeabead587ed084cbf5fc330ac827f9a3137de8"
+CHKSUMS="sha256::fbeab3d85c6c8a5763c8d9b7fe20b5c69ca9f9e7f2b824bedc73135bdca332e2"
 CHKUPDATE="anitya::id=5137"

--- a/topics/wireshark-4.6.4.toml
+++ b/topics/wireshark-4.6.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Wireshark 4.6.4"
+
+[caution]
+default = "7 security vulnerabilities of medium severity"
+zh_CN = "修复 7 个中危安全漏洞"
+
+[packages-v2]
+"wireshark" = "< 4.6.4"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: update to 4.6.4
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- wireshark: 4.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
