### PR TITLE
PostgreSQL Survey 20260316

### DIFF
--- a/app-database/postgresql-13/01-runtime/defines
+++ b/app-database/postgresql-13/01-runtime/defines
@@ -4,8 +4,8 @@ PKGSEC=database
 PKGDEP="krb5 openssl glibc"
 # Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
 # will be recorded at 02-server/defines.
-BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
-	libxslt docbook2x perl docbook-xsl"
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm perl \
+          docbook-dtd docbook-xsl libxslt"
 PKGDES="PostgreSQL runtime libraries (13.x branch)"
 
 # IMPORTANT!
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--with-tcl"
 	"--with-llvm"
 	"--with-pam"
-	"--with-libxslt"
 	"--with-icu"
 	"--with-system-tzdata=/usr/share/zoneinfo"
 	"--with-uuid=e2fs"

--- a/app-database/postgresql-13/02-server/defines
+++ b/app-database/postgresql-13/02-server/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql-13
 PKGSEC=database
 PKGDEP="postgresql-runtime-13 krb5 libxml2 linux-pam openssl python-3
-        readline tcl util-linux llvm-runtime-20 libxslt"
+        readline tcl util-linux llvm-runtime libxslt"
 PKGDES="A sophisticated object-relational DBMS (13.x branch)"
 
 ABTYPE=self

--- a/app-database/postgresql-13/spec
+++ b/app-database/postgresql-13/spec
@@ -1,5 +1,4 @@
-VER=13.22
+VER=13.23
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::d36d83dc89e625502cf6fb1d0529642ba1266bd614b4e4a41cefd1dddcf09080"
+CHKSUMS="sha256::6ec3c82726af92b7dec873fa1cdf881eca92a4219787dfad05acb6b10e041fd6"
 CHKUPDATE="anitya::id=210464"
-REL="1"

--- a/app-database/postgresql-14/01-runtime/defines
+++ b/app-database/postgresql-14/01-runtime/defines
@@ -4,8 +4,8 @@ PKGSEC=database
 PKGDEP="krb5 openssl glibc"
 # Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
 # will be recorded at 02-server/defines.
-BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
-	libxslt docbook2x perl docbook-xsl"
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm perl \
+          docbook-dtd docbook-xsl libxslt"
 PKGDES="PostgreSQL runtime libraries (14.x branch)"
 
 # IMPORTANT!
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--with-tcl"
 	"--with-llvm"
 	"--with-pam"
-	"--with-libxslt"
 	"--with-icu"
 	"--with-system-tzdata=/usr/share/zoneinfo"
 	"--with-uuid=e2fs"

--- a/app-database/postgresql-14/02-server/defines
+++ b/app-database/postgresql-14/02-server/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql-14
 PKGSEC=database
 PKGDEP="postgresql-runtime-14 krb5 libxml2 linux-pam openssl python-3
-        readline tcl util-linux llvm-runtime-20 libxslt"
+        readline tcl util-linux llvm-runtime libxslt"
 PKGDES="A sophisticated object-relational DBMS (14.x branch)"
 
 ABTYPE=self

--- a/app-database/postgresql-14/spec
+++ b/app-database/postgresql-14/spec
@@ -1,5 +1,4 @@
-VER=14.19
+VER=14.22
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::727e9e334bc1a31940df808259f69fe47a59f6d42174b22ae62d67fe7a01ad80"
+CHKSUMS="sha256::f57938ad30067077720277f6d7db05aafc07d1545efd2ed82f199ba828a7ad34"
 CHKUPDATE="anitya::id=236443"
-REL="1"

--- a/app-database/postgresql-15/01-runtime/defines
+++ b/app-database/postgresql-15/01-runtime/defines
@@ -4,8 +4,8 @@ PKGSEC=database
 PKGDEP="krb5 openssl glibc"
 # Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
 # will be recorded at 02-server/defines.
-BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
-	libxslt docbook2x perl docbook-xsl"
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm perl \
+          docbook-dtd docbook-xsl libxslt"
 PKGDES="PostgreSQL runtime libraries (15.x branch)"
 
 # IMPORTANT!
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--with-tcl"
 	"--with-llvm"
 	"--with-pam"
