### PR TITLE
ffmpeg: enable libxml2

### DIFF
--- a/app-multimedia/ffmpeg/01-ffmpeg/build
+++ b/app-multimedia/ffmpeg/01-ffmpeg/build
@@ -65,6 +65,7 @@ CONFIGURE_OPTIONS=" \
     --enable-libvpx \
     --enable-libx264 \
     --enable-libx265 \
+    --enable-libxml2 \
     --enable-libxvid \
     --enable-runtime-cpudetect \
     --enable-shared \

--- a/app-multimedia/ffmpeg/01-ffmpeg/defines
+++ b/app-multimedia/ffmpeg/01-ffmpeg/defines
@@ -3,7 +3,8 @@ PKGSEC=sound
 PKGDEP="alsa-lib bzip2 fontconfig freetype glibc gnutls gsm lame libass \
         libbluray libdrm libmodplug libssh libtheora libva libvdpau libvorbis \
         libvpx libwebp libxcb opencore-amr opus pulseaudio samba sdl2 soxr \
-        speex dav1d svt-av1 v4l-utils x11-lib x264 x265 xvidcore xz zlib harfbuzz"
+        speex dav1d svt-av1 v4l-utils x11-lib x264 x265 xvidcore xz zlib harfbuzz \
+	libxml2"
 PKGDEP__AMD64="${PKGDEP} libvpl"
 PKGRECOM="avisynthplus"
 BUILDDEP="avisynthplus nasm"

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=7.1.1
-REL=4
+REL=5
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: enable libxml2

Package(s) Affected
-------------------

- ffmpeg: 7.1.1-5
- ffmpeg-static-libs-for-sunshine: 7.1.1-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
