### PR TITLE
texlive: update to 20260301

### DIFF
--- a/app-doc/texlive/autobuild/build
+++ b/app-doc/texlive/autobuild/build
@@ -17,7 +17,7 @@ if ab_match_arch loongarch64 || \
             --disable-mfluajit"
 fi
 
-mkdir "$SRCDIR"/build && cd "$SRCDIR"/build
+mkdir -v "$SRCDIR"/build && pushd "$SRCDIR"/build
 ../configure			   \
     ${AUTOTOOLS_DEF[@]}            \
     --enable-shared                \
@@ -54,7 +54,20 @@ abinfo "Creating symlinks to actual binaries.."
 LD_PRELOAD="$PKGDIR/usr/lib/libkpathsea.so.6" \
     make texlinks DESTDIR="$PKGDIR"
 
-cd ..
+popd
+
+# NOTE: From Arch Linux texlive-texmf PKGBUILD.
+abinfo "Installing TeXLive Perl modules ..."
+install -Dvm644 -t "$PKGDIR"/usr/share/perl5/vendor_perl/TeXLive \
+	"$SRCDIR"/../texlive-$PKGVER-extra/tlpkg/TeXLive/*
+
+abinfo "Installing tlpdb file ..."
+install -Dvm644 "$SRCDIR"/../texlive-$PKGVER-extra/tlpkg/texlive.tlpdb \
+	"$PKGDIR"/usr/share/tlpkg/texlive.tlpdb
+
+abinfo "Symlinking config.guess for tlpkg ..."
+ln -sv ../../../bin/config.guess \
+	"$PKGDIR"/usr/share/tlpkg/installer/config.guess
 
 abinfo "Phase 2. install texmf extras"
 tar -xf ../texlive-$PKGVER-texmf.tar.xz \
@@ -99,7 +112,3 @@ abinfo "Remove TL specific warnings in the language.{dat,def} files:"
 sed -i -e '/DO NOT EDIT/,+3 d' "$PKGDIR"/etc/texmf/tex/generic/config/language.*
 abinfo "Remove -dev engines from format lists, in order to supress warning during fmtutil-sys generation"
 sed -i '/-dev/d' "$PKGDIR"/etc/texmf/web2c/fmtutil.cnf
-
-abinfo "Phase 4. Perl hacks"
-mkdir -p "$PKGDIR"/usr/share/tlpkg
-cp -r texk/tests/TeXLive "$PKGDIR"/usr/share/tlpkg/

--- a/app-doc/texlive/autobuild/defines
+++ b/app-doc/texlive/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=texlive
 PKGSEC=tex
 PKGDEP="dialog ghostscript x11-lib x11-app fontconfig freetype gc graphite \
         harfbuzz icu libpaper libpng libgd t1lib python-3 ruby \
-        perl-tk openjdk libsigsegv mpfr pixman poppler ed"
+        perl-tk openjdk libsigsegv mpfr pixman poppler ed config"
 PKGDEP__NOJAVA="${PKGDEP/openjdk/}"
 PKGDEP__LOONGARCH64="${PKGDEP__NOJAVA}"
 PKGDEP__RISCV64="${PKGDEP__NOJAVA}"

--- a/app-doc/texlive/autobuild/postinst
+++ b/app-doc/texlive/autobuild/postinst
@@ -7,9 +7,6 @@ cp /usr/share/texmf-dist/web2c/updmap-hdr.cfg $UPDMAP
 
 echo "Updating the filename database..."
 mktexlsr > /dev/null
-for item in /var/lib/texmf/luatex-cache/context/*/trees/*.lua; do
-    grep -F '["root"]="."' "$item" >/dev/null && rm -f "$item" "${item%.lua}.luc"
-done
 
 echo "Creating all formats..."
 fmtutil-sys --all --cnffile /etc/texmf/web2c/fmtutil.cnf 1>/dev/null

--- a/app-doc/texlive/spec
+++ b/app-doc/texlive/spec
@@ -1,7 +1,9 @@
-VER=20250308
-REL=4
-SRCS="tbl::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-source.tar.xz \
-      file::rename=texlive-$VER-texmf.tar.xz::ftp://tug.org/texlive/historic/${VER:0:4}/texlive-$VER-texmf.tar.xz"
-CHKSUMS="sha512::0837c935488b96cfc8dd79f1298f283b467ab68b4163cee9cb04b79e80195982fdc5ae8a80058dc7d3e99206bfda8b3bdd11340425b08f60cbef70d5a0e22702 \
-         sha512::631a93f911437b9ebb075c09dfc592d6d8331ebaffb8cad62b6e7df55634345937342656db091dc0fb36686927131dbfdee5a03f54ef808a2a4d3ddc47cfbc17"
+VER=20260301
+SRCS="tbl::https://repo-hk.aosc.io/aosc-repacks/texlive/${VER:0:4}/texlive-$VER-source.tar.xz \
+      tbl::https://repo-hk.aosc.io/aosc-repacks/texlive/${VER:0:4}/texlive-$VER-extra.tar.xz \
+      file::rename=texlive-$VER-texmf.tar.xz::https://repo-hk.aosc.io/aosc-repacks/texlive/${VER:0:4}/texlive-$VER-texmf.tar.xz"
+CHKSUMS="sha512::c2ea189fee82475e3013e5e6d7bdbbeef80fe33d3636b99b35bf7c8d0ff06b48dcc54d12f4c3959a0fc9e24b80f9c4878a417d4b55ef4880ff238aefbcf189a3 \
+         sha512::bde992edb7cbaa119c79bfc73697203dfb6bb7d04488d8e50085c06ebbe241f9ef3d161afb996a814c3d1e35bc2cbfe6a957beb5dfcdcfcc7e0cc827b32c5fc3 \
+         sha512::0b8f87622e4b9e31d4bd8c7720376aa9685e5ee299c896e3e1660459546a31e11508946f2c40a71671944c8b467483e5d4d859ff17698d239c7d5aced65d4a6b"
 CHKUPDATE="anitya::id=11725"
+SUBDIR="texlive-$VER-source"


### PR DESCRIPTION
Topic Description
-----------------

- texlive: update to 20260301
    \* Drop unused commands in postinst.
    \* Switch to AOSC repoacks mirror.

Package(s) Affected
-------------------

- texlive: 20260301

Security Update?
----------------

No

Build Order
-----------

```
#buildit texlive
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