-	"--with-libxslt"
 	"--with-icu"
 	"--with-system-tzdata=/usr/share/zoneinfo"
 	"--with-uuid=e2fs"

--- a/app-database/postgresql-15/02-server/defines
+++ b/app-database/postgresql-15/02-server/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql-15
 PKGSEC=database
 PKGDEP="postgresql-runtime-15 krb5 libxml2 linux-pam openssl python-3
-        readline tcl util-linux llvm-runtime-20 libxslt"
+        readline tcl util-linux llvm-runtime libxslt"
 PKGDES="A sophisticated object-relational DBMS (15.x branch)"
 
 ABTYPE=self

--- a/app-database/postgresql-15/spec
+++ b/app-database/postgresql-15/spec
@@ -1,5 +1,4 @@
-VER=15.14
+VER=15.17
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::06dd75d305cd3870ee62b3932e661c624543eaf9ae2ba37cdec0a4f8edd051d2"
+CHKSUMS="sha256::ae14f24c14727e0b2ded1c5553031666099bd1054db3ef44bfa6e2bd6d554a56"
 CHKUPDATE="anitya::id=301832"
-REL="1"

--- a/app-database/postgresql-16/01-runtime/defines
+++ b/app-database/postgresql-16/01-runtime/defines
@@ -4,8 +4,8 @@ PKGSEC=database
 PKGDEP="krb5 openssl glibc"
 # Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
 # will be recorded at 02-server/defines.
-BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
-	libxslt docbook2x perl docbook-xsl"
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm perl \
+          docbook-dtd docbook-xsl libxslt"
 PKGDES="PostgreSQL runtime libraries (16.x branch)"
 
 # IMPORTANT!
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--with-tcl"
 	"--with-llvm"
 	"--with-pam"
-	"--with-libxslt"
 	"--with-icu"
 	"--with-system-tzdata=/usr/share/zoneinfo"
 	"--with-uuid=e2fs"

--- a/app-database/postgresql-16/02-server/defines
+++ b/app-database/postgresql-16/02-server/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql-16
 PKGSEC=database
 PKGDEP="postgresql-runtime-16 krb5 libxml2 linux-pam openssl python-3
-        readline tcl util-linux llvm-runtime-20 libxslt"
+        readline tcl util-linux llvm-runtime libxslt"
 PKGDES="A sophisticated object-relational DBMS (16.x branch)"
 
 ABTYPE=self

--- a/app-database/postgresql-16/spec
+++ b/app-database/postgresql-16/spec
@@ -1,5 +1,4 @@
-VER=16.10
+VER=16.13
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::de8485f4ce9c32e3ddfeef0b7c261eed1cecb54c9bcd170e437ff454cb292b42"
+CHKSUMS="sha256::dc2ddbbd245c0265a689408e3d2f2f3f9ba2da96bd19318214b313cdd9797287"
 CHKUPDATE="anitya::id=375691"
-REL="1"

--- a/app-database/postgresql-17/01-runtime/defines
+++ b/app-database/postgresql-17/01-runtime/defines
@@ -4,8 +4,8 @@ PKGSEC=database
 PKGDEP="krb5 openssl glibc"
 # Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
 # will be recorded at 02-server/defines.
-BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
-	libxslt docbook2x perl docbook-xsl"
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm perl \
+          docbook-dtd docbook-xsl libxslt"
 PKGDES="PostgreSQL runtime libraries (17.x branch)"
 
 # IMPORTANT!
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--with-tcl"
 	"--with-llvm"
 	"--with-pam"
-	"--with-libxslt"
 	"--with-icu"
 	"--with-system-tzdata=/usr/share/zoneinfo"
 	"--with-uuid=e2fs"

--- a/app-database/postgresql-17/02-server/defines
+++ b/app-database/postgresql-17/02-server/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql-17
 PKGSEC=database
 PKGDEP="postgresql-runtime-17 krb5 libxml2 linux-pam openssl python-3
