### PR TITLE
libheif: update to 1.21.2

### DIFF
--- a/runtime-imaging/libheif/spec
+++ b/runtime-imaging/libheif/spec
@@ -1,5 +1,4 @@
-VER=1.20.2
-REL=1
-SRCS="tbl::https://github.com/strukturag/libheif/releases/download/v${VER}/libheif-${VER}.tar.gz"
-CHKSUMS="sha256::68ac9084243004e0ef3633f184eeae85d615fe7e4444373a0a21cebccae9d12a"
+VER=1.21.2
+SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libheif"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=64439"

--- a/runtime-multimedia/aom/autobuild/defines
+++ b/runtime-multimedia/aom/autobuild/defines
@@ -1,15 +1,14 @@
 PKGNAME=aom
 PKGDES="AV1 Video Codec Library"
 PKGDEP="gcc-runtime"
-BUILDDEP="doxygen"
 BUILDDEP__AMD64="${BUILDDEP} yasm"
 PKGSEC="libs"
 
-CMAKE_AFTER=("-DBUILD_SHARED_LIBS=1"
-#FIXME: This option will cause OOM(Yerus) in the current version
-             "-DENABLE_DOCS=OFF")
-
 ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    "-DBUILD_SHARED_LIBS=1"
+    "-DENABLE_DOCS=OFF"
+)
 
 # FIXME: lto1: fatal error: target specific builtin not available
 NOLTO__RISCV64=1

--- a/runtime-multimedia/aom/autobuild/patches/0001-disable-static.patch
+++ b/runtime-multimedia/aom/autobuild/patches/0001-disable-static.patch
@@ -1,0 +1,13 @@
+diff --git a/build/cmake/aom_install.cmake b/build/cmake/aom_install.cmake
+index 4291782da1..818f74a833 100644
+--- a/build/cmake/aom_install.cmake
++++ b/build/cmake/aom_install.cmake
+@@ -79,7 +79,7 @@ macro(setup_aom_install_targets)
+     endif()
+ 
+     if(BUILD_SHARED_LIBS)
+-      set(AOM_INSTALL_LIBS aom aom_static)
++      set(AOM_INSTALL_LIBS aom)
+     else()
+       set(AOM_INSTALL_LIBS aom)
+     endif()

--- a/runtime-multimedia/aom/spec
+++ b/runtime-multimedia/aom/spec
@@ -1,4 +1,5 @@
 VER=3.13.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://aomedia.googlesource.com/aom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17628"

--- a/topics/libheif-1.21.2.toml
+++ b/topics/libheif-1.21.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libheif 1.21.2"
+
+[caution]
+default = "Fixes a heap buffer over vulnerability - CVE-2025-68431 (Severity: High)"
+zh_CN = "修复一个堆缓冲区溢出漏洞，漏洞编号 CVE-2025-68431（严重性：高）"
+
+[packages-v2]
+"libheif" = "< 1.21.2"


### PR DESCRIPTION
Topic Description
-----------------

- libheif: update to 1.21.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libheif: 1.21.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit aom libheif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
