### PR TITLE
lfortran: update to 0.61.0

### DIFF
--- a/app-devel/lfortran/spec
+++ b/app-devel/lfortran/spec
@@ -1,5 +1,4 @@
-VER=0.57.0
+VER=0.61.0
 SRCS="tbl::https://github.com/lfortran/lfortran/releases/download/v$VER/lfortran-$VER.tar.gz"
-CHKSUMS="sha256::187e80ff267257332a929eeabf1f7bb4cc348af2e6c54fcae63c3f49d6c392cf"
+CHKSUMS="sha256::e832c1d76c371da7a7e11ef9e7b686d9047788136dcfb20093da5dc165fcd20f"
 CHKUPDATE="anitya::id=370998"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- lfortran: update to 0.61.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- lfortran: 0.61.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lfortran
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
