### PR TITLE
pyasn1-modules: update to 0.4.2

### DIFF
--- a/lang-python/pyasn1-modules/autobuild/defines
+++ b/lang-python/pyasn1-modules/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=pyasn1-modules
 PKGSEC=python
-PKGDEP="python-3 pyasn1 pyopenssl"
+PKGDEP="python-3 pyasn1"
 BUILDDEP="setuptools"
-PKGDES="Modules for ASN.1 protocol, python bindings"
+PKGDES="ASN.1 modules for Python"
 
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/pyasn1-modules/spec
+++ b/lang-python/pyasn1-modules/spec
@@ -1,5 +1,4 @@
-VER=0.2.8
-SRCS="tbl::https://pypi.io/packages/source/p/pyasn1-modules/pyasn1-modules-$VER.tar.gz"
-CHKSUMS="sha256::905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"
-REL="4"
+VER=0.4.2
+SRCS="pypi::version=$VER::pyasn1-modules"
+CHKSUMS="sha256::677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"
 CHKUPDATE="anitya::id=11987"

--- a/lang-python/pyasn1/spec
+++ b/lang-python/pyasn1/spec
@@ -1,5 +1,4 @@
-VER=0.6.1
-SRCS="tbl::https://pypi.io/packages/source/p/pyasn1/pyasn1-$VER.tar.gz"
-CHKSUMS="sha256::6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"
+VER=0.6.3
+SRCS="pypi::version=$VER::pyasn1"
+CHKSUMS="sha256::697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"
 CHKUPDATE="anitya::id=44489"
-REL="1"

--- a/lang-python/pyopenssl/autobuild/defines
+++ b/lang-python/pyopenssl/autobuild/defines
@@ -4,5 +4,6 @@ PKGDEP="cryptography six"
 BUILDDEP="setuptools python-build wheel python-installer"
 PKGDES="Python wrapper around the OpenSSL library"
 
+ABTYPE=pep517
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/pyopenssl/spec
+++ b/lang-python/pyopenssl/spec
@@ -1,5 +1,4 @@
-VER=25.3.0
-SRCS="https://pypi.io/packages/source/p/pyOpenSSL/pyopenssl-$VER.tar.gz"
-CHKSUMS="sha256::c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329"
+VER=26.0.0
+SRCS="pypi::version=$VER::pyOpenSSL"
+CHKSUMS="sha256::f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc"
 CHKUPDATE="anitya::id=5535"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pyasn1-modules: update to 0.4.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- pyopenssl: update to 26.0.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- pyasn1: update to 0.6.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit pyasn1 pyopenssl pyasn1-modules
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
