### PR TITLE
dart-sdk: update to 3.11.3

### DIFF
--- a/app-devel/dart-sass-js/spec
+++ b/app-devel/dart-sass-js/spec
@@ -1,4 +1,4 @@
-VER=1.97.3
+VER=1.98.0
 SASS_VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/sass/dart-sass.git \
       git::commit=tags/embedded-protocol-$SASS_VER;rename=dart-sass-js/embedded-protocol::https://github.com/sass/sass.git"

--- a/app-devel/dart-sass/autobuild/defines
+++ b/app-devel/dart-sass/autobuild/defines
@@ -9,3 +9,5 @@ ABTYPE=self
 
 # Note: Architectures supported by dart-sdk
 FAIL_ARCH="!(amd64|armv7hf|arm64|riscv64)"
+
+PKGBREAK="dartaotruntime<=3.10.7-2"

--- a/app-devel/dart-sass/spec
+++ b/app-devel/dart-sass/spec
@@ -1,4 +1,4 @@
-VER=1.97.3
+VER=1.98.0
 SASS_VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/sass/dart-sass.git \
       git::commit=tags/embedded-protocol-$SASS_VER;rename=dart-sass/embedded-protocol::https://github.com/sass/sass.git"

--- a/lang-dart/dart-sdk/01-main/patches/0002-DEPS.patch
+++ b/lang-dart/dart-sdk/01-main/patches/0002-DEPS.patch
@@ -1,25 +1,25 @@
-From e9c49605e6542787b1cee2d3f62d9ab04cc2428e Mon Sep 17 00:00:00 2001
+From 4d605c8083fb1e6a60d759cc5a86b2136a0f5482 Mon Sep 17 00:00:00 2001
 From: pugaizai <i@pugai.life>
-Date: Thu, 22 Jan 2026 00:39:25 +0800
+Date: Mon, 23 Mar 2026 14:19:46 +0800
 Subject: [PATCH] DEPS
 
 ---
- DEPS | 396 +----------------------------------------------------------
- 1 file changed, 1 insertion(+), 395 deletions(-)
+ DEPS | 385 +----------------------------------------------------------
+ 1 file changed, 1 insertion(+), 384 deletions(-)
 
 diff --git a/DEPS b/DEPS