-        readline tcl util-linux llvm-runtime-20 libxslt"
+        readline tcl util-linux llvm-runtime libxslt"
 PKGDES="A sophisticated object-relational DBMS (17.x branch)"
 
 ABTYPE=self

--- a/app-database/postgresql-17/spec
+++ b/app-database/postgresql-17/spec
@@ -1,5 +1,4 @@
-VER=17.6
+VER=17.9
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::e0630a3600aea27511715563259ec2111cd5f4353a4b040e0be827f94cd7a8b0"
+CHKSUMS="sha256::3b9a62538a8da151e807a3ddb1198e8605f2032544d78f403ae883d27ecf1ee4"
 CHKUPDATE="anitya::id=375014"
-REL="1"

--- a/app-database/postgresql-18/01-runtime/defines
+++ b/app-database/postgresql-18/01-runtime/defines
@@ -4,8 +4,8 @@ PKGSEC=database
 PKGDEP="krb5 openssl glibc"
 # Dependencies to build the entire PostgreSQL. PKGDEP for PostgreSQL itself
 # will be recorded at 02-server/defines.
-BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm-20 \
-	libxslt docbook2x perl docbook-xsl"
+BUILDDEP="libxml2 linux-pam python-3 readline tcl util-linux llvm perl \
+          docbook-dtd docbook-xsl libxslt"
 PKGDES="PostgreSQL runtime libraries (18.x branch)"
 
 # IMPORTANT!
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--with-tcl"
 	"--with-llvm"
 	"--with-pam"
-	"--with-libxslt"
 	"--with-icu"
 	"--with-system-tzdata=/usr/share/zoneinfo"
 	"--with-uuid=e2fs"

--- a/app-database/postgresql-18/02-server/defines
+++ b/app-database/postgresql-18/02-server/defines
@@ -1,7 +1,7 @@
 PKGNAME=postgresql-18
 PKGSEC=database
 PKGDEP="postgresql-runtime-18 krb5 libxml2 linux-pam openssl python-3
-        readline tcl util-linux llvm-runtime-20 libxslt"
+        readline tcl util-linux llvm-runtime libxslt"
 PKGDES="A sophisticated object-relational DBMS (18.x branch)"
 
 ABTYPE=self

--- a/app-database/postgresql-18/spec
+++ b/app-database/postgresql-18/spec
@@ -1,5 +1,4 @@
-VER=18.0
+VER=18.3
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::0d5b903b1e5fe361bca7aa9507519933773eb34266b1357c4e7780fdee6d6078"
+CHKSUMS="sha256::d95663fbbf3a80f81a9d98d895266bdcb74ba274bcc04ef6d76630a72dee016f"
 CHKUPDATE="anitya::id=383697"
-REL="1"

--- a/app-database/postgresql/01-runtime/build
+++ b/app-database/postgresql/01-runtime/build
@@ -4,6 +4,11 @@ if ! [[ "$MAJORVER" =~ ^[0-9]+$ ]] ; then
 	abdie "Unexpected major version $MAJORVER."
 fi
 
+# Check if PKGDEP actually contains the release we want to point to.
+if [ "${PKGDEP/postgresql-$MAJORVER/}" == "$PKGVER" ] ; then
+	abdie "PKGDEP isn't updated - Check the defines file."
+fi
+
 # TODO: I think this step is not necessary since pkg-config files have the
 #       location of the libraries. But this might be required if a user
 #       wants to link with libpq without knowing the actual location of

--- a/app-database/postgresql/01-runtime/defines
+++ b/app-database/postgresql/01-runtime/defines
@@ -1,6 +1,6 @@
 PKGNAME=postgresql-runtime
 PKGDES="Runtime libraries of PostgreSQL"
-PKGDEP="postgresql-runtime-17"
+PKGDEP="postgresql-runtime-18"
 PKGSEC=libs
 
 ABHOST=noarch

--- a/app-database/postgresql/02-server/build
+++ b/app-database/postgresql/02-server/build
@@ -4,6 +4,11 @@ if ! [[ "$MAJORVER" =~ ^[0-9]+$ ]] ; then
 	abdie "Unexpected major version $MAJORVER."
 fi
 
