### PR TITLE
capnproto: update to 1.4.0

### DIFF
--- a/app-multimedia/sonic-visualiser/spec
+++ b/app-multimedia/sonic-visualiser/spec
@@ -1,5 +1,5 @@
 VER=5.2.1
-REL=1
+REL=2
 SRCS="tbl::https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v$VER/sonic-visualiser-$VER.tar.gz"
 CHKSUMS="sha256::2f338af0231e930539c5e5e04dac7c3384257866cc29fda112215f8c410898c9"
 CHKUPDATE="anitya::id=4854"

--- a/runtime-common/capnproto/autobuild/defines
+++ b/runtime-common/capnproto/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=capnproto
 PKGSEC=libs
 PKGDEP="gcc-runtime"
 PKGDES="Library for data interchange format and capability-based RPC system"
-PKGBREAK="nextpnr<=1:0.9 sonic-visualiser<=5.2.1"
+PKGBREAK="nextpnr<=1:0.9 sonic-visualiser<=5.2.1-1"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(

--- a/runtime-common/capnproto/spec
+++ b/runtime-common/capnproto/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/capnproto/capnproto"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11515"

--- a/topics/capnproto-1.4.0.toml
+++ b/topics/capnproto-1.4.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Cap'n Proto 1.4.0"
+
+[caution]
+default = "Fixes 2 HTTP request/response smuggling vulnerabilities - CVE-2026-32239, CVE-2026-32240 (Severity: Medium)"
+zh_CN = "修复两个 HTTP 请求响应走私漏洞，漏洞编号 CVE-2026-32239、CVE-2026-32240（严重性：中）"
+
+[packages-v2]
+"capnproto" = "< 1.4.0"


### PR DESCRIPTION
Topic Description
-----------------

- capnproto: update to 1.4.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- capnproto: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit capnproto sonic-visualiser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
