### PR TITLE
android-platform-tools: add adb spiral marker

### DIFF
--- a/app-devices/android-platform-tools/autobuild/defines
+++ b/app-devices/android-platform-tools/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=android-platform-tools
 PKGSEC=utils
 PKGDES="Android platform tools, adb, mkbootimg, fastboot, and simg2img"
 PKGDEP="libusb protobuf brotli zstd"
+PKGPROV="android-tools-adb_spiral"
 BUILDDEP="cmake ninja go pcre2 gtest"
 PKGRECOM="android-udev"
 

--- a/app-devices/android-platform-tools/spec
+++ b/app-devices/android-platform-tools/spec
@@ -1,5 +1,5 @@
 VER=35.0.2
-REL=7
+REL=8
 SRCS="tbl::https://github.com/nmeum/android-tools/releases/download/$VER/android-tools-$VER.tar.xz"
 CHKSUMS="sha256::d2c3222280315f36d8bfa5c02d7632b47e365bfe2e77e99a3564fb6576f04097"
 CHKUPDATE="anitya::id=226905"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

android-platform-tools: add adb spiral marker

Package(s) Affected
-------------------

android-platform-tools: 35.0.2-8

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit android-platform-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