+# Check if PKGDEP actually contains the release we want to point to.
+if [ "${PKGDEP/postgresql-$MAJORVER/}" == "$PKGVER" ] ; then
+	abdie "PKGDEP isn't updated - Check the defines file."
+fi
+
 abinfo "Creating directories ..."
 mkdir -pv "$PKGDIR"/usr/{bin,lib/pkgconfig}
 

--- a/app-database/postgresql/02-server/defines
+++ b/app-database/postgresql/02-server/defines
@@ -1,6 +1,6 @@
 PKGNAME=postgresql
 PKGDES="Latest current version of PostgreSQL (Meta package)"
-PKGDEP="postgresql-runtime dialog postgresql-17"
+PKGDEP="postgresql-runtime dialog postgresql-18"
 PKGSEC=misc
 PKGEPOCH=2
 ABHOST=noarch

--- a/app-database/postgresql/02-server/po/aosc-postgresql-preinst.pot
+++ b/app-database/postgresql/02-server/po/aosc-postgresql-preinst.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: aosc-postgresql-preinst 0.1.0\n"
+"Project-Id-Version: aosc-postgresql-preinst 0.1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-09 00:29+0800\n"
+"POT-Creation-Date: 2026-03-16 15:14+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: preinst.in:83
+#: preinst.2:25
 msgid "OK"
 msgstr ""
 
-#: preinst.in:85
+#: preinst.2:27
 msgid "Cursor keys to scroll, Enter to acknowledge"
 msgstr ""
 
-#: preinst.in:93
+#: preinst.2:35
 msgid "ATTENTION - POSTGRESQL PACKAGE TRANSITION"
 msgstr ""
 
-#: preinst.in:95
+#: preinst.2:37
 #, sh-format
 msgid ""
 "The \\`postgresql' package no longer holds the PostgreSQL server itself,\n"
@@ -71,7 +71,7 @@ msgid ""
 "  sudo oma remove postgresql-$OLDMAJOR\n"
 msgstr ""
 
-#: preinst.in:133
+#: preinst.2:75
 msgid ""
 "The old PostgreSQL server which is installed before this transition\n"
 "is still running.\n"
@@ -84,7 +84,7 @@ msgid ""
 "now, and press Enter to shut down the PostgreSQL server."
 msgstr ""
 
-#: preinst.in:146
+#: preinst.2:88
 #, sh-format
 msgid ""
 "The new major release of PostgreSQL ($PGMAJOR) is installed on your\n"
@@ -93,7 +93,20 @@ msgid ""
 "prevent it from being automatically removed.\n"
 msgstr ""
 
-#: preinst.in:153
+#: preinst.2:94
+msgid "Pending Removal of Older Releases of PostgreSQL"
+msgstr ""
+
+#: preinst.2:96
+msgid ""
+"PostgreSQL releases from 13 to 16 will be removed from the AOSC OS\n"
+"package repository during our next PostgreSQL updating survey.\n"
+"\n"
+"If you are still running these PostgreSQL releases, please migrate to\n"
+"the latest PostgreSQL release before May 2026.\n"
+msgstr ""
+
+#: preinst.2:104
 #, sh-format
 msgid ""
 "To migrate from a previous PostgreSQL release, you can use either\n"
@@ -103,16 +116,16 @@ msgid ""
 "  $DOCURL\n"
 msgstr ""
 
-#: preinst.in:161
+#: preinst.2:112
 msgid ""
 "Due to the transition, this upgrade must be manually performed.\n"
 "Rejecting upgrade."
 msgstr ""
 
-#: preinst.in:164 preinst.in:259 preinst.in:270
+#: preinst.2:115 preinst.2:221 preinst.2:232
 msgid "The upgrade is interrupted."
 msgstr ""
 
-#: preinst.in:166
+#: preinst.2:117
 msgid "Please run 'oma fix-broken -n' to try again."
 msgstr ""

