### PR TITLE
samba: update to 4.24.0

### DIFF
--- a/app-database/tdb/spec
+++ b/app-database/tdb/spec
@@ -1,5 +1,4 @@
-VER=1.4.14
+VER=1.4.15
 SRCS="tbl::https://www.samba.org/ftp/tdb/tdb-$VER.tar.gz"
-CHKSUMS="sha256::144f407d42ed7a0ec1470a40ef17ad41133fe910bce865dd9fe084d49c907526"
+CHKSUMS="sha256::fba09d8df1f1b9072aeae8e78b2bd43c5afef20b2f6deefa633aa14a377a8dd2"
 CHKUPDATE="anitya::id=1735"
-REL="1"

--- a/app-network/samba/spec
+++ b/app-network/samba/spec
@@ -1,5 +1,4 @@
-VER=4.23.4
+VER=4.24.0
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
-CHKSUMS="sha256::af429d078a86f1ce16d0d1ecee35c42a3610790b47b84468f31284a8c4060140"
+CHKSUMS="sha256::1b1e457fd651a612cd08226cc6efd04e5d01e36d918c8b4c4e470e74e86881ea"
 CHKUPDATE="anitya::id=4758"
-REL="1"

--- a/runtime-common/talloc/spec
+++ b/runtime-common/talloc/spec
@@ -1,5 +1,4 @@
-VER=2.4.3
+VER=2.4.4
 SRCS="tbl::https://www.samba.org/ftp/talloc/talloc-$VER.tar.gz"
-CHKSUMS="sha256::dc46c40b9f46bb34dd97fe41f548b0e8b247b77a918576733c528e83abd854dd"
+CHKSUMS="sha256::55e47994018c13743485544e7206780ffbb3c8495e704a99636503e6e77abf59"
 CHKUPDATE="anitya::id=1733"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- talloc: update to 2.4.4
- tdb: update to 1.4.15
- samba: update to 4.24.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ldb: 2:4.24.0
- samba: 4.24.0
- talloc: 2.4.4
- tdb: 1.4.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit talloc tdb samba
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
