### PR TITLE
taglib: update to 2.2.1

### DIFF
--- a/runtime-multimedia/taglib/autobuild/defines
+++ b/runtime-multimedia/taglib/autobuild/defines
@@ -7,7 +7,7 @@ BUILDDEP="utfcpp"
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
     "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_EXAMPLES=ON"
+    "-DBUILD_EXAMPLES=OFF"
 )
 
 PKGBREAK="amarok-trinity<=14.1.2-2 easytag<=2.4.3-5 flacon<=11.4.0 \

--- a/runtime-multimedia/taglib/spec
+++ b/runtime-multimedia/taglib/spec
@@ -1,4 +1,4 @@
-VER=2.0.2
+VER=2.2.1
 SRCS="tbl::https://taglib.github.io/releases/taglib-$VER.tar.gz"
-CHKSUMS="sha256::0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737"
+CHKSUMS="sha256::7e76b5299dcef427c486bffe455098470c8da91cf3ccb9ea804893df57389b5e"
 CHKUPDATE="anitya::id=1982"

--- a/runtime-optenv32/taglib+32/spec
+++ b/runtime-optenv32/taglib+32/spec
@@ -1,4 +1,4 @@
-VER=1.13.1
+VER=2.2.1
 SRCS="tbl::https://taglib.github.io/releases/taglib-$VER.tar.gz"
-CHKSUMS="sha256::c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
+CHKSUMS="sha256::7e76b5299dcef427c486bffe455098470c8da91cf3ccb9ea804893df57389b5e"
 CHKUPDATE="anitya::id=1982"


### PR DESCRIPTION
Topic Description
-----------------

- taglib: update to 2.2.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- taglib: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit taglib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