--- a/app-database/postgresql/02-server/po/en_US.po
+++ b/app-database/postgresql/02-server/po/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aosc-postgresql-preinst 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-09 00:29+0800\n"
+"POT-Creation-Date: 2026-03-16 15:14+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,19 +16,19 @@ msgstr ""
 "Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: preinst.in:83
+#: preinst.2:25
 msgid "OK"
 msgstr "OK"
 
-#: preinst.in:85
+#: preinst.2:27
 msgid "Cursor keys to scroll, Enter to acknowledge"
 msgstr "Cursor keys to scroll, Enter to acknowledge"
 
-#: preinst.in:93
+#: preinst.2:35
 msgid "ATTENTION - POSTGRESQL PACKAGE TRANSITION"
 msgstr "ATTENTION - POSTGRESQL PACKAGE TRANSITION"
 
-#: preinst.in:95
+#: preinst.2:37
 #, sh-format
 msgid ""
 "The \\`postgresql' package no longer holds the PostgreSQL server itself,\n"
@@ -107,7 +107,7 @@ msgstr ""
 "  systemctl start postgresql-$PGMAJOR\n"
 "  sudo oma remove postgresql-$OLDMAJOR\n"
 
-#: preinst.in:133
+#: preinst.2:75
 msgid ""
 "The old PostgreSQL server which is installed before this transition\n"
 "is still running.\n"
@@ -129,7 +129,7 @@ msgstr ""
 "Please shut down any services that uses the PostgreSQL on your system\n"
 "now, and press Enter to shut down the PostgreSQL server."
 
-#: preinst.in:146
+#: preinst.2:88
 #, sh-format
 msgid ""
 "The new major release of PostgreSQL ($PGMAJOR) is installed on your\n"
@@ -142,7 +142,25 @@ msgstr ""
 "the next major release. You can run \\`oma hold postgresql-$OLDMAJOR' to\n"
 "prevent it from being automatically removed.\n"
 
-#: preinst.in:153
+#: preinst.2:94
+msgid "Pending Removal of Older Releases of PostgreSQL"
+msgstr "Pending Removal of Older Releases of PostgreSQL"
+
+#: preinst.2:96
+msgid ""
+"PostgreSQL releases from 13 to 16 will be removed from the AOSC OS\n"
+"package repository during our next PostgreSQL updating survey.\n"
+"\n"
+"If you are still running these PostgreSQL releases, please migrate to\n"
+"the latest PostgreSQL release before May 2026.\n"
+msgstr ""
+"PostgreSQL releases from 13 to 16 will be removed from the AOSC OS\n"
+"package repository during our next PostgreSQL updating survey.\n"
+"\n"
+"If you are still running these PostgreSQL releases, please migrate to\n"
+"the latest PostgreSQL release before May 2026.\n"
+
+#: preinst.2:104
 #, sh-format
 msgid ""
 "To migrate from a previous PostgreSQL release, you can use either\n"
@@ -157,7 +175,7 @@ msgstr ""
 "\n"
 "  $DOCURL\n"
 
-#: preinst.in:161
+#: preinst.2:112
 msgid ""
 "Due to the transition, this upgrade must be manually performed.\n"
 "Rejecting upgrade."
@@ -165,10 +183,10 @@ msgstr ""
 "Due to the transition, this upgrade must be manually performed.\n"
 "Rejecting upgrade."
 
-#: preinst.in:164 preinst.in:259 preinst.in:270
+#: preinst.2:115 preinst.2:221 preinst.2:232
 msgid "The upgrade is interrupted."
 msgstr "The upgrade is interrupted."
 
-#: preinst.in:166
+#: preinst.2:117
 msgid "Please run 'oma fix-broken -n' to try again."
 msgstr "Please run 'oma fix-broken -n' to try again."

--- a/app-database/postgresql/02-server/po/zh_CN.po
+++ b/app-database/postgresql/02-server/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aosc-postgresql-preinst 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-09 00:29+0800\n"
+"POT-Creation-Date: 2026-03-16 15:14+0800\n"
 "PO-Revision-Date: 2025-05-09 00:00+0800\n"
 "Last-Translator: 老嘟嘟 <cyan@cyano.uk>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: preinst.in:83
