### PR TITLE
sing-box: update to 1.13.3

### DIFF
--- a/app-proxy/sing-box/autobuild/defines
+++ b/app-proxy/sing-box/autobuild/defines
@@ -5,7 +5,6 @@ PKGDEP="glibc"
 BUILDDEP="go llvm"
 
 ABTYPE=gomod
-GO_LDFLAGS=("-X github.com/sagernet/sing-box/constant.Version=$PKGVER")
 GO_PACKAGES=("cmd/sing-box")
 
 # FIXME: For `with_naive_outbound`, though it does not support ppc64el.

--- a/app-proxy/sing-box/autobuild/prepare
+++ b/app-proxy/sing-box/autobuild/prepare
@@ -1,17 +1,27 @@
 abinfo "Reading build tags from release/ ..."
+_EXTRA_LDFLAGS=$(cat "$SRCDIR"/release/LDFLAGS)
+
+# FIXME: For `with_naive_outbound`, though it does not support ppc64el.
 if ! ab_match_arch ppc64el; then
     _CGO_LDFLAGS="-fuse-ld=lld"
-    if ab_match_arch armv6hf || ab_match_arch armv7hf || \
-       ab_match_arch loongson3 || ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
-        _CGO_LDFLAGS="${_CGO_LDFLAGS} -Wl,-no-pie"
-    fi
-    export CGO_LDFLAGS="${LDFLAGS} ${_CGO_LDFLAGS}"
-    _TAGS=$(cat release/DEFAULT_BUILD_TAGS)
+    _TAGS=$(cat "$SRCDIR"/release/DEFAULT_BUILD_TAGS)
 else
-    _TAGS=$(cat release/DEFAULT_BUILD_TAGS_OTHERS)
+    _TAGS=$(cat "$SRCDIR"/release/DEFAULT_BUILD_TAGS_OTHERS)
 fi
-_EXTRA_LDFLAGS=$(cat release/LDFLAGS)
-GO_BUILD_AFTER=(
-    -tags "${_TAGS}"
+
+# Note: For `with_naive_outbound`, the prebuilt cronet-go static library 
+# is non-PIC for some architectures.
+#
+# Ref: https://github.com/SagerNet/cronet-go/blob/33e95201970b8e3a35cada9a43c010acd811bece/cmd/build-naive/cmd_env.go#L105
+if ab_match_arch armv6hf || ab_match_arch armv7hf || \
+   ab_match_arch loongson3 || ab_match_arch loongarch64 || \
+   ab_match_arch loongarch64_nosimd; then
+    _CGO_LDFLAGS="${_CGO_LDFLAGS} -Wl,-no-pie"
+fi
+
+CGO_LDFLAGS="${LDFLAGS} ${_CGO_LDFLAGS}"
+GO_BUILD_AFTER=(-tags "${_TAGS}")
+GO_LDFLAGS=(
+    "-X github.com/sagernet/sing-box/constant.Version=$PKGVER"
+    "${_EXTRA_LDFLAGS}"
 )
-GO_LDFLAGS+=("${_EXTRA_LDFLAGS}")

--- a/app-proxy/sing-box/spec
+++ b/app-proxy/sing-box/spec
@@ -1,5 +1,4 @@
-VER=1.13.2
-REL=1
+VER=1.13.3
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.13.3
    - Adjust prepare and defines scripts.

Package(s) Affected
-------------------

- sing-box: 1.13.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
