### PR TITLE
ptyxis: update to 50.1

### DIFF
--- a/desktop-gnome/ptyxis/spec
+++ b/desktop-gnome/ptyxis/spec
@@ -1,4 +1,4 @@
-VER=49.3
+VER=50.1
 SRCS="https://download.gnome.org/sources/ptyxis/${VER%%.*}/ptyxis-$VER.tar.xz"
-CHKSUMS="sha256::d15b6ed8ebd19dfbe46be48ea4ab3ba4dc5048e277c9733a62ea19111f0bfc5b"
+CHKSUMS="sha256::73f4b76480644b2840415859a51d20cd7487b0619714f8defcd38212c3ddcffe"
 CHKUPDATE="anitya::id=371673"


### PR DESCRIPTION
Topic Description
-----------------

- ptyxis: update to 50.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- ptyxis: 50.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ptyxis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
