### PR TITLE
webkit2gtk: update to 2.52.1

### DIFF
--- a/runtime-web/webkit2gtk-4.0/autobuild/defines
+++ b/runtime-web/webkit2gtk-4.0/autobuild/defines
@@ -1,0 +1,76 @@
+PKGNAME=webkit2gtk-4.0
+PKGSEC=gnome
+PKGDEP="bubblewrap enchant-2 geoclue2 gstreamer gtk-3 hyphen icu \
+        libavif libjxl libmanette libnotify libsecret libsoup libwebp libxslt \
+        openjpeg sqlite woff2 xdg-dbus-proxy flite"
+BUILDDEP="gobject-introspection gperf ruby unifdef"
+PKGDES="WebKit rendering engine port for GTK (4.0 ABI runtime for legacy applications)"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+    '-DLIB_INSTALL_DIR=/usr/lib'
+    '-DENABLE_BUBBLEWRAP_SANDBOX=ON'
+    '-DENABLE_DRAG_SUPPORT=ON'
+    '-DENABLE_GAMEPAD=ON'
+    '-DENABLE_DOCUMENTATION=OFF'
+    '-DENABLE_INTROSPECTION=ON'
+    '-DENABLE_JOURNALD_LOG=ON'
+    '-DENABLE_MEDIA_SOURCE=ON'
+    '-DENABLE_MINIBROWSER=OFF'
+    '-DENABLE_QUARTZ_TARGET=OFF'
+    '-DENABLE_SPELLCHECK=ON'
+    '-DENABLE_TOUCH_EVENTS=ON'
+    '-DENABLE_VIDEO=ON'
+    '-DENABLE_WAYLAND_TARGET=ON'
+    '-DENABLE_WEBDRIVER=ON'
+    '-DENABLE_WEB_AUDIO=ON'
+    '-DENABLE_X11_TARGET=ON'
+    '-DENABLE_SPEECH_SYNTHESIS=ON'
+    '-DPORT=GTK'
+    '-DSHOULD_INSTALL_JS_SHELL=OFF'
+    '-DUSE_APPLE_ICU=OFF'
+    '-DUSE_AVIF=ON'
+    '-DUSE_GTK4=OFF'
+    '-DUSE_JPEGXL=ON'
+    '-DUSE_LCMS=ON'
+    '-DUSE_LIBHYPHEN=ON'
+    '-DUSE_LIBSECRET=ON'
+    '-DUSE_THIN_ARCHIVES=ON'
+    '-DUSE_WOFF2=ON'
+    '-DUSE_SYSTEM_SYSPROF_CAPTURE=OFF'
+    '-DUSE_SKIA=OFF'
+    '-DUSE_SOUP2=ON'
+    '-DUSE_GTK4=OFF'
+)
+
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER[@]}"
+    '-DUSE_64KB_PAGE_BLOCK=ON'
+)
+
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER[@]}"
+    '-DUSE_64KB_PAGE_BLOCK=ON'
+)
+
+PKGBREAK="webkit2gtk<=1:2.50.3-1"
+
+# FIXME: Insufficient RAM for LTO on all current loongson3 buildbots
+NOLTO__LOONGSON3=1
+
+# FIXME: cannot tail-call: target is not able to optimize the call into a sibling call
+NOLTO__PPC64EL=1
+
+# Note: Extra Provides for Spiral (Debian compatibility).
+PKGPROV="libwebkit2gtk-4.0-37_spiral"
+
+# Limit the number of parallel jobs so we won't require too much memory
+# (or the number of builders able to build WebKit will be too small or
+# even zero for some platform).  This should match the set in spec:
+# 3.75 GiB per job should be enough.
+#
+# Note that autobuild4 also passes MAKE_AFTER to ninja as well as make.
+MAKE_AFTER=-j16
+MAKE_AFTER__LOONGSON3=-j8
+MAKE_AFTER__RISCV64=-j32

