### PR TITLE
buf: update to 1.66.1

### DIFF
--- a/app-devel/buf/spec
+++ b/app-devel/buf/spec
@@ -1,5 +1,4 @@
-VER=1.65.0
-REL=2
+VER=1.66.1
 SRCS="git::commit=tags/v$VER::https://github.com/bufbuild/buf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328143"


### PR DESCRIPTION
Topic Description
-----------------

- buf: update to 1.66.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- buf: 1.66.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit buf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
