### PR TITLE
expat: update to 2.7.5

### DIFF
--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,4 @@
-VER=2.7.4
+VER=2.7.5
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/runtime-optenv32/expat+32/spec
+++ b/runtime-optenv32/expat+32/spec
@@ -1,4 +1,4 @@
-VER=2.7.4
+VER=2.7.5
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/topics/expat-2.7.5.toml
+++ b/topics/expat-2.7.5.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Expat 2.7.5"
+
+[caution]
+default = "Fixes 2 null pointer dereference vulnerability (CVE-2026-32776, CVE-2026-32778, Severity: Medium) and an infinite loop vulnerability (CVE-2026-32777, Severity: Medium)"
+zh_CN = "修复两个空指针解引用漏洞（CVE-2026-32776，CVE-2026-32778，严重性：中）和一个无限循环漏洞（CVE-2026-32777，严重性：中）"
+
+[packages-v2]
+"expat" = "< 2.7.5"
+"expat+32" = "< 2.7.5"


### PR DESCRIPTION
Topic Description
-----------------

- expat: update to 2.7.5
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- expat: 2.7.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
