### PR TITLE
clash-verge-rev: update to 2.4.7

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/build
+++ b/app-proxy/clash-verge-rev/autobuild/build
@@ -1,9 +1,23 @@
 abinfo "Fetching dependencies and assets ..."
-# FIXME: override in package.json conflicts with --frozen-lockfile
-pnpm install # --frozen-lockfile
+pnpm approve-builds --all
+if ab_match_arch amd64 ; then
+	export ARCH_STR=x64
+elif ab_match_arch arm64 ; then
+	export ARCH_STR=arm64
+elif ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd ; then
+	export ARCH_STR=loong64
+elif ab_match_arch loongson3 ; then
+	export ARCH_STR=mips64el
+elif ab_match_arch riscv64 ; then
+	export ARCH_STR=riscv64
+elif ab_match_arch ppc64el ; then
+	export ARCH_STR=ppc64
+fi
+pnpm i @esbuild/linux-"$ARCH_STR"
+pnpm install
+pnpm run prebuild
 
 abinfo "Building Clash Verge ..."
-pnpm run prebuild
 cargo tauri build
 
 abinfo "Installing Clash Verge ..."

--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -14,7 +14,3 @@ FAIL_ARCH="(loongson3|riscv64)"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_0_17_8_LIMBS_are_zero
 NOLTO=1
-
-# FIXME: got Segmentation fault from pnpm with nodejs-24
-BUILDDEP__LOONGARCH64="${BUILDDEP/nodejs/nodejs-22}"
-BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP/nodejs/nodejs-22}"

--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From d1f99a1fe94060f4271ed67f5d0941fd99ed11dd Mon Sep 17 00:00:00 2001
+From 75656f8de8dd43b5519f2cb1db5f697bfb93247b Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
@@ -9,11 +9,11 @@ Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
  2 files changed, 2 insertions(+), 32 deletions(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 3b74293b..d05b350f 100755
+index 2a8e5468..a4f4ebb5 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -2,7 +2,7 @@
-   "version": "2.4.6",
+   "version": "2.4.7",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
@@ -1,28 +1,30 @@
-From e1a5e9142e8def2abf4f5b9cce5bafea44319ffd Mon Sep 17 00:00:00 2001
+From 4e820103cc5b66123259d1fd60a5cef9963ebec9 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 02/13] feat: drop mihomo-alpha support
 
 ---
- src/components/setting/mods/clash-core-viewer.tsx | 5 -----
- 1 file changed, 5 deletions(-)
+ src/components/setting/mods/clash-core-viewer.tsx | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 1cd4c31a..9bc76e53 100644
+index 2779eaa8..cd82d7af 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -29,11 +29,6 @@ const VALID_CORE = [
-     core: "verge-mihomo",
-     chipKey: "settings.modals.clashCore.variants.release",
+@@ -29,12 +29,7 @@ const VALID_CORE = [
+     core: 'verge-mihomo',
+     chipKey: 'settings.modals.clashCore.variants.release',
    },
 -  {
--    name: "Mihomo Alpha",
--    core: "verge-mihomo-alpha",
--    chipKey: "settings.modals.clashCore.variants.alpha",
+-    name: 'Mihomo Alpha',
+-    core: 'verge-mihomo-alpha',
+-    chipKey: 'settings.modals.clashCore.variants.alpha',
 -  },
- ];
+-]
++];
  
  export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
+   const { t } = useTranslation()
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
@@ -1,38 +1,42 @@
-From b818e49e651fc9ac2983c78243737af7a1ca8094 Mon Sep 17 00:00:00 2001
+From 03e5af59fda980825dc9a3f444c3fe4a6a18d52d Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
 
 ---
- scripts/prebuild.mjs      | 12 ------------
+ scripts/prebuild.mjs      | 15 ---------------
  src-tauri/tauri.conf.json |  1 -
- 2 files changed, 13 deletions(-)
+ 2 files changed, 16 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index abf93456..4f6acebd 100644
+index 404631c4..38591af5 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -646,18 +646,6 @@ const resolveUnSetDnsScript = () =>
+@@ -642,22 +642,7 @@ const resolveUnSetDnsScript = () =>
  // Tasks
  // =======================
  const tasks = [
 -  {
--    name: "verge-mihomo-alpha",
+-    name: 'verge-mihomo-alpha',
 -    func: () =>
 -      getLatestAlphaVersion().then(() => resolveSidecar(clashMetaAlpha())),
 -    retry: 5,
 -  },
 -  {
--    name: "verge-mihomo",
+-    name: 'verge-mihomo',
 -    func: () =>
 -      getLatestReleaseVersion().then(() => resolveSidecar(clashMeta())),
 -    retry: 5,
 -  },
-   { name: "plugin", func: resolvePlugin, retry: 5, winOnly: true },
-   { name: "service", func: resolveService, retry: 5 },
-   { name: "install", func: resolveInstall, retry: 5 },
+   { name: 'plugin', func: resolvePlugin, retry: 5, winOnly: true },
+-  { name: 'service', func: resolveService, retry: 5 },
+-  { name: 'install', func: resolveInstall, retry: 5 },
+-  { name: 'uninstall', func: resolveUninstall, retry: 5 },
+   { name: 'mmdb', func: resolveMmdb, retry: 5 },
+   { name: 'geosite', func: resolveGeosite, retry: 5 },
+   { name: 'geoip', func: resolveGeoIP, retry: 5 },
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index d05b350f..4b3363c9 100755
+index a4f4ebb5..cfeff15d 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -13,7 +13,6 @@

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
@@ -1,4 +1,4 @@
-From 39cb3a9f3104809e1be625f9d06e44432b15a09b Mon Sep 17 00:00:00 2001
+From e4b3ab7557d86708747e72db6aaf37b57a93fe13 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 04/13] Drop check update feature and update checker component
@@ -6,97 +6,101 @@ Subject: [PATCH 04/13] Drop check update feature and update checker component
 Co-authored-by: eatradish <sakiiily@aosc.io>
 Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
 ---
- src/components/home/system-info-card.tsx      |  65 -------
+ src/components/home/system-info-card.tsx      |  69 +-------
  src/components/layout/update-button.tsx       |  36 ----
  src/components/setting/mods/update-viewer.tsx | 167 ------------------
- .../setting/setting-verge-advanced.tsx        |  27 +--
+ .../setting/setting-verge-advanced.tsx        |  22 ---
  .../setting/setting-verge-basic.tsx           |   3 -
  src/pages/_layout.tsx                         |   1 -
- 6 files changed, 1 insertion(+), 298 deletions(-)
+ 6 files changed, 2 insertions(+), 296 deletions(-)
  delete mode 100644 src/components/layout/update-button.tsx
  delete mode 100644 src/components/setting/mods/update-viewer.tsx
 
 diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
-index 11fcdf91..365128f6 100644
+index bca595b0..3541b8b4 100644
 --- a/src/components/home/system-info-card.tsx
 +++ b/src/components/home/system-info-card.tsx
-@@ -94,36 +94,6 @@ export const SystemInfoCard = () => {
+@@ -93,37 +93,7 @@ export const SystemInfoCard = () => {
+           })
          }
        })
-       .catch(console.error);
+-      .catch(console.error)
 -
 -    // 获取最后检查更新时间
