### PR TITLE
vscode: update to 1.113.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.112.0
+VER=1.113.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::0caff3db6dfa18da1dde4bcaf04d2f5b98c7879a33d82ba4fd4a95f37fb6c3b5"
-CHKSUMS__ARM64="sha256::513695d0ac213ddccc4d0295dbb54be636410ae29eb991fba3a2968788972db2"
+CHKSUMS__AMD64="sha256::0daf8199b129ef7c999292fea9ad57dc29a67b75464586a90c777c1de4e10179"
+CHKSUMS__ARM64="sha256::5d2612fb7c3be20acee6665082a97ec50a00f25ac2b2d782902c59be483e252a"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.113.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.113.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
