### PR TITLE
perl-xml-parser: update to 2.51

### DIFF
--- a/lang-perl/perl-xml-parser/autobuild/defines
+++ b/lang-perl/perl-xml-parser/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=perl-xml-parser
 PKGSEC=perl
-PKGDEP="perl expat"
-PKGDES="Perl module XML::Parser"
+PKGDEP="perl expat perl-file-sharedir"
+BUILDDEP="perl-file-sharedir-install"
+PKGDES="Perl module to parse XML documents"

--- a/lang-perl/perl-xml-parser/spec
+++ b/lang-perl/perl-xml-parser/spec
@@ -1,5 +1,4 @@
-VER=2.44
-REL=8
+VER=2.51
 SRCS="tbl::https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-$VER.tar.gz"
-CHKSUMS="sha256::1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216"
+CHKSUMS="sha256::61b07878ff5095375fbbf095c1779808d6d99cf142a176bbf8900f42604e82eb"
 CHKUPDATE="anitya::id=3531"

--- a/topics/perl-xml-parser-2.51.toml
+++ b/topics/perl-xml-parser-2.51.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Perl XML::Parser 2.51"
+
+[caution]
+default = "Fixes a Heap-based Buffer Overflow and Improper Handling of Unicode Encoding vulnerability - CVE-2006-10002 (Severity: Critical)"
+zh_CN = "修复一个堆缓冲区溢出 (Heap-based Buffer Overflow) 及 Unicode 编码处理不当漏洞，漏洞编号 CVE-2006-10002（严重性：严重）"
+
+[packages]
+"perl-xml-parser" = "< 2.51"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add perl-xml-parser-2.51.toml
- perl-xml-parser: update to 2.51

Package(s) Affected
-------------------

- perl-xml-parser: 2.51

Security Update?
----------------

Yes, CVE-2006-10002 (Critical)

Build Order
-----------

```
#buildit perl-xml-parser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
