### PR TITLE
adaptivecpp: update to 25.10.0

### DIFF
--- a/app-devel/adaptivecpp/autobuild/defines
+++ b/app-devel/adaptivecpp/autobuild/defines
@@ -3,24 +3,30 @@ PKGSEC=devel
 PKGDEP="boost gcc-runtime glibc llvm python-3"
 PKGDES="Compiler for C++-based heterogeneous programming models"
 ABTYPE=cmakeninja
-CMAKE_AFTER__BASE=" \
-    -DACPP_COMPILER_FEATURE_PROFILE=full \
-    -DACPP_CONFIG_FILE_GLOBAL_INSTALLATION=ON \
-    -DCMAKE_SKIP_INSTALL_RPATH=OFF \
-    -DWITH_CUDA_BACKEND=OFF \
-    -DWITH_LEVEL_ZERO_BACKEND=OFF \
-    -DWITH_OPENCL_BACKEND=OFF \
-    -DWITH_ROCM_BACKEND=OFF \
-"
+CMAKE_AFTER__BASE=(
+    '-DACPP_COMPILER_FEATURE_PROFILE=full'
+    '-DACPP_CONFIG_FILE_GLOBAL_INSTALLATION=ON'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DWITH_CUDA_BACKEND=OFF'
+    '-DWITH_LEVEL_ZERO_BACKEND=OFF'
+    '-DWITH_OPENCL_BACKEND=OFF'
+    '-DWITH_ROCM_BACKEND=OFF'
+)
 # Note: LLVM supports OpenMP 5.1, newer than GCC's 4.5.
 USECLANG=1
-CMAKE_AFTER=" \
-    ${CMAKE_AFTER__BASE} \
-    -DDEFAULT_TARGETS='omp.accelerated' \
-"
+CMAKE_AFTER=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DDEFAULT_TARGETS=omp.accelerated'
+)
+# FIXME: Clang LTO on riscv64 rejects Minicoro's asm backend (fsd/fld). Use ucontext instead.
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DDEFAULT_TARGETS=omp.accelerated'
+    '-DCMAKE_CXX_FLAGS_INIT=-DMCO_USE_UCONTEXT'
+)
 # FIXME: LLVM OpenMP runtime is not available on loongson3.
 USECLANG__LOONGSON3=0
-CMAKE_AFTER__LOONGSON3=" \
-    ${CMAKE_AFTER__BASE} \
-    -DDEFAULT_TARGETS='omp.library-only' \
-"
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DDEFAULT_TARGETS=omp.library-only'
+)

--- a/app-devel/adaptivecpp/spec
+++ b/app-devel/adaptivecpp/spec
@@ -1,5 +1,4 @@
-VER=25.02.0
-REL="3"
+VER=25.10.0
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/AdaptiveCpp/AdaptiveCpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=176075"


### PR DESCRIPTION
Topic Description
-----------------

- adaptivecpp: update to 25.10.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- adaptivecpp: 25.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit adaptivecpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
