### PR TITLE
ncurses: remove WezTerm terminfo

### DIFF
--- a/runtime-common/ncurses/autobuild/beyond
+++ b/runtime-common/ncurses/autobuild/beyond
@@ -48,4 +48,5 @@ abinfo "Removing a file provided by other terminal emulators ..."
 rm -v \
     "$PKGDIR"/usr/share/terminfo/f/fbterm \
     "$PKGDIR"/usr/share/terminfo/a/alacritty* \
-    "$PKGDIR"/usr/share/terminfo/f/{foot,foot-direct}
+    "$PKGDIR"/usr/share/terminfo/f/{foot,foot-direct} \
+    "$PKGDIR"/usr/share/terminfo/w/wezterm

--- a/runtime-common/ncurses/spec
+++ b/runtime-common/ncurses/spec
@@ -1,4 +1,5 @@
 VER=6.6
+REL=1
 SRCS="https://ftp.gnu.org/gnu/ncurses/ncurses-${VER}.tar.gz"
 CHKSUMS="sha256::355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11"
 CHKUPDATE="anitya::id=2057"


### PR DESCRIPTION
Topic Description
-----------------

- ncurses: remove WezTerm terminfo
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- ncurses: 1:6.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncurses
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
