### PR TITLE
honkers-launcher: new, 1.13.0

### DIFF
--- a/app-games/honkers-launcher/autobuild/beyond
+++ b/app-games/honkers-launcher/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing desktop icon ..."
+install -Dvm644 "$SRCDIR"/assets/images/icon.png \
+    "$PKGDIR"/usr/share/pixmaps/honkers-launcher.png

--- a/app-games/honkers-launcher/autobuild/defines
+++ b/app-games/honkers-launcher/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=honkers-launcher
+PKGSEC=games
+PKGDES="Launcher for Honkers 3 game"
+PKGDEP="libadwaita libwebp gtk-4 git p7zip xdg-desktop-portal"
+BUILDDEP="rustc llvm"
+ABTYPE=rust
+
+# FIXME: `ring` seems broken in LTO
+NOLTO=1

--- a/app-games/honkers-launcher/autobuild/overrides/usr/share/applications/honkers-launcher.desktop
+++ b/app-games/honkers-launcher/autobuild/overrides/usr/share/applications/honkers-launcher.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Honkers Launcher
+Name[zh_CN]=崩崩崩启动器
+Comment=Honkers 3 launcher for Linux with automatic patching and telemetry disabling
+Comment[zh_CN]=带有自动打补丁及禁用遥测功能的崩崩崩启动器
+Exec=honkers-launcher
+Terminal=false
+Type=Application
+Icon=honkers-launcher
+StartupWMClass=moe.launcher.honkers-launcher
+Categories=Game

--- a/app-games/honkers-launcher/spec
+++ b/app-games/honkers-launcher/spec
@@ -1,0 +1,4 @@
+VER=1.13.0
+SRCS="git::commit=$VER::https://github.com/an-anime-team/honkers-launcher.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=389325"


### PR DESCRIPTION
Topic Description
-----------------

- honkers-launcher: new, 1.13.0

Package(s) Affected
-------------------

- honkers-launcher: 1.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit honkers-launcher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