-index df7f2863e48..78519b143cb 100644
+index 76a69a3469e..9a08d6f13d9 100644
 --- a/DEPS
 +++ b/DEPS
 @@ -81,7 +81,7 @@ vars = {
-   "gn_version": "git_revision:81b24e01531ecf0eff12ec9359a555ec3944ec4e",
+   "gn_version": "git_revision:40aac3f15d34b3469e80b0c086a37bd069af2d6e",
  
    "reclient_version": "re_client_version:28341fc74c68f05a5c8be35160ada940c4edb969",
 -  "download_reclient": True,
 +  "download_reclient": False,
  
    # Update from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core
-   "fuchsia_sdk_version": "version:29.20250925.5.1",
+   "fuchsia_sdk_version": "version:30.20260102.4.1",
 @@ -185,18 +185,6 @@ deps = {
      Var("chromium_git") + "/chromium/llvm-project/cfe/tools/clang-format.git" +
      "@" + Var("clang_format_scripts_rev"),
@@ -109,7 +109,7 @@ index df7f2863e48..78519b143cb 100644
 -      Var("chromium_git") + "/chromium/src/third_party/jinja2.git" +
 -      "@" + Var("jinja2_rev"),
 -
-   Var("dart_root") + "/third_party/perfetto":
+   Var("dart_root") + "/third_party/perfetto/src":
        Var("android_git") + "/platform/external/perfetto" +
        "@" + Var("perfetto_rev"),
 @@ -353,10 +289,6 @@ deps = {
@@ -136,11 +136,10 @@ index df7f2863e48..78519b143cb 100644
    Var("dart_root") + "/third_party/pkg/native":
        Var("dart_git") + "native.git" + "@" + Var("native_rev"),
    Var("dart_root") + "/third_party/pkg/protobuf":
-@@ -400,216 +326,6 @@ deps = {
-       "@" + Var("webkit_inspection_protocol_rev"),
+@@ -401,205 +327,6 @@ deps = {
    Var("dart_root") + "/third_party/pkg/web":
        Var("dart_git") + "web.git" + "@" + Var("web_rev"),
--
+ 
 -  Var("dart_root") + "/buildtools/sysroot/linux": {
 -      "packages": [
 -          {
@@ -296,26 +295,16 @@ index df7f2863e48..78519b143cb 100644
 -      "dep_type": "cipd",
 -  },
 -
--  Var("dart_root") + "/third_party/android_tools/ndk": {
--      "packages": [
--          {
--            "package": "flutter/android/ndk/${{os}}-amd64",
--            "version": "version:r27.0.10869015"
--          }
--      ],
--      "condition": "download_android_deps",
--      "dep_type": "cipd",
--  },
--  Var("dart_root") + "/third_party/android_tools/sdk/platform-tools": {
--      "packages": [
--          {
--            "package": "flutter/android/sdk/platform-tools/linux-amd64",
--            "version": "1tZc4sOxZS6FQIvT5i0wwdycmM8AO7QZY32FC9_HfR4C"
--          }
--      ],
--      "condition": "download_android_deps",
--      "dep_type": "cipd",
--  },
+-  Var("dart_root") + "/third_party/android_tools": {
+-     "packages": [
+-       {
+-        "package": "flutter/android/sdk/all/${{platform}}",
+-        "version": "version:36v3"
+-       }
+-     ],
+-     "condition": "download_android_deps",
+-     "dep_type": "cipd",
+-   },
 -
 -  Var("dart_root") + "/third_party/fuchsia/sdk/linux": {
 -    "packages": [
@@ -332,7 +321,7 @@ index df7f2863e48..78519b143cb 100644
 -    "packages": [
 -      {
 -      "package": "chromium/fuchsia/test-scripts",
--      "version": "JUeFbA8y0E-_pj-bgvR6glsLIO-gJIHlR9RtM5zxni8C",
+-      "version": "MHF-UAfO6sVKqSEYknqkl3nsdAQmODJNHF-pYBSpRzgC",
 -      }
 -    ],
 -    "condition": 'download_fuchsia_deps',
@@ -343,7 +332,7 @@ index df7f2863e48..78519b143cb 100644
 -    "packages": [
 -      {
 -      "package": "chromium/fuchsia/gn-sdk",
--      "version": "NAEC5tfgSl8g94nwpKsGtNMEdbiAlgwrNa9XQ7cIcbcC",
+-      "version": "JLBh4Z9PKsjIJcqDUDzEL8Q7whJ3CGRd4QmUL6IzizUC",
 -      }
 -    ],
 -    "condition": 'download_fuchsia_deps',
@@ -353,7 +342,7 @@ index df7f2863e48..78519b143cb 100644
    Var("dart_root") + "/pkg/front_end/test/types/benchmark_data": {
      "packages": [
        {
-@@ -619,73 +335,6 @@ deps = {
+@@ -609,73 +336,6 @@ deps = {
      ],
      "dep_type": "cipd",
    },
@@ -427,7 +416,7 @@ index df7f2863e48..78519b143cb 100644
  }
  
  hooks = [
-@@ -712,47 +361,4 @@ hooks = [
+@@ -702,47 +362,4 @@ hooks = [
      'pattern': '.',
      'action': ['python3', Var("dart_root") + '/tools/buildtools/update.py'],
    },

--- a/lang-dart/dart-sdk/01-main/patches/0007-ALPINE-zlib-not-found.patch
+++ b/lang-dart/dart-sdk/01-main/patches/0007-ALPINE-zlib-not-found.patch
@@ -1,9 +1,9 @@
 --- ./runtime/bin/BUILD.gn.orig
 +++ ./runtime/bin/BUILD.gn
-@@ -1013,6 +1013,7 @@
+@@ -1152,6 +1152,7 @@ source_set("run_vm_tests_set") {
    deps = [
-     "../vm:libprotozero",  # for timeline_test
      "//third_party/boringssl",  # for secure_socket_utils_test
+     "//third_party/perfetto:libprotozero",  # for timeline_test
 +    "//third_party/zlib",  # for gzip
    ]
  

--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -1,5 +1,4 @@
-VER="3.10.7"
-REL="2"
+VER=3.11.3
 ### Note: Pinned commit for depot_tools since it does not have release tags
 SRCS="git::rename=sdk;commit=tags/$VER;copy-repo=true::https://github.com/dart-lang/sdk.git \
       git::rename=sdk/depot_tools;commit=679386aca8b1aa9037f21d1a590e3424cd4bde5d::https://chromium.googlesource.com/chromium/tools/depot_tools.git"
@@ -9,4 +8,4 @@ CHKUPDATE="anitya::id=14718"
 SUBDIR="sdk"
 
 # Note: LTO requires larger RAM.
-ENVREQ__ARM64="total_mem=20"
+ENVREQ__ARM64="total_mem=60"

--- a/lang-dart/fvm/autobuild/defines
+++ b/lang-dart/fvm/autobuild/defines
@@ -8,3 +8,5 @@ ABTYPE=self
 
 # Note: Architectures supported by dart-sdk
 FAIL_ARCH="!(amd64|armv7hf|arm64|riscv64)"
+
+PKGBREAK="dartaotruntime<=3.10.7-2"

--- a/lang-dart/fvm/spec
+++ b/lang-dart/fvm/spec
@@ -1,4 +1,5 @@
 VER=4.0.5
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/leoafarias/fvm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379051"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sass-js: update to 1.98.0
- dart-sass: update to 1.98.0
- fvm: bump REL for dartaotruntime update
- dart-sdk: update to 3.11.3
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- dart-sass: 1.98.0
- dart-sass-js: 1.98.0
- dart-sdk: 3.11.3
- dartaotruntime: 3.11.3
- fvm: 4.0.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk fvm dart-sass dart-sass-js
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
