### PR TITLE
gparted: update to 1.8.1

### DIFF
--- a/app-admin/gparted/spec
+++ b/app-admin/gparted/spec
@@ -1,4 +1,4 @@
-VER=1.8.0
+VER=1.8.1
 SRCS="tbl::https://sourceforge.net/projects/gparted/files/gparted/gparted-$VER/gparted-$VER.tar.gz"
-CHKSUMS="sha256::f584ed4be7fd09c2cf6a784778a8540970d985f0ac8e5a7bd0628528a3ab5609"
+CHKSUMS="sha256::67388ac405f9fe92a40636cb03b0e1e0bb6403ad89ccc174b2ff190ef6f32349"
 CHKUPDATE="anitya::id=1235"


### PR DESCRIPTION
Topic Description
-----------------

- gparted: update to 1.8.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gparted: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gparted
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
