### PR TITLE
parso: update to 0.8.6

### DIFF
--- a/lang-python/parso/autobuild/defines
+++ b/lang-python/parso/autobuild/defines
@@ -4,7 +4,6 @@ PKGDEP="python-3"
 BUILDDEP="setuptools-python3"
 PKGDES="Python parser that supports error recovery and round-trip parsing for different Python versions"
 
+ABTYPE=pep517
 ABHOST=noarch
-ABTYPE=python
-
 NOPYTHON2=1

--- a/lang-python/parso/spec
+++ b/lang-python/parso/spec
@@ -1,5 +1,4 @@
-VER=0.3.3
-REL="6"
-SRCS="tbl::https://pypi.io/packages/source/p/parso/parso-$VER.tar.gz"
-CHKSUMS="sha256::8162be7570ffb34ec0b8d215d7f3b6c5fab24f51eb3886d6dee362de96b6db94"
+VER=0.8.6
+SRCS="pypi::version=$VER::parso"
+CHKSUMS="sha256::2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd"
 CHKUPDATE="anitya::id=16689"


### PR DESCRIPTION
Topic Description
-----------------

- parso: update to 0.8.6
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- parso: 0.8.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit parso
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
