### PR TITLE
ppsspp: use vendored zip

### DIFF
--- a/app-games/ppsspp/autobuild/defines
+++ b/app-games/ppsspp/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ppsspp
 PKGSEC=games
-PKGDEP="ffmpeg glew libpng libuv libzip miniupnpc sdl2 sdl2-ttf snappy"
+PKGDEP="ffmpeg glew libpng libuv miniupnpc sdl2 sdl2-ttf snappy"
 BUILDDEP="glu llvm"
 PKGDES="Emulator for PlayStation® Portable (PSP)"
 
@@ -37,7 +37,9 @@ CMAKE_AFTER=(
     '-DUSE_SYSTEM_FFMPEG=ON'
     '-DUSE_SYSTEM_LIBPNG=ON'
     '-DUSE_SYSTEM_LIBSDL2=ON'
-    '-DUSE_SYSTEM_LIBZIP=ON'
+    # FIXME: Enabling system libzip causes games to fail to install and
+    # launch from the built-in homebrew store.
+    '-DUSE_SYSTEM_LIBZIP=OFF'
     '-DUSE_SYSTEM_MINIUPNPC=ON'
     '-DUSE_SYSTEM_SNAPPY=ON'
     '-DUSE_SYSTEM_ZSTD=ON'

--- a/app-games/ppsspp/spec
+++ b/app-games/ppsspp/spec
@@ -1,5 +1,5 @@
 VER=1.20.1
-REL=1
+REL=2
 SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12295"


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] ppsspp: disable system libzip

Package(s) Affected
-------------------

- ppsspp: 1.20.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppsspp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] RISC-V 64-bit `riscv64`
