### PR TITLE
wayland: update to 1.25.0

### DIFF
--- a/runtime-display/wayland/spec
+++ b/runtime-display/wayland/spec
@@ -1,5 +1,4 @@
-VER=1.24.0
-REL=2
+VER=1.25.0
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10061"


### PR DESCRIPTION
Topic Description
-----------------

- wayland: update to 1.25.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wayland: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
