### PR TITLE
lcms Survey 20260323

### DIFF
--- a/app-web/netsurf/autobuild/defines
+++ b/app-web/netsurf/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=netsurf
 PKGSEC=web
-PKGDEP="curl desktop-file-utils duktape gtk-3 lcms1 libcss libdom libmng \
+PKGDEP="curl desktop-file-utils duktape gtk-3 lcms2 libcss libdom libmng \
         libnsbmp libnsgif libnslog libnspsl libnsutils libparserutils \
         librsvg libutf8proc libwapcaplet libwebp"
 PKGDEP__RETRO=" \
-        curl desktop-file-utils duktape gtk-2 lcms1 libcss libdom libmng \
+        curl desktop-file-utils duktape gtk-2 lcms2 libcss libdom libmng \
         libnsbmp libnsgif libnslog libnspsl libnsutils libparserutils \
         librsvg libutf8proc libwapcaplet libwebp gnome-icon-theme"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"

--- a/app-web/netsurf/spec
+++ b/app-web/netsurf/spec
@@ -1,5 +1,5 @@
 VER=3.11
-REL=2
+REL=3
 SRCS="tbl::https://download.netsurf-browser.org/netsurf/releases/source/netsurf-$VER-src.tar.gz"
 CHKSUMS="sha256::c28a626aefee428d053b13f88b5c440922245976522d12eaf137cfd32d201cb2"
 CHKUPDATE="anitya::id=5386"

--- a/desktop-trinity/koffice-trinity/autobuild/defines
+++ b/desktop-trinity/koffice-trinity/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=koffice-trinity
 PKGSEC=Trinity
-PKGDEP="graphicsmagick mariadb lcms1 libpqxx libwpd poppler ruby \
+PKGDEP="graphicsmagick mariadb lcms2 libpqxx libwpd poppler ruby \
         tdegraphics tdelibs wv2"
-PKGDEP__RETRO=" \
-        lcms1 poppler tdegraphics tdelibs wv2"
+PKGDEP__RETRO="lcms2 poppler tdegraphics tdelibs wv2"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
@@ -15,24 +14,28 @@ PKGDEP__PPC64="${PKGDEP__RETRO}"
 BUILDDEP="tde-common-cmake"
 PKGDES="Office productivity suite for the Trinity Desktop Environment"
 
+ABTYPE=self
 # FIXME: Kexi macros broken due to missing header and mis-referenced
 # TQt private headers.
-AUTOTOOLS_AFTER="--disable-dependency-tracking \
-                 --disable-debug \
-                 --enable-new-ldflags \
-                 --enable-final \
-                 --enable-closure \
-                 --disable-rpath \
-                 --disable-gcc-hidden-visibility \
-                 --enable-mysql \
-                 --enable-pgsql \
-                 --disable-kexi-macros \
-                 --enable-scripting"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-mysql \
-                 --disable-pgsql \
-                 --disable-scripting"
+AUTOTOOLS_AFTER=(
+    '--disable-dependency-tracking'
+    '--disable-debug'
+    '--enable-new-ldflags'
+    '--enable-final'
+    '--enable-closure'
+    '--disable-rpath'
+    '--disable-gcc-hidden-visibility'
+    '--enable-mysql'
+    '--enable-pgsql'
+    '--disable-kexi-macros'
+    '--enable-scripting'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-mysql'
+    '--disable-pgsql'
+    '--disable-scripting'
+)
 AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
 AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"

--- a/desktop-trinity/koffice-trinity/spec
+++ b/desktop-trinity/koffice-trinity/spec
@@ -1,5 +1,5 @@
 VER=14.1.5
-REL=1
+REL=2
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/applications/office/koffice-trinity-$VER.tar.xz \
       tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/applications/office/koffice-i18n-trinity-$VER.tar.xz"
 CHKSUMS="sha256::fa538261101ff51a634cd759247d09a81da8dfda4feae8c55bf576c09178e9a8 \

--- a/runtime-imaging/lcms2/spec
+++ b/runtime-imaging/lcms2/spec
@@ -1,5 +1,4 @@
-VER=2.17
-REL=1
+VER=2.18
 SRCS="tbl::https://downloads.sourceforge.net/lcms/lcms2-$VER.tar.gz"
-CHKSUMS="sha256::d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074"
+CHKSUMS="sha256::ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347"
 CHKUPDATE="anitya::id=9815"

--- a/runtime-optenv32/lcms2+32/spec
+++ b/runtime-optenv32/lcms2+32/spec
@@ -1,5 +1,4 @@
-VER=2.17
-REL=1
+VER=2.18
 SRCS="tbl::https://downloads.sourceforge.net/lcms/lcms2-$VER.tar.gz"
-CHKSUMS="sha256::d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074"
+CHKSUMS="sha256::ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347"
 CHKUPDATE="anitya::id=9815"


### PR DESCRIPTION
Topic Description
-----------------

- lcms2: update to 2.18
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- lcms2: 2.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit lcms2 netsurf koffice-trinity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