+#: preinst.2:25
 msgid "OK"
 msgstr "确认"
 
-#: preinst.in:85
+#: preinst.2:27
 msgid "Cursor keys to scroll, Enter to acknowledge"
 msgstr "使用光标键滚动，回车键确认"
 
-#: preinst.in:93
+#: preinst.2:35
 msgid "ATTENTION - POSTGRESQL PACKAGE TRANSITION"
 msgstr "注意：PostgreSQL 软件包打包方式出现变动"
 
-#: preinst.in:95
+#: preinst.2:37
 #, sh-format
 msgid ""
 "The \\`postgresql' package no longer holds the PostgreSQL server itself,\n"
@@ -104,7 +104,7 @@ msgstr ""
 "  sudo systemctl start postgresql-$PGMAJOR\n"
 "  sudo oma remove postgresql-$OLDMAJOR\n"
 
-#: preinst.in:133
+#: preinst.2:75
 msgid ""
 "The old PostgreSQL server which is installed before this transition\n"
 "is still running.\n"
@@ -119,10 +119,11 @@ msgstr ""
 "我们检测到升级前安装的 PostgreSQL 服务器仍在运行。\n"
 "\n"
 "由于打包方式发生变化，为了保证数据完整及方便数据迁移，必须停止旧版的\n"
-"服务器才能继续升级。\n\n"
+"服务器才能继续升级。\n"
+"\n"
 "请先停止任何与该数据库建立连接的服务或程序，然后按回车键停止该服务器。"
 
-#: preinst.in:146
+#: preinst.2:88
 #, sh-format
 msgid ""
 "The new major release of PostgreSQL ($PGMAJOR) is installed on your\n"
@@ -131,10 +132,29 @@ msgid ""
 "prevent it from being automatically removed.\n"
 msgstr ""
 "已成功安装新大版本的 PostgreSQL ($PGMAJOR)。PostgreSQL $OLDMAJOR 将一直留在\n"
-"系统中，直到下一个大版本发布之后。您可以运行 “oma hold postgresql-$OLDMAJOR”\n"
+"系统中，直到下一个大版本发布之后。您可以运行 “oma hold postgresql-"
+"$OLDMAJOR”\n"
 "来避免 PostgreSQL $OLDMAJOR 在更新时被自动移除。\n"
 
-#: preinst.in:153
+#: preinst.2:94
+msgid "Pending Removal of Older Releases of PostgreSQL"
+msgstr "旧版 PostgreSQL 将从软件源移除"
+
+#: preinst.2:96
+msgid ""
+"PostgreSQL releases from 13 to 16 will be removed from the AOSC OS\n"
+"package repository during our next PostgreSQL updating survey.\n"
+"\n"
+"If you are still running these PostgreSQL releases, please migrate to\n"
+"the latest PostgreSQL release before May 2026.\n"
+msgstr ""
+"PostgreSQL 版本 13 到 16 将在下一期 PostgreSQL 升级维护期间从 AOSC OS\n"
+"软件源移除。\n"
+"\n"
+"如果您依旧在使用这些版本的 PostgreSQL 服务器，请您在 2026 年五月前将\n"
+"您的数据库迁移至最新版本。\n"
+
+#: preinst.2:104
 #, sh-format
 msgid ""
 "To migrate from a previous PostgreSQL release, you can use either\n"
@@ -144,10 +164,11 @@ msgid ""
 "  $DOCURL\n"
 msgstr ""
 "您可以使用 “pg_upgrade” 或 “pg_dump” 工具迁移旧版的 PostgreSQL 数据。\n"
-"您可以浏览以下链接获得关于迁移数据到新大版本的信息：\n\n"
+"您可以浏览以下链接获得关于迁移数据到新大版本的信息：\n"
+"\n"
 "  $DOCURL\n"
 
-#: preinst.in:161
+#: preinst.2:112
 msgid ""
 "Due to the transition, this upgrade must be manually performed.\n"
 "Rejecting upgrade."
@@ -155,10 +176,10 @@ msgstr ""
 "由于打包方式出现变化，此次升级必须由人工介入。\n"
 "将拒绝此次升级。"
 
