### PR TITLE
libp11: update to 0.4.18

### DIFF
--- a/runtime-cryptography/libp11/spec
+++ b/runtime-cryptography/libp11/spec
@@ -1,4 +1,4 @@
-VER=0.4.16
+VER=0.4.18
 SRCS="git::commit=tags/libp11-$VER::https://github.com/OpenSC/libp11"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1699"


### PR DESCRIPTION
Topic Description
-----------------

- libp11: update to 0.4.18
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libp11: 0.4.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit libp11
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
