### PR TITLE
swtpm: new,0.10.0

### DIFF
--- a/app-virtualization/libvirt/autobuild/defines
+++ b/app-virtualization/libvirt/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="avahi bridge-utils curl cyrus-sasl dbus dmidecode dnsmasq \
         libcap-ng libgcrypt libgpg-error libnl libpcap libssh2 libxml2 \
         lxc netcat netcf numactl openssl parted pm-utils polkit python-3 \
         radvd systemd x11-lib libssh qemu open-iscsi perl-xml-xpath \
-        libiscsi sanlock"
+        libiscsi sanlock swtpm"
 BUILDDEP="docutils qemu rpcsvc-proto firewalld wireshark"
 # NOTE: We dropped LTS kernel recently, thus ZFS support is not guranteed.
 PKGRECOM="qemu"

--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -2,4 +2,4 @@ VER=11.9.0
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::104f70ee591e72989d4f8c6caa79ed9dacd5dc84efdb0125b848afe544ad0c2d"
 CHKUPDATE="anitya::id=13830"
-REL="1"
+REL="2"

--- a/runtime-virtualization/swtpm/autobuild/defines
+++ b/runtime-virtualization/swtpm/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=swtpm
+PKGSEC=libs
+PKGDEP="libtpms glib openssl libseccomp json-glib gnutls"
+BUILDDEP="libtool fuse socat"
+PKGDES="TPM emulators with different front-end interfaces to libtpms"
+
+# FIXME: <command-line>: error: '_FORTIFY_SOURCE' redefined [-Werror]
+# ACBS had already enabled hardening, disabling it here.
+AUTOTOOLS_AFTER=(
+        "--disable-hardening"
+)

--- a/runtime-virtualization/swtpm/autobuild/overrides/usr/lib/tmpfiles.d/swtpm.conf
+++ b/runtime-virtualization/swtpm/autobuild/overrides/usr/lib/tmpfiles.d/swtpm.conf
@@ -1,0 +1,1 @@
+d /var/lib/swtpm-localca 0755 tss tss

--- a/runtime-virtualization/swtpm/autobuild/postinst
+++ b/runtime-virtualization/swtpm/autobuild/postinst
@@ -1,0 +1,1 @@
+systemd-tmpfiles --create swtpm.conf

--- a/runtime-virtualization/swtpm/spec
+++ b/runtime-virtualization/swtpm/spec
@@ -1,0 +1,4 @@
+VER=0.10.1
+SRCS="git::commit=tags/v$VER::https://github.com/stefanberger/swtpm"
+CHKSUMS="SKIP"
+CHKUPDATE="116461"


### PR DESCRIPTION
Topic Description
-----------------

- swtpm: new, 0.10.1

Package(s) Affected
-------------------

- swtpm: 0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit swtpm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
