### PR TITLE
scapy: update to 2.7.0

### DIFF
--- a/app-network/scapy/autobuild/defines
+++ b/app-network/scapy/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=scapy
 PKGSEC=net
 PKGDEP="tcpdump python-3"
-PKGSUG="pycryptodome pyx python-matplotlib graphviz sox"
-BUILDDEP="python-build python-installer wheel"
-PKGDES="An interactive packet manipulation program"
+PKGSUG="ipython pyx cryptography matplotlib"
+BUILDDEP="setuptools-python3"
+PKGDES="Python-based interactive packet manipulation program and library"
 
 ABTYPE=pep517
 ABHOST=noarch

--- a/app-network/scapy/spec
+++ b/app-network/scapy/spec
@@ -1,5 +1,4 @@
-VER=2.6.1
+VER=2.7.0
 SRCS="git::commit=tags/v${VER}::https://github.com/secdev/scapy.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=115624"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- scapy: update to 2.7.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- scapy: 2.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit scapy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
