### PR TITLE
grub: add framebuffer rotation support

### DIFF
--- a/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
+++ b/app-admin/grub/autobuild/patches/0001-Revert-templates-Properly-disable-the-os-prober-by-d.patch
@@ -1,7 +1,7 @@
 From e88970e73fd8f08a10fd13483ac2ee49586c1746 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:54 +0200
-Subject: [PATCH 01/75] Revert "templates: Properly disable the os-prober by
+Subject: [PATCH 01/78] Revert "templates: Properly disable the os-prober by
  default"
 
 This reverts commit 54e0a1bbf1e9106901a557195bb35e5e20fb3925.

--- a/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
+++ b/app-admin/grub/autobuild/patches/0002-Revert-templates-Disable-the-os-prober-by-default.patch
@@ -1,7 +1,7 @@
 From 4ff98b915f5603b206ca9cccf0553814c57a02d9 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Fri, 11 Jun 2021 12:10:58 +0200
-Subject: [PATCH 02/75] Revert "templates: Disable the os-prober by default"
+Subject: [PATCH 02/78] Revert "templates: Disable the os-prober by default"
 
 This reverts commit e346414725a70e5c74ee87ca14e580c66f517666.
 ---

--- a/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
+++ b/app-admin/grub/autobuild/patches/0003-Don-t-add-to-highlighted-row.patch
@@ -1,7 +1,7 @@
 From 3e6574ea506f9d1aceda508e156d1b2cd04333a1 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 17:49:45 -0400
-Subject: [PATCH 03/75] Don't add '*' to highlighted row
+Subject: [PATCH 03/78] Don't add '*' to highlighted row
 
 It is already highlighted.
 ---

--- a/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
+++ b/app-admin/grub/autobuild/patches/0004-Fix-border-spacing-now-that-we-aren-t-displaying-it.patch
@@ -1,7 +1,7 @@
 From 6df62e9e0bf85ae25fa59efbc29059a64dac71b7 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:08:23 -0400
-Subject: [PATCH 04/75] Fix border spacing now that we aren't displaying it
+Subject: [PATCH 04/78] Fix border spacing now that we aren't displaying it
 
 ---
  grub-core/normal/menu_text.c | 6 +++---

--- a/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
+++ b/app-admin/grub/autobuild/patches/0005-Indent-menu-entries.patch
@@ -1,7 +1,7 @@
 From 5c7235bde4bb48e21e974fb1c3801d4e08b1552a Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:30:55 -0400
-Subject: [PATCH 05/75] Indent menu entries
+Subject: [PATCH 05/78] Indent menu entries
 
 ---
  grub-core/normal/menu_text.c | 3 ++-

--- a/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
+++ b/app-admin/grub/autobuild/patches/0006-Fix-margins.patch
@@ -1,7 +1,7 @@
 From 2f4a261e8342d96ba4fdda30e6330f5de2283eb7 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 14:59:36 -0400
-Subject: [PATCH 06/75] Fix margins
+Subject: [PATCH 06/78] Fix margins
 
 ---
  grub-core/normal/menu_text.c | 8 +++-----

--- a/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
+++ b/app-admin/grub/autobuild/patches/0007-Use-2-instead-of-1-for-our-right-hand-margin-so-line.patch
@@ -1,7 +1,7 @@
 From 7cdbcd176a51a5112dfb8657cdb6ec7f01d34b64 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 21 Jun 2013 14:44:08 -0400
