### PR TITLE
duckdb: update to 1.5.0

### DIFF
--- a/app-database/duckdb/spec
+++ b/app-database/duckdb/spec
@@ -1,4 +1,4 @@
-VER=1.4.3
+VER=1.5.0
 SRCS="git::commit=v$VER;copy-repo=true::https://github.com/duckdb/duckdb"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375556"


### PR DESCRIPTION
Topic Description
-----------------

- duckdb: update to 1.5.0

Package(s) Affected
-------------------

- duckdb: 1.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit duckdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
