### PR TITLE
openldap: update to 2.6.13

### DIFF
--- a/app-admin/openldap/autobuild/beyond
+++ b/app-admin/openldap/autobuild/beyond
@@ -31,18 +31,8 @@ install -Dvm644 "$SRCDIR"/contrib/slapd-modules/lastbind/slapo-lastbind.5 \
     "$PKGDIR"/usr/share/man/man5/slapo-lastbind.5
 
 abinfo "Creating a symlink for /usr/bin/slapd ..."
-ln -sv ../lib/slapd \
+ln -sv ../libexec/slapd \
     "$PKGDIR"/usr/bin/slapd
-
-abinfo "Fixing up permissions for slapd configurations ..."
-chown -v root:439 "$PKGDIR"/etc/openldap/slapd.*
-chmod -v 640 "$PKGDIR"/etc/openldap/slapd.*
-
-abinfo "Creating daemon directories ..."
-install -dvm700 -o 439 -g 439 "$PKGDIR"/var/lib/openldap
-install -dvm700 -o 439 -g 439 "$PKGDIR"/var/lib/openldap/openldap-data
-chown -R 439:439 "$PKGDIR"/var/lib/openldap
-install -dvm700 -o 439 -g 439 "$PKGDIR"/etc/openldap/slapd.d
 
 abinfo "Setting executable bits for /usr/lib/*.so* ..."
 chmod -v +x "$PKGDIR"/usr/lib/*.so*

--- a/app-admin/openldap/autobuild/defines
+++ b/app-admin/openldap/autobuild/defines
@@ -4,38 +4,34 @@ PKGDEP="e2fsprogs cyrus-sasl"
 BUILDDEP="groff"
 PKGDES="Lightweight Directory Access Protocol (LDAP) client/server"
 
+# FIXME: Fails to build with shadow build
+#
+# [INFO]:  Building extra module nssov ...
+# make: Entering directory '[...]/openldap-2.6.13/contrib/slapd-modules/nssov'
+# ../../../libtool --mode=compile gcc -pipe -Wno-error -fstack-protector-strong --param=ssp-buffer-size=4 -fexceptions -fcf-protection=full -ggdb -fira-loop-pressure -fira-hoist-pressure -specs=/usr/lib/gcc/specs/hardened-cc1 -O2 -fno-omit-frame-pointer -flto=auto -march=x86-64 -mtune=znver4 -msse2 -mno-omit-leaf-frame-pointer -pipe -Wno-error -fstack-protector-strong --param=ssp-buffer-size=4 -fexceptions -fcf-protection=full -ggdb -fira-loop-pressure -fira-hoist-pressure -specs=/usr/lib/gcc/specs/hardened-cc1 -O2 -fno-omit-frame-pointer -flto=auto -march=x86-64 -mtune=znver4 -msse2 -mno-omit-leaf-frame-pointer -D_GLIBCXX_ASSERTIONS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -O2 -D_GLIBCXX_ASSERTIONS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -O2  -I../../../include -I../../../include -I../../../servers/slapd -Inss-pam-ldapd -c alias.c
+# make: ../../../libtool: No such file or directory
+# make: *** [Makefile:60: alias.lo] Error 127
 ABSHADOW=0
-NOSTATIC=0
-NOSTATIC__RETRO=1
-NOSTATIC__ARMV4="$NOSTATIC__RETRO"
-NOSTATIC__ARMV6HF="$NOSTATIC__RETRO"
-NOSTATIC__ARMV7HF="$NOSTATIC__RETRO"
-NOSTATIC__I486="$NOSTATIC__RETRO"
-NOSTATIC__LOONGSON2F="$NOSTATIC__RETRO"
-NOSTATIC__M68K="$NOSTATIC__RETRO"
-NOSTATIC__POWERPC="$NOSTATIC__RETRO"
-NOSTATIC__PPC64="$NOSTATIC__RETRO"
 
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
-                 --localstatedir=/var/lib/openldap \
-                 --enable-ipv6 \
-                 --enable-syslog \
-                 --enable-local \
-                 --enable-crypt \
-                 --enable-dynamic \
-                 --with-threads \
-                 --disable-wrappers \
-                 --without-fetch \
-                 --enable-spasswd \
-                 --with-cyrus-sasl \
-                 --enable-overlays=mod \
-                 --enable-modules=yes \
-                 --enable-static \
-                 --enable-slapd \
-                 --enable-slapi"
+AUTOTOOLS_AFTER=(
+    '--localstatedir=/var/lib/openldap'
+    '--enable-ipv6'
+    '--enable-syslog'
+    '--enable-local'
+    '--enable-crypt'
+    '--enable-dynamic'
+    '--with-threads'
+    '--disable-wrappers'
+    '--without-fetch'
+    '--enable-spasswd'
+    '--with-cyrus-sasl'
+    '--enable-overlays=mod'
+    '--enable-modules=yes'
+    '--enable-static'
+    '--enable-slapd'
+    '--enable-slapi'
+)
 
-RECONF=0
-# SONAME change
 PKGBREAK="apr-util<=1.6.1-7 audit<=3.1 autofs<=5.1.8-2 balsa<=2.6.3-1 \
     cups-browsed<=2.0.0 cups-filters<=2.0.0 cyrus-sasl<=2.1.27-8 \
     dovecot<=2.3.10.1-3 evolution-data-server<=3.44.4 evolution<=3.44.4 \

--- a/app-admin/openldap/autobuild/overrides/usr/lib/tmpfiles.d/slapd.conf
+++ b/app-admin/openldap/autobuild/overrides/usr/lib/tmpfiles.d/slapd.conf
@@ -1,1 +1,6 @@
 D /run/openldap 0755 ldap ldap -
+z /etc/openldap/slapd.* 640 root ldap
+d /etc/openldap/slapd.d 700 ldap ldap
+Z /etc/openldap/slapd.d 700 ldap ldap
+d /var/lib/openldap 700 ldap ldap
+d /var/lib/openldap/openldap-data 700 ldap ldap

--- a/app-admin/openldap/autobuild/patches/0001-AOSCOS-use-run-as-local-state-directory.patch
+++ b/app-admin/openldap/autobuild/patches/0001-AOSCOS-use-run-as-local-state-directory.patch
@@ -1,0 +1,58 @@
+From 5a2397322bcb3e1b726633c9441ba9f91dda8fdd Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Sat, 4 Apr 2026 00:15:16 +0800
+Subject: [PATCH] AOSCOS: use /run as local state directory
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ servers/slapd/Makefile.in | 2 +-
+ servers/slapd/slapd.conf  | 4 ++--
+ servers/slapd/slapd.ldif  | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/servers/slapd/Makefile.in b/servers/slapd/Makefile.in
+index 2f223af565..65da32e869 100644
+--- a/servers/slapd/Makefile.in
++++ b/servers/slapd/Makefile.in
+@@ -374,7 +374,7 @@ install-local-srv: install-slapd install-tools \
+ 
+ install-slapd: FORCE
+ 	-$(MKDIR) $(DESTDIR)$(libexecdir)
+-	-$(MKDIR) $(DESTDIR)$(localstatedir)/run
++	-$(MKDIR) $(DESTDIR)/run/openldap
+ 	$(LTINSTALL) $(INSTALLFLAGS) $(STRIP_OPTS) -m 755 \
+ 		slapd$(EXEEXT) $(DESTDIR)$(libexecdir)
+ 	@for i in $(SUBDIRS); do \
+diff --git a/servers/slapd/slapd.conf b/servers/slapd/slapd.conf
+index 2fcab71fae..5915eee0b9 100644
+--- a/servers/slapd/slapd.conf
++++ b/servers/slapd/slapd.conf
+@@ -10,8 +10,8 @@ include		%SYSCONFDIR%/schema/core.schema
+ # service AND an understanding of referrals.
+ #referral	ldap://root.openldap.org
+ 
+-pidfile		%LOCALSTATEDIR%/run/slapd.pid
+-argsfile	%LOCALSTATEDIR%/run/slapd.args
++pidfile		/run/openldap/slapd.pid
++argsfile	/run/openldap/slapd.args
+ 
+ # Load dynamic backend modules:
+ modulepath	%MODULEDIR%
+diff --git a/servers/slapd/slapd.ldif b/servers/slapd/slapd.ldif
+index 99e53dee80..3f2638b225 100644
+--- a/servers/slapd/slapd.ldif
++++ b/servers/slapd/slapd.ldif
+@@ -9,8 +9,8 @@ cn: config
+ #
+ # Define global ACLs to disable default read access.
+ #
+-olcArgsFile: %LOCALSTATEDIR%/run/slapd.args
+-olcPidFile: %LOCALSTATEDIR%/run/slapd.pid
++olcArgsFile: /run/openldap/slapd.args
++olcPidFile: /run/openldap/slapd.pid
+ #
+ # Do not enable referrals until AFTER you have a working directory
+ # service AND an understanding of referrals.
+-- 
+2.52.0
+

--- a/app-admin/openldap/autobuild/prepare
+++ b/app-admin/openldap/autobuild/prepare
@@ -1,9 +1,0 @@
-abinfo "Tweaking ldap_defaults.h ..."
-sed -e 's|#define LDAPI_SOCK LDAP_RUNDIR LDAP_DIRSEP "run" LDAP_DIRSEP "ldapi"|#define LDAPI_SOCK LDAP_DIRSEP "run" LDAP_DIRSEP "openldap" LDAP_DIRSEP "ldapi"|' \
-    -i "$SRCDIR"/include/ldap_defaults.h
-
-abinfo "Setting daemon directory: /var/run => /run/openldap ..."
-sed -e 's|%LOCALSTATEDIR%/run|/run/openldap|' \
-    -i "$SRCDIR"/servers/slapd/slapd.{conf,ldif}
-sed -e 's|-$(MKDIR) $(DESTDIR)$(localstatedir)/run|-$(MKDIR) $(DESTDIR)/run/openldap|' \
-    -i "$SRCDIR"/servers/slapd/Makefile.in

--- a/app-admin/openldap/spec
+++ b/app-admin/openldap/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=2_6_9
+UPSTREAM_VER=2.6.13
 VER=${UPSTREAM_VER//_/.}
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::2cb7dc73e9c8340dff0d99357fbaa578abf30cc6619f0521972c555681e6b2ff"
+CHKSUMS="sha256::d693b49517a42efb85a1a364a310aed16a53d428d1b46c0d31ef3fba78fcb656"
 CHKUPDATE="anitya::id=2551"
-REL=1

--- a/runtime-optenv32/openldap+32/spec
+++ b/runtime-optenv32/openldap+32/spec
@@ -1,5 +1,5 @@
-UPSTREAM_VER=2_6_9
+UPSTREAM_VER=2.6.13
 VER=${UPSTREAM_VER//_/.}
 SRCS="tbl::https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-$VER.tgz"
-CHKSUMS="sha256::2cb7dc73e9c8340dff0d99357fbaa578abf30cc6619f0521972c555681e6b2ff"
+CHKSUMS="sha256::d693b49517a42efb85a1a364a310aed16a53d428d1b46c0d31ef3fba78fcb656"
 CHKUPDATE="anitya::id=2551"


### PR DESCRIPTION
Topic Description
-----------------

- openldap: update to 2.6.13
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- openldap: 2.6.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit openldap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
