### PR TITLE
snapd: backport a fix for CVE-2026-3888

### DIFF
--- a/app-admin/snapd/autobuild/patches/0001-AOSCOS-cmd-snap-confine-handle-multi-version-GCC-pre.patch
+++ b/app-admin/snapd/autobuild/patches/0001-AOSCOS-cmd-snap-confine-handle-multi-version-GCC-pre.patch
@@ -1,8 +1,8 @@
 From 41e6258c10ea403f535e98957a310dcdcacce414 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 14 Mar 2026 14:39:50 +0800
-Subject: [PATCH] AOSCOS: cmd/snap-confine: handle multi-version GCC prefixes
- in AOSC OS
+Subject: [PATCH 1/2] AOSCOS: cmd/snap-confine: handle multi-version GCC
+ prefixes in AOSC OS
 
 /usr/lib/libgcc_s.so.1 => [/usr/lib/]gcc/x86_64-aosc-linux-gnu/15/libgcc_s.so.1
 

--- a/app-admin/snapd/autobuild/patches/0002-FROMLIST-data-more-precise-prune-pattern-for-tmpfile.patch
+++ b/app-admin/snapd/autobuild/patches/0002-FROMLIST-data-more-precise-prune-pattern-for-tmpfile.patch
@@ -1,0 +1,35 @@
+From 9a5f6edba6e05e509374e6bc003e0f0de5a7efe4 Mon Sep 17 00:00:00 2001
+From: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+Date: Fri, 13 Feb 2026 15:38:01 +0100
+Subject: [PATCH 2/2] FROMLIST: data: more precise prune pattern for tmpfiles
+
+This way the structure of private tmp directories is left intact, while the
+(aging) content of such directories is allowed to be removed.
+
+Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
+
+Link: https://github.com/canonical/snapd/pull/16776
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ data/systemd-tmpfiles/snapd.conf | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/data/systemd-tmpfiles/snapd.conf b/data/systemd-tmpfiles/snapd.conf
+index da8f1c38b7..98329e3d6c 100644
+--- a/data/systemd-tmpfiles/snapd.conf
++++ b/data/systemd-tmpfiles/snapd.conf
+@@ -1,7 +1,7 @@
+ D! /tmp/snap-private-tmp 0700 root root -
+ 
+-# make sure the snap's private tmp folders are 
+-# not reaped by age if configured by the system (noble+)
+-# this will still let the contents be reaped, just not the
+-# folder itself
++# Allow removing content in the private tmp folders without affecting the
++# architectural structure of the folders themselves.
++X /tmp/snap-private-tmp
+ X /tmp/snap-private-tmp/*/tmp
++x /tmp/snap-private-tmp/*/tmp/.snap
+-- 
+2.52.0
+

--- a/app-admin/snapd/spec
+++ b/app-admin/snapd/spec
@@ -1,4 +1,5 @@
 VER=2.74.1
+REL=1
 SRCS="tbl::https://github.com/snapcore/snapd/releases/download/$VER/snapd_$VER.vendor.tar.xz"
 CHKSUMS="sha256::126f41aba651ec36c1d946b389687d937d3e96489b683cffdc4f37bd9deb1d46"
 CHKUPDATE="anitya::id=376770"

--- a/topics/snapd-2.74.1-cve-2026-3888.toml
+++ b/topics/snapd-2.74.1-cve-2026-3888.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Snapd 2.74.1, Revision 1"
+zh_CN = "Snapd 2.74.1，修订版本 1"
+
+[caution]
+default = "Fixes a Local Privilege Escalation vulnerability - CVE-2026-3888 (severity: High)"
+zh_CN = "修复一个本地提权漏洞，漏洞编号 CVE-2026-3888（严重性：高）"
+
+[packages-v2]
+snapd = "< 2.74.1-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add snapd-2.74.1-cve-2026-3888.toml
- snapd: backport a fix for CVE-2026-3888
    Link: https://discourse.ubuntu.com/t/snapd-local-privilege-escalation-cve-2026-3888/78627
    Link: https://cdn2.qualys.com/advisory/2026/03/17/snap-confine-systemd-tmpfiles.txt

Package(s) Affected
-------------------

- snapd: 2.74.1-1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit snapd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
