### PR TITLE
freetds: update to 1.5.14

### DIFF
--- a/runtime-database/freetds/autobuild/beyond
+++ b/runtime-database/freetds/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing documents ..."
+rm -rv "$PKGDIR"/usr/share/doc

--- a/runtime-database/freetds/autobuild/defines
+++ b/runtime-database/freetds/autobuild/defines
@@ -3,17 +3,11 @@ PKGSEC=database
 PKGDEP="openssl unixodbc"
 PKGDES="Library for accessing Sybase and MS SQL Server databases"
 
-# FIXME: Re-generation fails.
-#
-# configure.ac:121: error: possibly undefined macro: AM_ICONV
-#      If this token and others are legitimate, please use m4_pattern_allow.
-#      See the Autoconf documentation.
-RECONF=0
-
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--sysconfdir=/etc/freetds'
     '--enable-msdblib'
-    '--with-tdsver=7.0'
+    '--enable-krb5'
     '--with-unixodbc=/usr'
     '--with-openssl'
 )

--- a/runtime-database/freetds/spec
+++ b/runtime-database/freetds/spec
@@ -1,5 +1,4 @@
-VER=1.00.112
-REL=2
+VER=1.5.14
 SRCS="tbl::https://www.freetds.org/files/stable/freetds-$VER.tar.gz"
-CHKSUMS="sha256::0cfde9c30e92af7f9579a5da2033b9a8dc6252c09088c7831b6d56323479374d"
+CHKSUMS="sha256::e02a68ff925fa17da56ff42b9e095c3aff5ad65b41e4753469e70f2a50df5a12"
 CHKUPDATE="anitya::id=8198"

--- a/topics/freetds-1.5.14.toml
+++ b/topics/freetds-1.5.14.toml
@@ -1,0 +1,12 @@
+security = true
+must_match_all = false
+
+[name]
+default = "FreeTDS 1.5.14"
+
+[caution]
+default = "Fixes a buffer overflow vulnerability - CVE-2019-13508 (Severity: Critical)"
+zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2019-13508（严重性：高）"
+
+[packages-v2]
+"freetds" = "< 1.5.14"


### PR DESCRIPTION
Topic Description
-----------------

- freetds: update to 1.5.14
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- freetds: 1.5.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit freetds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