-Subject: [PATCH 07/75] Use -2 instead of -1 for our right-hand margin, so
+Subject: [PATCH 07/78] Use -2 instead of -1 for our right-hand margin, so
  linewrapping works (#976643).
 
 Signed-off-by: Peter Jones <grub2-owner@fedoraproject.org>

--- a/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
+++ b/app-admin/grub/autobuild/patches/0008-Don-t-say-GNU-Linux-in-generated-menus.patch
@@ -1,7 +1,7 @@
 From eb7eb307f0eb845ee95293cf0eeab2489c3ae70f Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 14 Mar 2011 14:27:42 -0400
-Subject: [PATCH 08/75] Don't say "GNU/Linux" in generated menus.
+Subject: [PATCH 08/78] Don't say "GNU/Linux" in generated menus.
 
 ---
  util/grub.d/10_linux.in     | 4 ++--

--- a/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0009-Don-t-draw-a-border-around-the-menu.patch
@@ -1,7 +1,7 @@
 From 14cb218fc9d996e928d7e1cf4392018bbd0bcf26 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Wed, 15 May 2013 16:47:33 -0400
-Subject: [PATCH 09/75] Don't draw a border around the menu
+Subject: [PATCH 09/78] Don't draw a border around the menu
 
 It looks cleaner without it.
 ---

--- a/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
+++ b/app-admin/grub/autobuild/patches/0010-Use-the-standard-margin-for-the-timeout-string.patch
@@ -1,7 +1,7 @@
 From 9165cb00c269609c823b7bba36667663dad8fe83 Mon Sep 17 00:00:00 2001
 From: William Jon McCann <william.jon.mccann@gmail.com>
 Date: Fri, 7 Jun 2013 10:52:32 -0400
-Subject: [PATCH 10/75] Use the standard margin for the timeout string
+Subject: [PATCH 10/78] Use the standard margin for the timeout string
 
 So that it aligns with the other messages
 ---

--- a/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
+++ b/app-admin/grub/autobuild/patches/0011-grub-mkrescue-specify-iso-level-3.patch
@@ -1,7 +1,7 @@
 From 353077b372583fd82bd9175fbdb12ec3949f68df Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:14 -0800
-Subject: [PATCH 11/75] grub-mkrescue: specify -iso-level 3
+Subject: [PATCH 11/78] grub-mkrescue: specify -iso-level 3
 
 This allows GRUB rescue ISOs to boot on LoongArch firmware.
 ---

--- a/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
+++ b/app-admin/grub/autobuild/patches/0012-10_linux-do-not-count-intel-ucode-image-as-a-valid-i.patch
@@ -1,7 +1,7 @@
 From 66751206633925a70d0cb7ea32c89e28a9cfaad9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:11:42 -0800
-Subject: [PATCH 12/75] 10_linux: do not count intel-ucode image as a valid
+Subject: [PATCH 12/78] 10_linux: do not count intel-ucode image as a valid
  initrd
 
 ---

--- a/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
+++ b/app-admin/grub/autobuild/patches/0013-util-add-GRUB_COLOR_-variables.patch
@@ -1,7 +1,7 @@
 From b64b7e0a816b2163263b90ff85ae8daa8022fcbc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:12:01 -0800
-Subject: [PATCH 13/75] util: add GRUB_COLOR_* variables
+Subject: [PATCH 13/78] util: add GRUB_COLOR_* variables
 
 ---
  util/grub-mkconfig.in    | 2 ++

--- a/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
+++ b/app-admin/grub/autobuild/patches/0014-grub-core-drop-GRUB-title-from-the-menu.patch
@@ -1,7 +1,7 @@
 From 3602577caef6826c20f48cb9f5f6588af1e333fc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.xyz>
 Date: Thu, 28 Dec 2023 22:26:57 -0800
-Subject: [PATCH 14/75] grub-core: drop GRUB title from the menu
+Subject: [PATCH 14/78] grub-core: drop GRUB title from the menu
 
 We did not display it before, and it's really not very useful since we don't
 encourage reinstalling GRUB anyway.

--- a/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
+++ b/app-admin/grub/autobuild/patches/0015-grub-install-add-efi-to-the-candidate-of-the-ESP-mou.patch
@@ -1,7 +1,7 @@
 From 19a18e7dddb513ec52dfa1bd5071543dc1194a45 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Jan 2024 13:58:02 +0800
-Subject: [PATCH 15/75] grub-install: add /efi to the candidate of the ESP
+Subject: [PATCH 15/78] grub-install: add /efi to the candidate of the ESP
  mountpoints
 
 ---

--- a/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
+++ b/app-admin/grub/autobuild/patches/0016-commands-add-new-command-memsize.patch
@@ -1,7 +1,7 @@
 From c0f948f451f969336100e1f4a9b6a79c5691de99 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 10 Nov 2023 10:57:02 +0800
-Subject: [PATCH 16/75] commands: add new command memsize
+Subject: [PATCH 16/78] commands: add new command memsize
 
 - This command traverses the entire GRUB memory map, adds the size of each
   region together. The result is the total amount of system memory

--- a/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
+++ b/app-admin/grub/autobuild/patches/0017-commands-add-new-command-pause.patch
@@ -1,7 +1,7 @@
 From 0a3f263585d911faa0d60e2c8750d5db81a9b15e Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Mon, 10 Jul 2023 00:14:13 +0800
-Subject: [PATCH 17/75] commands: add new command 'pause'
+Subject: [PATCH 17/78] commands: add new command 'pause'
 
 - Simple enough, this command prints out a prompt, either pre-defined or
   user specified, and awaits a key stroke from the user.

--- a/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
+++ b/app-admin/grub/autobuild/patches/0018-normal-align-countdown-text-with-rest-of-the-UI.patch
@@ -1,7 +1,7 @@
 From 16cd91ff2672c9935b691c93ebe4f01e2bb9ad80 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 21:30:22 +0800
-Subject: [PATCH 18/75] normal: align countdown text with rest of the UI
+Subject: [PATCH 18/78] normal: align countdown text with rest of the UI
 
 And add an extra blank line above it.
 ---

--- a/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
+++ b/app-admin/grub/autobuild/patches/0019-po-add-patch-to-disable-parallel-execution.patch
@@ -1,7 +1,7 @@
 From c5404d39a01bacf22fb1a563079b885f82180504 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Jan 2024 22:21:55 +0800
-Subject: [PATCH 19/75] po: add patch to disable parallel execution
+Subject: [PATCH 19/78] po: add patch to disable parallel execution
 
 - `msgfilter' might fail while processing de.po to generate de_CH.po, if
   there are too many prarallel jobs.

--- a/app-admin/grub/autobuild/patches/0020-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
+++ b/app-admin/grub/autobuild/patches/0020-util-grub-mkrescue-use-capitalised-paths-for-removab.patch
@@ -1,7 +1,7 @@
 From bd4d8f29ee747e32c3be7da1b862f1e48dd01c48 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 11 Jun 2024 22:40:24 +0800
-Subject: [PATCH 20/75] util/grub-mkrescue: use capitalised paths for removable
+Subject: [PATCH 20/78] util/grub-mkrescue: use capitalised paths for removable
  EFI images
 
 Per UEFI Specification, section 3.4.1.1:

--- a/app-admin/grub/autobuild/patches/0021-loongarch64-able-to-start-on-legacy-firmware.patch
+++ b/app-admin/grub/autobuild/patches/0021-loongarch64-able-to-start-on-legacy-firmware.patch
@@ -1,7 +1,7 @@
 From 0ef18b6fc26076e00b9deb864931f0b225c289bd Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:16:26 +0800
-Subject: [PATCH 21/75] loongarch64: able to start on legacy firmware
+Subject: [PATCH 21/78] loongarch64: able to start on legacy firmware
 
 On legacy firmware, the DMW is already enabled by the firmware, and the
 addresses in all the pointers and the PC register are virtual addresses.

--- a/app-admin/grub/autobuild/patches/0022-Add-support-for-forcing-EFI-installation-to-the-remo.patch
+++ b/app-admin/grub/autobuild/patches/0022-Add-support-for-forcing-EFI-installation-to-the-remo.patch
@@ -1,7 +1,7 @@
 From 866070c34b3f9d67e5374567182667923171bcca Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 19:29:21 +0800
-Subject: [PATCH 22/75] Add support for forcing EFI installation to the
+Subject: [PATCH 22/78] Add support for forcing EFI installation to the
  removable media path
 
 Add an extra option to grub-install "--force-extra-removable". On EFI

--- a/app-admin/grub/autobuild/patches/0023-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
+++ b/app-admin/grub/autobuild/patches/0023-grub-install-loongarch64-efi-also-install-BOOTLOONGA.patch
@@ -1,7 +1,7 @@
 From bb89bcfbe59b26096a987c65824b9b7d1c7262ef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 14 Aug 2024 19:34:26 +0800
-Subject: [PATCH 23/75] grub-install: (loongarch64-efi) also install
+Subject: [PATCH 23/78] grub-install: (loongarch64-efi) also install
  BOOTLOONGARCH.EFI
 
 Some old-world firmware (especially that of the BPI01000 revision) does not

--- a/app-admin/grub/autobuild/patches/0024-mips64-Add-support-for-64-bit-MIPS.patch
+++ b/app-admin/grub/autobuild/patches/0024-mips64-Add-support-for-64-bit-MIPS.patch
@@ -1,7 +1,7 @@
 From b339138392f98ff0e341d8eb423defa05d06ec6a Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Mon, 9 Jan 2017 14:42:41 +0800
-Subject: [PATCH 24/75] mips64: Add support for 64-bit MIPS.
+Subject: [PATCH 24/78] mips64: Add support for 64-bit MIPS.
 
 ---
  configure.ac                         |  21 +-

--- a/app-admin/grub/autobuild/patches/0025-mips64-Add-support-for-Loongson.patch
+++ b/app-admin/grub/autobuild/patches/0025-mips64-Add-support-for-Loongson.patch
@@ -1,7 +1,7 @@
 From 9407164f6fceff0ffa7992eb337b8ab3cad1db92 Mon Sep 17 00:00:00 2001
 From: Heiher <r@hev.cc>
 Date: Fri, 13 Jan 2017 16:02:41 +0800
-Subject: [PATCH 25/75] mips64: Add support for Loongson.
+Subject: [PATCH 25/78] mips64: Add support for Loongson.
 
 ---
  configure.ac                            |   6 +-

--- a/app-admin/grub/autobuild/patches/0026-loader-mips64-linux-fix-missing-type-args-while-load.patch
+++ b/app-admin/grub/autobuild/patches/0026-loader-mips64-linux-fix-missing-type-args-while-load.patch
@@ -1,7 +1,7 @@
 From 54811b85302fb0d2bfa3a84755538ef7e53b47f4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:59:42 +0800
-Subject: [PATCH 26/75] loader/mips64/linux: fix missing type args while
+Subject: [PATCH 26/78] loader/mips64/linux: fix missing type args while
  loading kernel
 
 ---

--- a/app-admin/grub/autobuild/patches/0027-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
+++ b/app-admin/grub/autobuild/patches/0027-util-grub-mkimagexx-fix-uncorrect-section-var-in-mak.patch
@@ -1,7 +1,7 @@
 From f4bef0a70b24da1594b2957988578e01caaea3a1 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 11:33:13 +0800
-Subject: [PATCH 27/75] util/grub-mkimagexx: fix uncorrect section var in
+Subject: [PATCH 27/78] util/grub-mkimagexx: fix uncorrect section var in
  `make_reloc_section`
 
 ---

--- a/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
+++ b/app-admin/grub/autobuild/patches/0028-loader-mips64-linux-drop-argv-args-when-calling-grub.patch
@@ -1,7 +1,7 @@
 From 3639cb8468b0ffada495a1c0e38375eae8266567 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:03:46 +0800
-Subject: [PATCH 28/75] loader/mips64/linux: drop argv[] args when calling
+Subject: [PATCH 28/78] loader/mips64/linux: drop argv[] args when calling
  grub_initrd_load()
 
 ---

--- a/app-admin/grub/autobuild/patches/0029-lib-mips64-drop-all-efi_call-wrappers.patch
+++ b/app-admin/grub/autobuild/patches/0029-lib-mips64-drop-all-efi_call-wrappers.patch
@@ -1,7 +1,7 @@
 From 1f6f20c3eae695beb15fa94655996cd43fb495cc Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:20:57 +0800
-Subject: [PATCH 29/75] lib/mips64: drop all efi_call wrappers
+Subject: [PATCH 29/78] lib/mips64: drop all efi_call wrappers
 
 ---
  grub-core/kern/mips64/efi/init.c    | 8 ++++----

--- a/app-admin/grub/autobuild/patches/0030-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
+++ b/app-admin/grub/autobuild/patches/0030-lib-mips64-use-a-common-GUID-impl-in-GRUB.patch
@@ -1,7 +1,7 @@
 From 0bd483beeeab454f9553777e5323008e2791e4ff Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:27:17 +0800
-Subject: [PATCH 30/75] lib/mips64: use a common GUID impl in GRUB
+Subject: [PATCH 30/78] lib/mips64: use a common GUID impl in GRUB
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 2 +-

--- a/app-admin/grub/autobuild/patches/0031-kern-mips64-fix-error-catch-output-type-mismatch.patch
+++ b/app-admin/grub/autobuild/patches/0031-kern-mips64-fix-error-catch-output-type-mismatch.patch
@@ -1,7 +1,7 @@
 From 18cf5c51b3866f269cfd920cd78f982b1377a7ee Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Mon, 28 Aug 2023 12:46:18 +0800
-Subject: [PATCH 31/75] kern/mips64: fix error catch output type mismatch
+Subject: [PATCH 31/78] kern/mips64: fix error catch output type mismatch
 
 ---
  grub-core/kern/mips64/dl.c | 2 +-

--- a/app-admin/grub/autobuild/patches/0032-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
+++ b/app-admin/grub/autobuild/patches/0032-kern-mips64-fix-missing-grub_install_get_time_ms-pro.patch
@@ -1,7 +1,7 @@
 From 99b3e5bac2803600e9a29703d4b3b144571dd502 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:01 +0800
-Subject: [PATCH 32/75] kern/mips64: fix missing grub_install_get_time_ms
+Subject: [PATCH 32/78] kern/mips64: fix missing grub_install_get_time_ms
  prototype
 
 ---

--- a/app-admin/grub/autobuild/patches/0033-lib-mips64-silence-werror.patch
+++ b/app-admin/grub/autobuild/patches/0033-lib-mips64-silence-werror.patch
@@ -1,7 +1,7 @@
 From 454af77cba4390bb8031b252d8c03b906e525346 Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:28:28 +0800
-Subject: [PATCH 33/75] lib/mips64: silence werror
+Subject: [PATCH 33/78] lib/mips64: silence werror
 
 ---
  grub-core/lib/mips64/efi/loongson.c | 5 ++++-

--- a/app-admin/grub/autobuild/patches/0034-loader-mips64-fix-warnings-and-style.patch
+++ b/app-admin/grub/autobuild/patches/0034-loader-mips64-fix-warnings-and-style.patch
@@ -1,7 +1,7 @@
 From 2a5822c78d6f8b15759b5774b4dcc2d71d0b080d Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Mon, 7 Oct 2024 15:32:14 +0800
-Subject: [PATCH 34/75] loader/mips64: fix warnings and style
+Subject: [PATCH 34/78] loader/mips64: fix warnings and style
 
 ---
  grub-core/loader/mips64/linux.c | 82 ++++++++++++++++++---------------

--- a/app-admin/grub/autobuild/patches/0035-util-grub-install-mips64el-efi-rename-removable-exec.patch
+++ b/app-admin/grub/autobuild/patches/0035-util-grub-install-mips64el-efi-rename-removable-exec.patch
@@ -1,7 +1,7 @@
 From 3074c0c30e22e96461a682617c228e92dfae7075 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Wed, 9 Oct 2024 15:26:25 +0800
-Subject: [PATCH 35/75] util/grub-install: mips64el-efi: rename removable
+Subject: [PATCH 35/78] util/grub-install: mips64el-efi: rename removable
  executable
 
 as loongson3 machines with 64-bit EFI only accept BOOTMIPS.EFI

--- a/app-admin/grub/autobuild/patches/0036-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
+++ b/app-admin/grub/autobuild/patches/0036-fix-util-grub-mkrescue-fix-EFI-executable-name-for-m.patch
@@ -1,7 +1,7 @@
 From b5ebf83b167df51ed8889deefa1991c831fac572 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 10 Oct 2024 14:40:32 +0800
-Subject: [PATCH 36/75] fix(util/grub-mkrescue): fix EFI executable name for
+Subject: [PATCH 36/78] fix(util/grub-mkrescue): fix EFI executable name for
  mips64el-efi
 
 Loongson 3A4000/3B4000 firmware expects BOOTMIPS.EFI, not bootmips64el.efi.

--- a/app-admin/grub/autobuild/patches/0037-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
+++ b/app-admin/grub/autobuild/patches/0037-grub.d-00-header-disable-graphical-output-for-MacBoo.patch
@@ -1,7 +1,7 @@
 From 609826867aadffa129d06dbadc2981baad9399f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:53:43 +0800
-Subject: [PATCH 37/75] grub.d: 00-header: disable graphical output for
+Subject: [PATCH 37/78] grub.d: 00-header: disable graphical output for
  MacBook6,2
 
 MacBook Pro 15'' (Mid-2010, MacBookPro6,2) are known to have broken

--- a/app-admin/grub/autobuild/patches/0038-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
+++ b/app-admin/grub/autobuild/patches/0038-menu-add-GRUB_RIGHT_TO_SELECT-to-toggle-select-by-ri.patch
@@ -1,7 +1,7 @@
 From 2fd913924369bf463e6671757202c169ce231327 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Nov 2024 19:33:38 +0800
-Subject: [PATCH 38/75] menu: add GRUB_RIGHT_TO_SELECT to toggle
+Subject: [PATCH 38/78] menu: add GRUB_RIGHT_TO_SELECT to toggle
  select-by-right-arrow-key
 
 Normally, GRUB allows using a combination of the Return/Enter (`\n' and

--- a/app-admin/grub/autobuild/patches/0039-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
+++ b/app-admin/grub/autobuild/patches/0039-templates-make-UEFI-fwsetup-menu-entry-label-transla.patch
@@ -1,7 +1,7 @@
 From 56573b2b4fd0933d6f15a67d892cc3c04850d72a Mon Sep 17 00:00:00 2001
 From: Cyan <cyan@cyano.uk>
 Date: Fri, 15 Nov 2024 16:49:55 +0800
-Subject: [PATCH 39/75] templates: make UEFI fwsetup menu entry label
+Subject: [PATCH 39/78] templates: make UEFI fwsetup menu entry label
  translatable
 
 When the "UEFI Firmware Settings" entries was added in commit 46d76f8fe

--- a/app-admin/grub/autobuild/patches/0040-gitignore-reconsider-PO-files-and-grub.pot-template.patch
+++ b/app-admin/grub/autobuild/patches/0040-gitignore-reconsider-PO-files-and-grub.pot-template.patch
@@ -1,7 +1,7 @@
 From c06dea59cf9c10387c7fccd2fae532376d0ad414 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:12 +0800
-Subject: [PATCH 40/75] gitignore: reconsider PO files and grub.pot template
+Subject: [PATCH 40/78] gitignore: reconsider PO files and grub.pot template
 
 ---
  .gitignore | 1 -

--- a/app-admin/grub/autobuild/patches/0041-po-add-PO-files-from-translationproject.org.patch
+++ b/app-admin/grub/autobuild/patches/0041-po-add-PO-files-from-translationproject.org.patch
@@ -1,7 +1,7 @@
 From 855d756f9cd4cbd610dde1492235f97201b7f89c Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 21:50:48 +0800
-Subject: [PATCH 41/75] po: add PO files from translationproject.org
+Subject: [PATCH 41/78] po: add PO files from translationproject.org
 
 To generate grub.pot, you can run the following command:
 

--- a/app-admin/grub/autobuild/patches/0042-po-update-zh_CN-translation.patch
+++ b/app-admin/grub/autobuild/patches/0042-po-update-zh_CN-translation.patch
@@ -1,7 +1,7 @@
 From 9f8fe461e420566dfbdbec23ae27758e72e0ce24 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 16 Nov 2024 22:38:48 +0800
-Subject: [PATCH 42/75] po: update zh_CN translation
+Subject: [PATCH 42/78] po: update zh_CN translation
 
 ---
  po/zh_CN.po | 1314 +++++++++++++++++++++++++++++++++------------------

--- a/app-admin/grub/autobuild/patches/0043-po-update-zh_TW-translations.patch
+++ b/app-admin/grub/autobuild/patches/0043-po-update-zh_TW-translations.patch
@@ -1,7 +1,7 @@
 From 4d449abb28a4957a9e90de13007ff867b160ebf1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 16 Nov 2024 22:46:05 +0800
-Subject: [PATCH 43/75] po: update zh_TW translations
+Subject: [PATCH 43/78] po: update zh_TW translations
 
 Add translation for UEFI Settings.
 ---

--- a/app-admin/grub/autobuild/patches/0044-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
+++ b/app-admin/grub/autobuild/patches/0044-grub.d-30_uefi-firmware-disable-fwsetup-menu-for-mip.patch
@@ -1,7 +1,7 @@
 From 32211360b1a52f724aaa51f308d79d4e10ca8814 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sun, 19 Jan 2025 23:18:56 +0800
-Subject: [PATCH 44/75] grub.d/30_uefi-firmware: disable fwsetup menu for
+Subject: [PATCH 44/78] grub.d/30_uefi-firmware: disable fwsetup menu for
  mips64el-efi
 
 ---

--- a/app-admin/grub/autobuild/patches/0045-loader-mips64-linux-properly-prepare-memory-for-init.patch
+++ b/app-admin/grub/autobuild/patches/0045-loader-mips64-linux-properly-prepare-memory-for-init.patch
@@ -1,7 +1,7 @@
 From 14c355fefcb8d1474b7b1301753b743f0b08e0ad Mon Sep 17 00:00:00 2001
 From: Henry Chen <chenx97@aosc.io>
 Date: Wed, 22 Jan 2025 21:13:13 +0800
-Subject: [PATCH 45/75] loader/mips64/linux: properly prepare memory for initrd
+Subject: [PATCH 45/78] loader/mips64/linux: properly prepare memory for initrd
 
 ... instead of allocating a fixed amount at initialization
 ---

--- a/app-admin/grub/autobuild/patches/0046-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
+++ b/app-admin/grub/autobuild/patches/0046-fix-util-grub-mkimagexx-unconditionaly-use-64-bit-ad.patch
@@ -1,7 +1,7 @@
 From bff9800b71ea5353bc03694272c9695e102462bf Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Fri, 14 Feb 2025 15:23:20 +0800
-Subject: [PATCH 46/75] fix(util/grub-mkimagexx): unconditionaly use 64-bit
+Subject: [PATCH 46/78] fix(util/grub-mkimagexx): unconditionaly use 64-bit
  addresses for mips64el-efi
 
 grub_addr_t uses host pointer size, which becomes undesirable if the host

--- a/app-admin/grub/autobuild/patches/0047-grub.d-10_linux-Use-an-in-house-script-to-generate-l.patch
+++ b/app-admin/grub/autobuild/patches/0047-grub.d-10_linux-Use-an-in-house-script-to-generate-l.patch
@@ -1,7 +1,7 @@
 From fe80c1e44d0913c931447e0da8972df8b94fbe94 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 11 Aug 2025 10:42:41 +0800
-Subject: [PATCH 47/75] grub.d/10_linux: Use an in-house script to generate
+Subject: [PATCH 47/78] grub.d/10_linux: Use an in-house script to generate
  linux menu entries
 
 Now we have to deal with different kernel configurations for each kernel

--- a/app-admin/grub/autobuild/patches/0048-po-update-PO-files.patch
+++ b/app-admin/grub/autobuild/patches/0048-po-update-PO-files.patch
@@ -1,7 +1,7 @@
 From a38a4dc4a654398c9a5b3f3697d056d27c3b25e8 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 3 Sep 2025 12:17:03 +0800
-Subject: [PATCH 48/75] po: update PO files
+Subject: [PATCH 48/78] po: update PO files
 
 ---
  po/ast.po   | 4785 ++++++++++++++++++++++-----------

--- a/app-admin/grub/autobuild/patches/0049-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0049-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From 6c63aa2014a88726e6334398f9517319da8edd33 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2?= <jeffbai@aosc.io>
 Date: Thu, 4 Sep 2025 01:36:34 +0000
-Subject: [PATCH 49/75] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 49/78] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1558 of 1558 strings)

