### PR TITLE
mpmath: update to 1.4.1

### DIFF
--- a/lang-python/gmpy2/autobuild/defines
+++ b/lang-python/gmpy2/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=gmpy2
 PKGSEC=python
-PKGDEP="mpc python-3"
+PKGDEP="python-3"
+BUILDDEP="setuptools setuptools-scm"
 PKGDES="Provides C-coded Python modules for fast multiple-precision arithmetic"
 
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/gmpy2/autobuild/patches/0001-edit-dependencies.patch
+++ b/lang-python/gmpy2/autobuild/patches/0001-edit-dependencies.patch
@@ -1,0 +1,11 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 1f00809..d49b987 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['setuptools>=77,<80', 'setuptools_scm[toml]>=6.0']
++requires = ['setuptools>=77,<81', 'setuptools_scm[toml]>=6.0']
+ build-backend = 'setuptools.build_meta'
+ 
+ [project]

--- a/lang-python/gmpy2/spec
+++ b/lang-python/gmpy2/spec
@@ -1,5 +1,4 @@
-VER=2.2.1
-SRCS="git::commit=tags/v${VER}::https://github.com/aleaxit/gmpy"
+VER=2.3.0
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/aleaxit/gmpy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7789"
-REL="1"

--- a/lang-python/mpmath/autobuild/defines
+++ b/lang-python/mpmath/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=mpmath
 PKGSEC=python
-PKGDEP="gmpy2"
+PKGDEP="python-3"
+PKGSUG="gmpy2"
+BUILDDEP="setuptools-scm"
 PKGDES="Python library for arbitrary-precision floating-point arithmetic"
 
 ABHOST=noarch

--- a/lang-python/mpmath/spec
+++ b/lang-python/mpmath/spec
@@ -1,5 +1,4 @@
-VER=1.1.0
-REL="4"
-SRCS="tbl::https://pypi.io/packages/source/m/mpmath/mpmath-$VER.tar.gz"
-CHKSUMS="sha256::fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6"
+VER=1.4.1
+SRCS="pypi::version=$VER::mpmath"
+CHKSUMS="sha256::efd6d1b75f09d69524a67609949812668b28e81ecbfe0ab449ced8c13e92642e"
 CHKUPDATE="anitya::id=151149"


### PR DESCRIPTION
Topic Description
-----------------

- mpmath: update to 1.4.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- mpmath: 1.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gmpy2 mpmath
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
