### PR TITLE
libconfig: update to 1.8.2

### DIFF
--- a/app-admin/udisks-2/spec
+++ b/app-admin/udisks-2/spec
@@ -2,4 +2,4 @@ VER=2.11.0
 SRCS="tbl::https://github.com/storaged-project/udisks/releases/download/udisks-$VER/udisks-$VER.tar.bz2"
 CHKSUMS="sha256::0bf30151fe8d9d2fb59b57f6630739dfbbd16417dee69ec57d43b37335bd649a"
 CHKUPDATE="anitya::id=5028"
-REL="1"
+REL=2

--- a/app-devel/cvechecker/spec
+++ b/app-devel/cvechecker/spec
@@ -1,5 +1,5 @@
 VER=3.9
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/sjvermeu/cvechecker"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15634"

--- a/app-network/sslh/spec
+++ b/app-network/sslh/spec
@@ -2,3 +2,4 @@ VER=2.2.4
 SRCS="git::commit=tags/v$VER::https://github.com/yrutschle/sslh.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6184"
+REL=1

--- a/app-web/toxcore/spec
+++ b/app-web/toxcore/spec
@@ -2,4 +2,4 @@ VER=0.2.18
 SRCS="git::commit=tags/v$VER::https://github.com/TokTok/c-toxcore"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14878"
-REL=1
+REL=2

--- a/desktop-wm/picom/spec
+++ b/desktop-wm/picom/spec
@@ -2,3 +2,4 @@ VER=13
 SRCS="git::commit=tags/v${VER}::https://github.com/yshui/picom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=48078"
+REL=1

--- a/runtime-admin/libstoragemgmt/spec
+++ b/runtime-admin/libstoragemgmt/spec
@@ -2,4 +2,4 @@ VER=1.10.2
 SRCS="tbl::https://github.com/libstorage/libstoragemgmt/releases/download/$VER/libstoragemgmt-$VER.tar.gz"
 CHKSUMS="sha256::5ca3b6e0996ef13ff0f6bb4af99d67004ffec3530723f57338caea48a23513cc"
 CHKUPDATE="anitya::id=17306"
-REL="1"
+REL=2

--- a/runtime-common/libconfig/autobuild/defines
+++ b/runtime-common/libconfig/autobuild/defines
@@ -4,3 +4,7 @@ PKGDES="C/C++ Configuration File Library"
 PKGSEC=libs
 
 ABSHADOW=no
+# SOVER differs every major release update. Be careful!
+PKGBREK="cvechecker<=3.9-1 libguestfs<=1.58.0-2 libstoragemgmt<=1.10.2-1 \
+         picom<=13 sslh<=2.2.4 toxcore<=1:0.2.18-1 udisks-2<=2.11.0-1 \
+	 libffado<=2.5.0"

--- a/runtime-common/libconfig/autobuild/prepare
+++ b/runtime-common/libconfig/autobuild/prepare
@@ -1,1 +1,0 @@
-touch "$SRCDIR"/lib/scanner.l

--- a/runtime-common/libconfig/spec
+++ b/runtime-common/libconfig/spec
@@ -1,5 +1,4 @@
-VER=1.7.2
-REL=2
-SRCS="tbl::https://github.com/hyperrealm/libconfig/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f67ac44099916ae260a6c9e290a90809e7d782d96cdd462cac656ebc5b685726"
+VER=1.8.2
+SRCS="git::commit=tags/v${VER}::https://github.com/hyperrealm/libconfig"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1580"

--- a/runtime-multimedia/libffado/spec
+++ b/runtime-multimedia/libffado/spec
@@ -1,4 +1,5 @@
 VER=2.5.0
+REL=1
 SRCS="tbl::http://www.ffado.org/files/libffado-$VER.tgz"
 CHKSUMS="sha256::25c12d93d53988f3caf9965236ed379f167abde3ea4cc633b134ee6254d87ca1"
 CHKUPDATE="anitya::id=141596"

--- a/runtime-virtualization/libguestfs/spec
+++ b/runtime-virtualization/libguestfs/spec
@@ -1,5 +1,5 @@
 VER=1.58.0
-REL=2
+REL=3
 SRCS="tbl::https://download.libguestfs.org/${VER%.*}-stable/libguestfs-$VER.tar.gz"
 CHKSUMS="sha256::701145c3b631a92166c90bd6100ce00817a9b760c3be1a3404350ac70bb3d7ba"
 CHKUPDATE="anitya::id=229572"


### PR DESCRIPTION
Topic Description
-----------------

- libffado: rebuild for libconfig++.so.15
- udisks-2: rebuild for libconfig.so.15
- toxcore: rebuild for libconfig.so.15
- sslh: rebuild for libconfig.so.15
- picom: rebuild for libconfig.so.15
- libstoragemgmt: rebuild for libconfig.so.15
- libguestfs: rebuild for libconfig.so.15
- cvechecker: rebuild for libconfig.so.15
- libconfig: update to 1.8.2
    \* Switch to Git source.
    \* Drop the mysterious prepare script.

Package(s) Affected
-------------------

- cvechecker: 3.9-2
- libconfig: 1.8.2
- libffado: 2.5.0-1
- libguestfs: 1.58.0-3
- libstoragemgmt: 1.10.2-2
- picom: 13-1
- sslh: 2.2.4-1
- toxcore: 1:0.2.18-2
- udisks-2: 2.11.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libconfig:-pkgbreak cvechecker libguestfs libstoragemgmt picom sslh toxcore udisks-2 libffado libconfig
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