--- a/app-admin/grub/autobuild/patches/0050-10_linux-show-the-latest-kernel-for-each-variant-on-.patch
+++ b/app-admin/grub/autobuild/patches/0050-10_linux-show-the-latest-kernel-for-each-variant-on-.patch
@@ -1,7 +1,7 @@
 From 3ec5dd0d04f422f2e101acce31cff6d1769baccc Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 5 Sep 2025 14:55:45 +0800
-Subject: [PATCH 50/75] 10_linux: show the latest kernel for each variant on
+Subject: [PATCH 50/78] 10_linux: show the latest kernel for each variant on
  toplevel menu
 
 Previously, this script just place the latest kernel in the top level

--- a/app-admin/grub/autobuild/patches/0051-po-process-transliterated-line-breaks-n.patch
+++ b/app-admin/grub/autobuild/patches/0051-po-process-transliterated-line-breaks-n.patch
@@ -1,7 +1,7 @@
 From 697b93a6caf5685ea86bb03d2a6acaca20980bfc Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 5 Sep 2025 18:03:12 +0800
-Subject: [PATCH 51/75] =?UTF-8?q?po:=20process=20transliterated=20line=20b?=
+Subject: [PATCH 51/78] =?UTF-8?q?po:=20process=20transliterated=20line=20b?=
  =?UTF-8?q?reaks:=20\=D0=BD=20->=20\n?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/grub/autobuild/patches/0052-10_linux-show-all-kernels-in-the-submenu.patch
+++ b/app-admin/grub/autobuild/patches/0052-10_linux-show-all-kernels-in-the-submenu.patch
@@ -1,7 +1,7 @@
 From 0eb104c0e22760c382b380c462fb000c7ebb12ce Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 6 Sep 2025 00:17:44 +0800
-Subject: [PATCH 52/75] 10_linux: show all kernels in the submenu
+Subject: [PATCH 52/78] 10_linux: show all kernels in the submenu
 
 ---
  util/grub.d/10_linux.in | 3 +--

--- a/app-admin/grub/autobuild/patches/0053-10_linux-skip-showing-Processing-for-kernels-in-the-.patch
+++ b/app-admin/grub/autobuild/patches/0053-10_linux-skip-showing-Processing-for-kernels-in-the-.patch
@@ -1,7 +1,7 @@
 From dd3ee9626a2de856f6f82e2bc9a584057088e0e7 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 6 Sep 2025 00:17:44 +0800
-Subject: [PATCH 53/75] 10_linux: skip showing 'Processing' for kernels in the
+Subject: [PATCH 53/78] 10_linux: skip showing 'Processing' for kernels in the
  toplevel menu
 
 ---

--- a/app-admin/grub/autobuild/patches/0054-po-update-PO-template-and-translation-files.patch
+++ b/app-admin/grub/autobuild/patches/0054-po-update-PO-template-and-translation-files.patch
@@ -1,7 +1,7 @@
 From 4abfd5f2e159de7957d01e4e38b85577b203bfbb Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 15:45:24 +0800
-Subject: [PATCH 54/75] po: update PO template and translation files
+Subject: [PATCH 54/78] po: update PO template and translation files
 
 ---
  po/ast.po   | 36 ++++++++++++++++++------------------

--- a/app-admin/grub/autobuild/patches/0055-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0055-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From a41769ef3edd86634eaa89504c1c17c438ff2bd9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E7=99=BD=E9=93=AD=E9=AA=A2?= <jeffbai@aosc.io>
 Date: Mon, 8 Sep 2025 07:57:32 +0000
-Subject: [PATCH 55/75] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 55/78] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1558 of 1558 strings)

--- a/app-admin/grub/autobuild/patches/0056-10_linux-fix-the-formatting-of-Booting-and-Loading-K.patch
+++ b/app-admin/grub/autobuild/patches/0056-10_linux-fix-the-formatting-of-Booting-and-Loading-K.patch
@@ -1,7 +1,7 @@
 From 8339cf221d0e9829aeb0ef17090321ca4a29a6cc Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 16:44:12 +0800
-Subject: [PATCH 56/75] 10_linux: fix the formatting of "Booting" and "Loading
+Subject: [PATCH 56/78] 10_linux: fix the formatting of "Booting" and "Loading
  Kernel" prompt
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/app-admin/grub/autobuild/patches/0057-10_linux-add-an-arrow-to-the-submenu-entry.patch
+++ b/app-admin/grub/autobuild/patches/0057-10_linux-add-an-arrow-to-the-submenu-entry.patch
@@ -1,7 +1,7 @@
 From f18e95d1f7d690797035619772d39cfebec4c063 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 8 Sep 2025 16:53:09 +0800
-Subject: [PATCH 57/75] 10_linux: add an arrow to the submenu entry
+Subject: [PATCH 57/78] 10_linux: add an arrow to the submenu entry
 
 ---
  util/grub.d/10_linux.in | 2 +-

--- a/app-admin/grub/autobuild/patches/0058-10_linux-fix-initrd-detection-when-generating-submen.patch
+++ b/app-admin/grub/autobuild/patches/0058-10_linux-fix-initrd-detection-when-generating-submen.patch
@@ -1,7 +1,7 @@
 From e3df9aa4292985880e9b47459f31b3fa6e591e8c Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 12:06:33 +0800
-Subject: [PATCH 58/75] 10_linux: fix initrd detection when generating submenu
+Subject: [PATCH 58/78] 10_linux: fix initrd detection when generating submenu
  entries
 
 The condition that controls the initrd message is awfully wrong. It

--- a/app-admin/grub/autobuild/patches/0059-10_linux-support-btrfs-subvolumes-for-kernel-initrd-.patch
+++ b/app-admin/grub/autobuild/patches/0059-10_linux-support-btrfs-subvolumes-for-kernel-initrd-.patch
@@ -1,7 +1,7 @@
 From 0fe1e4e53122f71c874695c9af8a4401ddc1fd66 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 15:35:46 +0800
-Subject: [PATCH 59/75] 10_linux: support btrfs subvolumes for kernel/initrd
+Subject: [PATCH 59/78] 10_linux: support btrfs subvolumes for kernel/initrd
  paths
 
 ---

--- a/app-admin/grub/autobuild/patches/0060-10_linux-sort-submenu-entries-by-versions.patch
+++ b/app-admin/grub/autobuild/patches/0060-10_linux-sort-submenu-entries-by-versions.patch
@@ -1,7 +1,7 @@
 From e33aae4dcbcb70a531548ee1af6ac1c79b9edce6 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 11 Sep 2025 17:15:15 +0800
