### PR TITLE
oma: update to 1.25.0

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.24.4
+VER=1.25.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.25.0.toml
+++ b/topics/oma-1.25.0.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.25"
+zh_CN = "小熊猫包管理 (oma) 1.25"
+
+[caution]
+default = "Introduces Y/N confirmation mode and improves user interfaces and lock behavior"
+zh_CN = "新增 Y/N 确认操作模式、改善部分用户界面并优化实例锁行为"
+
+[packages-v2]
+"oma" = "< 1.25.0"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.25.0

Package(s) Affected
-------------------

- oma: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



