### PR TITLE
ps3netsrv-go: new, 0.2.4

### DIFF
--- a/app-network/ps3netsrv-go/autobuild/beyond
+++ b/app-network/ps3netsrv-go/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Creating server directory for PS3 Network Server ..."
+mkdir -pv "$PKGDIR"/srv/ps3netsrv-go

--- a/app-network/ps3netsrv-go/autobuild/defines
+++ b/app-network/ps3netsrv-go/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=ps3netsrv-go
+PKGSEC=net
+BUILDDEP="go"
+GO_PACKAGES=("cmd/ps3netsrv-go")
+PKGDES="Utility to serve games and applications to PlayStation 3 consoles"
+ABTYPE=gomod
+# FIXME: Missing architcture support for MIPS
+#
+# # github.com/ebitengine/purego
+# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:189:9: undefined: addStruct
+# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:300:64: undefined: shouldBundleStackArgs
+# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:302:32: undefined: collectStackArgs
+# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:307:5: undefined: bundleStackArgs
+# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:380:8: undefined: getStruct
+# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:433:15: undefined: addStruct
+FAIL_ARCH="(loongson3)"

--- a/app-network/ps3netsrv-go/autobuild/overrides/etc/ps3netsrv-go.conf
+++ b/app-network/ps3netsrv-go/autobuild/overrides/etc/ps3netsrv-go.conf
@@ -1,0 +1,14 @@
+[server]
+# The directory where PlayStation 3 content are stored
+root = /srv/ps3netsrv-go
+# Optional client IP whitelist. 
+# Formats: 
+#   single IPv4/v6 ('192.168.0.2')
+#   IPv4/v6 CIDR ('192.168.0.1/24') 
+#   IPv4 + subnet mask ('192.168.0.1/255.255.255.0) 
+#   IPv4/IPv6 range ('192.168.0.1-192.168.0.255')
+client-whitelist = 0.0.0.0/0
+# Limit amount of connected clients. Negative or zero means no limit.
+max-clients = 10
+# Allow writing/modifying filesystem operations.
+allow-write = true

--- a/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/systemd/system/ps3netsrv-go.service
+++ b/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/systemd/system/ps3netsrv-go.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=PS3 (PlayStation 3) Network Server
+Documentation=https://github.com/xakep666/ps3netsrv-go
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ps3netsrv-go
+Group=ps3netsrv-go
+ExecStart=/usr/bin/ps3netsrv-go server --config=/etc/ps3netsrv-go.conf
+Restart=on-failure
+RestartSec=5s
+MemoryMax=128M
+
+[Install]
+WantedBy=multi-user.target

--- a/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/sysusers.d/ps3netsrv-go.conf
+++ b/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/sysusers.d/ps3netsrv-go.conf
@@ -1,0 +1,1 @@
+u ps3netsrv-go - "PS3 Network Server" /var/lib/ps3netsrv-go /usr/bin/nologin

--- a/app-network/ps3netsrv-go/autobuild/postinist
+++ b/app-network/ps3netsrv-go/autobuild/postinist
@@ -1,0 +1,2 @@
+echo "Creating temporary directories for PS3 Network Server..."
+systemd-sysusers ps3netsrv-go.conf

--- a/app-network/ps3netsrv-go/spec
+++ b/app-network/ps3netsrv-go/spec
@@ -1,0 +1,4 @@
+VER=0.2.4
+SRCS="git::commit=tags/v$VER::https://github.com/xakep666/ps3netsrv-go"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=383793"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

ps3netsrv-go: new, 0.2.4
- Add a new package named PS3 Network Server

Package(s) Affected
-------------------

No

Security Update?
----------------

No

Build Order
-----------

```
#buildit go
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