-#: preinst.in:164 preinst.in:259 preinst.in:270
+#: preinst.2:115 preinst.2:221 preinst.2:232
 msgid "The upgrade is interrupted."
 msgstr "升级过程被中断。"
 
-#: preinst.in:166
+#: preinst.2:117
 msgid "Please run 'oma fix-broken -n' to try again."
 msgstr "请运行 “oma fix-broken -n” 命令来重试。"

--- a/app-database/postgresql/02-server/preinst.2
+++ b/app-database/postgresql/02-server/preinst.2
@@ -1,3 +1,19 @@
+#!/bin/bash
+
+# NOTE: Procedures to update PO template and catalog files:
+# 1. Add or modify strings in this file. Be sure to use $"..." quoted strings
+#    otherwise the internationalization won't work.
+# 2. Update the PO template (Remember to bump the package version):
+#    xgettext --copyright-holder="AOSC OS Maintainers <maintainers@aosc.io>" \
+#        --package-name=aosc-postgresql-preinst \
+#        --package-version=0.1.1 \
+#        -L Shell -o po/aosc-postgresql-preinst.pot preinst.2
+# 3. Update the catalog files:
+#    for f in po/*.po ; do
+#        msgmerge -U $f po/aosc-postgresql-preinst.pot
+#    done
+# 4. Edit the PO catalog files.
+# 5. Inspect the diffs using `git diff'.
 
 TMPDIR=$(mktemp -d)
 if [ -z "$TMPDIR" ]; then
