### PR TITLE
ncurses: remove terminfo ghostty

### DIFF
--- a/runtime-common/ncurses/autobuild/beyond
+++ b/runtime-common/ncurses/autobuild/beyond
@@ -49,4 +49,5 @@ rm -v \
     "$PKGDIR"/usr/share/terminfo/f/fbterm \
     "$PKGDIR"/usr/share/terminfo/a/alacritty* \
     "$PKGDIR"/usr/share/terminfo/f/{foot,foot-direct} \
-    "$PKGDIR"/usr/share/terminfo/w/wezterm
+    "$PKGDIR"/usr/share/terminfo/w/wezterm \
+    "$PKGDIR"/usr/share/terminfo/g/ghostty

--- a/runtime-common/ncurses/spec
+++ b/runtime-common/ncurses/spec
@@ -1,5 +1,5 @@
 VER=6.6
-REL=1
+REL=2
 SRCS="https://ftp.gnu.org/gnu/ncurses/ncurses-${VER}.tar.gz"
 CHKSUMS="sha256::355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11"
 CHKUPDATE="anitya::id=2057"


### PR DESCRIPTION
Topic Description
-----------------

- ncurses: remove terminfo ghostty

Package(s) Affected
-------------------

- ncurses: 1:6.6-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncurses
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