--- a/runtime-web/webkit2gtk-4.0/autobuild/defines
+++ b/runtime-web/webkit2gtk-4.0/autobuild/defines
@@ -39,9 +39,10 @@ CMAKE_AFTER=(
     '-DUSE_THIN_ARCHIVES=ON'
     '-DUSE_WOFF2=ON'
     '-DUSE_SYSTEM_SYSPROF_CAPTURE=OFF'
-    '-DUSE_SKIA=OFF'
     '-DUSE_SOUP2=ON'
     '-DUSE_GTK4=OFF'
+    # USE_SKIA deliberately omitted to use the default (ON on little-endian,
+    # OFF on big-endian)
 )
 
 CMAKE_AFTER__ARM64=(

--- a/runtime-web/webkit2gtk-4.0/autobuild/defines
+++ b/runtime-web/webkit2gtk-4.0/autobuild/defines
@@ -65,12 +65,7 @@ NOLTO__PPC64EL=1
 # Note: Extra Provides for Spiral (Debian compatibility).
 PKGPROV="libwebkit2gtk-4.0-37_spiral"
 
-# Limit the number of parallel jobs so we won't require too much memory
-# (or the number of builders able to build WebKit will be too small or
-# even zero for some platform).  This should match the set in spec:
-# 3.75 GiB per job should be enough.
-#
-# Note that autobuild4 also passes MAKE_AFTER to ninja as well as make.
-MAKE_AFTER=-j16
-MAKE_AFTER__LOONGSON3=-j8
-MAKE_AFTER__RISCV64=-j32
+# See spec for the resource limit: arm64 and riscv64 have no builders
+# with 4 GiB memory per core so we need to limit the parallel job number.
+MAKE_AFTER__ARM64=-j60
+MAKE_AFTER__RISCV64=-j30

--- a/runtime-web/webkit2gtk-4.0/autobuild/patches/0001-Description-Use-WTF_CPU_UNKNOWN-when-building-for-ri.patch
+++ b/runtime-web/webkit2gtk-4.0/autobuild/patches/0001-Description-Use-WTF_CPU_UNKNOWN-when-building-for-ri.patch
@@ -1,0 +1,51 @@
+From 34e1061dc3a80bb141f065085f46056f0f77b4d7 Mon Sep 17 00:00:00 2001
+From: Alberto Garcia <berto@igalia.com>
+Date: Thu, 23 May 2024 19:48:44 +0800
+Subject: [PATCH] Description: Use WTF_CPU_UNKNOWN when building for riscv64
+
+WebKitGTK doesn't build on riscv64 even with the JIT disabled.
+Treating the CPU as unknown is perhaps a bit severe, but it allows us
+to get the build done until someone steps up to maintain this
+properly.
+
+Bug: https://bugs.webkit.org/show_bug.cgi?id=271371
+---
+ Source/WTF/wtf/PlatformCPU.h    | 8 --------
+ Source/cmake/WebKitCommon.cmake | 2 --
+ 2 files changed, 10 deletions(-)
+
+diff --git a/Source/WTF/wtf/PlatformCPU.h b/Source/WTF/wtf/PlatformCPU.h
+index 8aac10247bb..d9d69a40ec0 100644
+--- a/Source/WTF/wtf/PlatformCPU.h
++++ b/Source/WTF/wtf/PlatformCPU.h
+@@ -286,14 +286,6 @@
+ 
+ #endif /* ARM */
+ 
+-/* CPU(RISCV64) - RISC-V 64-bit */
+-#if    defined(__riscv) \
+-    && defined(__riscv_xlen) \
+-    && (__riscv_xlen == 64)
+-#define WTF_CPU_RISCV64 1
+-#define WTF_CPU_KNOWN 1
+-#endif
+-
+ #if !CPU(KNOWN)
+ #define WTF_CPU_UNKNOWN 1
+ #endif
+diff --git a/Source/cmake/WebKitCommon.cmake b/Source/cmake/WebKitCommon.cmake
+index 98ee788a5cd..3861c0a4366 100644
+--- a/Source/cmake/WebKitCommon.cmake
++++ b/Source/cmake/WebKitCommon.cmake
+@@ -129,8 +129,6 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
+         set(WTF_CPU_PPC64 1)
+     elseif (LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+         set(WTF_CPU_PPC64LE 1)
+-    elseif (LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64")
+-        set(WTF_CPU_RISCV64 1)
+     elseif (LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "^loongarch64")
+         set(WTF_CPU_LOONGARCH64 1)
+     else ()
+-- 
+2.51.0
+

--- a/runtime-web/webkit2gtk-4.0/autobuild/prepare
+++ b/runtime-web/webkit2gtk-4.0/autobuild/prepare
@@ -1,0 +1,10 @@
+abinfo "Removing bundled gtest ..."
+rm -rv "$SRCDIR"/Source/ThirdParty/gtest/
+
+abinfo "Appending /usr/include/openjpeg-2.3 to include dir ..."
+export CFLAGS="${CFLAGS} -I/usr/include/openjpeg-2.3"
+export CXXFLAGS="${CXXFLAGS} -I/usr/include/openjpeg-2.3"
+
+abinfo "Appending -gdwarf64 to fit the extremely large debug symbol ..."
+export CFLAGS="${CFLAGS} -gdwarf64"
+export CXXFLAGS="${CXXFLAGS} -gdwarf64"

--- a/runtime-web/webkit2gtk-4.0/spec
+++ b/runtime-web/webkit2gtk-4.0/spec
@@ -1,0 +1,14 @@
+VER=2.50.6
+SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
+CHKSUMS="sha256::2b281abf8894ffc6172152e5660b75eeeedbe1cc43d6783d09dc79f7c865bb42"
+
+# Let's be a little conservative than sorry.  Combined with the parallel job
+# number limited to 16 in the build script, we should have 3.75 GiB per job.
+ENVREQ="total_mem=60 core=16"
+
+# RISC-V is so slow, use more parallel jobs and also request more RAM.
+# FIXME: Many RV builders are down so we cannot satisfy this for now.
+# ENVREQ__RISCV64="total_mem=120 core=32"
+
+# We don't have a quad-3A4000 system as at now.
+ENVREQ__LOONGSON3="total_mem=60 core=8"

--- a/runtime-web/webkit2gtk-4.0/spec
+++ b/runtime-web/webkit2gtk-4.0/spec
@@ -2,13 +2,6 @@ VER=2.50.6
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
 CHKSUMS="sha256::2b281abf8894ffc6172152e5660b75eeeedbe1cc43d6783d09dc79f7c865bb42"
 
-# Let's be a little conservative than sorry.  Combined with the parallel job
-# number limited to 16 in the build script, we should have 3.75 GiB per job.
-ENVREQ="total_mem=60 core=16"
-
-# RISC-V is so slow, use more parallel jobs and also request more RAM.
-# FIXME: Many RV builders are down so we cannot satisfy this for now.
-# ENVREQ__RISCV64="total_mem=120 core=32"
-
-# We don't have a quad-3A4000 system as at now.
-ENVREQ__LOONGSON3="total_mem=60 core=8"
+ENVREQ="total_mem_per_core=4"
+ENVREQ__ARM64="total_mem=240 core=60"
+ENVREQ__RISCV64="total_mem=120 core=30"

--- a/runtime-web/webkit2gtk/autobuild/build
+++ b/runtime-web/webkit2gtk/autobuild/build
@@ -1,20 +1,18 @@
-for i in ON OFF; do
-    mkdir -pv "$SRCDIR"/build_${i}
-    cd "$SRCDIR"/build_${i}
+mkdir -pv "$SRCDIR"/build_gtk3
+cd "$SRCDIR"/build_gtk3
 
-    abinfo "Running CMake for WebKitGTK (SOUP2=${i}) ..."
-    cmake "$SRCDIR" \
-        ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
-        -DUSE_SOUP2=${i} \
-        -GNinja
+abinfo "Running CMake for WebKitGTK (GTK 3.x) ..."
+cmake "$SRCDIR" \
+    ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+    -DUSE_GTK4=OFF \
+    -GNinja
 
-    abinfo "Building WebKitGTK (SOUP2=${i}) ..."
-    ninja -C "$SRCDIR"/build_${i} ${NINJA_FLAGS}
+abinfo "Building WebKitGTK (GTK 3.x) ..."
+ninja -C "$SRCDIR"/build_gtk3 ${NINJA_FLAGS}
 
-    abinfo "Installing WebKitGTK (SOUP2=${i}) ..."
-    DESTDIR="$PKGDIR" \
-        cmake --install .
-done
+abinfo "Installing WebKitGTK (GTK 3.x) ..."
+DESTDIR="$PKGDIR" \
+    cmake --install .
 
 mkdir -pv "$SRCDIR"/build_gtk4
 cd "$SRCDIR"/build_gtk4
@@ -22,7 +20,6 @@ cd "$SRCDIR"/build_gtk4
 abinfo "Running CMake for WebKitGTK (GTK 4.x) ..."
 cmake "$SRCDIR" \
     ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
-    -DUSE_SOUP2=OFF \
     -DUSE_GTK4=ON \
     -GNinja
 

--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -37,9 +37,12 @@ CMAKE_AFTER=(
     '-DUSE_LIBHYPHEN=ON'
     '-DUSE_LIBSECRET=ON'
     '-DUSE_THIN_ARCHIVES=ON'
-    '-DUSE_WOFF2=ON'
+    # FreeType2 (built with Brotli) is preferred for handling WOFF since
+    # the 2.52 release
+    '-DUSE_WOFF2=OFF'
     '-DUSE_SYSTEM_SYSPROF_CAPTURE=OFF'
-    '-DUSE_SKIA=OFF'
+    # USE_SKIA deliberately omitted to use the default (ON on little-endian,
+    # OFF on big-endian)
 )
 
 CMAKE_AFTER__ARM64=(

--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -63,6 +63,16 @@ PKGBREAK="gnome-online-accounts<=3.40.0 devhelp<=40.1 \
           libgepub<=0.6.0 liferea<=1.13.8 midori<=9.0 remmina<=1.4.11 \
           shotwell<=0.31.3 wxgtk3<=3.0.4 xreader<=2.8.3"
 
+# FIXME: LTO build fails.
+#
+# lto1: fatal error: missing resolution data for _ZTVN7WebCore12CloseWatcherE
+# compilation terminated.
+# lto-wrapper: fatal error: /usr/bin/g++ returned 1 exit status
+# compilation terminated.
+# /usr/bin/ld: error: lto-wrapper failed
+# collect2: error: ld returned 1 exit status
+NOLTO=1
+
 # FIXME: Insufficient RAM for LTO on all current loongson3 buildbots
 NOLTO__LOONGSON3=1
 

--- a/runtime-web/webkit2gtk/autobuild/defines
+++ b/runtime-web/webkit2gtk/autobuild/defines
@@ -78,6 +78,3 @@ NOLTO__LOONGSON3=1
 
 # FIXME: cannot tail-call: target is not able to optimize the call into a sibling call
 NOLTO__PPC64EL=1
-
-# Note: Extra Provides for Spiral (Debian compatibility).
-PKGPROV="libwebkit2gtk-4.0-37_spiral"

--- a/runtime-web/webkit2gtk/autobuild/patches/0001-DEBIAN-Use-WTF_CPU_UNKNOWN-when-building-for-riscv64.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0001-DEBIAN-Use-WTF_CPU_UNKNOWN-when-building-for-riscv64.patch
@@ -1,14 +1,16 @@
-From 34e1061dc3a80bb141f065085f46056f0f77b4d7 Mon Sep 17 00:00:00 2001
+From 8d9c543704b2ea81a6f5802daeca2524161375af Mon Sep 17 00:00:00 2001
 From: Alberto Garcia <berto@igalia.com>
 Date: Thu, 23 May 2024 19:48:44 +0800
-Subject: [PATCH] Description: Use WTF_CPU_UNKNOWN when building for riscv64
+Subject: [PATCH 1/3] DEBIAN: Use WTF_CPU_UNKNOWN when building for riscv64
 
 WebKitGTK doesn't build on riscv64 even with the JIT disabled.
 Treating the CPU as unknown is perhaps a bit severe, but it allows us
 to get the build done until someone steps up to maintain this
 properly.
 
-Bug: https://bugs.webkit.org/show_bug.cgi?id=271371
+Link: https://bugs.webkit.org/show_bug.cgi?id=271371
+Link: https://salsa.debian.org/webkit-team/webkit/-/raw/debian/2.44.1-1/debian/patches/fix-ftbfs-riscv64.patch
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
  Source/WTF/wtf/PlatformCPU.h    | 8 --------
  Source/cmake/WebKitCommon.cmake | 2 --
@@ -34,7 +36,7 @@ index 8aac10247bb..d9d69a40ec0 100644
  #define WTF_CPU_UNKNOWN 1
  #endif
 diff --git a/Source/cmake/WebKitCommon.cmake b/Source/cmake/WebKitCommon.cmake
-index 98ee788a5cd..3861c0a4366 100644
+index ff058af835f..6da4a968fe8 100644
 --- a/Source/cmake/WebKitCommon.cmake
 +++ b/Source/cmake/WebKitCommon.cmake
 @@ -129,8 +129,6 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
@@ -47,5 +49,5 @@ index 98ee788a5cd..3861c0a4366 100644
          set(WTF_CPU_LOONGARCH64 1)
      else ()
 -- 
-2.51.0
+2.54.0
 

--- a/runtime-web/webkit2gtk/autobuild/patches/0002-FROMLIST-Fix-ENABLE-JIT-build.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0002-FROMLIST-Fix-ENABLE-JIT-build.patch
@@ -1,0 +1,330 @@
+From 0bfe1a828f83d64fae2bf614422fbe608eecd78b Mon Sep 17 00:00:00 2001
+From: Shu-yu Guo <syg@apple.com>
+Date: Fri, 6 Feb 2026 18:31:25 -0800
+Subject: [PATCH 2/3] FROMLIST: Fix !ENABLE(JIT) build
+
+https://bugs.webkit.org/show_bug.cgi?id=306638
+rdar://169822205
+
+Reviewed by NOBODY (OOPS!).
+
+* Source/JavaScriptCore/jit/ExecutableAllocator.h:
+(JSC::performJITMemcpy):
+* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
+* Source/JavaScriptCore/llint/LLIntData.cpp:
+(JSC::LLInt::initialize):
+* Source/JavaScriptCore/wasm/WasmCallee.cpp:
+* Source/WTF/wtf/PlatformEnable.h:
+
+Link: https://github.com/WebKit/WebKit/pull/58096
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ .../JavaScriptCore/jit/ExecutableAllocator.h  |  8 ++
+ .../llint/InPlaceInterpreter.asm              |  8 +-
+ Source/JavaScriptCore/llint/LLIntData.cpp     | 81 +++++++++++++++----
+ Source/JavaScriptCore/wasm/WasmCallee.cpp     | 18 ++++-
+ Source/WTF/wtf/PlatformEnable.h               |  2 +-
+ 5 files changed, 93 insertions(+), 24 deletions(-)
+
+diff --git a/Source/JavaScriptCore/jit/ExecutableAllocator.h b/Source/JavaScriptCore/jit/ExecutableAllocator.h
+index 3e8efce28cf..cb81579c870 100644
+--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
++++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
+@@ -390,6 +390,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+ }
+ 
++template<RepatchingInfo>
++inline void* performJITMemcpy(void *dst, const void *src, size_t n)
++{
++WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
++    return memcpy(dst, src, n);
++WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
++}
++
+ inline bool isJITPC(void*) { return false; }
+ #endif // ENABLE(JIT)
+ 
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+index 64db9cdb21d..dac1faa5260 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+@@ -420,7 +420,7 @@ end
+ 
+ # OSR
+ macro ipintPrologueOSR(increment)
+-if JIT
++if WEBASSEMBLY_BBQJIT
+     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
+     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::IPIntTierUpCounter::m_counter[ws0], .continue
+ 
+@@ -457,11 +457,11 @@ end
+     if ARMv7
+         break # FIXME: ipint support.
+     end # ARMv7
+-end # JIT
++end # WEBASSEMBLY_BBQJIT
+ end
+ 
+ macro ipintLoopOSR(increment)
+-if JIT and not ARMv7
++if WEBASSEMBLY_BBQJIT and not ARMv7
+     validateOpcodeConfig(ws0)
+     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
+     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::IPIntTierUpCounter::m_counter[ws0], .continue
+@@ -492,7 +492,7 @@ end
+ end
+ 
+ macro ipintEpilogueOSR(increment)
+-if JIT and not ARMv7
++if WEBASSEMBLY_BBQJIT and not ARMv7
+     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
+     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::IPIntTierUpCounter::m_counter[ws0], .continue
+ 
+diff --git a/Source/JavaScriptCore/llint/LLIntData.cpp b/Source/JavaScriptCore/llint/LLIntData.cpp
+index 5d7c88f7257..2509dc4132f 100644
+--- a/Source/JavaScriptCore/llint/LLIntData.cpp
++++ b/Source/JavaScriptCore/llint/LLIntData.cpp
+@@ -199,8 +199,28 @@ void initialize()
+ #if CPU(ARM64E)
+ 
+ #if ENABLE(JIT_CAGE)
+-    if (Options::useJITCage())
++    if (Options::useJITCage()) {
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::jitCagePtr)] = jitCagePtrThunk().code().taggedPtr();
++#if ENABLE(WEBASSEMBLY)
++        // JSPI JITCage gates
++        g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::jspiResignReturnPCs)] = jspiResignReturnPCsThunk().code().taggedPtr();
++        g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::jspiExecuteSliceEntry)] = jspiExecuteSliceEntryThunk().code().taggedPtr();
++        // jspiExitImplantedSlice is stored untagged because it's used as a return address
++        // (not as a jump target) and will be signed by JITCage with the stack pointer diversifier.
++        g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::jspiExitImplantedSlice)] = jspiExitImplantedSliceThunk().code().untaggedPtr();
++#endif // ENABLE(WEBASSEMBLY)
++    }
++#endif
++
++#if ENABLE(JIT)
++#define INITIALIZE_JS_GATE_JIT_PATH(name, tag) \
++    if (Options::useJIT()) { \
++        codeRef8.construct(createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name)); \
++        codeRef16.construct(createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide16CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide16")); \
++        codeRef32.construct(createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide32CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide32")); \
++    } else
++#else
++#define INITIALIZE_JS_GATE_JIT_PATH(name, tag)
+ #endif
+ 
+ #define INITIALIZE_JS_GATE(name, tag) \
+@@ -208,11 +228,7 @@ void initialize()
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef8; \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef16; \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef32; \
+-        if (Options::useJIT()) { \
+-            codeRef8.construct(createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name)); \
+-            codeRef16.construct(createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide16CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide16")); \
+-            codeRef32.construct(createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide32CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide32")); \
+-        } else { \
++        INITIALIZE_JS_GATE_JIT_PATH(name, tag) { \
+             codeRef8.construct(LLInt::getCodeRef<NativeToJITGatePtrTag>(js_trampoline_##name)); \
+             codeRef16.construct(LLInt::getWide16CodeRef<NativeToJITGatePtrTag>(js_trampoline_##name)); \
+             codeRef32.construct(LLInt::getWide32CodeRef<NativeToJITGatePtrTag>(js_trampoline_##name)); \
+@@ -226,16 +242,23 @@ void initialize()
+ 
+ #if ENABLE(WEBASSEMBLY)
+ 
++#if ENABLE(JIT)
++#define INITIALIZE_WASM_GATE_JIT_PATH(name, tag) \
++    if (Options::useJIT()) { \
++        codeRef8.construct(createWasmGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name)); \
++        codeRef16.construct(createWasmGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide16CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide16")); \
++        codeRef32.construct(createWasmGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide32CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide32")); \
++    } else
++#else
++#define INITIALIZE_WASM_GATE_JIT_PATH(name, tag)
++#endif
++
+ #define INITIALIZE_WASM_GATE(name, tag) \
+     do { \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef8; \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef16; \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef32; \
+-        if (Options::useJIT()) { \
+-            codeRef8.construct(createWasmGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name)); \
+-            codeRef16.construct(createWasmGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide16CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide16")); \
+-            codeRef32.construct(createWasmGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(LLInt::getWide32CodeFunctionPtr<CFunctionPtrTag>(name##_return_location)), tag, #name "_wide32")); \
+-        } else { \
++        INITIALIZE_WASM_GATE_JIT_PATH(name, tag) { \
+             codeRef8.construct(LLInt::getCodeRef<NativeToJITGatePtrTag>(wasm_trampoline_##name)); \
+             codeRef16.construct(LLInt::getWide16CodeRef<NativeToJITGatePtrTag>(wasm_trampoline_##name)); \
+             codeRef32.construct(LLInt::getWide32CodeRef<NativeToJITGatePtrTag>(wasm_trampoline_##name)); \
+@@ -253,10 +276,12 @@ void initialize()
+     // This is key to entering the interpreter.
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<VMEntryToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT()) {
+             auto gateCodeRef = createJSGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(&vmEntryToJavaScriptGateAfter), JSEntryPtrTag, "vmEntryToJavaScript");
+             codeRef.construct(gateCodeRef.retagged<VMEntryToJITGatePtrTag>());
+         } else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<VMEntryToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<VMEntryToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, VMEntryToJITGatePtrTag>(&vmEntryToJavaScriptTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::vmEntryToJavaScript)] = codeRef.get().code().taggedPtr();
+     }
+@@ -268,79 +293,103 @@ void initialize()
+ 
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(createTailCallGate(JSEntryPtrTag, true));
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&tailCallJSEntryTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::tailCallJSEntryPtrTag)]= codeRef.get().code().taggedPtr();
+     }
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(createTailCallGate(JSEntryPtrTag, true));
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&tailCallJSEntrySlowPathTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::tailCallJSEntrySlowPathPtrTag)] = codeRef.get().code().taggedPtr();
+     }
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(createTailCallGate(JSEntryPtrTag, false));
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&tailCallWithoutUntagJSEntryTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::tailCallWithoutUntagJSEntryPtrTag)]= codeRef.get().code().taggedPtr();
+     }
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(createWasmTailCallGate(WasmEntryPtrTag));
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&wasmTailCallTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmTailCallWasmEntryPtrTag)]= codeRef.get().code().taggedPtr();
+     }
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(createWasmTailCallGate(WasmEntryPtrTag));
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&wasmTailCallTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmIPIntTailCallWasmEntryPtrTag)]= codeRef.get().code().taggedPtr();
+     }
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(exceptionHandlerGateThunk());
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&exceptionHandlerTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::exceptionHandler)] = codeRef.get().code().taggedPtr();
+     }
+     {
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> codeRef;
++#if ENABLE(JIT)
+         if (Options::useJIT())
+             codeRef.construct(returnFromLLIntGateThunk());
+         else
++#endif
+             codeRef.construct(MacroAssemblerCodeRef<NativeToJITGatePtrTag>::createSelfManagedCodeRef(CodePtr<NativeToJITGatePtrTag>::fromTaggedPtr(retagCodePtr<void*, CFunctionPtrTag, NativeToJITGatePtrTag>(&returnFromLLIntTrampoline))));
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::returnFromLLInt)] = codeRef.get().code().taggedPtr();
+     }
+ 
++#if ENABLE(JIT)
+     if (Options::useJIT()) {
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::loopOSREntry)] = loopOSREntryGateThunk().code().taggedPtr();
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::entryOSREntry)] = entryOSREntryGateThunk().code().taggedPtr();
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmOSREntry)] = wasmOSREntryGateThunk().code().taggedPtr();
+-    } else {
++    } else
++#endif
++    {
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::loopOSREntry)] = LLInt::getCodeRef<NativeToJITGatePtrTag>(loop_osr_entry_gate).code().taggedPtr();
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::entryOSREntry)] = nullptr;
+         g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmOSREntry)] = nullptr;
+     }
+ 
++#if ENABLE(JIT)
++#define INITIALIZE_TAG_AND_UNTAG_THUNKS_JIT_PATH(name) \
++    if (Options::useJIT()) { \
++        tagCodeRef.construct(tagGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(name##TagGateAfter))); \
++        untagCodeRef.construct(untagGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(name##UntagGateAfter))); \
++    } else
++#else
++#define INITIALIZE_TAG_AND_UNTAG_THUNKS_JIT_PATH(name)
++#endif
++
+ #define INITIALIZE_TAG_AND_UNTAG_THUNKS(name) \
+     do { \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> tagCodeRef; \
+         static LazyNeverDestroyed<MacroAssemblerCodeRef<NativeToJITGatePtrTag>> untagCodeRef; \
+-        if (Options::useJIT()) { \
+-            tagCodeRef.construct(tagGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(name##TagGateAfter))); \
+-            untagCodeRef.construct(untagGateThunk(retagCodePtr<void*, CFunctionPtrTag, OperationPtrTag>(name##UntagGateAfter))); \
+-        } else { \
++        INITIALIZE_TAG_AND_UNTAG_THUNKS_JIT_PATH(name) { \
+             tagCodeRef.construct(LLInt::getCodeRef<NativeToJITGatePtrTag>(js_trampoline_##name##_tag)); \
+             untagCodeRef.construct(LLInt::getCodeRef<NativeToJITGatePtrTag>(js_trampoline_##name##_untag)); \
+         } \
+diff --git a/Source/JavaScriptCore/wasm/WasmCallee.cpp b/Source/JavaScriptCore/wasm/WasmCallee.cpp
+index 94a845ab47e..b689f00143a 100644
+--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
++++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
+@@ -55,13 +55,25 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(Callee);
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(JITCallee);
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(JSToWasmCallee);
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WasmToJSCallee);
++WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(IPIntCallee);
++WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WasmBuiltinCallee);
++
++#if ENABLE(JIT)
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(JSToWasmICCallee);
++#endif
++
++#if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OptimizingJITCallee);
++#endif
++
++#if ENABLE(WEBASSEMBLY_BBQJIT)
++WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(BBQCallee);
++#endif
++
++#if ENABLE(WEBASSEMBLY_OMGJIT)
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OMGCallee);
+ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(OMGOSREntryCallee);
+-WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(BBQCallee);
+-WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(IPIntCallee);
+-WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(WasmBuiltinCallee);
++#endif
+ 
+ Callee::Callee(Wasm::CompilationMode compilationMode)
+     : NativeCallee(NativeCallee::Category::Wasm, ImplementationVisibility::Private)
+diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
+index 9c20eb45de4..1561e5ecc85 100644
+--- a/Source/WTF/wtf/PlatformEnable.h
++++ b/Source/WTF/wtf/PlatformEnable.h
+@@ -1006,7 +1006,7 @@
+ #define ENABLE_JIT_OPERATION_DISASSEMBLY 1
+ #endif
+ 
+-#if CPU(ARM64E)
++#if CPU(ARM64E) && ENABLE(JIT)
+ #define ENABLE_JIT_SIGN_ASSEMBLER_BUFFER 1
+ #endif
+ 
+-- 
+2.54.0
+

--- a/runtime-web/webkit2gtk/autobuild/patches/0003-FROMLIST-skcms-Disable-musttail-on-MIPS-PowerPC-and-.patch
+++ b/runtime-web/webkit2gtk/autobuild/patches/0003-FROMLIST-skcms-Disable-musttail-on-MIPS-PowerPC-and-.patch
@@ -1,0 +1,36 @@
+From 367d5377a2b9f6e1df9034e382170cada9d9992e Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 7 Apr 2026 16:45:57 +0800
+Subject: [PATCH 3/3] FROMLIST: skcms: Disable musttail on MIPS, PowerPC, and
+ LoongArch with GCC
+
+The GCC issue linked for RISC-V also affects MIPS, PowerPC, and LoongArch
+(I've edited the GCC ticket to mention them as well).
+
+Change-Id: I5ac392142e58178300e3882baeb70695e31c8db8
+
+Link: https://skia-review.googlesource.com/c/skcms/+/1203676
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ Source/ThirdParty/skia/modules/skcms/src/skcms_internals.h | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Source/ThirdParty/skia/modules/skcms/src/skcms_internals.h b/Source/ThirdParty/skia/modules/skcms/src/skcms_internals.h
+index 02aa7b77a58..274471935fc 100644
+--- a/Source/ThirdParty/skia/modules/skcms/src/skcms_internals.h
++++ b/Source/ThirdParty/skia/modules/skcms/src/skcms_internals.h
+@@ -59,7 +59,10 @@ extern "C" {
+     #elif defined(__GNUC__) && !defined(SKCMS_HAS_MUSTTAIL)
+         // GCC on riscv64 does not support our tail call functions
+         // cf. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121784
+-        #if __has_cpp_attribute(clang::musttail) && !defined(__riscv)
++        #if __has_cpp_attribute(clang::musttail) && !defined(__riscv) \
++                                                 && !defined(__mips__) \
++                                                 && !defined(__powerpc__) \
++                                                 && !defined(__loongarch__)
+             #define SKCMS_HAS_MUSTTAIL 1
+         #else
+             #define SKCMS_HAS_MUSTTAIL 0
+-- 
+2.54.0
+

--- a/runtime-web/webkit2gtk/autobuild/prepare
+++ b/runtime-web/webkit2gtk/autobuild/prepare
@@ -5,6 +5,10 @@ abinfo "Appending /usr/include/openjpeg-2.3 to include dir ..."
 export CFLAGS="${CFLAGS} -I/usr/include/openjpeg-2.3"
 export CXXFLAGS="${CXXFLAGS} -I/usr/include/openjpeg-2.3"
 
+abinfo "Appending -gdwarf64 to fit the extremely large debug symbol ..."
+export CFLAGS="${CFLAGS} -gdwarf64"
+export CXXFLAGS="${CXXFLAGS} -gdwarf64"
+
 # This should match the set in spec.
 case "$(uname -m)" in
   mips*    ) NJOBS=8  ;;

--- a/runtime-web/webkit2gtk/autobuild/prepare
+++ b/runtime-web/webkit2gtk/autobuild/prepare
@@ -9,13 +9,14 @@ abinfo "Appending -gdwarf64 to fit the extremely large debug symbol ..."
 export CFLAGS="${CFLAGS} -gdwarf64"
 export CXXFLAGS="${CXXFLAGS} -gdwarf64"
 
-# This should match the set in spec.
+# See spec for the resource limit: arm64 and riscv64 have no builders
+# with 4 GiB memory per core so we need to limit the parallel job number.
 case "$(uname -m)" in
-  mips*    ) NJOBS=8  ;;
-# FIXME: see spec.
-#  riscv64* ) NJOBS=32 ;;
-  *        ) NJOBS=16 ;;
+  aarch64 ) NJOBS=60 ;;
+  riscv64 ) NJOBS=30 ;;
 esac
 
-abinfo "Limit the number of parallel jobs to ${NJOBS}"
-export NINJA_FLAGS="-j${NJOBS}"
+if [ -n "$NJOBS" ]; then
+  abinfo "Limit the number of parallel jobs to ${NJOBS}"
+  export NINJA_FLAGS="-j${NJOBS}"
+fi

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,6 +1,6 @@
-VER=2.52.0
+VER=2.52.3
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::b31c55f18194ac83ba08c9b93bbeffef57a7ecff7f41c874d17a9e7853dca19f"
+CHKSUMS="sha256::5b3e0d174e63dcc28848b1194e0e7448d5948c3c2427ecd931c2c5be5261aebb"
 CHKUPDATE="anitya::id=324014"
 
 # Let's be a little conservative than sorry.  Combined with the parallel job

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,7 +1,6 @@
-VER=2.50.3
-REL=2
+VER=2.52.0
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
-CHKSUMS="sha256::70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f"
+CHKSUMS="sha256::b31c55f18194ac83ba08c9b93bbeffef57a7ecff7f41c874d17a9e7853dca19f"
 CHKUPDATE="anitya::id=324014"
 
 # Let's be a little conservative than sorry.  Combined with the parallel job

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -3,13 +3,6 @@ SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
 CHKSUMS="sha256::5b3e0d174e63dcc28848b1194e0e7448d5948c3c2427ecd931c2c5be5261aebb"
 CHKUPDATE="anitya::id=324014"
 
-# Let's be a little conservative than sorry.  Combined with the parallel job
-# number limited to 16 in the build script, we should have 3.75 GiB per job.
-ENVREQ="total_mem=60 core=16"
-
-# RISC-V is so slow, use more parallel jobs and also request more RAM.
-# FIXME: Many RV builders are down so we cannot satisfy this for now.
-# ENVREQ__RISCV64="total_mem=120 core=32"
-
-# We don't have a quad-3A4000 system as at now.
-ENVREQ__LOONGSON3="total_mem=60 core=8"
+ENVREQ="total_mem_per_core=4"
+ENVREQ__ARM64="total_mem=240 core=60"
+ENVREQ__RISCV64="total_mem=120 core=30"

--- a/topics/webkit2gtk-2.52.0.toml
+++ b/topics/webkit2gtk-2.52.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "WebKitGTK 2.52.0"
+
+[caution]
+default = "Fixes 17 security vulnerabilities disclosed in WebKitGTK and WPE WebKit Security Advisories WSA-2026-0001 (including 4 of high severity, 13 of medium severity)"
+zh_CN = "修复 WebKitGTK 及 WPE WebKit 第 WSA-2026-0001 号安全公告中披露的 17 个安全漏洞（含 4 个高危漏洞及 13 个中危漏洞）"
+
+[packages-v2]
+"webkit2gtk" = "< 1:2.52.0"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk-4.0: new, 2.50.6
  - 2.52 has dropped soup 2 support, build the old version for the legacy applications like some game launchers.
- webkit2gtk: update to 2.52.1
    - The soup 2 support is dropped in 2.52 release so we cannot provide the
      compatibility libwebkit2gtk-4.0.so.37 library now.  We'll add a new
      package to build that from webkitgtk-2.50.
    - Backport a patch to fix FTBFS with GTK-3.
    - Apply a PR (not merged yet) to Fix FTBFS on AArch64 with 64-KiB page.
    - Backport two patches to fix runtime crash when scrolling the page.
    - Tracking AOSC patches at AOSC-Tracking/WebKit @ aosc/wpewebkit-2.52.1
      (HEAD: eda5d39c59a5aae29758595256fdac8958c6c30c).  Note that the
      release tarball seems cut from the wpewebkit tag instead of webkitgtk
      tag for some reason.
- webkit2gtk: update to 2.52.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- webkit2gtk: 1:2.52.1
- webkit2gtk-4.0: 2.50.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit webkit2gtk webkit2gtk-4.0
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
