### PR TITLE
libsixel: update to 1.10.5

### DIFF
--- a/runtime-imaging/libsixel/autobuild/defines
+++ b/runtime-imaging/libsixel/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libsixel
 PKGSEC=libs
 PKGDEP="curl gdk-pixbuf libgd libjpeg-turbo libpng python-3"
-PKGDES="A SIXEL (terminal graphics and printing format by DEC) codec implementation"
+PKGDES="SIXEL (terminal graphics and printing format by DEC) codec implementation"
 
 AUTOTOOLS_AFTER=(
     '--disable-img2sixel'

--- a/runtime-imaging/libsixel/spec
+++ b/runtime-imaging/libsixel/spec
@@ -1,5 +1,4 @@
-VER=1.8.7
-SRCS="git::commit=tags/v$VER::https://github.com/saitoha/libsixel"
+VER=1.10.5
+SRCS="git::commit=tags/v$VER::https://github.com/libsixel/libsixel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243242"
-REL="1"

--- a/topics/libsixel-1.10.5.toml
+++ b/topics/libsixel-1.10.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libsixel 1.10.5"
+
+[caution]
+default = "Fixes a buffer overflow vulnerability (CVE-2021-40656, Severity: High), a null pointer dereference vulnerability (CVE-2021-45340, Severity: Medium), and stack-based buffer overflow vulnerability (CVE-2025-9300, Severity: Medium)"
+zh_CN = "修复了一个缓冲区溢出漏洞（CVE-2021-40656，严重性：高）、一个空指针解引用漏洞（CVE-2021-45340，严重性：中），以及一个栈缓冲区溢出漏洞（CVE-2025-9300，严重性：中等）"
+
+[packages-v2]
+"libsixel" = "< 1.10.5"


### PR DESCRIPTION
Topic Description
-----------------

- libsixel: update to 1.10.5
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libsixel: 1.10.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsixel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
