### PR TITLE
samtools: update to 1.23.1

### DIFF
--- a/app-scientific/samtools/spec
+++ b/app-scientific/samtools/spec
@@ -1,4 +1,4 @@
-VER=1.21
+VER=1.23.1
 SRCS="tbl::https://github.com/samtools/samtools/releases/download/$VER/samtools-$VER.tar.bz2"
-CHKSUMS="sha256::05724b083a6b6f0305fcae5243a056cc36cf826309c3cb9347a6b89ee3fc5ada"
+CHKSUMS="sha256::32266198a4bc6a6df395d8526688c9697d9c8e472f888c749fdde2e08ea88dd2"
 CHKUPDATE="anitya::id=4759"


### PR DESCRIPTION
Topic Description
-----------------

- samtools: update to 1.23.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- samtools: 1.23.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit samtools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