-Subject: [PATCH 60/75] 10_linux: sort submenu entries by versions
+Subject: [PATCH 60/78] 10_linux: sort submenu entries by versions
 
 ---
  util/grub.d/10_linux.in | 38 ++++++++++++++++++++++----------------

--- a/app-admin/grub/autobuild/patches/0061-10_linux-strip-leading-whitespaces-when-printing-ker.patch
+++ b/app-admin/grub/autobuild/patches/0061-10_linux-strip-leading-whitespaces-when-printing-ker.patch
@@ -1,7 +1,7 @@
 From 5d3f04591b123613c9ecdb7e4a2fa99d417faf3d Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 12 Sep 2025 00:04:34 +0800
-Subject: [PATCH 61/75] 10_linux: strip leading whitespaces when printing
+Subject: [PATCH 61/78] 10_linux: strip leading whitespaces when printing
  kernel and initrd path
 
 ---

--- a/app-admin/grub/autobuild/patches/0062-10_linux-rework-prioritization-logic.patch
+++ b/app-admin/grub/autobuild/patches/0062-10_linux-rework-prioritization-logic.patch
@@ -1,7 +1,7 @@
 From 878d1f621f06276482fefcf3161ac56fb3b45000 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 2 Oct 2025 23:56:42 +0800
-Subject: [PATCH 62/75] 10_linux: rework prioritization logic
+Subject: [PATCH 62/78] 10_linux: rework prioritization logic
 
 Previously the kernel with default configuration (e.g. -16k for
 LoongArch) will always be on top regardless of its variant, i.e. a 16k

--- a/app-admin/grub/autobuild/patches/0063-10_linux.in-read-etc-os-release-to-specify-OS-class.patch
+++ b/app-admin/grub/autobuild/patches/0063-10_linux.in-read-etc-os-release-to-specify-OS-class.patch
@@ -1,7 +1,7 @@
 From 540bacdb1012366052d7f7c9297bccec0b02ba82 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Fri, 3 Oct 2025 00:07:52 +0800
-Subject: [PATCH 63/75] 10_linux.in: read /etc/os-release to specify OS class
+Subject: [PATCH 63/78] 10_linux.in: read /etc/os-release to specify OS class
 
 Some theme uses OS classes to determine OS type. We missed that in the
 initial rewrite.

--- a/app-admin/grub/autobuild/patches/0064-10_linux-fix-GRUB_KERNEL_DIR-when-using-separate-boo.patch
+++ b/app-admin/grub/autobuild/patches/0064-10_linux-fix-GRUB_KERNEL_DIR-when-using-separate-boo.patch
@@ -1,7 +1,7 @@
 From 63a39dc574e5c9eaaf95a68ee2316dda9052d153 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 11 Oct 2025 17:21:59 +0800
-Subject: [PATCH 64/75] 10_linux: fix GRUB_KERNEL_DIR when using separate /boot
+Subject: [PATCH 64/78] 10_linux: fix GRUB_KERNEL_DIR when using separate /boot
  w/ btrfs
 
 If /boot is on a separate partition, we should use / for

--- a/app-admin/grub/autobuild/patches/0065-Translated-using-Weblate-Esperanto.patch
+++ b/app-admin/grub/autobuild/patches/0065-Translated-using-Weblate-Esperanto.patch
@@ -1,7 +1,7 @@
 From bc8eb71f9826be1cff4b4711c6814a81c11832ad Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 17:42:49 +0800
-Subject: [PATCH 65/75] Translated using Weblate (Esperanto)
+Subject: [PATCH 65/78] Translated using Weblate (Esperanto)
 
 Currently translated at 97.6% (1522 of 1559 strings)
 

--- a/app-admin/grub/autobuild/patches/0066-10_linux-add-comment-string-for-Asahi-kernel.patch
+++ b/app-admin/grub/autobuild/patches/0066-10_linux-add-comment-string-for-Asahi-kernel.patch
@@ -1,7 +1,7 @@
 From 7e624543e95d8e789a7ead88d3d5b911dd37e974 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 18:21:07 +0800
-Subject: [PATCH 66/75] 10_linux: add comment string for Asahi kernel
+Subject: [PATCH 66/78] 10_linux: add comment string for Asahi kernel
 
 * Update PO Template.
 * Merge translations with the PO Template.

--- a/app-admin/grub/autobuild/patches/0067-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
+++ b/app-admin/grub/autobuild/patches/0067-Translated-using-Weblate-Chinese-Simplified-Han-scri.patch
@@ -1,7 +1,7 @@
 From 8d2ff292c074446d7e424098e2aac4157e9c714e Mon Sep 17 00:00:00 2001
 From: Old Dodo <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 10:30:39 +0000
-Subject: [PATCH 67/75] Translated using Weblate (Chinese (Simplified Han
+Subject: [PATCH 67/78] Translated using Weblate (Chinese (Simplified Han
  script))
 
 Currently translated at 100.0% (1561 of 1561 strings)

--- a/app-admin/grub/autobuild/patches/0068-Translated-using-Weblate-Chinese-Traditional-Han-scr.patch
+++ b/app-admin/grub/autobuild/patches/0068-Translated-using-Weblate-Chinese-Traditional-Han-scr.patch
@@ -1,7 +1,7 @@
 From 5782e7560c0c44590e5aa263f04d3c360e8daf0c Mon Sep 17 00:00:00 2001
 From: Old Dodo <cyan@cyano.uk>
 Date: Mon, 27 Oct 2025 10:31:57 +0000
-Subject: [PATCH 68/75] Translated using Weblate (Chinese (Traditional Han
+Subject: [PATCH 68/78] Translated using Weblate (Chinese (Traditional Han
  script))
 
 Currently translated at 22.2% (347 of 1561 strings)

--- a/app-admin/grub/autobuild/patches/0069-po-update-translation-catalogs.patch
+++ b/app-admin/grub/autobuild/patches/0069-po-update-translation-catalogs.patch
@@ -1,7 +1,7 @@
 From 9a69f5e02be993c4ac1ce5f3092c4d4c9a9f7b97 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 19 Jan 2026 10:47:57 +0800
-Subject: [PATCH 69/75] po: update translation catalogs
+Subject: [PATCH 69/78] po: update translation catalogs
 
 ---
  po/de.po    |  925 ++++++++++++++++++++++++++++++++++++++++++++-

--- a/app-admin/grub/autobuild/patches/0070-mips64-relocator-add-some-dummy-func-and-var.patch
+++ b/app-admin/grub/autobuild/patches/0070-mips64-relocator-add-some-dummy-func-and-var.patch
@@ -1,7 +1,7 @@
 From 7c462e0800326ed0a5d5eb99e8eff146026b6cf9 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Fri, 31 Oct 2025 15:56:48 +0800
-Subject: [PATCH 70/75] mips64/relocator: add some dummy func and var
+Subject: [PATCH 70/78] mips64/relocator: add some dummy func and var
 
 fix grub_cpu_relocator_preamble and grub_relocator_preamble_size not defined,
 introduced in 6898fcf74d134d7220c533e476585370f25bc378

--- a/app-admin/grub/autobuild/patches/0071-Revert-configure-Check-linker-for-image-base-support.patch
+++ b/app-admin/grub/autobuild/patches/0071-Revert-configure-Check-linker-for-image-base-support.patch
@@ -1,7 +1,7 @@
 From d4fb7a49f7ca0e2eda68ea75dbc769f73eb407fe Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Tue, 17 Feb 2026 03:58:36 +0800
-Subject: [PATCH 71/75] Revert "configure: Check linker for --image-base
+Subject: [PATCH 71/78] Revert "configure: Check linker for --image-base
  support"
 
 This reverts commit 1a5417f39a0ccefcdd5440f2a67f84d2d2e26960 and should

--- a/app-admin/grub/autobuild/patches/0072-Revert-configure-Print-a-more-helpful-error-if-autoc.patch
+++ b/app-admin/grub/autobuild/patches/0072-Revert-configure-Print-a-more-helpful-error-if-autoc.patch
@@ -1,7 +1,7 @@
 From 43bfd901e87d8ea182dbc9bc684882ba708570a3 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fsf@live.com>
 Date: Tue, 17 Feb 2026 23:39:20 +0800
-Subject: [PATCH 72/75] Revert "configure: Print a more helpful error if
+Subject: [PATCH 72/78] Revert "configure: Print a more helpful error if
  autoconf-archive is not installed"
 
 This reverts commit ac042f3f58d33ce9cd5ff61750f06da1a1d7b0eb.

--- a/app-admin/grub/autobuild/patches/0073-ieee1275-don-t-return-NULL-if-there-is-no-partition.patch
+++ b/app-admin/grub/autobuild/patches/0073-ieee1275-don-t-return-NULL-if-there-is-no-partition.patch
@@ -1,7 +1,7 @@
 From 04358635d191dcb577e0da65dfd5dec64baaf984 Mon Sep 17 00:00:00 2001
 From: AOSC Maintainers <maintainers@aosc.io>
 Date: Wed, 4 Mar 2026 10:28:44 +0000
-Subject: [PATCH 73/75] ieee1275: don't return NULL if there is no partition
+Subject: [PATCH 73/78] ieee1275: don't return NULL if there is no partition
 
 ISOs generated using grub-mkrescue does not contain "partitions", as seen
 in the SLOF firmware which is used in the QEMU pseries machines.

--- a/app-admin/grub/autobuild/patches/0074-loader-mips64-linux-directly-ask-EFI-to-allocate-ini.patch
+++ b/app-admin/grub/autobuild/patches/0074-loader-mips64-linux-directly-ask-EFI-to-allocate-ini.patch
@@ -1,7 +1,7 @@
 From 8c22693055cee21b3ab4af582e921fb71babc422 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Fri, 13 Mar 2026 22:17:39 +0800
-Subject: [PATCH 74/75] loader/mips64/linux: directly ask EFI to allocate
+Subject: [PATCH 74/78] loader/mips64/linux: directly ask EFI to allocate
  initrd memory
 
 Why work around issues of `malloc_in_range` on EFI if we can just

--- a/app-admin/grub/autobuild/patches/0075-10_linux.in-Handle-vanilla_rc-kernel-variant.patch
+++ b/app-admin/grub/autobuild/patches/0075-10_linux.in-Handle-vanilla_rc-kernel-variant.patch
@@ -1,7 +1,7 @@
 From 5476bfcd4a954ae5fd369a41a63b4c70323a8a0d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 15:24:19 +0800
-Subject: [PATCH 75/75] 10_linux.in: Handle vanilla_rc kernel variant
+Subject: [PATCH 75/78] 10_linux.in: Handle vanilla_rc kernel variant
 
 ---
  util/grub.d/10_linux.in | 7 +++++--

--- a/app-admin/grub/autobuild/patches/0076-util-grub-mkconfig-Add-GRUB_FB_ROTATION-configuratio.patch
+++ b/app-admin/grub/autobuild/patches/0076-util-grub-mkconfig-Add-GRUB_FB_ROTATION-configuratio.patch
@@ -1,0 +1,104 @@
+From 350fb0cba401ca0896719eca0eb5857dbbf5fca3 Mon Sep 17 00:00:00 2001
+From: kbader94 <kyle.bader94@gmail.com>
+Date: Wed, 29 May 2024 22:00:21 -0600
+Subject: [PATCH 76/78] util/grub-mkconfig: Add GRUB_FB_ROTATION configuration
+ option
+
+Adds config support for setting framebuffer rotation
+via the GRUB config.
+
+- `util/grub-mkconfig.in`: exports `GRUB_FB_ROTATION`
+- `util/grub.d/00_header.in`: evaluates the env var and sets rotation
+- `util/grub.d/10_linux.in`: passes the rotation setting to Linux when
+  `GRUB_GFXPAYLOAD_LINUX=keep` is used
+
+Supported values:
+  - Degrees: `90`, `180`, `270`
+  - Aliases: `right`, `inverted`, `left`
+
+[ CyberNeko-AI: Rebased and adapted `util/grub.d/10_linux.in` to
+  successfully integrate the framebuffer rotation parameters into
+  AOSC OS's kernel discovery and associative array menu generation
+  logic. ]
+
+Signed-off-by: Kyle Bader <kyle.bader94@gmail.com>
+Signed-off-by: CyberNeko-AI <cyberneko.ai@aosc.io>
+---
+ util/grub-mkconfig.in    |  1 +
+ util/grub.d/00_header.in | 16 ++++++++++++++++
+ util/grub.d/10_linux.in  | 13 +++++++++++++
+ 3 files changed, 30 insertions(+)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index 3af30beee..1c025eedd 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -243,6 +243,7 @@ export GRUB_DEFAULT \
+   GRUB_DISABLE_RECOVERY \
+   GRUB_VIDEO_BACKEND \
+   GRUB_GFXMODE \
++  GRUB_FB_ROTATION \
+   GRUB_BACKGROUND \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
+diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
+index 0de7101d1..8b3e47352 100644
+--- a/util/grub.d/00_header.in
++++ b/util/grub.d/00_header.in
+@@ -27,6 +27,21 @@ export TEXTDOMAINDIR="@localedir@"
+ 
+ . "$pkgdatadir/grub-mkconfig_lib"
+ 
++# Set fb rotation for grub
++if [ "x$GRUB_FB_ROTATION" != x ]; then
++    case "${GRUB_FB_ROTATION}" in
++        inverted | 180)
++    echo "set rotation=180"
++            ;;
++        left | 90)
++    echo "set rotation=90"
++            ;;
++        right | 270)
++    echo "set rotation=270"
++            ;;
++    esac
++fi
++
+ # Do this as early as possible, since other commands might depend on it.
+ # (e.g. the `loadfont' command might need lvm or raid modules)
+ for i in ${GRUB_PRELOAD_MODULES} ; do
+@@ -55,6 +70,7 @@ if [ "\${env_block}" ] ; then
+ fi
+ 
+ EOF
++
+ if [ "x$GRUB_BUTTON_CMOS_ADDRESS" != "x" ]; then
+     cat <<EOF
+ if cmostest $GRUB_BUTTON_CMOS_ADDRESS ; then
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index ba393094b..dccfb6bd9 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -212,6 +212,19 @@ linux_entry() {
+ 	local args="$4"
+ 	local _id="$5"
+ 	local os_class="$(get_os_id)"
++
++	case "${GRUB_FB_ROTATION}" in
++		inverted | 180)
++			args="$args fbcon=rotate:2"
++			;;
++		left | 90)
++			args="$args fbcon=rotate:3"
++			;;
++		right | 270)
++			args="$args fbcon=rotate:1"
++			;;
++	esac
++
+ 	if [ ! -z "$os_class" ];  then
+ 		os_class="--class $(echo $os_class | grub_quote)"
+ 	fi
+-- 
+2.52.0
+

