### PR TITLE
fluidsynth: update to 2.5.3

### DIFF
--- a/app-multimedia/fluidsynth/autobuild/defines
+++ b/app-multimedia/fluidsynth/autobuild/defines
@@ -1,15 +1,16 @@
 PKGNAME=fluidsynth
 PKGSEC=sound
 PKGDEP="glib jack pulseaudio ladspa-sdk"
-BUILDDEP="doxygen"
 PKGRECOM="soundfont-fluid-gm"
-PKGDES="A real-time software synthesizer based on the SoundFont 2 specifications"
+PKGDES="Real-time software synthesizer based on the SoundFont 2 specifications"
 
-CMAKE_AFTER="-DFLUID_DAEMON_ENV_FILE=/etc/conf.d/fluidsynth \
-             -Denable-ladspa=ON \
-             -Denable-floats=ON \
-             -Denable-lash=OFF \
-             -DLIB_SUFFIX="
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DFLUID_DAEMON_ENV_FILE=/etc/conf.d/fluidsynth'
+    '-Denable-ladspa=ON'
+    '-Denable-floats=ON'
+    '-DLIB_SUFFIX=""'
+)
 
 PKGBREAK="audacious<=4.4-2 carla<=1:2.5.8 drumstick<=2.9.0-1 \
           lmms<=2:1.2.2+git20240508-1 minuet<=23.08.5 mpd<=0.23.15-4 \

--- a/app-multimedia/fluidsynth/spec
+++ b/app-multimedia/fluidsynth/spec
@@ -1,4 +1,4 @@
-VER=2.5.1
+VER=2.5.3
 SRCS="git::commit=tags/v$VER::https://github.com/FluidSynth/fluidsynth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10437"

--- a/runtime-optenv32/fluidsynth+32/autobuild/defines
+++ b/runtime-optenv32/fluidsynth+32/autobuild/defines
@@ -2,8 +2,9 @@ PKGNAME=fluidsynth+32
 PKGSEC=sound
 PKGDEP="aosc-aaa+32 glib+32 pulseaudio+32"
 BUILDDEP="devel-base+32"
-PKGDES="A real-time software synthesizer based on the SoundFont 2 specifications (32-bit x86 runtime)"
+PKGDES="Real-time software synthesizer based on the SoundFont 2 specifications"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
     '-Denable-ladspa=ON'
     '-Denable-jack=OFF'

--- a/runtime-optenv32/fluidsynth+32/spec
+++ b/runtime-optenv32/fluidsynth+32/spec
@@ -1,4 +1,4 @@
-VER=2.3.6
+VER=2.5.3
 SRCS="git::commit=tags/v$VER::https://github.com/FluidSynth/fluidsynth"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10437"

--- a/topics/fluidsynth-2.5.3.toml
+++ b/topics/fluidsynth-2.5.3.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "FluidSynth 2.5.3"
+
+[caution]
+default = "Fixes a heap-based use-after-free vulnerability - CVE-2025-68617 (Severity: High)"
+zh_CN = "修复一个基于堆的释放后使用 (use-after-free) 漏洞，漏洞编号 CVE-2025-68617（严重性：高）"
+
+[packages-v2]
+"fluidsynth" = "< 2.5.3"
+"fluidsynth+32" = "< 2.5.3"


### PR DESCRIPTION
Topic Description
-----------------

- fluidsynth: update to 2.5.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- fluidsynth: 2.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit fluidsynth
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
