### PR TITLE
intel-oneapi-basekit: update to 2025.3.1

### DIFF
--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,6 +1,6 @@
-VER=2025.2.1
-PKG_URL=3b7a16b3-a7b0-460f-be16-de0d64fa6b1e
-PKG_CODE=44
+VER=2025.3.1
+PKG_URL=6caa93ca-e10a-4cc5-b210-68f385feea9e
+PKG_CODE=36
 SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha384::70c259c5a113e0ade58d3b3c33e5917ff2e2057a1ac52772323d241c90b8885b386bd328d6e94a7a3f06ee3c2ca52106"
+CHKSUMS="sha384::5b496bad1bb5d3fc835722931035be83612aa04777c6f6388aaf657f96f3bc671d50a92998da9b0f0c120aeaf877071c"
 CHKUPDATE="anitya::id=372585"


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2025.3.1

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2025.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
