### PR TITLE
checksec: update to 3.1.0

### DIFF
--- a/app-devel/checksec/autobuild/beyond
+++ b/app-devel/checksec/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing CHANGLOG and README ..."
+install -Dvm644 ChangeLog.old CHANGELOG.md README.md -t \
+    "$PKGDIR"/usr/share/doc/checksec
+
+abinfo "Installing manpage ..."
+install -Dvm644 extras/man/checksec.1 -t \
+    "$PKGDIR"/usr/share/man/man1

--- a/app-devel/checksec/autobuild/build
+++ b/app-devel/checksec/autobuild/build
@@ -1,4 +1,0 @@
-install -Dvm755 checksec -t "$PKGDIR"/usr/bin
-install -Dvm644 ChangeLog README.md -t "$PKGDIR"/usr/share/doc/checksec
-install -Dvm644 extras/zsh/_checksec -t "$PKGDIR"/usr/share/zsh/site-functions
-install -Dvm644 extras/man/checksec.1 -t "$PKGDIR"/usr/share/man/man1

--- a/app-devel/checksec/autobuild/defines
+++ b/app-devel/checksec/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=checksec
 PKGSEC=devel
-PKGDEP="bash"
+PKGDEP="bash go"
 PKGDES="Tool designed to test which standard Linux OS and PaX security features are being used"
 
 ABHOST=noarch

