### PR TITLE
dotnet: update to 10

### DIFF
--- a/lang-dotnet/dotnet/autobuild/defines
+++ b/lang-dotnet/dotnet/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=dotnet
 PKGSEC=devel
-PKGDES="Microsoft .NET SDK ${__VER}"
-PKGDEP="dotnet-sdk-8.0"
+PKGDES="Microsoft .NET SDK (LTS version)"
+PKGDEP="dotnet-sdk-10.0"
 
 ABSPLITDBG=0
 ABTYPE=dummy
-FAIL_ARCH="!(arm64|amd64|armv7hf)"
+
+# FIXME: no upstream support on loongson3
+FAIL_ARCH="loongson3"

--- a/lang-dotnet/dotnet/spec
+++ b/lang-dotnet/dotnet/spec
@@ -1,8 +1,4 @@
-VER=8.0.416
-
-# Note: For use inside autobuild/.
-__VER="${VER}"
+VER=10
 
 DUMMYSRC=1
 CHKSUMS="SKIP"
-CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(8\..+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- dotnet: update to 10

Package(s) Affected
-------------------

- dotnet: 10

Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
