### PR TITLE
htslib, samtools: update to 1.23.1

### DIFF
--- a/app-scientific/htslib/spec
+++ b/app-scientific/htslib/spec
@@ -1,4 +1,4 @@
-VER=1.21
+VER=1.23.1
 SRCS="tbl::https://github.com/samtools/htslib/releases/download/$VER/htslib-$VER.tar.bz2"
-CHKSUMS="sha256::84b510e735f4963641f26fd88c8abdee81ff4cb62168310ae716636aac0f1823"
+CHKSUMS="sha256::f8a3f36effeec38f043c53ab1f2d9ed45064f14205c5ef8e3c815763b90803c4"
 CHKUPDATE="anitya::id=13500"

--- a/app-scientific/samtools/spec
+++ b/app-scientific/samtools/spec
@@ -1,4 +1,4 @@
-VER=1.21
+VER=1.23.1
 SRCS="tbl::https://github.com/samtools/samtools/releases/download/$VER/samtools-$VER.tar.bz2"
-CHKSUMS="sha256::05724b083a6b6f0305fcae5243a056cc36cf826309c3cb9347a6b89ee3fc5ada"
+CHKSUMS="sha256::32266198a4bc6a6df395d8526688c9697d9c8e472f888c749fdde2e08ea88dd2"
 CHKUPDATE="anitya::id=4759"

--- a/topics/htslib-1.23.1.toml
+++ b/topics/htslib-1.23.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "HTSlib 1.23.1"
+
+[caution]
+default = "Fixes a Heap Buffer Overflow vulnerability - CVE-2026-31962 (severity: High)"
+zh_CN = "修复一个堆缓冲溢出漏洞，漏洞编号 CVE-2026-31962（严重性：高）"
+
+[packages-v2]
+htslib = "< 1.23.1"

--- a/topics/samtools-1.23.1.toml
+++ b/topics/samtools-1.23.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "SAMtools 1.23.1"
+
+[caution]
+default = "Fixes a NULL Pointer Dereference - CVE-2026-31973 (severity: Moderate)"
+zh_CN = "修复一个空指针解引用，漏洞编号 CVE-2026-31973（严重性：中）"
+
+[packages-v2]
+samtools = "< 1.23.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add samtools-1.23.1.toml
- samtools: update to 1.23.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
- topics: add htslib-1.23.1.toml
- htslib: update to 1.23.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- htslib: 1.23.1
- samtools: 1.23.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit htslib samtools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