--- a/app-devel/checksec/autobuild/patches/0001-docs-man-update-v3-usage-and-note-breaking-changes-f.patch
+++ b/app-devel/checksec/autobuild/patches/0001-docs-man-update-v3-usage-and-note-breaking-changes-f.patch
@@ -1,0 +1,189 @@
+From 831306752114a4946a3247011b92e8e86b73a94c Mon Sep 17 00:00:00 2001
+From: BRIAN DAVIS <briandavis@frank.internal>
+Date: Thu, 19 Feb 2026 16:45:40 -0500
+Subject: [PATCH 1/2] docs(man): update v3 usage and note breaking changes (fix
+ #327)
+
+---
+ extras/man/checksec.1 | 151 +++++++++++++++++++++++-------------------
+ 1 file changed, 82 insertions(+), 69 deletions(-)
+
+diff --git a/extras/man/checksec.1 b/extras/man/checksec.1
+index 47d5f41..3403852 100644
+--- a/extras/man/checksec.1
++++ b/extras/man/checksec.1
+@@ -1,89 +1,102 @@
+ .\" Process this file with
+-.\" groff -mdoc -Tascii foo.1
+-.\"
+-.Dd March 2023
+-.Dt checksec 1
++.\" groff -mdoc -Tascii checksec.1
++.Dd February 2026
++.Dt CHECKSEC 1
+ .Os
+ .Sh NAME
+ .Nm checksec
+-.Nd check executables and kernel properties
++.Nd check executable and kernel security properties
+ .Sh SYNOPSIS
+-.Nm checksec
+-.Op Fl -options
+-.Op Ar file
++.Nm
++.Op Fl -help
++.Op Fl -version
++.Op Fl -output Ar table|xml|json|yaml
++.Op Fl -libc Ar path
++.Op Fl -no-banner
++.Op Fl -no-headers
++.Ar command
++.Op Ar command-options
+ .Sh DESCRIPTION
+ .Nm
+-is a bash script used to check the properties of executables
+-(like PIE, RELRO, PaX, Canaries, ASLR, Fortify Source), library calls (Fortify Source),
+-and kernel security options (like GRSecurity and SELinux).
+-.Sh Options
+-Options specifying input and action:
++is a security-checking tool for binaries, running processes, and kernel settings.
++.Pp
++Since
++.Sy v3.0.0 ,
++.Nm
++uses a subcommand-based CLI. This is a breaking change from the older v2/bash-style interface.
++.Sh GLOBAL OPTIONS
+ .Bl -tag -width Ds
+-.It Fl \-file Ns = Ns Ar filename
+-Checks individual files for security features compiled into the executable
+-.It Fl \-dir Ns = Ns Ar directory
+-Recursively checks all executable files in the directory for security features compiled into the executables
+-.It Fl \-listfile Ns = Ns Ar listfile
+-Check all files specified in a newline-separeted text file for security features compiled into the executable
+-.It Fl \-proc Ns = Ns Ar pid
+-Checks the security features of a running process by name
+-.It Fl \-proc-all
+-Checks the security features of all running processes
+-.It Fl \-proc-libs
+-Checks the security features of the all libraries of a running process ID
+-.It Fl \-kernel Ns Op = Ns Ar config
+-Checks the security features of the running kernel or a specified kernel config
+-.It Fl \-fortify-file Ns = Ns Ar filename
+-Checks for the use of fortifiable and fortified library functions in a file
+-.It Fl \-fortify-proc Ns = Ns Ar pid
+-Checks for the use of fortifiable and fortified library functions in a running process
++.It Fl h , Fl -help
++Display help and exit.
++.It Fl v , Fl -version
++Show version and exit.
++.It Fl o , Fl -output Ns = Ns Ar table|xml|json|yaml
++Set output format. Default is
++.Sy table .
++.It Fl l , Fl -libc Ns = Ns Ar path
++Set libc location (useful for
++.Sy fortify
++checks on offline/embedded filesystems).
++.It Fl -no-banner
++Disable the startup banner.
++.It Fl -no-headers
++Disable table headers.
+ .El
+-
+-Options modifying behavior:
++.Sh COMMANDS
+ .Bl -tag -width Ds
+-.It Fl \-debug
+-Enable debug-level output.
+-.It Fl \-extended
+-Check for additional security features (e.g. Clang CFI, SafeStack)
+-.It Fl \-libcfile Ns = Ns Ar path
+-Specify the libc file path or a search path
+-.It Fl \-output Ns = Ns Ar (cli|csv|xml|json) No Ns , or Fl \-format Ns = Ns Ar (cli|csv|xml|json)
+-Output the results in different formats for ingestion to other applications.
+-.It Fl \-trace
+-Enable bash tracing (set
+-.Fl x No Ns ).
++.It Cm file Ar path
++Check security properties for a single binary file.
++.It Cm dir Ar directory
++Check security properties for binary files in a directory.
++.It Cm fortifyFile Ar path
++Check FORTIFY information for a binary file.
++.It Cm fortifyProc Ar pid
++Check FORTIFY information for a running process.
++.It Cm kernel
++Check kernel security flags.
++.It Cm proc Ar pid
++Check security properties for a running process.
++.It Cm procAll
++Check security properties for all running processes.
+ .El
+-
+-Miscellaneous options:
+-.Bl -tag -width Ds
+-.It Fl \-debug_report
+-Generate a system report and exit.
+-.It Fl h No or Fl \-help
+-Displays the help text and exit
+-.It Fl \-update No or Fl \-upgrade
+-Checks source for a signed update and updates the application if available and exit
+-.It Fl \-version
+-Shows the current version of the running software and exit
++.Sh COMPATIBILITY NOTES
++.Bl -bullet
++.It
++The legacy v2/bash options such as
++.Sy --file ,
++.Sy --dir ,
++and
++.Sy --proc-all
++are not the primary v3 interface.
++.It
++Use v3 subcommands instead (for example,
++.Sy checksec file /path/to/bin
++or
++.Sy checksec procAll ) .
++.It
++If you want compact output similar to older invocations, use
++.Sy --no-banner
++(and optionally
++.Sy --no-headers ) .
+ .El
+-\".Sh EXAMPLES
+-\" TODO
+-.Sh DIAGNOSTICS
+-The following diagnostics may be issued on stderr:
++.Sh EXAMPLES
+ .Bl -tag -width Ds
+-.It Permission Denied.
+-For most of the checks you must be root.
++.It
++.Sy checksec file /bin/ls
++.It
++.Sy checksec --no-banner file /bin/ls
++.It
++.Sy checksec --output json dir /usr/bin
++.It
++.Sy checksec proc 1
++.It
++.Sy checksec kernel
+ .El
+ .Sh SEE ALSO
+ .Xr hardening-check 1
+-.Ns ,
+-.Xr feature_test_macros 7
+-.Ns ,
+-.Xr gcc 1
+-.Ns ,
+-.Xr ld 1
+ .Sh HISTORY
+ .Nm
+ was originally written by
+ .An Tobias Klein .
+-This version is expanded and maintained by
+-.An Brian Davis Aq Mt slimm609@gmail.com
++The current project is maintained by
++.An Brian Davis Aq Mt slimm609@gmail.com .
+-- 
+2.52.0
+

--- a/app-devel/checksec/autobuild/patches/0002-docs-man-document-dir-recursive-flag-and-kernel-conf.patch
+++ b/app-devel/checksec/autobuild/patches/0002-docs-man-document-dir-recursive-flag-and-kernel-conf.patch
@@ -1,0 +1,53 @@
+From 31f1589fb3613dbf744651d1a72780f85844792f Mon Sep 17 00:00:00 2001
+From: BRIAN DAVIS <briandavis@frank.internal>
+Date: Thu, 19 Feb 2026 16:55:22 -0500
+Subject: [PATCH 2/2] docs(man): document dir recursive flag and kernel config
+ arg
+
+---
+ extras/man/checksec.1 | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/extras/man/checksec.1 b/extras/man/checksec.1
+index 3403852..8a4ccb3 100644
+--- a/extras/man/checksec.1
++++ b/extras/man/checksec.1
+@@ -48,12 +48,20 @@ Disable table headers.
+ Check security properties for a single binary file.
+ .It Cm dir Ar directory
+ Check security properties for binary files in a directory.
++Use
++.Fl r
++or
++.Fl -recursive
++to recurse into subdirectories.
+ .It Cm fortifyFile Ar path
+ Check FORTIFY information for a binary file.
+ .It Cm fortifyProc Ar pid
+ Check FORTIFY information for a running process.
+-.It Cm kernel
++.It Cm kernel Op Ar config
+ Check kernel security flags.
++If
++.Ar config
++is provided, use that kernel config file.
+ .It Cm proc Ar pid
+ Check security properties for a running process.
+ .It Cm procAll
+@@ -88,9 +96,13 @@ If you want compact output similar to older invocations, use
+ .It
+ .Sy checksec --output json dir /usr/bin
+ .It
++.Sy checksec dir /usr/bin --recursive
++.It
+ .Sy checksec proc 1
+ .It
+ .Sy checksec kernel
++.It
++.Sy checksec kernel /path/to/config
+ .El
+ .Sh SEE ALSO
+ .Xr hardening-check 1
+-- 
+2.52.0
+

--- a/app-devel/checksec/spec
+++ b/app-devel/checksec/spec
@@ -1,4 +1,4 @@
-VER=2.7.1
-SRCS="git::commit=tags/$VER::https://github.com/slimm609/checksec.sh"
+VER=3.1.0
+SRCS="git::commit=tags/v$VER::https://github.com/slimm609/checksec"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17677"


### PR DESCRIPTION
Topic Description
-----------------

- checksec: manpage update to v3
- checksec: update to 3.1.0
    Merge build into beyond

Package(s) Affected
-------------------

- checksec: 1:3.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit checksec
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
