### PR TITLE
pyside6: update to 6.10.2

### DIFF
--- a/lang-python/pyside6/autobuild/patches/0001-ARCHLINUX-Revert-Modify-headers-installation-for-CMa.patch
+++ b/lang-python/pyside6/autobuild/patches/0001-ARCHLINUX-Revert-Modify-headers-installation-for-CMa.patch
@@ -1,7 +1,7 @@
-From 594af563965501731b128b17cc57cdda5c4fd3b2 Mon Sep 17 00:00:00 2001
+From 6b450a3cab661acb8e82045dcf229605fc99fac8 Mon Sep 17 00:00:00 2001
 From: Ruikai Liu <rickliu2000@outlook.com>
 Date: Sat, 8 Nov 2025 19:03:17 +0800
-Subject: [PATCH] ARCHLINUX: Revert "Modify headers installation for CMake
+Subject: [PATCH 1/3] ARCHLINUX: Revert "Modify headers installation for CMake
  builds"
 
 /usr/include/ is the correct location for include headers.

--- a/lang-python/pyside6/autobuild/patches/0002-Revert-Build-Fix-super-project-build-for-libpyside.patch
+++ b/lang-python/pyside6/autobuild/patches/0002-Revert-Build-Fix-super-project-build-for-libpyside.patch
@@ -1,0 +1,36 @@
+From a8ad2c73f4c14b3a1db87106f3b94bd3824626ee Mon Sep 17 00:00:00 2001
+From: Ruikai Liu <rickliu2000@outlook.com>
+Date: Thu, 19 Mar 2026 10:25:41 +0800
+Subject: [PATCH 2/3] Revert "Build: Fix super project build for libpyside"
+
+This reverts commit c9d602ab4afa5c9834c4674a742dc9bab7f4b326.
+
+Inspired by: https://gitlab.archlinux.org/archlinux/packaging/packages/pyside6/-/blob/9846d593ab028c46c49fba8dc3d78f3b75df4484/PKGBUILD
+---
+ sources/pyside6/libpyside/CMakeLists.txt | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/sources/pyside6/libpyside/CMakeLists.txt b/sources/pyside6/libpyside/CMakeLists.txt
+index 68fd18970..f8b25a42e 100644
+--- a/sources/pyside6/libpyside/CMakeLists.txt
++++ b/sources/pyside6/libpyside/CMakeLists.txt
+@@ -189,12 +189,10 @@ install(TARGETS pyside6 EXPORT PySide6Targets
+ set_target_properties(pyside6 PROPERTIES
+     VERSION ${PYSIDE_SOVERSION})
+ 
+-if(NOT is_pyside6_superproject_build)
+-    install(TARGETS pyside6 EXPORT PySide6WheelTargets
+-                            LIBRARY DESTINATION "PySide6"
+-                            ARCHIVE DESTINATION "PySide6"
+-                            RUNTIME DESTINATION "PySide6")
+-endif()
++install(TARGETS pyside6 EXPORT PySide6WheelTargets
++                        LIBRARY DESTINATION "PySide6"
++                        ARCHIVE DESTINATION "PySide6"
++                        RUNTIME DESTINATION "PySide6")
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pyside6${pyside6_SUFFIX}.pc"
+         DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
+-- 
+2.52.0
+

--- a/lang-python/pyside6/autobuild/patches/0003-Revert-PySide6-Cleanup-CMake-configuration-files.patch
+++ b/lang-python/pyside6/autobuild/patches/0003-Revert-PySide6-Cleanup-CMake-configuration-files.patch
@@ -1,0 +1,113 @@
+From 04aedcb4dba6eafbd7a8f642e2d9cbca79896e67 Mon Sep 17 00:00:00 2001
+From: Ruikai Liu <rickliu2000@outlook.com>
+Date: Thu, 19 Mar 2026 10:25:48 +0800
+Subject: [PATCH 3/3] Revert "PySide6: Cleanup CMake configuration files"
+
+This reverts commit 05e328476f2d6ef8a0f3f44aca1e5b1cdb7499fc.
+
+Inspired by: https://gitlab.archlinux.org/archlinux/packaging/packages/pyside6/-/blob/9846d593ab028c46c49fba8dc3d78f3b75df4484/PKGBUILD
+---
+ sources/pyside6/cmake/PySideSetup.cmake       |  1 -
+ sources/pyside6/libpyside/CMakeLists.txt      | 37 +++++++------------
+ .../libpyside/PySide6Config-spec.cmake.in     |  4 --
+ 3 files changed, 14 insertions(+), 28 deletions(-)
+
+diff --git a/sources/pyside6/cmake/PySideSetup.cmake b/sources/pyside6/cmake/PySideSetup.cmake
+index 72d6a1ccf..71c820646 100644
+--- a/sources/pyside6/cmake/PySideSetup.cmake
++++ b/sources/pyside6/cmake/PySideSetup.cmake
+@@ -52,7 +52,6 @@ set(BINDING_API_MINOR_VERSION "${pyside_MINOR_VERSION}")
+ set(BINDING_API_MICRO_VERSION "${pyside_MICRO_VERSION}")
+ set(BINDING_API_PRE_RELEASE_VERSION_TYPE "${pyside_PRE_RELEASE_VERSION_TYPE}")
+ set(BINDING_API_PRE_RELEASE_VERSION "${pyside_PRE_RELEASE_VERSION}")
+-set(pyside6_library_so_version "${SHIBOKEN_SO_VERSION}")
+ 
+ # Detect if the Python interpreter is actually PyPy
+ execute_process(
+diff --git a/sources/pyside6/libpyside/CMakeLists.txt b/sources/pyside6/libpyside/CMakeLists.txt
+index f8b25a42e..15ab47494 100644
+--- a/sources/pyside6/libpyside/CMakeLists.txt
++++ b/sources/pyside6/libpyside/CMakeLists.txt
+@@ -146,29 +146,28 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pyside6.pc.in"
+ include(CMakePackageConfigHelpers)
+ 
+ # Build-tree / super project package config file.
+-set(PYSIDE_PYTHONPATH "${PYTHON_SITE_PACKAGES}/PySide6")
+-set(PYSIDE_TYPESYSTEMS "${CMAKE_INSTALL_PREFIX}/share/PySide6${pyside6_SUFFIX}/typesystems")
+-set(PYSIDE_GLUE "${CMAKE_INSTALL_PREFIX}/share/PySide6${pyside6_SUFFIX}/glue")
++set(PYSIDE_PYTHONPATH "${pysidebindings_BINARY_DIR}/PySide6")
++set(PYSIDE_TYPESYSTEMS "${pysidebindings_SOURCE_DIR}/PySide6/templates/")
++set(PYSIDE_GLUE "${pysidebindings_SOURCE_DIR}/PySide6/glue")
+ 
+ configure_package_config_file(
+     "${CMAKE_CURRENT_SOURCE_DIR}/PySide6Config-spec.cmake.in"
+     "${CMAKE_CURRENT_BINARY_DIR}/PySide6Config${SHIBOKEN_PYTHON_CONFIG_SUFFIX}.cmake"
+-    INSTALL_DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+-    PATH_VARS PYSIDE_PYTHONPATH PYSIDE_TYPESYSTEMS PYSIDE_GLUE
+-    INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
++     INSTALL_DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
++     PATH_VARS PYSIDE_PYTHONPATH PYSIDE_TYPESYSTEMS PYSIDE_GLUE
++     INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+ )
+ 
+-# Install-tree / wheel configuration
+-set(PYSIDE_PYTHONPATH "")
+-set(PYSIDE_TYPESYSTEMS "typesystems")
+-set(PYSIDE_GLUE "glue")
+-set(PYSIDE_SOVERSION "${pyside6_library_so_version}")
++set(PYSIDE_PYTHONPATH "${PYTHON_SITE_PACKAGES}/PySide6")
++set(PYSIDE_TYPESYSTEMS "${CMAKE_INSTALL_PREFIX}/share/PySide6${pyside6_SUFFIX}/typesystems")
++set(PYSIDE_GLUE "${CMAKE_INSTALL_PREFIX}/share/PySide6${pyside6_SUFFIX}/glue")
+ 
++# Install-tree / relocatable package config file.
+ configure_package_config_file(
+     "${CMAKE_CURRENT_SOURCE_DIR}/PySide6Config-spec.cmake.in"
+     "${CMAKE_CURRENT_BINARY_DIR}/install/PySide6Config${SHIBOKEN_PYTHON_CONFIG_SUFFIX}.cmake"
+-    INSTALL_DESTINATION "${LIB_INSTALL_DIR}/cmake/PySide6"
+-    PATH_VARS PYSIDE_PYTHONPATH PYSIDE_TYPESYSTEMS PYSIDE_GLUE
++     INSTALL_DESTINATION "${LIB_INSTALL_DIR}/cmake/PySide6"
++     PATH_VARS PYSIDE_PYTHONPATH PYSIDE_TYPESYSTEMS PYSIDE_GLUE
+ )
+ 
+ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/PySide6Config.cmake.in"
+@@ -179,20 +178,12 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/PySide6ConfigVersion.cmake.in"
+ install(FILES ${libpyside_HEADERS}
+         DESTINATION include/${BINDING_NAME}${pyside6_SUFFIX})
+ 
+-# build-time installation
+ install(TARGETS pyside6 EXPORT PySide6Targets
+                         LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+                         ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+                         RUNTIME DESTINATION bin)
+-
+-# wheel installation
+-set_target_properties(pyside6 PROPERTIES
+-    VERSION ${PYSIDE_SOVERSION})
+-
+-install(TARGETS pyside6 EXPORT PySide6WheelTargets
+-                        LIBRARY DESTINATION "PySide6"
+-                        ARCHIVE DESTINATION "PySide6"
+-                        RUNTIME DESTINATION "PySide6")
++install(EXPORT PySide6Targets NAMESPACE PySide6::
++        DESTINATION "${LIB_INSTALL_DIR}/cmake/PySide6")
+ 
+ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pyside6${pyside6_SUFFIX}.pc"
+         DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
+diff --git a/sources/pyside6/libpyside/PySide6Config-spec.cmake.in b/sources/pyside6/libpyside/PySide6Config-spec.cmake.in
+index f9e9a4900..fd3de1e75 100644
+--- a/sources/pyside6/libpyside/PySide6Config-spec.cmake.in
++++ b/sources/pyside6/libpyside/PySide6Config-spec.cmake.in
+@@ -10,10 +10,6 @@ if (NOT TARGET PySide6::pyside6)
+     include("${CMAKE_CURRENT_LIST_DIR}/PySide6Targets.cmake")
+ endif()
+ 
+-# set static variables
+-set(PYSIDE_PYTHON_CONFIG_SUFFIX "@PYTHON_CONFIG_SUFFIX@")
+-set(PYSIDE_SO_VERSION "@pyside6_library_so_version@")
+-
+ # Set relocatable variables.
+ set_and_check(PYSIDE_PYTHONPATH "@PACKAGE_PYSIDE_PYTHONPATH@")
+ set_and_check(PYSIDE_TYPESYSTEMS "@PACKAGE_PYSIDE_TYPESYSTEMS@")
+-- 
+2.52.0
+

--- a/lang-python/pyside6/spec
+++ b/lang-python/pyside6/spec
@@ -1,5 +1,4 @@
-VER=6.10.1
+VER=6.10.2
 SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-$VER-src/pyside-setup-everywhere-src-$VER.tar.xz"
-CHKSUMS="sha256::fd54f40853d61dfd845dbb40d4f89fbd63df5ed341b3d9a2c77bb5c947a0a838"
+CHKSUMS="sha256::05eec38bb71bffff8860786e3c0766cc4b86affc72439bd246c54889bdcb7400"
 CHKUPDATE="anitya::id=148812"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pyside6: update to 6.10.2

Package(s) Affected
-------------------

- pyside6: 6.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyside6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