--    const lastCheck = localStorage.getItem("last_check_update");
+-    const lastCheck = localStorage.getItem('last_check_update')
 -    if (lastCheck) {
 -      try {
--        const timestamp = parseInt(lastCheck, 10);
+-        const timestamp = parseInt(lastCheck, 10)
 -        if (!isNaN(timestamp)) {
 -          dispatchSystemState({
--            type: "set-last-check-update",
+-            type: 'set-last-check-update',
 -            payload: new Date(timestamp).toLocaleString(),
--          });
+-          })
 -        }
 -      } catch (e) {
--        console.error("Error parsing last check update time", e);
+-        console.error('Error parsing last check update time', e)
 -      }
 -    } else if (verge?.auto_check_update) {
 -      // 如果启用了自动检查更新但没有记录，设置当前时间并延迟检查
--      const now = Date.now();
--      localStorage.setItem("last_check_update", now.toString());
+-      const now = Date.now()
+-      localStorage.setItem('last_check_update', now.toString())
 -      dispatchSystemState({
--        type: "set-last-check-update",
+-        type: 'set-last-check-update',
 -        payload: new Date(now).toLocaleString(),
--      });
+-      })
 -
 -      timeoutId = window.setTimeout(() => {
 -        if (verge?.auto_check_update) {
--          triggerCheckUpdate().catch(console.error);
+-          triggerCheckUpdate().catch(console.error)
 -        }
--      }, 5000);
+-      }, 5000)
 -    }
++      .catch(console.error);
      return () => {
        if (timeoutId !== undefined) {
-         window.clearTimeout(timeoutId);
-@@ -153,23 +123,6 @@ export const SystemInfoCard = () => {
+         window.clearTimeout(timeoutId)
+@@ -151,24 +121,7 @@ export const SystemInfoCard = () => {
+     if (isSidecarMode || (isAdminMode && isSidecarMode)) {
+       installServiceAndRestartCore()
      }
-   }, [isSidecarMode, isAdminMode, installServiceAndRestartCore]);
- 
+-  }, [isSidecarMode, isAdminMode, installServiceAndRestartCore])
+-
 -  // 检查更新
 -  const onCheckUpdate = useLockFn(async () => {
 -    try {
--      const info = await triggerCheckUpdate();
+-      const info = await triggerCheckUpdate()
 -      if (!info?.available) {
 -        showNotice.success(
--          "settings.components.verge.advanced.notifications.latestVersion",
--        );
+-          'settings.components.verge.advanced.notifications.latestVersion',
+-        )
 -      } else {
--        showNotice.info("shared.feedback.notifications.updateAvailable", 2000);
--        goToSettings();
+-        showNotice.info('shared.feedback.notifications.updateAvailable', 2000)
+-        goToSettings()
 -      }
 -    } catch (err) {
--      showNotice.error(err);
+-      showNotice.error(err)
 -    }
--  });
--
+-  })
++  }, [isSidecarMode, isAdminMode, installServiceAndRestartCore]);
+ 
    // 是否启用自启动
    const autoLaunchEnabled = useMemo(
-     () => verge?.enable_auto_launch || false,
 @@ -321,24 +274,6 @@ export const SystemInfoCard = () => {
            </Typography>
          </Stack>
          <Divider />
 -        <Stack direction="row" justifyContent="space-between">
 -          <Typography variant="body2" color="text.secondary">
--            {t("home.components.systemInfo.fields.lastCheckUpdate")}
+-            {t('home.components.systemInfo.fields.lastCheckUpdate')}
 -          </Typography>
 -          <Typography
 -            variant="body2"
 -            fontWeight="medium"
 -            onClick={onCheckUpdate}
 -            sx={{
--              cursor: "pointer",
--              textDecoration: "underline",
--              "&:hover": { opacity: 0.7 },
+-              cursor: 'pointer',
+-              textDecoration: 'underline',
+-              '&:hover': { opacity: 0.7 },
 -            }}
 -          >
 -            {systemState.lastCheckUpdate}
@@ -105,32 +109,32 @@ index 11fcdf91..365128f6 100644
 -        <Divider />
          <Stack direction="row" justifyContent="space-between">
            <Typography variant="body2" color="text.secondary">
-             {t("home.components.systemInfo.fields.vergeVersion")}
+             {t('home.components.systemInfo.fields.vergeVersion')}
 diff --git a/src/components/layout/update-button.tsx b/src/components/layout/update-button.tsx
 deleted file mode 100644
-index 53dba06f..00000000
+index 67e4c110..00000000
 --- a/src/components/layout/update-button.tsx
 +++ /dev/null
 @@ -1,36 +0,0 @@
--import { Button } from "@mui/material";
--import { useRef } from "react";
+-import { Button } from '@mui/material'
+-import { useRef } from 'react'
 -
--import { DialogRef } from "@/components/base";
--import { useUpdate } from "@/hooks/use-update";
+-import { DialogRef } from '@/components/base'
+-import { useUpdate } from '@/hooks/use-update'
 -
--import { UpdateViewer } from "../setting/mods/update-viewer";
+-import { UpdateViewer } from '../setting/mods/update-viewer'
 -
 -interface Props {
--  className?: string;
+-  className?: string
 -}
 -
 -export const UpdateButton = (props: Props) => {
--  const { className } = props;
--  const viewerRef = useRef<DialogRef>(null);
+-  const { className } = props
+-  const viewerRef = useRef<DialogRef>(null)
 -
--  const { updateInfo } = useUpdate();
+-  const { updateInfo } = useUpdate()
 -
--  if (!updateInfo?.available) return null;
+-  if (!updateInfo?.available) return null
 -
 -  return (
 -    <>
@@ -146,131 +150,131 @@ index 53dba06f..00000000
 -        New
 -      </Button>
 -    </>
--  );
--};
+-  )
+-}
 diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
 deleted file mode 100644
-index 69ed5396..00000000
+index 0742c503..00000000
 --- a/src/components/setting/mods/update-viewer.tsx
 +++ /dev/null
 @@ -1,167 +0,0 @@
--import { Box, Button, LinearProgress } from "@mui/material";
--import { relaunch } from "@tauri-apps/plugin-process";
--import { open as openUrl } from "@tauri-apps/plugin-shell";
--import type { DownloadEvent } from "@tauri-apps/plugin-updater";
--import { useLockFn } from "ahooks";
--import type { Ref } from "react";
--import { useImperativeHandle, useMemo, useRef, useState } from "react";
--import { useTranslation } from "react-i18next";
--import ReactMarkdown from "react-markdown";
--import rehypeRaw from "rehype-raw";
+-import { Box, Button, LinearProgress } from '@mui/material'
+-import { relaunch } from '@tauri-apps/plugin-process'
+-import { open as openUrl } from '@tauri-apps/plugin-shell'
+-import type { DownloadEvent } from '@tauri-apps/plugin-updater'
+-import { useLockFn } from 'ahooks'
+-import type { Ref } from 'react'
+-import { useImperativeHandle, useMemo, useRef, useState } from 'react'
+-import { useTranslation } from 'react-i18next'
+-import ReactMarkdown from 'react-markdown'
+-import rehypeRaw from 'rehype-raw'
 -
