### PR TITLE
rcloneshuttle: update to 0.1.9

### DIFF
--- a/app-web/rcloneshuttle/spec
+++ b/app-web/rcloneshuttle/spec
@@ -1,4 +1,4 @@
-VER=0.1.7
+VER=0.1.9
 SRCS="git::commit=tags/$VER::https://github.com/pieterdd/RcloneShuttle.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=387806"


### PR DESCRIPTION
Topic Description
-----------------

- rcloneshuttle: update to 0.1.9
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- rcloneshuttle: 0.1.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit rcloneshuttle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
