### PR TITLE
kernel-tools: fix kvm_stat

### DIFF
--- a/app-admin/kernel-tools/autobuild/build
+++ b/app-admin/kernel-tools/autobuild/build
@@ -44,7 +44,7 @@ abinfo "Building kvm_stat ..."
 cd "$SRCDIR"/tools/kvm/kvm_stat
 make
 abinfo "Installing kvm_stat ..."
-make install DESTDIR="$PKGDIR"
+make install INSTALL_ROOT="$PKGDIR"
 
 for i in dslm freefall; do
     abinfo "Building $i ..."

--- a/app-admin/kernel-tools/autobuild/build.stage2
+++ b/app-admin/kernel-tools/autobuild/build.stage2
@@ -38,7 +38,7 @@ abinfo "Building kvm_stat ..."
 cd "$SRCDIR"/tools/kvm/kvm_stat
 make
 abinfo "Installing kvm_stat ..."
-make install DESTDIR="$PKGDIR"
+make install INSTALL_ROOT="$PKGDIR"
 
 for i in dslm freefall; do
     abinfo "Building $i ..."

--- a/app-admin/kernel-tools/spec
+++ b/app-admin/kernel-tools/spec
@@ -1,10 +1,9 @@
 VER=6.18.16
-
 # Note: For use inside autobuild/.
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=2
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- kernel-tools: fix kvm_stat

Package(s) Affected
-------------------

- kernel-tools: 6.18.16-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kernel-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
