### PR TITLE
libdatachannel: update to 0.24.1

### DIFF
--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,5 @@
 VER=32.1.0
+REL=1
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # Check https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux#obs-browser
 # for upstream required CEF version for reference.

--- a/runtime-multimedia/libdatachannel/autobuild/defines
+++ b/runtime-multimedia/libdatachannel/autobuild/defines
@@ -1,12 +1,14 @@
 PKGNAME=libdatachannel
 PKGSEC=libs
 PKGDEP="openssl libnice srtp usrsctp glib"
-BUILDDEP="cmake nlohmann-json plog"
-PKGDES="A C/C++ WebRTC network library"
+BUILDDEP="nlohmann-json plog"
+PKGDES="C/C++ library for WebRTC networking"
 
-PKGBREAK="obs-studio<=30.2.3-1"
+PKGBREAK="obs-studio<=32.1.0"
 
-ABTYPE=cmake
-CMAKE_AFTER="-DUSE_GNUTLS=ON \
-            -DUSE_NICE=ON \
-            -DPREFER_SYSTEM_LIB=ON"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DUSE_GNUTLS=ON'
+    '-DUSE_NICE=ON'
+    '-DPREFER_SYSTEM_LIB=ON'
+)

--- a/runtime-multimedia/libdatachannel/spec
+++ b/runtime-multimedia/libdatachannel/spec
@@ -1,4 +1,4 @@
-VER=0.22.6
+VER=0.24.1
 SRCS="git::commit=tags/v$VER::https://github.com/paullouisageneau/libdatachannel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369160"


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: rebuild for libdatachannel 0.24.1
- libdatachannel: update to 0.24.1

Package(s) Affected
-------------------

- libdatachannel: 0.24.1
- obs-studio: 32.1.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdatachannel obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