@@ -91,6 +107,15 @@ the next major release. You can run \`oma hold postgresql-$OLDMAJOR' to
 prevent it from being automatically removed.
 "
 
+TITLE_REMOVAL=$"Pending Removal of Older Releases of PostgreSQL"
+NOTE_ON_REMOVAL=\
+$"PostgreSQL releases from 13 to 16 will be removed from the AOSC OS
+package repository during our next PostgreSQL updating survey.
+
+If you are still running these PostgreSQL releases, please migrate to
+the latest PostgreSQL release before May 2026.
+"
+
 NOTE_ON_MIGRATING=\
 $"To migrate from a previous PostgreSQL release, you can use either
 \`pg_upgrade' or \`pg_dump'. Refer the following link to learn more
@@ -145,6 +170,20 @@ inform_transition() {
 	echo ""
 }
 
+inform_removal() {
+	if (( $INTERACTIVE )) ; then
+		"$DIALOG" \
+			"${DIALOG_OPTS[@]}" \
+			--title "$TITLE_REMOVAL" \
+			--msgbox \
+			"$NOTE_ON_REMOVAL" \
+			20 76
+	fi
+	info "$TITLE_REMOVAL"
+	info "$NOTE_ON_REMOVAL"
+	echo ""
+}
+
 inform_shutdown() {
 	if (( $INTERACTIVE )) ; then
 		"$DIALOG" \
@@ -185,6 +224,7 @@ fi
 if [ "$OLDMAJOR" = "13" ] ; then
 	# Inform the user about the transition.
 	inform_transition
+	inform_removal
 	if systemctl --quiet is-active postgresqld.service ; then
 		if !(( $INTERACTIVE )) ; then
 			err "$ERR_NOT_INTERACTIVE"
@@ -202,7 +242,7 @@ if [ "$OLDMAJOR" = "13" ] ; then
 else
 	# Inform the user about the new release.
 	# No more data directories scan and other fusses.
-	if inform_new_major_release ; then
+	if inform_new_major_release && inform_removal ; then
 		exit 0
 	else
 		err $"The upgrade is interrupted."

--- a/app-database/postgresql/spec
+++ b/app-database/postgresql/spec
@@ -20,7 +20,7 @@
 #    OTHER FIELDS UNLESS NECESSARY!
 # 10. Run a test build with your Ciel workspace.
 
-VER=17.5
+VER=18.3
 DUMMYSRC=1
 SUBDIR="."
 # Do NOT edit this field as this points to the latest release.

--- a/topics/postgresql-13-13.23.toml
+++ b/topics/postgresql-13-13.23.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 13.23"
+
+[caution]
+default = "Fixes an authentication vulnerability on CREATE STATISTICS command (CVE-2025-12817) , an integer wraparound vulnerability on libpq client library (CVE-2025-12818, moderate severity)"
+zh_CN = "修复 CREATE STATISTICS 语句缺乏鉴权的漏洞 (CVE-2025-12817) 及 libpq 客户端库中的一处整数回绕漏洞 (CVE-2025-12818, 中严重性)"
+
+[packages-v2]
+"postgresql-13" = "< 13.23"

--- a/topics/postgresql-14-14.22.toml
+++ b/topics/postgresql-14-14.22.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 14.22"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (3 of high severity)"
+zh_CN = "修复 6 个安全漏洞（含 3 个高危漏洞）"
+
+[packages-v2]
+"postgresql-14" = "< 14.22"

--- a/topics/postgresql-15-15.17.toml
+++ b/topics/postgresql-15-15.17.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 15.17"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (3 of high severity)"
+zh_CN = "修复 6 个安全漏洞（含 3 个高危漏洞）"
+
+[packages-v2]
+"postgresql-15" = "< 15.17"

--- a/topics/postgresql-16-16.13.toml
+++ b/topics/postgresql-16-16.13.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 16.13"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (3 of high severity)"
+zh_CN = "修复 6 个安全漏洞（含 3 个高危漏洞）"
+
+[packages-v2]
+"postgresql-16" = "< 16.13"

--- a/topics/postgresql-17-17.9.toml
+++ b/topics/postgresql-17-17.9.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 17.9"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (3 of high severity)"
+zh_CN = "修复 6 个安全漏洞（含 3 个高危漏洞）"
+
+[packages-v2]
+"postgresql-17" = "< 17.9"

--- a/topics/postgresql-18-18.3.toml
+++ b/topics/postgresql-18-18.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PostgreSQL 18.3"
+
+[caution]
+default = "Fixes 7 security vulnerabilities (4 of high severity)"
+zh_CN = "修复 7 个安全漏洞（含 4 个高危漏洞）"
+
+[packages-v2]
+"postgresql-17" = "< 18.3"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql: update to 18.3; point to postgresql-18
    \* Add a notice about the pending removal of older PostgreSQL releases.
    \* Add a check to make sure the PKGDEP points to the correct release.
- postgresql-18: update to 18.3
    \* Remove unnecessary doc related dependencies. This saves us from the
    texlive bomb.
    \* Use system-wide LLVM version.
- postgresql-17: update to 17.9
    \* Remove unnecessary doc related dependencies. This saves us from the
    texlive bomb.
    \* Use system-wide LLVM version.
- postgresql-16: update to 16.13
    \* Remove unnecessary doc related dependencies. This saves us from the
    texlive bomb.
    \* Use system-wide LLVM version.
- postgresql-15: update to 15.17
    \* Remove unnecessary doc related dependencies. This saves us from the
    texlive bomb.
    \* Use system-wide LLVM version.
- postgresql-14: update to 14.22
    \* Remove unnecessary doc related dependencies. This saves us from the
    texlive bomb.
    \* Use system-wide LLVM version.
- postgresql-13: update to 13.23
    \* Remove unnecessary doc related dependencies. This saves us from the
    texlive bomb.
    \* Use system-wide LLVM version.

Package(s) Affected
-------------------

- postgresql: 2:18.3
- postgresql-13: 13.23
- postgresql-14: 14.22
- postgresql-15: 15.17
- postgresql-16: 16.13
- postgresql-17: 17.9
- postgresql-18: 18.3
- postgresql-runtime: 18.3
- postgresql-runtime-13: 13.23
- postgresql-runtime-14: 14.22
- postgresql-runtime-15: 15.17
- postgresql-runtime-16: 16.13
- postgresql-runtime-17: 17.9
- postgresql-runtime-18: 18.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-13 postgresql-14 postgresql-15 postgresql-16 postgresql-17 postgresql-18 postgresql
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
