### PR TITLE
ggml: update to 0.9.8

### DIFF
--- a/runtime-creativity/llama.cpp/spec
+++ b/runtime-creativity/llama.cpp/spec
@@ -1,4 +1,4 @@
-VER=8232
+VER=8400
 # The build system uses git tags to determine version number
 SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggerganov/llama.cpp.git"
 CHKSUMS="SKIP"

--- a/runtime-scientific/ggml/autobuild/patches/0001-ggml-cpu-fix-RVV-checks-in-quants-and-repacking-2068.patch
+++ b/runtime-scientific/ggml/autobuild/patches/0001-ggml-cpu-fix-RVV-checks-in-quants-and-repacking-2068.patch
@@ -1,0 +1,481 @@
+From 7e49a393fe101d7d9a1e1c379caeffd088375123 Mon Sep 17 00:00:00 2001
+From: Taimur Ahmad <taimur.ahmad@10xengineers.ai>
+Date: Tue, 17 Mar 2026 19:03:40 +0500
+Subject: [PATCH] ggml-cpu: fix RVV checks in quants and repacking (#20682)
+
+* ggml-cpu: refactor quants.c; add rvv check
+
+* ggml-cpu: refactor; disable generic fallback
+---
+ src/ggml-cpu/arch/riscv/quants.c   | 40 ++++++++++++++++++++----------
+ src/ggml-cpu/arch/riscv/repack.cpp | 40 ++++--------------------------
+ src/ggml-cpu/repack.cpp            |  3 +++
+ 3 files changed, 35 insertions(+), 48 deletions(-)
+
+diff --git a/src/ggml-cpu/arch/riscv/quants.c b/src/ggml-cpu/arch/riscv/quants.c
+index 826055dd..d7e9ba46 100644
+--- a/src/ggml-cpu/arch/riscv/quants.c
++++ b/src/ggml-cpu/arch/riscv/quants.c
+@@ -115,10 +115,10 @@ void quantize_row_q8_1(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, i
+ 
+ void quantize_row_q8_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+     assert(k % QK_K == 0);
+-    block_q8_K * y_blocks = (block_q8_K *)y;
+     size_t nb = k / QK_K;
+ 
+ #if defined(__riscv_v_intrinsic)
++    block_q8_K * y_blocks = (block_q8_K *)y;
+     const size_t vlmax_f32m8 = __riscv_vsetvlmax_e32m8();
+ 
+     for (size_t i = 0; i < nb; i++) {
+@@ -2052,6 +2052,7 @@ void ggml_vec_dot_q6_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const voi
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq1_s_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+     assert(nrc == 1);
+@@ -2147,6 +2148,7 @@ static void ggml_vec_dot_iq1_s_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t
+ 
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq1_s_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -2163,6 +2165,7 @@ void ggml_vec_dot_iq1_s_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq1_m_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+     assert(nrc == 1);
+@@ -2269,6 +2272,7 @@ static void ggml_vec_dot_iq1_m_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t
+ 
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq1_m_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -2285,6 +2289,7 @@ void ggml_vec_dot_iq1_m_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static const uint8_t sign_gather_indices_arr[64] = {
+     0,0,0,0,0,0,0,0, 1,1,1,1,1,1,1,1, 2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,
+     4,4,4,4,4,4,4,4, 5,5,5,5,5,5,5,5, 6,6,6,6,6,6,6,6, 7,7,7,7,7,7,7,7
+@@ -2488,6 +2493,7 @@ static void ggml_vec_dot_iq2_s_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t
+     }
+     *s = 0.125f * sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq2_s_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -2507,7 +2513,7 @@ void ggml_vec_dot_iq2_s_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
+ #endif
+ }
+ 
+-#if defined(__riscv_v)
++#if defined(__riscv_v_intrinsic)
+ static const int8_t keven_signs_q2xs[1024] = {
+      1,  1,  1,  1,  1,  1,  1,  1, -1,  1,  1,  1,  1,  1,  1, -1,  1, -1,  1,  1,  1,  1,  1, -1, -1, -1,  1,  1,  1,  1,  1,  1,
+      1,  1, -1,  1,  1,  1,  1, -1, -1,  1, -1,  1,  1,  1,  1,  1,  1, -1, -1,  1,  1,  1,  1,  1, -1, -1, -1,  1,  1,  1,  1, -1,
+@@ -2542,7 +2548,6 @@ static const int8_t keven_signs_q2xs[1024] = {
+      1,  1,  1, -1, -1, -1, -1,  1, -1,  1,  1, -1, -1, -1, -1, -1,  1, -1,  1, -1, -1, -1, -1, -1, -1, -1,  1, -1, -1, -1, -1,  1,
+      1,  1, -1, -1, -1, -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,  1,  1, -1, -1, -1, -1, -1, -1,  1, -1, -1, -1, -1, -1, -1, -1, -1,
+ };
+-#endif
+ 
+ static void ggml_vec_dot_iq2_xs_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+@@ -2618,6 +2623,7 @@ static void ggml_vec_dot_iq2_xs_q8_K_vl256(int n, float * GGML_RESTRICT s, size_
+     }
+     *s = 0.125f * sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq2_xs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -2634,6 +2640,7 @@ void ggml_vec_dot_iq2_xs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq2_xxs_q8_K_vl128(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+     assert(nrc == 1);
+@@ -2818,6 +2825,7 @@ static void ggml_vec_dot_iq2_xxs_q8_K_vl256(int n, float * GGML_RESTRICT s, size
+     }
+     *s = 0.125f * sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq2_xxs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -2830,10 +2838,11 @@ void ggml_vec_dot_iq2_xxs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const
+             break;
+     }
+ #else
+-    ggml_vec_dot_iq2_xxs_q8_K(n, s, bs, vx, bx, vy, by, nrc);
++    ggml_vec_dot_iq2_xxs_q8_K_generic(n, s, bs, vx, bx, vy, by, nrc);
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq3_s_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+     UNUSED(nrc);
+@@ -2928,6 +2937,7 @@ static void ggml_vec_dot_iq3_s_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t
+     }
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq3_s_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -2944,6 +2954,7 @@ void ggml_vec_dot_iq3_s_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq3_xxs_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+     assert(nrc == 1);
+@@ -3036,6 +3047,7 @@ static void ggml_vec_dot_iq3_xxs_q8_K_vl256(int n, float * GGML_RESTRICT s, size
+     }
+     *s = 0.25f * sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq3_xxs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -3052,6 +3064,7 @@ void ggml_vec_dot_iq3_xxs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq4_nl_q8_0_vl128(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(nrc == 1);
+     UNUSED(nrc);
+@@ -3161,6 +3174,7 @@ static void ggml_vec_dot_iq4_nl_q8_0_vl256(int n, float * GGML_RESTRICT s, size_
+ 
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_iq4_nl_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -3177,6 +3191,7 @@ void ggml_vec_dot_iq4_nl_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_iq4_xs_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(nrc == 1);
+     UNUSED(nrc);
+@@ -3190,7 +3205,6 @@ static void ggml_vec_dot_iq4_xs_q8_K_vl256(int n, float * GGML_RESTRICT s, size_
+ 
+     const int nb = n / QK_K;
+ 
+-#if defined __riscv_v_intrinsic
+     const vint8m4_t values = __riscv_vle8_v_i8m4(kvalues_iq4nl, 16);
+     float sumf = 0;
+     int acc[4];
+@@ -3252,14 +3266,8 @@ static void ggml_vec_dot_iq4_xs_q8_K_vl256(int n, float * GGML_RESTRICT s, size_
+     }
+ 
+     *s = sumf;
+-
+-#else
+-    UNUSED(x);
+-    UNUSED(y);
+-    UNUSED(nb);
+-    ggml_vec_dot_iq4_xs_q8_K_generic(n, s, bs, vx, bx, vy, by, nrc);
+-#endif
+ }
++#endif
+ 
+ void ggml_vec_dot_iq4_xs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -3276,6 +3284,7 @@ void ggml_vec_dot_iq4_xs_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_tq1_0_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(nrc == 1);
+     UNUSED(nrc);
+@@ -3381,6 +3390,7 @@ static void ggml_vec_dot_tq1_0_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t
+ 
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_tq1_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -3397,6 +3407,7 @@ void ggml_vec_dot_tq1_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_tq2_0_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(n % QK_K == 0);
+     assert(nrc == 1);
+@@ -3467,6 +3478,7 @@ static void ggml_vec_dot_tq2_0_q8_K_vl256(int n, float * GGML_RESTRICT s, size_t
+ 
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_tq2_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -3483,6 +3495,7 @@ void ggml_vec_dot_tq2_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
+ #endif
+ }
+ 
++#if defined __riscv_v_intrinsic
+ static void ggml_vec_dot_mxfp4_q8_0_vl128(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+     assert(nrc == 1);
+     UNUSED(nrc);
+@@ -3592,6 +3605,7 @@ static void ggml_vec_dot_mxfp4_q8_0_vl256(int n, float * GGML_RESTRICT s, size_t
+ 
+     *s = sumf;
+ }
++#endif
+ 
+ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+ #if defined __riscv_v_intrinsic
+@@ -3604,6 +3618,6 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
+             break;
+     }
+ #else
+-    return ggml_vec_dot_mxfp4_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
++    ggml_vec_dot_mxfp4_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+ #endif
+ }
+diff --git a/src/ggml-cpu/arch/riscv/repack.cpp b/src/ggml-cpu/arch/riscv/repack.cpp
+index cd580787..c37488ca 100644
+--- a/src/ggml-cpu/arch/riscv/repack.cpp
++++ b/src/ggml-cpu/arch/riscv/repack.cpp
+@@ -107,8 +107,7 @@ void ggml_quantize_mat_q8_0_4x8(const float * GGML_RESTRICT x, void * GGML_RESTR
+     }
+ #else
+     UNUSED(nb);
+-    UNUSED(y);
+-    ggml_quantize_mat_q8_0_4x4_generic(x, vy, k);
++    ggml_quantize_mat_q8_0_4x8_generic(x, vy, k);
+ #endif
+ }
+ 
+@@ -203,6 +202,7 @@ void ggml_gemv_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
+     ggml_gemv_q4_0_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
++#if defined __riscv_zvfh
+ void ggml_gemv_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+     const int nb = n / qk;
+@@ -222,7 +222,6 @@ void ggml_gemv_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+     for (int x = 0; x < nc / ncols_interleaved; x++) {
+         const block_q4_0x16 * b_ptr = (const block_q4_0x16 *) vx + (x * nb);
+@@ -256,9 +255,6 @@ void ggml_gemv_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+ 
+         __riscv_vse32_v_f32m2(s + x * 16, sumf, 16);
+     }
+-    return;
+-#endif
+-    ggml_gemv_q4_0_16x1_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemv_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -280,7 +276,6 @@ void ggml_gemv_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     const block_q8_K * a_ptr = (const block_q8_K *) vy;
+ 
+     for (int x = 0; x < nc / ncols_interleaved; x++) {
+@@ -392,9 +387,6 @@ void ggml_gemv_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+ 
+         __riscv_vse32_v_f32m2(s + x * 16, sumf, 16);
+     }
+-    return;
+-#endif
+-    ggml_gemv_q4_K_16x1_q8_K_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemv_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -416,7 +408,6 @@ void ggml_gemv_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     const vint8mf2_t values = __riscv_vle8_v_i8mf2(kvalues_iq4nl, 16);
+     const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+     for (int x = 0; x < nc / ncols_interleaved; x++) {
+@@ -451,9 +442,6 @@ void ggml_gemv_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const
+ 
+         __riscv_vse32_v_f32m2(s + x * 16, sumf, 16);
+     }
+-    return;
+-#endif
+-    ggml_gemv_iq4_nl_16x1_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemv_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -476,7 +464,6 @@ void ggml_gemv_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+     UNUSED(blocklen);
+     UNUSED(bs);
+ 
+-#if defined __riscv_v_intrinsic
+     const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+     for (int x = 0; x < nc / ncols_interleaved; x++) {
+         const block_q8_0x16 * b_ptr = (const block_q8_0x16 *) vx + (x * nb);
+@@ -505,9 +492,6 @@ void ggml_gemv_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+ 
+         __riscv_vse32_v_f32m2(s + x * 16, sumf, 16);
+     }
+-    return;
+-#endif
+-    ggml_gemv_q8_0_16x1_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemv_q2_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -679,9 +663,9 @@ void ggml_gemv_q2_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+ 
+         } // End K-Block
+         __riscv_vse32_v_f32m2(s + col_tile, v_sumf, vl);
+-
+     }
+ }
++#endif
+ 
+ void ggml_gemm_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+@@ -909,6 +893,7 @@ void ggml_gemm_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
+     ggml_gemm_q4_0_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
++#if defined __riscv_zvfh
+ void ggml_gemm_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+     const int nb = n / qk;
+@@ -929,7 +914,6 @@ void ggml_gemm_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     for (int y = 0; y < nr / 4; y++) {
+         const block_q8_0x4 * a_ptr = (const block_q8_0x4 *) vy + (y * nb);
+         for (int x = 0; x < nc / ncols_interleaved; x++) {
+@@ -994,9 +978,6 @@ void ggml_gemm_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+             __riscv_vse32_v_f32m2(s + (y * 4 + 3) * bs + x * 16, sumf_3, 16);
+         }
+     }
+-    return;
+-#endif
+-    ggml_gemm_q4_0_16x1_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemm_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -1019,7 +1000,6 @@ void ggml_gemm_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     for (int y = 0; y < nr / 4; y++) {
+         const block_q8_Kx4 * a_ptr = (const block_q8_Kx4 *) vy + (y * nb);
+         for (int x = 0; x < nc / ncols_interleaved; x++) {
+@@ -1267,9 +1247,6 @@ void ggml_gemm_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+             __riscv_vse32_v_f32m2(s + (y * 4 + 3) * bs + x * 16, sumf_3, 16);
+         }
+     }
+-    return;
+-#endif
+-    ggml_gemm_q4_K_16x1_q8_K_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemm_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -1292,7 +1269,6 @@ void ggml_gemm_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     const vint8mf2_t values = __riscv_vle8_v_i8mf2(kvalues_iq4nl, 16);
+     for (int y = 0; y < nr / 4; y++) {
+         const block_q8_0x4 * a_ptr = (const block_q8_0x4 *) vy + (y * nb);
+@@ -1355,9 +1331,6 @@ void ggml_gemm_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const
+             __riscv_vse32_v_f32m2(s + (y * 4 + 3) * bs + x * 16, sumf_3, 16);
+         }
+     }
+-    return;
+-#endif
+-    ggml_gemm_iq4_nl_16x1_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemm_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -1380,7 +1353,6 @@ void ggml_gemm_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+     UNUSED(ncols_interleaved);
+     UNUSED(blocklen);
+ 
+-#if defined __riscv_v_intrinsic
+     for (int y = 0; y < nr / 4; y++) {
+         const block_q8_0x4 * a_ptr = (const block_q8_0x4 *) vy + (y * nb);
+         for (int x = 0; x < nc / ncols_interleaved; x++) {
+@@ -1429,9 +1401,6 @@ void ggml_gemm_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
+             __riscv_vse32_v_f32m2(s + (y * 4 + 3) * bs + x * 16, sumf_3, 16);
+         }
+     }
+-    return;
+-#endif
+-    ggml_gemm_q8_0_16x1_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+ }
+ 
+ void ggml_gemm_q2_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+@@ -1731,3 +1700,4 @@ void ggml_gemm_q2_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
+         }
+     }
+ }
++#endif
+diff --git a/src/ggml-cpu/repack.cpp b/src/ggml-cpu/repack.cpp
+index 6b76ab3b..f18758f1 100644
+--- a/src/ggml-cpu/repack.cpp
++++ b/src/ggml-cpu/repack.cpp
+@@ -1365,6 +1365,7 @@ void ggml_gemv_q8_0_4x8_q8_0_generic(int                        n,
+     }
+ }
+ 
++// Only enable these for RISC-V.
+ #if defined __riscv_zvfh
+ void ggml_gemv_q4_0_16x1_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+@@ -1568,6 +1569,7 @@ void ggml_gemv_q2_K_16x1_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs,
+     assert(nc % 16 == 0);
+ 
+     UNUSED(bs);
++    UNUSED(nr);
+ 
+     const int nb = n / QK_K;
+     const block_q2_Kx16 * x = (const block_q2_Kx16 *)vx;
+@@ -2381,6 +2383,7 @@ void ggml_gemm_q8_0_4x8_q8_0_generic(int                        n,
+     }
+ }
+ 
++// Only enable these for RISC-V.
+ #if defined __riscv_zvfh
+ void ggml_gemm_q4_0_16x1_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+-- 
+2.52.0
+

--- a/runtime-scientific/ggml/spec
+++ b/runtime-scientific/ggml/spec
@@ -1,4 +1,4 @@
-VER=0.9.7
+VER=0.9.8
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ggml-org/ggml"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383765"


### PR DESCRIPTION
Topic Description
-----------------

- llama.cpp: update to 8400
- ggml: update to 0.9.8

Package(s) Affected
-------------------

- ggml: 0.9.8
- llama.cpp: 8400

Security Update?
----------------

No

Build Order
-----------

```
#buildit ggml llama.cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
