### PR TITLE
difftastic: update to 0.68.0

### DIFF
--- a/app-utils/difftastic/spec
+++ b/app-utils/difftastic/spec
@@ -1,4 +1,4 @@
-VER=0.67.0
+VER=0.68.0
 # URL not found for submodule in .gitmodules.
 SRCS="git::commit=tags/$VER;submodule=false::https://github.com/Wilfred/difftastic"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- difftastic: update to 0.68.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- difftastic: 0.68.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit difftastic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
