### PR TITLE
gdu: update to 5.34.1

### DIFF
--- a/app-utils/gdu/spec
+++ b/app-utils/gdu/spec
@@ -1,4 +1,4 @@
-VER=5.34.0
+VER=5.34.1
 SRCS="git::commit=tags/v$VER::https://github.com/dundee/gdu.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141586"


### PR DESCRIPTION
Topic Description
-----------------

- gdu: update to 5.34.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- gdu: 5.34.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gdu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