--- a/app-admin/grub/autobuild/patches/0077-video-fb-video_fb-Support-2D-dirty-regions-for-parti.patch
+++ b/app-admin/grub/autobuild/patches/0077-video-fb-video_fb-Support-2D-dirty-regions-for-parti.patch
@@ -1,0 +1,317 @@
+From b3077dce40e9863ab19ddcac0c90fb7888233d2b Mon Sep 17 00:00:00 2001
+From: kbader94 <kyle.bader94@gmail.com>
+Date: Tue, 28 May 2024 17:40:35 -0600
+Subject: [PATCH 77/78] video/fb/video_fb: Support 2D dirty regions for partial
+ screen updates
+
+    GRUB previously tracked only vertical (Y-span) dirty regions,
+    causing entire pixel rows to be refreshed when even a small region
+    changed.
+
+    This patch introduces 2D rectangle-based tracking for screen updates,
+    allowing minimal partial updates and simplifying future work applying
+    rotation transformations to framebuffer drawing operations.
+
+    - Modifies `video_fb.c` to track (x, y, width, height) dirty rectangles
+    - Updates `doublebuf_*_update_screen()` to use the new region tracking
+    - Updates the `dirty` function signature to accept `x` and `width`
+
+    This patch is required to be applied first before other patches
+    in the Frambuffer Rotation patch series.
+
+Signed-off-by: Kyle Bader <kyle.bader94@gmail.com>
+---
+ grub-core/video/fb/video_fb.c | 199 +++++++++++++++++++++-------------
+ 1 file changed, 122 insertions(+), 77 deletions(-)
+
+diff --git a/grub-core/video/fb/video_fb.c b/grub-core/video/fb/video_fb.c
+index fa4ebde26..d17c47b11 100644
+--- a/grub-core/video/fb/video_fb.c
++++ b/grub-core/video/fb/video_fb.c
+@@ -31,13 +31,6 @@ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+ typedef grub_err_t (*grub_video_fb_doublebuf_update_screen_t) (void);
+ typedef volatile void *framebuf_t;
+-
+-struct dirty
+-{
+-  int first_line;
+-  int last_line;
+-};
+-
+ static struct
+ {
+   struct grub_video_fbrender_target *render_target;
+@@ -47,8 +40,8 @@ static struct
+ 
+   unsigned int palette_size;
+ 
+-  struct dirty current_dirty;
+-  struct dirty previous_dirty;
++  struct grub_video_rect current_dirty;
++  struct grub_video_rect previous_dirty;
+ 
+   /* For page flipping strategy.  */
+   int displayed_page;           /* The page # that is the front buffer.  */
+@@ -831,14 +824,36 @@ grub_video_fb_unmap_color_int (struct grub_video_fbblit_info * source,
+ }
+ 
+ static void
+-dirty (int y, int height)
++dirty (int x, int y, int width, int height)
+ {
++  
++  grub_video_rect_t *current_dirty = &framebuffer.current_dirty;
++  grub_video_rect_t dirty_rect = {
++    .x = x,
++    .y = y,
++    .width = width,
++    .height = height
++  };
++
+   if (framebuffer.render_target != framebuffer.back_target)
+     return;
+-  if (framebuffer.current_dirty.first_line > y)
+-    framebuffer.current_dirty.first_line = y;
+-  if (framebuffer.current_dirty.last_line < y + height)
+-    framebuffer.current_dirty.last_line = y + height;
++
++  /* extend dirty_rect bounds if dirty x min is less than current x */
++  if (dirty_rect.x < current_dirty->x) 
++    current_dirty->x = dirty_rect.x;
++
++  /* extend dirty_rect bounds if dirty x max is greater than current width */
++  if (dirty_rect.x + dirty_rect.width > current_dirty->x + current_dirty->width)
++    current_dirty->width = (dirty_rect.x + dirty_rect.width) - current_dirty->x;
++
++  /* extend dirty_rect bounds if dirty y min is less than current y */
++  if (dirty_rect.y < current_dirty->y)
++    current_dirty->y = dirty_rect.y;
++
++  /* extend dirty_rect bounds if dirty y max is greater than current height */
++  if (dirty_rect.y + dirty_rect.height > current_dirty->y + current_dirty->height)
++    current_dirty->height = (dirty_rect.y + dirty_rect.height) - current_dirty->y;
++
+ }
+ 
+ grub_err_t
+@@ -896,7 +911,7 @@ grub_video_fb_fill_rect (grub_video_color_t color, int x, int y,
+   x += area_x;
+   y += area_y;
+ 
+-  dirty (y, height);
++  dirty (x, y, width, height);
+ 
+   /* Use fbblit_info to encapsulate rendering.  */
+   target.mode_info = &framebuffer.render_target->mode_info;
+@@ -1008,8 +1023,7 @@ grub_video_fb_blit_source (struct grub_video_fbblit_info *source,
+   target.mode_info = &framebuffer.render_target->mode_info;
+   target.data = framebuffer.render_target->data;
+ 
+-  /* Do actual blitting.  */
+-  dirty (y, height);
++  dirty (x, y, width, height);
+   grub_video_fb_dispatch_blit (&target, source, oper, x, y, width, height,
+                                offset_x, offset_y);
+ 
+@@ -1061,7 +1075,9 @@ grub_video_fb_scroll (grub_video_color_t color, int dx, int dy)
+   width = framebuffer.render_target->viewport.width - grub_abs (dx);
+   height = framebuffer.render_target->viewport.height - grub_abs (dy);
+ 
+-  dirty (framebuffer.render_target->viewport.y,
++  dirty (framebuffer.render_target->viewport.x,
++	 framebuffer.render_target->viewport.y,
++   framebuffer.render_target->viewport.width,
+ 	 framebuffer.render_target->viewport.height);
+ 
+   if (dx < 0)
+@@ -1416,28 +1432,33 @@ grub_video_fb_get_active_render_target (struct grub_video_fbrender_target **targ
+ static grub_err_t
+ doublebuf_blit_update_screen (void)
+ {
+-  if (framebuffer.current_dirty.first_line
+-      <= framebuffer.current_dirty.last_line)
+-    {
+-      grub_size_t copy_size;
+-
+-      if (grub_sub (framebuffer.current_dirty.last_line,
+-		    framebuffer.current_dirty.first_line, &copy_size) ||
+-	  grub_mul (framebuffer.back_target->mode_info.pitch, copy_size, &copy_size))
+-	{
+-	  /* Shouldn't happen, but if it does we've a bug. */
+-	  return GRUB_ERR_BUG;
+-	}
+-
+-      grub_memcpy ((char *) framebuffer.pages[0] + framebuffer.current_dirty.first_line *
+-		   framebuffer.back_target->mode_info.pitch,
+-		   (char *) framebuffer.back_target->data + framebuffer.current_dirty.first_line *
+-		   framebuffer.back_target->mode_info.pitch,
+-		   copy_size);
++  if (framebuffer.current_dirty.height > 0 || framebuffer.current_dirty.width > 0) {
++    /* dirty row size in bytes */
++    grub_size_t row_size = framebuffer.current_dirty.width 
++                           * framebuffer.back_target->mode_info.bytes_per_pixel;
++
++    /* address of dirty_rect origin on render target */
++    char *src_base = (char *)framebuffer.back_target->data + framebuffer.current_dirty.y
++                      * framebuffer.back_target->mode_info.pitch + framebuffer.current_dirty.x
++                      * framebuffer.back_target->mode_info.bytes_per_pixel;
++
++    /* address of dirty_rect origin on display target */
++    char *dst_base = (char *)framebuffer.pages[0] + framebuffer.current_dirty.y
++                      * framebuffer.back_target->mode_info.pitch + framebuffer.current_dirty.x
++                      * framebuffer.back_target->mode_info.bytes_per_pixel;
++
++    /* blit each row from render_target to display */
++    grub_size_t pitch = framebuffer.back_target->mode_info.pitch;
++    for (unsigned int y = 0; y < framebuffer.current_dirty.height; y++) {
++      grub_memcpy(dst_base + y * pitch, src_base + y * pitch, row_size);
+     }
+-  framebuffer.current_dirty.first_line
+-    = framebuffer.back_target->mode_info.height;
+-  framebuffer.current_dirty.last_line = 0;
++  }
++
++  /* reset current_dirty rect */
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.height = 0;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.width = 0;
+ 
+   return GRUB_ERR_NONE;
+ }
+@@ -1470,8 +1491,10 @@ grub_video_fb_doublebuf_blit_init (struct grub_video_fbrender_target **back,
+   framebuffer.pages[0] = framebuf;
+   framebuffer.displayed_page = 0;
+   framebuffer.render_page = 0;
+-  framebuffer.current_dirty.first_line = mode_info.height;
+-  framebuffer.current_dirty.last_line = 0;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.height = 0;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.width = 0;
+ 
+   return GRUB_ERR_NONE;
+ }
+@@ -1481,37 +1504,52 @@ doublebuf_pageflipping_update_screen (void)
+ {
+   int new_displayed_page;
+   grub_err_t err;
+-  int first_line, last_line;
+-
+-  first_line = framebuffer.current_dirty.first_line;
+-  last_line = framebuffer.current_dirty.last_line;
+-  if (first_line > framebuffer.previous_dirty.first_line)
+-    first_line = framebuffer.previous_dirty.first_line;
+-  if (last_line < framebuffer.previous_dirty.last_line)
+-    last_line = framebuffer.previous_dirty.last_line;
+ 
+-  if (first_line <= last_line)
+-    {
+-      grub_size_t copy_size;
+-
+-      if (grub_sub (last_line, first_line, &copy_size) ||
+-	  grub_mul (framebuffer.back_target->mode_info.pitch, copy_size, &copy_size))
+-	{
+-	  /* Shouldn't happen, but if it does we've a bug. */
+-	  return GRUB_ERR_BUG;
+-	}
+-
+-      grub_memcpy ((char *) framebuffer.pages[framebuffer.render_page] + first_line *
+-		   framebuffer.back_target->mode_info.pitch,
+-		   (char *) framebuffer.back_target->data + first_line *
+-		   framebuffer.back_target->mode_info.pitch,
+-		   copy_size);
++  /* compare current and previous dirty_rects, and use greatest extents */
++  unsigned int min_x = framebuffer.current_dirty.x;
++  unsigned int min_y = framebuffer.current_dirty.y;
++  unsigned int max_x = framebuffer.current_dirty.x + framebuffer.current_dirty.width;
++  unsigned int max_y = framebuffer.current_dirty.y + framebuffer.current_dirty.height;  
++  if (framebuffer.previous_dirty.x < min_x)
++    min_x = framebuffer.previous_dirty.x;
++  if (framebuffer.previous_dirty.y < min_y)
++    min_y = framebuffer.previous_dirty.y;
++  if (framebuffer.previous_dirty.x + framebuffer.previous_dirty.width > max_x)
++    max_x = framebuffer.previous_dirty.x + framebuffer.previous_dirty.width;
++  if (framebuffer.previous_dirty.y + framebuffer.previous_dirty.height > max_y)
++    max_y = framebuffer.previous_dirty.y + framebuffer.previous_dirty.height;
++  int dirty_width = max_x - min_x;
++  int dirty_height = max_y - min_y;
++
++  /* check if there is anything to do */
++  if (dirty_width > 0 && dirty_height > 0) {
++    /* byte size of dirty row */
++    grub_size_t row_size = dirty_width 
++                          * framebuffer.back_target->mode_info.bytes_per_pixel;
++
++    /* render target base address */
++    char *src_base = (char *)framebuffer.back_target->data + min_y
++                      * framebuffer.back_target->mode_info.pitch + min_x 
++                      * framebuffer.back_target->mode_info.bytes_per_pixel;
++
++    /* display target base address */
++    char *dst_base = (char *)framebuffer.pages[framebuffer.render_page] + min_y 
++                      * framebuffer.back_target->mode_info.pitch + min_x
++                      * framebuffer.back_target->mode_info.bytes_per_pixel;
++
++    /* blit each row from render_target to display */
++    grub_size_t pitch = framebuffer.back_target->mode_info.pitch;
++    for (int y = 0; y < dirty_height; y++) {
++      grub_memcpy(dst_base + y * pitch, src_base + y * pitch, row_size);
+     }
++  }
+ 
++  /* reset current_dirty rect */
+   framebuffer.previous_dirty = framebuffer.current_dirty;
+-  framebuffer.current_dirty.first_line
+-    = framebuffer.back_target->mode_info.height;
+-  framebuffer.current_dirty.last_line = 0;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.height = 0;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.width = 0;
+ 
+   /* Swap the page numbers in the framebuffer struct.  */
+   new_displayed_page = framebuffer.render_page;
+@@ -1570,12 +1608,17 @@ doublebuf_pageflipping_init (struct grub_video_mode_info *mode_info,
+   framebuffer.pages[0] = page0_ptr;
+   framebuffer.pages[1] = page1_ptr;
+ 
+-  framebuffer.current_dirty.first_line
+-    = framebuffer.back_target->mode_info.height;
+-  framebuffer.current_dirty.last_line = 0;
+-  framebuffer.previous_dirty.first_line
+-    = framebuffer.back_target->mode_info.height;
+-  framebuffer.previous_dirty.last_line = 0;
++  /* reset current_dirty rect */
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.height = 0;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.width = 0;
++
++   /* reset previous_dirty rect */
++  framebuffer.previous_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.previous_dirty.height = 0;
++  framebuffer.previous_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.previous_dirty.width = 0;
+ 
+   /* Set the framebuffer memory data pointer and display the right page.  */
+   err = set_page_in (framebuffer.displayed_page);
+@@ -1661,9 +1704,11 @@ grub_video_fb_setup (unsigned int mode_type, unsigned int mode_mask,
+   framebuffer.displayed_page = 0;
+   framebuffer.render_page = 0;
+   framebuffer.set_page = 0;
+-  framebuffer.current_dirty.first_line
+-    = framebuffer.back_target->mode_info.height;
+-  framebuffer.current_dirty.last_line = 0;
++ /* reset transformed_add_rect */
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.height = 0;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.width = 0;
+ 
+   mode_info->mode_type &= ~GRUB_VIDEO_MODE_TYPE_DOUBLE_BUFFERED;
+ 
+-- 
+2.52.0
+

--- a/app-admin/grub/autobuild/patches/0078-video_fb-Implement-framebuffer-rotation-transforms.patch
+++ b/app-admin/grub/autobuild/patches/0078-video_fb-Implement-framebuffer-rotation-transforms.patch
@@ -1,0 +1,631 @@
+From 628be2473b61fdf7b45df2f493aae3ccbd9cbe06 Mon Sep 17 00:00:00 2001
+From: kbader94 <kyle.bader94@gmail.com>
+Date: Tue, 28 May 2024 19:38:58 -0600
+Subject: [PATCH 78/78] video_fb: Implement framebuffer rotation transforms
+
+    Adds rotation-aware rendering to framebuffer drawing operations.
+
+    - Introduces `rotation`, `original_width`, and `original_height`
+      to `grub_video_mode_info`
+    - Updates all framebuffer operations (`blit`, `fill`, `scroll`, `dirty`)
+      to apply rotation transforms
+
+    Key implementation points:
+
+    - `grub_video_fb_create_render_target_from_pointer()` assumes the
+      target is the framebuffer and sets the configured rotation
+    - `grub_video_fb_create_render_target()` is used for off-screen
+      render targets and always disables rotation
+    - Off-screen render targets explicitly set `rotation = NONE`
+
+    TODO:
+
+    - `grub_video_fb_dispatch_blit' Uses unoptimized default(slow) blitter when rotation
+    env_var is provided. Optimized blitters currently do not support transformed coordinates.
+
+Signed-off-by: Kyle Bader <kyle.bader94@gmail.com>
+---
+ grub-core/video/fb/fbblit.c   |  72 +++++++++++++++++-
+ grub-core/video/fb/fbfill.c   |  28 ++++---
+ grub-core/video/fb/fbutil.c   |  68 +++++++++++++++++
+ grub-core/video/fb/video_fb.c | 136 +++++++++++++++++++++-------------
+ include/grub/fbutil.h         |   7 ++
+ include/grub/video.h          |  20 ++++-
+ 6 files changed, 266 insertions(+), 65 deletions(-)
+
+diff --git a/grub-core/video/fb/fbblit.c b/grub-core/video/fb/fbblit.c
+index 1010ef393..fe812383f 100644
+--- a/grub-core/video/fb/fbblit.c
++++ b/grub-core/video/fb/fbblit.c
+@@ -62,7 +62,8 @@ grub_video_fbblit_replace (struct grub_video_fbblit_info *dst,
+ 	  dst_color = grub_video_fb_map_rgba (src_red, src_green,
+ 					      src_blue, src_alpha);
+ 
+-	  set_pixel (dst, x + i, y + j, dst_color);
++	  set_pixel (dst, x + trans_x(i, j, dst->mode_info), 
++               y + trans_y(i,j, dst->mode_info), dst_color);
+ 	}
+     }
+ }
+@@ -1195,11 +1196,13 @@ grub_video_fbblit_blend (struct grub_video_fbblit_info *dst,
+             {
+               dst_color = grub_video_fb_map_rgba (src_red, src_green,
+ 						  src_blue, src_alpha);
+-              set_pixel (dst, x + i, y + j, dst_color);
++              set_pixel (dst, x + trans_x(i, j, dst->mode_info), 
++                         y + trans_y(i,j, dst->mode_info), dst_color);
+               continue;
+             }
+ 
+-          dst_color = get_pixel (dst, x + i, y + j);
++          dst_color = get_pixel (dst, x + trans_x(i, j, dst->mode_info), 
++                                 y + trans_y(i,j, dst->mode_info));
+ 
+           grub_video_fb_unmap_color_int (dst, dst_color, &dst_red,
+ 					 &dst_green, &dst_blue, &dst_alpha);
+@@ -1212,7 +1215,8 @@ grub_video_fbblit_blend (struct grub_video_fbblit_info *dst,
+           dst_color = grub_video_fb_map_rgba (dst_red, dst_green, dst_blue,
+ 					      dst_alpha);
+ 
+-          set_pixel (dst, x + i, y + j, dst_color);
++          set_pixel (dst, x + trans_x(i, j, dst->mode_info), 
++                     y + trans_y(i,j, dst->mode_info), dst_color);
+         }
+     }
+ }
+@@ -1936,6 +1940,66 @@ grub_video_fb_dispatch_blit (struct grub_video_fbblit_info *target,
+ 			     unsigned int width, unsigned int height,
+ 			     int offset_x, int offset_y)
+ {
++  if (target->mode_info->rotation == GRUB_VIDEO_ROTATE_90)
++  {
++    int nx = y;
++    int ny = target->mode_info->width - x - 1;
++    if (oper == GRUB_VIDEO_BLIT_REPLACE)
++    {
++      /* No optimized replace operator found, use default (slow) blitter.  */
++      grub_video_fbblit_replace(target, source, nx, ny, width, height,
++                                offset_x, offset_y);
++      return;
++    }
++    else
++    {
++      /* No optimized replace operator found, use default (slow) blitter.  */
++      grub_video_fbblit_blend(target, source, nx, ny, width, height,
++                              offset_x, offset_y);
++      return;
++    }
++  }
++
++  if (target->mode_info->rotation == GRUB_VIDEO_ROTATE_180)
++  {
++    int nx = target->mode_info->width - x - 1;
++    int ny = target->mode_info->height - y - 1;
++    if (oper == GRUB_VIDEO_BLIT_REPLACE)
++    {
++      /* No optimized replace operator found, use default (slow) blitter.  */
++      grub_video_fbblit_replace(target, source, nx, ny, width, height,
++                                offset_x, offset_y);
++      return;
++    }
++    else
++    {
++      /* No optimized replace operator found, use default (slow) blitter.  */
++      grub_video_fbblit_blend(target, source, nx, ny, width, height,
++                              offset_x, offset_y);
++      return;
++    }
++  }
++
++  if (target->mode_info->rotation == GRUB_VIDEO_ROTATE_270)
++  {
++    int nx = target->mode_info->height - y - 1;
++    int ny = x;
++    if (oper == GRUB_VIDEO_BLIT_REPLACE)
++    {
++      /* No optimized replace operator found, use default (slow) blitter.  */
++      grub_video_fbblit_replace(target, source, nx, ny, width, height,
++                                offset_x, offset_y);
++      return;
++    }
++    else
++    {
++      /* No optimized replace operator found, use default (slow) blitter.  */
++      grub_video_fbblit_blend(target, source, nx, ny, width, height,
++                              offset_x, offset_y);
++      return;
++    }
++  }
++
+   if (oper == GRUB_VIDEO_BLIT_REPLACE)
+     {
+       /* Try to figure out more optimized version for replace operator.  */
+diff --git a/grub-core/video/fb/fbfill.c b/grub-core/video/fb/fbfill.c
+index 49fa16b92..4a67e2379 100644
+--- a/grub-core/video/fb/fbfill.c
++++ b/grub-core/video/fb/fbfill.c
+@@ -185,28 +185,38 @@ grub_video_fb_fill_dispatch (struct grub_video_fbblit_info *target,
+ 			     grub_video_color_t color, int x, int y,
+ 			     unsigned int width, unsigned int height)
+ {
++  grub_video_rect_t orig = {
++    .x = x,
++    .y = y,
++    .width = width,
++    .height = height
++  };
++  grub_video_rect_t fill_rect = grub_video_transform_rectangle (orig, target->mode_info);
++  
+   /* Try to figure out more optimized version.  Note that color is already
+      mapped to target format so we can make assumptions based on that.  */
+   switch (target->mode_info->bytes_per_pixel)
+     {
+     case 4:
+-      grub_video_fbfill_direct32 (target, color, x, y,
+-				  width, height);
++      grub_video_fbfill_direct32 (target, color, fill_rect.x, fill_rect.y,
++				                          fill_rect.width, fill_rect.height);
+       return;
+     case 3:
+-      grub_video_fbfill_direct24 (target, color, x, y,
+-				  width, height);
++      grub_video_fbfill_direct24 (target, color, fill_rect.x, fill_rect.y,
++				                          fill_rect.width, fill_rect.height);
++      return;
+       return;
+     case 2:
+-      grub_video_fbfill_direct16 (target, color, x, y,
+-                                        width, height);
++      grub_video_fbfill_direct16 (target, color, fill_rect.x, fill_rect.y,
++				                          fill_rect.width, fill_rect.height);
+       return;
+     case 1:
+-      grub_video_fbfill_direct8 (target, color, x, y,
+-				       width, height);
++      grub_video_fbfill_direct8 (target, color, fill_rect.x, fill_rect.y,
++				                         fill_rect.width, fill_rect.height);
+       return;
+     }
+ 
+   /* No optimized version found, use default (slow) filler.  */
+-  grub_video_fbfill (target, color, x, y, width, height);
++  grub_video_fbfill  (target, color, fill_rect.x, fill_rect.y,
++				  fill_rect.width, fill_rect.height);
+ }
+diff --git a/grub-core/video/fb/fbutil.c b/grub-core/video/fb/fbutil.c
+index 25ef39f47..c12fa6e96 100644
+--- a/grub-core/video/fb/fbutil.c
++++ b/grub-core/video/fb/fbutil.c
+@@ -149,3 +149,71 @@ set_pixel (struct grub_video_fbblit_info *source,
+       break;
+     }
+ }
++
++int trans_x (int x, int y, struct grub_video_mode_info *mode_info)
++{
++  switch (mode_info->rotation)
++  {
++  case GRUB_VIDEO_ROTATE_90:
++    return y;
++  case GRUB_VIDEO_ROTATE_180:
++    return -x;
++  case GRUB_VIDEO_ROTATE_270:
++    return -y;
++  case GRUB_VIDEO_ROTATE_NONE:
++  default:
++    return x;
++  }
++}
++
++int trans_y(int x, int y, struct grub_video_mode_info *mode_info)
++{
++  switch (mode_info->rotation)
++  {
++  case GRUB_VIDEO_ROTATE_90:
++    return -x;
++  case GRUB_VIDEO_ROTATE_180:
++    return -y;
++  case GRUB_VIDEO_ROTATE_270:
++    return x;
++  case GRUB_VIDEO_ROTATE_NONE:
++  default:
++    return y;
++  }
++}
++
++grub_video_rect_t
++grub_video_transform_rectangle (grub_video_rect_t r,
++                                const struct grub_video_mode_info *mode_info)
++{
++  grub_video_rect_t n;
++
++  switch (mode_info->rotation)
++    {
++    case GRUB_VIDEO_ROTATE_NONE:
++      return r;
++
++    case GRUB_VIDEO_ROTATE_90:
++      n.width = r.height;
++      n.height = r.width;
++      n.x = r.y;
++      n.y = mode_info->width - r.x - r.width;
++      return n;
++
++    case GRUB_VIDEO_ROTATE_180:
++      n.width = r.width;
++      n.height = r.height;
++      n.x = mode_info->width - r.x - r.width;
++      n.y = mode_info->height - r.y - r.height;
++      return n;
++
++    case GRUB_VIDEO_ROTATE_270:
++      n.width = r.height;
++      n.height = r.width;
++      n.x = mode_info->height - r.y - r.height;
++      n.y = r.x;
++      return n;
++    }
++
++  return r;
++}
+diff --git a/grub-core/video/fb/video_fb.c b/grub-core/video/fb/video_fb.c
+index d17c47b11..907c2cfb6 100644
+--- a/grub-core/video/fb/video_fb.c
++++ b/grub-core/video/fb/video_fb.c
+@@ -26,6 +26,7 @@
+ #include <grub/bitmap.h>
+ #include <grub/dl.h>
+ #include <grub/safemath.h>
++#include <grub/env.h>
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+@@ -826,9 +827,9 @@ grub_video_fb_unmap_color_int (struct grub_video_fbblit_info * source,
+ static void
+ dirty (int x, int y, int width, int height)
+ {
+-  
+   grub_video_rect_t *current_dirty = &framebuffer.current_dirty;
+-  grub_video_rect_t dirty_rect = {
++  grub_video_rect_t dirty_rect;
++  grub_video_rect_t origin_rect = {
+     .x = x,
+     .y = y,
+     .width = width,
+@@ -838,22 +839,21 @@ dirty (int x, int y, int width, int height)
+   if (framebuffer.render_target != framebuffer.back_target)
+     return;
+ 
+-  /* extend dirty_rect bounds if dirty x min is less than current x */
+-  if (dirty_rect.x < current_dirty->x) 
+-    current_dirty->x = dirty_rect.x;
+-
+-  /* extend dirty_rect bounds if dirty x max is greater than current width */
+-  if (dirty_rect.x + dirty_rect.width > current_dirty->x + current_dirty->width)
+-    current_dirty->width = (dirty_rect.x + dirty_rect.width) - current_dirty->x;
+-
+-  /* extend dirty_rect bounds if dirty y min is less than current y */
+-  if (dirty_rect.y < current_dirty->y)
+-    current_dirty->y = dirty_rect.y;
+-
+-  /* extend dirty_rect bounds if dirty y max is greater than current height */
+-  if (dirty_rect.y + dirty_rect.height > current_dirty->y + current_dirty->height)
+-    current_dirty->height = (dirty_rect.y + dirty_rect.height) - current_dirty->y;
+-
++  dirty_rect = grub_video_transform_rectangle(origin_rect,
++                &framebuffer.render_target->mode_info);
++
++  /* Expand current_dirty to include dirty_rect */
++  int x1 = grub_min(current_dirty->x, dirty_rect.x);
++  int y1 = grub_min(current_dirty->y, dirty_rect.y);
++  int x2 = grub_max(current_dirty->x + current_dirty->width,
++                    dirty_rect.x + dirty_rect.width);
++  int y2 = grub_max(current_dirty->y + current_dirty->height,
++                    dirty_rect.y + dirty_rect.height);
++
++  current_dirty->x = x1;
++  current_dirty->y = y1;
++  current_dirty->width = x2 - x1;
++  current_dirty->height = y2 - y1;
+ }
+ 
+ grub_err_t
+@@ -1063,6 +1063,8 @@ grub_video_fb_scroll (grub_video_color_t color, int dx, int dy)
+ {
+   int width;
+   int height;
++  int tx; /* transformed scroll coords */
++  int ty; /* transformed scroll coords */
+   int src_x;
+   int src_y;
+   int dst_x;
+@@ -1072,39 +1074,41 @@ grub_video_fb_scroll (grub_video_color_t color, int dx, int dy)
+   if ((dx == 0) && (dy == 0))
+     return GRUB_ERR_NONE;
+ 
+-  width = framebuffer.render_target->viewport.width - grub_abs (dx);
+-  height = framebuffer.render_target->viewport.height - grub_abs (dy);
++  tx = trans_x(dx,dy, &framebuffer.render_target->mode_info);
++  ty = trans_y(dx,dy, &framebuffer.render_target->mode_info);
++  width = framebuffer.render_target->mode_info.original_width - grub_abs (tx);
++  height = framebuffer.render_target->mode_info.original_height - grub_abs (ty);
+ 
+   dirty (framebuffer.render_target->viewport.x,
+ 	 framebuffer.render_target->viewport.y,
+-   framebuffer.render_target->viewport.width,
++	 framebuffer.render_target->viewport.width,
+ 	 framebuffer.render_target->viewport.height);
+ 
+-  if (dx < 0)
++  if (tx < 0)
+     {
+-      src_x = framebuffer.render_target->viewport.x - dx;
++      src_x = framebuffer.render_target->viewport.x - tx;
+       dst_x = framebuffer.render_target->viewport.x;
+     }
+   else
+     {
+       src_x = framebuffer.render_target->viewport.x;
+-      dst_x = framebuffer.render_target->viewport.x + dx;
++      dst_x = framebuffer.render_target->viewport.x + tx;
+     }
+ 
+-  if (dy < 0)
++  if (ty < 0)
+     {
+-      src_y = framebuffer.render_target->viewport.y - dy;
++      src_y = framebuffer.render_target->viewport.y - ty;
+       dst_y = framebuffer.render_target->viewport.y;
+     }
+   else
+     {
+       src_y = framebuffer.render_target->viewport.y;
+-      dst_y = framebuffer.render_target->viewport.y + dy;
++      dst_y = framebuffer.render_target->viewport.y + ty;
+     }
+ 
+   /* 2. Check if there is need to copy data.  */
+-  if ((grub_abs (dx) < framebuffer.render_target->viewport.width)
+-       && (grub_abs (dy) < framebuffer.render_target->viewport.height))
++  if ((grub_abs (tx) < framebuffer.render_target->viewport.width)
++       && (grub_abs (ty) < framebuffer.render_target->viewport.height))
+     {
+       /* 3. Move data in render target.  */
+       struct grub_video_fbblit_info target;
+@@ -1119,7 +1123,7 @@ grub_video_fb_scroll (grub_video_color_t color, int dx, int dy)
+       linelen = width * target.mode_info->bytes_per_pixel;
+ #define DO_SCROLL                                                    \
+       /* Check vertical direction of the move.  */                   \
+-      if (dy < 0 || (dy == 0 && dx < 0))                             \
++      if (ty < 0 || (ty == 0 && tx < 0))                             \
+ 	{                                                            \
+ 	  dst = (void *) grub_video_fb_get_video_ptr (&target,       \
+ 						      dst_x, dst_y); \
+@@ -1245,6 +1249,9 @@ grub_video_fb_create_render_target (struct grub_video_fbrender_target **result,
+   /* TODO: Implement other types too.
+      Currently only 32bit render targets are supported.  */
+ 
++/* only used by text_layers, so do not rotate */
++  target->mode_info.rotation = GRUB_VIDEO_ROTATE_NONE;
++
+   /* Mark render target as allocated.  */
+   target->is_allocated = 1;
+ 
+@@ -1270,6 +1277,8 @@ grub_video_fb_create_render_target (struct grub_video_fbrender_target **result,
+   /* Setup render target format.  */
+   target->mode_info.width = width;
+   target->mode_info.height = height;
++  target->mode_info.original_width = width;
++  target->mode_info.original_height = height;
+   switch (mode_type)
+     {
+     case GRUB_VIDEO_MODE_TYPE_INDEX_COLOR
+@@ -1332,6 +1341,7 @@ grub_video_fb_create_render_target_from_pointer (struct grub_video_fbrender_targ
+ {
+   struct grub_video_fbrender_target *target;
+   unsigned y;
++  const char *rot_env;
+ 
+ #ifndef GRUB_HAVE_UNALIGNED_ACCESS
+   if (!(mode_info->bytes_per_pixel & (mode_info->bytes_per_pixel - 1))
+@@ -1352,30 +1362,53 @@ grub_video_fb_create_render_target_from_pointer (struct grub_video_fbrender_targ
+   target->data = ptr;
+ 
+   grub_memcpy (&(target->mode_info), mode_info, sizeof (target->mode_info));
++  rot_env = grub_env_get("rotation");
++
++  if (!rot_env) {
++        target->mode_info.rotation = GRUB_VIDEO_ROTATE_NONE;
++    } else if (grub_strcmp(rot_env, "90") == 0) {
++        target->mode_info.rotation = GRUB_VIDEO_ROTATE_90;
++    } else if (grub_strcmp(rot_env, "180") == 0) {
++        target->mode_info.rotation = GRUB_VIDEO_ROTATE_180;
++    } else if (grub_strcmp(rot_env, "270") == 0) {
++        target->mode_info.rotation = GRUB_VIDEO_ROTATE_270;
++    } else {
++        target->mode_info.rotation = GRUB_VIDEO_ROTATE_NONE;
++    }
++
++  target->mode_info.original_width = mode_info->width;
++  target->mode_info.original_height = mode_info->height;
++
++  if (target->mode_info.rotation == GRUB_VIDEO_ROTATE_90
++      || target->mode_info.rotation == GRUB_VIDEO_ROTATE_270)
++    {
++      target->mode_info.width = target->mode_info.original_height;
++      target->mode_info.height = target->mode_info.original_width;
++    }
+ 
+   /* Reset viewport, region and area to match new mode.  */
+   target->viewport.x = 0;
+   target->viewport.y = 0;
+-  target->viewport.width = mode_info->width;
+-  target->viewport.height = mode_info->height;
++  target->viewport.width = target->mode_info.width;
++  target->viewport.height = target->mode_info.height;
+ 
+   target->region.x = 0;
+   target->region.y = 0;
+-  target->region.width = mode_info->width;
+-  target->region.height = mode_info->height;
++  target->region.width = target->mode_info.width;
++  target->region.height = target->mode_info.height;
+ 
+   target->area_enabled = 0;
+   target->area.x = 0;
+   target->area.y = 0;
+-  target->area.width = mode_info->width;
+-  target->area.height = mode_info->height;
++  target->area.width = target->mode_info.width;
++  target->area.height = target->mode_info.height;
+   target->area_offset_x = 0;
+   target->area_offset_y = 0;
+ 
+   /* Clear render target with black and maximum transparency.  */
+-  for (y = 0; y < mode_info->height; y++)
++  for (y = 0; y < target->mode_info.original_height; y++)
+     grub_memset (target->data + mode_info->pitch * y, 0,
+-		 mode_info->bytes_per_pixel * mode_info->width);
++		 mode_info->bytes_per_pixel * target->mode_info.original_width);
+ 
+   /* Save result to caller.  */
+   *result = target;
+@@ -1455,9 +1488,9 @@ doublebuf_blit_update_screen (void)
+   }
+ 
+   /* reset current_dirty rect */
+-  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.original_height;
+   framebuffer.current_dirty.height = 0;
+-  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.original_width;
+   framebuffer.current_dirty.width = 0;
+ 
+   return GRUB_ERR_NONE;
+@@ -1491,9 +1524,9 @@ grub_video_fb_doublebuf_blit_init (struct grub_video_fbrender_target **back,
+   framebuffer.pages[0] = framebuf;
+   framebuffer.displayed_page = 0;
+   framebuffer.render_page = 0;
+-  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.original_height;
+   framebuffer.current_dirty.height = 0;
+-  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.original_width;
+   framebuffer.current_dirty.width = 0;
+ 
+   return GRUB_ERR_NONE;
+@@ -1546,9 +1579,9 @@ doublebuf_pageflipping_update_screen (void)
+ 
+   /* reset current_dirty rect */
+   framebuffer.previous_dirty = framebuffer.current_dirty;
+-  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.original_height;
+   framebuffer.current_dirty.height = 0;
+-  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.original_width;
+   framebuffer.current_dirty.width = 0;
+ 
+   /* Swap the page numbers in the framebuffer struct.  */
+@@ -1609,15 +1642,15 @@ doublebuf_pageflipping_init (struct grub_video_mode_info *mode_info,
+   framebuffer.pages[1] = page1_ptr;
+ 
+   /* reset current_dirty rect */
+-  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.original_height;
+   framebuffer.current_dirty.height = 0;
+-  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.original_width;
+   framebuffer.current_dirty.width = 0;
+ 
+    /* reset previous_dirty rect */
+-  framebuffer.previous_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.previous_dirty.y = framebuffer.back_target->mode_info.original_height;
+   framebuffer.previous_dirty.height = 0;
+-  framebuffer.previous_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.previous_dirty.x = framebuffer.back_target->mode_info.original_width;
+   framebuffer.previous_dirty.width = 0;
+ 
+   /* Set the framebuffer memory data pointer and display the right page.  */
+@@ -1705,9 +1738,9 @@ grub_video_fb_setup (unsigned int mode_type, unsigned int mode_mask,
+   framebuffer.render_page = 0;
+   framebuffer.set_page = 0;
+  /* reset transformed_add_rect */
+-  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.height;
++  framebuffer.current_dirty.y = framebuffer.back_target->mode_info.original_height;
+   framebuffer.current_dirty.height = 0;
+-  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.width;
++  framebuffer.current_dirty.x = framebuffer.back_target->mode_info.original_width;
+   framebuffer.current_dirty.width = 0;
+ 
+   mode_info->mode_type &= ~GRUB_VIDEO_MODE_TYPE_DOUBLE_BUFFERED;
+@@ -1739,6 +1772,9 @@ grub_video_fb_get_info_and_fini (struct grub_video_mode_info *mode_info,
+   grub_memcpy (mode_info, &(framebuffer.back_target->mode_info),
+ 	       sizeof (*mode_info));
+ 
++  mode_info->width = framebuffer.back_target->mode_info.original_width;
++  mode_info->height = framebuffer.back_target->mode_info.original_height;
++
+   /* We are about to load a kernel.  Switch back to page zero, since some
+      kernel drivers expect that.  */
+   if (framebuffer.set_page && framebuffer.displayed_page != 0)
+diff --git a/include/grub/fbutil.h b/include/grub/fbutil.h
+index 78a1ab3b4..19850b6e4 100644
+--- a/include/grub/fbutil.h
++++ b/include/grub/fbutil.h
+@@ -61,4 +61,11 @@ grub_video_color_t get_pixel (struct grub_video_fbblit_info *source,
+ void set_pixel (struct grub_video_fbblit_info *source,
+                 unsigned int x, unsigned int y, grub_video_color_t color);
+ 
++int trans_x(int x,int y, struct grub_video_mode_info *mode_info);
++
++int trans_y(int x, int y, struct grub_video_mode_info *mode_info);
++
++grub_video_rect_t grub_video_transform_rectangle (grub_video_rect_t r, 
++                                                  const struct grub_video_mode_info *mode_info);
++
+ #endif /* ! GRUB_VBEUTIL_MACHINE_HEADER */
+diff --git a/include/grub/video.h b/include/grub/video.h
+index 761ee994a..baa8dec03 100644
+--- a/include/grub/video.h
++++ b/include/grub/video.h
+@@ -75,6 +75,14 @@ typedef enum grub_video_mode_type
+     GRUB_VIDEO_MODE_TYPE_INFO_MASK        = 0x00FF0000,
+   } grub_video_mode_type_t;
+ 
++enum grub_video_rotation
++  {
++    GRUB_VIDEO_ROTATE_NONE,
++    GRUB_VIDEO_ROTATE_90,
++    GRUB_VIDEO_ROTATE_180,
++    GRUB_VIDEO_ROTATE_270
++  };
++
+ /* The basic render target representing the whole display.  This always
+    renders to the back buffer when double-buffering is in use.  */
+ #define GRUB_VIDEO_RENDER_TARGET_DISPLAY \
+@@ -122,12 +130,20 @@ enum grub_video_blit_operators
+ 
+ struct grub_video_mode_info
+ {
+-  /* Width of the screen.  */
++  /* Width of the screen, before the rotation.  */
++  unsigned int original_width;
++
++  /* Height of the screen, before the rotation.  */
++  unsigned int original_height;
++
++  /* Width of the screen, after the rotation.  */
+   unsigned int width;
+ 
+-  /* Height of the screen.  */
++  /* Height of the screen, after the rotation.  */
+   unsigned int height;
+ 
++  enum grub_video_rotation rotation;
++
+   /* Mode type bitmask.  Contains information like is it Index color or
+      RGB mode.  */
+   grub_video_mode_type_t mode_type;
+-- 
+2.52.0
+

--- a/app-admin/grub/spec
+++ b/app-admin/grub/spec
@@ -6,7 +6,7 @@ __UNIFONTVER=17.0.02
 RETROFONTVER=20200402
 
 VER=${GRUBVER}+unifont${__UNIFONTVER}
-REL=6
+REL=7
 SRCS="git::commit=tags/grub-${__UPSTREAM_VER};rename=grub-${__UPSTREAM_VER}::https://https.git.savannah.gnu.org/git/grub.git \
       file::rename=unifont-${__UNIFONTVER}.bdf.gz::https://ftpmirror.gnu.org/gnu/unifont/unifont-${__UNIFONTVER}/unifont-${__UNIFONTVER}.bdf.gz \
       tbl::rename=grub-fonts-$RETROFONTVER.tar.xz::https://repo.aosc.io/aosc-repacks/grub-fonts-$RETROFONTVER.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- grub: add framebuffer rotation support

Package(s) Affected
-------------------

- grub: 2:2.14+unifont17.0.02-7

Security Update?
----------------

No

Build Order
-----------

```
#buildit grub
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
