### PR TITLE
upx: update to 5.1.1

### DIFF
--- a/app-devel/upx/spec
+++ b/app-devel/upx/spec
@@ -1,4 +1,4 @@
-VER=4.2.4
+VER=5.1.1
 SRCS="tbl::https://github.com/upx/upx/releases/download/v$VER/upx-$VER-src.tar.xz"
-CHKSUMS="sha256::5ed6561607d27fb4ef346fc19f08a93696fa8fa127081e7a7114068306b8e1c4"
+CHKSUMS="sha256::8eb914115b306fd9fd2110bd3d27ddb8ae7c5a03bb965f7d10f046a3a4ff9dfe"
 CHKUPDATE="anitya::id=13737"


### PR DESCRIPTION
Topic Description
-----------------

- upx: update to 5.1.1

Package(s) Affected
-------------------

- upx: 5.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit upx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
