### PR TITLE
deno: update to 2.7.6

### DIFF
--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From 66c176c992ef800bfba3611931419dff414067c7 Mon Sep 17 00:00:00 2001
+From a7957ae0a731d3508728b32b99a9986c3cbe99fb Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 4 Mar 2026 20:16:58 +0800
 Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
@@ -9,20 +9,20 @@ Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 8b1070aa0..e91838750 100644
+index cdfd1d25b..b1a9ad35b 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -11160,8 +11160,6 @@ dependencies = [
+@@ -11172,8 +11172,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "146.3.0"
+ version = "146.8.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "8741c1f33d1ebf6c81f53fbb0c66fdd7a2b55feeead0ec40ec9468b387d67176"
+-checksum = "67519d234f7bc5a54a71f7fbc52258b0f3a7e9c11f365213d49016a59207ec10"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index 0bb92c704..f37b23810 100644
+index e57819f8e..7f296e004 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -601,3 +601,6 @@ opt-level = 3

--- a/lang-js/deno/autobuild/patches/0002-ALPINE-Link-with-system-provided-libraries.patch
+++ b/lang-js/deno/autobuild/patches/0002-ALPINE-Link-with-system-provided-libraries.patch
@@ -1,4 +1,4 @@
-From 1eaad673e7b2a121eca2943021e5d8cea19c6498 Mon Sep 17 00:00:00 2001
+From 133566c94d3403e49cdcfafd89052899c5b3273e Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 4 Mar 2026 20:25:49 +0800
 Subject: [PATCH 2/3] ALPINE: Link with system-provided libraries
@@ -10,10 +10,10 @@ Subject: [PATCH 2/3] ALPINE: Link with system-provided libraries
  3 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index e91838750..1e2e4b127 100644
+index b1a9ad35b..c9a969de7 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -6510,7 +6510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -6522,7 +6522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
  dependencies = [
   "bindgen 0.72.1",
@@ -22,7 +22,7 @@ index e91838750..1e2e4b127 100644
   "vcpkg",
  ]
 diff --git a/Cargo.toml b/Cargo.toml
-index f37b23810..730a9d151 100644
+index 7f296e004..196d1f158 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -276,7 +276,7 @@ rayon = "1.11.0"
@@ -53,7 +53,7 @@ index f37b23810..730a9d151 100644
  
  # napi
 diff --git a/cli/Cargo.toml b/cli/Cargo.toml
-index 3b16912d9..42dba7400 100644
+index beb43a348..1f63aa3c1 100644
 --- a/cli/Cargo.toml
 +++ b/cli/Cargo.toml
 @@ -24,7 +24,7 @@ path = "integration_tests_runner.rs"

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-disable-self-update-feature.patch
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-disable-self-update-feature.patch
@@ -1,4 +1,4 @@
-From 0781e891f29f1502bb72c81f217ce21c912763b7 Mon Sep 17 00:00:00 2001
+From 5e3c780894a9869107ec7ce951035c7db6d22c25 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 18 Feb 2026 11:44:43 +0800
 Subject: [PATCH 3/3] AOSCOS: disable self-update feature
@@ -8,7 +8,7 @@ Subject: [PATCH 3/3] AOSCOS: disable self-update feature
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cli/Cargo.toml b/cli/Cargo.toml
-index 42dba7400..abb0c51f4 100644
+index 1f63aa3c1..f6d9c8df7 100644
 --- a/cli/Cargo.toml
 +++ b/cli/Cargo.toml
 @@ -24,7 +24,7 @@ path = "integration_tests_runner.rs"

--- a/lang-js/deno/autobuild/patches/0004-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0004-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,4 +1,4 @@
-From 19dc9b0caa25f1e064b9f0ffd59b92c6d3b9a8f0 Mon Sep 17 00:00:00 2001
+From 2d7e26cefe9682334b98e4e5a23936e4502678cc Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Thu, 29 Jan 2026 23:09:43 +0800
 Subject: [PATCH 4/5] AOSCOS: Disable cross-compilation setup on arm64
@@ -9,10 +9,10 @@ Because we have native linux arm64 CI :)
  1 file changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index a27baf1..e905e3f 100644
+index 512c6ee..42bcd53 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -352,14 +352,14 @@ fn build_v8(is_asan: bool) {
+@@ -357,14 +357,14 @@ fn build_v8(is_asan: bool) {
      }
    }
    // cross-compilation setup

--- a/lang-js/deno/autobuild/patches/0005-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0005-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,4 +1,4 @@
-From 0a37b2243276b6932b99719026cfa76651df57b5 Mon Sep 17 00:00:00 2001
+From bd6d2f6a9c2a57a2dbc59b2af79b56d931fb19f5 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
 Subject: [PATCH 5/5] AOSCOS: build: correct Clang builtins path

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.7.5
+VER=2.7.6
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=146.3.0
+RUSTY_V8_VER=146.8.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::40fcc09009fbfcf925776721dbbc6e40a5979380f8d12fb01429b6f6a3e94dd2 \
+CHKSUMS="sha256::e458ae64f137f4905c0f02e9e67e9cb7c784b970d7bf72768f7ef2cd59e02bbd \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.7.6

Package(s) Affected
-------------------

- deno: 2.7.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
