### PR TITLE
vim: update to 9.2.0209

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0
+VER=9.2.0209
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0209.toml
+++ b/topics/vim-9.2.0209.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0209"
+
+[caution]
+default = "Fixes a OS Command Injection vulnerability - CVE-2026-33412 (severity: Medium)"
+zh_CN = "修复一个操作系统命令注入 (OS Command Injection) 漏洞，漏洞编号 CVE-2026-33412（严重性：中）"
+
+[packages-v2]
+"vim" = "< 9.2.0209"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0209
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gvim: 9.2.0209
- vim: 9.2.0209

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