--import { BaseDialog, DialogRef } from "@/components/base";
--import { useUpdate } from "@/hooks/use-update";
--import { portableFlag } from "@/pages/_layout";
--import { showNotice } from "@/services/notice-service";
--import { useSetUpdateState, useUpdateState } from "@/services/states";
+-import { BaseDialog, DialogRef } from '@/components/base'
+-import { useUpdate } from '@/hooks/use-update'
+-import { portableFlag } from '@/pages/_layout'
+-import { showNotice } from '@/services/notice-service'
+-import { useSetUpdateState, useUpdateState } from '@/services/states'
 -
 -export function UpdateViewer({ ref }: { ref?: Ref<DialogRef> }) {
--  const { t } = useTranslation();
+-  const { t } = useTranslation()
 -
--  const [open, setOpen] = useState(false);
--  const updateState = useUpdateState();
--  const setUpdateState = useSetUpdateState();
+-  const [open, setOpen] = useState(false)
+-  const updateState = useUpdateState()
+-  const setUpdateState = useSetUpdateState()
 -
--  const { updateInfo } = useUpdate();
+-  const { updateInfo } = useUpdate()
 -
--  const [downloaded, setDownloaded] = useState(0);
--  const [total, setTotal] = useState(0);
--  const downloadedRef = useRef(0);
--  const totalRef = useRef(0);
+-  const [downloaded, setDownloaded] = useState(0)
+-  const [total, setTotal] = useState(0)
+-  const downloadedRef = useRef(0)
+-  const totalRef = useRef(0)
 -
 -  const progress = useMemo(() => {
--    if (total <= 0) return 0;
--    return Math.min((downloaded / total) * 100, 100);
--  }, [downloaded, total]);
+-    if (total <= 0) return 0
+-    return Math.min((downloaded / total) * 100, 100)
+-  }, [downloaded, total])
 -
 -  useImperativeHandle(ref, () => ({
 -    open: () => setOpen(true),
 -    close: () => setOpen(false),
--  }));
+-  }))
 -
 -  const markdownContent = useMemo(() => {
 -    if (!updateInfo?.body) {
--      return "New Version is available";
+-      return 'New Version is available'
 -    }
--    return updateInfo?.body;
--  }, [updateInfo]);
+-    return updateInfo?.body
+-  }, [updateInfo])
 -
 -  const breakChangeFlag = useMemo(() => {
 -    if (!updateInfo?.body) {
--      return false;
+-      return false
 -    }
--    return updateInfo?.body.toLowerCase().includes("break change");
--  }, [updateInfo]);
+-    return updateInfo?.body.toLowerCase().includes('break change')
+-  }, [updateInfo])
 -
 -  const onUpdate = useLockFn(async () => {
 -    if (portableFlag) {
--      showNotice.error("settings.modals.update.messages.portableError");
--      return;
+-      showNotice.error('settings.modals.update.messages.portableError')
+-      return
 -    }
--    if (!updateInfo?.body) return;
+-    if (!updateInfo?.body) return
 -    if (breakChangeFlag) {
--      showNotice.error("settings.modals.update.messages.breakChangeError");
--      return;
+-      showNotice.error('settings.modals.update.messages.breakChangeError')
+-      return
 -    }
--    if (updateState) return;
--    setUpdateState(true);
--    setDownloaded(0);
--    setTotal(0);
--    downloadedRef.current = 0;
--    totalRef.current = 0;
+-    if (updateState) return
+-    setUpdateState(true)
+-    setDownloaded(0)
+-    setTotal(0)
+-    downloadedRef.current = 0
+-    totalRef.current = 0
 -
 -    const onDownloadEvent = (event: DownloadEvent) => {
--      if (event.event === "Started") {
--        const contentLength = event.data.contentLength ?? 0;
--        totalRef.current = contentLength;
--        setTotal(contentLength);
--        setDownloaded(0);
--        downloadedRef.current = 0;
--        return;
+-      if (event.event === 'Started') {
+-        const contentLength = event.data.contentLength ?? 0
+-        totalRef.current = contentLength
+-        setTotal(contentLength)
+-        setDownloaded(0)
+-        downloadedRef.current = 0
+-        return
 -      }
 -
--      if (event.event === "Progress") {
+-      if (event.event === 'Progress') {
 -        setDownloaded((prev) => {
--          const next = prev + event.data.chunkLength;
--          downloadedRef.current = next;
--          return next;
--        });
+-          const next = prev + event.data.chunkLength
+-          downloadedRef.current = next
+-          return next
+-        })
 -      }
 -
--      if (event.event === "Finished" && totalRef.current === 0) {
--        totalRef.current = downloadedRef.current;
--        setTotal(downloadedRef.current);
+-      if (event.event === 'Finished' && totalRef.current === 0) {
+-        totalRef.current = downloadedRef.current
+-        setTotal(downloadedRef.current)
 -      }
--    };
+-    }
 -
 -    try {
--      await updateInfo.downloadAndInstall(onDownloadEvent);
--      await relaunch();
+-      await updateInfo.downloadAndInstall(onDownloadEvent)
+-      await relaunch()
 -    } catch (err: any) {
--      showNotice.error(err);
+-      showNotice.error(err)
 -    } finally {
--      setUpdateState(false);
--      setDownloaded(0);
--      setTotal(0);
--      downloadedRef.current = 0;
--      totalRef.current = 0;
+-      setUpdateState(false)
+-      setDownloaded(0)
+-      setTotal(0)
+-      downloadedRef.current = 0
+-      totalRef.current = 0
 -    }
--  });
+-  })
 -
 -  return (
 -    <BaseDialog
 -      open={open}
 -      title={
 -        <Box display="flex" justifyContent="space-between">
--          {t("settings.modals.update.title", {
--            version: updateInfo?.version ?? "",
+-          {t('settings.modals.update.title', {
+-            version: updateInfo?.version ?? '',
 -          })}
 -          <Box>
 -            <Button
@@ -279,32 +283,32 @@ index 69ed5396..00000000
 -              onClick={() => {
 -                openUrl(
 -                  `https://github.com/clash-verge-rev/clash-verge-rev/releases/tag/v${updateInfo?.version}`,
--                );
+-                )
 -              }}
 -            >
--              {t("settings.modals.update.actions.goToRelease")}
+-              {t('settings.modals.update.actions.goToRelease')}
 -            </Button>
 -          </Box>
 -        </Box>
 -      }
--      contentSx={{ minWidth: 360, maxWidth: 400, height: "50vh" }}
--      okBtn={t("settings.modals.update.actions.update")}
--      cancelBtn={t("shared.actions.cancel")}
+-      contentSx={{ minWidth: 360, maxWidth: 400, height: '50vh' }}
+-      okBtn={t('settings.modals.update.actions.update')}
+-      cancelBtn={t('shared.actions.cancel')}
 -      onClose={() => setOpen(false)}
 -      onCancel={() => setOpen(false)}
 -      onOk={onUpdate}
 -    >
--      <Box sx={{ height: "calc(100% - 10px)", overflow: "auto" }}>
+-      <Box sx={{ height: 'calc(100% - 10px)', overflow: 'auto' }}>
 -        <ReactMarkdown
 -          rehypePlugins={[rehypeRaw]}
 -          components={{
 -            a: ({ ...props }) => {
--              const { children } = props;
+-              const { children } = props
 -              return (
 -                <a {...props} target="_blank">
 -                  {children}
 -                </a>
--              );
+-              )
 -            },
 -          }}
 -        >
@@ -313,52 +317,52 @@ index 69ed5396..00000000
 -      </Box>
 -      {updateState && (
 -        <LinearProgress
--          variant={total > 0 ? "determinate" : "indeterminate"}
+-          variant={total > 0 ? 'determinate' : 'indeterminate'}
 -          value={progress}
--          sx={{ marginTop: "5px" }}
+-          sx={{ marginTop: '5px' }}
 -        />
 -      )}
 -    </BaseDialog>
--  );
+-  )
 -}
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 43f95e32..42df5263 100644
+index 625bf3bc..71318fb7 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -24,7 +24,6 @@ import { LiteModeViewer } from "./mods/lite-mode-viewer";
- import { MiscViewer } from "./mods/misc-viewer";
- import { SettingItem, SettingList } from "./mods/setting-comp";
- import { ThemeViewer } from "./mods/theme-viewer";
--import { UpdateViewer } from "./mods/update-viewer";
+@@ -24,7 +24,6 @@ import { LiteModeViewer } from './mods/lite-mode-viewer'
+ import { MiscViewer } from './mods/misc-viewer'
+ import { SettingItem, SettingList } from './mods/setting-comp'
+ import { ThemeViewer } from './mods/theme-viewer'
+-import { UpdateViewer } from './mods/update-viewer'
  
  interface Props {
-   onError?: (err: Error) => void;
+   onError?: (err: Error) => void
 @@ -38,24 +37,9 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
-   const miscRef = useRef<DialogRef>(null);
-   const themeRef = useRef<DialogRef>(null);
-   const layoutRef = useRef<DialogRef>(null);
--  const updateRef = useRef<DialogRef>(null);
-   const backupRef = useRef<DialogRef>(null);
-   const liteModeRef = useRef<DialogRef>(null);
+   const miscRef = useRef<DialogRef>(null)
+   const themeRef = useRef<DialogRef>(null)
+   const layoutRef = useRef<DialogRef>(null)
+-  const updateRef = useRef<DialogRef>(null)
+   const backupRef = useRef<DialogRef>(null)
+   const liteModeRef = useRef<DialogRef>(null)
  
 -  const onCheckUpdate = async () => {
 -    try {
--      const info = await checkUpdate();
+-      const info = await checkUpdate()
 -      if (!info?.available) {
 -        showNotice.success(
--          "settings.components.verge.advanced.notifications.latestVersion",
--        );
+-          'settings.components.verge.advanced.notifications.latestVersion',
+-        )
 -      } else {
--        updateRef.current?.open();
+-        updateRef.current?.open()
 -      }
 -    } catch (err: any) {
--      showNotice.error(err);
+-      showNotice.error(err)
 -    }
--  };
+-  }
  
    const onExportDiagnosticInfo = useCallback(async () => {
-     await exportDiagnosticInfo();
-@@ -81,7 +65,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+     await exportDiagnosticInfo()
+@@ -78,7 +62,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
@@ -366,58 +370,53 @@ index 43f95e32..42df5263 100644
        <BackupViewer ref={backupRef} />
        <LiteModeViewer ref={liteModeRef} />
  
-@@ -117,15 +100,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
-         label={t("settings.components.verge.advanced.fields.openCoreDir")}
+@@ -119,11 +102,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+         label={t('settings.components.verge.advanced.fields.openLogsDir')}
        />
  
 -      <SettingItem
--        onClick={openLogsDir}
--        label={t("settings.components.verge.advanced.fields.openLogsDir")}
+-        onClick={onCheckUpdate}
+-        label={t('settings.components.verge.advanced.fields.checkUpdates')}
 -      />
 -
--      <SettingItem
--        onClick={onCheckUpdate}
--        label={t("settings.components.verge.advanced.fields.checkUpdates")}
--      />
-+      <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
- 
        <SettingItem
          onClick={openDevTools}
+         label={t('settings.components.verge.advanced.fields.openDevTools')}
 diff --git a/src/components/setting/setting-verge-basic.tsx b/src/components/setting/setting-verge-basic.tsx
-index ab516d31..7a0d52d3 100644
+index 4d451246..099cce8d 100644
 --- a/src/components/setting/setting-verge-basic.tsx
 +++ b/src/components/setting/setting-verge-basic.tsx
-@@ -21,7 +21,6 @@ import { MiscViewer } from "./mods/misc-viewer";
- import { SettingItem, SettingList } from "./mods/setting-comp";
- import { ThemeModeSwitch } from "./mods/theme-mode-switch";
- import { ThemeViewer } from "./mods/theme-viewer";
--import { UpdateViewer } from "./mods/update-viewer";
+@@ -21,7 +21,6 @@ import { MiscViewer } from './mods/misc-viewer'
+ import { SettingItem, SettingList } from './mods/setting-comp'
+ import { ThemeModeSwitch } from './mods/theme-mode-switch'
+ import { ThemeViewer } from './mods/theme-viewer'
+-import { UpdateViewer } from './mods/update-viewer'
  
  interface Props {
-   onError?: (err: Error) => void;
+   onError?: (err: Error) => void
 @@ -66,7 +65,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
-   const miscRef = useRef<DialogRef>(null);
-   const themeRef = useRef<DialogRef>(null);
-   const layoutRef = useRef<DialogRef>(null);
--  const updateRef = useRef<DialogRef>(null);
-   const backupRef = useRef<DialogRef>(null);
+   const miscRef = useRef<DialogRef>(null)
+   const themeRef = useRef<DialogRef>(null)
+   const layoutRef = useRef<DialogRef>(null)
+-  const updateRef = useRef<DialogRef>(null)
+   const backupRef = useRef<DialogRef>(null)
  
    const onChangeData = (patch: any) => {
-@@ -88,7 +86,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
+@@ -85,7 +83,6 @@ const SettingVergeBasic = ({ onError }: Props) => {
        <HotkeyViewer ref={hotkeyRef} />
        <MiscViewer ref={miscRef} />
        <LayoutViewer ref={layoutRef} />
 -      <UpdateViewer ref={updateRef} />
        <BackupViewer ref={backupRef} />
  
-       <SettingItem label={t("settings.components.verge.basic.fields.language")}>
+       <SettingItem label={t('settings.components.verge.basic.fields.language')}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index 9ba2576f..ddbeab0a 100644
+index 410e136c..c1672fd9 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -353,7 +353,6 @@ const Layout = () => {
+@@ -349,7 +349,6 @@ const Layout = () => {
                    />
-                   <LogoSvg fill={isDark ? "white" : "black"} />
+                   <LogoSvg fill={isDark ? 'white' : 'black'} />
                  </div>
 -                <UpdateButton className="the-newbtn" />
                </div>

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From 7d7fe513e60c4ce50c47e022e8710f4dbca511c1 Mon Sep 17 00:00:00 2001
+From 5015da70dfa721f2ff2bf0653091764988a62118 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 05/13] Set core binary name as mihomo
@@ -6,71 +6,70 @@ Subject: [PATCH 05/13] Set core binary name as mihomo
 Co-authored-by: eatradish <sakiiily@aosc.io>
 ---
  scripts/portable-fixed-webview2.mjs           |  4 ++--
- scripts/portable.mjs                          |  7 +++---
+ scripts/portable.mjs                          |  5 ++--
  scripts/prebuild.mjs                          |  8 +++----
  src-tauri/packages/windows/installer.nsi      | 24 +++++++++----------
  src-tauri/src/config/verge.rs                 | 12 +++++-----
  src-tauri/src/enhance/chain.rs                |  2 +-
  .../setting/mods/clash-core-viewer.tsx        |  4 ++--
- 7 files changed, 31 insertions(+), 30 deletions(-)
+ 7 files changed, 30 insertions(+), 29 deletions(-)
 
 diff --git a/scripts/portable-fixed-webview2.mjs b/scripts/portable-fixed-webview2.mjs
-index 1a62be3f..911befb1 100644
+index 3f9ec035..6b904c81 100644
 --- a/scripts/portable-fixed-webview2.mjs
 +++ b/scripts/portable-fixed-webview2.mjs
 @@ -44,8 +44,8 @@ async function resolvePortable() {
-   const zip = new AdmZip();
+   const zip = new AdmZip()
  
-   zip.addLocalFile(path.join(releaseDir, "Clash Verge.exe"));
--  zip.addLocalFile(path.join(releaseDir, "verge-mihomo.exe"));
--  zip.addLocalFile(path.join(releaseDir, "verge-mihomo-alpha.exe"));
-+  zip.addLocalFile(path.join(releaseDir, "mihomo.exe"));
-+  zip.addLocalFile(path.join(releaseDir, "mihomo-alpha.exe"));
-   zip.addLocalFolder(path.join(releaseDir, "resources"), "resources");
+   zip.addLocalFile(path.join(releaseDir, 'Clash Verge.exe'))
+-  zip.addLocalFile(path.join(releaseDir, 'verge-mihomo.exe'))
+-  zip.addLocalFile(path.join(releaseDir, 'verge-mihomo-alpha.exe'))
++  zip.addLocalFile(path.join(releaseDir, 'mihomo.exe'))
++  zip.addLocalFile(path.join(releaseDir, 'mihomo-alpha.exe'))
+   zip.addLocalFolder(path.join(releaseDir, 'resources'), 'resources')
    zip.addLocalFolder(
      path.join(
 diff --git a/scripts/portable.mjs b/scripts/portable.mjs
-index e1918971..ff6bf2ca 100644
+index b306b2fe..571aefdc 100644
 --- a/scripts/portable.mjs
 +++ b/scripts/portable.mjs
 @@ -36,9 +36,10 @@ async function resolvePortable() {
    }
-   const zip = new AdmZip();
+   const zip = new AdmZip()
  
--  zip.addLocalFile(path.join(releaseDir, "clash-verge.exe"));
--  zip.addLocalFile(path.join(releaseDir, "verge-mihomo.exe"));
--  zip.addLocalFile(path.join(releaseDir, "verge-mihomo-alpha.exe"));
 +
-+  zip.addLocalFile(path.join(releaseDir, "Clash Verge.exe"));
-+  zip.addLocalFile(path.join(releaseDir, "mihomo.exe"));
-+  zip.addLocalFile(path.join(releaseDir, "mihomo-alpha.exe"));
-   zip.addLocalFolder(path.join(releaseDir, "resources"), "resources");
-   zip.addLocalFolder(configDir, ".config");
+   zip.addLocalFile(path.join(releaseDir, 'clash-verge.exe'))
+-  zip.addLocalFile(path.join(releaseDir, 'verge-mihomo.exe'))
+-  zip.addLocalFile(path.join(releaseDir, 'verge-mihomo-alpha.exe'))
++  zip.addLocalFile(path.join(releaseDir, 'mihomo.exe'))
++  zip.addLocalFile(path.join(releaseDir, 'mihomo-alpha.exe'))
+   zip.addLocalFolder(path.join(releaseDir, 'resources'), 'resources')
+   zip.addLocalFolder(configDir, '.config')
  
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 4f6acebd..090cffc3 100644
+index 38591af5..45529a83 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -299,8 +299,8 @@ function clashMetaAlpha() {
-   const isWin = platform === "win32";
-   const urlExt = isWin ? "zip" : "gz";
+@@ -295,8 +295,8 @@ function clashMetaAlpha() {
+   const isWin = platform === 'win32'
+   const urlExt = isWin ? 'zip' : 'gz'
    return {
--    name: "verge-mihomo-alpha",
--    targetFile: `verge-mihomo-alpha-${SIDECAR_HOST}${isWin ? ".exe" : ""}`,
-+    name: "mihomo-alpha",
-+    targetFile: `mihomo-alpha-${SIDECAR_HOST}${isWin ? ".exe" : ""}`,
-     exeFile: `${name}${isWin ? ".exe" : ""}`,
+-    name: 'verge-mihomo-alpha',
+-    targetFile: `verge-mihomo-alpha-${SIDECAR_HOST}${isWin ? '.exe' : ''}`,
++    name: 'mihomo-alpha',
++    targetFile: `mihomo-alpha-${SIDECAR_HOST}${isWin ? '.exe' : ''}`,
+     exeFile: `${name}${isWin ? '.exe' : ''}`,
      zipFile: `${name}-${META_ALPHA_VERSION}.${urlExt}`,
      downloadURL: `${META_ALPHA_URL_PREFIX}/${name}-${META_ALPHA_VERSION}.${urlExt}`,
-@@ -312,8 +312,8 @@ function clashMeta() {
-   const isWin = platform === "win32";
-   const urlExt = isWin ? "zip" : "gz";
+@@ -308,8 +308,8 @@ function clashMeta() {
+   const isWin = platform === 'win32'
+   const urlExt = isWin ? 'zip' : 'gz'
    return {
--    name: "verge-mihomo",
--    targetFile: `verge-mihomo-${SIDECAR_HOST}${isWin ? ".exe" : ""}`,
-+    name: "mihomo",
-+    targetFile: `mihomo-${SIDECAR_HOST}${isWin ? ".exe" : ""}`,
-     exeFile: `${name}${isWin ? ".exe" : ""}`,
+-    name: 'verge-mihomo',
+-    targetFile: `verge-mihomo-${SIDECAR_HOST}${isWin ? '.exe' : ''}`,
++    name: 'mihomo',
++    targetFile: `mihomo-${SIDECAR_HOST}${isWin ? '.exe' : ''}`,
+     exeFile: `${name}${isWin ? '.exe' : ''}`,
      zipFile: `${name}-${META_VERSION}.${urlExt}`,
      downloadURL: `${META_URL_PREFIX}/${META_VERSION}/${name}-${META_VERSION}.${urlExt}`,
 diff --git a/src-tauri/packages/windows/installer.nsi b/src-tauri/packages/windows/installer.nsi
@@ -126,10 +125,10 @@ index e6fc4940..f2469ee6 100644
    ${EndIf}
  
 diff --git a/src-tauri/src/config/verge.rs b/src-tauri/src/config/verge.rs
-index 7f9bcd9e..2821b8ec 100644
+index 1f095285..c9e9309c 100644
 --- a/src-tauri/src/config/verge.rs
 +++ b/src-tauri/src/config/verge.rs
-@@ -282,7 +282,7 @@ pub struct IVergeTheme {
+@@ -285,7 +285,7 @@ pub struct IVergeTheme {
  
  impl IVerge {
      /// 有效的clash核心名称
@@ -138,7 +137,7 @@ index 7f9bcd9e..2821b8ec 100644
  
      /// 验证并修正配置文件中的clash_core值
      pub async fn validate_and_fix_config() -> Result<()> {
-@@ -300,19 +300,19 @@ impl IVerge {
+@@ -303,19 +303,19 @@ impl IVerge {
                  logging!(
                      warn,
                      Type::Config,
@@ -162,7 +161,7 @@ index 7f9bcd9e..2821b8ec 100644
              needs_fix = true;
          }
  
-@@ -380,7 +380,7 @@ impl IVerge {
+@@ -383,7 +383,7 @@ impl IVerge {
          Self {
              app_log_max_size: Some(128),
              app_log_max_count: Some(8),
@@ -185,27 +184,27 @@ index c2132e84..454842b6 100644
              None => true,
          }
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 9bc76e53..ba6d6fb5 100644
+index cd82d7af..3323de92 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -26,7 +26,7 @@ import { showNotice } from "@/services/notice-service";
+@@ -26,7 +26,7 @@ import { showNotice } from '@/services/notice-service'
  const VALID_CORE = [
    {
-     name: "Mihomo",
--    core: "verge-mihomo",
-+    core: "mihomo",
-     chipKey: "settings.modals.clashCore.variants.release",
+     name: 'Mihomo',
+-    core: 'verge-mihomo',
++    core: 'mihomo',
+     chipKey: 'settings.modals.clashCore.variants.release',
    },
  ];
 @@ -46,7 +46,7 @@ export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
      close: () => setOpen(false),
-   }));
+   }))
  
--  const { clash_core = "verge-mihomo" } = verge ?? {};
-+  const { clash_core = "mihomo" } = verge ?? {};
+-  const { clash_core = 'verge-mihomo' } = verge ?? {}
++  const { clash_core = 'mihomo' } = verge ?? {}
  
    const onCoreChange = useLockFn(async (core: string) => {
-     if (core === clash_core) return;
+     if (core === clash_core) return
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From a0a33c9797fc31dc14cb1268827adc51cf18b769 Mon Sep 17 00:00:00 2001
+From 86a9bb6369ef3dc0659637a4d5af0fd135cc9c03 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 06/13] feat: always not portable

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,4 +1,4 @@
-From d503bf44075362c29f137f2847961f854de545e8 Mon Sep 17 00:00:00 2001
+From 1862c701e7233e8980a453d9031cdd39a7fdbbee Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 07/13] Set service install/uninstall script path to

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From 1c8330b7c73218a35c48c4b96dd56c3f97bb8502 Mon Sep 17 00:00:00 2001
+From 5ce7c861e6bbcf95ae9ffad1ff17331c012e193b Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 08/13] Do not use gcc

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
@@ -1,46 +1,47 @@
-From 5d8fe2f85b7d6c2790ed8b4527040b8f1ec98e59 Mon Sep 17 00:00:00 2001
+From 86bd328730c45727c251a944debd74a6c6367a1f Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 09/13] Drop "Upgrade core" button
 
 ---
- .../setting/mods/clash-core-viewer.tsx        | 30 -------------------
- .../setting/setting-verge-advanced.tsx        |  2 +-
+ .../setting/mods/clash-core-viewer.tsx        | 32 +------------------
  src/pages/_layout.tsx                         |  1 -
- 3 files changed, 1 insertion(+), 32 deletions(-)
+ 2 files changed, 1 insertion(+), 32 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index ba6d6fb5..14e5b148 100644
+index 3323de92..46e47a62 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
-@@ -88,24 +88,6 @@ export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
+@@ -86,25 +86,7 @@ export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
+       setRestarting(false)
+       showNotice.error(err)
      }
-   });
- 
+-  })
+-
 -  const onUpgrade = useLockFn(async () => {
 -    try {
--      setUpgrading(true);
--      await upgradeCore();
--      setUpgrading(false);
+-      setUpgrading(true)
+-      await upgradeCore()
+-      setUpgrading(false)
 -      showNotice.success(
--        t("settings.feedback.notifications.clash.versionUpdated"),
--      );
+-        t('settings.feedback.notifications.clash.versionUpdated'),
+-      )
 -    } catch (err: any) {
--      setUpgrading(false);
--      const errMsg = err?.response?.data?.message ?? String(err);
--      const showMsg = errMsg.includes("already using latest version")
--        ? t("settings.feedback.notifications.clash.alreadyLatestVersion")
--        : errMsg;
--      showNotice.info(showMsg);
+-      setUpgrading(false)
+-      const errMsg = err?.response?.data?.message ?? String(err)
+-      const showMsg = errMsg.includes('already using latest version')
+-        ? t('settings.feedback.notifications.clash.alreadyLatestVersion')
+-        : errMsg
+-      showNotice.info(showMsg)
 -    }
--  });
--
+-  })
++  });
+ 
    return (
      <BaseDialog
-       open={open}
 @@ -113,18 +95,6 @@ export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
          <Box display="flex" justifyContent="space-between">
-           {t("settings.sections.clash.form.fields.clashCore")}
+           {t('settings.sections.clash.form.fields.clashCore')}
            <Box>
 -            <LoadingButton
 -              variant="contained"
@@ -49,39 +50,26 @@ index ba6d6fb5..14e5b148 100644
 -              loadingPosition="start"
 -              loading={upgrading}
 -              disabled={restarting || changingCore !== null}
--              sx={{ marginRight: "8px" }}
+-              sx={{ marginRight: '8px' }}
 -              onClick={onUpgrade}
 -            >
--              {t("shared.actions.upgrade")}
+-              {t('shared.actions.upgrade')}
 -            </LoadingButton>
              <LoadingButton
                variant="contained"
                size="small"
-diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 42df5263..42bd9c8c 100644
---- a/src/components/setting/setting-verge-advanced.tsx
-+++ b/src/components/setting/setting-verge-advanced.tsx
-@@ -100,7 +100,7 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
-         label={t("settings.components.verge.advanced.fields.openCoreDir")}
-       />
- 
--      <SettingItem onClick={openLogsDir} label={t("Open Logs Dir")} />
-+      <SettingItem onClick={openLogsDir} label={t("settings.components.verge.advanced.fields.openLogsDir")} />
- 
-       <SettingItem
-         onClick={openDevTools}
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index ddbeab0a..6ef43b3c 100644
+index c1672fd9..7acef7bf 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -36,7 +36,6 @@ import { BaseErrorBoundary } from "@/components/base";
- import { LayoutItem } from "@/components/layout/layout-item";
- import { LayoutTraffic } from "@/components/layout/layout-traffic";
- import { NoticeManager } from "@/components/layout/notice-manager";
--import { UpdateButton } from "@/components/layout/update-button";
- import { WindowControls } from "@/components/layout/window-controller";
- import { useI18n } from "@/hooks/use-i18n";
- import { useVerge } from "@/hooks/use-verge";
+@@ -36,7 +36,6 @@ import { BaseErrorBoundary } from '@/components/base'
+ import { LayoutItem } from '@/components/layout/layout-item'
+ import { LayoutTraffic } from '@/components/layout/layout-traffic'
+ import { NoticeManager } from '@/components/layout/notice-manager'
+-import { UpdateButton } from '@/components/layout/update-button'
+ import { WindowControls } from '@/components/layout/window-controller'
+ import { useI18n } from '@/hooks/use-i18n'
+ import { useVerge } from '@/hooks/use-verge'
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
@@ -1,4 +1,4 @@
-From e6384fcc33305446c527365894cc026dbcc76c04 Mon Sep 17 00:00:00 2001
+From 891169e8e9af51a900e03b94740c1f7fb4a98088 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 10/13] fix: drop Open Core Dir function
@@ -14,10 +14,10 @@ This is useless for our users as it would just open /usr/bin.
  6 files changed, 1 insertion(+), 26 deletions(-)
 
 diff --git a/src-tauri/src/cmd/app.rs b/src-tauri/src/cmd/app.rs
-index 77a98ab6..18b9678e 100644
+index 2f57a23e..7ef24148 100644
 --- a/src-tauri/src/cmd/app.rs
 +++ b/src-tauri/src/cmd/app.rs
-@@ -20,14 +20,6 @@ pub async fn open_app_dir() -> CmdResult<()> {
+@@ -13,14 +13,6 @@ pub async fn open_app_dir() -> CmdResult<()> {
      open::that(app_dir).stringify_err()
  }
  
@@ -45,7 +45,7 @@ index 7012ce21..2fd3de09 100644
      open_dir => OPEN_DIR, "tray_open_dir", "tray.openDir",
      app_log => APP_LOG, "tray_app_log", "tray.appLog",
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index e13abd39..7377547e 100644
+index 86b8fdf2..f50aff26 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
 @@ -786,8 +786,6 @@ async fn create_tray_menu(
@@ -66,7 +66,7 @@ index e13abd39..7377547e 100644
      )?;
  
      let restart_clash = &MenuItem::with_id(
-@@ -964,9 +962,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+@@ -969,9 +967,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
              MenuIds::CONF_DIR => {
                  let _ = cmd::open_app_dir().await;
              }
@@ -77,7 +77,7 @@ index e13abd39..7377547e 100644
                  let _ = cmd::open_logs_dir().await;
              }
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index bd3fa20c..bde67c87 100644
+index 26cbc91d..52318ae8 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
 @@ -139,7 +139,6 @@ mod app_init {
@@ -89,7 +89,7 @@ index bd3fa20c..bde67c87 100644
              cmd::open_core_log,
              cmd::get_portable_flag,
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
-index 42bd9c8c..c2f420f1 100644
+index 71318fb7..2de2aab2 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
 +++ b/src/components/setting/setting-verge-advanced.tsx
 @@ -8,7 +8,6 @@ import {
@@ -99,33 +99,33 @@ index 42bd9c8c..c2f420f1 100644
 -  openCoreDir,
    openDevTools,
    openLogsDir,
- } from "@/services/cmds";
-@@ -95,11 +94,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
+ } from '@/services/cmds'
+@@ -92,11 +91,6 @@ const SettingVergeAdvanced = ({ onError: _ }: Props) => {
          }
        />
  
 -      <SettingItem
 -        onClick={openCoreDir}
--        label={t("settings.components.verge.advanced.fields.openCoreDir")}
+-        label={t('settings.components.verge.advanced.fields.openCoreDir')}
 -      />
 -
-       <SettingItem onClick={openLogsDir} label={t("settings.components.verge.advanced.fields.openLogsDir")} />
- 
        <SettingItem
+         onClick={openLogsDir}
+         label={t('settings.components.verge.advanced.fields.openLogsDir')}
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index d2a959e2..f5780678 100644
+index 2715fa81..3ffdf57d 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
 @@ -318,10 +318,6 @@ export async function openAppDir() {
-   return invoke<void>("open_app_dir").catch((err) => showNotice.error(err));
+   return invoke<void>('open_app_dir').catch((err) => showNotice.error(err))
  }
  
 -export async function openCoreDir() {
--  return invoke<void>("open_core_dir").catch((err) => showNotice.error(err));
+-  return invoke<void>('open_core_dir').catch((err) => showNotice.error(err))
 -}
 -
  export async function openLogsDir() {
-   return invoke<void>("open_logs_dir").catch((err) => showNotice.error(err));
+   return invoke<void>('open_logs_dir').catch((err) => showNotice.error(err))
  }
 -- 
 2.52.0

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
@@ -1,75 +1,77 @@
-From d0a7b328b76b9f047f1c994dacb859a3e9b93cd8 Mon Sep 17 00:00:00 2001
+From 9bc68bf8c434b668ab541596867f503d5445c7d6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 11/13] fix: disable GeoData update
 
 We handle this via mihomo-rules-dat.
 ---
- scripts/prebuild.mjs                     | 12 ------------
- src/components/setting/setting-clash.tsx | 14 +-------------
- 2 files changed, 1 insertion(+), 25 deletions(-)
+ scripts/prebuild.mjs                     | 14 +-------------
+ src/components/setting/setting-clash.tsx | 14 ++------------
+ 2 files changed, 3 insertions(+), 25 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 090cffc3..217e7dd3 100644
+index 45529a83..3254a1c4 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -615,16 +615,6 @@ const resolveMmdb = () =>
-     file: "Country.mmdb",
+@@ -610,17 +610,7 @@ const resolveMmdb = () =>
+   resolveResource({
+     file: 'Country.mmdb',
      downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb`,
-   });
+-  })
 -const resolveGeosite = () =>
 -  resolveResource({
--    file: "geosite.dat",
+-    file: 'geosite.dat',
 -    downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat`,
--  });
+-  })
 -const resolveGeoIP = () =>
 -  resolveResource({
--    file: "geoip.dat",
+-    file: 'geoip.dat',
 -    downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.dat`,
--  });
+-  })
++  });
  const resolveEnableLoopback = () =>
    resolveResource({
-     file: "enableLoopback.exe",
-@@ -651,8 +641,6 @@ const tasks = [
-   { name: "install", func: resolveInstall, retry: 5 },
-   { name: "uninstall", func: resolveUninstall, retry: 5 },
-   { name: "mmdb", func: resolveMmdb, retry: 5 },
--  { name: "geosite", func: resolveGeosite, retry: 5 },
--  { name: "geoip", func: resolveGeoIP, retry: 5 },
+     file: 'enableLoopback.exe',
+@@ -644,8 +634,6 @@ const resolveUnSetDnsScript = () =>
+ const tasks = [
+   { name: 'plugin', func: resolvePlugin, retry: 5, winOnly: true },
+   { name: 'mmdb', func: resolveMmdb, retry: 5 },
+-  { name: 'geosite', func: resolveGeosite, retry: 5 },
+-  { name: 'geoip', func: resolveGeoIP, retry: 5 },
    {
-     name: "enableLoopback",
+     name: 'enableLoopback',
      func: resolveEnableLoopback,
 diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
-index 50d336b7..3463fd94 100644
+index f823cbf5..75ab1b92 100644
 --- a/src/components/setting/setting-clash.tsx
 +++ b/src/components/setting/setting-clash.tsx
-@@ -66,14 +66,7 @@ const SettingClash = ({ onError }: Props) => {
-     mutateClash((old) => ({ ...old!, ...patch }), false);
-   };
+@@ -66,13 +66,8 @@ const SettingClash = ({ onError }: Props) => {
+     mutateClash((old) => ({ ...old!, ...patch }), false)
+   }
    const onUpdateGeo = async () => {
 -    try {
--      await updateGeo();
--      showNotice.success(
--        "settings.feedback.notifications.clash.geoDataUpdated",
--      );
+-      await updateGeo()
+-      showNotice.success('settings.feedback.notifications.clash.geoDataUpdated')
 -    } catch (err: any) {
--      showNotice.error(err);
+-      showNotice.error(err)
 -    }
-+    showNotice.error("GeoData should be updated with oma");
-   };
+-  }
++    showNotice.error('GeoData should be updated with oma');
++  };
  
    // 实现DNS设置开关处理函数
-@@ -280,11 +273,6 @@ const SettingClash = ({ onError }: Props) => {
+   const handleDnsToggle = useLockFn(async (enable: boolean) => {
+@@ -278,11 +273,6 @@ const SettingClash = ({ onError }: Props) => {
          />
        )}
  
 -      <SettingItem
 -        onClick={onUpdateGeo}
--        label={t("settings.sections.clash.form.fields.updateGeoData")}
+-        label={t('settings.sections.clash.form.fields.updateGeoData')}
 -      />
 -
        <SettingItem
-         label={t("settings.sections.clash.form.fields.tunnels.title")}
+         label={t('settings.sections.clash.form.fields.tunnels.title')}
          onClick={() => tunnelRef.current?.open()}
 -- 
 2.52.0

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From 913fa12814d65915ff971f9215357500f053c6b2 Mon Sep 17 00:00:00 2001
+From b209bb10128c107fc59adf98603dec705c7db564 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 12/13] Do not sidecar mihomo program

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
@@ -1,4 +1,4 @@
-From 5e95df22591dd8aca70448f47b5324718d4ff697 Mon Sep 17 00:00:00 2001
+From d2131456ccd52babf3da4bd86739e6f80c0c6075 Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Sun, 9 Nov 2025 19:15:18 +0800
 Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
@@ -6,17 +6,18 @@ Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
 Signed-off-by: stydxm <stydxm@outlook.com>
 ---
  Cargo.lock           | 11 -----------
- package.json         | 13 ++++---------
+ package.json         |  9 ++++++++-
+ pnpm-workspace.yaml  |  5 +++++
  scripts/prebuild.mjs |  6 ++++--
  src-tauri/Cargo.toml |  2 +-
- vite.config.mts      |  2 +-
- 5 files changed, 10 insertions(+), 24 deletions(-)
+ 5 files changed, 18 insertions(+), 15 deletions(-)
+ create mode 100644 pnpm-workspace.yaml
 
 diff --git a/Cargo.lock b/Cargo.lock
-index d5895c0b..15f393aa 100644
+index d0669022..f6a840ad 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -706,7 +706,6 @@ dependencies = [
+@@ -721,7 +721,6 @@ dependencies = [
   "dashmap 6.1.0",
   "dynify",
   "fast-float2",
@@ -24,7 +25,7 @@ index d5895c0b..15f393aa 100644
   "futures-channel",
   "futures-concurrency",
   "futures-lite 2.6.1",
-@@ -2474,16 +2473,6 @@ dependencies = [
+@@ -2525,16 +2524,6 @@ dependencies = [
   "thiserror 2.0.18",
  ]
  
@@ -42,85 +43,72 @@ index d5895c0b..15f393aa 100644
  name = "fnv"
  version = "1.0.7"
 diff --git a/package.json b/package.json
-index 083f590a..b409b093 100644
+index 9ac6a4e3..bbce755b 100644
 --- a/package.json
 +++ b/package.json
-@@ -90,7 +90,7 @@
-     "@types/react": "19.2.14",
-     "@types/react-dom": "19.2.3",
-     "@vitejs/plugin-legacy": "^7.2.1",
--    "@vitejs/plugin-react-swc": "^4.2.3",
-+    "@vitejs/plugin-react": "^5.1.4",
-     "adm-zip": "^0.5.16",
-     "cli-color": "^2.0.4",
-     "commander": "^14.0.3",
-@@ -132,13 +132,8 @@
-   "type": "module",
-   "packageManager": "pnpm@10.29.2",
-   "pnpm": {
--    "onlyBuiltDependencies": [
--      "@parcel/watcher",
--      "@swc/core",
--      "core-js",
--      "es5-ext",
--      "esbuild",
--      "unrs-resolver"
+@@ -140,6 +140,13 @@
+       "es5-ext",
+       "meta-json-schema",
+       "unrs-resolver"
 -    ]
++    ],
 +    "overrides": {
-+      "rollup": "npm:@rollup/wasm-node"
++      "rollup": "npm:@rollup/wasm-node",
++      "lightningcss": "npm:lightningcss-wasm",
++      "vite": "^7.0.0",
++      "@vitejs/plugin-legacy": "^7.0.0",
++      "@vitejs/plugin-react": "^5.0.0"
 +    }
    }
  }
+diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
+new file mode 100644
+index 00000000..3c58f6d7
+--- /dev/null
++++ b/pnpm-workspace.yaml
+@@ -0,0 +1,5 @@
++supportedArchitectures:
++  os:
++    - wasip1-threads
++  cpu:
++    - wasm32
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 217e7dd3..47905141 100644
+index 3254a1c4..1cfcc7ed 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -191,7 +191,8 @@ const META_ALPHA_MAP = {
-   "linux-arm64": "mihomo-linux-arm64",
-   "linux-arm": "mihomo-linux-armv7",
-   "linux-riscv64": "mihomo-linux-riscv64",
--  "linux-loong64": "mihomo-linux-loong64",
-+  "linux-loong64": "mihomo-linux-loong64-abi2",
-+  "linux-ppc64": "mihomo-linux-ppc64le",
- };
+   'linux-arm64': 'mihomo-linux-arm64',
+   'linux-arm': 'mihomo-linux-armv7',
+   'linux-riscv64': 'mihomo-linux-riscv64',
+-  'linux-loong64': 'mihomo-linux-loong64',
++  'linux-loong64': 'mihomo-linux-loong64-abi2',
++  'linux-ppc64': 'mihomo-linux-ppc64le',
+ }
  
  const META_MAP = {
 @@ -205,7 +206,8 @@ const META_MAP = {
-   "linux-arm64": "mihomo-linux-arm64",
-   "linux-arm": "mihomo-linux-armv7",
-   "linux-riscv64": "mihomo-linux-riscv64",
--  "linux-loong64": "mihomo-linux-loong64",
-+  "linux-loong64": "mihomo-linux-loong64-abi2",
-+  "linux-ppc64": "mihomo-linux-ppc64le",
- };
+   'linux-arm64': 'mihomo-linux-arm64',
+   'linux-arm': 'mihomo-linux-armv7',
+   'linux-riscv64': 'mihomo-linux-riscv64',
+-  'linux-loong64': 'mihomo-linux-loong64',
++  'linux-loong64': 'mihomo-linux-loong64-abi2',
++  'linux-ppc64': 'mihomo-linux-ppc64le',
+ }
  
  // =======================
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index f2273b21..3407db5e 100755
+index 0c930f1f..78f84d6a 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
 @@ -60,7 +60,7 @@ open = "5.3.3"
  dunce = "1.0.5"
  nanoid = "0.4"
- chrono = "0.4.43"
+ chrono = "0.4.44"
 -boa_engine = "0.21.0"
 +boa_engine = { version = "0.21.0", features = ["xsum"], default-features = false }
- once_cell = { version = "1.21.3", features = ["parking_lot"] }
+ once_cell = { version = "1.21.4", features = ["parking_lot"] }
  delay_timer = "0.11.6"
  percent-encoding = "2.3.2"
-diff --git a/vite.config.mts b/vite.config.mts
-index a5ef33af..3fc10b22 100644
---- a/vite.config.mts
-+++ b/vite.config.mts
-@@ -2,7 +2,7 @@ import path from "node:path";
- import { fileURLToPath } from "node:url";
- 
- import legacy from "@vitejs/plugin-legacy";
--import react from "@vitejs/plugin-react-swc";
-+import react from "@vitejs/plugin-react";
- import { defineConfig } from "vite";
- import svgr from "vite-plugin-svgr";
- 
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0014-update-aws-lc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0014-update-aws-lc.patch
@@ -1,0 +1,28 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index d0669022..bc2b93f6 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -463,9 +463,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+ 
+ [[package]]
+ name = "aws-lc-rs"
+-version = "1.16.1"
++version = "1.16.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
++checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+ dependencies = [
+  "aws-lc-sys",
+  "zeroize",
+@@ -473,9 +473,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "aws-lc-sys"
+-version = "0.38.0"
++version = "0.39.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
++checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+ dependencies = [
+  "cc",
+  "cmake",

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,4 +1,4 @@
-VER=2.4.6
+VER=2.4.7
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.4.7

Package(s) Affected
-------------------

- clash-verge-rev: 1:2.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
