### PR TITLE
linux-kernel: add panel orientation quirk for GPD Pocket 4

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-net-stmmac-remove-xstats.pcs_-members.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-net-stmmac-remove-xstats.pcs_-members.patch
@@ -1,7 +1,7 @@
 From 85449c2681f7c5100d18254fdfa309735dd70646 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:51 +0100
-Subject: [PATCH 001/449] UPSTREAM: net: stmmac: remove xstats.pcs_* members
+Subject: [PATCH 001/450] UPSTREAM: net: stmmac: remove xstats.pcs_* members
 
 As a result of the previous commit, the pcs_link, pcs_duplex and
 pcs_speed members are not used outside of the interrupt handling code,
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 2 insertions(+), 57 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 23ec3a59ca8f1..7b432279272d0 100644
+index 23ec3a59ca8f..7b432279272d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -197,9 +197,6 @@ struct stmmac_extra_stats {
@@ -41,7 +41,7 @@ index 23ec3a59ca8f1..7b432279272d0 100644
  	unsigned long mtl_tx_status_fifo_full;
  	unsigned long mtl_tx_fifo_not_empty;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
-index fe776ddf68895..2c5ee59c32086 100644
+index fe776ddf6889..2c5ee59c3208 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 @@ -266,34 +266,8 @@ static void dwmac1000_pmt(struct mac_device_info *hw, unsigned long mode)
@@ -81,7 +81,7 @@ index fe776ddf68895..2c5ee59c32086 100644
  
  static int dwmac1000_irq_status(struct mac_device_info *hw,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
-index d85bc0bb5c3c0..8a19df7b05775 100644
+index d85bc0bb5c3c..8a19df7b0577 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 @@ -592,34 +592,8 @@ static void dwmac4_ctrl_ane(struct stmmac_priv *priv, bool ane, bool srgmi_ral,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-net-stmmac-remove-SGMII-RGMII-SMII-interrup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-net-stmmac-remove-SGMII-RGMII-SMII-interrup.patch
@@ -1,7 +1,7 @@
 From 9378f32812afbef8db09920086e860b6f283e7f9 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:56 +0100
-Subject: [PATCH 002/449] UPSTREAM: net: stmmac: remove SGMII/RGMII/SMII
+Subject: [PATCH 002/450] UPSTREAM: net: stmmac: remove SGMII/RGMII/SMII
  interrupt handling
 
 Now that the only use for the interrupt is to clear it and increment a
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 4 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000.h b/drivers/net/ethernet/stmicro/stmmac/dwmac1000.h
-index 0c011a47d5a3e..8f3002d9de78b 100644
+index 0c011a47d5a3..8f3002d9de78 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000.h
 @@ -38,10 +38,10 @@
@@ -47,7 +47,7 @@ index 0c011a47d5a3e..8f3002d9de78b 100644
  
  /* PMT Control and Status */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
-index 2c5ee59c32086..654331b411f44 100644
+index 2c5ee59c3208..654331b411f4 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 @@ -263,13 +263,6 @@ static void dwmac1000_pmt(struct mac_device_info *hw, unsigned long mode)
@@ -75,7 +75,7 @@ index 2c5ee59c32086..654331b411f44 100644
  }
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4.h b/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
-index 3dec1a264cf60..6dd84b6544cc0 100644
+index 3dec1a264cf6..6dd84b6544cc 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
 @@ -106,8 +106,7 @@
@@ -89,7 +89,7 @@ index 3dec1a264cf60..6dd84b6544cc0 100644
  #define	GMAC_INT_DEFAULT_ENABLE	(GMAC_INT_PMT_EN | GMAC_INT_LPI_EN | \
  				 GMAC_INT_TSIE)
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
-index 8a19df7b05775..bff4c371c1d26 100644
+index 8a19df7b0577..bff4c371c1d2 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 @@ -589,13 +589,6 @@ static void dwmac4_ctrl_ane(struct stmmac_priv *priv, bool ane, bool srgmi_ral,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-net-stmmac-remove-PCS-mode-pause-handling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-net-stmmac-remove-PCS-mode-pause-handling.patch
@@ -1,7 +1,7 @@
 From 624dde4cfbfdb6b0532f08d2b295ca9304e488cf Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:01 +0100
-Subject: [PATCH 003/449] UPSTREAM: net: stmmac: remove PCS "mode" pause
+Subject: [PATCH 003/450] UPSTREAM: net: stmmac: remove PCS "mode" pause
  handling
 
 Remove the "we always autoneg pause" forcing when the stmmac driver
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 11 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_ethtool.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_ethtool.c
-index 81d4039e1c082..df016c4eb7104 100644
+index 81d4039e1c08..df016c4eb710 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_ethtool.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_ethtool.c
 @@ -425,11 +425,7 @@ stmmac_get_pauseparam(struct net_device *netdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-net-stmmac-remove-unused-PCS-loopback-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-net-stmmac-remove-unused-PCS-loopback-suppo.patch
@@ -1,7 +1,7 @@
 From 589e4287a2a764c89dd1ef3e9deaec1006b915c2 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:06 +0100
-Subject: [PATCH 004/449] UPSTREAM: net: stmmac: remove unused PCS loopback
+Subject: [PATCH 004/450] UPSTREAM: net: stmmac: remove unused PCS loopback
  support
 
 Nothing calls stmmac_pcs_ctrl_ane() with the "loopback" argument set to
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  6 files changed, 9 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
-index 74c208dd86519..d1e48b524d7a9 100644
+index 74c208dd8651..d1e48b524d7a 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
 @@ -622,7 +622,7 @@ static void ethqos_set_serdes_speed(struct qcom_ethqos *ethqos, int speed)
@@ -40,7 +40,7 @@ index 74c208dd86519..d1e48b524d7a9 100644
  
  /* On interface toggle MAC registers gets reset.
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
-index 654331b411f44..5c653be3d453f 100644
+index 654331b411f4..5c653be3d453 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 @@ -358,9 +358,9 @@ static void dwmac1000_set_eee_timer(struct mac_device_info *hw, int ls, int tw)
@@ -56,7 +56,7 @@ index 654331b411f44..5c653be3d453f 100644
  
  static void dwmac1000_debug(struct stmmac_priv *priv, void __iomem *ioaddr,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
-index bff4c371c1d26..21e4461db9378 100644
+index bff4c371c1d2..21e4461db937 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 @@ -583,10 +583,9 @@ static void dwmac4_flow_ctrl(struct mac_device_info *hw, unsigned int duplex,
@@ -73,7 +73,7 @@ index bff4c371c1d26..21e4461db9378 100644
  
  static int dwmac4_irq_mtl_status(struct stmmac_priv *priv,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/hwif.h b/drivers/net/ethernet/stmicro/stmmac/hwif.h
-index 14dbe0685997d..7796f5f3c96f1 100644
+index 14dbe0685997..7796f5f3c96f 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/hwif.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/hwif.h
 @@ -374,8 +374,8 @@ struct stmmac_ops {
@@ -88,7 +88,7 @@ index 14dbe0685997d..7796f5f3c96f1 100644
  	int (*safety_feat_config)(void __iomem *ioaddr, unsigned int asp,
  				  struct stmmac_safety_feature_cfg *safety_cfg);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 46299b7925b44..1d5800e3142ed 100644
+index 46299b7925b4..1d5800e3142e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -3494,7 +3494,7 @@ static int stmmac_hw_setup(struct net_device *dev)
@@ -101,7 +101,7 @@ index 46299b7925b44..1d5800e3142ed 100644
  	/* set TX and RX rings length */
  	stmmac_set_rings_length(priv);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h b/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h
-index 4a684c97dfaeb..5778f5b2f3139 100644
+index 4a684c97dfae..5778f5b2f313 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h
 @@ -82,13 +82,12 @@ static inline void dwmac_pcs_isr(void __iomem *ioaddr, u32 reg,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-net-stmmac-remove-hw-ps-xxx_core_init-hardw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-net-stmmac-remove-hw-ps-xxx_core_init-hardw.patch
@@ -1,7 +1,7 @@
 From a0ab5ac0f9d3eeb628758a9b7f64f39b05b845d3 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:11 +0100
-Subject: [PATCH 005/449] UPSTREAM: net: stmmac: remove hw->ps xxx_core_init()
+Subject: [PATCH 005/450] UPSTREAM: net: stmmac: remove hw->ps xxx_core_init()
  hardware setup
 
 After a lot of digging, it seems that the oddly named hw->ps member is
@@ -55,7 +55,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 8 insertions(+), 64 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
-index 5c653be3d453f..d35db8958be15 100644
+index 5c653be3d453..d35db8958be1 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 @@ -26,35 +26,18 @@ static void dwmac1000_core_init(struct mac_device_info *hw,
@@ -98,7 +98,7 @@ index 5c653be3d453f..d35db8958be15 100644
  	/* Mask GMAC interrupts */
  	value = GMAC_INT_DEFAULT_MASK;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
-index 21e4461db9378..d855ab6b91458 100644
+index 21e4461db937..d855ab6b9145 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 @@ -27,29 +27,11 @@ static void dwmac4_core_init(struct mac_device_info *hw,
@@ -135,7 +135,7 @@ index 21e4461db9378..d855ab6b91458 100644
  	/* Configure LPI 1us counter to number of CSR clock ticks in 1us - 1 */
  	clk_rate = clk_get_rate(priv->plat->stmmac_clk);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_core.c b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_core.c
-index 00e929bf280ba..0430af27da407 100644
+index 00e929bf280b..0430af27da40 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_core.c
 @@ -23,29 +23,8 @@ static void dwxgmac2_core_init(struct mac_device_info *hw,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-net-stmmac-remove-RGMII-pcs-mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-net-stmmac-remove-RGMII-pcs-mode.patch
@@ -1,7 +1,7 @@
 From d55261cefdf2c86dc5c816d1440e1530652fe7d2 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:17 +0100
-Subject: [PATCH 006/449] UPSTREAM: net: stmmac: remove RGMII "pcs" mode
+Subject: [PATCH 006/450] UPSTREAM: net: stmmac: remove RGMII "pcs" mode
 
 Remove the RGMII "pcs" code in stmmac_check_pcs_mode() due to:
 
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 3 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 7b432279272d0..26291bcc54ada 100644
+index 7b432279272d..26291bcc54ad 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -275,7 +275,6 @@ struct stmmac_safety_stats {
@@ -40,7 +40,7 @@ index 7b432279272d0..26291bcc54ada 100644
  
  #define SF_DMA_MODE 1		/* DMA STORE-AND-FORWARD Operation Mode */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 1d5800e3142ed..1e0ffcd870a5c 100644
+index 1d5800e3142e..1e0ffcd870a5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1088,17 +1088,9 @@ static void stmmac_check_pcs_mode(struct stmmac_priv *priv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-net-stmmac-move-reverse-pcs-mode-setup-to-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-net-stmmac-move-reverse-pcs-mode-setup-to-s.patch
@@ -1,7 +1,7 @@
 From 1e74c2e0748efd1f61f3a0a2a17a85de84230a18 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:22 +0100
-Subject: [PATCH 007/449] UPSTREAM: net: stmmac: move reverse-"pcs" mode setup
+Subject: [PATCH 007/450] UPSTREAM: net: stmmac: move reverse-"pcs" mode setup
  to stmmac_check_pcs_mode()
 
 The broken reverse-mode, selected by snps,ps-speed, is configured when
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 13 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 1e0ffcd870a5c..d960d9ec14d23 100644
+index 1e0ffcd870a5..d960d9ec14d2 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1092,6 +1092,19 @@ static void stmmac_check_pcs_mode(struct stmmac_priv *priv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-net-stmmac-simplify-stmmac_check_pcs_mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-net-stmmac-simplify-stmmac_check_pcs_mode.patch
@@ -1,7 +1,7 @@
 From ddf87955631c2a83a45a6de3fb93c87eac4d076d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:27 +0100
-Subject: [PATCH 008/449] UPSTREAM: net: stmmac: simplify
+Subject: [PATCH 008/450] UPSTREAM: net: stmmac: simplify
  stmmac_check_pcs_mode()
 
 Now that we only support one mode, simplify stmmac_check_pcs_mode().
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index d960d9ec14d23..c38d174143853 100644
+index d960d9ec14d2..c38d17414385 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1087,22 +1087,23 @@ static const struct phylink_mac_ops stmmac_phylink_mac_ops = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-net-stmmac-hw-ps-becomes-hw-reverse_sgmii_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-net-stmmac-hw-ps-becomes-hw-reverse_sgmii_e.patch
@@ -1,7 +1,7 @@
 From 98d2256ba05e0623059e17b240afed621c274dd3 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:32 +0100
-Subject: [PATCH 009/449] UPSTREAM: net: stmmac: hw->ps becomes
+Subject: [PATCH 009/450] UPSTREAM: net: stmmac: hw->ps becomes
  hw->reverse_sgmii_enable
 
 After a lot of digging, it seems that the oddly named hw->ps member
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 26291bcc54ada..31254ba525d56 100644
+index 26291bcc54ad..31254ba525d5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -604,13 +604,13 @@ struct mac_device_info {
@@ -60,7 +60,7 @@ index 26291bcc54ada..31254ba525d56 100644
  
  struct stmmac_rx_routing {
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index c38d174143853..3dce0fa87f581 100644
+index c38d17414385..3dce0fa87f58 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1097,12 +1097,12 @@ static void stmmac_check_pcs_mode(struct stmmac_priv *priv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-net-stmmac-do-not-require-snps-ps-speed-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-net-stmmac-do-not-require-snps-ps-speed-for.patch
@@ -1,7 +1,7 @@
 From b9e6f7e93564cb45e68ca2669946e2f5ffe1ec19 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:37 +0100
-Subject: [PATCH 010/449] UPSTREAM: net: stmmac: do not require snps,ps-speed
+Subject: [PATCH 010/450] UPSTREAM: net: stmmac: do not require snps,ps-speed
  for SGMII
 
 SGMII mode does not require port-speed to be specified; this only
@@ -35,7 +35,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 3dce0fa87f581..d987970b64f2a 100644
+index 3dce0fa87f58..d987970b64f2 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -1102,6 +1102,8 @@ static void stmmac_check_pcs_mode(struct stmmac_priv *priv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-net-stmmac-only-call-stmmac_pcs_ctrl_ane-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-net-stmmac-only-call-stmmac_pcs_ctrl_ane-fo.patch
@@ -1,7 +1,7 @@
 From a4883c5299983002de97810b0575da6a349309fb Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:42 +0100
-Subject: [PATCH 011/449] UPSTREAM: net: stmmac: only call
+Subject: [PATCH 011/450] UPSTREAM: net: stmmac: only call
  stmmac_pcs_ctrl_ane() for integrated SGMII PCS
 
 The internal PCS registers only exist if the core is synthesized with
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index d987970b64f2a..f92e0d37c23e8 100644
+index d987970b64f2..f92e0d37c23e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -3488,7 +3488,11 @@ static int stmmac_hw_setup(struct net_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-net-stmmac-provide-PCS-initialisation-hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-net-stmmac-provide-PCS-initialisation-hook.patch
@@ -1,7 +1,7 @@
 From ae37a76f2dabb82ef681d4a24807f13ae1587a11 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:47 +0100
-Subject: [PATCH 012/449] UPSTREAM: net: stmmac: provide PCS initialisation
+Subject: [PATCH 012/450] UPSTREAM: net: stmmac: provide PCS initialisation
  hook
 
 dwmac cores provide a feature bit to indicate when the PCS block is
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 11 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/hwif.h b/drivers/net/ethernet/stmicro/stmmac/hwif.h
-index 7796f5f3c96f1..82cfb6bec334a 100644
+index 7796f5f3c96f..82cfb6bec334 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/hwif.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/hwif.h
 @@ -313,6 +313,8 @@ enum stmmac_lpi_mode {
@@ -48,7 +48,7 @@ index 7796f5f3c96f1..82cfb6bec334a 100644
  	stmmac_do_void_callback(__priv, mac, core_init, __args)
  #define stmmac_mac_update_caps(__priv) \
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index f92e0d37c23e8..98680f94593a2 100644
+index f92e0d37c23e..98680f94593a 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7266,6 +7266,13 @@ static int stmmac_hw_init(struct stmmac_priv *priv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-net-stmmac-convert-to-phylink-PCS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-net-stmmac-convert-to-phylink-PCS-support.patch
@@ -1,7 +1,7 @@
 From 036517b0dc2d8f71868cc6e6a991d7e5035e8bb4 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:52 +0100
-Subject: [PATCH 013/449] UPSTREAM: net: stmmac: convert to phylink PCS support
+Subject: [PATCH 013/450] UPSTREAM: net: stmmac: convert to phylink PCS support
 
 Now that stmmac's PCS support is much more simple - just a matter of
 configuring the control register - the basic conversion to phylink PCS
@@ -49,7 +49,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.c
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index 51e068e26ce49..11c0ba2ccdb13 100644
+index 51e068e26ce4..11c0ba2ccdb1 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -7,7 +7,7 @@ stmmac-objs:= stmmac_main.o stmmac_ethtool.o stmmac_mdio.o ring_mode.o	\
@@ -62,7 +62,7 @@ index 51e068e26ce49..11c0ba2ccdb13 100644
  stmmac-$(CONFIG_STMMAC_SELFTESTS) += stmmac_selftests.o
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
-index d35db8958be15..571e483624442 100644
+index d35db8958be1..571e48362444 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_core.c
 @@ -22,6 +22,14 @@
@@ -89,7 +89,7 @@ index d35db8958be15..571e483624442 100644
  	.set_mac = stmmac_set_mac,
  	.rx_ipc = dwmac1000_rx_ipc_enable,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
-index d855ab6b91458..0b785389b7eff 100644
+index d855ab6b9145..0b785389b7ef 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
 @@ -22,6 +22,14 @@
@@ -132,7 +132,7 @@ index d855ab6b91458..0b785389b7eff 100644
  	.update_caps = dwmac4_update_caps,
  	.set_mac = stmmac_dwmac4_set_mac,
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac.h b/drivers/net/ethernet/stmicro/stmmac/stmmac.h
-index 7ca5477be390b..34f62993a4dae 100644
+index 7ca5477be390..34f62993a4da 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac.h
 @@ -25,6 +25,8 @@
@@ -154,7 +154,7 @@ index 7ca5477be390b..34f62993a4dae 100644
  	struct phylink *phylink;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 98680f94593a2..e422326beb7a6 100644
+index 98680f94593a..e422326beb7a 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -46,6 +46,7 @@
@@ -195,7 +195,7 @@ index 98680f94593a2..e422326beb7a6 100644
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.c
 new file mode 100644
-index 0000000000000..50ea51d7a1cc8
+index 000000000000..50ea51d7a1cc
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.c
 @@ -0,0 +1,47 @@
@@ -247,7 +247,7 @@ index 0000000000000..50ea51d7a1cc8
 +	return 0;
 +}
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h b/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h
-index 5778f5b2f3139..64397ac8ecab8 100644
+index 5778f5b2f313..64397ac8ecab 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pcs.h
 @@ -9,6 +9,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-net-stmmac-dwc-qos-eth-simplify-switch-in-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-net-stmmac-dwc-qos-eth-simplify-switch-in-d.patch
@@ -1,7 +1,7 @@
 From 397a48ee782ca94294c90f22f72ef88bd10ba4a5 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:14 +0000
-Subject: [PATCH 014/449] UPSTREAM: net: stmmac: dwc-qos-eth: simplify switch()
+Subject: [PATCH 014/450] UPSTREAM: net: stmmac: dwc-qos-eth: simplify switch()
  in dwc_eth_dwmac_config_dt()
 
 Simplify the switch() statement in dwc_eth_dwmac_config_dt().
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 23 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
-index 1d30f2fb984f1..c54515ebf1ade 100644
+index 1d30f2fb984f..c54515ebf1ad 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
 @@ -84,29 +84,9 @@ static int dwc_eth_dwmac_config_dt(struct platform_device *pdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-net-stmmac-move-common-DMA-AXI-register-bit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-net-stmmac-move-common-DMA-AXI-register-bit.patch
@@ -1,7 +1,7 @@
 From f8100b489068e97933fed21648fab189564c432c Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:19 +0000
-Subject: [PATCH 015/449] UPSTREAM: net: stmmac: move common DMA AXI register
+Subject: [PATCH 015/450] UPSTREAM: net: stmmac: move common DMA AXI register
  bits to common.h
 
 Move the common DMA AXI register bits to common.h so they can be shared
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 21 insertions(+), 25 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 31254ba525d56..20958e85b8768 100644
+index 31254ba525d5..20958e85b876 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -535,6 +535,16 @@ struct dma_features {
@@ -42,7 +42,7 @@ index 31254ba525d56..20958e85b8768 100644
  #define STMMAC_RING_MODE	0x2
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h
-index 4f980dcd39582..dfcb7ce79e765 100644
+index 4f980dcd3958..dfcb7ce79e76 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h
 @@ -69,15 +69,8 @@
@@ -63,7 +63,7 @@ index 4f980dcd39582..dfcb7ce79e765 100644
  
  #define DMA_BURST_LEN_DEFAULT		(DMA_AXI_BLEN256 | DMA_AXI_BLEN128 | \
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h b/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
-index 5d9c18f5bbf58..967a735e9a0bd 100644
+index 5d9c18f5bbf5..967a735e9a0b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
 @@ -68,20 +68,13 @@ static inline u32 dma_chan_base_addr(u32 base, u32 chan)
@@ -90,7 +90,7 @@ index 5d9c18f5bbf58..967a735e9a0bd 100644
  
  #define DMA_AXI_BURST_LEN_MASK	0x000000FE
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h
-index 0d408ee17f337..16c254ddc8f00 100644
+index 0d408ee17f33..16c254ddc8f0 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h
 @@ -333,16 +333,16 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-net-stmmac-provide-common-stmmac_axi_blen_t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-net-stmmac-provide-common-stmmac_axi_blen_t.patch
@@ -1,7 +1,7 @@
 From 96a31e0107950ef0118c7f8f04c8c5442e123b8c Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:25 +0000
-Subject: [PATCH 016/449] UPSTREAM: net: stmmac: provide common
+Subject: [PATCH 016/450] UPSTREAM: net: stmmac: provide common
  stmmac_axi_blen_to_mask()
 
 Provide a common stmmac_axi_blen_to_mask() function to translate the
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  8 files changed, 56 insertions(+), 93 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 20958e85b8768..05fbd91b89b65 100644
+index 20958e85b876..05fbd91b89b6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -544,6 +544,9 @@ struct dma_features {
@@ -44,7 +44,7 @@ index 20958e85b8768..05fbd91b89b65 100644
  #define STMMAC_CHAIN_MODE	0x1
  #define STMMAC_RING_MODE	0x2
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
-index 118a22406a2e9..b6476a1bfeab0 100644
+index 118a22406a2e..b6476a1bfeab 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 @@ -19,7 +19,6 @@
@@ -94,7 +94,7 @@ index 118a22406a2e9..b6476a1bfeab0 100644
  	writel(value, ioaddr + DMA_AXI_BUS_MODE);
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
-index d87a8b595e6a3..90d03c7b29f4c 100644
+index d87a8b595e6a..90d03c7b29f4 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
 @@ -18,7 +18,6 @@
@@ -144,7 +144,7 @@ index d87a8b595e6a3..90d03c7b29f4c 100644
  	writel(value, ioaddr + DMA_SYS_BUS_MODE);
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h
-index dfcb7ce79e765..f27126f055515 100644
+index dfcb7ce79e76..f27126f05551 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.h
 @@ -78,8 +78,6 @@
@@ -157,7 +157,7 @@ index dfcb7ce79e765..f27126f055515 100644
  #define DMA_TBS_FTOS			GENMASK(31, 8)
  #define DMA_TBS_FTOV			BIT(0)
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h b/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
-index 967a735e9a0bd..d1c149f7a3dd9 100644
+index 967a735e9a0b..d1c149f7a3dd 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac_dma.h
 @@ -77,8 +77,6 @@ static inline u32 dma_chan_base_addr(u32 base, u32 chan)
@@ -170,7 +170,7 @@ index 967a735e9a0bd..d1c149f7a3dd9 100644
  #define DMA_CUR_RX_BUF_ADDR	0x00001054	/* Current Host Rx Buffer */
  #define DMA_HW_FEATURE		0x00001058	/* HW Feature Register */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h
-index 16c254ddc8f00..5aec183e25641 100644
+index 16c254ddc8f0..5aec183e2564 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2.h
 @@ -335,14 +335,7 @@
@@ -190,7 +190,7 @@ index 16c254ddc8f00..5aec183e25641 100644
  #define XGMAC_TX_EDMA_CTRL		0x00003040
  #define XGMAC_TDPS			GENMASK(29, 0)
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
-index 4d6bb995d8d84..8a2cb6ca9588e 100644
+index 4d6bb995d8d8..8a2cb6ca9588 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
 @@ -84,7 +84,6 @@ static void dwxgmac2_dma_init_tx_chan(struct stmmac_priv *priv,
@@ -242,7 +242,7 @@ index 4d6bb995d8d84..8a2cb6ca9588e 100644
  	writel(value, ioaddr + XGMAC_DMA_SYSBUS_MODE);
  	writel(XGMAC_TDPS, ioaddr + XGMAC_TX_EDMA_CTRL);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index e422326beb7a6..1bef663f3d88b 100644
+index e422326beb7a..1bef663f3d88 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -181,6 +181,43 @@ int stmmac_set_clk_tx_rate(void *bsp_priv, struct clk *clk_tx_i,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
@@ -1,7 +1,7 @@
 From 304bbfe86d96ebaca6e9e0e0d47d979f43618cdd Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:30 +0000
-Subject: [PATCH 017/449] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
+Subject: [PATCH 017/450] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
  to stmmac_main.c
 
 Move the call to stmmac_axi_blen_to_mask() out of the individual
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 10 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
-index b6476a1bfeab0..6d9b8fac3c6d0 100644
+index b6476a1bfeab..6d9b8fac3c6d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
 @@ -41,8 +41,7 @@ static void dwmac1000_dma_axi(void __iomem *ioaddr, struct stmmac_axi *axi)
@@ -40,7 +40,7 @@ index b6476a1bfeab0..6d9b8fac3c6d0 100644
  	writel(value, ioaddr + DMA_AXI_BUS_MODE);
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
-index 90d03c7b29f4c..7b513324cfb08 100644
+index 90d03c7b29f4..7b513324cfb0 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_dma.c
 @@ -40,8 +40,7 @@ static void dwmac4_dma_axi(void __iomem *ioaddr, struct stmmac_axi *axi)
@@ -54,7 +54,7 @@ index 90d03c7b29f4c..7b513324cfb08 100644
  	writel(value, ioaddr + DMA_SYS_BUS_MODE);
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
-index 8a2cb6ca9588e..cc1bdc0975d5b 100644
+index 8a2cb6ca9588..cc1bdc0975d5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwxgmac2_dma.c
 @@ -106,8 +106,7 @@ static void dwxgmac2_dma_axi(void __iomem *ioaddr, struct stmmac_axi *axi)
@@ -68,7 +68,7 @@ index 8a2cb6ca9588e..cc1bdc0975d5b 100644
  	writel(value, ioaddr + XGMAC_DMA_SYSBUS_MODE);
  	writel(XGMAC_TDPS, ioaddr + XGMAC_TX_EDMA_CTRL);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 1bef663f3d88b..9e4b2a0d2a93b 100644
+index 1bef663f3d88..9e4b2a0d2a93 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -215,7 +215,7 @@ void stmmac_axi_blen_to_mask(u32 *regval, const u32 *blen, size_t len)
@@ -95,7 +95,7 @@ index 1bef663f3d88b..9e4b2a0d2a93b 100644
  	/* DMA CSR Channel configuration */
  	for (chan = 0; chan < dma_csr_ch; chan++) {
 diff --git a/include/linux/stmmac.h b/include/linux/stmmac.h
-index 151c81c560c8c..d4e9a597d14af 100644
+index 151c81c560c8..d4e9a597d14a 100644
 --- a/include/linux/stmmac.h
 +++ b/include/linux/stmmac.h
 @@ -113,6 +113,7 @@ struct stmmac_axi {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
@@ -1,7 +1,7 @@
 From ca689fcb16d35cf794476969005f43b9c5ae9e07 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:35 +0000
-Subject: [PATCH 018/449] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
+Subject: [PATCH 018/450] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
  to axi_blen init sites
 
 Move stmmac_axi_blen_to_mask() to the axi->axi_blen array init sites
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 10 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
-index c54515ebf1ade..18bf6fff4be5d 100644
+index c54515ebf1ad..18bf6fff4be5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
 @@ -88,6 +88,9 @@ static int dwc_eth_dwmac_config_dt(struct platform_device *pdev,
@@ -37,7 +37,7 @@ index c54515ebf1ade..18bf6fff4be5d 100644
  	plat_dat->core_type = DWMAC_CORE_GMAC4;
  	plat_dat->dma_cfg->aal = 1;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index b2194e414ec1f..5b9ab06829cba 100644
+index b2194e414ec1..5b9ab06829cb 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -680,6 +680,8 @@ static int intel_mgbe_common_data(struct pci_dev *pdev,
@@ -50,7 +50,7 @@ index b2194e414ec1f..5b9ab06829cba 100644
  	plat->axi->axi_blen[1] = 8;
  	plat->axi->axi_blen[2] = 16;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 9e4b2a0d2a93b..b7fd4388afa8c 100644
+index 9e4b2a0d2a93..b7fd4388afa8 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -217,6 +217,7 @@ void stmmac_axi_blen_to_mask(u32 *regval, const u32 *blen, size_t len)
@@ -76,7 +76,7 @@ index 9e4b2a0d2a93b..b7fd4388afa8c 100644
  	/* DMA CSR Channel configuration */
  	for (chan = 0; chan < dma_csr_ch; chan++) {
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index 94b3a3b272706..e27db4111aef8 100644
+index 94b3a3b27270..e27db4111aef 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -127,6 +127,8 @@ static int snps_gmac5_default_data(struct pci_dev *pdev,
@@ -89,7 +89,7 @@ index 94b3a3b272706..e27db4111aef8 100644
  	plat->axi->axi_blen[1] = 8;
  	plat->axi->axi_blen[2] = 16;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index fbb92cc6ab598..bbd4a56af5560 100644
+index fbb92cc6ab59..bbd4a56af556 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -118,6 +118,7 @@ static struct stmmac_axi *stmmac_axi_setup(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-net-stmmac-remove-axi_blen-array.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-net-stmmac-remove-axi_blen-array.patch
@@ -1,7 +1,7 @@
 From 06154539290aaa8448eade9d76b5f6a99c8cccd1 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:40 +0000
-Subject: [PATCH 019/449] UPSTREAM: net: stmmac: remove axi_blen array
+Subject: [PATCH 019/450] UPSTREAM: net: stmmac: remove axi_blen array
 
 Remove the axi_blen array from struct stmmac_axi as we set this array,
 and then immediately convert it ot the register value, never looking at
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 5 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
-index 18bf6fff4be5d..94d97e2342761 100644
+index 18bf6fff4be5..94d97e234276 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-dwc-qos-eth.c
 @@ -38,8 +38,6 @@ static int dwc_eth_dwmac_config_dt(struct platform_device *pdev,
@@ -51,7 +51,7 @@ index 18bf6fff4be5d..94d97e2342761 100644
  	/* dwc-qos needs GMAC4, AAL, TSO and PMT */
  	plat_dat->core_type = DWMAC_CORE_GMAC4;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 5b9ab06829cba..05b107b00ba0e 100644
+index 5b9ab06829cb..05b107b00ba0 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -682,9 +682,6 @@ static int intel_mgbe_common_data(struct pci_dev *pdev,
@@ -65,7 +65,7 @@ index 5b9ab06829cba..05b107b00ba0e 100644
  	plat->ptp_max_adj = plat->clk_ptp_rate;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index e27db4111aef8..7d5b27db22598 100644
+index e27db4111aef..7d5b27db2259 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -129,10 +129,6 @@ static int snps_gmac5_default_data(struct pci_dev *pdev,
@@ -80,7 +80,7 @@ index e27db4111aef8..7d5b27db22598 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index bbd4a56af5560..e8dc1830f318d 100644
+index bbd4a56af556..e8dc1830f318 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -95,6 +95,7 @@ static struct stmmac_axi *stmmac_axi_setup(struct platform_device *pdev)
@@ -103,7 +103,7 @@ index bbd4a56af5560..e8dc1830f318d 100644
  
  	return axi;
 diff --git a/include/linux/stmmac.h b/include/linux/stmmac.h
-index d4e9a597d14af..3ae3e01e45a91 100644
+index d4e9a597d14a..3ae3e01e45a9 100644
 --- a/include/linux/stmmac.h
 +++ b/include/linux/stmmac.h
 @@ -114,7 +114,6 @@ struct stmmac_axi {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-BACKPORT-UPSTREAM-net-stmmac-add-stmmac_plat_dat_all.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-BACKPORT-UPSTREAM-net-stmmac-add-stmmac_plat_dat_all.patch
@@ -1,7 +1,7 @@
 From 2763592162b6c3e99497a1e81464013bce0e200d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:24 +0000
-Subject: [PATCH 020/449] BACKPORT: UPSTREAM: net: stmmac: add
+Subject: [PATCH 020/450] BACKPORT: UPSTREAM: net: stmmac: add
  stmmac_plat_dat_alloc()
 
 Add a function to allocate and initialise the plat_stmmacenet_data
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  6 files changed, 18 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 05b107b00ba0e..3073ebd1f33aa 100644
+index 05b107b00ba0..3073ebd1f33a 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -1285,7 +1285,7 @@ static int intel_eth_pci_probe(struct pci_dev *pdev,
@@ -38,7 +38,7 @@ index 05b107b00ba0e..3073ebd1f33aa 100644
  		return -ENOMEM;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 47bc3aeee857d..85cfd197f0966 100644
+index 47bc3aeee857..85cfd197f096 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -564,7 +564,7 @@ static int loongson_dwmac_probe(struct pci_dev *pdev, const struct pci_device_id
@@ -51,7 +51,7 @@ index 47bc3aeee857d..85cfd197f0966 100644
  		return -ENOMEM;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac.h b/drivers/net/ethernet/stmicro/stmmac/stmmac.h
-index 34f62993a4dae..abdd631a761c1 100644
+index 34f62993a4da..abdd631a761c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac.h
 @@ -411,6 +411,8 @@ int stmmac_reinit_ringparam(struct net_device *dev, u32 rx_size, u32 tx_size);
@@ -64,7 +64,7 @@ index 34f62993a4dae..abdd631a761c1 100644
  {
  	return !!priv->xdp_prog;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index b7fd4388afa8c..49ebfbed4a77e 100644
+index b7fd4388afa8..49ebfbed4a77 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7438,6 +7438,18 @@ static const struct xdp_metadata_ops stmmac_xdp_metadata_ops = {
@@ -87,7 +87,7 @@ index b7fd4388afa8c..49ebfbed4a77e 100644
   * stmmac_dvr_probe
   * @device: device pointer
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index 7d5b27db22598..67bdbe2cfd770 100644
+index 7d5b27db2259..67bdbe2cfd77 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -189,7 +189,7 @@ static int stmmac_pci_probe(struct pci_dev *pdev,
@@ -100,7 +100,7 @@ index 7d5b27db22598..67bdbe2cfd770 100644
  		return -ENOMEM;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index e8dc1830f318d..8d53fd51f5c8a 100644
+index e8dc1830f318..8d53fd51f5c8 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -438,7 +438,7 @@ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-net-stmmac-move-initialisation-of-phy_addr-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-net-stmmac-move-initialisation-of-phy_addr-.patch
@@ -1,7 +1,7 @@
 From a14ae458b5dac7712e9bbccca88e8333764fc189 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:29 +0000
-Subject: [PATCH 021/449] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 021/450] UPSTREAM: net: stmmac: move initialisation of
  phy_addr to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->phy_addr to
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 85cfd197f0966..2d6acdd7846d8 100644
+index 85cfd197f096..2d6acdd7846d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -114,9 +114,6 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -34,7 +34,7 @@ index 85cfd197f0966..2d6acdd7846d8 100644
  	plat->dma_cfg->pblx8 = true;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 49ebfbed4a77e..e0c7fa3d1afe9 100644
+index 49ebfbed4a77..e0c7fa3d1afe 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7446,6 +7446,11 @@ struct plat_stmmacenet_data *stmmac_plat_dat_alloc(struct device *dev)
@@ -50,7 +50,7 @@ index 49ebfbed4a77e..e0c7fa3d1afe9 100644
  }
  EXPORT_SYMBOL_GPL(stmmac_plat_dat_alloc);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index 67bdbe2cfd770..b545b0808a88e 100644
+index 67bdbe2cfd77..b545b0808a88 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -112,7 +112,6 @@ static int snps_gmac5_default_data(struct pci_dev *pdev,
@@ -62,7 +62,7 @@ index 67bdbe2cfd770..b545b0808a88e 100644
  
  	plat->dma_cfg->pbl = 32;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 8d53fd51f5c8a..5b27044dc78dd 100644
+index 8d53fd51f5c8..5b27044dc78d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -482,8 +482,6 @@ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-UPSTREAM-net-stmmac-move-initialisation-of-clk_csr-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-UPSTREAM-net-stmmac-move-initialisation-of-clk_csr-t.patch
@@ -1,7 +1,7 @@
 From 046a9dd58bd7d3ebd31ea30d25408df89f00db94 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:34 +0000
-Subject: [PATCH 022/449] UPSTREAM: net: stmmac: move initialisation of clk_csr
+Subject: [PATCH 022/450] UPSTREAM: net: stmmac: move initialisation of clk_csr
  to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->clk_csr to
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 2 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index e0c7fa3d1afe9..a4fc21b376738 100644
+index e0c7fa3d1afe..a4fc21b37673 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7448,8 +7448,10 @@ struct plat_stmmacenet_data *stmmac_plat_dat_alloc(struct device *dev)
@@ -33,7 +33,7 @@ index e0c7fa3d1afe9..a4fc21b376738 100644
  	return plat_dat;
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 5b27044dc78dd..c64352cc67577 100644
+index 5b27044dc78d..c64352cc6757 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -482,11 +482,6 @@ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-move-initialisation-of-maxmtu-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-move-initialisation-of-maxmtu-to.patch
@@ -1,7 +1,7 @@
 From ce9c62ef40bdd9b00dbd86b4585893e505b0a4e0 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:39 +0000
-Subject: [PATCH 023/449] UPSTREAM: net: stmmac: move initialisation of maxmtu
+Subject: [PATCH 023/450] UPSTREAM: net: stmmac: move initialisation of maxmtu
  to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->maxmtu to JUMBO_LEN to
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 2 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 3073ebd1f33aa..4c84cac43eb5b 100644
+index 3073ebd1f33a..4c84cac43eb5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -576,9 +576,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -45,7 +45,7 @@ index 3073ebd1f33aa..4c84cac43eb5b 100644
  
  	/* Use the last Rx queue */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 2d6acdd7846d8..8cc009af7ff44 100644
+index 2d6acdd7846d..8cc009af7ff4 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -101,9 +101,6 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -59,7 +59,7 @@ index 2d6acdd7846d8..8cc009af7ff44 100644
  	plat->tx_queues_cfg[0].use_prio = false;
  	plat->rx_queues_cfg[0].use_prio = false;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index a4fc21b376738..5b4f14d8ca27b 100644
+index a4fc21b37673..5b4f14d8ca27 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7449,9 +7449,11 @@ struct plat_stmmacenet_data *stmmac_plat_dat_alloc(struct device *dev)
@@ -75,7 +75,7 @@ index a4fc21b376738..5b4f14d8ca27b 100644
  	return plat_dat;
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index b545b0808a88e..c44808f614f3a 100644
+index b545b0808a88..c44808f614f3 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -34,9 +34,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -99,7 +99,7 @@ index b545b0808a88e..c44808f614f3a 100644
  	plat->tx_queues_to_use = 4;
  	plat->rx_queues_to_use = 4;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index c64352cc67577..e5edf909395cf 100644
+index c64352cc6757..e5edf909395c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -510,11 +510,6 @@ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-move-initialisation-of-multicast.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-move-initialisation-of-multicast.patch
@@ -1,7 +1,7 @@
 From 80b2f808aba02dc96b99c11385ef81cc66c2724d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:44 +0000
-Subject: [PATCH 024/449] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 024/450] UPSTREAM: net: stmmac: move initialisation of
  multicast_filter_bins to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->multicast_filter_bins to
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 3 insertions(+), 16 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 4c84cac43eb5b..e47cad01b16c2 100644
+index 4c84cac43eb5..e47cad01b16c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -570,9 +570,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -46,7 +46,7 @@ index 4c84cac43eb5b..e47cad01b16c2 100644
  	plat->unicast_filter_entries = 1;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 8cc009af7ff44..4b775e3c70472 100644
+index 8cc009af7ff4..4b775e3c7047 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -95,7 +95,7 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -59,7 +59,7 @@ index 8cc009af7ff44..4b775e3c70472 100644
  
  	/* Set default value for unicast filter entries */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 5b4f14d8ca27b..4bdd09e83a199 100644
+index 5b4f14d8ca27..4bdd09e83a19 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7450,10 +7450,12 @@ struct plat_stmmacenet_data *stmmac_plat_dat_alloc(struct device *dev)
@@ -76,7 +76,7 @@ index 5b4f14d8ca27b..4bdd09e83a199 100644
  	return plat_dat;
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index c44808f614f3a..f16d1c81e6a71 100644
+index c44808f614f3..f16d1c81e6a7 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -28,9 +28,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -100,7 +100,7 @@ index c44808f614f3a..f16d1c81e6a71 100644
  	plat->unicast_filter_entries = 1;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index e5edf909395cf..d7ebfdf28499a 100644
+index e5edf909395c..d7ebfdf28499 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -510,9 +510,6 @@ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-net-stmmac-move-initialisation-of-unicast_f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-net-stmmac-move-initialisation-of-unicast_f.patch
@@ -1,7 +1,7 @@
 From 632e2e37170c3427b22fcb6c74307c2bfe5ea822 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:49 +0000
-Subject: [PATCH 025/449] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 025/450] UPSTREAM: net: stmmac: move initialisation of
  unicast_filter_entries to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->unicast_filter_entries to
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  6 files changed, 2 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index e47cad01b16c2..106a9c49c567f 100644
+index e47cad01b16c..106a9c49c567 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -570,9 +570,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -47,7 +47,7 @@ index e47cad01b16c2..106a9c49c567f 100644
  
  	/* Use the last Rx queue */
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 4b775e3c70472..a564d536a274f 100644
+index 4b775e3c7047..a564d536a274 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -98,9 +98,6 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -61,7 +61,7 @@ index 4b775e3c70472..a564d536a274f 100644
  	plat->tx_queues_cfg[0].use_prio = false;
  	plat->rx_queues_cfg[0].use_prio = false;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sophgo.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sophgo.c
-index fcdda2401968b..44d4ceb8415f6 100644
+index fcdda2401968..44d4ceb8415f 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sophgo.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sophgo.c
 @@ -29,7 +29,6 @@ static int sophgo_sg2044_dwmac_init(struct platform_device *pdev,
@@ -73,7 +73,7 @@ index fcdda2401968b..44d4ceb8415f6 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 4bdd09e83a199..ab60456c296d3 100644
+index 4bdd09e83a19..ab60456c296d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7451,11 +7451,13 @@ struct plat_stmmacenet_data *stmmac_plat_dat_alloc(struct device *dev)
@@ -91,7 +91,7 @@ index 4bdd09e83a199..ab60456c296d3 100644
  	return plat_dat;
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index f16d1c81e6a71..c9b3b6658f282 100644
+index f16d1c81e6a7..c9b3b6658f28 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -28,9 +28,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -115,7 +115,7 @@ index f16d1c81e6a71..c9b3b6658f282 100644
  	plat->tx_queues_to_use = 4;
  	plat->rx_queues_to_use = 4;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index d7ebfdf28499a..7c3b686c3dff8 100644
+index d7ebfdf28499..7c3b686c3dff 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -510,9 +510,6 @@ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-net-stmmac-move-initialisation-of-queues_to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-net-stmmac-move-initialisation-of-queues_to.patch
@@ -1,7 +1,7 @@
 From c65ddf6c5664d9cab4fb91b5455038ada3122014 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:54 +0000
-Subject: [PATCH 026/449] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 026/450] UPSTREAM: net: stmmac: move initialisation of
  queues_to_use to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->tx_queues_to_use and
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 8 insertions(+), 23 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 106a9c49c567f..96c912b74fd48 100644
+index 106a9c49c567..96c912b74fd4 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -570,10 +570,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -37,7 +37,7 @@ index 106a9c49c567f..96c912b74fd48 100644
  	plat->tx_queues_cfg[0].use_prio = false;
  	plat->rx_queues_cfg[0].use_prio = false;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index a564d536a274f..311da4000b8d1 100644
+index a564d536a274..311da4000b8d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -131,8 +131,6 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -50,7 +50,7 @@ index a564d536a274f..311da4000b8d1 100644
  	}
  }
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index ab60456c296d3..c129b399f913f 100644
+index ab60456c296d..c129b399f913 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7459,6 +7459,10 @@ struct plat_stmmacenet_data *stmmac_plat_dat_alloc(struct device *dev)
@@ -65,7 +65,7 @@ index ab60456c296d3..c129b399f913f 100644
  }
  EXPORT_SYMBOL_GPL(stmmac_plat_dat_alloc);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index c9b3b6658f282..711a922240b3a 100644
+index c9b3b6658f28..711a922240b3 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -28,10 +28,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -80,7 +80,7 @@ index c9b3b6658f282..711a922240b3a 100644
  	plat->tx_queues_cfg[0].use_prio = false;
  	plat->rx_queues_cfg[0].use_prio = false;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 7c3b686c3dff8..bc916c44ded6b 100644
+index 7c3b686c3dff..bc916c44ded6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -139,13 +139,6 @@ static int stmmac_mtl_setup(struct platform_device *pdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-net-stmmac-setup-default-RX-channel-map-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-net-stmmac-setup-default-RX-channel-map-in-.patch
@@ -1,7 +1,7 @@
 From f6765935092892a902ae7a0b40d4812566e06d92 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:00 +0000
-Subject: [PATCH 027/449] UPSTREAM: net: stmmac: setup default RX channel map
+Subject: [PATCH 027/450] UPSTREAM: net: stmmac: setup default RX channel map
  in stmmac_plat_dat_alloc()
 
 Setup the default 1:1 RX channel map in stmmac_plat_dat_alloc() and
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 96c912b74fd48..98ba12cf3d917 100644
+index 96c912b74fd4..98ba12cf3d91 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -618,7 +618,6 @@ static int intel_mgbe_common_data(struct pci_dev *pdev,
@@ -32,7 +32,7 @@ index 96c912b74fd48..98ba12cf3d917 100644
  		/* Disable Priority config by default */
  		plat->rx_queues_cfg[i].use_prio = false;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index c129b399f913f..e81585795dc5c 100644
+index c129b399f913..e81585795dc5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -7441,6 +7441,7 @@ static const struct xdp_metadata_ops stmmac_xdp_metadata_ops = {
@@ -55,7 +55,7 @@ index c129b399f913f..e81585795dc5c 100644
  }
  EXPORT_SYMBOL_GPL(stmmac_plat_dat_alloc);
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index 711a922240b3a..c6bb9d52a6a44 100644
+index 711a922240b3..c6bb9d52a6a4 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -86,7 +86,6 @@ static int snps_gmac5_default_data(struct pci_dev *pdev,
@@ -67,7 +67,7 @@ index 711a922240b3a..c6bb9d52a6a44 100644
  
  	plat->bus_id = 1;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index bc916c44ded6b..0ce4814d77b64 100644
+index bc916c44ded6..0ce4814d77b6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -179,9 +179,8 @@ static int stmmac_mtl_setup(struct platform_device *pdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-net-stmmac-remove-unnecessary-.use_prio-que.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-net-stmmac-remove-unnecessary-.use_prio-que.patch
@@ -1,7 +1,7 @@
 From 2b4f5fc32c0ffa2bc67607abfeed27cb7b7834e0 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:05 +0000
-Subject: [PATCH 028/449] UPSTREAM: net: stmmac: remove unnecessary .use_prio
+Subject: [PATCH 028/450] UPSTREAM: net: stmmac: remove unnecessary .use_prio
  queue initialisation
 
 Several drivers (see below) explicitly set the queue .use_prio
@@ -40,7 +40,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 21 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 98ba12cf3d917..356291dfe0460 100644
+index 98ba12cf3d91..356291dfe046 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -570,10 +570,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -74,7 +74,7 @@ index 98ba12cf3d917..356291dfe0460 100644
  		if (i > 0)
  			plat->tx_queues_cfg[i].tbs_en = 1;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index 311da4000b8d1..fb864e50b510d 100644
+index 311da4000b8d..fb864e50b510 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -98,10 +98,6 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -89,7 +89,7 @@ index 311da4000b8d1..fb864e50b510d 100644
  	plat->rx_queues_cfg[0].pkt_route = 0x0;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index c6bb9d52a6a44..6047e749dc37f 100644
+index c6bb9d52a6a4..6047e749dc37 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -28,10 +28,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -120,7 +120,7 @@ index c6bb9d52a6a44..6047e749dc37f 100644
  		plat->rx_queues_cfg[i].pkt_route = 0x0;
  	}
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 0ce4814d77b64..093ebdcd1213e 100644
+index 0ce4814d77b6..093ebdcd1213 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -186,7 +186,6 @@ static int stmmac_mtl_setup(struct platform_device *pdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-net-stmmac-remove-unnecessary-.prio-queue-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-net-stmmac-remove-unnecessary-.prio-queue-i.patch
@@ -1,7 +1,7 @@
 From 1bfda16d34cede94991d2f381b1c4a9cc4594269 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:10 +0000
-Subject: [PATCH 029/449] UPSTREAM: net: stmmac: remove unnecessary .prio queue
+Subject: [PATCH 029/450] UPSTREAM: net: stmmac: remove unnecessary .prio queue
  initialisation
 
 stmmac_platform.c explicitly sets .prio to zero if the snps,priority
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 093ebdcd1213e..a3bca53b155bf 100644
+index 093ebdcd1213..a3bca53b155b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -183,12 +183,9 @@ static int stmmac_mtl_setup(struct platform_device *pdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-net-stmmac-remove-unnecessary-.pkt_route-qu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-net-stmmac-remove-unnecessary-.pkt_route-qu.patch
@@ -1,7 +1,7 @@
 From 21a42f526621fe5be224a374c50ec700d5ed3d10 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:15 +0000
-Subject: [PATCH 030/449] UPSTREAM: net: stmmac: remove unnecessary .pkt_route
+Subject: [PATCH 030/450] UPSTREAM: net: stmmac: remove unnecessary .pkt_route
  queue initialisation
 
 PCI drivers explicitly set .pkt_route to zero. However, as the struct
@@ -37,7 +37,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 2 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
-index 356291dfe0460..aad1be1ec4c11 100644
+index 356291dfe046..aad1be1ec4c1 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.c
 @@ -569,9 +569,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -66,7 +66,7 @@ index 356291dfe0460..aad1be1ec4c11 100644
  		plat->tx_queues_cfg[i].mode_to_use = MTL_QUEUE_DCB;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index fb864e50b510d..a6e4349904657 100644
+index fb864e50b510..a6e434990465 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -98,9 +98,6 @@ static void loongson_default_data(struct pci_dev *pdev,
@@ -80,7 +80,7 @@ index fb864e50b510d..a6e4349904657 100644
  	plat->clk_ptp_rate = 125000000;
  
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index 6047e749dc37f..afb1c53ca6f87 100644
+index 6047e749dc37..afb1c53ca6f8 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -27,9 +27,6 @@ static void common_default_data(struct plat_stmmacenet_data *plat)
@@ -106,7 +106,7 @@ index 6047e749dc37f..afb1c53ca6f87 100644
  	plat->bus_id = 1;
  	plat->phy_interface = PHY_INTERFACE_MODE_GMII;
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index a3bca53b155bf..e4d313c02fc6b 100644
+index a3bca53b155b..e4d313c02fc6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -198,8 +198,6 @@ static int stmmac_mtl_setup(struct platform_device *pdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-arm64-dts-cix-add-DT-nodes-for-SPI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-arm64-dts-cix-add-DT-nodes-for-SPI.patch
@@ -1,7 +1,7 @@
 From 9c42c395100b1829effd06afddfa6ab12b1ab56e Mon Sep 17 00:00:00 2001
 From: Jun Guo <jun.guo@cixtech.com>
 Date: Fri, 19 Sep 2025 09:31:18 +0800
-Subject: [PATCH 031/449] UPSTREAM: arm64: dts: cix: add DT nodes for SPI
+Subject: [PATCH 031/450] UPSTREAM: arm64: dts: cix: add DT nodes for SPI
 
 Add the device tree node for the spi controller of the CIX SKY1 SoC.
 
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 20 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/cix/sky1.dtsi b/arch/arm64/boot/dts/cix/sky1.dtsi
-index 2fb2c99c0796d..ea324336bf343 100644
+index 2fb2c99c0796..ea324336bf34 100644
 --- a/arch/arm64/boot/dts/cix/sky1.dtsi
 +++ b/arch/arm64/boot/dts/cix/sky1.dtsi
 @@ -264,6 +264,26 @@ i2c7: i2c@4080000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-dt-bindings-pinctrl-Add-cix-sky1-pinctrl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-dt-bindings-pinctrl-Add-cix-sky1-pinctrl.patch
@@ -1,7 +1,7 @@
 From a0e530195b9b11464f763f4744dd5d93d654607c Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:08 +0800
-Subject: [PATCH 032/449] UPSTREAM: dt-bindings: pinctrl: Add cix,sky1-pinctrl
+Subject: [PATCH 032/450] UPSTREAM: dt-bindings: pinctrl: Add cix,sky1-pinctrl
 
 The pin-controller is used to control the Soc pins.
 There are two pin-controllers on Cix Sky1 platform.
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/pinctrl/cix,sky1-pinctrl.yaml b/Documentation/devicetree/bindings/pinctrl/cix,sky1-pinctrl.yaml
 new file mode 100644
-index 0000000000000..36977b0d745bd
+index 000000000000..36977b0d745b
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pinctrl/cix,sky1-pinctrl.yaml
 @@ -0,0 +1,92 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-pinctrl-cix-Add-pin-controller-support-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-pinctrl-cix-Add-pin-controller-support-for-.patch
@@ -1,7 +1,7 @@
 From f59a9a48cbd6054d6ab8db87b5a02f07dacfa99a Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:09 +0800
-Subject: [PATCH 033/449] UPSTREAM: pinctrl: cix: Add pin-controller support
+Subject: [PATCH 033/450] UPSTREAM: pinctrl: cix: Add pin-controller support
  for sky1
 
 There are two pin-controllers on Cix Sky1 platform.
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/pinctrl/cix/pinctrl-sky1.h
 
 diff --git a/drivers/pinctrl/Kconfig b/drivers/pinctrl/Kconfig
-index 4f8507ebbdacd..cb84b2f9896c8 100644
+index 4f8507ebbdac..cb84b2f9896c 100644
 --- a/drivers/pinctrl/Kconfig
 +++ b/drivers/pinctrl/Kconfig
 @@ -686,6 +686,7 @@ source "drivers/pinctrl/aspeed/Kconfig"
@@ -40,7 +40,7 @@ index 4f8507ebbdacd..cb84b2f9896c8 100644
  source "drivers/pinctrl/intel/Kconfig"
  source "drivers/pinctrl/mediatek/Kconfig"
 diff --git a/drivers/pinctrl/Makefile b/drivers/pinctrl/Makefile
-index e0cfb9b7c99ba..82d40eecbe22d 100644
+index e0cfb9b7c99b..82d40eecbe22 100644
 --- a/drivers/pinctrl/Makefile
 +++ b/drivers/pinctrl/Makefile
 @@ -69,6 +69,7 @@ obj-$(CONFIG_ARCH_ASPEED)	+= aspeed/
@@ -53,7 +53,7 @@ index e0cfb9b7c99ba..82d40eecbe22d 100644
  obj-y				+= mediatek/
 diff --git a/drivers/pinctrl/cix/Kconfig b/drivers/pinctrl/cix/Kconfig
 new file mode 100644
-index 0000000000000..455120dd73189
+index 000000000000..455120dd7318
 --- /dev/null
 +++ b/drivers/pinctrl/cix/Kconfig
 @@ -0,0 +1,14 @@
@@ -73,7 +73,7 @@ index 0000000000000..455120dd73189
 +	  Say Y here to enable the sky1 pinctrl driver
 diff --git a/drivers/pinctrl/cix/Makefile b/drivers/pinctrl/cix/Makefile
 new file mode 100644
-index 0000000000000..22685d6a107b2
+index 000000000000..22685d6a107b
 --- /dev/null
 +++ b/drivers/pinctrl/cix/Makefile
 @@ -0,0 +1,4 @@
@@ -83,7 +83,7 @@ index 0000000000000..22685d6a107b2
 +obj-$(CONFIG_PINCTRL_SKY1)	+= pinctrl-sky1.o
 diff --git a/drivers/pinctrl/cix/pinctrl-sky1-base.c b/drivers/pinctrl/cix/pinctrl-sky1-base.c
 new file mode 100644
-index 0000000000000..b03e10147b09f
+index 000000000000..b03e10147b09
 --- /dev/null
 +++ b/drivers/pinctrl/cix/pinctrl-sky1-base.c
 @@ -0,0 +1,572 @@
@@ -661,7 +661,7 @@ index 0000000000000..b03e10147b09f
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/pinctrl/cix/pinctrl-sky1.c b/drivers/pinctrl/cix/pinctrl-sky1.c
 new file mode 100644
-index 0000000000000..5d0d8be815b2b
+index 000000000000..5d0d8be815b2
 --- /dev/null
 +++ b/drivers/pinctrl/cix/pinctrl-sky1.c
 @@ -0,0 +1,559 @@
@@ -1226,7 +1226,7 @@ index 0000000000000..5d0d8be815b2b
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/pinctrl/cix/pinctrl-sky1.h b/drivers/pinctrl/cix/pinctrl-sky1.h
 new file mode 100644
-index 0000000000000..a8b0998529651
+index 000000000000..a8b099852965
 --- /dev/null
 +++ b/drivers/pinctrl/cix/pinctrl-sky1.h
 @@ -0,0 +1,48 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-UPSTREAM-arm64-dts-cix-Add-pinctrl-nodes-for-sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-UPSTREAM-arm64-dts-cix-Add-pinctrl-nodes-for-sky1.patch
@@ -1,7 +1,7 @@
 From 000a880f3f1fc79e9e9d7758822db934cff2f9ce Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:10 +0800
-Subject: [PATCH 034/449] UPSTREAM: arm64: dts: cix: Add pinctrl nodes for sky1
+Subject: [PATCH 034/450] UPSTREAM: arm64: dts: cix: Add pinctrl nodes for sky1
 
 Add the pin-controller nodes for Sky1 platform.
 
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/arm64/boot/dts/cix/sky1-pinfunc.h
 
 diff --git a/arch/arm64/boot/dts/cix/sky1-orion-o6.dts b/arch/arm64/boot/dts/cix/sky1-orion-o6.dts
-index d74964d53c3bc..cdaca197edda4 100644
+index d74964d53c3b..cdaca197edda 100644
 --- a/arch/arm64/boot/dts/cix/sky1-orion-o6.dts
 +++ b/arch/arm64/boot/dts/cix/sky1-orion-o6.dts
 @@ -7,6 +7,8 @@
@@ -69,7 +69,7 @@ index d74964d53c3bc..cdaca197edda4 100644
  };
 diff --git a/arch/arm64/boot/dts/cix/sky1-pinfunc.h b/arch/arm64/boot/dts/cix/sky1-pinfunc.h
 new file mode 100644
-index 0000000000000..ebe9f6fef4036
+index 000000000000..ebe9f6fef403
 --- /dev/null
 +++ b/arch/arm64/boot/dts/cix/sky1-pinfunc.h
 @@ -0,0 +1,401 @@
@@ -475,7 +475,7 @@ index 0000000000000..ebe9f6fef4036
 +
 +#endif
 diff --git a/arch/arm64/boot/dts/cix/sky1.dtsi b/arch/arm64/boot/dts/cix/sky1.dtsi
-index ea324336bf343..3bc4c4f09ec22 100644
+index ea324336bf34..3bc4c4f09ec2 100644
 --- a/arch/arm64/boot/dts/cix/sky1.dtsi
 +++ b/arch/arm64/boot/dts/cix/sky1.dtsi
 @@ -348,6 +348,11 @@ i3c1: i3c@4100000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-UPSTREAM-PCI-cadence-Add-module-support-for-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-UPSTREAM-PCI-cadence-Add-module-support-for-platform.patch
@@ -1,7 +1,7 @@
 From 03acefed1c23686dfcf08ffdd133bb3f9241edc3 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:56 +0800
-Subject: [PATCH 035/449] UPSTREAM: PCI: cadence: Add module support for
+Subject: [PATCH 035/450] UPSTREAM: PCI: cadence: Add module support for
  platform controller driver
 
 Add support for building PCI cadence platforms as a module.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/pci/controller/cadence/Kconfig b/drivers/pci/controller/cadence/Kconfig
-index 02a639e55fd8c..0b96499ae354e 100644
+index 02a639e55fd8..0b96499ae354 100644
 --- a/drivers/pci/controller/cadence/Kconfig
 +++ b/drivers/pci/controller/cadence/Kconfig
 @@ -19,10 +19,10 @@ config PCIE_CADENCE_EP
@@ -44,7 +44,7 @@ index 02a639e55fd8c..0b96499ae354e 100644
  	depends on PCI_ENDPOINT
  	select PCIE_CADENCE_EP
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-plat.c b/drivers/pci/controller/cadence/pcie-cadence-plat.c
-index 0456845dabb96..ebd5c3afdfcdc 100644
+index 0456845dabb9..ebd5c3afdfcd 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence-plat.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence-plat.c
 @@ -177,4 +177,7 @@ static struct platform_driver cdns_plat_pcie_driver = {
@@ -57,7 +57,7 @@ index 0456845dabb96..ebd5c3afdfcdc 100644
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("Cadence PCIe controller platform driver");
 diff --git a/drivers/pci/controller/cadence/pcie-cadence.c b/drivers/pci/controller/cadence/pcie-cadence.c
-index bd683d0fecb22..8186947134d64 100644
+index bd683d0fecb2..8186947134d6 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence.c
 @@ -293,6 +293,7 @@ const struct dev_pm_ops cdns_pcie_pm_ops = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-UPSTREAM-PCI-cadence-Split-PCIe-controller-header-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-UPSTREAM-PCI-cadence-Split-PCIe-controller-header-fi.patch
@@ -1,7 +1,7 @@
 From 4dc45d1b84f46e1ad1e1a6fcca59de592a4badb0 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:57 +0800
-Subject: [PATCH 036/449] UPSTREAM: PCI: cadence: Split PCIe controller header
+Subject: [PATCH 036/450] UPSTREAM: PCI: cadence: Split PCIe controller header
  file
 
 Split the Cadence PCIe header file by moving the Legacy (LGA) controller
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-lga-regs.h b/drivers/pci/controller/cadence/pcie-cadence-lga-regs.h
 new file mode 100644
-index 0000000000000..857b2140c5d20
+index 000000000000..857b2140c5d2
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-cadence-lga-regs.h
 @@ -0,0 +1,230 @@
@@ -256,7 +256,7 @@ index 0000000000000..857b2140c5d20
 +
 +#endif /* _PCIE_CADENCE_LGA_REGS_H */
 diff --git a/drivers/pci/controller/cadence/pcie-cadence.h b/drivers/pci/controller/cadence/pcie-cadence.h
-index e2a853d2c0ab0..0b8ba4ed5913c 100644
+index e2a853d2c0ab..0b8ba4ed5913 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence.h
 +++ b/drivers/pci/controller/cadence/pcie-cadence.h
 @@ -7,211 +7,11 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-UPSTREAM-PCI-cadence-Move-PCIe-RP-common-functions-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-UPSTREAM-PCI-cadence-Move-PCIe-RP-common-functions-t.patch
@@ -1,7 +1,7 @@
 From a29809323e87022d62aed51fa9e79811d98da727 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:58 +0800
-Subject: [PATCH 037/449] UPSTREAM: PCI: cadence: Move PCIe RP common functions
+Subject: [PATCH 037/450] UPSTREAM: PCI: cadence: Move PCIe RP common functions
  to a separate file
 
 Move the Cadence PCIe controller RP common functions into a separate file.
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/pci/controller/cadence/pcie-cadence-host-common.h
 
 diff --git a/drivers/pci/controller/cadence/Makefile b/drivers/pci/controller/cadence/Makefile
-index 5e23f8539ecc1..91ffdbfd3aaac 100644
+index 5e23f8539ecc..91ffdbfd3aaa 100644
 --- a/drivers/pci/controller/cadence/Makefile
 +++ b/drivers/pci/controller/cadence/Makefile
 @@ -1,7 +1,11 @@
@@ -44,7 +44,7 @@ index 5e23f8539ecc1..91ffdbfd3aaac 100644
  obj-$(CONFIG_PCIE_SG2042_HOST) += pcie-sg2042.o
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-host-common.c b/drivers/pci/controller/cadence/pcie-cadence-host-common.c
 new file mode 100644
-index 0000000000000..15415d7f35ee9
+index 000000000000..15415d7f35ee
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-cadence-host-common.c
 @@ -0,0 +1,288 @@
@@ -338,7 +338,7 @@ index 0000000000000..15415d7f35ee9
 +MODULE_DESCRIPTION("Cadence PCIe host controller driver");
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-host-common.h b/drivers/pci/controller/cadence/pcie-cadence-host-common.h
 new file mode 100644
-index 0000000000000..fe7d4202a8b6d
+index 000000000000..fe7d4202a8b6
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-cadence-host-common.h
 @@ -0,0 +1,46 @@
@@ -389,7 +389,7 @@ index 0000000000000..fe7d4202a8b6d
 +
 +#endif /* _PCIE_CADENCE_HOST_COMMON_H */
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-host.c b/drivers/pci/controller/cadence/pcie-cadence-host.c
-index fffd63d6665e8..db3154c1eccbf 100644
+index fffd63d6665e..db3154c1eccb 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence-host.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence-host.c
 @@ -12,14 +12,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-UPSTREAM-PCI-cadence-Add-support-for-High-Perf-Archi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-UPSTREAM-PCI-cadence-Add-support-for-High-Perf-Archi.patch
@@ -1,7 +1,7 @@
 From aeb68c4ca6e53d440a925eaec453762071d20a3c Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:59 +0800
-Subject: [PATCH 038/449] UPSTREAM: PCI: cadence: Add support for High Perf
+Subject: [PATCH 038/450] UPSTREAM: PCI: cadence: Add support for High Perf
  Architecture (HPA) controller
 
 Add support for Cadence PCIe RP configuration for High Performance
@@ -32,7 +32,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/pci/controller/cadence/pcie-cadence-hpa.c
 
 diff --git a/drivers/pci/controller/cadence/Makefile b/drivers/pci/controller/cadence/Makefile
-index 91ffdbfd3aaac..30189045a1663 100644
+index 91ffdbfd3aaa..30189045a166 100644
 --- a/drivers/pci/controller/cadence/Makefile
 +++ b/drivers/pci/controller/cadence/Makefile
 @@ -1,6 +1,6 @@
@@ -46,7 +46,7 @@ index 91ffdbfd3aaac..30189045a1663 100644
  obj-$(CONFIG_PCIE_CADENCE) = pcie-cadence-mod.o
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-host-hpa.c b/drivers/pci/controller/cadence/pcie-cadence-host-hpa.c
 new file mode 100644
-index 0000000000000..0f540bed58e88
+index 000000000000..0f540bed58e8
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-cadence-host-hpa.c
 @@ -0,0 +1,368 @@
@@ -420,7 +420,7 @@ index 0000000000000..0f540bed58e88
 +MODULE_DESCRIPTION("Cadence PCIe host controller driver");
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-hpa-regs.h b/drivers/pci/controller/cadence/pcie-cadence-hpa-regs.h
 new file mode 100644
-index 0000000000000..026e131600dec
+index 000000000000..026e131600de
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-cadence-hpa-regs.h
 @@ -0,0 +1,193 @@
@@ -619,7 +619,7 @@ index 0000000000000..026e131600dec
 +#endif /* _PCIE_CADENCE_HPA_REGS_H */
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-hpa.c b/drivers/pci/controller/cadence/pcie-cadence-hpa.c
 new file mode 100644
-index 0000000000000..f60a169382656
+index 000000000000..f60a16938265
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pcie-cadence-hpa.c
 @@ -0,0 +1,167 @@
@@ -791,7 +791,7 @@ index 0000000000000..f60a169382656
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("Cadence PCIe controller driver");
 diff --git a/drivers/pci/controller/cadence/pcie-cadence-plat.c b/drivers/pci/controller/cadence/pcie-cadence-plat.c
-index ebd5c3afdfcdc..b067a3296dd37 100644
+index ebd5c3afdfcd..b067a3296dd3 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence-plat.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence-plat.c
 @@ -22,10 +22,6 @@ struct cdns_plat_pcie {
@@ -806,7 +806,7 @@ index ebd5c3afdfcdc..b067a3296dd37 100644
  
  static u64 cdns_plat_cpu_addr_fixup(struct cdns_pcie *pcie, u64 cpu_addr)
 diff --git a/drivers/pci/controller/cadence/pcie-cadence.c b/drivers/pci/controller/cadence/pcie-cadence.c
-index 8186947134d64..e6f1a4ac0fb7a 100644
+index 8186947134d6..e6f1a4ac0fb7 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence.c
 +++ b/drivers/pci/controller/cadence/pcie-cadence.c
 @@ -23,6 +23,17 @@ u16 cdns_pcie_find_ext_capability(struct cdns_pcie *pcie, u8 cap)
@@ -828,7 +828,7 @@ index 8186947134d64..e6f1a4ac0fb7a 100644
  {
  	u32 delay = 0x3;
 diff --git a/drivers/pci/controller/cadence/pcie-cadence.h b/drivers/pci/controller/cadence/pcie-cadence.h
-index 0b8ba4ed5913c..311a13ae46e7e 100644
+index 0b8ba4ed5913..311a13ae46e7 100644
 --- a/drivers/pci/controller/cadence/pcie-cadence.h
 +++ b/drivers/pci/controller/cadence/pcie-cadence.h
 @@ -12,6 +12,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-UPSTREAM-dt-bindings-PCI-Add-CIX-Sky1-PCIe-Root-Comp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-UPSTREAM-dt-bindings-PCI-Add-CIX-Sky1-PCIe-Root-Comp.patch
@@ -1,7 +1,7 @@
 From 9d0d9e6096864951a4ddd4f42bbbcc8a0bc9c990 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:00 +0800
-Subject: [PATCH 039/449] UPSTREAM: dt-bindings: PCI: Add CIX Sky1 PCIe Root
+Subject: [PATCH 039/450] UPSTREAM: dt-bindings: PCI: Add CIX Sky1 PCIe Root
  Complex bindings
 
 Document the bindings for CIX Sky1 PCIe Controller configured in Root
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/pci/cix,sky1-pcie-host.yaml b/Documentation/devicetree/bindings/pci/cix,sky1-pcie-host.yaml
 new file mode 100644
-index 0000000000000..b910a42e0843d
+index 000000000000..b910a42e0843
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pci/cix,sky1-pcie-host.yaml
 @@ -0,0 +1,83 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-UPSTREAM-PCI-sky1-Add-PCIe-host-support-for-CIX-Sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-UPSTREAM-PCI-sky1-Add-PCIe-host-support-for-CIX-Sky1.patch
@@ -1,7 +1,7 @@
 From 20a6671973ff5c3507699d59fc9d1cfd95f3b7ed Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:02 +0800
-Subject: [PATCH 040/449] UPSTREAM: PCI: sky1: Add PCIe host support for CIX
+Subject: [PATCH 040/450] UPSTREAM: PCI: sky1: Add PCIe host support for CIX
  Sky1
 
 Add driver for the CIX Sky1 SoC PCIe Gen4 16 GT/s controller based on the
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/pci/controller/cadence/pci-sky1.c
 
 diff --git a/drivers/pci/controller/cadence/Kconfig b/drivers/pci/controller/cadence/Kconfig
-index 0b96499ae354e..65e97c8183c2a 100644
+index 0b96499ae354..65e97c8183c2 100644
 --- a/drivers/pci/controller/cadence/Kconfig
 +++ b/drivers/pci/controller/cadence/Kconfig
 @@ -51,6 +51,21 @@ config PCIE_SG2042_HOST
@@ -52,7 +52,7 @@ index 0b96499ae354e..65e97c8183c2a 100644
  	tristate
  	select PCIE_CADENCE_HOST if PCI_J721E_HOST != n
 diff --git a/drivers/pci/controller/cadence/Makefile b/drivers/pci/controller/cadence/Makefile
-index 30189045a1663..b8ec1cecfaa88 100644
+index 30189045a166..b8ec1cecfaa8 100644
 --- a/drivers/pci/controller/cadence/Makefile
 +++ b/drivers/pci/controller/cadence/Makefile
 @@ -9,3 +9,4 @@ obj-$(CONFIG_PCIE_CADENCE_EP) += pcie-cadence-ep-mod.o
@@ -62,7 +62,7 @@ index 30189045a1663..b8ec1cecfaa88 100644
 +obj-$(CONFIG_PCI_SKY1_HOST) += pci-sky1.o
 diff --git a/drivers/pci/controller/cadence/pci-sky1.c b/drivers/pci/controller/cadence/pci-sky1.c
 new file mode 100644
-index 0000000000000..d8c216dc120d6
+index 000000000000..d8c216dc120d
 --- /dev/null
 +++ b/drivers/pci/controller/cadence/pci-sky1.c
 @@ -0,0 +1,238 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-UPSTREAM-arm64-dts-cix-Add-PCIe-Root-Complex-on-sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-UPSTREAM-arm64-dts-cix-Add-PCIe-Root-Complex-on-sky1.patch
@@ -1,7 +1,7 @@
 From d5aa7648ae70019530044e54fa3a8d7c10a79900 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:04 +0800
-Subject: [PATCH 041/449] UPSTREAM: arm64: dts: cix: Add PCIe Root Complex on
+Subject: [PATCH 041/450] UPSTREAM: arm64: dts: cix: Add PCIe Root Complex on
  sky1
 
 Add pcie_x*_rc node to support Sky1 PCIe driver based on the
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 126 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/cix/sky1.dtsi b/arch/arm64/boot/dts/cix/sky1.dtsi
-index 3bc4c4f09ec22..f4be70a6278b2 100644
+index 3bc4c4f09ec2..f4be70a6278b 100644
 --- a/arch/arm64/boot/dts/cix/sky1.dtsi
 +++ b/arch/arm64/boot/dts/cix/sky1.dtsi
 @@ -413,6 +413,132 @@ mbox_ap2sfh: mailbox@80a0000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-UPSTREAM-arm64-dts-cix-Enable-PCIe-on-the-Orion-O6-b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-UPSTREAM-arm64-dts-cix-Enable-PCIe-on-the-Orion-O6-b.patch
@@ -1,7 +1,7 @@
 From 740dfe4859e7b8f199b96c311a1f91b733e9cdd4 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:05 +0800
-Subject: [PATCH 042/449] UPSTREAM: arm64: dts: cix: Enable PCIe on the Orion
+Subject: [PATCH 042/450] UPSTREAM: arm64: dts: cix: Enable PCIe on the Orion
  O6 board
 
 Add PCIe RC support on Orion O6 board.
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 20 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/cix/sky1-orion-o6.dts b/arch/arm64/boot/dts/cix/sky1-orion-o6.dts
-index cdaca197edda4..4dee8cd0b86da 100644
+index cdaca197edda..4dee8cd0b86d 100644
 --- a/arch/arm64/boot/dts/cix/sky1-orion-o6.dts
 +++ b/arch/arm64/boot/dts/cix/sky1-orion-o6.dts
 @@ -66,6 +66,26 @@ pins {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-UPSTREAM-arm64-dts-cix-add-a-compatible-string-for-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-UPSTREAM-arm64-dts-cix-add-a-compatible-string-for-t.patch
@@ -1,7 +1,7 @@
 From 14e013f4f2aa9a228b0ef3862b060456a8a594f2 Mon Sep 17 00:00:00 2001
 From: Jun Guo <jun.guo@cixtech.com>
 Date: Fri, 31 Oct 2025 15:30:03 +0800
-Subject: [PATCH 043/449] UPSTREAM: arm64: dts: cix: add a compatible string
+Subject: [PATCH 043/450] UPSTREAM: arm64: dts: cix: add a compatible string
  for the cix sky1 SoC
 
 The SPI IP design for the cix sky1 SoC uses a FIFO with a data width
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/cix/sky1.dtsi b/arch/arm64/boot/dts/cix/sky1.dtsi
-index f4be70a6278b2..64b76905cbff5 100644
+index f4be70a6278b..64b76905cbff 100644
 --- a/arch/arm64/boot/dts/cix/sky1.dtsi
 +++ b/arch/arm64/boot/dts/cix/sky1.dtsi
 @@ -265,7 +265,7 @@ i2c7: i2c@4080000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-UPSTREAM-drm-ttm-add-pgprot-handling-for-RISC-V.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-UPSTREAM-drm-ttm-add-pgprot-handling-for-RISC-V.patch
@@ -1,7 +1,7 @@
 From 4c2ed69a025bd79717b542820cdc6150b9aa452e Mon Sep 17 00:00:00 2001
 From: Han Gao <gaohan@iscas.ac.cn>
 Date: Fri, 5 Dec 2025 10:42:07 +0800
-Subject: [PATCH 044/449] UPSTREAM: drm/ttm: add pgprot handling for RISC-V
+Subject: [PATCH 044/450] UPSTREAM: drm/ttm: add pgprot handling for RISC-V
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_module.c b/drivers/gpu/drm/ttm/ttm_module.c
-index b3fffe7b5062a..aa137ead5cc59 100644
+index b3fffe7b5062..aa137ead5cc5 100644
 --- a/drivers/gpu/drm/ttm/ttm_module.c
 +++ b/drivers/gpu/drm/ttm/ttm_module.c
 @@ -74,7 +74,8 @@ pgprot_t ttm_prot_from_caching(enum ttm_caching caching, pgprot_t tmp)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-UPSTREAM-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-UPSTREAM-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
@@ -1,7 +1,7 @@
 From 8458cddce1f6b842d5bc94436c5d912d759d6b6d Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:33:43 +0800
-Subject: [PATCH 045/449] UPSTREAM: riscv: sophgo: dts: add PCIe controllers
+Subject: [PATCH 045/450] UPSTREAM: riscv: sophgo: dts: add PCIe controllers
  for SG2042
 
 Add PCIe controller nodes in DTS for Sophgo SG2042.
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 88 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042.dtsi b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
-index c5e49709b3088..85d8b89cf9fc9 100644
+index c5e49709b308..85d8b89cf9fc 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 @@ -240,6 +240,94 @@ clkgen: clock-controller@7030012000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
@@ -1,7 +1,7 @@
 From 71e256de362b232fa1edc737f9c5072232788b13 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:34:05 +0800
-Subject: [PATCH 046/449] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 046/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  PioneerBox
 
 Enable PCIe controllers for PioneerBox, which uses SG2042 SoC.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
-index ef3a602172b1e..c4d5f8d7d4ad3 100644
+index ef3a602172b1..c4d5f8d7d4ad 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 @@ -128,6 +128,18 @@ uart0-rx-pins {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 9cdba38d4e01bc9bbd095fd49cac4ea494c40dc2 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:39:22 +0800
-Subject: [PATCH 047/449] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 047/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V1.X
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V1.X board,
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
-index 3320bc1dd2c66..a186d036cf360 100644
+index 3320bc1dd2c6..a186d036cf36 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 @@ -164,6 +164,18 @@ phy0: phy@0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 11ab32fd7c47907005b23057c1631e9deeabaf82 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:40:09 +0800
-Subject: [PATCH 048/449] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 048/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V2.0
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V2.0 board,
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
-index 46980e41b886c..0cd0dc0f537c1 100644
+index 46980e41b886..0cd0dc0f537c 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 @@ -152,6 +152,18 @@ phy0: phy@0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-UPSTREAM-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-UPSTREAM-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
@@ -1,7 +1,7 @@
 From aa1766dfeb33d4a7db4d96c32a13003bb94e9eb0 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:50 +0800
-Subject: [PATCH 049/449] UPSTREAM: riscv: dts: sophgo: Add SPI NOR node for
+Subject: [PATCH 049/450] UPSTREAM: riscv: dts: sophgo: Add SPI NOR node for
  SG2042
 
 Add SPI NOR controller node for SG2042
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042.dtsi b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
-index 85d8b89cf9fc9..ec99da39150f7 100644
+index 85d8b89cf9fc..ec99da39150f 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 +++ b/arch/riscv/boot/dts/sophgo/sg2042.dtsi
 @@ -68,6 +68,30 @@ soc: soc {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
@@ -1,7 +1,7 @@
 From 6a4df7e5a17240233159e0c3c8bf785f93dba400 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:51 +0800
-Subject: [PATCH 050/449] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 050/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  PioneerBox
 
 Enable SPI NOR node for PioneerBox device tree
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
-index c4d5f8d7d4ad3..54d8386bf9c0f 100644
+index c4d5f8d7d4ad..54d8386bf9c0 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-milkv-pioneer.dts
 @@ -150,6 +150,30 @@ &sd {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 333c10aab0cf9c2d79d73c66f9e3ba97255e7358 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:52 +0800
-Subject: [PATCH 051/449] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 051/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V1
 
 Enable SPI NOR node for SG2042_EVB_V1 device tree
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
-index a186d036cf360..b116dfa904cd9 100644
+index a186d036cf36..b116dfa904cd 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v1.dts
 @@ -250,6 +250,30 @@ &sd {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 52330652a8789ec4f43bb63e1f76c91a606ec516 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:53 +0800
-Subject: [PATCH 052/449] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 052/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V2
 
 Enable SPI NOR node for SG2042_EVB_V2 device tree
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
-index 0cd0dc0f537c1..b2ceae2d8829e 100644
+index 0cd0dc0f537c..b2ceae2d8829 100644
 --- a/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 +++ b/arch/riscv/boot/dts/sophgo/sg2042-evb-v2.dts
 @@ -238,6 +238,18 @@ &sd {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-add-phy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-add-phy.patch
@@ -1,7 +1,7 @@
 From 3951bb3466fb467be83f842acaf5631c52f08cec Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Fri, 14 Nov 2025 08:38:03 +0800
-Subject: [PATCH 053/449] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: add
+Subject: [PATCH 053/450] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: add
  phy mode restriction
 
 As the ethernet controller of SG2044 and SG2042 only supports
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 19 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/net/sophgo,sg2044-dwmac.yaml b/Documentation/devicetree/bindings/net/sophgo,sg2044-dwmac.yaml
-index ce21979a2d9a4..e8d3814db0e94 100644
+index ce21979a2d9a..e8d3814db0e9 100644
 --- a/Documentation/devicetree/bindings/net/sophgo,sg2044-dwmac.yaml
 +++ b/Documentation/devicetree/bindings/net/sophgo,sg2044-dwmac.yaml
 @@ -70,6 +70,25 @@ required:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-UPSTREAM-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-UPSTREAM-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
@@ -1,7 +1,7 @@
 From 918463546746a417787db07316cd2db3cb0637e5 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 14 Oct 2025 09:48:29 +0800
-Subject: [PATCH 054/449] UPSTREAM: perf vendor events riscv: add T-HEAD C920V2
+Subject: [PATCH 054/450] UPSTREAM: perf vendor events riscv: add T-HEAD C920V2
  JSON support
 
 T-HEAD C920 has a V2 iteration, which supports Sscompmf. The V2
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/tools/perf/pmu-events/arch/riscv/mapfile.csv b/tools/perf/pmu-events/arch/riscv/mapfile.csv
-index 0a7e7dcc81be4..d5eea7f9aa9a4 100644
+index 0a7e7dcc81be..d5eea7f9aa9a 100644
 --- a/tools/perf/pmu-events/arch/riscv/mapfile.csv
 +++ b/tools/perf/pmu-events/arch/riscv/mapfile.csv
 @@ -20,5 +20,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-UPSTREAM-rust-macros-Add-support-for-imports_ns-to-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-UPSTREAM-rust-macros-Add-support-for-imports_ns-to-m.patch
@@ -1,7 +1,7 @@
 From 5a104d7d4185ebc565773566b3c3b7b3f0764055 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:32 +0100
-Subject: [PATCH 055/449] UPSTREAM: rust: macros: Add support for 'imports_ns'
+Subject: [PATCH 055/450] UPSTREAM: rust: macros: Add support for 'imports_ns'
  to module!
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/rust/macros/module.rs b/rust/macros/module.rs
-index 5ee54a00c0b65..408cd11548751 100644
+index 5ee54a00c0b6..408cd1154875 100644
 --- a/rust/macros/module.rs
 +++ b/rust/macros/module.rs
 @@ -98,6 +98,7 @@ struct ModuleInfo {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-UPSTREAM-pwm-Export-pwmchip_release-for-external-use.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-UPSTREAM-pwm-Export-pwmchip_release-for-external-use.patch
@@ -1,7 +1,7 @@
 From 2dd835f59aed8b65bfee661797e6a5a7823a35b6 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:01 +0200
-Subject: [PATCH 056/449] UPSTREAM: pwm: Export `pwmchip_release` for external
+Subject: [PATCH 056/450] UPSTREAM: pwm: Export `pwmchip_release` for external
  use
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -33,7 +33,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/pwm/core.c b/drivers/pwm/core.c
-index 462c91a034c8e..ec8731515333a 100644
+index 462c91a034c8..ec8731515333 100644
 --- a/drivers/pwm/core.c
 +++ b/drivers/pwm/core.c
 @@ -1608,12 +1608,13 @@ void pwmchip_put(struct pwm_chip *chip)
@@ -52,7 +52,7 @@ index 462c91a034c8e..ec8731515333a 100644
  struct pwm_chip *pwmchip_alloc(struct device *parent, unsigned int npwm, size_t sizeof_priv)
  {
 diff --git a/include/linux/pwm.h b/include/linux/pwm.h
-index 549ac4aaad59b..148f056f336bb 100644
+index 549ac4aaad59..148f056f336b 100644
 --- a/include/linux/pwm.h
 +++ b/include/linux/pwm.h
 @@ -488,6 +488,12 @@ int __pwmchip_add(struct pwm_chip *chip, struct module *owner);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-UPSTREAM-rust-pwm-Add-Kconfig-and-basic-data-structu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-UPSTREAM-rust-pwm-Add-Kconfig-and-basic-data-structu.patch
@@ -1,7 +1,7 @@
 From b2e5d4a8a14a22c471f2ecf0884143bf45d96eb0 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:02 +0200
-Subject: [PATCH 057/449] UPSTREAM: rust: pwm: Add Kconfig and basic data
+Subject: [PATCH 057/450] UPSTREAM: rust: pwm: Add Kconfig and basic data
  structures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -45,7 +45,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 rust/kernel/pwm.rs
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index e8f06145fb54c..990436459862a 100644
+index e8f06145fb54..990436459862 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -20798,6 +20798,14 @@ F:	include/linux/pwm.h
@@ -64,7 +64,7 @@ index e8f06145fb54c..990436459862a 100644
  M:	Robert Jarzmik <robert.jarzmik@free.fr>
  L:	linux-gpio@vger.kernel.org
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index c2fd3f4b62d9e..d87c4521268c1 100644
+index c2fd3f4b62d9..d87c4521268c 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -819,4 +819,16 @@ config PWM_XILINX
@@ -85,7 +85,7 @@ index c2fd3f4b62d9e..d87c4521268c1 100644
 +
  endif
 diff --git a/rust/bindings/bindings_helper.h b/rust/bindings/bindings_helper.h
-index 2e43c66635a2c..70b11fc6338c4 100644
+index 2e43c66635a2..70b11fc6338c 100644
 --- a/rust/bindings/bindings_helper.h
 +++ b/rust/bindings/bindings_helper.h
 @@ -72,6 +72,7 @@
@@ -97,7 +97,7 @@ index 2e43c66635a2c..70b11fc6338c4 100644
  #include <linux/refcount.h>
  #include <linux/regulator/consumer.h>
 diff --git a/rust/helpers/helpers.c b/rust/helpers/helpers.c
-index 551da6c9b5064..014f20df91482 100644
+index 551da6c9b506..014f20df9148 100644
 --- a/rust/helpers/helpers.c
 +++ b/rust/helpers/helpers.c
 @@ -43,6 +43,7 @@
@@ -110,7 +110,7 @@ index 551da6c9b5064..014f20df91482 100644
  #include "refcount.c"
 diff --git a/rust/helpers/pwm.c b/rust/helpers/pwm.c
 new file mode 100644
-index 0000000000000..d75c588863685
+index 000000000000..d75c58886368
 --- /dev/null
 +++ b/rust/helpers/pwm.c
 @@ -0,0 +1,20 @@
@@ -135,7 +135,7 @@ index 0000000000000..d75c588863685
 +	pwmchip_set_drvdata(chip, data);
 +}
 diff --git a/rust/kernel/lib.rs b/rust/kernel/lib.rs
-index 3dd7bebe78882..68c71d888fdb8 100644
+index 3dd7bebe7888..68c71d888fdb 100644
 --- a/rust/kernel/lib.rs
 +++ b/rust/kernel/lib.rs
 @@ -129,6 +129,8 @@
@@ -149,7 +149,7 @@ index 3dd7bebe78882..68c71d888fdb8 100644
  pub mod str;
 diff --git a/rust/kernel/pwm.rs b/rust/kernel/pwm.rs
 new file mode 100644
-index 0000000000000..beabf0086a2f1
+index 000000000000..beabf0086a2f
 --- /dev/null
 +++ b/rust/kernel/pwm.rs
 @@ -0,0 +1,102 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-UPSTREAM-rust-pwm-Add-complete-abstraction-layer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-UPSTREAM-rust-pwm-Add-complete-abstraction-layer.patch
@@ -1,7 +1,7 @@
 From 41a346fc369e62cc8e5535be49b34a801794b16c Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:03 +0200
-Subject: [PATCH 058/449] UPSTREAM: rust: pwm: Add complete abstraction layer
+Subject: [PATCH 058/450] UPSTREAM: rust: pwm: Add complete abstraction layer
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -44,7 +44,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 662 insertions(+), 2 deletions(-)
 
 diff --git a/rust/kernel/pwm.rs b/rust/kernel/pwm.rs
-index beabf0086a2f1..79fbb13cd47f7 100644
+index beabf0086a2f..79fbb13cd47f 100644
 --- a/rust/kernel/pwm.rs
 +++ b/rust/kernel/pwm.rs
 @@ -8,10 +8,14 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-UPSTREAM-rust-pwm-Add-module_pwm_platform_driver-mac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-UPSTREAM-rust-pwm-Add-module_pwm_platform_driver-mac.patch
@@ -1,7 +1,7 @@
 From c55e51fc49dcbf3c33d420c7c1b91d1138cb2e29 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:33 +0100
-Subject: [PATCH 059/449] UPSTREAM: rust: pwm: Add module_pwm_platform_driver!
+Subject: [PATCH 059/450] UPSTREAM: rust: pwm: Add module_pwm_platform_driver!
  macro
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -38,7 +38,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 23 insertions(+)
 
 diff --git a/rust/kernel/pwm.rs b/rust/kernel/pwm.rs
-index 79fbb13cd47f7..6f2f78c687d5b 100644
+index 79fbb13cd47f..6f2f78c687d5 100644
 --- a/rust/kernel/pwm.rs
 +++ b/rust/kernel/pwm.rs
 @@ -760,3 +760,26 @@ fn drop(&mut self) {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-UPSTREAM-rust-pwm-Drop-wrapping-of-PWM-polarity-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-UPSTREAM-rust-pwm-Drop-wrapping-of-PWM-polarity-and-.patch
@@ -1,7 +1,7 @@
 From 4228cd8f92f41fc58735501c39fe0a87f5dbfa39 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Uwe=20Kleine-K=C3=B6nig?= <u.kleine-koenig@baylibre.com>
 Date: Sat, 25 Oct 2025 14:23:56 +0200
-Subject: [PATCH 060/449] UPSTREAM: rust: pwm: Drop wrapping of PWM polarity
+Subject: [PATCH 060/450] UPSTREAM: rust: pwm: Drop wrapping of PWM polarity
  and state
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 55 deletions(-)
 
 diff --git a/rust/kernel/pwm.rs b/rust/kernel/pwm.rs
-index 6f2f78c687d5b..b19661b83b0f3 100644
+index 6f2f78c687d5..b19661b83b0f 100644
 --- a/rust/kernel/pwm.rs
 +++ b/rust/kernel/pwm.rs
 @@ -15,38 +15,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-UPSTREAM-rust-pwm-Fix-broken-intra-doc-link.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-UPSTREAM-rust-pwm-Fix-broken-intra-doc-link.patch
@@ -1,7 +1,7 @@
 From 3b06c9f15400789feb8e6eb8d0ee76f0163d6efe Mon Sep 17 00:00:00 2001
 From: Miguel Ojeda <ojeda@kernel.org>
 Date: Wed, 29 Oct 2025 19:19:40 +0100
-Subject: [PATCH 061/449] UPSTREAM: rust: pwm: Fix broken intra-doc link
+Subject: [PATCH 061/450] UPSTREAM: rust: pwm: Fix broken intra-doc link
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rust/kernel/pwm.rs b/rust/kernel/pwm.rs
-index b19661b83b0f3..e6d1278d83169 100644
+index b19661b83b0f..e6d1278d8316 100644
 --- a/rust/kernel/pwm.rs
 +++ b/rust/kernel/pwm.rs
 @@ -660,7 +660,7 @@ unsafe impl<T: PwmOps + Sync> Sync for Chip<T> {}

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-UPSTREAM-pwm-Add-Rust-driver-for-T-HEAD-TH1520-SoC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-UPSTREAM-pwm-Add-Rust-driver-for-T-HEAD-TH1520-SoC.patch
@@ -1,7 +1,7 @@
 From c2582f16a5082088746377ef449bb59e0c7ff056 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:04 +0200
-Subject: [PATCH 062/449] UPSTREAM: pwm: Add Rust driver for T-HEAD TH1520 SoC
+Subject: [PATCH 062/450] UPSTREAM: pwm: Add Rust driver for T-HEAD TH1520 SoC
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/pwm/pwm_th1520.rs
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 990436459862a..d67c5c8d5c2e9 100644
+index 990436459862..d67c5c8d5c2e 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -22225,6 +22225,7 @@ F:	drivers/pinctrl/pinctrl-th1520.c
@@ -53,7 +53,7 @@ index 990436459862a..d67c5c8d5c2e9 100644
  F:	include/dt-bindings/clock/thead,th1520-clk-ap.h
  F:	include/dt-bindings/power/thead,th1520-power.h
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index d87c4521268c1..0b47456e2d57b 100644
+index d87c4521268c..0b47456e2d57 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -748,6 +748,17 @@ config PWM_TEGRA
@@ -75,7 +75,7 @@ index d87c4521268c1..0b47456e2d57b 100644
  	tristate "ECAP PWM support"
  	depends on ARCH_OMAP2PLUS || ARCH_DAVINCI_DA8XX || ARCH_KEYSTONE || ARCH_K3 || COMPILE_TEST
 diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index dfa8b4966ee19..aed403f0a42b3 100644
+index dfa8b4966ee1..aed403f0a42b 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -68,6 +68,7 @@ obj-$(CONFIG_PWM_STMPE)		+= pwm-stmpe.o
@@ -88,7 +88,7 @@ index dfa8b4966ee19..aed403f0a42b3 100644
  obj-$(CONFIG_PWM_TWL)		+= pwm-twl.o
 diff --git a/drivers/pwm/pwm_th1520.rs b/drivers/pwm/pwm_th1520.rs
 new file mode 100644
-index 0000000000000..0ad38b78be854
+index 000000000000..0ad38b78be85
 --- /dev/null
 +++ b/drivers/pwm/pwm_th1520.rs
 @@ -0,0 +1,378 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-UPSTREAM-dt-bindings-pwm-thead-Add-T-HEAD-TH1520-PWM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-UPSTREAM-dt-bindings-pwm-thead-Add-T-HEAD-TH1520-PWM.patch
@@ -1,7 +1,7 @@
 From 8283ee5ecefcf69dbc5814f19fea5ddbb40eabe1 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:05 +0200
-Subject: [PATCH 063/449] UPSTREAM: dt-bindings: pwm: thead: Add T-HEAD TH1520
+Subject: [PATCH 063/450] UPSTREAM: dt-bindings: pwm: thead: Add T-HEAD TH1520
  PWM controller
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/pwm/thead,th1520-pwm.yaml b/Documentation/devicetree/bindings/pwm/thead,th1520-pwm.yaml
 new file mode 100644
-index 0000000000000..855aec59ac53c
+index 000000000000..855aec59ac53
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/pwm/thead,th1520-pwm.yaml
 @@ -0,0 +1,48 @@
@@ -80,7 +80,7 @@ index 0000000000000..855aec59ac53c
 +      };
 +    };
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d67c5c8d5c2e9..3e54b488b76ba 100644
+index d67c5c8d5c2e..3e54b488b76b 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -22215,6 +22215,7 @@ F:	Documentation/devicetree/bindings/firmware/thead,th1520-aon.yaml

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-UPSTREAM-pwm-Fix-Rust-formatting.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-UPSTREAM-pwm-Fix-Rust-formatting.patch
@@ -1,7 +1,7 @@
 From 8b5ce0bf30be7a1c2587ed7bce623de58369f8cb Mon Sep 17 00:00:00 2001
 From: Miguel Ojeda <ojeda@kernel.org>
 Date: Wed, 29 Oct 2025 19:25:02 +0100
-Subject: [PATCH 064/449] UPSTREAM: pwm: Fix Rust formatting
+Subject: [PATCH 064/450] UPSTREAM: pwm: Fix Rust formatting
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 39 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/pwm/pwm_th1520.rs b/drivers/pwm/pwm_th1520.rs
-index 0ad38b78be854..ee2a6d573bc23 100644
+index 0ad38b78be85..ee2a6d573bc2 100644
 --- a/drivers/pwm/pwm_th1520.rs
 +++ b/drivers/pwm/pwm_th1520.rs
 @@ -200,7 +200,10 @@ fn round_waveform_fromhw(
@@ -70,7 +70,7 @@ index 0ad38b78be854..ee2a6d573bc23 100644
          // The `TH1520_PWM_START` bit must be written in a separate, final transaction, and
          // only when enabling the channel from a disabled state.
 diff --git a/rust/kernel/lib.rs b/rust/kernel/lib.rs
-index 68c71d888fdb8..584aa3282029c 100644
+index 68c71d888fdb..584aa3282029 100644
 --- a/rust/kernel/lib.rs
 +++ b/rust/kernel/lib.rs
 @@ -121,6 +121,8 @@
@@ -92,7 +92,7 @@ index 68c71d888fdb8..584aa3282029c 100644
  pub mod std_vendor;
  pub mod str;
 diff --git a/rust/kernel/pwm.rs b/rust/kernel/pwm.rs
-index e6d1278d83169..cb00f8a8765c8 100644
+index e6d1278d8316..cb00f8a8765c 100644
 --- a/rust/kernel/pwm.rs
 +++ b/rust/kernel/pwm.rs
 @@ -13,7 +13,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-UPSTREAM-pwm-th1520-Fix-clippy-warning-for-redundant.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-UPSTREAM-pwm-th1520-Fix-clippy-warning-for-redundant.patch
@@ -1,7 +1,7 @@
 From dcf17cabf0991d77bec2464a5906e86f988eefcd Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:35 +0100
-Subject: [PATCH 065/449] UPSTREAM: pwm: th1520: Fix clippy warning for
+Subject: [PATCH 065/450] UPSTREAM: pwm: th1520: Fix clippy warning for
  redundant struct field init
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pwm/pwm_th1520.rs b/drivers/pwm/pwm_th1520.rs
-index ee2a6d573bc23..b2d83c121c5c7 100644
+index ee2a6d573bc2..b2d83c121c5c 100644
 --- a/drivers/pwm/pwm_th1520.rs
 +++ b/drivers/pwm/pwm_th1520.rs
 @@ -185,7 +185,7 @@ fn round_waveform_tohw(

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-UPSTREAM-pwm-th1520-Use-module_pwm_platform_driver-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-UPSTREAM-pwm-th1520-Use-module_pwm_platform_driver-m.patch
@@ -1,7 +1,7 @@
 From b3d894d8c9873aca53939042470f1d571a2724dd Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:34 +0100
-Subject: [PATCH 066/449] UPSTREAM: pwm: th1520: Use
+Subject: [PATCH 066/450] UPSTREAM: pwm: th1520: Use
  module_pwm_platform_driver! macro
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pwm/pwm_th1520.rs b/drivers/pwm/pwm_th1520.rs
-index b2d83c121c5c7..955c359b07fb4 100644
+index b2d83c121c5c..955c359b07fb 100644
 --- a/drivers/pwm/pwm_th1520.rs
 +++ b/drivers/pwm/pwm_th1520.rs
 @@ -378,7 +378,7 @@ fn probe(

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-UPSTREAM-pwm-th1520-Fix-missing-Kconfig-dependencies.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-UPSTREAM-pwm-th1520-Fix-missing-Kconfig-dependencies.patch
@@ -1,7 +1,7 @@
 From f960d77dc0fd5f4a35b4351f1738afbf1b83c7c2 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 9 Dec 2025 21:06:03 +0100
-Subject: [PATCH 067/449] UPSTREAM: pwm: th1520: Fix missing Kconfig
+Subject: [PATCH 067/450] UPSTREAM: pwm: th1520: Fix missing Kconfig
  dependencies
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index 0b47456e2d57b..a2e5b73799513 100644
+index 0b47456e2d57..a2e5b7379951 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -750,7 +750,9 @@ config PWM_TEGRA

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-UPSTREAM-riscv-dts-thead-add-xtheadvector-to-the-th1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-UPSTREAM-riscv-dts-thead-add-xtheadvector-to-the-th1.patch
@@ -1,7 +1,7 @@
 From a73b9042e40db073dd1d53d80a2e4ff1444be9a7 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:47 +0800
-Subject: [PATCH 068/449] UPSTREAM: riscv: dts: thead: add xtheadvector to the
+Subject: [PATCH 068/450] UPSTREAM: riscv: dts: thead: add xtheadvector to the
  th1520 devicetree
 
 The th1520 support xtheadvector [1] so it can be included in the
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index e680d1a7c821f..0b57699ba398d 100644
+index e680d1a7c821..0b57699ba398 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -25,7 +25,8 @@ c910_0: cpu@0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-UPSTREAM-riscv-dts-thead-add-ziccrse-for-th1520.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-UPSTREAM-riscv-dts-thead-add-ziccrse-for-th1520.patch
@@ -1,7 +1,7 @@
 From 7cbe361278ca0bc45e3355490496a1c12c013aab Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:48 +0800
-Subject: [PATCH 069/449] UPSTREAM: riscv: dts: thead: add ziccrse for th1520
+Subject: [PATCH 069/450] UPSTREAM: riscv: dts: thead: add ziccrse for th1520
 
 Existing rv64 hardware conforms to the rva20 profile.
 
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 16 insertions(+), 8 deletions(-)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index 0b57699ba398d..8e50e24040c2b 100644
+index 0b57699ba398..8e50e24040c2 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -24,8 +24,10 @@ c910_0: cpu@0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-UPSTREAM-riscv-dts-thead-add-zfh-for-th1520.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-UPSTREAM-riscv-dts-thead-add-zfh-for-th1520.patch
@@ -1,7 +1,7 @@
 From 1d43a8d03a459259b7b5ac5af5696b7f66836bce Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:49 +0800
-Subject: [PATCH 070/449] UPSTREAM: riscv: dts: thead: add zfh for th1520
+Subject: [PATCH 070/450] UPSTREAM: riscv: dts: thead: add zfh for th1520
 
 th1520 support Zfh ISA extension.
 It supports the same RISC-V extensions as SG2042.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index 8e50e24040c2b..dfc868e5b19aa 100644
+index 8e50e24040c2..dfc868e5b19a 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -26,7 +26,7 @@ c910_0: cpu@0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-UPSTREAM-riscv-dts-thead-Add-PWM-controller-node.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-UPSTREAM-riscv-dts-thead-Add-PWM-controller-node.patch
@@ -1,7 +1,7 @@
 From b38e3a2f07016fd655ad69d9f5da73ca7bff0d24 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:06 +0200
-Subject: [PATCH 071/449] UPSTREAM: riscv: dts: thead: Add PWM controller node
+Subject: [PATCH 071/450] UPSTREAM: riscv: dts: thead: Add PWM controller node
 
 Add the Device Tree node for the T-HEAD TH1520 SoC's PWM controller.
 
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index dfc868e5b19aa..c24d6b779fa44 100644
+index dfc868e5b19a..c24d6b779fa4 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -514,6 +514,13 @@ uart2: serial@ffec010000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-UPSTREAM-riscv-dts-thead-Add-PWM-fan-and-thermal-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-UPSTREAM-riscv-dts-thead-Add-PWM-fan-and-thermal-con.patch
@@ -1,7 +1,7 @@
 From 98b2c40eea6d1c0c831aeaed089e0005c93fc76b Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:07 +0200
-Subject: [PATCH 072/449] UPSTREAM: riscv: dts: thead: Add PWM fan and thermal
+Subject: [PATCH 072/450] UPSTREAM: riscv: dts: thead: Add PWM fan and thermal
  control
 
 Add Device Tree nodes to enable a PWM controlled fan and it's associated
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 67 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
-index 4020c727f09e8..c58c2085ca92a 100644
+index 4020c727f09e..c58c2085ca92 100644
 --- a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 +++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 @@ -28,9 +28,76 @@ aliases {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-UPSTREAM-MIPS-Loongson64-dts-fix-phy-related-definit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-UPSTREAM-MIPS-Loongson64-dts-fix-phy-related-definit.patch
@@ -1,7 +1,7 @@
 From 50ead3569b57edcba557f0c9852651ad514eab1c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 2 Jan 2026 23:52:43 +0800
-Subject: [PATCH 073/449] UPSTREAM: MIPS: Loongson64: dts: fix phy-related
+Subject: [PATCH 073/450] UPSTREAM: MIPS: Loongson64: dts: fix phy-related
  definition of LS7A GMAC
 
 Currently the LS7A GMAC device tree node lacks a proper phy-handle
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
-index ee71045883e7e..6dee85909f5a6 100644
+index ee71045883e7..6dee85909f5a 100644
 --- a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
 +++ b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
 @@ -199,7 +199,8 @@ gmac@3,0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 4755496d961f8ec89539f03ed19c5b0cb678201a Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 074/449] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 074/450] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/phy/phy-tegra-usb.c b/drivers/usb/phy/phy-tegra-usb.c
-index fb9031628d397..5374aa99cca48 100644
+index fb9031628d39..5374aa99cca4 100644
 --- a/drivers/usb/phy/phy-tegra-usb.c
 +++ b/drivers/usb/phy/phy-tegra-usb.c
 @@ -174,7 +174,7 @@ struct tegra_xtal_freq {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
@@ -1,7 +1,7 @@
 From 10bc21d227744cb4fa0ae929a7622debfc6f6a3d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 075/449] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
+Subject: [PATCH 075/450] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
  before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from
@@ -40,7 +40,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/Makefile b/drivers/gpu/drm/Makefile
-index 742f0d590c5af..af5bde24efc74 100644
+index 742f0d590c5a..af5bde24efc7 100644
 --- a/drivers/gpu/drm/Makefile
 +++ b/drivers/gpu/drm/Makefile
 @@ -170,6 +170,7 @@ obj-y			+= clients/

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From d831ec2a8deb716bbf893e08dc172f2a7e5ea0c4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 076/449] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 076/450] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of
@@ -52,7 +52,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 581ae20c46e4b..346f0e49bb2ea 100644
+index 581ae20c46e4..346f0e49bb2e 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,6 +185,7 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From d148b9375c0b1d9fccc18ab94853c2c24591512e Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 077/449] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 077/450] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/mm/cache.c b/arch/loongarch/mm/cache.c
-index 496916845ff76..b1e6d70252fa8 100644
+index 496916845ff7..b1e6d70252fa 100644
 --- a/arch/loongarch/mm/cache.c
 +++ b/arch/loongarch/mm/cache.c
 @@ -63,6 +63,27 @@ static void flush_cache_leaf(unsigned int leaf)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
@@ -1,7 +1,7 @@
 From 4924bfe3f94da1a96d1e81e4fea81fe471d12064 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:47 +0800
-Subject: [PATCH 078/449] FROMLIST: dt-bindings: serial: 8250: Add Loongson
+Subject: [PATCH 078/450] FROMLIST: dt-bindings: serial: 8250: Add Loongson
  uart compatible
 
 The Loongson family have a mostly NS16550A-compatible UART and
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 14 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/serial/8250.yaml b/Documentation/devicetree/bindings/serial/8250.yaml
-index b243afa69a1ae..167ddcbd88005 100644
+index b243afa69a1a..167ddcbd8800 100644
 --- a/Documentation/devicetree/bindings/serial/8250.yaml
 +++ b/Documentation/devicetree/bindings/serial/8250.yaml
 @@ -125,6 +125,8 @@ properties:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
@@ -1,7 +1,7 @@
 From 13c79907564c8be8ca562b8e0a2635d7505c4d09 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:48 +0800
-Subject: [PATCH 079/449] FROMLIST: serial: 8250: Add Loongson uart driver
+Subject: [PATCH 079/450] FROMLIST: serial: 8250: Add Loongson uart driver
  support
 
 Add the driver for on-chip UART used on Loongson family chips.
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/drivers/tty/serial/8250/8250_loongson.c b/drivers/tty/serial/8250/8250_loongson.c
 new file mode 100644
-index 0000000000000..53153a116c011
+index 000000000000..53153a116c01
 --- /dev/null
 +++ b/drivers/tty/serial/8250/8250_loongson.c
 @@ -0,0 +1,238 @@
@@ -272,7 +272,7 @@ index 0000000000000..53153a116c011
 +MODULE_AUTHOR("Loongson Technology Corporation Limited.");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/tty/serial/8250/Kconfig b/drivers/tty/serial/8250/Kconfig
-index f64ef0819cd4e..98236b3bec102 100644
+index f64ef0819cd4..98236b3bec10 100644
 --- a/drivers/tty/serial/8250/Kconfig
 +++ b/drivers/tty/serial/8250/Kconfig
 @@ -468,6 +468,16 @@ config SERIAL_8250_OMAP_TTYO_FIXUP
@@ -293,7 +293,7 @@ index f64ef0819cd4e..98236b3bec102 100644
  	tristate "NXP LPC18xx/43xx serial port support"
  	depends on SERIAL_8250 && OF && (ARCH_LPC18XX || COMPILE_TEST)
 diff --git a/drivers/tty/serial/8250/Makefile b/drivers/tty/serial/8250/Makefile
-index 9ec4d5fe64de5..672f895d61f93 100644
+index 9ec4d5fe64de..672f895d61f9 100644
 --- a/drivers/tty/serial/8250/Makefile
 +++ b/drivers/tty/serial/8250/Makefile
 @@ -38,6 +38,7 @@ obj-$(CONFIG_SERIAL_8250_HP300)		+= 8250_hp300.o

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
@@ -1,7 +1,7 @@
 From 296b4e3f301ec3da7db1532c8c093c434c4db4b6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:49 +0800
-Subject: [PATCH 080/449] FROMLIST: LoongArch: dts: Add uart new compatible
+Subject: [PATCH 080/450] FROMLIST: LoongArch: dts: Add uart new compatible
  string
 
 Add loongson,ls2k*-uart compatible string on uarts.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/boot/dts/loongson-2k0500.dtsi b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
-index 51d990890803c..e759fae77dcf4 100644
+index 51d990890803..e759fae77dcf 100644
 --- a/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k0500.dtsi
 @@ -383,7 +383,7 @@ tsensor: thermal-sensor@1fe11500 {
@@ -32,7 +32,7 @@ index 51d990890803c..e759fae77dcf4 100644
  			clock-frequency = <100000000>;
  			interrupt-parent = <&eiointc>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k1000.dtsi b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
-index 830815a5da863..be4f7d119660e 100644
+index 830815a5da86..be4f7d119660 100644
 --- a/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k1000.dtsi
 @@ -299,7 +299,7 @@ dma-controller@1fe00c40 {
@@ -45,7 +45,7 @@ index 830815a5da863..be4f7d119660e 100644
  			clock-frequency = <125000000>;
  			interrupt-parent = <&liointc0>;
 diff --git a/arch/loongarch/boot/dts/loongson-2k2000.dtsi b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
-index ff094e60af1c9..3678c084adf71 100644
+index ff094e60af1c..3678c084adf7 100644
 --- a/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 +++ b/arch/loongarch/boot/dts/loongson-2k2000.dtsi
 @@ -253,7 +253,7 @@ i2c@1fe00130 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From 11159bb264d2c4a9f912d23d239dfbe146219786 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 081/449] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 081/450] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 83a6b68d8a39a..3ab48b34b8024 100644
+index 83a6b68d8a39..3ab48b34b802 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2890,9 +2890,6 @@ config ARCH_SUPPORTS_KEXEC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 65deacfcad21cbebacbcdbee2052e89b1c267f03 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 082/449] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 082/450] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/fpu/xstate.h b/arch/x86/kernel/fpu/xstate.h
-index 52ce192899892..fb5ea65a70ca9 100644
+index 52ce19289989..fb5ea65a70ca 100644
 --- a/arch/x86/kernel/fpu/xstate.h
 +++ b/arch/x86/kernel/fpu/xstate.h
 @@ -93,6 +93,9 @@ static inline int update_pkru_in_sigframe(struct xregs_state __user *buf, u32 pk

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From a1c0d528a734fceb7283607e33cfe26c8a00e5f2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 083/449] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 083/450] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 256fe8c86828d..390f82b4845df 100644
+index 256fe8c86828..390f82b4845d 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3522,6 +3522,7 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
@@ -1,7 +1,7 @@
 From 7c42efd5afaedb28c50ed1a9fcc3178da7c9140a Mon Sep 17 00:00:00 2001
 From: WangYuli <wangyuli@uniontech.com>
 Date: Tue, 18 Mar 2025 14:11:25 +0800
-Subject: [PATCH 084/449] FROMLIST: scsi: Bypass certain SCSI commands on disks
+Subject: [PATCH 084/450] FROMLIST: scsi: Bypass certain SCSI commands on disks
  with "use_192_bytes_for_3f" attribute
 
 On some external USB hard drives, mounting can fail if "lshw" is
@@ -123,7 +123,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+)
 
 diff --git a/drivers/scsi/scsi_lib.c b/drivers/scsi/scsi_lib.c
-index 7ddb73cd6d9fe..cef5ffbbe3993 100644
+index 7ddb73cd6d9f..cef5ffbbe399 100644
 --- a/drivers/scsi/scsi_lib.c
 +++ b/drivers/scsi/scsi_lib.c
 @@ -1576,6 +1576,7 @@ static void scsi_complete(struct request *rq)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
@@ -1,7 +1,7 @@
 From 65fc9d4103e7626442c8d4707b552ec6b21bbd8f Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Sun, 11 May 2025 16:34:12 +0800
-Subject: [PATCH 085/449] FROMLIST: PCI: Use local_pci_probe() when best
+Subject: [PATCH 085/450] FROMLIST: PCI: Use local_pci_probe() when best
  selected cpu is offline
 
 When the best selected CPU is offline, work_on_cpu() will stuck forever.
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index b4111c92c9572..542cd20428397 100644
+index b4111c92c957..542cd2042839 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -386,7 +386,7 @@ static int pci_call_probe(struct pci_driver *drv, struct pci_dev *dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From 9f49f0fadc057eacb2902931090e8e373b641307 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 11 May 2025 16:34:13 +0800
-Subject: [PATCH 086/449] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 086/450] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 542cd20428397..26657a3b824f8 100644
+index 542cd2042839..26657a3b824f 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -517,7 +517,7 @@ static void pci_device_shutdown(struct device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
@@ -1,7 +1,7 @@
 From f7113b37a54fe540832b0e038fd663e98cc11ecf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 17 Aug 2025 22:19:09 +0800
-Subject: [PATCH 087/449] REVERT: Revert "Mark xe driver as BROKEN if kernel
+Subject: [PATCH 087/450] REVERT: Revert "Mark xe driver as BROKEN if kernel
  page size is not 4kB"
 
 This reverts commit 022906afdf90327bce33d52fb4fb41b6c7d618fb.
@@ -12,7 +12,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/xe/Kconfig b/drivers/gpu/drm/xe/Kconfig
-index c34be1be155b3..52aa4dc35fa26 100644
+index c34be1be155b..52aa4dc35fa2 100644
 --- a/drivers/gpu/drm/xe/Kconfig
 +++ b/drivers/gpu/drm/xe/Kconfig
 @@ -5,7 +5,6 @@ config DRM_XE

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
@@ -1,7 +1,7 @@
 From 1d94e0f218c3986c57c191949dcaa149a880b97f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 088/449] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
+Subject: [PATCH 088/450] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
  non-4K kernel page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU
@@ -104,7 +104,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_bo.c b/drivers/gpu/drm/xe/xe_bo.c
-index a270aef7c4980..2a98d7fac6498 100644
+index a270aef7c498..2a98d7fac649 100644
 --- a/drivers/gpu/drm/xe/xe_bo.c
 +++ b/drivers/gpu/drm/xe/xe_bo.c
 @@ -2127,9 +2127,9 @@ struct xe_bo *xe_bo_init_locked(struct xe_device *xe, struct xe_bo *bo,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From 6fb386d83f4424914e35ff5c7a2f86a52660ec75 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 089/449] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
+Subject: [PATCH 089/450] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
  alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -72,7 +72,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  6 files changed, 26 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_guc.c b/drivers/gpu/drm/xe/xe_guc.c
-index ae0c88da422b2..29db407948994 100644
+index ae0c88da422b..29db40794899 100644
 --- a/drivers/gpu/drm/xe/xe_guc.c
 +++ b/drivers/gpu/drm/xe/xe_guc.c
 @@ -95,7 +95,7 @@ static u32 guc_ctl_feature_flags(struct xe_guc *guc)
@@ -94,7 +94,7 @@ index ae0c88da422b2..29db407948994 100644
  
  	return flags;
 diff --git a/drivers/gpu/drm/xe/xe_guc_ads.c b/drivers/gpu/drm/xe/xe_guc_ads.c
-index 0e2bece1d8b83..98b4a0da2cd44 100644
+index 0e2bece1d8b8..98b4a0da2cd4 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ads.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ads.c
 @@ -144,17 +144,17 @@ static size_t guc_ads_regset_size(struct xe_guc_ads *ads)
@@ -217,7 +217,7 @@ index 0e2bece1d8b83..98b4a0da2cd44 100644
  
  		xe_map_memcpy_to(xe, ads_to_map(ads), offset,
 diff --git a/drivers/gpu/drm/xe/xe_guc_capture.c b/drivers/gpu/drm/xe/xe_guc_capture.c
-index 243dad3e24185..548bf778d8003 100644
+index 243dad3e2418..548bf778d800 100644
 --- a/drivers/gpu/drm/xe/xe_guc_capture.c
 +++ b/drivers/gpu/drm/xe/xe_guc_capture.c
 @@ -591,8 +591,8 @@ guc_capture_getlistsize(struct xe_guc *guc, u32 owner, u32 type,
@@ -250,7 +250,7 @@ index 243dad3e24185..548bf778d8003 100644
  
  static int guc_capture_output_size_est(struct xe_guc *guc)
 diff --git a/drivers/gpu/drm/xe/xe_guc_ct.c b/drivers/gpu/drm/xe/xe_guc_ct.c
-index 3aac1a7aa2e7b..6c02b9bdb1966 100644
+index 3aac1a7aa2e7..6c02b9bdb196 100644
 --- a/drivers/gpu/drm/xe/xe_guc_ct.c
 +++ b/drivers/gpu/drm/xe/xe_guc_ct.c
 @@ -226,7 +226,7 @@ int xe_guc_ct_init_noalloc(struct xe_guc_ct *ct)
@@ -263,7 +263,7 @@ index 3aac1a7aa2e7b..6c02b9bdb1966 100644
  	err = drmm_mutex_init(&xe->drm, &ct->lock);
  	if (err)
 diff --git a/drivers/gpu/drm/xe/xe_guc_log.c b/drivers/gpu/drm/xe/xe_guc_log.c
-index c01ccb35dc752..0f40286bc7fb7 100644
+index c01ccb35dc75..0f40286bc7fb 100644
 --- a/drivers/gpu/drm/xe/xe_guc_log.c
 +++ b/drivers/gpu/drm/xe/xe_guc_log.c
 @@ -58,7 +58,7 @@ static size_t guc_log_size(void)
@@ -285,7 +285,7 @@ index c01ccb35dc752..0f40286bc7fb7 100644
  	for (i = GUC_LOG_BUFFER_CRASH_DUMP; i < GUC_LOG_BUFFER_TYPE_MAX; ++i) {
  		if (i == type)
 diff --git a/drivers/gpu/drm/xe/xe_guc_pc.c b/drivers/gpu/drm/xe/xe_guc_pc.c
-index a3e9796e6430f..f138ad3fb2057 100644
+index a3e9796e6430..f138ad3fb205 100644
 --- a/drivers/gpu/drm/xe/xe_guc_pc.c
 +++ b/drivers/gpu/drm/xe/xe_guc_pc.c
 @@ -1269,7 +1269,7 @@ int xe_guc_pc_start(struct xe_guc_pc *pc)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
 From f5885f2c98a81c005b04369d0f1571c314bfaac1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 090/449] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 090/450] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),
@@ -86,7 +86,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/xe/regs/xe_engine_regs.h b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
-index f4c3e1187a00a..5b978ad19663c 100644
+index f4c3e1187a00..5b978ad19663 100644
 --- a/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_engine_regs.h
 @@ -56,7 +56,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From d68f49d9e1d436aecd9593281da1bd2a0d798125 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 091/449] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 091/450] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 
@@ -95,7 +95,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_migrate.c b/drivers/gpu/drm/xe/xe_migrate.c
-index b6905f35d6c81..4990c8f3c3949 100644
+index b6905f35d6c8..4990c8f3c394 100644
 --- a/drivers/gpu/drm/xe/xe_migrate.c
 +++ b/drivers/gpu/drm/xe/xe_migrate.c
 @@ -617,7 +617,7 @@ static void emit_pte(struct xe_migrate *m,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From ac7d3b7a639f521db34dd43e0601ce7f4ae02c7f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 092/449] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 092/450] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/xe/xe_query.c b/drivers/gpu/drm/xe/xe_query.c
-index 856089f64c341..dfd8f9f1e584a 100644
+index 856089f64c34..dfd8f9f1e584 100644
 --- a/drivers/gpu/drm/xe/xe_query.c
 +++ b/drivers/gpu/drm/xe/xe_query.c
 @@ -345,7 +345,7 @@ static int query_config(struct xe_device *xe, struct drm_xe_device_query *query)
@@ -42,7 +42,7 @@ index 856089f64c341..dfd8f9f1e584a 100644
  	config->info[DRM_XE_QUERY_CONFIG_MAX_EXEC_QUEUE_PRIORITY] =
  		xe_exec_queue_device_get_max_priority(xe);
 diff --git a/include/uapi/drm/xe_drm.h b/include/uapi/drm/xe_drm.h
-index 400555a8af187..a9ffdea312a02 100644
+index 400555a8af18..a9ffdea312a0 100644
 --- a/include/uapi/drm/xe_drm.h
 +++ b/include/uapi/drm/xe_drm.h
 @@ -404,7 +404,7 @@ struct drm_xe_query_mem_regions {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
@@ -1,7 +1,7 @@
 From 7f2bd85e5436a36b04a706fa90e2802bb717cfd4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Aug 2025 11:21:36 +0800
-Subject: [PATCH 093/449] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
+Subject: [PATCH 093/450] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
  LoongArch and AArch64
 
 While testing my ROCm port for LoongArch and AArch64 (patches pending) on
@@ -132,7 +132,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/amd/amdkfd/Kconfig b/drivers/gpu/drm/amd/amdkfd/Kconfig
-index 16e12c9913f94..5d2fa86f60bf8 100644
+index 16e12c9913f9..5d2fa86f60bf 100644
 --- a/drivers/gpu/drm/amd/amdkfd/Kconfig
 +++ b/drivers/gpu/drm/amd/amdkfd/Kconfig
 @@ -14,7 +14,7 @@ config HSA_AMD

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
@@ -1,7 +1,7 @@
 From 0fdadc3f08f3f3c5140d5c4201cd7e7cc9601bc2 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:46 +0800
-Subject: [PATCH 094/449] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
+Subject: [PATCH 094/450] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
  coherency status in ttm_device
 
 Currently TTM utilizes cached memory regardless of whether the device
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 15 insertions(+)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_device.c b/drivers/gpu/drm/ttm/ttm_device.c
-index c3e2fcbdd2cc6..1758d94b3d445 100644
+index c3e2fcbdd2cc..1758d94b3d44 100644
 --- a/drivers/gpu/drm/ttm/ttm_device.c
 +++ b/drivers/gpu/drm/ttm/ttm_device.c
 @@ -246,6 +246,12 @@ int ttm_device_init(struct ttm_device *bdev, const struct ttm_device_funcs *func
@@ -40,7 +40,7 @@ index c3e2fcbdd2cc6..1758d94b3d445 100644
  }
  EXPORT_SYMBOL(ttm_device_init);
 diff --git a/include/drm/ttm/ttm_device.h b/include/drm/ttm/ttm_device.h
-index 592b5f8028599..c2e61312a43a2 100644
+index 592b5f802859..c2e61312a43a 100644
 --- a/include/drm/ttm/ttm_device.h
 +++ b/include/drm/ttm/ttm_device.h
 @@ -225,6 +225,15 @@ struct ttm_device {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
@@ -1,7 +1,7 @@
 From c2552bc229facfe6e3d66c62bb49d697967e2f5b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:47 +0800
-Subject: [PATCH 095/449] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
+Subject: [PATCH 095/450] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
  write_combined when snooping not available
 
 As we can now acquire the presence of the full DMA coherency (snooping
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_bo_util.c b/drivers/gpu/drm/ttm/ttm_bo_util.c
-index acbbca9d5c92f..b31b22ee03e9c 100644
+index acbbca9d5c92..b31b22ee03e9 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo_util.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo_util.c
 @@ -307,6 +307,14 @@ pgprot_t ttm_io_prot(struct ttm_buffer_object *bo, struct ttm_resource *res,
@@ -39,7 +39,7 @@ index acbbca9d5c92f..b31b22ee03e9c 100644
  }
  EXPORT_SYMBOL(ttm_io_prot);
 diff --git a/drivers/gpu/drm/ttm/ttm_tt.c b/drivers/gpu/drm/ttm/ttm_tt.c
-index 506e257dfba85..8338deb3330f6 100644
+index 506e257dfba8..8338deb3330f 100644
 --- a/drivers/gpu/drm/ttm/ttm_tt.c
 +++ b/drivers/gpu/drm/ttm/ttm_tt.c
 @@ -154,6 +154,14 @@ static void ttm_tt_init_fields(struct ttm_tt *ttm,
@@ -58,7 +58,7 @@ index 506e257dfba85..8338deb3330f6 100644
  	ttm->page_flags = page_flags;
  	ttm->dma_address = NULL;
 diff --git a/include/drm/ttm/ttm_caching.h b/include/drm/ttm/ttm_caching.h
-index a18f43e93abab..f92d7911f50e4 100644
+index a18f43e93aba..f92d7911f50e 100644
 --- a/include/drm/ttm/ttm_caching.h
 +++ b/include/drm/ttm/ttm_caching.h
 @@ -47,7 +47,8 @@ enum ttm_caching {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
@@ -1,7 +1,7 @@
 From c5c2c88351392fea5d0b61d51087f74db83e551f Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:21 -0400
-Subject: [PATCH 096/449] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
+Subject: [PATCH 096/450] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
  fixup
 
 The early version of XuanTie C910 core has a store merge buffer
@@ -39,7 +39,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/riscv/include/asm/rwonce.h
 
 diff --git a/arch/riscv/Kconfig.errata b/arch/riscv/Kconfig.errata
-index aca9b0cfcfecf..ac64123433e71 100644
+index aca9b0cfcfec..ac64123433e7 100644
 --- a/arch/riscv/Kconfig.errata
 +++ b/arch/riscv/Kconfig.errata
 @@ -153,4 +153,21 @@ config ERRATA_THEAD_GHOSTWRITE
@@ -65,7 +65,7 @@ index aca9b0cfcfecf..ac64123433e71 100644
 +
  endmenu # "CPU errata selection"
 diff --git a/arch/riscv/errata/thead/errata.c b/arch/riscv/errata/thead/errata.c
-index 0b942183f708f..fbe46f2fa8fbb 100644
+index 0b942183f708..fbe46f2fa8fb 100644
 --- a/arch/riscv/errata/thead/errata.c
 +++ b/arch/riscv/errata/thead/errata.c
 @@ -168,6 +168,23 @@ static bool errata_probe_ghostwrite(unsigned int stage,
@@ -103,7 +103,7 @@ index 0b942183f708f..fbe46f2fa8fbb 100644
  }
  
 diff --git a/arch/riscv/include/asm/errata_list_vendors.h b/arch/riscv/include/asm/errata_list_vendors.h
-index ec7eba3734371..8fd7c36307e2a 100644
+index ec7eba373437..8fd7c36307e2 100644
 --- a/arch/riscv/include/asm/errata_list_vendors.h
 +++ b/arch/riscv/include/asm/errata_list_vendors.h
 @@ -18,7 +18,8 @@
@@ -118,7 +118,7 @@ index ec7eba3734371..8fd7c36307e2a 100644
  #ifdef CONFIG_ERRATA_MIPS
 diff --git a/arch/riscv/include/asm/rwonce.h b/arch/riscv/include/asm/rwonce.h
 new file mode 100644
-index 0000000000000..081793d4d772d
+index 000000000000..081793d4d772
 --- /dev/null
 +++ b/arch/riscv/include/asm/rwonce.h
 @@ -0,0 +1,34 @@
@@ -157,7 +157,7 @@ index 0000000000000..081793d4d772d
 +
 +#endif	/* __ASM_RWONCE_H */
 diff --git a/include/asm-generic/rwonce.h b/include/asm-generic/rwonce.h
-index 52b969c7cef93..4e2d941f15a11 100644
+index 52b969c7cef9..4e2d941f15a1 100644
 --- a/include/asm-generic/rwonce.h
 +++ b/include/asm-generic/rwonce.h
 @@ -50,10 +50,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
@@ -1,7 +1,7 @@
 From be2778832c8d0b2fa778e40ad2f3fb5b9e2176d4 Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sat, 11 Oct 2025 11:57:46 -0400
-Subject: [PATCH 097/449] FROMLIST: riscv: Add pgprot_dmacoherent definition
+Subject: [PATCH 097/450] FROMLIST: riscv: Add pgprot_dmacoherent definition
 
 RISC-V Svpbmt Standard Extension for Page-Based Memory Types
 defines three modes:
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/arch/riscv/include/asm/pgtable.h b/arch/riscv/include/asm/pgtable.h
-index 30d1ea93dde34..c2e1d615b287c 100644
+index 30d1ea93dde3..c2e1d615b287 100644
 --- a/arch/riscv/include/asm/pgtable.h
 +++ b/arch/riscv/include/asm/pgtable.h
 @@ -652,6 +652,15 @@ static inline pgprot_t pgprot_writecombine(pgprot_t _prot)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
@@ -1,7 +1,7 @@
 From bc9ef7fad3dfd1f1495c58354718be69e48901a4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ilpo=20J=C3=A4rvinen?= <ilpo.jarvinen@linux.intel.com>
 Date: Thu, 18 Sep 2025 13:58:56 -0700
-Subject: [PATCH 098/449] FROMLIST: PCI: Release BAR0 of an integrated bridge
+Subject: [PATCH 098/450] FROMLIST: PCI: Release BAR0 of an integrated bridge
  to allow GPU BAR resize
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -49,7 +49,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 23 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index d32a47e81fcf3..34bd05bdfa0a0 100644
+index d32a47e81fcf..34bd05bdfa0a 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -6378,3 +6378,26 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-LoongArch-KVM-Get-VM-PMU-capability-from-HW.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-LoongArch-KVM-Get-VM-PMU-capability-from-HW.patch
@@ -1,7 +1,7 @@
 From c3d0a4af835249c7eb63378617d6509dd0165da1 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Sep 2025 17:37:41 +0800
-Subject: [PATCH 099/449] FROMLIST: LoongArch: KVM: Get VM PMU capability from
+Subject: [PATCH 099/450] FROMLIST: LoongArch: KVM: Get VM PMU capability from
  HW GCFG register
 
 Now VM PMU capability comes from host PMU capability directly, instead
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 30 insertions(+), 10 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/kvm_host.h b/arch/loongarch/include/asm/kvm_host.h
-index 0cecbd038bb3c..392480c9b9582 100644
+index 0cecbd038bb3..392480c9b958 100644
 --- a/arch/loongarch/include/asm/kvm_host.h
 +++ b/arch/loongarch/include/asm/kvm_host.h
 @@ -126,6 +126,8 @@ struct kvm_arch {
@@ -47,7 +47,7 @@ index 0cecbd038bb3c..392480c9b9582 100644
  
  /* Debug: dump vcpu state */
 diff --git a/arch/loongarch/include/asm/loongarch.h b/arch/loongarch/include/asm/loongarch.h
-index 3de03cb864b24..58a4a3b6b035d 100644
+index 3de03cb864b2..58a4a3b6b035 100644
 --- a/arch/loongarch/include/asm/loongarch.h
 +++ b/arch/loongarch/include/asm/loongarch.h
 @@ -511,6 +511,8 @@
@@ -60,7 +60,7 @@ index 3de03cb864b24..58a4a3b6b035d 100644
  #define  CSR_GCFG_GCI_WIDTH		2
  #define  CSR_GCFG_GCI			(_ULCAST_(0x3) << CSR_GCFG_GCI_SHIFT)
 diff --git a/arch/loongarch/kvm/vm.c b/arch/loongarch/kvm/vm.c
-index a49b1c1a3dd1f..d8c813e2d72ef 100644
+index a49b1c1a3dd1..d8c813e2d72e 100644
 --- a/arch/loongarch/kvm/vm.c
 +++ b/arch/loongarch/kvm/vm.c
 @@ -6,6 +6,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From 2c52cbc66d3b988b04d59caf71c33ab1e2b92a1a Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia.pukngae@linux.dev>
 Date: Wed, 22 Oct 2025 18:40:42 +0800
-Subject: [PATCH 100/449] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 100/450] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 6c999d89ee4bd..422e28ad1e8e2 100644
+index 6c999d89ee4b..422e28ad1e8e 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -1937,6 +1937,13 @@ static const struct dmi_system_id atkbd_dmi_quirk_table[] __initconst = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-FROMLIST-gpio-loongson-64bit-Switch-to-dynamic-alloc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-FROMLIST-gpio-loongson-64bit-Switch-to-dynamic-alloc.patch
@@ -1,7 +1,7 @@
 From 6b4e80321278460fa2d13582663f7bb4a7ed42bb Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 23 Oct 2025 17:03:46 +0800
-Subject: [PATCH 101/449] FROMLIST: gpio: loongson-64bit: Switch to dynamic
+Subject: [PATCH 101/450] FROMLIST: gpio: loongson-64bit: Switch to dynamic
  allocate GPIO base in byte mode
 
 gpiolib want to get completely rid of static gpiobase allocation, so
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpio/gpio-loongson-64bit.c b/drivers/gpio/gpio-loongson-64bit.c
-index d5573fb0616ce..0fdf15faa344d 100644
+index d5573fb0616c..0fdf15faa344 100644
 --- a/drivers/gpio/gpio-loongson-64bit.c
 +++ b/drivers/gpio/gpio-loongson-64bit.c
 @@ -312,6 +312,7 @@ static int loongson_gpio_init(struct platform_device *pdev, struct loongson_gpio

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-FROMLIST-dt-bindings-clock-thead-th1520-clk-ap-Add-I.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-FROMLIST-dt-bindings-clock-thead-th1520-clk-ap-Add-I.patch
@@ -1,7 +1,7 @@
 From e2c1e4841bc00a3ad73be5b9664d50e3a1df558e Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:10 +0000
-Subject: [PATCH 102/449] FROMLIST: dt-bindings: clock: thead,th1520-clk-ap:
+Subject: [PATCH 102/450] FROMLIST: dt-bindings: clock: thead,th1520-clk-ap:
  Add ID for C910 bus clock
 
 Add binding ID for C910 bus clock, which takes CLK_C910 as parent and is
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/include/dt-bindings/clock/thead,th1520-clk-ap.h b/include/dt-bindings/clock/thead,th1520-clk-ap.h
-index 09a9aa7b3ab19..68b35cc612041 100644
+index 09a9aa7b3ab1..68b35cc61204 100644
 --- a/include/dt-bindings/clock/thead,th1520-clk-ap.h
 +++ b/include/dt-bindings/clock/thead,th1520-clk-ap.h
 @@ -93,6 +93,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-FROMLIST-clk-thead-th1520-ap-Add-C910-bus-clock.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-FROMLIST-clk-thead-th1520-ap-Add-C910-bus-clock.patch
@@ -1,7 +1,7 @@
 From 9e3155346b730e9b6b73c12e0b7351fbc65d9a40 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:12 +0000
-Subject: [PATCH 103/449] FROMLIST: clk: thead: th1520-ap: Add C910 bus clock
+Subject: [PATCH 103/450] FROMLIST: clk: thead: th1520-ap: Add C910 bus clock
 
 This divider takes c910_clk as parent and is essential for the C910
 cluster to operate, thus is marked as CLK_IS_CRITICAL.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 16 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/clk/thead/clk-th1520-ap.c b/drivers/clk/thead/clk-th1520-ap.c
-index d870f0c665f8a..b820d47387bb9 100644
+index d870f0c665f8..b820d47387bb 100644
 --- a/drivers/clk/thead/clk-th1520-ap.c
 +++ b/drivers/clk/thead/clk-th1520-ap.c
 @@ -539,6 +539,20 @@ static struct ccu_mux c910_clk = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-FROMLIST-clk-thead-th1520-ap-Support-setting-PLL-rat.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-FROMLIST-clk-thead-th1520-ap-Support-setting-PLL-rat.patch
@@ -1,7 +1,7 @@
 From 0c650ed96b108e066b53ac62fe315e7c00930537 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:13 +0000
-Subject: [PATCH 104/449] FROMLIST: clk: thead: th1520-ap: Support setting PLL
+Subject: [PATCH 104/450] FROMLIST: clk: thead: th1520-ap: Support setting PLL
  rates
 
 TH1520 ships several PLLs that could operate in either integer or
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 142 insertions(+)
 
 diff --git a/drivers/clk/thead/clk-th1520-ap.c b/drivers/clk/thead/clk-th1520-ap.c
-index b820d47387bb9..bf8e80c39a9ed 100644
+index b820d47387bb..bf8e80c39a9e 100644
 --- a/drivers/clk/thead/clk-th1520-ap.c
 +++ b/drivers/clk/thead/clk-th1520-ap.c
 @@ -22,6 +22,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-FROMLIST-clk-thead-th1520-ap-Add-macro-to-define-mul.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-FROMLIST-clk-thead-th1520-ap-Add-macro-to-define-mul.patch
@@ -1,7 +1,7 @@
 From e0fefe0eef1a3c37c0881a874fab454b7bc6009f Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:14 +0000
-Subject: [PATCH 105/449] FROMLIST: clk: thead: th1520-ap: Add macro to define
+Subject: [PATCH 105/450] FROMLIST: clk: thead: th1520-ap: Add macro to define
  multiplexers with flags
 
 The new macro, TH_CCU_MUX_FLAGS, extends TH_CCU_MUX macro by adding two
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/clk/thead/clk-th1520-ap.c b/drivers/clk/thead/clk-th1520-ap.c
-index bf8e80c39a9ed..79f001a047b2c 100644
+index bf8e80c39a9e..79f001a047b2 100644
 --- a/drivers/clk/thead/clk-th1520-ap.c
 +++ b/drivers/clk/thead/clk-th1520-ap.c
 @@ -101,17 +101,22 @@ struct ccu_pll {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-FROMLIST-clk-thead-th1520-ap-Support-CPU-frequency-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-FROMLIST-clk-thead-th1520-ap-Support-CPU-frequency-s.patch
@@ -1,7 +1,7 @@
 From 4665f554b84bebb396c9193d7903aac809ef8a3f Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:15 +0000
-Subject: [PATCH 106/449] FROMLIST: clk: thead: th1520-ap: Support CPU
+Subject: [PATCH 106/450] FROMLIST: clk: thead: th1520-ap: Support CPU
  frequency scaling
 
 On TH1520 SoC, c910_clk feeds the CPU cluster. It could be glitchlessly
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 146 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/clk/thead/clk-th1520-ap.c b/drivers/clk/thead/clk-th1520-ap.c
-index 79f001a047b2c..cd3b396c9a3db 100644
+index 79f001a047b2..cd3b396c9a3d 100644
 --- a/drivers/clk/thead/clk-th1520-ap.c
 +++ b/drivers/clk/thead/clk-th1520-ap.c
 @@ -7,9 +7,11 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-FROMLIST-NFU-riscv-dts-thead-Add-CPU-clock-and-OPP-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-FROMLIST-NFU-riscv-dts-thead-Add-CPU-clock-and-OPP-t.patch
@@ -1,7 +1,7 @@
 From 928a2cfe502724ad16f6603e08ee8b01e5f5cc8e Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:16 +0000
-Subject: [PATCH 107/449] FROMLIST: NFU: riscv: dts: thead: Add CPU clock and
+Subject: [PATCH 107/450] FROMLIST: NFU: riscv: dts: thead: Add CPU clock and
  OPP table for TH1520
 
 Add operating point table for CPU cores, and wire up clocks for CPU
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 35 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index c24d6b779fa44..e6e49605a392c 100644
+index c24d6b779fa4..e6e49605a392 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -38,6 +38,8 @@ c910_0: cpu@0 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-FROMLIST-dt-bindings-vendor-prefixes-add-verisilicon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-FROMLIST-dt-bindings-vendor-prefixes-add-verisilicon.patch
@@ -1,7 +1,7 @@
 From 05ec845bd6e9f8ab089c46cbe180a6fb8e520e86 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:18 +0800
-Subject: [PATCH 108/449] FROMLIST: dt-bindings: vendor-prefixes: add
+Subject: [PATCH 108/450] FROMLIST: dt-bindings: vendor-prefixes: add
  verisilicon
 
 VeriSilicon is a Silicon IP vendor, which is the current owner of
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/vendor-prefixes.yaml b/Documentation/devicetree/bindings/vendor-prefixes.yaml
-index f1d1882009ba9..88a83031f4d6b 100644
+index f1d1882009ba..88a83031f4d6 100644
 --- a/Documentation/devicetree/bindings/vendor-prefixes.yaml
 +++ b/Documentation/devicetree/bindings/vendor-prefixes.yaml
 @@ -1721,6 +1721,8 @@ patternProperties:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-FROMLIST-dt-bindings-display-add-verisilicon-dc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-FROMLIST-dt-bindings-display-add-verisilicon-dc.patch
@@ -1,7 +1,7 @@
 From 4dbf506b86915b3df03e913faf7f932ad941e5bf Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:19 +0800
-Subject: [PATCH 109/449] FROMLIST: dt-bindings: display: add verisilicon,dc
+Subject: [PATCH 109/450] FROMLIST: dt-bindings: display: add verisilicon,dc
 
 Verisilicon has a series of display controllers prefixed with DC and
 with self-identification facility like their GC series GPUs.
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/display/verisilicon,dc.yaml b/Documentation/devicetree/bindings/display/verisilicon,dc.yaml
 new file mode 100644
-index 0000000000000..522a544498bea
+index 000000000000..522a544498be
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/display/verisilicon,dc.yaml
 @@ -0,0 +1,146 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-FROMLIST-drm-verisilicon-add-a-driver-for-Verisilico.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-FROMLIST-drm-verisilicon-add-a-driver-for-Verisilico.patch
@@ -1,7 +1,7 @@
 From a7b8a9e7487b38325ee620340cf7129830a52bda Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:20 +0800
-Subject: [PATCH 110/449] FROMLIST: drm: verisilicon: add a driver for
+Subject: [PATCH 110/450] FROMLIST: drm: verisilicon: add a driver for
  Verisilicon display controllers
 
 This is a from-scratch driver targeting Verisilicon DC-series display
@@ -66,7 +66,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/gpu/drm/verisilicon/vs_primary_plane_regs.h
 
 diff --git a/drivers/gpu/drm/Kconfig b/drivers/gpu/drm/Kconfig
-index ed85d0ceee3ba..a0917595d11ca 100644
+index ed85d0ceee3b..a0917595d11c 100644
 --- a/drivers/gpu/drm/Kconfig
 +++ b/drivers/gpu/drm/Kconfig
 @@ -398,6 +398,8 @@ source "drivers/gpu/drm/imagination/Kconfig"
@@ -79,7 +79,7 @@ index ed85d0ceee3ba..a0917595d11ca 100644
  	tristate "DRM Support for Hyper-V synthetic video device"
  	depends on DRM && PCI && HYPERV_VMBUS
 diff --git a/drivers/gpu/drm/Makefile b/drivers/gpu/drm/Makefile
-index af5bde24efc74..a404f580f1756 100644
+index af5bde24efc7..a404f580f175 100644
 --- a/drivers/gpu/drm/Makefile
 +++ b/drivers/gpu/drm/Makefile
 @@ -234,6 +234,7 @@ obj-y			+= solomon/
@@ -92,7 +92,7 @@ index af5bde24efc74..a404f580f1756 100644
  hdrtest-files := \
 diff --git a/drivers/gpu/drm/verisilicon/Kconfig b/drivers/gpu/drm/verisilicon/Kconfig
 new file mode 100644
-index 0000000000000..0235577c72824
+index 000000000000..0235577c7282
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/Kconfig
 @@ -0,0 +1,15 @@
@@ -113,7 +113,7 @@ index 0000000000000..0235577c72824
 +	  verisilicon-dc.
 diff --git a/drivers/gpu/drm/verisilicon/Makefile b/drivers/gpu/drm/verisilicon/Makefile
 new file mode 100644
-index 0000000000000..fd8d805fbcde1
+index 000000000000..fd8d805fbcde
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/Makefile
 @@ -0,0 +1,5 @@
@@ -124,7 +124,7 @@ index 0000000000000..fd8d805fbcde1
 +obj-$(CONFIG_DRM_VERISILICON_DC) += verisilicon-dc.o
 diff --git a/drivers/gpu/drm/verisilicon/vs_bridge.c b/drivers/gpu/drm/verisilicon/vs_bridge.c
 new file mode 100644
-index 0000000000000..9696e574bcc7c
+index 000000000000..9696e574bcc7
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_bridge.c
 @@ -0,0 +1,330 @@
@@ -460,7 +460,7 @@ index 0000000000000..9696e574bcc7c
 +}
 diff --git a/drivers/gpu/drm/verisilicon/vs_bridge.h b/drivers/gpu/drm/verisilicon/vs_bridge.h
 new file mode 100644
-index 0000000000000..4120abafdaed6
+index 000000000000..4120abafdaed
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_bridge.h
 @@ -0,0 +1,40 @@
@@ -506,7 +506,7 @@ index 0000000000000..4120abafdaed6
 +#endif /* _VS_BRIDGE_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_bridge_regs.h b/drivers/gpu/drm/verisilicon/vs_bridge_regs.h
 new file mode 100644
-index 0000000000000..9eb30e4564beb
+index 000000000000..9eb30e4564be
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_bridge_regs.h
 @@ -0,0 +1,54 @@
@@ -566,7 +566,7 @@ index 0000000000000..9eb30e4564beb
 +#endif /* _VS_BRIDGE_REGS_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_crtc.c b/drivers/gpu/drm/verisilicon/vs_crtc.c
 new file mode 100644
-index 0000000000000..8825b77ed3ca0
+index 000000000000..8825b77ed3ca
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_crtc.c
 @@ -0,0 +1,217 @@
@@ -789,7 +789,7 @@ index 0000000000000..8825b77ed3ca0
 +}
 diff --git a/drivers/gpu/drm/verisilicon/vs_crtc.h b/drivers/gpu/drm/verisilicon/vs_crtc.h
 new file mode 100644
-index 0000000000000..6f862d609b984
+index 000000000000..6f862d609b98
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_crtc.h
 @@ -0,0 +1,29 @@
@@ -824,7 +824,7 @@ index 0000000000000..6f862d609b984
 +#endif /* _VS_CRTC_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_crtc_regs.h b/drivers/gpu/drm/verisilicon/vs_crtc_regs.h
 new file mode 100644
-index 0000000000000..c7930e817635c
+index 000000000000..c7930e817635
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_crtc_regs.h
 @@ -0,0 +1,60 @@
@@ -890,7 +890,7 @@ index 0000000000000..c7930e817635c
 +#endif /* _VS_CRTC_REGS_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_dc.c b/drivers/gpu/drm/verisilicon/vs_dc.c
 new file mode 100644
-index 0000000000000..a413479c6cfff
+index 000000000000..a413479c6cff
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_dc.c
 @@ -0,0 +1,205 @@
@@ -1101,7 +1101,7 @@ index 0000000000000..a413479c6cfff
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/gpu/drm/verisilicon/vs_dc.h b/drivers/gpu/drm/verisilicon/vs_dc.h
 new file mode 100644
-index 0000000000000..5e071501b1c38
+index 000000000000..5e071501b1c3
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_dc.h
 @@ -0,0 +1,39 @@
@@ -1146,7 +1146,7 @@ index 0000000000000..5e071501b1c38
 +#endif /* _VS_DC_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_dc_top_regs.h b/drivers/gpu/drm/verisilicon/vs_dc_top_regs.h
 new file mode 100644
-index 0000000000000..50509bbbff08f
+index 000000000000..50509bbbff08
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_dc_top_regs.h
 @@ -0,0 +1,27 @@
@@ -1179,7 +1179,7 @@ index 0000000000000..50509bbbff08f
 +#endif /* _VS_DC_TOP_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_drm.c b/drivers/gpu/drm/verisilicon/vs_drm.c
 new file mode 100644
-index 0000000000000..f356d7832c449
+index 000000000000..f356d7832c44
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_drm.c
 @@ -0,0 +1,177 @@
@@ -1362,7 +1362,7 @@ index 0000000000000..f356d7832c449
 +}
 diff --git a/drivers/gpu/drm/verisilicon/vs_drm.h b/drivers/gpu/drm/verisilicon/vs_drm.h
 new file mode 100644
-index 0000000000000..bbcd2e527deb6
+index 000000000000..bbcd2e527deb
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_drm.h
 @@ -0,0 +1,29 @@
@@ -1397,7 +1397,7 @@ index 0000000000000..bbcd2e527deb6
 +#endif /* _VS_DRM_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_hwdb.c b/drivers/gpu/drm/verisilicon/vs_hwdb.c
 new file mode 100644
-index 0000000000000..4a87e5d4701f3
+index 000000000000..4a87e5d4701f
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_hwdb.c
 @@ -0,0 +1,150 @@
@@ -1553,7 +1553,7 @@ index 0000000000000..4a87e5d4701f3
 +}
 diff --git a/drivers/gpu/drm/verisilicon/vs_hwdb.h b/drivers/gpu/drm/verisilicon/vs_hwdb.h
 new file mode 100644
-index 0000000000000..92192e4fa0862
+index 000000000000..92192e4fa086
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_hwdb.h
 @@ -0,0 +1,29 @@
@@ -1588,7 +1588,7 @@ index 0000000000000..92192e4fa0862
 +#endif /* _VS_HWDB_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_plane.c b/drivers/gpu/drm/verisilicon/vs_plane.c
 new file mode 100644
-index 0000000000000..f3c9963b6a4ea
+index 000000000000..f3c9963b6a4e
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_plane.c
 @@ -0,0 +1,102 @@
@@ -1696,7 +1696,7 @@ index 0000000000000..f3c9963b6a4ea
 +}
 diff --git a/drivers/gpu/drm/verisilicon/vs_plane.h b/drivers/gpu/drm/verisilicon/vs_plane.h
 new file mode 100644
-index 0000000000000..3595267c89b53
+index 000000000000..3595267c89b5
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_plane.h
 @@ -0,0 +1,68 @@
@@ -1770,7 +1770,7 @@ index 0000000000000..3595267c89b53
 +#endif /* _VS_PLANE_H_ */
 diff --git a/drivers/gpu/drm/verisilicon/vs_primary_plane.c b/drivers/gpu/drm/verisilicon/vs_primary_plane.c
 new file mode 100644
-index 0000000000000..5b03783d4f284
+index 000000000000..5b03783d4f28
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_primary_plane.c
 @@ -0,0 +1,157 @@
@@ -1933,7 +1933,7 @@ index 0000000000000..5b03783d4f284
 +}
 diff --git a/drivers/gpu/drm/verisilicon/vs_primary_plane_regs.h b/drivers/gpu/drm/verisilicon/vs_primary_plane_regs.h
 new file mode 100644
-index 0000000000000..cbb125c46b390
+index 000000000000..cbb125c46b39
 --- /dev/null
 +++ b/drivers/gpu/drm/verisilicon/vs_primary_plane_regs.h
 @@ -0,0 +1,53 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-FROMLIST-dt-bindings-display-bridge-add-binding-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-FROMLIST-dt-bindings-display-bridge-add-binding-for-.patch
@@ -1,7 +1,7 @@
 From 7b45c024efccd9dbea4361942499d89982ae94cb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:21 +0800
-Subject: [PATCH 111/449] FROMLIST: dt-bindings: display/bridge: add binding
+Subject: [PATCH 111/450] FROMLIST: dt-bindings: display/bridge: add binding
  for TH1520 HDMI controller
 
 T-Head TH1520 SoC contains a Synopsys DesignWare HDMI controller paired
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/display/bridge/thead,th1520-dw-hdmi.yaml b/Documentation/devicetree/bindings/display/bridge/thead,th1520-dw-hdmi.yaml
 new file mode 100644
-index 0000000000000..68fff885ce15b
+index 000000000000..68fff885ce15
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/display/bridge/thead,th1520-dw-hdmi.yaml
 @@ -0,0 +1,120 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-FROMLIST-drm-bridge-add-a-driver-for-T-Head-TH1520-H.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-FROMLIST-drm-bridge-add-a-driver-for-T-Head-TH1520-H.patch
@@ -1,7 +1,7 @@
 From 2b59a9c322f8f64a1b4005f7db0df3476bb4cc41 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:22 +0800
-Subject: [PATCH 112/449] FROMLIST: drm/bridge: add a driver for T-Head TH1520
+Subject: [PATCH 112/450] FROMLIST: drm/bridge: add a driver for T-Head TH1520
  HDMI controller
 
 T-Head TH1520 SoC contains a Synopsys DesignWare HDMI controller (paired
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/gpu/drm/bridge/th1520-dw-hdmi.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 3e54b488b76ba..a7c804fe16b67 100644
+index 3e54b488b76b..a7c804fe16b6 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -22220,6 +22220,7 @@ F:	Documentation/devicetree/bindings/reset/thead,th1520-reset.yaml
@@ -36,7 +36,7 @@ index 3e54b488b76ba..a7c804fe16b67 100644
  F:	drivers/net/ethernet/stmicro/stmmac/dwmac-thead.c
  F:	drivers/pinctrl/pinctrl-th1520.c
 diff --git a/drivers/gpu/drm/bridge/Kconfig b/drivers/gpu/drm/bridge/Kconfig
-index a250afd8d6622..8e19f5fb9ad7c 100644
+index a250afd8d662..8e19f5fb9ad7 100644
 --- a/drivers/gpu/drm/bridge/Kconfig
 +++ b/drivers/gpu/drm/bridge/Kconfig
 @@ -335,6 +335,16 @@ config DRM_THINE_THC63LVD1024
@@ -57,7 +57,7 @@ index a250afd8d6622..8e19f5fb9ad7c 100644
  	tristate "TC358762 DSI/DPI bridge"
  	depends on OF
 diff --git a/drivers/gpu/drm/bridge/Makefile b/drivers/gpu/drm/bridge/Makefile
-index c7dc03182e592..085b5db45d6fd 100644
+index c7dc03182e59..085b5db45d6f 100644
 --- a/drivers/gpu/drm/bridge/Makefile
 +++ b/drivers/gpu/drm/bridge/Makefile
 @@ -28,6 +28,7 @@ obj-$(CONFIG_DRM_SII902X) += sii902x.o
@@ -70,7 +70,7 @@ index c7dc03182e592..085b5db45d6fd 100644
  obj-$(CONFIG_DRM_TOSHIBA_TC358764) += tc358764.o
 diff --git a/drivers/gpu/drm/bridge/th1520-dw-hdmi.c b/drivers/gpu/drm/bridge/th1520-dw-hdmi.c
 new file mode 100644
-index 0000000000000..389eead5f1c45
+index 000000000000..389eead5f1c4
 --- /dev/null
 +++ b/drivers/gpu/drm/bridge/th1520-dw-hdmi.c
 @@ -0,0 +1,173 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-FROMLIST-riscv-dts-thead-add-DPU-and-HDMI-device-tre.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-FROMLIST-riscv-dts-thead-add-DPU-and-HDMI-device-tre.patch
@@ -1,7 +1,7 @@
 From 864c15cc7a9292858f5ec0c3e231ff032e68aa97 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:23 +0800
-Subject: [PATCH 113/449] FROMLIST: riscv: dts: thead: add DPU and HDMI device
+Subject: [PATCH 113/450] FROMLIST: riscv: dts: thead: add DPU and HDMI device
  tree nodes
 
 T-Head TH1520 SoC contains a Verisilicon DC8200 display controller
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 70 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index e6e49605a392c..3a2730e251592 100644
+index e6e49605a392..3a2730e25159 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -590,6 +590,76 @@ clk_vo: clock-controller@ffef528050 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-FROMLIST-MAINTAINERS-assign-myself-as-maintainer-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-FROMLIST-MAINTAINERS-assign-myself-as-maintainer-for.patch
@@ -1,7 +1,7 @@
 From e9682b01ace0b3171b0e97236b94b7b525b58a22 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:25 +0800
-Subject: [PATCH 114/449] FROMLIST: MAINTAINERS: assign myself as maintainer
+Subject: [PATCH 114/450] FROMLIST: MAINTAINERS: assign myself as maintainer
  for verisilicon DC driver
 
 As I am the author of this rewritten driver, it makes sense for me to be
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index a7c804fe16b67..94ccb7d8d3289 100644
+index a7c804fe16b6..94ccb7d8d328 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -8546,6 +8546,13 @@ F:	Documentation/devicetree/bindings/display/brcm,bcm2835-*.yaml

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-FROMLIST-mailmap-map-all-Icenowy-Zheng-s-mail-addres.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-FROMLIST-mailmap-map-all-Icenowy-Zheng-s-mail-addres.patch
@@ -1,7 +1,7 @@
 From 62fd7a8a917d949b31a9100e1e9d00c02f645312 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:26 +0800
-Subject: [PATCH 115/449] FROMLIST: mailmap: map all Icenowy Zheng's mail
+Subject: [PATCH 115/450] FROMLIST: mailmap: map all Icenowy Zheng's mail
  addresses
 
 Map all mail addresses Icenowy Zheng had used to the personal mailbox
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/.mailmap b/.mailmap
-index fffbfd413474b..0c80b8eaab671 100644
+index fffbfd413474..0c80b8eaab67 100644
 --- a/.mailmap
 +++ b/.mailmap
 @@ -311,6 +311,10 @@ Henrik Rydberg <rydberg@bitmath.org>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-FROMLIST-dt-bindings-usb-Add-T-HEAD-TH1520-USB-contr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-FROMLIST-dt-bindings-usb-Add-T-HEAD-TH1520-USB-contr.patch
@@ -1,7 +1,7 @@
 From 1ead46c043478ec3f017997f86188026ce8468f3 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 28 Sep 2023 00:42:21 +0800
-Subject: [PATCH 116/449] FROMLIST: dt-bindings: usb: Add T-HEAD TH1520 USB
+Subject: [PATCH 116/450] FROMLIST: dt-bindings: usb: Add T-HEAD TH1520 USB
  controller
 
 T-HEAD TH1520 platform's USB has a wrapper module around
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/usb/thead,th1520-usb.yaml b/Documentation/devicetree/bindings/usb/thead,th1520-usb.yaml
 new file mode 100644
-index 0000000000000..afb618eb50139
+index 000000000000..afb618eb5013
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/usb/thead,th1520-usb.yaml
 @@ -0,0 +1,73 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-FROMLIST-usb-dwc3-add-T-HEAD-TH1520-usb-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-FROMLIST-usb-dwc3-add-T-HEAD-TH1520-usb-driver.patch
@@ -1,7 +1,7 @@
 From 29cbc2ebf312468395c385a7c458851b41793024 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 28 Sep 2023 00:42:22 +0800
-Subject: [PATCH 117/449] FROMLIST: usb: dwc3: add T-HEAD TH1520 usb driver
+Subject: [PATCH 117/450] FROMLIST: usb: dwc3: add T-HEAD TH1520 usb driver
 
 Adds TH1520 Glue layer to support USB controller on T-HEAD TH1520 SoC.
 There is a DesignWare USB3 DRD core in TH1520 SoCs, the dwc3 core is
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/usb/dwc3/dwc3-thead.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 94ccb7d8d3289..cdc3541b6871a 100644
+index 94ccb7d8d328..cdc3541b6871 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -22236,6 +22236,7 @@ F:	drivers/power/reset/th1520-aon-reboot.c
@@ -33,7 +33,7 @@ index 94ccb7d8d3289..cdc3541b6871a 100644
  F:	include/dt-bindings/power/thead,th1520-power.h
  F:	include/dt-bindings/reset/thead,th1520-reset.h
 diff --git a/drivers/usb/dwc3/Kconfig b/drivers/usb/dwc3/Kconfig
-index 4925d15084f81..3a6679a513077 100644
+index 4925d15084f8..3a6679a51307 100644
 --- a/drivers/usb/dwc3/Kconfig
 +++ b/drivers/usb/dwc3/Kconfig
 @@ -200,4 +200,13 @@ config USB_DWC3_GENERIC_PLAT
@@ -51,7 +51,7 @@ index 4925d15084f81..3a6679a513077 100644
 +
  endif
 diff --git a/drivers/usb/dwc3/Makefile b/drivers/usb/dwc3/Makefile
-index 96469e48ff9d1..bef4aa926053b 100644
+index 96469e48ff9d..bef4aa926053 100644
 --- a/drivers/usb/dwc3/Makefile
 +++ b/drivers/usb/dwc3/Makefile
 @@ -58,3 +58,4 @@ obj-$(CONFIG_USB_DWC3_XILINX)		+= dwc3-xilinx.o
@@ -61,7 +61,7 @@ index 96469e48ff9d1..bef4aa926053b 100644
 +obj-$(CONFIG_USB_DWC3_THEAD)		+= dwc3-thead.o
 diff --git a/drivers/usb/dwc3/dwc3-thead.c b/drivers/usb/dwc3/dwc3-thead.c
 new file mode 100644
-index 0000000000000..9a4cc0b5a6461
+index 000000000000..9a4cc0b5a646
 --- /dev/null
 +++ b/drivers/usb/dwc3/dwc3-thead.c
 @@ -0,0 +1,119 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-FROMLIST-net-stmmac-Add-generic-suspend-resume-helpe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-FROMLIST-net-stmmac-Add-generic-suspend-resume-helpe.patch
@@ -1,7 +1,7 @@
 From 68147a454238d58419ee1b8d277e040ec18c4878 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:15 +0000
-Subject: [PATCH 118/449] FROMLIST: net: stmmac: Add generic suspend/resume
+Subject: [PATCH 118/450] FROMLIST: net: stmmac: Add generic suspend/resume
  helper for PCI-based controllers
 
 Most glue driver for PCI-based DWMAC controllers utilize similar
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.h
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 9507131875b2c..2f8bfe6911840 100644
+index 9507131875b2..2f8bfe691184 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -339,6 +339,11 @@ config DWMAC_VISCONTI
@@ -38,7 +38,7 @@ index 9507131875b2c..2f8bfe6911840 100644
  	tristate "Intel GMAC support"
  	default X86
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index 11c0ba2ccdb13..1638f4227ced0 100644
+index 11c0ba2ccdb1..1638f4227ced 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -43,6 +43,7 @@ obj-$(CONFIG_DWMAC_VISCONTI)	+= dwmac-visconti.o
@@ -51,7 +51,7 @@ index 11c0ba2ccdb13..1638f4227ced0 100644
  obj-$(CONFIG_DWMAC_LOONGSON)	+= dwmac-loongson.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.c
 new file mode 100644
-index 0000000000000..5c5dd502f79a6
+index 000000000000..5c5dd502f79a
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.c
 @@ -0,0 +1,48 @@
@@ -105,7 +105,7 @@ index 0000000000000..5c5dd502f79a6
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.h b/drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.h
 new file mode 100644
-index 0000000000000..71553184f9823
+index 000000000000..71553184f982
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_libpci.h
 @@ -0,0 +1,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-FROMLIST-net-stmmac-loongson-Use-generic-PCI-suspend.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-FROMLIST-net-stmmac-loongson-Use-generic-PCI-suspend.patch
@@ -1,7 +1,7 @@
 From dcf348689ac2503f8bf17678e920415c8880223c Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:16 +0000
-Subject: [PATCH 119/449] FROMLIST: net: stmmac: loongson: Use generic PCI
+Subject: [PATCH 119/450] FROMLIST: net: stmmac: loongson: Use generic PCI
  suspend/resume routines
 
 Convert glue driver for Loongson DWMAC controller to use the generic
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 5 insertions(+), 34 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 2f8bfe6911840..8d15373313d09 100644
+index 2f8bfe691184..8d15373313d0 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -357,8 +357,9 @@ config DWMAC_INTEL
@@ -35,7 +35,7 @@ index 2f8bfe6911840..8d15373313d09 100644
  	  This selects the LOONGSON PCI bus support for the stmmac driver,
  	  Support for ethernet controller on Loongson-2K1000 SoC and LS7A1000 bridge.
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
-index a6e4349904657..4e530f75fc97d 100644
+index a6e434990465..4e530f75fc97 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-loongson.c
 @@ -8,6 +8,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-FROMLIST-net-stmmac-pci-Use-generic-PCI-suspend-resu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-FROMLIST-net-stmmac-pci-Use-generic-PCI-suspend-resu.patch
@@ -1,7 +1,7 @@
 From fa960ccc1e8131791d106c04d6699f269e8cacb8 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:17 +0000
-Subject: [PATCH 120/449] FROMLIST: net: stmmac: pci: Use generic PCI
+Subject: [PATCH 120/450] FROMLIST: net: stmmac: pci: Use generic PCI
  suspend/resume routines
 
 Convert STMMAC PCI glue driver to use the generic platform
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 5 insertions(+), 34 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 8d15373313d09..44593c0bb2268 100644
+index 8d15373313d0..44593c0bb226 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -366,8 +366,9 @@ config DWMAC_LOONGSON
@@ -35,7 +35,7 @@ index 8d15373313d09..44593c0bb2268 100644
  	  This selects the platform specific bus support for the stmmac driver.
  	  This driver was tested on XLINX XC2V3000 FF1152AMT0221
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
-index afb1c53ca6f87..270ad066ced31 100644
+index afb1c53ca6f8..270ad066ced3 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_pci.c
 @@ -14,6 +14,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-FROMLIST-net-phy-motorcomm-Support-YT8531S-PHY-in-YT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-FROMLIST-net-phy-motorcomm-Support-YT8531S-PHY-in-YT.patch
@@ -1,7 +1,7 @@
 From 0d986fa3bad422b7a200babf8a4b8286484dbf74 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:09 +0000
-Subject: [PATCH 121/449] FROMLIST: net: phy: motorcomm: Support YT8531S PHY in
+Subject: [PATCH 121/450] FROMLIST: net: phy: motorcomm: Support YT8531S PHY in
  YT6801 Ethernet controller
 
 YT6801's internal PHY is confirmed as a GMII-capable variant of YT8531S
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
-index b49897500a592..ae386415b7f98 100644
+index b49897500a59..ae386415b7f9 100644
 --- a/drivers/net/phy/motorcomm.c
 +++ b/drivers/net/phy/motorcomm.c
 @@ -910,6 +910,10 @@ static int ytphy_rgmii_clk_delay_config(struct phy_device *phydev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-FROMLIST-net-stmmac-Add-glue-driver-for-Motorcomm-YT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-FROMLIST-net-stmmac-Add-glue-driver-for-Motorcomm-YT.patch
@@ -1,7 +1,7 @@
 From b332249e0a27cb552c11be1071f711ef25b43483 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:10 +0000
-Subject: [PATCH 122/449] FROMLIST: net: stmmac: Add glue driver for Motorcomm
+Subject: [PATCH 122/450] FROMLIST: net: stmmac: Add glue driver for Motorcomm
  YT6801 ethernet controller
 
 Motorcomm YT6801 is a PCIe ethernet controller based on DWMAC4 IP. It
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 44593c0bb2268..5ca694bdcfc6b 100644
+index 44593c0bb226..5ca694bdcfc6 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -364,6 +364,15 @@ config DWMAC_LOONGSON
@@ -48,7 +48,7 @@ index 44593c0bb2268..5ca694bdcfc6b 100644
  	tristate "STMMAC PCI bus support"
  	depends on PCI
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index 1638f4227ced0..49ba02bb7c022 100644
+index 1638f4227ced..49ba02bb7c02 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -47,4 +47,5 @@ obj-$(CONFIG_STMMAC_LIBPCI)	+= stmmac_libpci.o
@@ -59,7 +59,7 @@ index 1638f4227ced0..49ba02bb7c022 100644
  stmmac-pci-objs:= stmmac_pci.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c
 new file mode 100644
-index 0000000000000..fc87192af4467
+index 000000000000..fc87192af446
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-motorcomm.c
 @@ -0,0 +1,378 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-FROMLIST-MAINTAINERS-Assign-myself-as-maintainer-of-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-FROMLIST-MAINTAINERS-Assign-myself-as-maintainer-of-.patch
@@ -1,7 +1,7 @@
 From 2dfa2135f1965c614b53ae7fb0ec0356af8f76a4 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:11 +0000
-Subject: [PATCH 123/449] FROMLIST: MAINTAINERS: Assign myself as maintainer of
+Subject: [PATCH 123/450] FROMLIST: MAINTAINERS: Assign myself as maintainer of
  Motorcomm DWMAC glue driver
 
 I volunteer to maintain the DWMAC glue driver for Motorcomm ethernet
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index cdc3541b6871a..7da3d1160d35d 100644
+index cdc3541b6871..7da3d1160d35 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -17455,6 +17455,12 @@ F:	drivers/most/

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From cf6278598eb66abb5885f74f14c1d9a9b45b0099 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 27 Nov 2025 16:02:03 +0800
-Subject: [PATCH 124/449] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 124/450] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/input/mouse/pixart_ps2.h
 
 diff --git a/drivers/input/mouse/Kconfig b/drivers/input/mouse/Kconfig
-index 833b643f06164..8a27a20d04b01 100644
+index 833b643f0616..8a27a20d04b0 100644
 --- a/drivers/input/mouse/Kconfig
 +++ b/drivers/input/mouse/Kconfig
 @@ -69,6 +69,18 @@ config MOUSE_PS2_LOGIPS2PP
@@ -54,7 +54,7 @@ index 833b643f06164..8a27a20d04b01 100644
  	bool "Synaptics PS/2 mouse protocol extension" if EXPERT
  	default y
 diff --git a/drivers/input/mouse/Makefile b/drivers/input/mouse/Makefile
-index a1336d5bee6f3..5630295515291 100644
+index a1336d5bee6f..563029551529 100644
 --- a/drivers/input/mouse/Makefile
 +++ b/drivers/input/mouse/Makefile
 @@ -32,6 +32,7 @@ psmouse-$(CONFIG_MOUSE_PS2_ELANTECH)	+= elantech.o
@@ -67,7 +67,7 @@ index a1336d5bee6f3..5630295515291 100644
  psmouse-$(CONFIG_MOUSE_PS2_TOUCHKIT)	+= touchkit_ps2.o
 diff --git a/drivers/input/mouse/pixart_ps2.c b/drivers/input/mouse/pixart_ps2.c
 new file mode 100644
-index 0000000000000..682aa6499e63c
+index 000000000000..682aa6499e63
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.c
 @@ -0,0 +1,310 @@
@@ -383,7 +383,7 @@ index 0000000000000..682aa6499e63c
 +}
 diff --git a/drivers/input/mouse/pixart_ps2.h b/drivers/input/mouse/pixart_ps2.h
 new file mode 100644
-index 0000000000000..47a1d040f2d10
+index 000000000000..47a1d040f2d1
 --- /dev/null
 +++ b/drivers/input/mouse/pixart_ps2.h
 @@ -0,0 +1,36 @@
@@ -424,7 +424,7 @@ index 0000000000000..47a1d040f2d10
 +
 +#endif  /* _PIXART_PS2_H */
 diff --git a/drivers/input/mouse/psmouse-base.c b/drivers/input/mouse/psmouse-base.c
-index 77ea7da3b1c50..f708b75eb91b4 100644
+index 77ea7da3b1c5..f708b75eb91b 100644
 --- a/drivers/input/mouse/psmouse-base.c
 +++ b/drivers/input/mouse/psmouse-base.c
 @@ -36,6 +36,7 @@
@@ -466,7 +466,7 @@ index 77ea7da3b1c50..f708b75eb91b4 100644
  		if (psmouse_try_protocol(psmouse, PSMOUSE_GENPS,
  					 &max_proto, set_properties, true))
 diff --git a/drivers/input/mouse/psmouse.h b/drivers/input/mouse/psmouse.h
-index 4d8acfe0d82aa..23f7fa7243cb5 100644
+index 4d8acfe0d82a..23f7fa7243cb 100644
 --- a/drivers/input/mouse/psmouse.h
 +++ b/drivers/input/mouse/psmouse.h
 @@ -69,6 +69,7 @@ enum psmouse_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-FROMLIST-PCI-Add-Cix-Technology-Vendor-and-Device-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-FROMLIST-PCI-Add-Cix-Technology-Vendor-and-Device-ID.patch
@@ -1,7 +1,7 @@
 From 80a0583c00ef3dc1657416ed746675dfbf653d1d Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Mon, 20 Oct 2025 12:28:53 +0800
-Subject: [PATCH 125/449] FROMLIST: PCI: Add Cix Technology Vendor and Device
+Subject: [PATCH 125/450] FROMLIST: PCI: Add Cix Technology Vendor and Device
  ID
 
 Add CIX P1 (internal name sky1) as a vendor and device ID for PCI
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 03b7c0380f71c..02ee9cfee3fb5 100644
+index 03b7c0380f71..02ee9cfee3fb 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -2631,6 +2631,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-FROMLIST-MAINTAINERS-add-entry-for-CIX-Sky1-PCIe-dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-FROMLIST-MAINTAINERS-add-entry-for-CIX-Sky1-PCIe-dri.patch
@@ -1,7 +1,7 @@
 From 9f49f005db6937705f6e2f3c6a93629088d55b18 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Mon, 20 Oct 2025 12:28:55 +0800
-Subject: [PATCH 126/449] FROMLIST: MAINTAINERS: add entry for CIX Sky1 PCIe
+Subject: [PATCH 126/450] FROMLIST: MAINTAINERS: add entry for CIX Sky1 PCIe
  driver
 
 Add myself as maintainer of Sky1 PCIe host driver
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 7da3d1160d35d..cf619a1e10b01 100644
+index 7da3d1160d35..cf619a1e10b0 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -19668,6 +19668,13 @@ S:	Orphan

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-FROMLIST-dt-bindings-reset-add-sky1-reset-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-FROMLIST-dt-bindings-reset-add-sky1-reset-controller.patch
@@ -1,7 +1,7 @@
 From bf2e557d2c357f59b2235f9e35a145bf6064909b Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Thu, 13 Nov 2025 15:59:33 +0800
-Subject: [PATCH 127/449] FROMLIST: dt-bindings: reset: add sky1 reset
+Subject: [PATCH 127/450] FROMLIST: dt-bindings: reset: add sky1 reset
  controller
 
 There are two reset controllers on Cix sky1 Soc.
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/reset/cix,sky1-rst.yaml b/Documentation/devicetree/bindings/reset/cix,sky1-rst.yaml
 new file mode 100644
-index 0000000000000..6339ed3f296ae
+index 000000000000..6339ed3f296a
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/reset/cix,sky1-rst.yaml
 @@ -0,0 +1,48 @@
@@ -77,7 +77,7 @@ index 0000000000000..6339ed3f296ae
 +    };
 diff --git a/include/dt-bindings/reset/cix,sky1-rst-fch.h b/include/dt-bindings/reset/cix,sky1-rst-fch.h
 new file mode 100644
-index 0000000000000..8e67d7eb92aa5
+index 000000000000..8e67d7eb92aa
 --- /dev/null
 +++ b/include/dt-bindings/reset/cix,sky1-rst-fch.h
 @@ -0,0 +1,42 @@
@@ -125,7 +125,7 @@ index 0000000000000..8e67d7eb92aa5
 +#endif
 diff --git a/include/dt-bindings/reset/cix,sky1-rst.h b/include/dt-bindings/reset/cix,sky1-rst.h
 new file mode 100644
-index 0000000000000..72c0d6a60452e
+index 000000000000..72c0d6a60452
 --- /dev/null
 +++ b/include/dt-bindings/reset/cix,sky1-rst.h
 @@ -0,0 +1,164 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-FROMLIST-reset-cix-add-support-for-cix-sky1-resets.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-FROMLIST-reset-cix-add-support-for-cix-sky1-resets.patch
@@ -1,7 +1,7 @@
 From 1fd219f301f77d852aef463ad4baf826c5c4adf7 Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Thu, 13 Nov 2025 15:59:34 +0800
-Subject: [PATCH 128/449] FROMLIST: reset: cix: add support for cix sky1 resets
+Subject: [PATCH 128/450] FROMLIST: reset: cix: add support for cix sky1 resets
 
 There are two reset controllers on Cix Sky1 Soc.
 One is located in S0 domain, and the other is located
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/reset/reset-sky1.c
 
 diff --git a/drivers/reset/Kconfig b/drivers/reset/Kconfig
-index b3b9e0f9d8c48..15edaf5a993d3 100644
+index b3b9e0f9d8c4..15edaf5a993d 100644
 --- a/drivers/reset/Kconfig
 +++ b/drivers/reset/Kconfig
 @@ -278,6 +278,13 @@ config RESET_SIMPLE
@@ -37,7 +37,7 @@ index b3b9e0f9d8c48..15edaf5a993d3 100644
  	bool "SoCFPGA Reset Driver" if COMPILE_TEST && (!ARM || !ARCH_INTEL_SOCFPGA)
  	default ARM && ARCH_INTEL_SOCFPGA
 diff --git a/drivers/reset/Makefile b/drivers/reset/Makefile
-index f7934f9fb90bb..a878ac4a6e4b2 100644
+index f7934f9fb90b..a878ac4a6e4b 100644
 --- a/drivers/reset/Makefile
 +++ b/drivers/reset/Makefile
 @@ -36,6 +36,7 @@ obj-$(CONFIG_RESET_RZG2L_USBPHY_CTRL) += reset-rzg2l-usbphy-ctrl.o
@@ -50,7 +50,7 @@ index f7934f9fb90bb..a878ac4a6e4b2 100644
  obj-$(CONFIG_RESET_SUNPLUS) += reset-sunplus.o
 diff --git a/drivers/reset/reset-sky1.c b/drivers/reset/reset-sky1.c
 new file mode 100644
-index 0000000000000..b9e03e76736a3
+index 000000000000..b9e03e76736a
 --- /dev/null
 +++ b/drivers/reset/reset-sky1.c
 @@ -0,0 +1,381 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-FROMLIST-arm64-dts-cix-add-support-for-cix-sky1-rese.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-FROMLIST-arm64-dts-cix-add-support-for-cix-sky1-rese.patch
@@ -1,7 +1,7 @@
 From 460c09e66715abf8ad2ff7e37572765c027c15fe Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 2 Dec 2025 19:29:22 +0800
-Subject: [PATCH 129/449] FROMLIST: arm64: dts: cix: add support for cix sky1
+Subject: [PATCH 129/450] FROMLIST: arm64: dts: cix: add support for cix sky1
  resets
 
 There are two reset conctrollers on Cix Sky1 Soc.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/arm64/boot/dts/cix/sky1.dtsi.orig
 
 diff --git a/arch/arm64/boot/dts/cix/sky1.dtsi b/arch/arm64/boot/dts/cix/sky1.dtsi
-index 64b76905cbff5..6a41316341671 100644
+index 64b76905cbff..6a4131634167 100644
 --- a/arch/arm64/boot/dts/cix/sky1.dtsi
 +++ b/arch/arm64/boot/dts/cix/sky1.dtsi
 @@ -348,6 +348,12 @@ i3c1: i3c@4100000 {
@@ -50,7 +50,7 @@ index 64b76905cbff5..6a41316341671 100644
  			reg = <0x0 0x16007000 0x0 0x1000>;
 diff --git a/arch/arm64/boot/dts/cix/sky1.dtsi.orig b/arch/arm64/boot/dts/cix/sky1.dtsi.orig
 new file mode 100644
-index 0000000000000..64b76905cbff5
+index 000000000000..64b76905cbff
 --- /dev/null
 +++ b/arch/arm64/boot/dts/cix/sky1.dtsi.orig
 @@ -0,0 +1,586 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-FROMLIST-ALSA-hda-dt-bindings-add-CIX-IPBLOQ-HDA-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-FROMLIST-ALSA-hda-dt-bindings-add-CIX-IPBLOQ-HDA-con.patch
@@ -1,7 +1,7 @@
 From 2aa958cdd3a9ebae168065cd5961e27f4e34a3b9 Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:56:58 +0800
-Subject: [PATCH 130/449] FROMLIST: ALSA: hda: dt-bindings: add CIX IPBLOQ HDA
+Subject: [PATCH 130/450] FROMLIST: ALSA: hda: dt-bindings: add CIX IPBLOQ HDA
  controller support
 
 Add CIX IPBLOQ HDA controller support, which integrated in
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/sound/cix,sky1-ipbloq-hda.yaml b/Documentation/devicetree/bindings/sound/cix,sky1-ipbloq-hda.yaml
 new file mode 100644
-index 0000000000000..b27d47523af3d
+index 000000000000..b27d47523af3
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/sound/cix,sky1-ipbloq-hda.yaml
 @@ -0,0 +1,72 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-FROMLIST-ALSA-hda-core-add-addr_offset-field-for-bus.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-FROMLIST-ALSA-hda-core-add-addr_offset-field-for-bus.patch
@@ -1,7 +1,7 @@
 From 4f53ce214ccaa6248bb924836dc821d19c45aa8b Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:56:59 +0800
-Subject: [PATCH 131/449] FROMLIST: ALSA: hda/core: add addr_offset field for
+Subject: [PATCH 131/450] FROMLIST: ALSA: hda/core: add addr_offset field for
  bus address translation
 
 Add bus addr_offset field for dma address translation,
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 15 insertions(+), 11 deletions(-)
 
 diff --git a/include/sound/hdaudio.h b/include/sound/hdaudio.h
-index 4e0c1d8af09f7..f11bfc6b9f428 100644
+index 4e0c1d8af09f..f11bfc6b9f42 100644
 --- a/include/sound/hdaudio.h
 +++ b/include/sound/hdaudio.h
 @@ -380,6 +380,9 @@ struct hdac_bus {
@@ -35,7 +35,7 @@ index 4e0c1d8af09f7..f11bfc6b9f428 100644
  
  int snd_hdac_bus_init(struct hdac_bus *bus, struct device *dev,
 diff --git a/sound/hda/core/bus.c b/sound/hda/core/bus.c
-index 9b196c915f378..81498f1e413e2 100644
+index 9b196c915f37..81498f1e413e 100644
 --- a/sound/hda/core/bus.c
 +++ b/sound/hda/core/bus.c
 @@ -47,6 +47,7 @@ int snd_hdac_bus_init(struct hdac_bus *bus, struct device *dev,
@@ -47,7 +47,7 @@ index 9b196c915f378..81498f1e413e2 100644
  	/*
  	 * Default value of '8' is as per the HD audio specification (Rev 1.0a).
 diff --git a/sound/hda/core/controller.c b/sound/hda/core/controller.c
-index a7c00ad801170..69e11d62bbfa7 100644
+index a7c00ad80117..69e11d62bbfa 100644
 --- a/sound/hda/core/controller.c
 +++ b/sound/hda/core/controller.c
 @@ -48,8 +48,8 @@ void snd_hdac_bus_init_cmd_io(struct hdac_bus *bus)
@@ -84,7 +84,7 @@ index a7c00ad801170..69e11d62bbfa7 100644
  
  	bus->chip_init = true;
 diff --git a/sound/hda/core/stream.c b/sound/hda/core/stream.c
-index 579ec544ef4a4..b471a038b3140 100644
+index 579ec544ef4a..b471a038b314 100644
 --- a/sound/hda/core/stream.c
 +++ b/sound/hda/core/stream.c
 @@ -288,16 +288,16 @@ int snd_hdac_stream_setup(struct hdac_stream *azx_dev, bool code_loading)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-FROMLIST-ALSA-hda-add-CIX-IPBLOQ-HDA-controller-supp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-FROMLIST-ALSA-hda-add-CIX-IPBLOQ-HDA-controller-supp.patch
@@ -1,7 +1,7 @@
 From 86fe55a52e4f8061a7e46515c30a76fa2f1da02b Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:57:00 +0800
-Subject: [PATCH 132/449] FROMLIST: ALSA: hda: add CIX IPBLOQ HDA controller
+Subject: [PATCH 132/450] FROMLIST: ALSA: hda: add CIX IPBLOQ HDA controller
  support
 
 Add CIX IPBLOQ HDA controller support, which integrated
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 sound/hda/controllers/cix-ipbloq.c
 
 diff --git a/sound/hda/controllers/Kconfig b/sound/hda/controllers/Kconfig
-index 34721f50b055a..72855f2df4514 100644
+index 34721f50b055..72855f2df451 100644
 --- a/sound/hda/controllers/Kconfig
 +++ b/sound/hda/controllers/Kconfig
 @@ -30,6 +30,20 @@ config SND_HDA_TEGRA
@@ -44,7 +44,7 @@ index 34721f50b055a..72855f2df4514 100644
  	tristate "HD Audio ACPI"
  	depends on ACPI
 diff --git a/sound/hda/controllers/Makefile b/sound/hda/controllers/Makefile
-index a4bcd055e9aef..8967b6771d904 100644
+index a4bcd055e9ae..8967b6771d90 100644
 --- a/sound/hda/controllers/Makefile
 +++ b/sound/hda/controllers/Makefile
 @@ -1,6 +1,7 @@
@@ -63,7 +63,7 @@ index a4bcd055e9aef..8967b6771d904 100644
  obj-$(CONFIG_SND_HDA_ACPI) += snd-hda-acpi.o
 diff --git a/sound/hda/controllers/cix-ipbloq.c b/sound/hda/controllers/cix-ipbloq.c
 new file mode 100644
-index 0000000000000..8332bde2d8cb8
+index 000000000000..8332bde2d8cb
 --- /dev/null
 +++ b/sound/hda/controllers/cix-ipbloq.c
 @@ -0,0 +1,438 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From ef9ab18c1984eb06a82d8984633502f99ec8eb90 Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia@aosc.io>
 Date: Wed, 22 Oct 2025 18:16:30 +0800
-Subject: [PATCH 133/449] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 133/450] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 422e28ad1e8e2..4a08411348242 100644
+index 422e28ad1e8e..4a0841134824 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -1944,6 +1944,13 @@ static const struct dmi_system_id atkbd_dmi_quirk_table[] __initconst = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-FROMLIST-rust-export-BINDGEN_TARGET-from-a-separate-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-FROMLIST-rust-export-BINDGEN_TARGET-from-a-separate-.patch
@@ -1,7 +1,7 @@
 From 009100641c69ecbf6651dd8a87814596ad568a74 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:51 +0100
-Subject: [PATCH 134/449] FROMLIST: rust: export BINDGEN_TARGET from a separate
+Subject: [PATCH 134/450] FROMLIST: rust: export BINDGEN_TARGET from a separate
  Makefile
 
 A subsequent commit will add a new function `bindgen-option` to
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 scripts/Makefile.rust
 
 diff --git a/Makefile b/Makefile
-index 35c1fcb095717..c6463a05eac22 100644
+index 35c1fcb09571..c6463a05eac2 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -718,9 +718,10 @@ ifneq ($(findstring clang,$(CC_VERSION_TEXT)),)
@@ -46,7 +46,7 @@ index 35c1fcb095717..c6463a05eac22 100644
  endif
  
 diff --git a/rust/Makefile b/rust/Makefile
-index d4618f646b05b..c311d16e7e741 100644
+index d4618f646b05..c311d16e7e74 100644
 --- a/rust/Makefile
 +++ b/rust/Makefile
 @@ -300,14 +300,6 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
@@ -66,7 +66,7 @@ index d4618f646b05b..c311d16e7e741 100644
  # some configurations, with new GCC versions, etc.
 diff --git a/scripts/Makefile.rust b/scripts/Makefile.rust
 new file mode 100644
-index 0000000000000..5c12b4b8c8b65
+index 000000000000..5c12b4b8c8b6
 --- /dev/null
 +++ b/scripts/Makefile.rust
 @@ -0,0 +1,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-FROMLIST-rust-generate-a-fatal-error-if-BINDGEN_TARG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-FROMLIST-rust-generate-a-fatal-error-if-BINDGEN_TARG.patch
@@ -1,7 +1,7 @@
 From 73686c35315e3d78f4d40874e6cf6fa2f1cf3e05 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:52 +0100
-Subject: [PATCH 135/449] FROMLIST: rust: generate a fatal error if
+Subject: [PATCH 135/450] FROMLIST: rust: generate a fatal error if
  BINDGEN_TARGET is undefined
 
 Generate a friendly fatal error if the target triplet is undefined for
@@ -36,7 +36,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/scripts/Makefile.rust b/scripts/Makefile.rust
-index 5c12b4b8c8b65..b219244cd0510 100644
+index 5c12b4b8c8b6..b219244cd051 100644
 --- a/scripts/Makefile.rust
 +++ b/scripts/Makefile.rust
 @@ -6,4 +6,8 @@ BINDGEN_TARGET_loongarch	:= loongarch64-linux-gnusf

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-FROMLIST-rust-add-a-Kconfig-function-to-test-for-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-FROMLIST-rust-add-a-Kconfig-function-to-test-for-sup.patch
@@ -1,7 +1,7 @@
 From 27ed6c2d09b39a9a1c8ebf97aa3fb9149116fbeb Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:53 +0100
-Subject: [PATCH 136/449] FROMLIST: rust: add a Kconfig function to test for
+Subject: [PATCH 136/450] FROMLIST: rust: add a Kconfig function to test for
  support of bindgen options
 
 Add a new `bindgen-backend-option` Kconfig function to test whether the
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/scripts/Kconfig.include b/scripts/Kconfig.include
-index 33193ca6e8030..bf940e68e4679 100644
+index 33193ca6e803..bf940e68e467 100644
 --- a/scripts/Kconfig.include
 +++ b/scripts/Kconfig.include
 @@ -75,3 +75,8 @@ rustc-llvm-version := $(shell,$(srctree)/scripts/rustc-llvm-version.sh $(RUSTC))

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-FROMLIST-RISC-V-handle-extension-configs-for-bindgen.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-FROMLIST-RISC-V-handle-extension-configs-for-bindgen.patch
@@ -1,7 +1,7 @@
 From 5f25f46ab0dc40b49423185242a9be4fcb502fd8 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:54 +0100
-Subject: [PATCH 137/449] FROMLIST: RISC-V: handle extension configs for
+Subject: [PATCH 137/450] FROMLIST: RISC-V: handle extension configs for
  bindgen, re-enable gcc + rust builds
 
 Commit 33549fcf37ec ("RISC-V: disallow gcc + rust builds") disabled GCC
@@ -39,7 +39,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 38 insertions(+), 3 deletions(-)
 
 diff --git a/Documentation/rust/arch-support.rst b/Documentation/rust/arch-support.rst
-index 6e6a515d08991..5282e0e174e8d 100644
+index 6e6a515d0899..5282e0e174e8 100644
 --- a/Documentation/rust/arch-support.rst
 +++ b/Documentation/rust/arch-support.rst
 @@ -18,7 +18,7 @@ Architecture   Level of support  Constraints
@@ -52,7 +52,7 @@ index 6e6a515d08991..5282e0e174e8d 100644
  ``x86``        Maintained        ``x86_64`` only.
  =============  ================  ==============================================
 diff --git a/arch/riscv/Kconfig b/arch/riscv/Kconfig
-index fadec20b87a8e..9a56063966460 100644
+index fadec20b87a8..9a5606396646 100644
 --- a/arch/riscv/Kconfig
 +++ b/arch/riscv/Kconfig
 @@ -193,7 +193,7 @@ config RISCV
@@ -154,7 +154,7 @@ index fadec20b87a8e..9a56063966460 100644
  	bool "FPU support"
  	default y
 diff --git a/rust/Makefile b/rust/Makefile
-index c311d16e7e741..4f5ea9a6b2814 100644
+index c311d16e7e74..4f5ea9a6b281 100644
 --- a/rust/Makefile
 +++ b/rust/Makefile
 @@ -298,7 +298,8 @@ bindgen_skip_c_flags := -mno-fp-ret-in-387 -mpreferred-stack-boundary=% \
@@ -168,7 +168,7 @@ index c311d16e7e741..4f5ea9a6b2814 100644
  # All warnings are inhibited since GCC builds are very experimental,
  # many GCC warnings are not supported by Clang, they may only appear in
 diff --git a/scripts/Makefile.rust b/scripts/Makefile.rust
-index b219244cd0510..cee28a6048302 100644
+index b219244cd051..cee28a604830 100644
 --- a/scripts/Makefile.rust
 +++ b/scripts/Makefile.rust
 @@ -3,6 +3,7 @@ BINDGEN_TARGET_x86	:= x86_64-linux-gnu

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-FROMLIST-riscv-dts-thead-lichee-pi-4a-enable-HDMI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-FROMLIST-riscv-dts-thead-lichee-pi-4a-enable-HDMI.patch
@@ -1,7 +1,7 @@
 From d32c7b395099d2d7a706add5c0e01f7bd0c6e551 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:24 +0800
-Subject: [PATCH 138/449] FROMLIST: riscv: dts: thead: lichee-pi-4a: enable
+Subject: [PATCH 138/450] FROMLIST: riscv: dts: thead: lichee-pi-4a: enable
  HDMI
 
 Lichee Pi 4A board features a HDMI Type-A connector connected to the
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
-index c58c2085ca92a..e8971cafd1b1c 100644
+index c58c2085ca92..e8971cafd1b1 100644
 --- a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 +++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 @@ -83,6 +83,16 @@ fan: pwm-fan {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2042-PC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2042-PC.patch
@@ -1,7 +1,7 @@
 From 15b02d728041ad78fef867dd34fbbc56e827311a Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 25 Dec 2025 18:05:28 +0800
-Subject: [PATCH 139/449] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2042
+Subject: [PATCH 139/450] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2042
  PCIe [1f1c:2042] Root Ports
 
 Since commit f3ac2ff14834 ("PCI/ASPM: Enable all ClockPM and ASPM
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 3 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 34bd05bdfa0a0..115ef3d02a080 100644
+index 34bd05bdfa0a..115ef3d02a08 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -2536,6 +2536,7 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_ASMEDIA, 0x1080, quirk_disable_aspm_l0s_l
@@ -36,7 +36,7 @@ index 34bd05bdfa0a0..115ef3d02a080 100644
  /*
   * Some Pericom PCIe-to-PCI bridges in reverse mode need the PCIe Retrain
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 02ee9cfee3fb5..3c0b7d48ddb9a 100644
+index 02ee9cfee3fb..3c0b7d48ddb9 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -2631,6 +2631,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2044-PC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2044-PC.patch
@@ -1,7 +1,7 @@
 From 43d659c92b74c287984ef97b35dfdc5d67b32ba2 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 25 Dec 2025 18:05:29 +0800
-Subject: [PATCH 140/449] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2044
+Subject: [PATCH 140/450] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2044
  PCIe [1f1c:2044] Root Ports
 
 Since commit f3ac2ff14834 ("PCI/ASPM: Enable all ClockPM and ASPM
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 115ef3d02a080..b8647f9b1ef3a 100644
+index 115ef3d02a08..b8647f9b1ef3 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -2537,6 +2537,7 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_FREESCALE, 0x0451, quirk_disable_aspm_l0s

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-FROMLIST-PCI-loongson-Override-PCIe-bridge-supported.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-FROMLIST-PCI-loongson-Override-PCIe-bridge-supported.patch
@@ -1,7 +1,7 @@
 From 8b6b4b419eaebf0e8b3df138e2d90f383399736b Mon Sep 17 00:00:00 2001
 From: Ziyao Li <liziyao@uniontech.com>
 Date: Wed, 21 Jan 2026 16:22:40 +0800
-Subject: [PATCH 141/449] FROMLIST: PCI: loongson: Override PCIe bridge
+Subject: [PATCH 141/450] FROMLIST: PCI: loongson: Override PCIe bridge
  supported speeds for Loongson-3C6000 series
 
 Older steppings of the Loongson-3C6000 series incorrectly report the
@@ -46,7 +46,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 36 insertions(+)
 
 diff --git a/drivers/pci/controller/pci-loongson.c b/drivers/pci/controller/pci-loongson.c
-index bc630ab8a2831..a4250d7af1bfa 100644
+index bc630ab8a283..a4250d7af1bf 100644
 --- a/drivers/pci/controller/pci-loongson.c
 +++ b/drivers/pci/controller/pci-loongson.c
 @@ -176,6 +176,42 @@ static void loongson_pci_msi_quirk(struct pci_dev *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-FROMLIST-loongarch-wire-up-memfd_secret-sys.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-FROMLIST-loongarch-wire-up-memfd_secret-sys.patch
@@ -1,7 +1,7 @@
 From 2f932a963537c1772978400491e36f6a8b3f7fa4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fearyncess@aosc.io>
 Date: Fri, 9 Jan 2026 13:10:51 +0800
-Subject: [PATCH 142/449] BACKPORT: FROMLIST: loongarch: wire up memfd_secret
+Subject: [PATCH 142/450] BACKPORT: FROMLIST: loongarch: wire up memfd_secret
  system call
 
 LoongArch supports ARCH_HAS_SET_DIRECT_MAP, therefore wire up the
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/arch/loongarch/include/asm/unistd.h b/arch/loongarch/include/asm/unistd.h
-index e2c0f3d86c7bd..e7649c1582482 100644
+index e2c0f3d86c7b..e7649c158248 100644
 --- a/arch/loongarch/include/asm/unistd.h
 +++ b/arch/loongarch/include/asm/unistd.h
 @@ -10,5 +10,6 @@
@@ -33,7 +33,7 @@ index e2c0f3d86c7bd..e7649c1582482 100644
  
  #define NR_syscalls (__NR_syscalls)
 diff --git a/arch/loongarch/kernel/Makefile.syscalls b/arch/loongarch/kernel/Makefile.syscalls
-index ab7d9baa29152..6360381baf931 100644
+index ab7d9baa2915..6360381baf93 100644
 --- a/arch/loongarch/kernel/Makefile.syscalls
 +++ b/arch/loongarch/kernel/Makefile.syscalls
 @@ -1,4 +1,5 @@
@@ -45,7 +45,7 @@ index ab7d9baa29152..6360381baf931 100644
 +syscall_abis_32 += memfd_secret
 +syscall_abis_64 += memfd_secret
 diff --git a/tools/testing/selftests/mm/Makefile b/tools/testing/selftests/mm/Makefile
-index eaf9312097f7b..79582438efc4d 100644
+index eaf9312097f7..79582438efc4 100644
 --- a/tools/testing/selftests/mm/Makefile
 +++ b/tools/testing/selftests/mm/Makefile
 @@ -72,7 +72,7 @@ TEST_GEN_FILES += madv_populate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-FROMLIST-loongarch-retrieve-CPU-package-ID-from-PPTT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-FROMLIST-loongarch-retrieve-CPU-package-ID-from-PPTT.patch
@@ -1,7 +1,7 @@
 From e823a4c998fad1cad5f7a875581745f2c7450838 Mon Sep 17 00:00:00 2001
 From: Rong Bao <rong.bao@csmantle.top>
 Date: Fri, 23 Jan 2026 23:56:06 +0800
-Subject: [PATCH 143/449] FROMLIST: loongarch: retrieve CPU package ID from
+Subject: [PATCH 143/450] FROMLIST: loongarch: retrieve CPU package ID from
  PPTT when available
 
 Currently, the LoongArch CPU topology initialization code calculates
@@ -55,7 +55,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/arch/loongarch/kernel/acpi.c b/arch/loongarch/kernel/acpi.c
-index 1367ca759468f..82c7ffd4f1ac6 100644
+index 1367ca759468..82c7ffd4f1ac 100644
 --- a/arch/loongarch/kernel/acpi.c
 +++ b/arch/loongarch/kernel/acpi.c
 @@ -176,7 +176,7 @@ int pptt_enabled;
@@ -82,7 +82,7 @@ index 1367ca759468f..82c7ffd4f1ac6 100644
  
  	pptt_enabled = 1;
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 46036d98da75b..4513b15b72691 100644
+index 46036d98da75..4513b15b7269 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -412,7 +412,7 @@ void loongson_init_secondary(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-BACKPORT-FROMLIST-ACPI-PCI-check-if-the-root-io-spac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-BACKPORT-FROMLIST-ACPI-PCI-check-if-the-root-io-spac.patch
@@ -1,7 +1,7 @@
 From d8d17a65525f9737984599e4370fa38fdc896c90 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 20:09:15 +0800
-Subject: [PATCH 144/449] BACKPORT: FROMLIST: ACPI: PCI: check if the root io
+Subject: [PATCH 144/450] BACKPORT: FROMLIST: ACPI: PCI: check if the root io
  space is page aligned
 
 When the IO resource given by _CRS method is not page aligned, especially
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 11 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index 74ade41603145..961fdfd0e5a13 100644
+index 74ade4160314..961fdfd0e5a1 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -858,7 +858,7 @@ static void acpi_pci_root_validate_resources(struct device *dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-FROMLIST-PCI-MSI-Conservatively-generalize-no_64bit_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-FROMLIST-PCI-MSI-Conservatively-generalize-no_64bit_.patch
@@ -1,7 +1,7 @@
 From 889425bfad0c46d336f75e416a10e4e195b8e283 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:28 +0800
-Subject: [PATCH 145/449] FROMLIST: PCI/MSI: Conservatively generalize
+Subject: [PATCH 145/450] FROMLIST: PCI/MSI: Conservatively generalize
  no_64bit_msi into msi_addr_mask
 
 Some PCI devices have PCI_MSI_FLAGS_64BIT in the MSI capability, but
@@ -48,7 +48,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  9 files changed, 22 insertions(+), 9 deletions(-)
 
 diff --git a/arch/powerpc/platforms/powernv/pci-ioda.c b/arch/powerpc/platforms/powernv/pci-ioda.c
-index b0c1d9d16fb52..1c78fdfb7b036 100644
+index b0c1d9d16fb5..1c78fdfb7b03 100644
 --- a/arch/powerpc/platforms/powernv/pci-ioda.c
 +++ b/arch/powerpc/platforms/powernv/pci-ioda.c
 @@ -1666,7 +1666,7 @@ static int __pnv_pci_ioda_msi_setup(struct pnv_phb *phb, struct pci_dev *dev,
@@ -61,7 +61,7 @@ index b0c1d9d16fb52..1c78fdfb7b036 100644
  
  	/* Assign XIVE to PE */
 diff --git a/arch/powerpc/platforms/pseries/msi.c b/arch/powerpc/platforms/pseries/msi.c
-index edc30cda5dbcb..4cd70a8201f1a 100644
+index edc30cda5dbc..4cd70a8201f1 100644
 --- a/arch/powerpc/platforms/pseries/msi.c
 +++ b/arch/powerpc/platforms/pseries/msi.c
 @@ -388,7 +388,7 @@ static int rtas_prepare_msi_irqs(struct pci_dev *pdev, int nvec_in, int type,
@@ -83,7 +83,7 @@ index edc30cda5dbcb..4cd70a8201f1a 100644
  		else
  			rc = rtas_change_msi(pdn, RTAS_CHANGE_MSIX_FN, nvec);
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index 9961251b44ba0..d550554a6f3f2 100644
+index 9961251b44ba..d550554a6f3f 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -252,7 +252,7 @@ static bool radeon_msi_ok(struct radeon_device *rdev)
@@ -96,7 +96,7 @@ index 9961251b44ba0..d550554a6f3f2 100644
  
  	/* force MSI on */
 diff --git a/drivers/net/ethernet/pensando/ionic/ionic_bus_pci.c b/drivers/net/ethernet/pensando/ionic/ionic_bus_pci.c
-index 70d86c5f52fbb..0671deae9a286 100644
+index 70d86c5f52fb..0671deae9a28 100644
 --- a/drivers/net/ethernet/pensando/ionic/ionic_bus_pci.c
 +++ b/drivers/net/ethernet/pensando/ionic/ionic_bus_pci.c
 @@ -331,7 +331,7 @@ static int ionic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
@@ -109,7 +109,7 @@ index 70d86c5f52fbb..0671deae9a286 100644
  
  	err = ionic_setup_one(ionic);
 diff --git a/drivers/pci/msi/msi.c b/drivers/pci/msi/msi.c
-index e010ecd9f90dd..fb9a42bec62eb 100644
+index e010ecd9f90d..fb9a42bec62e 100644
 --- a/drivers/pci/msi/msi.c
 +++ b/drivers/pci/msi/msi.c
 @@ -322,7 +322,7 @@ static int msi_verify_entries(struct pci_dev *dev)
@@ -122,7 +122,7 @@ index e010ecd9f90dd..fb9a42bec62eb 100644
  
  	msi_for_each_desc(entry, &dev->dev, MSI_DESC_ALL) {
 diff --git a/drivers/pci/msi/pcidev_msi.c b/drivers/pci/msi/pcidev_msi.c
-index 5520aff53b567..0b03468130926 100644
+index 5520aff53b56..0b0346813092 100644
 --- a/drivers/pci/msi/pcidev_msi.c
 +++ b/drivers/pci/msi/pcidev_msi.c
 @@ -24,7 +24,7 @@ void pci_msi_init(struct pci_dev *dev)
@@ -135,7 +135,7 @@ index 5520aff53b567..0b03468130926 100644
  
  void pci_msix_init(struct pci_dev *dev)
 diff --git a/drivers/pci/probe.c b/drivers/pci/probe.c
-index 23833fd7265e2..37f0b931ecb3b 100644
+index 23833fd7265e..37f0b931ecb3 100644
 --- a/drivers/pci/probe.c
 +++ b/drivers/pci/probe.c
 @@ -2026,6 +2026,13 @@ int pci_setup_device(struct pci_dev *dev)
@@ -153,7 +153,7 @@ index 23833fd7265e2..37f0b931ecb3b 100644
  		     dev->bus->number, PCI_SLOT(dev->devfn),
  		     PCI_FUNC(dev->devfn));
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index 05aeee8c8844a..528e31ed5bea7 100644
+index 05aeee8c8844..528e31ed5bea 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -377,6 +377,13 @@ struct pci_dev {
@@ -179,7 +179,7 @@ index 05aeee8c8844a..528e31ed5bea7 100644
  	unsigned int	broken_parity_status:1;	/* Generates false positive parity */
  	unsigned int	irq_reroute_variant:2;	/* Needs IRQ rerouting variant */
 diff --git a/sound/hda/controllers/intel.c b/sound/hda/controllers/intel.c
-index a19258c95886c..766e42b8a6d8e 100644
+index a19258c95886..766e42b8a6d8 100644
 --- a/sound/hda/controllers/intel.c
 +++ b/sound/hda/controllers/intel.c
 @@ -1905,7 +1905,7 @@ static int azx_first_init(struct azx *chip)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-FROMLIST-PCI-MSI-Check-msi_addr_mask-in-msi_verify_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-FROMLIST-PCI-MSI-Check-msi_addr_mask-in-msi_verify_e.patch
@@ -1,7 +1,7 @@
 From 8f3730a4dd913859ed8cf531b554217b1d6e5a9a Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:29 +0800
-Subject: [PATCH 146/449] FROMLIST: PCI/MSI: Check msi_addr_mask in
+Subject: [PATCH 146/450] FROMLIST: PCI/MSI: Check msi_addr_mask in
  msi_verify_entries()
 
 Instead of a 32-bit/64-bit dichotomy, check the MSI address against
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/pci/msi/msi.c b/drivers/pci/msi/msi.c
-index fb9a42bec62eb..10c414626fa82 100644
+index fb9a42bec62e..10c414626fa8 100644
 --- a/drivers/pci/msi/msi.c
 +++ b/drivers/pci/msi/msi.c
 @@ -321,14 +321,17 @@ static int msi_setup_msi_desc(struct pci_dev *dev, int nvec,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-FROMLIST-drm-radeon-Raise-msi_addr_mask-to-dma_bits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-FROMLIST-drm-radeon-Raise-msi_addr_mask-to-dma_bits.patch
@@ -1,7 +1,7 @@
 From 2a691419388ac2a0d7baa6905c6021d9ce935c25 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:30 +0800
-Subject: [PATCH 147/449] FROMLIST: drm/radeon: Raise msi_addr_mask to dma_bits
+Subject: [PATCH 147/450] FROMLIST: drm/radeon: Raise msi_addr_mask to dma_bits
 
 The code was originally written using no_64bit_msi, which restricts the
 device to 32-bit MSI addresses.
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 1 insertion(+), 10 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 9e35b14e2bf0e..92a3e3ee673c7 100644
+index 9e35b14e2bf0..92a3e3ee673c 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1374,6 +1374,7 @@ int radeon_device_init(struct radeon_device *rdev,
@@ -34,7 +34,7 @@ index 9e35b14e2bf0e..92a3e3ee673c7 100644
  
  	/* Registers mapping */
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index d550554a6f3f2..839d619e5602b 100644
+index d550554a6f3f..839d619e5602 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -245,16 +245,6 @@ static bool radeon_msi_ok(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-FROMLIST-ALSA-hda-intel-Raise-msi_addr_mask-to-dma_b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-FROMLIST-ALSA-hda-intel-Raise-msi_addr_mask-to-dma_b.patch
@@ -1,7 +1,7 @@
 From 1e592fbc7c821efb437ffbdc64213696f12bb1ab Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:31 +0800
-Subject: [PATCH 148/449] FROMLIST: ALSA: hda/intel: Raise msi_addr_mask to
+Subject: [PATCH 148/450] FROMLIST: ALSA: hda/intel: Raise msi_addr_mask to
  dma_bits
 
 The code was originally written using no_64bit_msi, which restricts the
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/sound/hda/controllers/intel.c b/sound/hda/controllers/intel.c
-index 766e42b8a6d8e..c378237a4cf4f 100644
+index 766e42b8a6d8..c378237a4cf4 100644
 --- a/sound/hda/controllers/intel.c
 +++ b/sound/hda/controllers/intel.c
 @@ -1903,11 +1903,6 @@ static int azx_first_init(struct azx *chip)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-FROMLIST-genirq-reserve-NR_IRQS_LEGACY-IRQs-in-dynir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-FROMLIST-genirq-reserve-NR_IRQS_LEGACY-IRQs-in-dynir.patch
@@ -1,7 +1,7 @@
 From 679d1574c77e9a232f6975726f38082f3c553f9f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Sat, 31 Jan 2026 16:51:42 +0800
-Subject: [PATCH 149/449] FROMLIST: genirq: reserve NR_IRQS_LEGACY IRQs in
+Subject: [PATCH 149/450] FROMLIST: genirq: reserve NR_IRQS_LEGACY IRQs in
  dynirq by default
 
 Several architectures define NR_IRQS_LEGACY to reserve a low range of IRQ
@@ -34,7 +34,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/kernel/softirq.c b/kernel/softirq.c
-index 77198911b8dd4..cdc77d52c36b2 100644
+index 77198911b8dd..cdc77d52c36b 100644
 --- a/kernel/softirq.c
 +++ b/kernel/softirq.c
 @@ -1184,5 +1184,5 @@ int __init __weak arch_early_irq_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-FROMLIST-dt-bindings-interrupt-controller-add-LS7A-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-FROMLIST-dt-bindings-interrupt-controller-add-LS7A-P.patch
@@ -1,7 +1,7 @@
 From 590eacf8ed5c67060158c02b949b61b6a08d4cc5 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:59:33 +0800
-Subject: [PATCH 150/449] FROMLIST: dt-bindings: interrupt-controller: add LS7A
+Subject: [PATCH 150/450] FROMLIST: dt-bindings: interrupt-controller: add LS7A
  PCH LPC
 
 Loongson 7A series PCH contains an LPC controller with an interrupt
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/interrupt-controller/loongson,pch-lpc.yaml b/Documentation/devicetree/bindings/interrupt-controller/loongson,pch-lpc.yaml
 new file mode 100644
-index 0000000000000..c00fbf31f47f0
+index 000000000000..c00fbf31f47f
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/interrupt-controller/loongson,pch-lpc.yaml
 @@ -0,0 +1,52 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-BACKPORT-FROMLIST-irqchip-loongson-pch-lpc-extract-n.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-BACKPORT-FROMLIST-irqchip-loongson-pch-lpc-extract-n.patch
@@ -1,7 +1,7 @@
 From 8d70fcbb099d76ce36d66230e01619f8a4b479c9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:22:40 +0800
-Subject: [PATCH 151/449] BACKPORT: FROMLIST: irqchip/loongson-pch-lpc: extract
+Subject: [PATCH 151/450] BACKPORT: FROMLIST: irqchip/loongson-pch-lpc: extract
  non-ACPI-related code from ACPI init
 
 A lot of code could be shared between the current ACPI init flow with
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 36 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/irqchip/irq-loongson-pch-lpc.c b/drivers/irqchip/irq-loongson-pch-lpc.c
-index 912bf50a5c7ca..4463e6435e8ac 100644
+index 912bf50a5c7c..4463e6435e8a 100644
 --- a/drivers/irqchip/irq-loongson-pch-lpc.c
 +++ b/drivers/irqchip/irq-loongson-pch-lpc.c
 @@ -171,13 +171,11 @@ static struct syscore_ops pch_lpc_syscore_ops = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-FROMLIST-irqchip-loongson-pch-lpc-guard-ACPI-init-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-FROMLIST-irqchip-loongson-pch-lpc-guard-ACPI-init-co.patch
@@ -1,7 +1,7 @@
 From 7658b2ea790bf2f930aacea7970cf768828b9ea8 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:27:26 +0800
-Subject: [PATCH 152/449] FROMLIST: irqchip/loongson-pch-lpc: guard ACPI init
+Subject: [PATCH 152/450] FROMLIST: irqchip/loongson-pch-lpc: guard ACPI init
  code with CONFIG_ACPI
 
 As OF-based initialization is going to be added to the driver, guard the
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/irqchip/irq-loongson-pch-lpc.c b/drivers/irqchip/irq-loongson-pch-lpc.c
-index 4463e6435e8ac..11f1df2bafaf4 100644
+index 4463e6435e8a..11f1df2bafaf 100644
 --- a/drivers/irqchip/irq-loongson-pch-lpc.c
 +++ b/drivers/irqchip/irq-loongson-pch-lpc.c
 @@ -221,6 +221,7 @@ static int __init pch_lpc_init(phys_addr_t addr, unsigned long size,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-FROMLIST-irqchip-loongson-pch-lpc-add-OF-init-code.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-FROMLIST-irqchip-loongson-pch-lpc-add-OF-init-code.patch
@@ -1,7 +1,7 @@
 From 8f7b296b1a7836fdb9f13a9f3d5442449870a2f7 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:41:50 +0800
-Subject: [PATCH 153/449] FROMLIST: irqchip/loongson-pch-lpc: add OF init code
+Subject: [PATCH 153/450] FROMLIST: irqchip/loongson-pch-lpc: add OF init code
 
 As the (kernel-internally) OF-based MIPS Loongson-3 systems can also
 have PCH LPC interrupt controller, add OF-based initialization code for
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 28 insertions(+)
 
 diff --git a/drivers/irqchip/irq-loongson-pch-lpc.c b/drivers/irqchip/irq-loongson-pch-lpc.c
-index 11f1df2bafaf4..cea34de994cef 100644
+index 11f1df2bafaf..cea34de994ce 100644
 --- a/drivers/irqchip/irq-loongson-pch-lpc.c
 +++ b/drivers/irqchip/irq-loongson-pch-lpc.c
 @@ -13,6 +13,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-FROMLIST-irqchip-loongson-pch-lpc-enable-building-on.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-FROMLIST-irqchip-loongson-pch-lpc-enable-building-on.patch
@@ -1,7 +1,7 @@
 From 49ddcc79907984fb37932c8ca5ee8925089bd4f4 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:45:01 +0800
-Subject: [PATCH 154/449] FROMLIST: irqchip/loongson-pch-lpc: enable building
+Subject: [PATCH 154/450] FROMLIST: irqchip/loongson-pch-lpc: enable building
  on MIPS Loongson64
 
 As the driver can now support OF-based platforms, it's now possible to
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/irqchip/Kconfig b/drivers/irqchip/Kconfig
-index a61c6dc63c29c..b478b3089d778 100644
+index a61c6dc63c29..b478b3089d77 100644
 --- a/drivers/irqchip/Kconfig
 +++ b/drivers/irqchip/Kconfig
 @@ -758,7 +758,6 @@ config LOONGSON_PCH_MSI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-FROMLIST-MIPS-Loongson64-dts-sort-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-FROMLIST-MIPS-Loongson64-dts-sort-nodes.patch
@@ -1,7 +1,7 @@
 From f6c79561a103624f84ef7786345802557ace4ec4 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Thu, 15 Jan 2026 12:03:45 +0800
-Subject: [PATCH 155/449] FROMLIST: MIPS: Loongson64: dts: sort nodes
+Subject: [PATCH 155/450] FROMLIST: MIPS: Loongson64: dts: sort nodes
 
 The RTC's address is after UARTs, however the node is currently before
 them.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
-index 6dee85909f5a6..59ca1ef0a7b64 100644
+index 6dee85909f5a..59ca1ef0a7b6 100644
 --- a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
 +++ b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
 @@ -19,13 +19,6 @@ pic: interrupt-controller@10000000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-FROMLIST-MIPS-Loongson64-dts-add-node-for-LS7A-PCH-L.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-FROMLIST-MIPS-Loongson64-dts-add-node-for-LS7A-PCH-L.patch
@@ -1,7 +1,7 @@
 From 4591dc8f1059ca71e66d1ebe472cde72125dd6e1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:48:34 +0800
-Subject: [PATCH 156/449] FROMLIST: MIPS: Loongson64: dts: add node for LS7A
+Subject: [PATCH 156/450] FROMLIST: MIPS: Loongson64: dts: add node for LS7A
  PCH LPC
 
 Loongson 7A series PCH contain a LPC IRQ controller.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
-index 59ca1ef0a7b64..d41ca0b3d6511 100644
+index 59ca1ef0a7b6..d41ca0b3d651 100644
 --- a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
 +++ b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
 @@ -19,6 +19,15 @@ pic: interrupt-controller@10000000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-FROMLIST-kbuild-install-extmod-build-do-not-exclude-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-FROMLIST-kbuild-install-extmod-build-do-not-exclude-.patch
@@ -1,7 +1,7 @@
 From d3873e505585207fa850d640b98e15c515ffd2fd Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Sun, 1 Feb 2026 20:39:30 +0800
-Subject: [PATCH 157/449] FROMLIST: kbuild: install-extmod-build: do not
+Subject: [PATCH 157/450] FROMLIST: kbuild: install-extmod-build: do not
  exclude scripts/dtc/libfdt/
 
 There exists a header file in include/linux/ called libfdt.h that is
@@ -19,7 +19,7 @@ Signed-off-by: Icenowy Zheng <zhengxingda@iscas.ac.cn>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/scripts/package/install-extmod-build b/scripts/package/install-extmod-build
-index 2576cf7902dbb..d1e448d7f59f6 100755
+index 2576cf7902db..d1e448d7f59f 100755
 --- a/scripts/package/install-extmod-build
 +++ b/scripts/package/install-extmod-build
 @@ -11,7 +11,8 @@ is_enabled() {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-FROMLIST-x86-cpu-centaur-Disable-X86_FEATURE_FSGSBAS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-FROMLIST-x86-cpu-centaur-Disable-X86_FEATURE_FSGSBAS.patch
@@ -1,7 +1,7 @@
 From 728521c46ec93715bc0393de4b8783c55f9c6746 Mon Sep 17 00:00:00 2001
 From: Yao Zi <me@ziyao.cc>
 Date: Sat, 28 Feb 2026 17:37:04 +0000
-Subject: [PATCH 158/449] FROMLIST: x86/cpu/centaur: Disable
+Subject: [PATCH 158/450] FROMLIST: x86/cpu/centaur: Disable
  X86_FEATURE_FSGSBASE on Zhaoxin C4600
 
 Zhaoxin C4600, which names itself as CentaurHauls, claims
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 25 insertions(+)
 
 diff --git a/arch/x86/kernel/cpu/centaur.c b/arch/x86/kernel/cpu/centaur.c
-index a3b55db35c961..e38a26cead677 100644
+index a3b55db35c96..e38a26cead67 100644
 --- a/arch/x86/kernel/cpu/centaur.c
 +++ b/arch/x86/kernel/cpu/centaur.c
 @@ -111,6 +111,29 @@ static void early_init_centaur(struct cpuinfo_x86 *c)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-FROMLIST-drm-amd-display-Wrap-dcn32_override_min_req.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-FROMLIST-drm-amd-display-Wrap-dcn32_override_min_req.patch
@@ -1,7 +1,7 @@
 From c2f68795b759d998f764d2265235e7fceda5710a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 6 Mar 2026 14:28:03 +0800
-Subject: [PATCH 159/449] FROMLIST: drm/amd/display: Wrap
+Subject: [PATCH 159/450] FROMLIST: drm/amd/display: Wrap
  dcn32_override_min_req_memclk() in DC_FP_{START,END}
 
 [Why]
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c b/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c
-index 9cace432ce364..8f054d9b5d57a 100644
+index 9cace432ce36..8f054d9b5d57 100644
 --- a/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c
 +++ b/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c
 @@ -1786,7 +1786,10 @@ static bool dml1_validate(struct dc *dc, struct dc_state *context, enum dc_valid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 1f9f66e3b1fe46628755808ec1509759504fa3ee Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 160/449] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 160/450] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 3ab48b34b8024..8abc9ece3738d 100644
+index 3ab48b34b802..8abc9ece3738 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -545,6 +545,7 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From 80a276fd838fc681761479af0e48aa6efd8aa116 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 161/449] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 161/450] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/scsi/lpfc/lpfc_compat.h b/drivers/scsi/lpfc/lpfc_compat.h
-index 43cf46a3a71fe..0cd1e3c82d875 100644
+index 43cf46a3a71f..0cd1e3c82d87 100644
 --- a/drivers/scsi/lpfc/lpfc_compat.h
 +++ b/drivers/scsi/lpfc/lpfc_compat.h
 @@ -91,8 +91,8 @@ lpfc_memcpy_to_slim( void __iomem *dest, void *src, unsigned int bytes)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From 5b222a8f51427ec9d4904799c4b1cf3b801d2cb6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 162/449] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 162/450] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 32 insertions(+)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index c89e70df43d82..cc0360e8dd62c 100644
+index c89e70df43d8..cc0360e8dd62 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,6 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 8bb0c8c03ab6c117bb27db2780f9292e1f5901c1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 163/449] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 163/450] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it
@@ -49,7 +49,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  9 files changed, 51 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/include/asm/cpu-info.h b/arch/mips/include/asm/cpu-info.h
-index fd60837ce50bc..ec34bcb9953e5 100644
+index fd60837ce50b..ec34bcb9953e 100644
 --- a/arch/mips/include/asm/cpu-info.h
 +++ b/arch/mips/include/asm/cpu-info.h
 @@ -126,7 +126,9 @@ extern void cpu_report(void);
@@ -63,7 +63,7 @@ index fd60837ce50bc..ec34bcb9953e5 100644
  struct seq_file;
  struct notifier_block;
 diff --git a/arch/mips/include/asm/mach-loongson64/boot_param.h b/arch/mips/include/asm/mach-loongson64/boot_param.h
-index 3a11ce85762be..943c576220732 100644
+index 3a11ce85762b..943c57622073 100644
 --- a/arch/mips/include/asm/mach-loongson64/boot_param.h
 +++ b/arch/mips/include/asm/mach-loongson64/boot_param.h
 @@ -66,6 +66,7 @@ struct efi_cpuinfo_loongson {
@@ -75,7 +75,7 @@ index 3a11ce85762be..943c576220732 100644
  
  #define MAX_UARTS 64
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index 5e7193b759f33..93f8cd52e3d47 100644
+index 5e7193b759f3..93f8cd52e3d4 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -22,6 +22,8 @@ extern spinlock_t rtc_lock;
@@ -88,7 +88,7 @@ index 5e7193b759f33..93f8cd52e3d47 100644
   * mips_hpt_frequency - must be set if you intend to use an R4k-compatible
   * counter as a timer interrupt source.
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index 1e49e05ac8b1c..12370ae3e4c5e 100644
+index 1e49e05ac8b1..12370ae3e4c5 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -1250,32 +1250,44 @@ static inline void cpu_probe_legacy(struct cpuinfo_mips *c, unsigned int cpu)
@@ -181,7 +181,7 @@ index 1e49e05ac8b1c..12370ae3e4c5e 100644
  const char *__elf_base_platform;
  
 diff --git a/arch/mips/kernel/proc.c b/arch/mips/kernel/proc.c
-index 8f0a0001540c7..9b2e85a2a932e 100644
+index 8f0a0001540c..9b2e85a2a932 100644
 --- a/arch/mips/kernel/proc.c
 +++ b/arch/mips/kernel/proc.c
 @@ -15,6 +15,7 @@
@@ -205,7 +205,7 @@ index 8f0a0001540c7..9b2e85a2a932e 100644
  		      cpu_data[n].udelay_val / (500000/HZ),
  		      (cpu_data[n].udelay_val / (5000/HZ)) % 100);
 diff --git a/arch/mips/kernel/time.c b/arch/mips/kernel/time.c
-index ed339d7979f3f..849c6be53b296 100644
+index ed339d7979f3..849c6be53b29 100644
 --- a/arch/mips/kernel/time.c
 +++ b/arch/mips/kernel/time.c
 @@ -120,6 +120,8 @@ EXPORT_SYMBOL(perf_irq);
@@ -218,7 +218,7 @@ index ed339d7979f3f..849c6be53b296 100644
  EXPORT_SYMBOL_GPL(mips_hpt_frequency);
  
 diff --git a/arch/mips/loongson64/env.c b/arch/mips/loongson64/env.c
-index be8d2ad10750f..c15a68c72dd46 100644
+index be8d2ad10750..c15a68c72dd4 100644
 --- a/arch/mips/loongson64/env.c
 +++ b/arch/mips/loongson64/env.c
 @@ -18,6 +18,7 @@
@@ -272,7 +272,7 @@ index be8d2ad10750f..c15a68c72dd46 100644
  	id = readl(HOST_BRIDGE_CONFIG_ADDR);
  	vendor = id & 0xffff;
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 147acd972a07b..69c1e77e6bfc7 100644
+index 147acd972a07..69c1e77e6bfc 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -418,6 +418,7 @@ static void loongson3_init_secondary(void)
@@ -284,7 +284,7 @@ index 147acd972a07b..69c1e77e6bfc7 100644
  
  static void loongson3_smp_finish(void)
 diff --git a/arch/mips/loongson64/smp.h b/arch/mips/loongson64/smp.h
-index 957bde81e0e4e..6112d9d7dd226 100644
+index 957bde81e0e4..6112d9d7dd22 100644
 --- a/arch/mips/loongson64/smp.h
 +++ b/arch/mips/loongson64/smp.h
 @@ -3,6 +3,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From 2d9a0d26eac362086724b07b3a251661e5ea1055 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 164/449] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 164/450] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six
@@ -55,7 +55,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.c
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 8abc9ece3738d..1e7c8d2b034ac 100644
+index 8abc9ece3738..1e7c8d2b034a 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -28,6 +28,7 @@ config MIPS
@@ -107,7 +107,7 @@ index 8abc9ece3738d..1e7c8d2b034ac 100644
  	  Select this option if you want to run n32 binaries.  These are
  	  64-bit binaries using 32-bit quantities for addressing and certain
 diff --git a/arch/mips/include/asm/abi.h b/arch/mips/include/asm/abi.h
-index dba7f4b6bebfa..6e717a4a13ceb 100644
+index dba7f4b6bebf..6e717a4a13ce 100644
 --- a/arch/mips/include/asm/abi.h
 +++ b/arch/mips/include/asm/abi.h
 @@ -21,6 +21,7 @@ struct mips_abi {
@@ -119,7 +119,7 @@ index dba7f4b6bebfa..6e717a4a13ceb 100644
  	unsigned	off_sc_fpregs;
  	unsigned	off_sc_fpc_csr;
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index 6a974b990f4b2..91d0c7fd6d4b0 100644
+index 6a974b990f4b..91d0c7fd6d4b 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,4 +64,14 @@
@@ -138,7 +138,7 @@ index 6a974b990f4b2..91d0c7fd6d4b0 100644
 +
  #endif /* _ASM_UNISTD_H */
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index 4abe387549ad2..b501ea16ccd40 100644
+index 4abe387549ad..b501ea16ccd4 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,34 +6,37 @@
@@ -189,7 +189,7 @@ index 4abe387549ad2..b501ea16ccd40 100644
  
  #endif /* _UAPI_ASM_UNISTD_H */
 diff --git a/arch/mips/kernel/Makefile b/arch/mips/kernel/Makefile
-index 95a1e674fd678..b9786a289592c 100644
+index 95a1e674fd67..b9786a289592 100644
 --- a/arch/mips/kernel/Makefile
 +++ b/arch/mips/kernel/Makefile
 @@ -105,6 +105,10 @@ obj-$(CONFIG_HW_PERF_EVENTS)	+= perf_event_mipsxx.o
@@ -205,7 +205,7 @@ index 95a1e674fd678..b9786a289592c 100644
  
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
 new file mode 100644
-index 0000000000000..2248badc3acb6
+index 000000000000..2248badc3acb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -0,0 +1,58 @@
@@ -269,7 +269,7 @@ index 0000000000000..2248badc3acb6
 +__initcall(audit_classes_n32_init);
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
 new file mode 100644
-index 0000000000000..09ae3dbcfecbc
+index 000000000000..09ae3dbcfecb
 --- /dev/null
 +++ b/arch/mips/kernel/audit-native.c
 @@ -0,0 +1,97 @@
@@ -372,7 +372,7 @@ index 0000000000000..09ae3dbcfecbc
 +__initcall(audit_classes_init);
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
 new file mode 100644
-index 0000000000000..e8b9b50f7d267
+index 000000000000..e8b9b50f7d26
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -0,0 +1,60 @@
@@ -437,7 +437,7 @@ index 0000000000000..e8b9b50f7d267
 +
 +__initcall(audit_classes_o32_init);
 diff --git a/arch/mips/kernel/signal.c b/arch/mips/kernel/signal.c
-index 4a10f18a88060..c803c39f5cbe5 100644
+index 4a10f18a8806..c803c39f5cbe 100644
 --- a/arch/mips/kernel/signal.c
 +++ b/arch/mips/kernel/signal.c
 @@ -8,6 +8,7 @@
@@ -473,7 +473,7 @@ index 4a10f18a88060..c803c39f5cbe5 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_n32.c b/arch/mips/kernel/signal_n32.c
-index 139d2596b0d40..fb9ddefae9648 100644
+index 139d2596b0d4..fb9ddefae964 100644
 --- a/arch/mips/kernel/signal_n32.c
 +++ b/arch/mips/kernel/signal_n32.c
 @@ -2,6 +2,7 @@
@@ -499,7 +499,7 @@ index 139d2596b0d40..fb9ddefae9648 100644
  	.off_sc_fpregs = offsetof(struct sigcontext, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext, sc_fpc_csr),
 diff --git a/arch/mips/kernel/signal_o32.c b/arch/mips/kernel/signal_o32.c
-index 4f04584596507..ea3f280a18aa0 100644
+index 4f0458459650..ea3f280a18aa 100644
 --- a/arch/mips/kernel/signal_o32.c
 +++ b/arch/mips/kernel/signal_o32.c
 @@ -8,6 +8,7 @@
@@ -525,7 +525,7 @@ index 4f04584596507..ea3f280a18aa0 100644
  	.off_sc_fpregs = offsetof(struct sigcontext32, sc_fpregs),
  	.off_sc_fpc_csr = offsetof(struct sigcontext32, sc_fpc_csr),
 diff --git a/include/uapi/linux/audit.h b/include/uapi/linux/audit.h
-index 14a1c1fe013ac..2b405bc603eb8 100644
+index 14a1c1fe013a..2b405bc603eb 100644
 --- a/include/uapi/linux/audit.h
 +++ b/include/uapi/linux/audit.h
 @@ -193,7 +193,11 @@
@@ -554,7 +554,7 @@ index 14a1c1fe013ac..2b405bc603eb8 100644
   * are currently used in an audit field constant understood by the kernel.
   * If you are adding a new #define AUDIT_<whatever>, please ensure that
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index d1966144bdfe7..6ba5cbd45d040 100644
+index d1966144bdfe..6ba5cbd45d04 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -189,6 +189,19 @@ static int audit_match_perm(struct audit_context *ctx, int mask)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 81e38cd2f0dc338951591eefb2e72773a2fbb7fa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 165/449] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 165/450] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are
@@ -37,7 +37,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/arch/mips/loongson64/init.c b/arch/mips/loongson64/init.c
-index b9f90f33fc9a6..21cd12ec24e27 100644
+index b9f90f33fc9a..21cd12ec24e2 100644
 --- a/arch/mips/loongson64/init.c
 +++ b/arch/mips/loongson64/init.c
 @@ -22,6 +22,16 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From de15f6d65e5a9b0f0f0d187ce13d90cfa61b3c79 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 166/449] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 166/450] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 11b9b6b63e19f..36ae7c5ff48b9 100644
+index 11b9b6b63e19..36ae7c5ff48b 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -357,8 +357,10 @@ static int __init early_parse_mem(char *p)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From 6bebf19585da2ca27658173e493161d1cad10d81 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 167/449] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 167/450] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 62 insertions(+)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 36ae7c5ff48b9..22f4f9158413d 100644
+index 36ae7c5ff48b..22f4f9158413 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -54,6 +54,10 @@ struct cpuinfo_mips cpu_data[NR_CPUS] __read_mostly;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 30a568f290cb54e695a32bcee6cc3857e7208be4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 168/449] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 168/450] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 33 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 1e7c8d2b034ac..887935175127d 100644
+index 1e7c8d2b034a..887935175127 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -18,6 +18,7 @@ config MIPS
@@ -37,7 +37,7 @@ index 1e7c8d2b034ac..887935175127d 100644
  	select ARCH_USE_BUILTIN_BSWAP
  	select ARCH_USE_CMPXCHG_LOCKREF if 64BIT
 diff --git a/arch/mips/include/asm/pgtable-64.h b/arch/mips/include/asm/pgtable-64.h
-index 6e854bb11f37d..1f2c3e5d0ad43 100644
+index 6e854bb11f37..1f2c3e5d0ad4 100644
 --- a/arch/mips/include/asm/pgtable-64.h
 +++ b/arch/mips/include/asm/pgtable-64.h
 @@ -260,7 +260,7 @@ static inline int pmd_present(pmd_t pmd)
@@ -50,7 +50,7 @@ index 6e854bb11f37d..1f2c3e5d0ad43 100644
  
  	return pmd_val(pmd) != (unsigned long) invalid_pte_table;
 diff --git a/arch/mips/include/asm/pgtable-bits.h b/arch/mips/include/asm/pgtable-bits.h
-index 088623ba7b8b1..9ee6e189d329f 100644
+index 088623ba7b8b..9ee6e189d329 100644
 --- a/arch/mips/include/asm/pgtable-bits.h
 +++ b/arch/mips/include/asm/pgtable-bits.h
 @@ -52,6 +52,9 @@ enum pgtable_bits {
@@ -106,7 +106,7 @@ index 088623ba7b8b1..9ee6e189d329f 100644
  # define _PAGE_SPECIAL		(1 << _PAGE_SPECIAL_SHIFT)
  #else
 diff --git a/arch/mips/include/asm/pgtable.h b/arch/mips/include/asm/pgtable.h
-index ae73ecf4c41aa..c061e5ed295ad 100644
+index ae73ecf4c41a..c061e5ed295a 100644
 --- a/arch/mips/include/asm/pgtable.h
 +++ b/arch/mips/include/asm/pgtable.h
 @@ -160,7 +160,7 @@ static inline void pte_clear(struct mm_struct *mm, unsigned long addr, pte_t *pt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From ea9457d0bcaf4495bede2a7ebfcec4bf47dc1f1d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 169/449] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 169/450] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/numa.c b/arch/mips/loongson64/numa.c
-index 95d5f553ce198..d7771472b5673 100644
+index 95d5f553ce19..d7771472b567 100644
 --- a/arch/mips/loongson64/numa.c
 +++ b/arch/mips/loongson64/numa.c
 @@ -60,7 +60,7 @@ static int __init compute_node_distance(int row, int col)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From 921a74ce2c5ee160d99714f4968d5d3f4bc736b1 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 170/449] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 170/450] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid
@@ -37,7 +37,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+), 15 deletions(-)
 
 diff --git a/arch/mips/mm/tlbex.c b/arch/mips/mm/tlbex.c
-index 69ea54bdc0c36..33f613d6665b8 100644
+index 69ea54bdc0c3..33f613d6665b 100644
 --- a/arch/mips/mm/tlbex.c
 +++ b/arch/mips/mm/tlbex.c
 @@ -676,13 +676,12 @@ static void build_huge_tlb_write_entry(u32 **p, struct uasm_label **l,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 05ee466ba0f4f1a4edf97bb9b1da39e2df3efa2b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 171/449] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 171/450] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 887935175127d..58f2089c1d91f 100644
+index 887935175127..58f2089c1d91 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -548,7 +548,6 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From ae08d68869165be8d73c43151a2ff65fe68bd88d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 172/449] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 172/450] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 27 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/irqchip/irq-loongson-eiointc.c b/drivers/irqchip/irq-loongson-eiointc.c
-index 39e5a72ccd3c8..451df8549306d 100644
+index 39e5a72ccd3c..451df8549306 100644
 --- a/drivers/irqchip/irq-loongson-eiointc.c
 +++ b/drivers/irqchip/irq-loongson-eiointc.c
 @@ -140,21 +140,46 @@ static void veiointc_set_irq_route(unsigned int vector, unsigned int cpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From 832c8e683f568d10c02697981a29d0cbea79b15d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 173/449] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 173/450] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/loongarch/cpu_hwmon.c
 
 diff --git a/drivers/platform/loongarch/Kconfig b/drivers/platform/loongarch/Kconfig
-index 447528797d07a..b87f51c4e4b66 100644
+index 447528797d07..b87f51c4e4b6 100644
 --- a/drivers/platform/loongarch/Kconfig
 +++ b/drivers/platform/loongarch/Kconfig
 @@ -16,6 +16,14 @@ menuconfig LOONGARCH_PLATFORM_DEVICES
@@ -38,7 +38,7 @@ index 447528797d07a..b87f51c4e4b66 100644
  	tristate "Generic Loongson-3 Laptop Driver"
  	depends on ACPI_EC
 diff --git a/drivers/platform/loongarch/Makefile b/drivers/platform/loongarch/Makefile
-index f43ab03db1a2d..8038291bae3aa 100644
+index f43ab03db1a2..8038291bae3a 100644
 --- a/drivers/platform/loongarch/Makefile
 +++ b/drivers/platform/loongarch/Makefile
 @@ -1 +1,2 @@
@@ -46,7 +46,7 @@ index f43ab03db1a2d..8038291bae3aa 100644
  obj-$(CONFIG_LOONGSON_LAPTOP) += loongson-laptop.o
 diff --git a/drivers/platform/loongarch/cpu_hwmon.c b/drivers/platform/loongarch/cpu_hwmon.c
 new file mode 100644
-index 0000000000000..93a05993745aa
+index 000000000000..93a05993745a
 --- /dev/null
 +++ b/drivers/platform/loongarch/cpu_hwmon.c
 @@ -0,0 +1,194 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From 4f21230c07c14d51d46112d189ed85eeac143dd2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 174/449] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 174/450] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:
@@ -44,7 +44,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/firmware/sysfb.c b/drivers/firmware/sysfb.c
-index 889e5b05c739c..8988df462ef08 100644
+index 889e5b05c739..8988df462ef0 100644
 --- a/drivers/firmware/sysfb.c
 +++ b/drivers/firmware/sysfb.c
 @@ -221,4 +221,4 @@ static __init int sysfb_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 732ab0b8c397c4687cf57d677c893f7f7254ff0c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 175/449] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 175/450] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 4 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 51a3e0fc2f56b..0b804e951b7b6 100644
+index 51a3e0fc2f56..0b804e951b7b 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -8093,6 +8093,7 @@ int cik_irq_process(struct radeon_device *rdev)
@@ -34,7 +34,7 @@ index 51a3e0fc2f56b..0b804e951b7b6 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index bc4ab71613a55..1ce165c627a6c 100644
+index bc4ab71613a5..1ce165c627a6 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -4919,6 +4919,7 @@ int evergreen_irq_process(struct radeon_device *rdev)
@@ -46,7 +46,7 @@ index bc4ab71613a55..1ce165c627a6c 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 8b62f7faa5b99..88e38fb3f3476 100644
+index 8b62f7faa5b9..88e38fb3f347 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -4328,6 +4328,7 @@ int r600_irq_process(struct radeon_device *rdev)
@@ -58,7 +58,7 @@ index 8b62f7faa5b99..88e38fb3f3476 100644
  
  	/* make sure wptr hasn't changed while processing */
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 26197aceb001c..2d7eeb781969d 100644
+index 26197aceb001..2d7eeb781969 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -6423,6 +6423,7 @@ int si_irq_process(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
@@ -1,7 +1,7 @@
 From c33c915f988f39156525006ed42e59b662dcea11 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 May 2025 20:08:26 +0800
-Subject: [PATCH 176/449] LOONGSON: drm/ast: Restore vaddr field to struct
+Subject: [PATCH 176/450] LOONGSON: drm/ast: Restore vaddr field to struct
  ast_plane
 
 Revert "drm/ast: Remove vaddr field from struct ast_plane".
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 14 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/ast_cursor.c b/drivers/gpu/drm/ast/ast_cursor.c
-index 2d3ad7610c2e9..5ee724bfd682a 100644
+index 2d3ad7610c2e..5ee724bfd682 100644
 --- a/drivers/gpu/drm/ast/ast_cursor.c
 +++ b/drivers/gpu/drm/ast/ast_cursor.c
 @@ -91,7 +91,7 @@ static u32 ast_cursor_calculate_checksum(const void *src, unsigned int width, un
@@ -59,7 +59,7 @@ index 2d3ad7610c2e9..5ee724bfd682a 100644
  			     ast_cursor_plane_formats, ARRAY_SIZE(ast_cursor_plane_formats),
  			     NULL, DRM_PLANE_TYPE_CURSOR);
 diff --git a/drivers/gpu/drm/ast/ast_drv.h b/drivers/gpu/drm/ast/ast_drv.h
-index d41bd876167c9..94c9798357911 100644
+index d41bd876167c..94c979835791 100644
 --- a/drivers/gpu/drm/ast/ast_drv.h
 +++ b/drivers/gpu/drm/ast/ast_drv.h
 @@ -124,6 +124,7 @@ enum ast_dram_layout {
@@ -85,7 +85,7 @@ index d41bd876167c9..94c9798357911 100644
  
  #endif
 diff --git a/drivers/gpu/drm/ast/ast_mode.c b/drivers/gpu/drm/ast/ast_mode.c
-index 30b011ed0a056..85defef6862fe 100644
+index 30b011ed0a05..85defef6862f 100644
 --- a/drivers/gpu/drm/ast/ast_mode.c
 +++ b/drivers/gpu/drm/ast/ast_mode.c
 @@ -473,7 +473,7 @@ static void ast_wait_for_vretrace(struct ast_device *ast)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From 63486419b7bf40bc35ac873d60a3c8407da11e37 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 28 Feb 2025 20:28:08 +0800
-Subject: [PATCH 177/449] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 177/450] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  6 files changed, 131 insertions(+), 38 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/Kconfig b/drivers/gpu/drm/ast/Kconfig
-index 242fbccdf8443..1f1c24c58663a 100644
+index 242fbccdf844..1f1c24c58663 100644
 --- a/drivers/gpu/drm/ast/Kconfig
 +++ b/drivers/gpu/drm/ast/Kconfig
 @@ -5,6 +5,9 @@ config DRM_AST
@@ -43,7 +43,7 @@ index 242fbccdf8443..1f1c24c58663a 100644
  	select I2C_ALGOBIT
  	help
 diff --git a/drivers/gpu/drm/ast/ast_cursor.c b/drivers/gpu/drm/ast/ast_cursor.c
-index 5ee724bfd682a..54c0d4e3ed81f 100644
+index 5ee724bfd682..54c0d4e3ed81 100644
 --- a/drivers/gpu/drm/ast/ast_cursor.c
 +++ b/drivers/gpu/drm/ast/ast_cursor.c
 @@ -28,6 +28,7 @@
@@ -151,7 +151,7 @@ index 5ee724bfd682a..54c0d4e3ed81f 100644
  			     ast_cursor_plane_formats, ARRAY_SIZE(ast_cursor_plane_formats),
  			     NULL, DRM_PLANE_TYPE_CURSOR);
 diff --git a/drivers/gpu/drm/ast/ast_drv.c b/drivers/gpu/drm/ast/ast_drv.c
-index 473faa92d08c3..5678f53eea654 100644
+index 473faa92d08c..5678f53eea65 100644
 --- a/drivers/gpu/drm/ast/ast_drv.c
 +++ b/drivers/gpu/drm/ast/ast_drv.c
 @@ -33,9 +33,12 @@
@@ -223,7 +223,7 @@ index 473faa92d08c3..5678f53eea654 100644
  	if (ret)
  		return ret;
 diff --git a/drivers/gpu/drm/ast/ast_drv.h b/drivers/gpu/drm/ast/ast_drv.h
-index 94c9798357911..e8fb62966dfde 100644
+index 94c979835791..e8fb62966dfd 100644
 --- a/drivers/gpu/drm/ast/ast_drv.h
 +++ b/drivers/gpu/drm/ast/ast_drv.h
 @@ -29,6 +29,7 @@
@@ -264,7 +264,7 @@ index 94c9798357911..e8fb62966dfde 100644
  		   const uint32_t *formats, unsigned int format_count,
  		   const uint64_t *format_modifiers,
 diff --git a/drivers/gpu/drm/ast/ast_mm.c b/drivers/gpu/drm/ast/ast_mm.c
-index 0bc1403194649..b68bea7b5dec8 100644
+index 0bc140319464..b68bea7b5dec 100644
 --- a/drivers/gpu/drm/ast/ast_mm.c
 +++ b/drivers/gpu/drm/ast/ast_mm.c
 @@ -28,6 +28,7 @@
@@ -293,7 +293,7 @@ index 0bc1403194649..b68bea7b5dec8 100644
  	ast->vram_base = base;
  	ast->vram_size = vram_size;
 diff --git a/drivers/gpu/drm/ast/ast_mode.c b/drivers/gpu/drm/ast/ast_mode.c
-index 85defef6862fe..0059dd3da61ff 100644
+index 85defef6862f..0059dd3da61f 100644
 --- a/drivers/gpu/drm/ast/ast_mode.c
 +++ b/drivers/gpu/drm/ast/ast_mode.c
 @@ -41,6 +41,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
@@ -1,7 +1,7 @@
 From 8223e1a017593e1945f72b15ec17b0623c5639a7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 26 Aug 2025 19:01:09 +0800
-Subject: [PATCH 178/449] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
+Subject: [PATCH 178/450] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
 
 If I read the upstream commit 62e1e11a4916
 ("drm/client: Do not pin in drm_client_buffer_vmap()") correctly, we
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/ast/ast_cursor.c b/drivers/gpu/drm/ast/ast_cursor.c
-index 54c0d4e3ed81f..9921bd6c0d28b 100644
+index 54c0d4e3ed81..9921bd6c0d28 100644
 --- a/drivers/gpu/drm/ast/ast_cursor.c
 +++ b/drivers/gpu/drm/ast/ast_cursor.c
 @@ -285,7 +285,6 @@ static void ast_cursor_plane_destroy(struct drm_plane *plane)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-LOONGSON-dt-bindings-dmaengine-Add-Loongson-Multi-Ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-LOONGSON-dt-bindings-dmaengine-Add-Loongson-Multi-Ch.patch
@@ -1,7 +1,7 @@
 From 642c4f41442dc3216dc40ad754063d53b862d69e Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 23 Oct 2025 20:27:08 +0800
-Subject: [PATCH 179/449] LOONGSON: dt-bindings: dmaengine: Add Loongson
+Subject: [PATCH 179/450] LOONGSON: dt-bindings: dmaengine: Add Loongson
  Multi-Channel DMA controller
 
 The Loongson-2K0300/Loongson-2K3000 have built-in multi-channel DMA
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/Documentation/devicetree/bindings/dma/loongson,ls2k0300-dma.yaml b/Documentation/devicetree/bindings/dma/loongson,ls2k0300-dma.yaml
 new file mode 100644
-index 0000000000000..d5316885ca858
+index 000000000000..d5316885ca85
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/dma/loongson,ls2k0300-dma.yaml
 @@ -0,0 +1,78 @@
@@ -110,7 +110,7 @@ index 0000000000000..d5316885ca858
 +    };
 +...
 diff --git a/MAINTAINERS b/MAINTAINERS
-index cf619a1e10b01..4c20076042cf6 100644
+index cf619a1e10b0..4c20076042cf 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -14598,10 +14598,11 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-LOONGSON-dmaengine-loongson2-mcdma-New-driver-for-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-LOONGSON-dmaengine-loongson2-mcdma-New-driver-for-th.patch
@@ -1,7 +1,7 @@
 From 56e230baed51f5d9ee79ab1b09b93a462ca55086 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 18 Oct 2025 12:46:21 +0800
-Subject: [PATCH 180/449] LOONGSON: dmaengine: loongson2-mcdma: New driver for
+Subject: [PATCH 180/450] LOONGSON: dmaengine: loongson2-mcdma: New driver for
  the Loongson Multi-Channel DMA controller
 
 This DMA controller appears in Loongson-2K0300 and Loongson-2K3000.
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/dma/loongson2-mcdma.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 4c20076042cf6..e2f7230fccdd2 100644
+index 4c20076042cf..e2f7230fccdd 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -14605,6 +14605,7 @@ S:	Maintained
@@ -40,7 +40,7 @@ index 4c20076042cf6..e2f7230fccdd2 100644
  LOONGSON LS2X I2C DRIVER
  M:	Binbin Zhou <zhoubinbin@loongson.cn>
 diff --git a/drivers/dma/Kconfig b/drivers/dma/Kconfig
-index b8a74b1798ba1..6b56838fc3888 100644
+index b8a74b1798ba..6b56838fc388 100644
 --- a/drivers/dma/Kconfig
 +++ b/drivers/dma/Kconfig
 @@ -399,6 +399,17 @@ config LOONGSON2_APB_DMA
@@ -62,7 +62,7 @@ index b8a74b1798ba1..6b56838fc3888 100644
  	bool "NXP LPC18xx/43xx DMA MUX for PL080"
  	depends on ARCH_LPC18XX || COMPILE_TEST
 diff --git a/drivers/dma/Makefile b/drivers/dma/Makefile
-index a54d7688392b1..2df372d119837 100644
+index a54d7688392b..2df372d11983 100644
 --- a/drivers/dma/Makefile
 +++ b/drivers/dma/Makefile
 @@ -51,6 +51,7 @@ obj-y += idxd/
@@ -75,7 +75,7 @@ index a54d7688392b1..2df372d119837 100644
  obj-$(CONFIG_MILBEAUT_HDMAC) += milbeaut-hdmac.o
 diff --git a/drivers/dma/loongson2-mcdma.c b/drivers/dma/loongson2-mcdma.c
 new file mode 100644
-index 0000000000000..63013e78b1630
+index 000000000000..63013e78b163
 --- /dev/null
 +++ b/drivers/dma/loongson2-mcdma.c
 @@ -0,0 +1,761 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-LOONGSON-LoongArch-Add-canfd-support-for-ls2k3000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-LOONGSON-LoongArch-Add-canfd-support-for-ls2k3000.patch
@@ -1,7 +1,7 @@
 From 81b71150774d38f74c67c822173a1b9ef5fea259 Mon Sep 17 00:00:00 2001
 From: libingxiong <libingxiong@loongson.cn>
 Date: Fri, 30 May 2025 14:22:46 +0800
-Subject: [PATCH 181/449] LOONGSON: LoongArch: Add canfd support for ls2k3000
+Subject: [PATCH 181/450] LOONGSON: LoongArch: Add canfd support for ls2k3000
 
 Add new canfd controller and dma controller driver support for ls2k3000
 
@@ -34,7 +34,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/net/can/loongson_canfd/lscanfd_platform.c
 
 diff --git a/drivers/net/can/Kconfig b/drivers/net/can/Kconfig
-index d43d566946676..6ccefe3d81235 100644
+index d43d56694667..6ccefe3d8123 100644
 --- a/drivers/net/can/Kconfig
 +++ b/drivers/net/can/Kconfig
 @@ -225,6 +225,7 @@ source "drivers/net/can/ifi_canfd/Kconfig"
@@ -46,7 +46,7 @@ index d43d566946676..6ccefe3d81235 100644
  source "drivers/net/can/rockchip/Kconfig"
  source "drivers/net/can/sja1000/Kconfig"
 diff --git a/drivers/net/can/Makefile b/drivers/net/can/Makefile
-index 56138d8ddfd23..4f9e10762e5d2 100644
+index 56138d8ddfd2..4f9e10762e5d 100644
 --- a/drivers/net/can/Makefile
 +++ b/drivers/net/can/Makefile
 @@ -29,6 +29,7 @@ obj-$(CONFIG_CAN_KVASER_PCIEFD)	+= kvaser_pciefd/
@@ -58,7 +58,7 @@ index 56138d8ddfd23..4f9e10762e5d2 100644
  obj-$(CONFIG_CAN_SUN4I)		+= sun4i_can.o
  obj-$(CONFIG_CAN_TI_HECC)	+= ti_hecc.o
 diff --git a/drivers/net/can/dev/bittiming.c b/drivers/net/can/dev/bittiming.c
-index 0b93900b1dfa3..ea527a3b54fe0 100644
+index 0b93900b1dfa..ea527a3b54fe 100644
 --- a/drivers/net/can/dev/bittiming.c
 +++ b/drivers/net/can/dev/bittiming.c
 @@ -52,6 +52,7 @@ static int can_fixup_bittiming(const struct net_device *dev, struct can_bittimin
@@ -94,7 +94,7 @@ index 0b93900b1dfa3..ea527a3b54fe0 100644
  	return 0;
  }
 diff --git a/drivers/net/can/dev/calc_bittiming.c b/drivers/net/can/dev/calc_bittiming.c
-index 394d6974f4815..9113f19648305 100644
+index 394d6974f481..9113f1964830 100644
 --- a/drivers/net/can/dev/calc_bittiming.c
 +++ b/drivers/net/can/dev/calc_bittiming.c
 @@ -103,8 +103,22 @@ int can_calc_bittiming(const struct net_device *dev, struct can_bittiming *bt,
@@ -140,7 +140,7 @@ index 394d6974f4815..9113f19648305 100644
  }
 diff --git a/drivers/net/can/loongson_canfd/Kconfig b/drivers/net/can/loongson_canfd/Kconfig
 new file mode 100644
-index 0000000000000..1d2121178f586
+index 000000000000..1d2121178f58
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/Kconfig
 @@ -0,0 +1,18 @@
@@ -164,7 +164,7 @@ index 0000000000000..1d2121178f586
 +endif
 diff --git a/drivers/net/can/loongson_canfd/Makefile b/drivers/net/can/loongson_canfd/Makefile
 new file mode 100644
-index 0000000000000..095815a6ef437
+index 000000000000..095815a6ef43
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/Makefile
 @@ -0,0 +1,13 @@
@@ -183,7 +183,7 @@ index 0000000000000..095815a6ef437
 +obj-$(CONFIG_CAN_LSCANFD_PLATFORM) += lscanfd_platform.o
 diff --git a/drivers/net/can/loongson_canfd/lscanfd.h b/drivers/net/can/loongson_canfd/lscanfd.h
 new file mode 100644
-index 0000000000000..2ee40ef0be528
+index 000000000000..2ee40ef0be52
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/lscanfd.h
 @@ -0,0 +1,45 @@
@@ -234,7 +234,7 @@ index 0000000000000..2ee40ef0be528
 +#endif /*__LSCANFD__*/
 diff --git a/drivers/net/can/loongson_canfd/lscanfd_base.c b/drivers/net/can/loongson_canfd/lscanfd_base.c
 new file mode 100644
-index 0000000000000..d0f21c6dbc4a2
+index 000000000000..d0f21c6dbc4a
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/lscanfd_base.c
 @@ -0,0 +1,1673 @@
@@ -1913,7 +1913,7 @@ index 0000000000000..d0f21c6dbc4a2
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/net/can/loongson_canfd/lscanfd_kframe.h b/drivers/net/can/loongson_canfd/lscanfd_kframe.h
 new file mode 100644
-index 0000000000000..95dc1909c6c33
+index 000000000000..95dc1909c6c3
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/lscanfd_kframe.h
 @@ -0,0 +1,155 @@
@@ -2074,7 +2074,7 @@ index 0000000000000..95dc1909c6c33
 +#endif
 diff --git a/drivers/net/can/loongson_canfd/lscanfd_kregs.h b/drivers/net/can/loongson_canfd/lscanfd_kregs.h
 new file mode 100644
-index 0000000000000..529c5e21c5e6b
+index 000000000000..529c5e21c5e6
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/lscanfd_kregs.h
 @@ -0,0 +1,327 @@
@@ -2407,7 +2407,7 @@ index 0000000000000..529c5e21c5e6b
 +#endif
 diff --git a/drivers/net/can/loongson_canfd/lscanfd_platform.c b/drivers/net/can/loongson_canfd/lscanfd_platform.c
 new file mode 100644
-index 0000000000000..c1627b08b2a13
+index 000000000000..c1627b08b2a1
 --- /dev/null
 +++ b/drivers/net/can/loongson_canfd/lscanfd_platform.c
 @@ -0,0 +1,152 @@
@@ -2564,7 +2564,7 @@ index 0000000000000..c1627b08b2a13
 +MODULE_DESCRIPTION("Looongson LS CANFD Controller driver");
 +MODULE_LICENSE("GPL");
 diff --git a/include/linux/can/dev.h b/include/linux/can/dev.h
-index a2229a61ccde8..f741183e7375b 100644
+index a2229a61ccde..f741183e7375 100644
 --- a/include/linux/can/dev.h
 +++ b/include/linux/can/dev.h
 @@ -61,7 +61,9 @@ struct can_priv {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From 315ef8fc81ab6f98652aa1ba337e4c16d62f8965 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 182/449] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 182/450] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm64/Kconfig.platforms b/arch/arm64/Kconfig.platforms
-index 13173795c43d4..2670adc5c91d9 100644
+index 13173795c43d..2670adc5c91d 100644
 --- a/arch/arm64/Kconfig.platforms
 +++ b/arch/arm64/Kconfig.platforms
 @@ -311,6 +311,14 @@ config ARCH_PENSANDO

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From ed1d00bf91be0cad94208d7f1fdcf3f26eed524a Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 183/449] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 183/450] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 3c0b7d48ddb9a..30598b776f0e6 100644
+index 3c0b7d48ddb9..30598b776f0e 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -3261,4 +3261,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From b4f641cb86f8a88b4a962b4dd8cd7630c170aca5 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 184/449] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 184/450] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index e2f7230fccdd2..4ffcf2cb5e183 100644
+index e2f7230fccdd..4ffcf2cb5e18 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -3151,6 +3151,12 @@ S:	Maintained
@@ -43,7 +43,7 @@ index e2f7230fccdd2..4ffcf2cb5e183 100644
  R:	cros-qcom-dts-watchers@chromium.org
  F:	arch/arm64/boot/dts/qcom/sc7180*
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 5ca694bdcfc6b..7afca7a49776e 100644
+index 5ca694bdcfc6..7afca7a49776 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
 @@ -122,6 +122,16 @@ config DWMAC_MESON
@@ -64,7 +64,7 @@ index 5ca694bdcfc6b..7afca7a49776e 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index 49ba02bb7c022..dd0e70ba66857 100644
+index 49ba02bb7c02..dd0e70ba6685 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
 @@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
@@ -77,7 +77,7 @@ index 49ba02bb7c022..dd0e70ba66857 100644
  obj-$(CONFIG_DWMAC_ROCKCHIP)	+= dwmac-rk.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 new file mode 100644
-index 0000000000000..db1672deae824
+index 000000000000..db1672deae82
 --- /dev/null
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -0,0 +1,229 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From 3ed0bde5831b54bbc1fda55e9663173e34b61f37 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 185/449] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 185/450] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/common.h b/drivers/net/ethernet/stmicro/stmmac/common.h
-index 05fbd91b89b65..c2857d379f217 100644
+index 05fbd91b89b6..c2857d379f21 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/common.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/common.h
 @@ -56,10 +56,10 @@ static inline bool dwmac_is_xmac(enum dwmac_core_type core_type)
@@ -39,7 +39,7 @@ index 05fbd91b89b65..c2857d379f217 100644
  
  #undef FRAME_FILTER_DEBUG
 diff --git a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
-index 68a7cfcb1d8f3..40088a390f7b3 100644
+index 68a7cfcb1d8f..40088a390f7b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/norm_desc.c
 @@ -200,6 +200,10 @@ static void ndesc_prepare_tx_desc(struct dma_desc *p, int is_fs, int len,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From 9faae736f4fb500222a4b029203e6201eae87ac4 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 186/449] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 186/450] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index db1672deae824..86f491ea569e6 100644
+index db1672deae82..86f491ea569e 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -73,14 +73,14 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From 6807726267bb86a6fb05a78b1337e36ab032748a Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 187/449] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 187/450] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
@@ -115,7 +115,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 86f491ea569e6..a930cea6280b6 100644
+index 86f491ea569e..a930cea6280b 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -2,7 +2,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From adb47c21fd92ae97750bd982d964f96fc63289e2 Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 188/449] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 188/450] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 4ffcf2cb5e183..d0d77a5818083 100644
+index 4ffcf2cb5e18..d0d77a581808 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -3151,12 +3151,6 @@ S:	Maintained

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From b4651b53389f8f622dce9764db7dca9a55845571 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 189/449] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 189/450] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 16 insertions(+), 22 deletions(-)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d0d77a5818083..dbfc4479a180f 100644
+index d0d77a581808..dbfc4479a180 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -20865,6 +20865,7 @@ ARM/PHYTIUM SOC SUPPORT
@@ -33,7 +33,7 @@ index d0d77a5818083..dbfc4479a180f 100644
  QAT DRIVER
  M:	Giovanni Cabiddu <giovanni.cabiddu@intel.com>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index a930cea6280b6..d31b8e870f647 100644
+index a930cea6280b..d31b8e870f64 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -37,8 +37,7 @@ static int phytium_get_mac_mode(struct fwnode_handle *fwnode)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From 5875561679067e912c6ef3ca7aca28348659ce0b Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 190/449] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 190/450] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index d31b8e870f647..6e8e44730bec6 100644
+index d31b8e870f64..6e8e44730bec 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -209,6 +209,7 @@ static struct platform_driver phytium_dwmac_driver = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From 671ad72f97ef07a1326c8548a836675a9376cfaf Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 191/449] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 191/450] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.
@@ -48,7 +48,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/net/ethernet/phytium/phytmac_v2.h
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index dbfc4479a180f..f3bedd041bcfd 100644
+index dbfc4479a180..f3bedd041bcf 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -20865,6 +20865,9 @@ ARM/PHYTIUM SOC SUPPORT
@@ -62,7 +62,7 @@ index dbfc4479a180f..f3bedd041bcfd 100644
  
  QAT DRIVER
 diff --git a/drivers/net/ethernet/Kconfig b/drivers/net/ethernet/Kconfig
-index aead145dd91d1..07aded1e1bf93 100644
+index aead145dd91d..07aded1e1bf9 100644
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -173,6 +173,7 @@ config OA_TC6
@@ -74,7 +74,7 @@ index aead145dd91d1..07aded1e1bf93 100644
  source "drivers/net/ethernet/brocade/Kconfig"
  source "drivers/net/ethernet/qualcomm/Kconfig"
 diff --git a/drivers/net/ethernet/Makefile b/drivers/net/ethernet/Makefile
-index 998dd628b202c..ee9c74cd4e22a 100644
+index 998dd628b202..ee9c74cd4e22 100644
 --- a/drivers/net/ethernet/Makefile
 +++ b/drivers/net/ethernet/Makefile
 @@ -77,6 +77,7 @@ obj-$(CONFIG_NET_VENDOR_OKI) += oki-semi/
@@ -87,7 +87,7 @@ index 998dd628b202c..ee9c74cd4e22a 100644
  obj-$(CONFIG_NET_VENDOR_REALTEK) += realtek/
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
 new file mode 100644
-index 0000000000000..14a77adbfdc12
+index 000000000000..14a77adbfdc1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -0,0 +1,58 @@
@@ -151,7 +151,7 @@ index 0000000000000..14a77adbfdc12
 +endif # NET_VENDOR_PHYTIUM
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
 new file mode 100644
-index 0000000000000..6e710d4d54b66
+index 000000000000..6e710d4d54b6
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -0,0 +1,17 @@
@@ -174,7 +174,7 @@ index 0000000000000..6e710d4d54b66
 +phytmac-pci-objs := phytmac_pci.o
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
 new file mode 100644
-index 0000000000000..b90e1551499ef
+index 000000000000..b90e1551499e
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -0,0 +1,591 @@
@@ -771,7 +771,7 @@ index 0000000000000..b90e1551499ef
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 new file mode 100644
-index 0000000000000..592d2d9dc6d4b
+index 000000000000..592d2d9dc6d4
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -0,0 +1,544 @@
@@ -1321,7 +1321,7 @@ index 0000000000000..592d2d9dc6d4b
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
 new file mode 100644
-index 0000000000000..b0977f5cae755
+index 000000000000..b0977f5cae75
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -0,0 +1,2236 @@
@@ -3563,7 +3563,7 @@ index 0000000000000..b0977f5cae755
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
 new file mode 100644
-index 0000000000000..fd21bf80f1388
+index 000000000000..fd21bf80f138
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -0,0 +1,318 @@
@@ -3887,7 +3887,7 @@ index 0000000000000..fd21bf80f1388
 +MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
 new file mode 100644
-index 0000000000000..305ff5866e2fe
+index 000000000000..305ff5866e2f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -0,0 +1,255 @@
@@ -4148,7 +4148,7 @@ index 0000000000000..305ff5866e2fe
 +MODULE_ALIAS("platform:phytmac");
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
 new file mode 100644
-index 0000000000000..26b1b75edbde1
+index 000000000000..26b1b75edbde
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -0,0 +1,304 @@
@@ -4458,7 +4458,7 @@ index 0000000000000..26b1b75edbde1
 +
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
 new file mode 100644
-index 0000000000000..72c8b7c674137
+index 000000000000..72c8b7c67413
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -0,0 +1,55 @@
@@ -4519,7 +4519,7 @@ index 0000000000000..72c8b7c674137
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
 new file mode 100644
-index 0000000000000..2d9f67c82050c
+index 000000000000..2d9f67c82050
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -0,0 +1,1370 @@
@@ -5895,7 +5895,7 @@ index 0000000000000..2d9f67c82050c
 +EXPORT_SYMBOL_GPL(phytmac_1p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
 new file mode 100644
-index 0000000000000..6f2b521aaebdb
+index 000000000000..6f2b521aaebd
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -0,0 +1,453 @@
@@ -6354,7 +6354,7 @@ index 0000000000000..6f2b521aaebdb
 +#endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
 new file mode 100644
-index 0000000000000..df142aa6797f6
+index 000000000000..df142aa6797f
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -0,0 +1,1254 @@
@@ -7614,7 +7614,7 @@ index 0000000000000..df142aa6797f6
 +EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
 new file mode 100644
-index 0000000000000..92e4806ac2c1f
+index 000000000000..92e4806ac2c1
 --- /dev/null
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -0,0 +1,362 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From d9748446416887f064bf0e021ec7a50b6fcee721 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 192/449] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 192/450] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 19 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index b0977f5cae755..da4e067362803 100644
+index b0977f5cae75..da4e06736280 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1508,7 +1508,7 @@ int phytmac_mdio_register(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From c3d3cea66a58dda1f8e3c8e75cf5c5e129f6dcb6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 193/449] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 193/450] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 2d9f67c82050c..79df9a7f981f1 100644
+index 2d9f67c82050..79df9a7f981f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -357,8 +357,11 @@ static int phytmac_init_hw(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From d8c52bf95911c9ca29dbb2c7162ecc94ae02b7bf Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 194/449] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 194/450] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index da4e067362803..c172103a97362 100644
+index da4e06736280..c172103a9736 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1560,6 +1560,7 @@ static void phytmac_validate(struct phylink_config *config,
@@ -31,7 +31,7 @@ index da4e067362803..c172103a97362 100644
  	    state->interface != PHY_INTERFACE_MODE_5GBASER &&
  	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 79df9a7f981f1..ec95c6c79b066 100644
+index 79df9a7f981f..ec95c6c79b06 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -161,6 +161,20 @@ static int phytmac_enable_autoneg(struct phytmac *pdata, int enable)
@@ -106,7 +106,7 @@ index 79df9a7f981f1..ec95c6c79b066 100644
  		return PHYTMAC_READ_BITS(pdata, PHYTMAC_NSTATUS, PCS_LINK);
  	else if (interface == PHY_INTERFACE_MODE_USXGMII ||
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 6f2b521aaebdb..d8de2c26cab4b 100644
+index 6f2b521aaebd..d8de2c26cab4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -228,6 +228,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From aab92932271974f145b023ebeecaa36e5b57a951 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 195/449] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 195/450] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 74 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c172103a97362..07f8476946bc6 100644
+index c172103a9736..07f8476946bc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -46,6 +46,7 @@ MODULE_PARM_DESC(debug, "Debug level (0=none,...,16=all)");

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From 4fb857515ed1cbe3405654defcb40bd778df5873 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 196/449] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 196/450] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 07f8476946bc6..ca1a03fa35526 100644
+index 07f8476946bc..ca1a03fa3552 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1416,10 +1416,12 @@ void phytmac_pcs_link_up(struct phylink_pcs *pcs, unsigned int mode,
@@ -47,7 +47,7 @@ index 07f8476946bc6..ca1a03fa35526 100644
  		goto reset_hw;
  	}
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index ec95c6c79b066..4a690b6a96cfe 100644
+index ec95c6c79b06..4a690b6a96cf 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -414,7 +414,7 @@ static int phytmac_init_hw(struct phytmac *pdata)
@@ -69,7 +69,7 @@ index ec95c6c79b066..4a690b6a96cfe 100644
  	if (pdata->capacities & PHYTMAC_CAPS_START)
  		PHYTMAC_WRITE(pdata, PHYTMAC_NCTRL,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index d8de2c26cab4b..2cabadfed2f11 100644
+index d8de2c26cab4..2cabadfed2f1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -356,6 +356,14 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From 75a507aebfae9562e7d93cc37df44b20bc666199 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 197/449] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 197/450] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index ca1a03fa35526..058f9647b8551 100644
+index ca1a03fa3552..058f9647b855 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1843,7 +1843,7 @@ static int phytmac_close(struct net_device *ndev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From f3c3ce6b49ed0f4d4e71775218bc04bfc9f1d2d2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 198/449] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 198/450] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 19 insertions(+), 29 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 592d2d9dc6d4b..7cddb01802f21 100644
+index 592d2d9dc6d4..7cddb01802f2 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -382,43 +382,32 @@ static int phytmac_get_link_ksettings(struct net_device *ndev,
@@ -89,7 +89,7 @@ index 592d2d9dc6d4b..7cddb01802f21 100644
  
  		ethtool_convert_legacy_u32_to_link_mode(kset->link_modes.supported,
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index fd21bf80f1388..af69329fe06de 100644
+index fd21bf80f138..af69329fe06d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -225,7 +225,7 @@ struct phytmac_data phytmac_1000basex = {
@@ -102,7 +102,7 @@ index fd21bf80f1388..af69329fe06de 100644
  };
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index df142aa6797f6..41e5df41226e9 100644
+index df142aa6797f..41e5df41226e 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -842,6 +842,7 @@ static int phytmac_pcs_linkdown(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From 930b892d79e544a3ac372db28a34da2f708d86f5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 199/449] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 199/450] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 26 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 058f9647b8551..28b6dc86f6688 100644
+index 058f9647b855..28b6dc86f668 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1732,12 +1732,6 @@ static int phytmac_open(struct net_device *ndev)
@@ -52,7 +52,7 @@ index 058f9647b8551..28b6dc86f6688 100644
  		dev_dbg(pdata->dev, "probe successfully! Phytium %s at 0x%08lx irq %d (%pM)\n",
  			"MAC", ndev->base_addr, ndev->irq, ndev->dev_addr);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 4a690b6a96cfe..b96547e54d822 100644
+index 4a690b6a96cf..b96547e54d82 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -489,6 +489,15 @@ static int phytmac_set_wake(struct phytmac *pdata, int wake)
@@ -72,7 +72,7 @@ index 4a690b6a96cfe..b96547e54d822 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 2cabadfed2f11..1f49d4ec79a04 100644
+index 2cabadfed2f1..1f49d4ec79a0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -140,6 +140,8 @@ extern struct phytmac_hw_if phytmac_1p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From 9d6a074b6e73f31f974a569bea96448503a9b3e5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 200/449] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 200/450] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 16 insertions(+), 33 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index b90e1551499ef..33c0fc78415b2 100644
+index b90e1551499e..33c0fc78415b 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -38,7 +38,6 @@
@@ -40,7 +40,7 @@ index b90e1551499ef..33c0fc78415b2 100644
  	void (*restart)(struct phytmac *pdata);
  	int (*tx_complete)(const struct phytmac_dma_desc *desc);
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 28b6dc86f6688..0053412c2632c 100644
+index 28b6dc86f668..0053412c2632 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -793,16 +793,12 @@ static void phytmac_rx_clean(struct phytmac_queue *queue)
@@ -108,7 +108,7 @@ index 28b6dc86f6688..0053412c2632c 100644
  	unsigned int offset, size, count = 0;
  	unsigned int f, nr_frags = skb_shinfo(skb)->nr_frags;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index b96547e54d822..b823a07a731b6 100644
+index b96547e54d82..b823a07a731b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -927,22 +927,14 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From 78d095c3897378f78f0a54c4386ee2a8879d0b9d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 201/449] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 201/450] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 341 insertions(+), 137 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 33c0fc78415b2..363bc65c72d47 100644
+index 33c0fc78415b..363bc65c72d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -307,6 +307,13 @@ struct phytmac_tx_ts {
@@ -81,7 +81,7 @@ index 33c0fc78415b2..363bc65c72d47 100644
  					  unsigned int index);
  inline struct phytmac_dma_desc *phytmac_get_tx_desc(struct phytmac_queue *queue,
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 0053412c2632c..a2b3ed84e895a 100644
+index 0053412c2632..a2b3ed84e895 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -36,6 +36,8 @@
@@ -716,7 +716,7 @@ index 0053412c2632c..a2b3ed84e895a 100644
  
  	ret = phytmac_phylink_connect(pdata);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index b823a07a731b6..9582b587342bb 100644
+index b823a07a731b..9582b587342b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -986,16 +986,6 @@ static int phytmac_rx_pkt_len(struct phytmac *pdata, const struct phytmac_dma_de
@@ -745,7 +745,7 @@ index b823a07a731b6..9582b587342bb 100644
  	.rx_map = phytmac_rx_map_desc,
  	.rx_checksum = phytmac_rx_checksum,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 41e5df41226e9..bcfc8ad68edc1 100644
+index 41e5df41226e..bcfc8ad68edc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -952,16 +952,6 @@ static int phytmac_rx_pkt_len(struct phytmac *pdata, const struct phytmac_dma_de

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From 790f15c8b534410cfd8d9715cc8f2055f2539bd2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 202/449] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 202/450] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index a2b3ed84e895a..72b5a15870a08 100644
+index a2b3ed84e895..72b5a15870a0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -298,9 +298,9 @@ static struct net_device_stats *phytmac_get_stats(struct net_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From 531e270d9a6eb172f4a828b2b43baa5d4423169a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 203/449] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 203/450] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 363bc65c72d47..7e6cf22d7b4f7 100644
+index 363bc65c72d4..7e6cf22d7b4f 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -38,7 +38,7 @@ index 363bc65c72d47..7e6cf22d7b4f7 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 7cddb01802f21..4f632591142fc 100644
+index 7cddb01802f2..4f632591142f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -2,6 +2,8 @@
@@ -79,7 +79,7 @@ index 7cddb01802f21..4f632591142fc 100644
  
  void phytmac_set_ethtool_ops(struct net_device *ndev)
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 72b5a15870a08..79170097fd830 100644
+index 72b5a15870a0..79170097fd83 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2488,4 +2488,5 @@ MODULE_LICENSE("GPL");
@@ -89,7 +89,7 @@ index 72b5a15870a08..79170097fd830 100644
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index af69329fe06de..60bd296d8f0b6 100644
+index af69329fe06d..60bd296d8f0b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -316,3 +316,4 @@ module_pci_driver(phytmac_driver);
@@ -98,7 +98,7 @@ index af69329fe06de..60bd296d8f0b6 100644
  MODULE_DESCRIPTION("Phytium NIC PCI wrapper");
 +MODULE_VERSION(PHYTMAC_DRIVER_VERSION);
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 305ff5866e2fe..9390056fdc7a9 100644
+index 305ff5866e2f..9390056fdc7a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -253,3 +253,4 @@ MODULE_LICENSE("GPL");

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From 5dda99021f9f0c180b99576bb0cbdea449a446b9 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 204/449] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 204/450] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 56 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 7e6cf22d7b4f7..6eb1d7d1b8293 100644
+index 7e6cf22d7b4f..6eb1d7d1b829 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -55,7 +55,7 @@ index 7e6cf22d7b4f7..6eb1d7d1b8293 100644
  	void (*clear_tx_desc)(struct phytmac_queue *queue);
  	/* ptp */
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 79170097fd830..d932d011b261f 100644
+index 79170097fd83..d932d011b261 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -442,6 +442,7 @@ static int phytmac_alloc_tx_resource(struct phytmac *pdata)
@@ -134,7 +134,7 @@ index 79170097fd830..d932d011b261f 100644
  		if (offset + frag_len > total_len) {
  			if (unlikely(frag != last_frag)) {
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 9582b587342bb..1d7c2e1759178 100644
+index 9582b587342b..1d7c2e175917 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -940,6 +940,14 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,
@@ -192,7 +192,7 @@ index 9582b587342bb..1d7c2e1759178 100644
  	.init_ts_hw = phytmac_ptp_init_hw,
  	.set_time = phytmac_set_time,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 1f49d4ec79a04..32bb129491096 100644
+index 1f49d4ec79a0..32bb12949109 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -374,7 +374,6 @@ extern struct phytmac_hw_if phytmac_1p0_hw;
@@ -204,7 +204,7 @@ index 1f49d4ec79a04..32bb129491096 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index bcfc8ad68edc1..25f1ba6c1d6ef 100644
+index bcfc8ad68edc..25f1ba6c1d6e 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -934,14 +934,32 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue, u32 index,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From 38ae43f4ab57e1eb6faeaf8adbb79c599f75c128 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 205/449] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 205/450] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 6eb1d7d1b8293..cb9359c7bd4db 100644
+index 6eb1d7d1b829..cb9359c7bd4d 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -34,7 +34,7 @@ index 6eb1d7d1b8293..cb9359c7bd4db 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index d932d011b261f..732358ea40afe 100644
+index d932d011b261..732358ea40af 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2208,7 +2208,6 @@ static int phytmac_init(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 4425c6f402cb0ff5b66dc9de6ba56765a22df449 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 206/449] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 206/450] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index cb9359c7bd4db..bc0d2670c2f59 100644
+index cb9359c7bd4d..bc0d2670c2f5 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -35,7 +35,7 @@ index cb9359c7bd4db..bc0d2670c2f59 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 4f632591142fc..a97a4c28c04fe 100644
+index 4f632591142f..a97a4c28c04f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -429,7 +429,7 @@ static int phytmac_set_link_ksettings(struct net_device *ndev,
@@ -48,7 +48,7 @@ index 4f632591142fc..a97a4c28c04fe 100644
  	} else {
  		phy_ethtool_set_link_ksettings(ndev, kset);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 1d7c2e1759178..20595aca17834 100644
+index 1d7c2e175917..20595aca1783 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -182,7 +182,7 @@ static int phytmac_mac_linkup(struct phytmac *pdata, phy_interface_t interface,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From 6320a21fb54266d1272cfc1733281edfc2801124 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 207/449] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 207/450] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 23 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index bc0d2670c2f59..a4e0d4e4fa1f3 100644
+index bc0d2670c2f5..a4e0d4e4fa1f 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -33,7 +33,7 @@ index bc0d2670c2f59..a4e0d4e4fa1f3 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 732358ea40afe..43c15b8baf0b7 100644
+index 732358ea40af..43c15b8baf0b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1726,6 +1726,9 @@ static void phytmac_mac_link_up(struct phylink_config *config,
@@ -63,7 +63,7 @@ index 732358ea40afe..43c15b8baf0b7 100644
  		phylink_set(mask, 10baseT_Half);
  		phylink_set(mask, 10baseT_Full);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 20595aca17834..72a6eeaec3563 100644
+index 20595aca1783..72a6eeaec356 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1078,12 +1078,15 @@ static void phytmac_mac_interface_config(struct phytmac *pdata, unsigned int mod

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From 1f3d9c7d7793487cc6738dde586985acf23a8423 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 208/449] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 208/450] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 37 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index a4e0d4e4fa1f3..df4ec49a08512 100644
+index a4e0d4e4fa1f..df4ec49a0851 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -13,7 +13,7 @@
@@ -41,7 +41,7 @@ index a4e0d4e4fa1f3..df4ec49a08512 100644
 +void phytmac_set_bios_wol_enable(struct phytmac *pdata, u32 wol);
  #endif
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index a97a4c28c04fe..306a9934deabd 100644
+index a97a4c28c04f..306a9934deab 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -131,6 +131,7 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)
@@ -53,7 +53,7 @@ index a97a4c28c04fe..306a9934deabd 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 43c15b8baf0b7..fd29c647e2775 100644
+index 43c15b8baf0b..fd29c647e277 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -111,6 +111,8 @@ static int phytmac_set_mac_address(struct net_device *netdev, void *addr)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 60ab990ddc7707455c9284e9206080cbd3c2a29b Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 209/449] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 209/450] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 306a9934deabd..8bba0af005be8 100644
+index 306a9934deab..8bba0af005be 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -116,7 +116,8 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From ae73cc7be37950e6e2bc97b20d76cb76686cdcc2 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 210/449] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 210/450] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 8bba0af005be8..e1698fa10b095 100644
+index 8bba0af005be..e1698fa10b09 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -89,23 +89,23 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
@@ -1,7 +1,7 @@
 From 6aab08ebe5994b45f398548851136e58f03fce20 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 15 Aug 2024 17:06:59 +0800
-Subject: [PATCH 211/449] PHYTIUM: net/phytmac: Add support for phytmac v2.0
+Subject: [PATCH 211/450] PHYTIUM: net/phytmac: Add support for phytmac v2.0
 
 This patch Adds support for phtymac v2.0,including acpi description,
 rx tail pointer supporting, power management and other functions.
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  12 files changed, 796 insertions(+), 340 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/Makefile b/drivers/net/ethernet/phytium/Makefile
-index 6e710d4d54b66..debaed63e4538 100644
+index 6e710d4d54b6..debaed63e453 100644
 --- a/drivers/net/ethernet/phytium/Makefile
 +++ b/drivers/net/ethernet/phytium/Makefile
 @@ -1,9 +1,9 @@
@@ -45,7 +45,7 @@ index 6e710d4d54b66..debaed63e4538 100644
  obj-$(CONFIG_PHYTMAC) += phytmac.o
  
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index df4ec49a08512..3806e09bc1220 100644
+index df4ec49a0851..3806e09bc122 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -1,4 +1,6 @@
@@ -196,7 +196,7 @@ index df4ec49a08512..3806e09bc1220 100644
  void phytmac_free_pdata(struct phytmac *pdata);
  int phytmac_reset_ringsize(struct phytmac *pdata, u32 rx_size, u32 tx_size);
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index e1698fa10b095..e05274b961e4b 100644
+index e1698fa10b09..e05274b961e4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -1,4 +1,5 @@
@@ -206,7 +206,7 @@ index e1698fa10b095..e05274b961e4b 100644
  #include <linux/ethtool.h>
  #include <linux/phy.h>
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index fd29c647e2775..dcede058512c6 100644
+index fd29c647e277..dcede058512c 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2,6 +2,8 @@
@@ -537,7 +537,7 @@ index fd29c647e2775..dcede058512c6 100644
  MODULE_DESCRIPTION("Phytium Ethernet driver");
  MODULE_AUTHOR("Wenting Song");
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index 60bd296d8f0b6..62766c49d1a62 100644
+index 60bd296d8f0b..62766c49d1a6 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -2,6 +2,9 @@
@@ -559,7 +559,7 @@ index 60bd296d8f0b6..62766c49d1a62 100644
  	int			speed;
  	bool			duplex;
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 9390056fdc7a9..95509711894b0 100644
+index 9390056fdc7a..95509711894b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -2,6 +2,9 @@
@@ -804,7 +804,7 @@ index 9390056fdc7a9..95509711894b0 100644
  
  module_platform_driver(phytmac_driver);
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.c b/drivers/net/ethernet/phytium/phytmac_ptp.c
-index 26b1b75edbde1..4803842bd7c17 100644
+index 26b1b75edbde..4803842bd7c1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ptp.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.c
 @@ -2,6 +2,9 @@
@@ -818,7 +818,7 @@ index 26b1b75edbde1..4803842bd7c17 100644
  #include <linux/kernel.h>
  #include <linux/types.h>
 diff --git a/drivers/net/ethernet/phytium/phytmac_ptp.h b/drivers/net/ethernet/phytium/phytmac_ptp.h
-index 72c8b7c674137..e9497a172d25e 100644
+index 72c8b7c67413..e9497a172d25 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ptp.h
 +++ b/drivers/net/ethernet/phytium/phytmac_ptp.h
 @@ -2,6 +2,7 @@
@@ -830,7 +830,7 @@ index 72c8b7c674137..e9497a172d25e 100644
   * This program is free software; you can redistribute it and/or modify
   * it under the terms of the GNU General Public License version 2 as
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 72a6eeaec3563..4fc0bfa2f696e 100644
+index 72a6eeaec356..4fc0bfa2f696 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1,4 +1,5 @@
@@ -1095,7 +1095,7 @@ index 72a6eeaec3563..4fc0bfa2f696e 100644
  	.init_ts_hw = phytmac_ptp_init_hw,
  	.set_time = phytmac_set_time,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.h b/drivers/net/ethernet/phytium/phytmac_v1.h
-index 32bb129491096..e0ca0ab835474 100644
+index 32bb12949109..e0ca0ab83547 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.h
 @@ -1,4 +1,6 @@
@@ -1151,7 +1151,7 @@ index 32bb129491096..e0ca0ab835474 100644
  #define SEC_MAX_VAL (((u64)1 << PHYTMAC_TSEC_WIDTH) - 1)
  #define NSEC_MAX_VAL ((1 << PHYTMAC_NSEC_WIDTH) - 1)
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 25f1ba6c1d6ef..b8af75b3d9341 100644
+index 25f1ba6c1d6e..b8af75b3d934 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -1,4 +1,6 @@
@@ -2495,7 +2495,7 @@ index 25f1ba6c1d6ef..b8af75b3d9341 100644
  };
  EXPORT_SYMBOL_GPL(phytmac_2p0_hw);
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 92e4806ac2c1f..d2da4acb69a7d 100644
+index 92e4806ac2c1..d2da4acb69a7 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -1,11 +1,15 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
@@ -1,7 +1,7 @@
 From 333705d20ad2d9484fca74435c9cd96fead85b18 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 212/449] PHYTIUM: net/phytmac: Slove left-shift out of bound
+Subject: [PATCH 212/450] PHYTIUM: net/phytmac: Slove left-shift out of bound
  issue
 
 When the value of the bd_prefetch is equal to 0, subtracting 1 and
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 8 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 3806e09bc1220..4d66ae498b88f 100644
+index 3806e09bc122..4d66ae498b88 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -33,7 +33,7 @@ index 3806e09bc1220..4d66ae498b88f 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index b8af75b3d9341..9bab3d2a5ca4d 100644
+index b8af75b3d934..9bab3d2a5ca4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -342,10 +342,13 @@ static int phytmac_v2_get_feature_all(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
@@ -1,7 +1,7 @@
 From fe3a8ced305072d20a38fb6f7660d1043297a34b Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:29:38 +0800
-Subject: [PATCH 213/449] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
+Subject: [PATCH 213/450] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
  PHY supports WOL"
 
 This reverts commit 94967211afe596a9e9c5d80ca9d54e915de3a335.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index e05274b961e4b..7e0c749477914 100644
+index e05274b961e4..7e0c74947791 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -117,8 +117,7 @@ static int phytmac_set_wol(struct net_device *ndev, struct ethtool_wolinfo *wol)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
@@ -1,7 +1,7 @@
 From a5df6aec6237478de2830c435b960391efb8e2a0 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:36:36 +0800
-Subject: [PATCH 214/449] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
+Subject: [PATCH 214/450] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
  issue"
 
 This reverts commit 3161ed880479e35c7759e127c62c37d2d722edee.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 7e0c749477914..23c46bd91f263 100644
+index 7e0c74947791..23c46bd91f26 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -90,23 +90,23 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 806578981cddc957c9b4f833f01e956948351be0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 215/449] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 215/450] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
  supports WOL feature
 
 Don't manage WoL on MAC, if PHY sets wol fails, So modify if
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 4d66ae498b88f..2c9f2966071c1 100644
+index 4d66ae498b88..2c9f2966071c 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
@@ -1,7 +1,7 @@
 From 2cac519dd74e51d0cbb32461906fc624ed1843a2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 216/449] PHYTIUM: net/phytmac: Fixed the PTP test failure
+Subject: [PATCH 216/450] PHYTIUM: net/phytmac: Fixed the PTP test failure
  issue
 
 The bit of RX_TS_VALID should be retained in the process of zero RX
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 2c9f2966071c1..1351f8f7a8953 100644
+index 2c9f2966071c..1351f8f7a895 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -34,7 +34,7 @@ index 2c9f2966071c1..1351f8f7a8953 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 4fc0bfa2f696e..a9cd9cb9a2f57 100644
+index 4fc0bfa2f696..a9cd9cb9a2f5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1003,7 +1003,7 @@ static unsigned int phytmac_rx_map_desc(struct phytmac_queue *queue,
@@ -47,7 +47,7 @@ index 4fc0bfa2f696e..a9cd9cb9a2f57 100644
  	return 0;
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 9bab3d2a5ca4d..3eb4b0424bf75 100644
+index 9bab3d2a5ca4..3eb4b0424bf7 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -1038,7 +1038,7 @@ static unsigned int phytmac_v2_rx_map_desc(struct phytmac_queue *queue, u32 inde

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
@@ -1,7 +1,7 @@
 From a6abc4e7cec4e0245a81608249369712ac96ed45 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 217/449] PHYTIUM: net/phytmac: Cancels the power-on/off
+Subject: [PATCH 217/450] PHYTIUM: net/phytmac: Cancels the power-on/off
  capability
 
 The MAC register is powered on by default in the firmware
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 1351f8f7a8953..c53277e566318 100644
+index 1351f8f7a895..c53277e56631 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -33,7 +33,7 @@ index 1351f8f7a8953..c53277e566318 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 95509711894b0..eb3cc7d8f4290 100644
+index 95509711894b..eb3cc7d8f429 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -30,7 +30,6 @@ static const struct phytmac_config phytium_2p0_config = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
@@ -1,7 +1,7 @@
 From 87dea9f50950a684fa916c79e55dce413555b1b6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 218/449] PHYTIUM: net/phytmac: Exit probe when MDIO times out
+Subject: [PATCH 218/450] PHYTIUM: net/phytmac: Exit probe when MDIO times out
 
 Exit early to avoid system stuck due to MDIO timeout.
 We have added a callback function for mdio_idle and improved
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 30 insertions(+), 13 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index c53277e566318..98f2cd1ba0299 100644
+index c53277e56631..98f2cd1ba029 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -15,7 +15,7 @@
@@ -53,7 +53,7 @@ index c53277e566318..98f2cd1ba0299 100644
  	int (*mdio_write_c45)(struct phytmac *pdata, int mii_id, int devad,
  			      int regnum, u16 data);
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index dcede058512c6..80d3495362ad4 100644
+index dcede058512c..80d3495362ad 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1776,6 +1776,12 @@ int phytmac_mdio_register(struct phytmac *pdata)
@@ -70,7 +70,7 @@ index dcede058512c6..80d3495362ad4 100644
  	pdata->mii_bus->read = &phytmac_mdio_read_c22;
  	pdata->mii_bus->write = &phytmac_mdio_write_c22;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index a9cd9cb9a2f57..e7ac69753dd19 100644
+index a9cd9cb9a2f5..e7ac69753dd1 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -558,16 +558,18 @@ static int phytmac_set_wake(struct phytmac *pdata, int wake)
@@ -107,7 +107,7 @@ index a9cd9cb9a2f57..e7ac69753dd19 100644
  	.mdio_write = phytmac_mdio_data_write_c22,
  	.mdio_read_c45 = phytmac_mdio_data_read_c45,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 3eb4b0424bf75..7b337d13329fa 100644
+index 3eb4b0424bf7..7b337d13329f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -421,16 +421,18 @@ static void phytmac_v2_get_hw_stats(struct phytmac *pdata)
@@ -144,7 +144,7 @@ index 3eb4b0424bf75..7b337d13329fa 100644
  	.mdio_write = phytmac_v2_mdio_data_write_c22,
  	.mdio_read_c45 = phytmac_v2_mdio_data_read_c45,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index d2da4acb69a7d..57594732fab98 100644
+index d2da4acb69a7..57594732fab9 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -237,6 +237,8 @@ extern struct phytmac_hw_if phytmac_2p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
@@ -1,7 +1,7 @@
 From 58c9b8a059250bd848281bf233fc33b2fcb2ca2b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 219/449] PHYTIUM: net/phytmac: Add XDP feature support
+Subject: [PATCH 219/450] PHYTIUM: net/phytmac: Add XDP feature support
 
 Add XDP feature support to the phytmac driver.XDP by optimizing
 the data processing flow provided significant performance improvements
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 452 insertions(+), 36 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 98f2cd1ba0299..1d89c9bd023de 100644
+index 98f2cd1ba029..1d89c9bd023d 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -12,6 +12,7 @@
@@ -125,7 +125,7 @@ index 98f2cd1ba0299..1d89c9bd023de 100644
  #define PHYTMAC_RXBUFFER_2048	2048
  #define PHYTMAC_MAX_FRAME_BUILD_SKB \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 80d3495362ad4..26d70d9ccaef9 100644
+index 80d3495362ad..26d70d9ccaef 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -40,6 +40,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
@@ -1,7 +1,7 @@
 From d4dc42f7260d6a7c15b6bf0d61f1ea49a9d742cb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 220/449] PHYTIUM: net/phytmac: Clear RX descriptor address
+Subject: [PATCH 220/450] PHYTIUM: net/phytmac: Clear RX descriptor address
  after the skb construction
 
 If the skb build failed, the descriptor address has been cleared,
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 1d89c9bd023de..5ea2a383c1074 100644
+index 1d89c9bd023d..5ea2a383c107 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -16,7 +16,7 @@
@@ -34,7 +34,7 @@ index 1d89c9bd023de..5ea2a383c1074 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 26d70d9ccaef9..df0aea0de7a41 100644
+index 26d70d9ccaef..df0aea0de7a4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -972,8 +972,6 @@ static struct sk_buff *phytmac_rx_xdp_single(struct phytmac_queue *queue,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
@@ -1,7 +1,7 @@
 From 6518854ae051842745d779c740a5a26f5ff7f425 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 221/449] PHYTIUM: net/phytmac: Enable the tail pointer by the
+Subject: [PATCH 221/450] PHYTIUM: net/phytmac: Enable the tail pointer by the
  driver
 
 It is need to enable the RX/TX tail pointer to ensure the NIC
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 16 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 5ea2a383c1074..abe43324cd6aa 100644
+index 5ea2a383c107..abe43324cd6a 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -16,7 +16,7 @@
@@ -34,7 +34,7 @@ index 5ea2a383c1074..abe43324cd6aa 100644
  		(NETIF_MSG_DRV		| \
  		NETIF_MSG_PROBE	| \
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 7b337d13329fa..2e9d14dcb9f31 100644
+index 7b337d13329f..2e9d14dcb9f3 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -159,8 +159,16 @@ static int phytmac_v2_init_hw(struct phytmac *pdata)
@@ -55,7 +55,7 @@ index 7b337d13329fa..2e9d14dcb9f31 100644
  		cmd_id = PHYTMAC_MSG_CMD_SET;
  		cmd_subid = PHYTMAC_MSG_CMD_SET_ENABLE_MDIO;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 57594732fab98..1303bde7cff05 100644
+index 57594732fab9..1303bde7cff0 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -17,6 +17,7 @@ extern struct phytmac_hw_if phytmac_2p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
@@ -1,7 +1,7 @@
 From 0c5c1e381031d8bea6ef19ee6446700ed158cdcb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 222/449] PHYTIUM: net/phytmac: Modify cmd processing function
+Subject: [PATCH 222/450] PHYTIUM: net/phytmac: Modify cmd processing function
 
 Change the para size in the msg struct from 64 to 56
 and add mutux to avoid race.
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 114 insertions(+), 96 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index abe43324cd6aa..e8a640de47a69 100644
+index abe43324cd6a..e8a640de47a6 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -75,7 +75,8 @@
@@ -46,7 +46,7 @@ index abe43324cd6aa..e8a640de47a69 100644
  	u32			rx_msg_tail;
  	/*use msg_mutex to protect msg */
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 23c46bd91f263..2c0bbb8f27720 100644
+index 23c46bd91f26..2c0bbb8f2772 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -70,7 +70,7 @@ static void phytmac_get_ethtool_strings(struct net_device *ndev, u32 sset, u8 *p
@@ -68,7 +68,7 @@ index 23c46bd91f263..2c0bbb8f27720 100644
  	hw_if->get_regs(pdata, regs_buff);
  }
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index e7ac69753dd19..515825627fedc 100644
+index e7ac69753dd1..515825627fed 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -1226,15 +1226,15 @@ static void phytmac_clear_tx_desc(struct phytmac_queue *queue)
@@ -91,7 +91,7 @@ index e7ac69753dd19..515825627fedc 100644
  			val = (u64)stats[i + 1] << 32 | stats[i];
  			*p += val;
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 2e9d14dcb9f31..e43a55fe47700 100644
+index 2e9d14dcb9f3..e43a55fe4770 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -20,44 +20,64 @@
@@ -447,7 +447,7 @@ index 2e9d14dcb9f31..e43a55fe47700 100644
  	struct phytmac_dma_desc *desc;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 1303bde7cff05..4e195dcef04fe 100644
+index 1303bde7cff0..4e195dcef04f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -6,10 +6,11 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 7229900aaa54842d0dd35672b91104586bb730ea Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 223/449] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 223/450] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 2c0bbb8f27720..bac59327087fc 100644
+index 2c0bbb8f2772..bac59327087f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -90,24 +90,20 @@ static void phytmac_get_wol(struct net_device *ndev, struct ethtool_wolinfo *wol

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
@@ -1,7 +1,7 @@
 From b3c7872e7fd9e75e3bc48fc96679f631e548b70a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 224/449] PHYTIUM: net/phytmac: Bugfix invalid wait context
+Subject: [PATCH 224/450] PHYTIUM: net/phytmac: Bugfix invalid wait context
 
 After the spinlock is called, the mutex should no longer to be
 invoked, which will lead to unnecessary sleep.
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 7 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index e8a640de47a69..7acfc97d3fc29 100644
+index e8a640de47a6..7acfc97d3fc2 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -434,8 +434,8 @@ struct phytmac_msg {
@@ -44,7 +44,7 @@ index e8a640de47a69..7acfc97d3fc29 100644
  	u32				tx_ring_size;
  	u32				dma_data_width;
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index df0aea0de7a41..765b01503c1f4 100644
+index df0aea0de7a4..765b01503c1f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2725,8 +2725,6 @@ int phytmac_drv_probe(struct phytmac *pdata)
@@ -75,7 +75,7 @@ index df0aea0de7a41..765b01503c1f4 100644
  	pdata->msg_enable = netif_msg_init(debug, PHYTMAC_DEFAULT_MSG_ENABLE);
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index e43a55fe47700..65db2c0d15dea 100644
+index e43a55fe4770..65db2c0d15de 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -27,7 +27,7 @@ static int phytmac_v2_msg_send(struct phytmac *pdata, u16 cmd_id,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
@@ -1,7 +1,7 @@
 From b4804c5556de3cc7ffd584fc89ed66ecbff12760 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 225/449] PHYTIUM: net/phytmac: Change the requested resource
+Subject: [PATCH 225/450] PHYTIUM: net/phytmac: Change the requested resource
  type from nRE to nRnE
 
 The resource type is changed from nRE to nRnE to avoid interrupt
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 70 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 7acfc97d3fc29..6b72b45bc0d4a 100644
+index 7acfc97d3fc2..6b72b45bc0d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -680,6 +680,8 @@ struct phytmac_hw_if {
@@ -34,7 +34,7 @@ index 7acfc97d3fc29..6b72b45bc0d4a 100644
  					  unsigned int index);
  inline struct phytmac_dma_desc *phytmac_get_tx_desc(struct phytmac_queue *queue,
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 765b01503c1f4..c32dd959cca55 100644
+index 765b01503c1f..c32dd959cca5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2933,6 +2933,72 @@ void phytmac_drv_shutdown(struct phytmac *pdata)
@@ -111,7 +111,7 @@ index 765b01503c1f4..c32dd959cca55 100644
  MODULE_DESCRIPTION("Phytium Ethernet driver");
  MODULE_AUTHOR("Wenting Song");
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index eb3cc7d8f4290..540159f8fc3a8 100644
+index eb3cc7d8f429..540159f8fc3a 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -203,7 +203,8 @@ static int phytmac_plat_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
@@ -1,7 +1,7 @@
 From d4321c9453b14af6d1a0ee9cd6874ce9c313bcbb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 226/449] PHYTIUM: net/phytmac: BugFix Memory leak when
+Subject: [PATCH 226/450] PHYTIUM: net/phytmac: BugFix Memory leak when
  releasing resource
 
 The size of the memory released in the dma_free_coherent is smaller
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 8 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 6b72b45bc0d4a..09e3c99232d35 100644
+index 6b72b45bc0d4..09e3c99232d3 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -114,9 +114,6 @@
@@ -35,7 +35,7 @@ index 6b72b45bc0d4a..09e3c99232d35 100644
  #define LSO_TSO		2
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index c32dd959cca55..eeaf60a6e9cde 100644
+index c32dd959cca5..eeaf60a6e9cd 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -391,6 +391,7 @@ static int phytmac_free_tx_resource(struct phytmac *pdata)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
@@ -1,7 +1,7 @@
 From c9fa7554b8e1b3d0f622e18a308db43f7f2349d7 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 227/449] PHYTIUM: net/phytmac: Limit the number of retries to
+Subject: [PATCH 227/450] PHYTIUM: net/phytmac: Limit the number of retries to
  avoid deadlock
 
 It is need to limit retries that messages are processed
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 20 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 65db2c0d15dea..20c49bf5f4b86 100644
+index 65db2c0d15de..20c49bf5f4b8 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -25,6 +25,7 @@ static int phytmac_v2_msg_send(struct phytmac *pdata, u16 cmd_id,
@@ -69,7 +69,7 @@ index 65db2c0d15dea..20c49bf5f4b86 100644
  
  		memcpy(&msg_rx, pdata->msg_regs + PHYTMAC_MSG(pdata->msg_ring.tx_msg_rd_tail),
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index 4e195dcef04fe..b32044d696ae2 100644
+index 4e195dcef04f..b32044d696ae 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -246,6 +246,8 @@ extern struct phytmac_hw_if phytmac_2p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-PHYTIUM-net-phytmac-update-to-1.0.47.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-PHYTIUM-net-phytmac-update-to-1.0.47.patch
@@ -1,7 +1,7 @@
 From a772f0e5ff16d5b03d7c2ed5b51da8be35ae23f9 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 11:41:46 +0800
-Subject: [PATCH 228/449] PHYTIUM: net: phytmac: update to 1.0.47
+Subject: [PATCH 228/450] PHYTIUM: net: phytmac: update to 1.0.47
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
 
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  8 files changed, 31 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac.h b/drivers/net/ethernet/phytium/phytmac.h
-index 09e3c99232d35..ee22cda030e94 100644
+index 09e3c99232d3..ee22cda030e9 100644
 --- a/drivers/net/ethernet/phytium/phytmac.h
 +++ b/drivers/net/ethernet/phytium/phytmac.h
 @@ -14,9 +14,10 @@
@@ -54,7 +54,7 @@ index 09e3c99232d35..ee22cda030e94 100644
  
  /* phytmac_desc_unused - calculate if we have unused descriptors */
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index bac59327087fc..26478b090ced0 100644
+index bac59327087f..26478b090ced 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -506,13 +506,16 @@ static void phytmac_get_drvinfo(struct net_device *ndev, struct ethtool_drvinfo
@@ -78,7 +78,7 @@ index bac59327087fc..26478b090ced0 100644
  
  static const struct ethtool_ops phytmac_ethtool_ops = {
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index eeaf60a6e9cde..9ed5ec09523b3 100644
+index eeaf60a6e9cd..9ed5ec09523b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -62,7 +62,7 @@ MODULE_PARM_DESC(debug, "Debug level (0=none,...,16=all)");
@@ -128,7 +128,7 @@ index eeaf60a6e9cde..9ed5ec09523b3 100644
  
  	return 0;
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index 62766c49d1a62..fac5d717ad766 100644
+index 62766c49d1a6..fac5d717ad76 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -74,7 +74,7 @@ static int phytmac_pci_probe(struct pci_dev *pdev, const struct pci_device_id *i
@@ -150,7 +150,7 @@ index 62766c49d1a62..fac5d717ad766 100644
  	.probe = phytmac_pci_probe,
  	.remove = phytmac_pci_remove,
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 540159f8fc3a8..2f2170cf0775a 100644
+index 540159f8fc3a..2f2170cf0775 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -356,7 +356,7 @@ static struct platform_driver phytmac_driver = {
@@ -163,7 +163,7 @@ index 540159f8fc3a8..2f2170cf0775a 100644
  		.acpi_match_table = phytmac_acpi_ids,
  		.pm = &phytmac_plat_pm_ops,
 diff --git a/drivers/net/ethernet/phytium/phytmac_v1.c b/drivers/net/ethernet/phytium/phytmac_v1.c
-index 515825627fedc..870f07edc58fc 100644
+index 515825627fed..870f07edc58f 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v1.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v1.c
 @@ -564,7 +564,7 @@ static int phytmac_mdio_idle(struct phytmac *pdata)
@@ -176,7 +176,7 @@ index 515825627fedc..870f07edc58fc 100644
  	if (ret)
  		netdev_err(pdata->ndev, "mdio wait for idle time out!");
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.c b/drivers/net/ethernet/phytium/phytmac_v2.c
-index 20c49bf5f4b86..1afff67d625d9 100644
+index 20c49bf5f4b8..1afff67d625d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.c
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.c
 @@ -453,7 +453,7 @@ static int phytmac_v2_mdio_idle(struct phytmac *pdata)
@@ -189,7 +189,7 @@ index 20c49bf5f4b86..1afff67d625d9 100644
  	if (ret)
  		netdev_err(pdata->ndev, "mdio wait for idle time out!");
 diff --git a/drivers/net/ethernet/phytium/phytmac_v2.h b/drivers/net/ethernet/phytium/phytmac_v2.h
-index b32044d696ae2..c9e159b1eb9b6 100644
+index b32044d696ae..c9e159b1eb9b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_v2.h
 +++ b/drivers/net/ethernet/phytium/phytmac_v2.h
 @@ -248,7 +248,7 @@ extern struct phytmac_hw_if phytmac_2p0_hw;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From 74c122fef80ebefe004496f163cc718d5cf10949 Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 229/449] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 229/450] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/kernel/fpu-probe.c b/arch/mips/kernel/fpu-probe.c
-index 6bf3f19b1c335..404d753120582 100644
+index 6bf3f19b1c33..404d75312058 100644
 --- a/arch/mips/kernel/fpu-probe.c
 +++ b/arch/mips/kernel/fpu-probe.c
 @@ -144,7 +144,12 @@ static void cpu_set_fpu_2008(struct cpuinfo_mips *c)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From d12c6e902caedbfda6b98249d5d4f3885173e956 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 230/449] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 230/450] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/hwmon/hwmon-aaeon.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 2760feb9f83b5..8702e93e23c4b 100644
+index 2760feb9f83b..8702e93e23c4 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -38,6 +38,18 @@ config HWMON_DEBUG_CHIP
@@ -50,7 +50,7 @@ index 2760feb9f83b5..8702e93e23c4b 100644
  	tristate "Abit uGuru (rev 1 & 2)"
  	depends on (X86 && DMI) || COMPILE_TEST && HAS_IOPORT
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index 73b2abdcc6dd9..f0750b067db9a 100644
+index 73b2abdcc6dd..f0750b067db9 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -15,6 +15,7 @@ obj-$(CONFIG_SENSORS_HP_WMI)	+= hp-wmi-sensors.o
@@ -63,7 +63,7 @@ index 73b2abdcc6dd9..f0750b067db9a 100644
  obj-$(CONFIG_SENSORS_W83773G)	+= w83773g.o
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
 new file mode 100644
-index 0000000000000..146da10309bbb
+index 000000000000..146da10309bb
 --- /dev/null
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -0,0 +1,568 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 4fa9949befbddff329acb6904723dadc85fe40a3 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 231/449] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 231/450] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/leds/leds-aaeon.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 06e6291be11b2..df3ca4fc55425 100644
+index 06e6291be11b..df3ca4fc5542 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -72,6 +72,18 @@ config LEDS_88PM860X
@@ -50,7 +50,7 @@ index 06e6291be11b2..df3ca4fc55425 100644
  	tristate "LED support for Panasonic AN30259A"
  	depends on LEDS_CLASS && I2C && OF
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 9a0333ec1a861..cbb759e92d55a 100644
+index 9a0333ec1a86..cbb759e92d55 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -10,6 +10,7 @@ obj-$(CONFIG_LEDS_KUNIT_TEST)		+= led-test.o
@@ -63,7 +63,7 @@ index 9a0333ec1a861..cbb759e92d55a 100644
  obj-$(CONFIG_LEDS_AN30259A)		+= leds-an30259a.o
 diff --git a/drivers/leds/leds-aaeon.c b/drivers/leds/leds-aaeon.c
 new file mode 100644
-index 0000000000000..10090a4bff654
+index 000000000000..10090a4bff65
 --- /dev/null
 +++ b/drivers/leds/leds-aaeon.c
 @@ -0,0 +1,142 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From f55f1d1bbcfcd0a6093c92158cf04db751c2821f Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 232/449] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 232/450] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/gpio/gpio-aaeon.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index 4d644dcecad93..f06e97bc0c862 100644
+index 4d644dcecad9..f06e97bc0c86 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1743,6 +1743,18 @@ endmenu
@@ -50,7 +50,7 @@ index 4d644dcecad93..f06e97bc0c862 100644
  	tristate "AMD 8111 GPIO driver"
  	depends on X86 || COMPILE_TEST
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index ec296fa14bfdb..3e59519667a6d 100644
+index ec296fa14bfd..3e59519667a6 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -28,6 +28,7 @@ obj-$(CONFIG_GPIO_104_IDI_48)		+= gpio-104-idi-48.o
@@ -63,7 +63,7 @@ index ec296fa14bfdb..3e59519667a6d 100644
  obj-$(CONFIG_GPIO_ADP5585)		+= gpio-adp5585.o
 diff --git a/drivers/gpio/gpio-aaeon.c b/drivers/gpio/gpio-aaeon.c
 new file mode 100644
-index 0000000000000..3183c45dd1946
+index 000000000000..3183c45dd194
 --- /dev/null
 +++ b/drivers/gpio/gpio-aaeon.c
 @@ -0,0 +1,205 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From 82fc28c2d0bd5fe9740feb4a0023b52a6ce5ac36 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 233/449] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 233/450] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
@@ -38,7 +38,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/mfd/mfd-aaeon.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index f3bedd041bcfd..c80698be33742 100644
+index f3bedd041bcf..c80698be3374 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -199,6 +199,18 @@ M:	Linus Walleij <linus.walleij@linaro.org>
@@ -61,7 +61,7 @@ index f3bedd041bcfd..c80698be33742 100644
  L:	linux-api@vger.kernel.org
  F:	include/linux/syscalls.h
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 55a9fea95195b..080607b313a74 100644
+index 55a9fea95195..080607b313a7 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2393,6 +2393,18 @@ config MFD_QCOM_PM8008
@@ -84,7 +84,7 @@ index 55a9fea95195b..080607b313a74 100644
  	depends on ARCH_SA1100
  
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 865e9f12faff0..948eeaf6a59dc 100644
+index 865e9f12faff..948eeaf6a59d 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -294,6 +294,7 @@ obj-$(CONFIG_MFD_LS2K_BMC_CORE)		+= ls2k-bmc-core.o
@@ -97,7 +97,7 @@ index 865e9f12faff0..948eeaf6a59dc 100644
  
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
 new file mode 100644
-index 0000000000000..9d2efde53cad3
+index 000000000000..9d2efde53cad
 --- /dev/null
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -0,0 +1,77 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From ea6456c1399199efe1412c02ee5df771b6d09727 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 234/449] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 234/450] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/mfd/mfd-aaeon.c b/drivers/mfd/mfd-aaeon.c
-index 9d2efde53cad3..74211d01ce656 100644
+index 9d2efde53cad..74211d01ce65 100644
 --- a/drivers/mfd/mfd-aaeon.c
 +++ b/drivers/mfd/mfd-aaeon.c
 @@ -16,12 +16,17 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From 1c66a8558ec732dab7c135e193a3c4b80d9ab6ca Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 235/449] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 235/450] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/hwmon/hwmon-aaeon.c b/drivers/hwmon/hwmon-aaeon.c
-index 146da10309bbb..80bf4d1224f3f 100644
+index 146da10309bb..80bf4d1224f3 100644
 --- a/drivers/hwmon/hwmon-aaeon.c
 +++ b/drivers/hwmon/hwmon-aaeon.c
 @@ -49,7 +49,7 @@ static ssize_t name_show(struct device *dev, struct device_attribute *devattr,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
@@ -1,7 +1,7 @@
 From 93790f59aa53ae8ea2c79933260cbf3df87455bc Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 12 Aug 2024 14:28:31 +0800
-Subject: [PATCH 236/449] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 236/450] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for SKL integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2062951
@@ -35,7 +35,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 27 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 49e83c8566a32..43f97958bf832 100644
+index 49e83c8566a3..43f97958bf83 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -4555,6 +4555,33 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
@@ -1,7 +1,7 @@
 From 2703984340a62ab4710186e6326eaa5cb929e36d Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 18 Nov 2024 09:28:40 +0800
-Subject: [PATCH 237/449] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 237/450] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for KBL and CML integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2086587
@@ -34,7 +34,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 41 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 43f97958bf832..e2e6468578e1e 100644
+index 43f97958bf83..e2e6468578e1 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -4582,6 +4582,47 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x193A, quirk_iommu_igfx);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From a508280f5ed15d0474f66f49aa8e5421044c714b Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 238/449] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 238/450] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 6e8e44730bec6..078e3ee52bdcb 100644
+index 6e8e44730bec..078e3ee52bdc 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -198,6 +198,7 @@ MODULE_DEVICE_TABLE(of, phytium_dwmac_of_match);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From cf44686438f5c2b774dfb49e0c2b5b0bf0985713 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 239/449] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 239/450] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index e81585795dc5c..3ff6d0c889add 100644
+index e81585795dc5..3ff6d0c889ad 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -2005,13 +2005,18 @@ static void __free_dma_rx_desc_resources(struct stmmac_priv *priv,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From 4785bc6a77fe218be926d46f6d1c0a1080eb253f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 240/449] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 240/450] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index 078e3ee52bdcb..ba86b6bb047dc 100644
+index 078e3ee52bdc..ba86b6bb047d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -68,6 +68,21 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
@@ -1,7 +1,7 @@
 From 5ac6fa96de1a257b9ea530dfe24581c67e80c33f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 241/449] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
+Subject: [PATCH 241/450] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
  transition of devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 31 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index b8647f9b1ef3a..25ee85d5e9de6 100644
+index b8647f9b1ef3..25ee85d5e9de 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -399,6 +399,36 @@ static void quirk_tigerpoint_bm_sts(struct pci_dev *dev)
@@ -62,7 +62,7 @@ index b8647f9b1ef3a..25ee85d5e9de6 100644
  static void quirk_nopcipci(struct pci_dev *dev)
  {
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index 528e31ed5bea7..b9abf0ca18ca3 100644
+index 528e31ed5bea..b9abf0ca18ca 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -248,6 +248,7 @@ enum pci_dev_flags {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From cd9115f3e36d211b41258433080764acb5fa292e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 242/449] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 242/450] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index ba86b6bb047dc..eea8421955134 100644
+index ba86b6bb047d..eea842195513 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 3d1f89016a8d67ab6cd810c1b3f443622212234d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 243/449] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 243/450] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index 2f2170cf0775a..ce6271ac52cd0 100644
+index 2f2170cf0775..ce6271ac52cd 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -17,6 +17,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From 185d5475752b175b59f83708e00d79066821b019 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 244/449] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 244/450] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 9ed5ec09523b3..6ef55093d6d4a 100644
+index 9ed5ec09523b..6ef55093d6d4 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1848,7 +1848,7 @@ static int phytmac_phylink_connect(struct phytmac *pdata)
@@ -60,7 +60,7 @@ index 9ed5ec09523b3..6ef55093d6d4a 100644
  	struct net_device *ndev = pdata->ndev;
  
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index ce6271ac52cd0..cf628a4517284 100644
+index ce6271ac52cd..cf628a451728 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -168,7 +168,6 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From 3eb6960d4c3cacfe476b3d7b26040c1a77f0a120 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 245/449] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 245/450] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index cf628a4517284..d958ca1f168bb 100644
+index cf628a451728..d958ca1f168b 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -168,6 +168,7 @@ static int phytmac_get_phy_mode(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From ced4f073673ef245bcf90cfc25993ee4e6ced2b9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 246/449] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 246/450] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+), 65 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 6ef55093d6d4a..2a0caf15671d5 100644
+index 6ef55093d6d4..2a0caf15671d 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -2063,72 +2063,7 @@ static void phytmac_pcs_get_state(struct phylink_config *config,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From c51e63c5cb7ef9df2b09de4f30d53211fc684dcc Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 247/449] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 247/450] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index 8b72ae6449c91..5f607e83dd44c 100644
+index 8b72ae6449c9..5f607e83dd44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 @@ -300,7 +300,7 @@ &gmac {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
@@ -1,7 +1,7 @@
 From d0d50c7f515549bd864dede400fd0b795d21114e Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
-Subject: [PATCH 248/449] SURFACE: (surface3-oemb) add DMI matches for Surface
+Subject: [PATCH 248/450] SURFACE: (surface3-oemb) add DMI matches for Surface
  3 with broken DMI table
 
 On some Surface 3, the DMI table gets corrupted for unknown reasons
@@ -43,7 +43,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 24 insertions(+)
 
 diff --git a/drivers/platform/surface/surface3-wmi.c b/drivers/platform/surface/surface3-wmi.c
-index 6c8fb7a4dde44..22797a53f4d8f 100644
+index 6c8fb7a4dde4..22797a53f4d8 100644
 --- a/drivers/platform/surface/surface3-wmi.c
 +++ b/drivers/platform/surface/surface3-wmi.c
 @@ -37,6 +37,13 @@ static const struct dmi_system_id surface3_dmi_table[] = {
@@ -61,7 +61,7 @@ index 6c8fb7a4dde44..22797a53f4d8f 100644
  	{ }
  };
 diff --git a/sound/soc/codecs/rt5645.c b/sound/soc/codecs/rt5645.c
-index 29a403526cd9e..986f32132c3d8 100644
+index 29a403526cd9..986f32132c3d 100644
 --- a/sound/soc/codecs/rt5645.c
 +++ b/sound/soc/codecs/rt5645.c
 @@ -3792,6 +3792,15 @@ static const struct dmi_system_id dmi_platform_data[] = {
@@ -81,7 +81,7 @@ index 29a403526cd9e..986f32132c3d8 100644
  		/*
  		 * Match for the GPDwin which unfortunately uses somewhat
 diff --git a/sound/soc/intel/common/soc-acpi-intel-cht-match.c b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
-index e4c3492a0c282..0b930c91bccb3 100644
+index e4c3492a0c28..0b930c91bccb 100644
 --- a/sound/soc/intel/common/soc-acpi-intel-cht-match.c
 +++ b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
 @@ -27,6 +27,14 @@ static const struct dmi_system_id cht_table[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
@@ -1,7 +1,7 @@
 From a6a4afc54a6b23dbbd7b1d1ca452f7ad28c5e5d8 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
-Subject: [PATCH 249/449] SURFACE: surface3-spi: workaround: disable DMA mode
+Subject: [PATCH 249/450] SURFACE: surface3-spi: workaround: disable DMA mode
  to avoid crash by default
 
 On Arch Linux kernel at least after 4.19, touch input is broken after suspend
@@ -81,7 +81,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/drivers/input/touchscreen/surface3_spi.c b/drivers/input/touchscreen/surface3_spi.c
-index 6074b7730e862..6aa3e1d6f160a 100644
+index 6074b7730e86..6aa3e1d6f160 100644
 --- a/drivers/input/touchscreen/surface3_spi.c
 +++ b/drivers/input/touchscreen/surface3_spi.c
 @@ -25,6 +25,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From c877183ade142e1b73f1cee60c5d64462e26485f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 250/449] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 250/450] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 
 The most recent firmware of the 88W8897 card reports a hardcoded LTR
@@ -35,7 +35,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 31 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index a760de191fce7..db9b203226a89 100644
+index a760de191fce..db9b203226a8 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -1702,9 +1702,21 @@ mwifiex_pcie_send_boot_cmd(struct mwifiex_adapter *adapter, struct sk_buff *skb)
@@ -61,7 +61,7 @@ index a760de191fce7..db9b203226a89 100644
  	mwifiex_write_reg(adapter, reg->rx_rdptr, card->rxbd_rdptr | tx_wrap);
  }
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index dd6d21f1dbfd7..f46b06f8d6435 100644
+index dd6d21f1dbfd..f46b06f8d643 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -13,7 +13,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -154,7 +154,7 @@ index dd6d21f1dbfd7..f46b06f8d6435 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index d6ff964aec5bf..5d30ae39d65ec 100644
+index d6ff964aec5b..5d30ae39d65e 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -4,6 +4,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From 23c7ca8fecb5046f808caaa504935106fcf7e720 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 251/449] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 251/450] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 27 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
-index db9b203226a89..ffd0c1fe92239 100644
+index db9b203226a8..ffd0c1fe9223 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
 @@ -377,6 +377,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
@@ -49,7 +49,7 @@ index db9b203226a89..ffd0c1fe92239 100644
  }
  
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
-index f46b06f8d6435..99b024ecbadea 100644
+index f46b06f8d643..99b024ecbade 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
 @@ -14,7 +14,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
@@ -143,7 +143,7 @@ index f46b06f8d6435..99b024ecbadea 100644
  
  static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
 diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
-index 5d30ae39d65ec..c14eb56eb9118 100644
+index 5d30ae39d65e..c14eb56eb911 100644
 --- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 +++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
 @@ -5,6 +5,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-BACKPORT-SURFACE-Bluetooth-btusb-Lower-passive-lesca.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-BACKPORT-SURFACE-Bluetooth-btusb-Lower-passive-lesca.patch
@@ -1,7 +1,7 @@
 From b2236eb29f028d200a245ece1ef545f7a52fb0bd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 252/449] BACKPORT: SURFACE: Bluetooth: btusb: Lower passive
+Subject: [PATCH 252/450] BACKPORT: SURFACE: Bluetooth: btusb: Lower passive
  lescan interval on Marvell 88W8897
 
 The Marvell 88W8897 combined wifi and bluetooth card (pcie+usb version)
@@ -40,7 +40,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 7c7955afa8e8a..c1c464bf33c66 100644
+index 7c7955afa8e8..c1c464bf33c6 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -67,6 +67,7 @@ static struct usb_driver btusb_driver;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
@@ -1,7 +1,7 @@
 From 31efd02fad063acc3c9a0a0008abc2e03adccf03 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
-Subject: [PATCH 253/449] SURFACE: ath10k: Add module parameters to override
+Subject: [PATCH 253/450] SURFACE: ath10k: Add module parameters to override
  board files
 
 Some Surface devices, specifically the Surface Go and AMD version of the
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 57 insertions(+)
 
 diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
-index 9ae3595fb6986..b26a39c97998b 100644
+index 9ae3595fb698..b26a39c97998 100644
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
 @@ -41,6 +41,9 @@ static bool fw_diag_log;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From 4241b8562f1ec9b7b79f9969fe53dafa430508b8 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 254/449] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 254/450] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 2 insertions(+)
 
 diff --git a/drivers/misc/mei/hw-me-regs.h b/drivers/misc/mei/hw-me-regs.h
-index fa30899a5fa26..a1864dcb713d5 100644
+index fa30899a5fa2..a1864dcb713d 100644
 --- a/drivers/misc/mei/hw-me-regs.h
 +++ b/drivers/misc/mei/hw-me-regs.h
 @@ -92,6 +92,7 @@
@@ -26,7 +26,7 @@ index fa30899a5fa26..a1864dcb713d5 100644
  
  #define MEI_DEV_ID_JSP_N      0x4DE0  /* Jasper Lake Point N */
 diff --git a/drivers/misc/mei/pci-me.c b/drivers/misc/mei/pci-me.c
-index 2a6e569558b94..c19dfba542c1b 100644
+index 2a6e569558b9..c19dfba542c1 100644
 --- a/drivers/misc/mei/pci-me.c
 +++ b/drivers/misc/mei/pci-me.c
 @@ -97,6 +97,7 @@ static const struct pci_device_id mei_me_pci_tbl[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
@@ -1,7 +1,7 @@
 From fd8b0d2b3fbe11efeaa0f49a59f27495c30bcc39 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 255/449] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
+Subject: [PATCH 255/450] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
  for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 29 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index e2e6468578e1e..caeddd92533bb 100644
+index e2e6468578e1..caeddd92533b 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -39,6 +39,11 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
@@ -1,7 +1,7 @@
 From f737c5be0b3e7dc16b394a0dcf54dcd6ed62215f Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 256/449] SURFACE: hid: Add support for Intel Precise Touch and
+Subject: [PATCH 256/450] SURFACE: hid: Add support for Intel Precise Touch and
  Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268
@@ -69,7 +69,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/hid/ipts/thread.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 03ad8b5c29a4d..c639bb1f6733c 100644
+index 03ad8b5c29a4..c639bb1f6733 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -1440,6 +1440,8 @@ source "drivers/hid/surface-hid/Kconfig"
@@ -82,7 +82,7 @@ index 03ad8b5c29a4d..c639bb1f6733c 100644
  
  # USB support may be used with HID disabled
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 361a7daedeb85..b73a1bbd3a1dd 100644
+index 361a7daedeb8..b73a1bbd3a1d 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
 @@ -176,3 +176,5 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
@@ -93,7 +93,7 @@ index 361a7daedeb85..b73a1bbd3a1dd 100644
 +obj-$(CONFIG_HID_IPTS)          += ipts/
 diff --git a/drivers/hid/ipts/Kconfig b/drivers/hid/ipts/Kconfig
 new file mode 100644
-index 0000000000000..297401bd388dd
+index 000000000000..297401bd388d
 --- /dev/null
 +++ b/drivers/hid/ipts/Kconfig
 @@ -0,0 +1,14 @@
@@ -113,7 +113,7 @@ index 0000000000000..297401bd388dd
 +	  module will be called ipts.
 diff --git a/drivers/hid/ipts/Makefile b/drivers/hid/ipts/Makefile
 new file mode 100644
-index 0000000000000..883896f68e6ad
+index 000000000000..883896f68e6a
 --- /dev/null
 +++ b/drivers/hid/ipts/Makefile
 @@ -0,0 +1,16 @@
@@ -135,7 +135,7 @@ index 0000000000000..883896f68e6ad
 +ipts-objs += thread.o
 diff --git a/drivers/hid/ipts/cmd.c b/drivers/hid/ipts/cmd.c
 new file mode 100644
-index 0000000000000..63a4934bbc5fa
+index 000000000000..63a4934bbc5f
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.c
 @@ -0,0 +1,61 @@
@@ -202,7 +202,7 @@ index 0000000000000..63a4934bbc5fa
 +}
 diff --git a/drivers/hid/ipts/cmd.h b/drivers/hid/ipts/cmd.h
 new file mode 100644
-index 0000000000000..2b4079075b642
+index 000000000000..2b4079075b64
 --- /dev/null
 +++ b/drivers/hid/ipts/cmd.h
 @@ -0,0 +1,60 @@
@@ -268,7 +268,7 @@ index 0000000000000..2b4079075b642
 +#endif /* IPTS_CMD_H */
 diff --git a/drivers/hid/ipts/context.h b/drivers/hid/ipts/context.h
 new file mode 100644
-index 0000000000000..ba33259f1f7c5
+index 000000000000..ba33259f1f7c
 --- /dev/null
 +++ b/drivers/hid/ipts/context.h
 @@ -0,0 +1,52 @@
@@ -326,7 +326,7 @@ index 0000000000000..ba33259f1f7c5
 +#endif /* IPTS_CONTEXT_H */
 diff --git a/drivers/hid/ipts/control.c b/drivers/hid/ipts/control.c
 new file mode 100644
-index 0000000000000..5360842d260ba
+index 000000000000..5360842d260b
 --- /dev/null
 +++ b/drivers/hid/ipts/control.c
 @@ -0,0 +1,486 @@
@@ -818,7 +818,7 @@ index 0000000000000..5360842d260ba
 +}
 diff --git a/drivers/hid/ipts/control.h b/drivers/hid/ipts/control.h
 new file mode 100644
-index 0000000000000..26629c5144edb
+index 000000000000..26629c5144ed
 --- /dev/null
 +++ b/drivers/hid/ipts/control.h
 @@ -0,0 +1,126 @@
@@ -950,7 +950,7 @@ index 0000000000000..26629c5144edb
 +#endif /* IPTS_CONTROL_H */
 diff --git a/drivers/hid/ipts/desc.h b/drivers/hid/ipts/desc.h
 new file mode 100644
-index 0000000000000..307438c7c80cd
+index 000000000000..307438c7c80c
 --- /dev/null
 +++ b/drivers/hid/ipts/desc.h
 @@ -0,0 +1,80 @@
@@ -1036,7 +1036,7 @@ index 0000000000000..307438c7c80cd
 +#endif /* IPTS_DESC_H */
 diff --git a/drivers/hid/ipts/eds1.c b/drivers/hid/ipts/eds1.c
 new file mode 100644
-index 0000000000000..7b9f54388a9f6
+index 000000000000..7b9f54388a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.c
 @@ -0,0 +1,104 @@
@@ -1146,7 +1146,7 @@ index 0000000000000..7b9f54388a9f6
 +}
 diff --git a/drivers/hid/ipts/eds1.h b/drivers/hid/ipts/eds1.h
 new file mode 100644
-index 0000000000000..eeeb6575e3e89
+index 000000000000..eeeb6575e3e8
 --- /dev/null
 +++ b/drivers/hid/ipts/eds1.h
 @@ -0,0 +1,35 @@
@@ -1187,7 +1187,7 @@ index 0000000000000..eeeb6575e3e89
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/eds2.c b/drivers/hid/ipts/eds2.c
 new file mode 100644
-index 0000000000000..639940794615d
+index 000000000000..639940794615
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.c
 @@ -0,0 +1,145 @@
@@ -1338,7 +1338,7 @@ index 0000000000000..639940794615d
 +}
 diff --git a/drivers/hid/ipts/eds2.h b/drivers/hid/ipts/eds2.h
 new file mode 100644
-index 0000000000000..064e3716907ab
+index 000000000000..064e3716907a
 --- /dev/null
 +++ b/drivers/hid/ipts/eds2.h
 @@ -0,0 +1,35 @@
@@ -1379,7 +1379,7 @@ index 0000000000000..064e3716907ab
 +			  enum hid_report_type report_type, enum hid_class_request request_type);
 diff --git a/drivers/hid/ipts/hid.c b/drivers/hid/ipts/hid.c
 new file mode 100644
-index 0000000000000..e34a1a4f9fa77
+index 000000000000..e34a1a4f9fa7
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.c
 @@ -0,0 +1,225 @@
@@ -1610,7 +1610,7 @@ index 0000000000000..e34a1a4f9fa77
 +}
 diff --git a/drivers/hid/ipts/hid.h b/drivers/hid/ipts/hid.h
 new file mode 100644
-index 0000000000000..1ebe77447903a
+index 000000000000..1ebe77447903
 --- /dev/null
 +++ b/drivers/hid/ipts/hid.h
 @@ -0,0 +1,24 @@
@@ -1640,7 +1640,7 @@ index 0000000000000..1ebe77447903a
 +#endif /* IPTS_HID_H */
 diff --git a/drivers/hid/ipts/main.c b/drivers/hid/ipts/main.c
 new file mode 100644
-index 0000000000000..fb5b5c13ee3ea
+index 000000000000..fb5b5c13ee3e
 --- /dev/null
 +++ b/drivers/hid/ipts/main.c
 @@ -0,0 +1,126 @@
@@ -1772,7 +1772,7 @@ index 0000000000000..fb5b5c13ee3ea
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/ipts/mei.c b/drivers/hid/ipts/mei.c
 new file mode 100644
-index 0000000000000..1e0395ceae4a4
+index 000000000000..1e0395ceae4a
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.c
 @@ -0,0 +1,188 @@
@@ -1966,7 +1966,7 @@ index 0000000000000..1e0395ceae4a4
 +}
 diff --git a/drivers/hid/ipts/mei.h b/drivers/hid/ipts/mei.h
 new file mode 100644
-index 0000000000000..973bade6b0fdd
+index 000000000000..973bade6b0fd
 --- /dev/null
 +++ b/drivers/hid/ipts/mei.h
 @@ -0,0 +1,66 @@
@@ -2038,7 +2038,7 @@ index 0000000000000..973bade6b0fdd
 +#endif /* IPTS_MEI_H */
 diff --git a/drivers/hid/ipts/receiver.c b/drivers/hid/ipts/receiver.c
 new file mode 100644
-index 0000000000000..977724c728c3e
+index 000000000000..977724c728c3
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.c
 @@ -0,0 +1,251 @@
@@ -2295,7 +2295,7 @@ index 0000000000000..977724c728c3e
 +}
 diff --git a/drivers/hid/ipts/receiver.h b/drivers/hid/ipts/receiver.h
 new file mode 100644
-index 0000000000000..3de7da62d40c1
+index 000000000000..3de7da62d40c
 --- /dev/null
 +++ b/drivers/hid/ipts/receiver.h
 @@ -0,0 +1,16 @@
@@ -2317,7 +2317,7 @@ index 0000000000000..3de7da62d40c1
 +#endif /* IPTS_RECEIVER_H */
 diff --git a/drivers/hid/ipts/resources.c b/drivers/hid/ipts/resources.c
 new file mode 100644
-index 0000000000000..cc14653b2a9f5
+index 000000000000..cc14653b2a9f
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.c
 @@ -0,0 +1,131 @@
@@ -2454,7 +2454,7 @@ index 0000000000000..cc14653b2a9f5
 +}
 diff --git a/drivers/hid/ipts/resources.h b/drivers/hid/ipts/resources.h
 new file mode 100644
-index 0000000000000..2068e13285f0e
+index 000000000000..2068e13285f0
 --- /dev/null
 +++ b/drivers/hid/ipts/resources.h
 @@ -0,0 +1,41 @@
@@ -2501,7 +2501,7 @@ index 0000000000000..2068e13285f0e
 +#endif /* IPTS_RESOURCES_H */
 diff --git a/drivers/hid/ipts/spec-data.h b/drivers/hid/ipts/spec-data.h
 new file mode 100644
-index 0000000000000..e8dd98895a7ee
+index 000000000000..e8dd98895a7e
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-data.h
 @@ -0,0 +1,100 @@
@@ -2607,7 +2607,7 @@ index 0000000000000..e8dd98895a7ee
 +#endif /* IPTS_SPEC_DATA_H */
 diff --git a/drivers/hid/ipts/spec-device.h b/drivers/hid/ipts/spec-device.h
 new file mode 100644
-index 0000000000000..41845f9d90257
+index 000000000000..41845f9d9025
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-device.h
 @@ -0,0 +1,290 @@
@@ -2903,7 +2903,7 @@ index 0000000000000..41845f9d90257
 +#endif /* IPTS_SPEC_DEVICE_H */
 diff --git a/drivers/hid/ipts/spec-hid.h b/drivers/hid/ipts/spec-hid.h
 new file mode 100644
-index 0000000000000..5a58d4a0a610f
+index 000000000000..5a58d4a0a610
 --- /dev/null
 +++ b/drivers/hid/ipts/spec-hid.h
 @@ -0,0 +1,34 @@
@@ -2943,7 +2943,7 @@ index 0000000000000..5a58d4a0a610f
 +#endif /* IPTS_SPEC_HID_H */
 diff --git a/drivers/hid/ipts/thread.c b/drivers/hid/ipts/thread.c
 new file mode 100644
-index 0000000000000..355e92bea26f8
+index 000000000000..355e92bea26f
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.c
 @@ -0,0 +1,84 @@
@@ -3033,7 +3033,7 @@ index 0000000000000..355e92bea26f8
 +}
 diff --git a/drivers/hid/ipts/thread.h b/drivers/hid/ipts/thread.h
 new file mode 100644
-index 0000000000000..1f966b8b32c45
+index 000000000000..1f966b8b32c4
 --- /dev/null
 +++ b/drivers/hid/ipts/thread.h
 @@ -0,0 +1,59 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
@@ -1,7 +1,7 @@
 From fb9f863716e68ca64eb953e6e9414fb4fe86e911 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
-Subject: [PATCH 257/449] SURFACE: iommu: intel: Disable source id verification
+Subject: [PATCH 257/450] SURFACE: iommu: intel: Disable source id verification
  for ITHC
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 16 insertions(+)
 
 diff --git a/drivers/iommu/intel/irq_remapping.c b/drivers/iommu/intel/irq_remapping.c
-index 8bcbfe3d9c722..c78806d35f2b1 100644
+index 8bcbfe3d9c72..c78806d35f2b 100644
 --- a/drivers/iommu/intel/irq_remapping.c
 +++ b/drivers/iommu/intel/irq_remapping.c
 @@ -381,6 +381,22 @@ static int set_msi_sid(struct irte *irte, struct pci_dev *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
@@ -1,7 +1,7 @@
 From 891a44d86f046faa0e12d27abd26aa7a1799a3d5 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
-Subject: [PATCH 258/449] SURFACE: hid: Add support for Intel Touch Host
+Subject: [PATCH 258/450] SURFACE: hid: Add support for Intel Touch Host
  Controller
 
 Based on quo/ithc-linux@34539af4726d.
@@ -49,7 +49,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/hid/ithc/ithc.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index c639bb1f6733c..b148be159c6bf 100644
+index c639bb1f6733..b148be159c6b 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -1442,6 +1442,8 @@ source "drivers/hid/intel-thc-hid/Kconfig"
@@ -62,7 +62,7 @@ index c639bb1f6733c..b148be159c6bf 100644
  
  # USB support may be used with HID disabled
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index b73a1bbd3a1dd..3190ece256267 100644
+index b73a1bbd3a1d..3190ece25626 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
 @@ -178,3 +178,4 @@ obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
@@ -72,7 +72,7 @@ index b73a1bbd3a1dd..3190ece256267 100644
 +obj-$(CONFIG_HID_ITHC)          += ithc/
 diff --git a/drivers/hid/ithc/Kbuild b/drivers/hid/ithc/Kbuild
 new file mode 100644
-index 0000000000000..4937ba1312973
+index 000000000000..4937ba131297
 --- /dev/null
 +++ b/drivers/hid/ithc/Kbuild
 @@ -0,0 +1,6 @@
@@ -84,7 +84,7 @@ index 0000000000000..4937ba1312973
 +
 diff --git a/drivers/hid/ithc/Kconfig b/drivers/hid/ithc/Kconfig
 new file mode 100644
-index 0000000000000..ede7130236096
+index 000000000000..ede713023609
 --- /dev/null
 +++ b/drivers/hid/ithc/Kconfig
 @@ -0,0 +1,12 @@
@@ -102,7 +102,7 @@ index 0000000000000..ede7130236096
 +	  module will be called ithc.
 diff --git a/drivers/hid/ithc/ithc-debug.c b/drivers/hid/ithc/ithc-debug.c
 new file mode 100644
-index 0000000000000..2d8c6afe99663
+index 000000000000..2d8c6afe9966
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-debug.c
 @@ -0,0 +1,149 @@
@@ -257,7 +257,7 @@ index 0000000000000..2d8c6afe99663
 +
 diff --git a/drivers/hid/ithc/ithc-debug.h b/drivers/hid/ithc/ithc-debug.h
 new file mode 100644
-index 0000000000000..38c53d916bdb5
+index 000000000000..38c53d916bdb
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-debug.h
 @@ -0,0 +1,7 @@
@@ -270,7 +270,7 @@ index 0000000000000..38c53d916bdb5
 +
 diff --git a/drivers/hid/ithc/ithc-dma.c b/drivers/hid/ithc/ithc-dma.c
 new file mode 100644
-index 0000000000000..bf4eab33062b0
+index 000000000000..bf4eab33062b
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-dma.c
 @@ -0,0 +1,312 @@
@@ -588,7 +588,7 @@ index 0000000000000..bf4eab33062b0
 +
 diff --git a/drivers/hid/ithc/ithc-dma.h b/drivers/hid/ithc/ithc-dma.h
 new file mode 100644
-index 0000000000000..1749a5819b3e7
+index 000000000000..1749a5819b3e
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-dma.h
 @@ -0,0 +1,47 @@
@@ -641,7 +641,7 @@ index 0000000000000..1749a5819b3e7
 +
 diff --git a/drivers/hid/ithc/ithc-hid.c b/drivers/hid/ithc/ithc-hid.c
 new file mode 100644
-index 0000000000000..065646ab499ef
+index 000000000000..065646ab499e
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-hid.c
 @@ -0,0 +1,207 @@
@@ -854,7 +854,7 @@ index 0000000000000..065646ab499ef
 +
 diff --git a/drivers/hid/ithc/ithc-hid.h b/drivers/hid/ithc/ithc-hid.h
 new file mode 100644
-index 0000000000000..599eb912c8c84
+index 000000000000..599eb912c8c8
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-hid.h
 @@ -0,0 +1,32 @@
@@ -892,7 +892,7 @@ index 0000000000000..599eb912c8c84
 +
 diff --git a/drivers/hid/ithc/ithc-legacy.c b/drivers/hid/ithc/ithc-legacy.c
 new file mode 100644
-index 0000000000000..8883987fb3521
+index 000000000000..8883987fb352
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-legacy.c
 @@ -0,0 +1,254 @@
@@ -1152,7 +1152,7 @@ index 0000000000000..8883987fb3521
 +
 diff --git a/drivers/hid/ithc/ithc-legacy.h b/drivers/hid/ithc/ithc-legacy.h
 new file mode 100644
-index 0000000000000..28d6924620722
+index 000000000000..28d692462072
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-legacy.h
 @@ -0,0 +1,8 @@
@@ -1166,7 +1166,7 @@ index 0000000000000..28d6924620722
 +
 diff --git a/drivers/hid/ithc/ithc-main.c b/drivers/hid/ithc/ithc-main.c
 new file mode 100644
-index 0000000000000..094d878d671b3
+index 000000000000..094d878d671b
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-main.c
 @@ -0,0 +1,438 @@
@@ -1610,7 +1610,7 @@ index 0000000000000..094d878d671b3
 +
 diff --git a/drivers/hid/ithc/ithc-quickspi.c b/drivers/hid/ithc/ithc-quickspi.c
 new file mode 100644
-index 0000000000000..e2d1690b8cf8c
+index 000000000000..e2d1690b8cf8
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-quickspi.c
 @@ -0,0 +1,607 @@
@@ -2223,7 +2223,7 @@ index 0000000000000..e2d1690b8cf8c
 +
 diff --git a/drivers/hid/ithc/ithc-quickspi.h b/drivers/hid/ithc/ithc-quickspi.h
 new file mode 100644
-index 0000000000000..74d882f6b2f0a
+index 000000000000..74d882f6b2f0
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-quickspi.h
 @@ -0,0 +1,39 @@
@@ -2268,7 +2268,7 @@ index 0000000000000..74d882f6b2f0a
 +
 diff --git a/drivers/hid/ithc/ithc-regs.c b/drivers/hid/ithc/ithc-regs.c
 new file mode 100644
-index 0000000000000..c0f13506af205
+index 000000000000..c0f13506af20
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-regs.c
 @@ -0,0 +1,154 @@
@@ -2428,7 +2428,7 @@ index 0000000000000..c0f13506af205
 +
 diff --git a/drivers/hid/ithc/ithc-regs.h b/drivers/hid/ithc/ithc-regs.h
 new file mode 100644
-index 0000000000000..4f541fe533fac
+index 000000000000..4f541fe533fa
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc-regs.h
 @@ -0,0 +1,211 @@
@@ -2645,7 +2645,7 @@ index 0000000000000..4f541fe533fac
 +
 diff --git a/drivers/hid/ithc/ithc.h b/drivers/hid/ithc/ithc.h
 new file mode 100644
-index 0000000000000..aec320d4e945c
+index 000000000000..aec320d4e945
 --- /dev/null
 +++ b/drivers/hid/ithc/ithc.h
 @@ -0,0 +1,89 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
@@ -1,7 +1,7 @@
 From 709259d6d7f40ab55160b4f71db081bc155de92e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
-Subject: [PATCH 259/449] SURFACE: rtc: Add basic support for RTC via Surface
+Subject: [PATCH 259/450] SURFACE: rtc: Add basic support for RTC via Surface
  System Aggregator Module
 
 Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/rtc/rtc-surface.c
 
 diff --git a/drivers/rtc/Kconfig b/drivers/rtc/Kconfig
-index 2933c41c77c88..050eba74d8a28 100644
+index 2933c41c77c8..050eba74d8a2 100644
 --- a/drivers/rtc/Kconfig
 +++ b/drivers/rtc/Kconfig
 @@ -1399,6 +1399,13 @@ config RTC_DRV_NTXEC
@@ -35,7 +35,7 @@ index 2933c41c77c88..050eba74d8a28 100644
  
  config RTC_DRV_ASM9260
 diff --git a/drivers/rtc/Makefile b/drivers/rtc/Makefile
-index 8221bda6e6dca..8932df6e03eda 100644
+index 8221bda6e6dc..8932df6e03ed 100644
 --- a/drivers/rtc/Makefile
 +++ b/drivers/rtc/Makefile
 @@ -183,6 +183,7 @@ obj-$(CONFIG_RTC_DRV_SUN4V)	+= rtc-sun4v.o
@@ -48,7 +48,7 @@ index 8221bda6e6dca..8932df6e03eda 100644
  obj-$(CONFIG_RTC_DRV_TI_K3)	+= rtc-ti-k3.o
 diff --git a/drivers/rtc/rtc-surface.c b/drivers/rtc/rtc-surface.c
 new file mode 100644
-index 0000000000000..f6c17c4e98d5f
+index 000000000000..f6c17c4e98d5
 --- /dev/null
 +++ b/drivers/rtc/rtc-surface.c
 @@ -0,0 +1,129 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
@@ -1,7 +1,7 @@
 From aa93c1208cfd82b5bea46773d7f254acb0b93161 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
-Subject: [PATCH 260/449] SURFACE: platform/surface: aggregator_registry: Add
+Subject: [PATCH 260/450] SURFACE: platform/surface: aggregator_registry: Add
  Surface Laptop 7 (ACPI)
 
 Patchset: surface-sam
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/platform/surface/surface_aggregator_registry.c b/drivers/platform/surface/surface_aggregator_registry.c
-index a594d5fcfcfd1..07b03aa4fa7f9 100644
+index a594d5fcfcfd..07b03aa4fa7f 100644
 --- a/drivers/platform/surface/surface_aggregator_registry.c
 +++ b/drivers/platform/surface/surface_aggregator_registry.c
 @@ -460,6 +460,9 @@ static const struct acpi_device_id ssam_platform_hub_acpi_match[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
@@ -1,7 +1,7 @@
 From b77289658fad0233987b0a25b74cd49cfbee59ba Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
-Subject: [PATCH 261/449] SURFACE: i2c: acpi: Implement RawBytes read access
+Subject: [PATCH 261/450] SURFACE: i2c: acpi: Implement RawBytes read access
 
 Microsoft Surface Pro 4 and Book 1 devices access the MSHW0030 I2C
 device via a generic serial bus operation region and RawBytes read
@@ -58,7 +58,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 34 insertions(+)
 
 diff --git a/drivers/i2c/i2c-core-acpi.c b/drivers/i2c/i2c-core-acpi.c
-index ed90858a27b7b..070c366378115 100644
+index ed90858a27b7..070c36637811 100644
 --- a/drivers/i2c/i2c-core-acpi.c
 +++ b/drivers/i2c/i2c-core-acpi.c
 @@ -662,6 +662,27 @@ static int acpi_gsb_i2c_write_bytes(struct i2c_client *client,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
@@ -1,7 +1,7 @@
 From 47b375f1a8697c576b90fd2f979fd0ed5ed13e6c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
-Subject: [PATCH 262/449] SURFACE: platform/surface: Add driver for Surface
+Subject: [PATCH 262/450] SURFACE: platform/surface: Add driver for Surface
  Book 1 dGPU switch
 
 Add driver exposing the discrete GPU power-switch of the  Microsoft
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/surface/surfacebook1_dgpu_switch.c
 
 diff --git a/drivers/platform/surface/Kconfig b/drivers/platform/surface/Kconfig
-index f775c6ca1ec1d..2075e3852053a 100644
+index f775c6ca1ec1..2075e3852053 100644
 --- a/drivers/platform/surface/Kconfig
 +++ b/drivers/platform/surface/Kconfig
 @@ -149,6 +149,13 @@ config SURFACE_AGGREGATOR_TABLET_SWITCH
@@ -43,7 +43,7 @@ index f775c6ca1ec1d..2075e3852053a 100644
  	tristate "Surface DTX (Detachment System) Driver"
  	depends on SURFACE_AGGREGATOR
 diff --git a/drivers/platform/surface/Makefile b/drivers/platform/surface/Makefile
-index 53344330939bf..7efcd0cdb5329 100644
+index 53344330939b..7efcd0cdb532 100644
 --- a/drivers/platform/surface/Makefile
 +++ b/drivers/platform/surface/Makefile
 @@ -12,6 +12,7 @@ obj-$(CONFIG_SURFACE_AGGREGATOR_CDEV)	+= surface_aggregator_cdev.o
@@ -56,7 +56,7 @@ index 53344330939bf..7efcd0cdb5329 100644
  obj-$(CONFIG_SURFACE_HOTPLUG)		+= surface_hotplug.o
 diff --git a/drivers/platform/surface/surfacebook1_dgpu_switch.c b/drivers/platform/surface/surfacebook1_dgpu_switch.c
 new file mode 100644
-index 0000000000000..68db237734a13
+index 000000000000..68db237734a1
 --- /dev/null
 +++ b/drivers/platform/surface/surfacebook1_dgpu_switch.c
 @@ -0,0 +1,136 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
@@ -1,7 +1,7 @@
 From 9057b820fc7dc213d07a8b6d327e1e1c68633a5f Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
-Subject: [PATCH 263/449] SURFACE: Input: soc_button_array - support AMD
+Subject: [PATCH 263/450] SURFACE: Input: soc_button_array - support AMD
  variant Surface devices
 
 The power button on the AMD variant of the Surface Laptop uses the
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 25 deletions(-)
 
 diff --git a/drivers/input/misc/soc_button_array.c b/drivers/input/misc/soc_button_array.c
-index b8cad415c62ca..43b5d56383e36 100644
+index b8cad415c62c..43b5d56383e3 100644
 --- a/drivers/input/misc/soc_button_array.c
 +++ b/drivers/input/misc/soc_button_array.c
 @@ -540,8 +540,8 @@ static const struct soc_device_data soc_device_MSHW0028 = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
@@ -1,7 +1,7 @@
 From a547c8cb49464a0b9fecbd60cd77746484935257 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
-Subject: [PATCH 264/449] SURFACE: platform/surface: surfacepro3_button: don't
+Subject: [PATCH 264/450] SURFACE: platform/surface: surfacepro3_button: don't
  load on amd variant
 
 The AMD variant of the Surface Laptop report 0 for their OEM platform
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/platform/surface/surfacepro3_button.c b/drivers/platform/surface/surfacepro3_button.c
-index 2755601f979cd..4240c98ca2265 100644
+index 2755601f979c..4240c98ca226 100644
 --- a/drivers/platform/surface/surfacepro3_button.c
 +++ b/drivers/platform/surface/surfacepro3_button.c
 @@ -149,7 +149,8 @@ static int surface_button_resume(struct device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
@@ -1,7 +1,7 @@
 From 7b0832499e64cee4cd12c6204b5ecc26a31e5757 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
-Subject: [PATCH 265/449] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
+Subject: [PATCH 265/450] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
  Surface Go 3 Type-Cover
 
 The touchpad on the Type-Cover of the Surface Go 3 is sometimes not
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index c4d85089d19b1..3d0d35c72189a 100644
+index c4d85089d19b..3d0d35c72189 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
 @@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From 6a684ca4abd51f9093fef9529a0bcca1bd8aad77 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 266/449] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 266/450] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 
 The Type Cover for Microsoft Surface devices supports a special usb
@@ -42,7 +42,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 96 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 4dcb1d43df27a..7f682f63eb600 100644
+index 4dcb1d43df27..7f682f63eb60 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-BACKPORT-SURFACE-hid-multitouch-Add-support-for-surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-BACKPORT-SURFACE-hid-multitouch-Add-support-for-surf.patch
@@ -1,7 +1,7 @@
 From 9e6ee7586c050213e93c81062135144e62c1e586 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 267/449] BACKPORT: SURFACE: hid/multitouch: Add support for
+Subject: [PATCH 267/450] BACKPORT: SURFACE: hid/multitouch: Add support for
  surface pro type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's
@@ -35,7 +35,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 124 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 7f682f63eb600..1d245e9986879 100644
+index 7f682f63eb60..1d245e998687 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -82,6 +82,7 @@ MODULE_LICENSE("GPL");

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
@@ -1,7 +1,7 @@
 From 338c1feda509da0b5ad92ccbf98d67a64d32577d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH 268/449] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
+Subject: [PATCH 268/450] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
  shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 40 insertions(+)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 26657a3b824f8..afa2dc0c00b7a 100644
+index 26657a3b824f..afa2dc0c00b7 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -505,6 +505,9 @@ static void pci_device_shutdown(struct device *dev)
@@ -43,7 +43,7 @@ index 26657a3b824f8..afa2dc0c00b7a 100644
  
  	if (drv && drv->shutdown)
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 25ee85d5e9de6..f15e2c4b9b99a 100644
+index 25ee85d5e9de..f15e2c4b9b99 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -6433,3 +6433,39 @@ static void pci_release_bar0(struct pci_dev *pdev)
@@ -87,7 +87,7 @@ index 25ee85d5e9de6..f15e2c4b9b99a 100644
 +DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x466d, quirk_no_shutdown);  // Thunderbolt 4 NHI
 +DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x46a8, quirk_no_shutdown);  // GPU
 diff --git a/include/linux/pci.h b/include/linux/pci.h
-index b9abf0ca18ca3..9b44196ea21d5 100644
+index b9abf0ca18ca..9b44196ea21d 100644
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
 @@ -495,6 +495,7 @@ struct pci_dev {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
@@ -1,7 +1,7 @@
 From a767dfa17d478fe69f09b3dae70569f9937720b2 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
-Subject: [PATCH 269/449] SURFACE: platform/surface: gpe: Add support for
+Subject: [PATCH 269/450] SURFACE: platform/surface: gpe: Add support for
  Surface Pro 9
 
 Add the lid GPE used by the Surface Pro 9.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 17 insertions(+)
 
 diff --git a/drivers/platform/surface/surface_gpe.c b/drivers/platform/surface/surface_gpe.c
-index b359413903b13..b4496db79f392 100644
+index b359413903b1..b4496db79f39 100644
 --- a/drivers/platform/surface/surface_gpe.c
 +++ b/drivers/platform/surface/surface_gpe.c
 @@ -41,6 +41,11 @@ static const struct property_entry lid_device_props_l4F[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 23fd4dd3d86c127050b9d51d3347dc7126d90b25 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 270/449] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 270/450] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices
@@ -61,7 +61,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
-index ef16d58b29499..a6bad2679a0c5 100644
+index ef16d58b2949..a6bad2679a0c 100644
 --- a/drivers/acpi/scan.c
 +++ b/drivers/acpi/scan.c
 @@ -2205,6 +2205,9 @@ static acpi_status acpi_bus_check_add_2(acpi_handle handle, u32 lvl_not_used,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
@@ -1,7 +1,7 @@
 From a6063ea18b67a0bfddab7c12c0a0978f7e04ce40 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 271/449] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
+Subject: [PATCH 271/450] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
  passthrough mode for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index caeddd92533bb..4d868e7a9bcc3 100644
+index caeddd92533b..4d868e7a9bcc 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -44,6 +44,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From 955d8c6c36e05884ff162e0004db5418fadc8b71 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 272/449] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 272/450] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index 0133405697dc3..9e0763bdc7587 100644
+index 0133405697dc..9e0763bdc758 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -46,6 +46,13 @@ static int tps68470_chip_init(struct device *dev, struct regmap *regmap)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From 9ec4aeed3f7800f8d2c14135c8c7c6aa707e38d9 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 273/449] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 273/450] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/i2c/ov7251.c b/drivers/media/i2c/ov7251.c
-index 27afc3fc01752..28b192c9a5ec5 100644
+index 27afc3fc0175..28b192c9a5ec 100644
 --- a/drivers/media/i2c/ov7251.c
 +++ b/drivers/media/i2c/ov7251.c
 @@ -1053,7 +1053,7 @@ static int ov7251_s_ctrl(struct v4l2_ctrl *ctrl)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From 99e8efdef65492e79854d86924677d60557a7e3c Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 274/449] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 274/450] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/v4l2-core/v4l2-async.c b/drivers/media/v4l2-core/v4l2-async.c
-index 1c08bba9ecb91..57a990d7dc848 100644
+index 1c08bba9ecb9..57a990d7dc84 100644
 --- a/drivers/media/v4l2-core/v4l2-async.c
 +++ b/drivers/media/v4l2-core/v4l2-async.c
 @@ -811,6 +811,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
@@ -35,7 +35,7 @@ index 1c08bba9ecb91..57a990d7dc848 100644
  	 * No reference taken. The reference is held by the device (struct
  	 * v4l2_subdev.dev), and async sub-device does not exist independently
 diff --git a/drivers/media/v4l2-core/v4l2-fwnode.c b/drivers/media/v4l2-core/v4l2-fwnode.c
-index cb153ce42c45d..f11b499e14bba 100644
+index cb153ce42c45..f11b499e14bb 100644
 --- a/drivers/media/v4l2-core/v4l2-fwnode.c
 +++ b/drivers/media/v4l2-core/v4l2-fwnode.c
 @@ -1260,10 +1260,6 @@ int v4l2_async_register_subdev_sensor(struct v4l2_subdev *sd)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From 0ef6f1d99a19b1e6c70831028cf68c2e7417f5d9 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 275/449] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 275/450] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
-index 9e0763bdc7587..0976b267972b9 100644
+index 9e0763bdc758..0976b267972b 100644
 --- a/drivers/platform/x86/intel/int3472/tps68470.c
 +++ b/drivers/platform/x86/intel/int3472/tps68470.c
 @@ -17,7 +17,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From 0d7b9b3d3827e79fe53d798375ff98237e36792b Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 276/449] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 276/450] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/include/linux/mfd/tps68470.h b/include/linux/mfd/tps68470.h
-index 7807fa329db00..2d2abb25b944f 100644
+index 7807fa329db0..2d2abb25b944 100644
 --- a/include/linux/mfd/tps68470.h
 +++ b/include/linux/mfd/tps68470.h
 @@ -34,6 +34,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From 36f2d3f1b3d76a110a136bb5869bfff64163eadd Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 277/449] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 277/450] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/leds/leds-tps68470.c
 
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index df3ca4fc55425..fe21092c09b08 100644
+index df3ca4fc5542..fe21092c09b0 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -1014,6 +1014,18 @@ config LEDS_TPS6105X
@@ -47,7 +47,7 @@ index df3ca4fc55425..fe21092c09b08 100644
  	tristate "LED support for SGI Octane machines"
  	depends on LEDS_CLASS
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index cbb759e92d55a..2baec45017a54 100644
+index cbb759e92d55..2baec45017a5 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -94,6 +94,7 @@ obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
@@ -60,7 +60,7 @@ index cbb759e92d55a..2baec45017a54 100644
  obj-$(CONFIG_LEDS_WM831X_STATUS)	+= leds-wm831x-status.o
 diff --git a/drivers/leds/leds-tps68470.c b/drivers/leds/leds-tps68470.c
 new file mode 100644
-index 0000000000000..35aeb5db89c8f
+index 000000000000..35aeb5db89c8
 --- /dev/null
 +++ b/drivers/leds/leds-tps68470.c
 @@ -0,0 +1,185 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From 6d3ac4de40d057d6471d6cd701fb9cf3359ef496 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 278/449] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 278/450] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
-index 032fbcb981f20..e03a1d8cdcb4e 100644
+index 032fbcb981f2..e03a1d8cdcb4 100644
 --- a/drivers/media/i2c/dw9719.c
 +++ b/drivers/media/i2c/dw9719.c
 @@ -87,6 +87,9 @@ static int dw9719_power_up(struct dw9719_device *dw9719, bool detect)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
@@ -1,7 +1,7 @@
 From 0ef2abe9b2779b8f2f4f27325246bd23d7cd67e0 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
-Subject: [PATCH 279/449] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
+Subject: [PATCH 279/450] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
  missing irq 7 override
 
 This patch is the work of Thomas Gleixner <tglx@linutronix.de> and is
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 17 insertions(+)
 
 diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
-index 9fa321a95eb33..8914a922be2bc 100644
+index 9fa321a95eb3..8914a922be2b 100644
 --- a/arch/x86/kernel/acpi/boot.c
 +++ b/arch/x86/kernel/acpi/boot.c
 @@ -22,6 +22,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
@@ -1,7 +1,7 @@
 From 5a5c235bac8d7ec6c6981994fea02acd345a1fe5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
-Subject: [PATCH 280/449] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
+Subject: [PATCH 280/450] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
  irq 7 override quirk
 
 The 13" version of the Surface Laptop 4 has the same problem as the 15"
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
-index 8914a922be2bc..c43d0a553867c 100644
+index 8914a922be2b..c43d0a553867 100644
 --- a/arch/x86/kernel/acpi/boot.c
 +++ b/arch/x86/kernel/acpi/boot.c
 @@ -1174,12 +1174,19 @@ static void __init mp_config_acpi_legacy_irqs(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
@@ -1,7 +1,7 @@
 From fedbb34be9e93cf7832de4c4659f728aafad28bd Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
-Subject: [PATCH 281/449] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
+Subject: [PATCH 281/450] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
  HW-reduced platforms
 
 The specification [1] allows so-called HW-reduced platforms,
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/acpi/acpi_tad.c b/drivers/acpi/acpi_tad.c
-index 33418dd6768a1..f94bbdc1de061 100644
+index 33418dd6768a..f94bbdc1de06 100644
 --- a/drivers/acpi/acpi_tad.c
 +++ b/drivers/acpi/acpi_tad.c
 @@ -433,6 +433,14 @@ static ssize_t caps_show(struct device *dev, struct device_attribute *attr,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-XUANTIE-riscv-dts-th1520-add-licheepi4a-16g-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-XUANTIE-riscv-dts-th1520-add-licheepi4a-16g-support.patch
@@ -1,7 +1,7 @@
 From b1e1fbbc678399af7322690a23f15c4a13423c05 Mon Sep 17 00:00:00 2001
 From: Han Gao <gaohan@iscas.ac.cn>
 Date: Mon, 24 Nov 2025 20:38:44 +0800
-Subject: [PATCH 282/449] XUANTIE: riscv: dts: th1520: add licheepi4a 16g
+Subject: [PATCH 282/450] XUANTIE: riscv: dts: th1520: add licheepi4a 16g
  support
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/01a510898e41e704bee1fe58a2c0c0a29cb96548
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/riscv/boot/dts/thead/th1520-lichee-pi-4a-16g.dts
 
 diff --git a/arch/riscv/boot/dts/thead/Makefile b/arch/riscv/boot/dts/thead/Makefile
-index b55a17127c2bc..281849e71ccb8 100644
+index b55a17127c2b..281849e71ccb 100644
 --- a/arch/riscv/boot/dts/thead/Makefile
 +++ b/arch/riscv/boot/dts/thead/Makefile
 @@ -1,2 +1,3 @@
@@ -24,7 +24,7 @@ index b55a17127c2bc..281849e71ccb8 100644
 +dtb-$(CONFIG_ARCH_THEAD) += th1520-lichee-pi-4a-16g.dtb
 diff --git a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a-16g.dts b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a-16g.dts
 new file mode 100644
-index 0000000000000..a3a991baf716b
+index 000000000000..a3a991baf716
 --- /dev/null
 +++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a-16g.dts
 @@ -0,0 +1,18 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-XUANTIE-riscv-dts-thead-Add-TH1520-USB-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-XUANTIE-riscv-dts-thead-Add-TH1520-USB-nodes.patch
@@ -1,7 +1,7 @@
 From 869af198b42e3140933fb3b296922b75cf1f72fe Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:51:56 +0800
-Subject: [PATCH 283/449] XUANTIE: riscv: dts: thead: Add TH1520 USB nodes
+Subject: [PATCH 283/450] XUANTIE: riscv: dts: thead: Add TH1520 USB nodes
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/2bd78742752e4f0eb07b421c3b3fc662c953aff0
 
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 23 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index 3a2730e251592..61a4103ef0b84 100644
+index 3a2730e25159..61a4103ef0b8 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -660,6 +660,29 @@ dpu_out_dp1: endpoint@1 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-XUANTIE-riscv-dts-thead-Add-TH1520-I2C-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-XUANTIE-riscv-dts-thead-Add-TH1520-I2C-nodes.patch
@@ -1,7 +1,7 @@
 From ce5f87adae5bf8908ccb085008b8bbece9af40f8 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:50:07 +0800
-Subject: [PATCH 284/449] XUANTIE: riscv: dts: thead: Add TH1520 I2C nodes
+Subject: [PATCH 284/450] XUANTIE: riscv: dts: thead: Add TH1520 I2C nodes
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/ef4ac920a874b013f7609fb1f88fa08bcd445a01
 
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 50 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index 61a4103ef0b84..cbaa7ca524db1 100644
+index 61a4103ef0b8..cbaa7ca524db 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -440,6 +440,36 @@ uart3: serial@ffe7f04000 {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-XUANTIE-riscv-dts-thead-Add-Lichee-Pi-4A-IO-expansio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-XUANTIE-riscv-dts-thead-Add-Lichee-Pi-4A-IO-expansio.patch
@@ -1,7 +1,7 @@
 From 1bfe23ac5d531bc26d0d4f6222cb79d98f922fd0 Mon Sep 17 00:00:00 2001
 From: Emil Renner Berthing <emil.renner.berthing@canonical.com>
 Date: Wed, 13 Dec 2023 01:58:00 +0100
-Subject: [PATCH 285/449] XUANTIE: riscv: dts: thead: Add Lichee Pi 4A IO
+Subject: [PATCH 285/450] XUANTIE: riscv: dts: thead: Add Lichee Pi 4A IO
  expansions
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/b41720b46f4b203f7935d7cf5613c1782949774b
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 109 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
-index e8971cafd1b1c..77f44118375d8 100644
+index e8971cafd1b1..77f44118375d 100644
 --- a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 +++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 @@ -95,6 +95,76 @@ hdmi_con_in: endpoint {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-XUANTIE-riscv-dts-thead-Enable-Lichee-Pi-4A-USB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-XUANTIE-riscv-dts-thead-Enable-Lichee-Pi-4A-USB.patch
@@ -1,7 +1,7 @@
 From 120ed48efda7f7e335e0e6debece1103de3231c4 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:56:37 +0800
-Subject: [PATCH 286/449] XUANTIE: riscv: dts: thead: Enable Lichee Pi 4A USB
+Subject: [PATCH 286/450] XUANTIE: riscv: dts: thead: Enable Lichee Pi 4A USB
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/9f2a969ac4596062d55412ee6b7f25a6774b5358
 
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
-index 77f44118375d8..748ab9dea6991 100644
+index 77f44118375d..748ab9dea699 100644
 --- a/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 +++ b/arch/riscv/boot/dts/thead/th1520-lichee-pi-4a.dts
 @@ -4,6 +4,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-REVYOS-HACK-riscv-dts-th1520-rename-thead-to-xuantie.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-REVYOS-HACK-riscv-dts-th1520-rename-thead-to-xuantie.patch
@@ -1,7 +1,7 @@
 From fa162a733e1f2a34f699a8feb9f67b08feb7b81d Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 14 May 2025 08:16:15 +0800
-Subject: [PATCH 287/449] REVYOS: HACK: riscv: dts: th1520: rename thead to
+Subject: [PATCH 287/450] REVYOS: HACK: riscv: dts: th1520: rename thead to
  xuantie
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/fe55f7b77b81749bfd2a5eac9328e016f299d7a6
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index cbaa7ca524db1..b3ebd88bdcea0 100644
+index cbaa7ca524db..b3ebd88bdcea 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -286,7 +286,7 @@ stmmac_axi_config: stmmac-axi-config {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-REVYOS-HACK-riscv-dts-th1520-add-xuantie-th1520-mbox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-REVYOS-HACK-riscv-dts-th1520-add-xuantie-th1520-mbox.patch
@@ -1,7 +1,7 @@
 From d240ca25329c75269b839e2ab6d110506a11287a Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 14 May 2025 08:27:18 +0800
-Subject: [PATCH 288/449] REVYOS: HACK: riscv: dts: th1520: add
+Subject: [PATCH 288/450] REVYOS: HACK: riscv: dts: th1520: add
  xuantie,th1520-mbox-r
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/1e57185ba18320bb4fb747a6089f9404f970964c
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 18 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/thead/th1520.dtsi b/arch/riscv/boot/dts/thead/th1520.dtsi
-index b3ebd88bdcea0..9e58cf7d45dcd 100644
+index b3ebd88bdcea..9e58cf7d45dc 100644
 --- a/arch/riscv/boot/dts/thead/th1520.dtsi
 +++ b/arch/riscv/boot/dts/thead/th1520.dtsi
 @@ -292,6 +292,24 @@ aon: aon {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-FROMEXT-cjktty-6.16.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-FROMEXT-cjktty-6.16.patch.patch
@@ -1,7 +1,7 @@
 From a12f580095203f065051704f30f197abf6330e31 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 3 Nov 2025 17:49:44 +0800
-Subject: [PATCH 289/449] FROMEXT: cjktty-6.16.patch
+Subject: [PATCH 289/450] FROMEXT: cjktty-6.16.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>
@@ -42,7 +42,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 lib/fonts/font_cjk_32x32.h
 
 diff --git a/drivers/tty/vt/selection.c b/drivers/tty/vt/selection.c
-index 07d3b93975d37..214ec3717ae14 100644
+index 07d3b93975d3..214ec3717ae1 100644
 --- a/drivers/tty/vt/selection.c
 +++ b/drivers/tty/vt/selection.c
 @@ -242,6 +242,8 @@ static int vc_selection_store_chars(struct vc_data *vc, bool unicode)
@@ -55,7 +55,7 @@ index 07d3b93975d37..214ec3717ae14 100644
  	vc_sel.buf_len = bp - vc_sel.buffer;
  
 diff --git a/drivers/tty/vt/vt.c b/drivers/tty/vt/vt.c
-index 6e0089b85c270..ff54da4ffd820 100644
+index 6e0089b85c27..ff54da4ffd82 100644
 --- a/drivers/tty/vt/vt.c
 +++ b/drivers/tty/vt/vt.c
 @@ -302,6 +302,14 @@ static void con_putc(struct vc_data *vc, u16 ca, unsigned int y, unsigned int x)
@@ -248,7 +248,7 @@ index 6e0089b85c270..ff54da4ffd820 100644
  		c |= 0x100;
  	return c;
 diff --git a/drivers/video/fbdev/core/bitblit.c b/drivers/video/fbdev/core/bitblit.c
-index dc5ad3fcc7be4..9f34a338975fc 100644
+index dc5ad3fcc7be..9f34a338975f 100644
 --- a/drivers/video/fbdev/core/bitblit.c
 +++ b/drivers/video/fbdev/core/bitblit.c
 @@ -16,6 +16,7 @@
@@ -365,7 +365,7 @@ index dc5ad3fcc7be4..9f34a338975fc 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
-index 7453377f34336..4b9a8e0f9001e 100644
+index 7453377f3433..4b9a8e0f9001 100644
 --- a/drivers/video/fbdev/core/fbcon.c
 +++ b/drivers/video/fbdev/core/fbcon.c
 @@ -1083,7 +1083,7 @@ static void fbcon_init(struct vc_data *vc, bool init)
@@ -447,7 +447,7 @@ index 7453377f34336..4b9a8e0f9001e 100644
  
  	updatescrollmode(p, info, vc);
 diff --git a/drivers/video/fbdev/core/fbcon.h b/drivers/video/fbdev/core/fbcon.h
-index 7e21c8b336692..b30323a0c4620 100644
+index 7e21c8b33669..b30323a0c462 100644
 --- a/drivers/video/fbdev/core/fbcon.h
 +++ b/drivers/video/fbdev/core/fbcon.h
 @@ -81,10 +81,12 @@ struct fbcon_ops {
@@ -474,7 +474,7 @@ index 7e21c8b336692..b30323a0c4620 100644
 +
  #endif /* _VIDEO_FBCON_H */
 diff --git a/drivers/video/fbdev/core/fbcon_ccw.c b/drivers/video/fbdev/core/fbcon_ccw.c
-index 89ef4ba7e8672..ba76f80617e12 100644
+index 89ef4ba7e867..ba76f80617e1 100644
 --- a/drivers/video/fbdev/core/fbcon_ccw.c
 +++ b/drivers/video/fbdev/core/fbcon_ccw.c
 @@ -18,6 +18,8 @@
@@ -505,7 +505,7 @@ index 89ef4ba7e8672..ba76f80617e12 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_cw.c b/drivers/video/fbdev/core/fbcon_cw.c
-index b9dac7940fb77..f2711c7faf059 100644
+index b9dac7940fb7..f2711c7faf05 100644
 --- a/drivers/video/fbdev/core/fbcon_cw.c
 +++ b/drivers/video/fbdev/core/fbcon_cw.c
 @@ -18,6 +18,8 @@
@@ -536,7 +536,7 @@ index b9dac7940fb77..f2711c7faf059 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/drivers/video/fbdev/core/fbcon_rotate.c b/drivers/video/fbdev/core/fbcon_rotate.c
-index ec3c883400f7b..d549b0880862e 100644
+index ec3c883400f7..d549b0880862 100644
 --- a/drivers/video/fbdev/core/fbcon_rotate.c
 +++ b/drivers/video/fbdev/core/fbcon_rotate.c
 @@ -14,10 +14,74 @@
@@ -643,7 +643,7 @@ index ec3c883400f7b..d549b0880862e 100644
  	return err;
  }
 diff --git a/drivers/video/fbdev/core/fbcon_ud.c b/drivers/video/fbdev/core/fbcon_ud.c
-index 0af7913a2abdc..e2da1f6340809 100644
+index 0af7913a2abd..e2da1f634080 100644
 --- a/drivers/video/fbdev/core/fbcon_ud.c
 +++ b/drivers/video/fbdev/core/fbcon_ud.c
 @@ -18,6 +18,8 @@
@@ -683,7 +683,7 @@ index 0af7913a2abdc..e2da1f6340809 100644
  	if (ops->cursor_state.image.data != src ||
  	    ops->cursor_reset) {
 diff --git a/include/linux/font.h b/include/linux/font.h
-index 81caffd51bb49..c073140557d74 100644
+index 81caffd51bb4..c073140557d7 100644
 --- a/include/linux/font.h
 +++ b/include/linux/font.h
 @@ -35,6 +35,8 @@ struct font_desc {
@@ -707,7 +707,7 @@ index 81caffd51bb49..c073140557d74 100644
  /* Find a font with a specific name */
  
 diff --git a/lib/fonts/Kconfig b/lib/fonts/Kconfig
-index ae59b5b4e225e..dd7ab91926b74 100644
+index ae59b5b4e225..dd7ab91926b7 100644
 --- a/lib/fonts/Kconfig
 +++ b/lib/fonts/Kconfig
 @@ -128,6 +128,26 @@ config FONT_6x8
@@ -747,7 +747,7 @@ index ae59b5b4e225e..dd7ab91926b74 100644
  
  endif # FONT_SUPPORT
 diff --git a/lib/fonts/Makefile b/lib/fonts/Makefile
-index e16f68492174a..3e1091d15bbb7 100644
+index e16f68492174..3e1091d15bbb 100644
 --- a/lib/fonts/Makefile
 +++ b/lib/fonts/Makefile
 @@ -16,6 +16,8 @@ font-objs-$(CONFIG_FONT_MINI_4x6)  += font_mini_4x6.o
@@ -761,7 +761,7 @@ index e16f68492174a..3e1091d15bbb7 100644
  
 diff --git a/lib/fonts/font_cjk_16x16.c b/lib/fonts/font_cjk_16x16.c
 new file mode 100644
-index 0000000000000..a0c56bd9f65b2
+index 000000000000..a0c56bd9f65b
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.c
 @@ -0,0 +1,27 @@
@@ -794,7 +794,7 @@ index 0000000000000..a0c56bd9f65b2
 +};
 diff --git a/lib/fonts/font_cjk_16x16.h b/lib/fonts/font_cjk_16x16.h
 new file mode 100644
-index 0000000000000..54e7e0db4a5e7
+index 000000000000..54e7e0db4a5e
 --- /dev/null
 +++ b/lib/fonts/font_cjk_16x16.h
 @@ -0,0 +1,196609 @@
@@ -197409,7 +197409,7 @@ index 0000000000000..54e7e0db4a5e7
 +0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 diff --git a/lib/fonts/font_cjk_32x32.c b/lib/fonts/font_cjk_32x32.c
 new file mode 100644
-index 0000000000000..88ba3f2783f54
+index 000000000000..88ba3f2783f5
 --- /dev/null
 +++ b/lib/fonts/font_cjk_32x32.c
 @@ -0,0 +1,27 @@
@@ -197442,9 +197442,9 @@ index 0000000000000..88ba3f2783f54
 +};
 diff --git a/lib/fonts/font_cjk_32x32.h b/lib/fonts/font_cjk_32x32.h
 new file mode 100644
-index 0000000000000..e69de29bb2d1d
+index 000000000000..e69de29bb2d1
 diff --git a/lib/fonts/fonts.c b/lib/fonts/fonts.c
-index 47e34950b665c..9e3ac0d00f49c 100644
+index 47e34950b665..9e3ac0d00f49 100644
 --- a/lib/fonts/fonts.c
 +++ b/lib/fonts/fonts.c
 @@ -60,6 +60,12 @@ static const struct font_desc *fonts[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From f7082f60edff70614e0cad6b4de3299290bb09da Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 291/449] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 291/450] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 335f7e2f4ce55..fa30523b1a7c4 100644
+index 335f7e2f4ce5..fa30523b1a7c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -631,13 +631,8 @@ module_param_named(timeout_period, amdgpu_watchdog_timer.period, uint, 0644);
@@ -54,7 +54,7 @@ index 335f7e2f4ce55..fa30523b1a7c4 100644
  module_param_named(cik_support, amdgpu_cik_support, int, 0444);
  #endif
 diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
-index 9c8907bc61d9f..8ed93481f714c 100644
+index 9c8907bc61d9..8ed93481f714 100644
 --- a/drivers/gpu/drm/radeon/radeon_drv.c
 +++ b/drivers/gpu/drm/radeon/radeon_drv.c
 @@ -241,12 +241,12 @@ module_param_named(uvd, radeon_uvd, int, 0444);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 14837632938715bd6d9402127225a86874f724e2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 292/449] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 292/450] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 24 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
-index 2b7aba22ecc19..d455a752f3ff1 100644
+index 2b7aba22ecc1..d455a752f3ff 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v7_0.c
 @@ -2125,6 +2125,13 @@ static void gfx_v7_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -48,7 +48,7 @@ index 2b7aba22ecc19..d455a752f3ff1 100644
  	/* Then send the real EOP event down the pipe. */
  	amdgpu_ring_write(ring, PACKET3(PACKET3_EVENT_WRITE_EOP, 4));
 diff --git a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
-index 8a81713d97aac..61b999f2e8c80 100644
+index 8a81713d97aa..61b999f2e8c8 100644
 --- a/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 +++ b/drivers/gpu/drm/amd/amdgpu/gfx_v8_0.c
 @@ -6113,6 +6113,13 @@ static void gfx_v8_0_ring_emit_fence_gfx(struct amdgpu_ring *ring, u64 addr,
@@ -74,7 +74,7 @@ index 8a81713d97aac..61b999f2e8c80 100644
  	/* Then send the real EOP event down the pipe:
  	 * EVENT_WRITE_EOP - flush caches, send int */
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 0b804e951b7b6..7e7f6248b63a6 100644
+index 0b804e951b7b..7e7f6248b63a 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -3543,6 +3543,13 @@ void cik_fence_gfx_ring_emit(struct radeon_device *rdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From 7e0823bdcdba4ce1675c6afc0f074b0769f1d77c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 293/449] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 293/450] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index eea8421955134..ea37d120113d1 100644
+index eea842195513..ea37d120113d 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -199,7 +199,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From 982ef4645f08e775dd01cef31f3485a9aa205539 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 294/449] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 294/450] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_ethtool.c b/drivers/net/ethernet/phytium/phytmac_ethtool.c
-index 26478b090ced0..5e8b670d1a205 100644
+index 26478b090ced..5e8b670d1a20 100644
 --- a/drivers/net/ethernet/phytium/phytmac_ethtool.c
 +++ b/drivers/net/ethernet/phytium/phytmac_ethtool.c
 @@ -176,7 +176,7 @@ static int phytmac_set_ringparam(struct net_device *ndev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From 7571feb141142ad27f7105df6365b7dabe7468a0 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 295/449] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 295/450] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_platform.c b/drivers/net/ethernet/phytium/phytmac_platform.c
-index d958ca1f168bb..3724936cc826e 100644
+index d958ca1f168b..3724936cc826 100644
 --- a/drivers/net/ethernet/phytium/phytmac_platform.c
 +++ b/drivers/net/ethernet/phytium/phytmac_platform.c
 @@ -313,14 +313,12 @@ static int phytmac_plat_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-net-stmmac-dwmac-phytium-convert-to-use-phy_i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-net-stmmac-dwmac-phytium-convert-to-use-phy_i.patch
@@ -1,7 +1,7 @@
 From 3aa3bcb5d87d9d80e3523d8274ee5ae91aac59e6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 15 Oct 2025 16:26:32 +0800
-Subject: [PATCH 296/449] AOSCOS: net: stmmac: dwmac-phytium: convert to use
+Subject: [PATCH 296/450] AOSCOS: net: stmmac: dwmac-phytium: convert to use
  phy_interface
 
 Follow upstream changes post-6.17 and replace mac_interface with
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index ea37d120113d1..d67a93c3c0ae9 100644
+index ea37d120113d..d67a93c3c0ae 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -86,9 +86,9 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-stmmac-stmmac-phytium-fix-build-against-post-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-stmmac-stmmac-phytium-fix-build-against-post-.patch
@@ -1,7 +1,7 @@
 From ba76228e3e94b69481d8f37994d3ae50c3d68774 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 5 Nov 2025 10:58:36 +0800
-Subject: [PATCH 297/449] AOSCOS: stmmac: stmmac-phytium: fix build against
+Subject: [PATCH 297/450] AOSCOS: stmmac: stmmac-phytium: fix build against
  post-6.18 net-next
 
 Since commit "net: stmmac: replace has_xxxx with core_type" from post-
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
-index d67a93c3c0ae9..36ef7b535983b 100644
+index d67a93c3c0ae..36ef7b535983 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
 @@ -106,7 +106,7 @@ static int phytium_dwmac_probe(struct platform_device *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From b56b4f17fca5d3dd795b8ab25766d4f835e77038 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 298/449] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 298/450] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
-index a9021c524afbf..429ac5492ab4d 100644
+index a9021c524afb..429ac5492ab4 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-quartz64-a.dts
 @@ -795,6 +795,10 @@ &usb_host0_xhci {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 91ff0eb854d87f2b26ef8d7e43224da5e78ffa90 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 299/449] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 299/450] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/perf/hisilicon/Makefile b/drivers/perf/hisilicon/Makefile
-index 186be3d02238b..1009d4f616aa4 100644
+index 186be3d02238..1009d4f616aa 100644
 --- a/drivers/perf/hisilicon/Makefile
 +++ b/drivers/perf/hisilicon/Makefile
 @@ -1,6 +1,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-loongarch-re-introduce-add_numamem_region-ini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-loongarch-re-introduce-add_numamem_region-ini.patch
@@ -1,7 +1,7 @@
 From e9483bbfe1623961e54dbe1a19ce809646a45a6a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Nov 2025 22:21:05 +0800
-Subject: [PATCH 300/449] AOSCOS: loongarch: re-introduce add_numamem_region(),
+Subject: [PATCH 300/450] AOSCOS: loongarch: re-introduce add_numamem_region(),
  init_node_memblock()
 
 This is a partial revert for commit acf5de1b23b0 ("LoongArch: Fix NUMA
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 67 insertions(+)
 
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index 8b89898e20df1..3efd2b4fe37bb 100644
+index 8b89898e20df..3efd2b4fe37b 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -158,8 +158,75 @@ static void __init node_mem_init(unsigned int node)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From 8623655790be5adb3d61181088f211cf92f6166e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 301/449] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 301/450] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the
@@ -32,7 +32,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 37 insertions(+)
 
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index 860a3bc030e06..b4db71690c70e 100644
+index 860a3bc030e0..b4db71690c70 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -98,6 +98,23 @@ static void __init init_screen_info(void)
@@ -68,7 +68,7 @@ index 860a3bc030e06..b4db71690c70e 100644
  	early_memunmap(config_tables, efi_nr_tables * size);
  
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index 8ab1ffedc52c5..d870e9e189736 100644
+index 8ab1ffedc52c..d870e9e18973 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -19,6 +19,7 @@ void __init memblock_init(void)
@@ -80,7 +80,7 @@ index 8ab1ffedc52c5..d870e9e189736 100644
  		mem_size = md->num_pages << EFI_PAGE_SHIFT;
  
 diff --git a/drivers/firmware/efi/libstub/loongarch.c b/drivers/firmware/efi/libstub/loongarch.c
-index 3782d0a187d1f..8bea96492ef21 100644
+index 3782d0a187d1..8bea96492ef2 100644
 --- a/drivers/firmware/efi/libstub/loongarch.c
 +++ b/drivers/firmware/efi/libstub/loongarch.c
 @@ -23,6 +23,8 @@ struct exit_boot_struct {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From 68ba575229c0eb4d56f247aaaf5368f172b4381e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 302/449] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 302/450] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/loongarch/kernel/legacy_boot.h
 
 diff --git a/arch/loongarch/kernel/Makefile b/arch/loongarch/kernel/Makefile
-index 001924877772f..53ad38c9c98f5 100644
+index 001924877772..53ad38c9c98f 100644
 --- a/arch/loongarch/kernel/Makefile
 +++ b/arch/loongarch/kernel/Makefile
 @@ -80,3 +80,5 @@ obj-$(CONFIG_UPROBES)		+= uprobes.o
@@ -51,7 +51,7 @@ index 001924877772f..53ad38c9c98f5 100644
 +
 +obj-y				+= legacy_boot.o
 diff --git a/arch/loongarch/kernel/efi.c b/arch/loongarch/kernel/efi.c
-index b4db71690c70e..999a7a75e0ace 100644
+index b4db71690c70..999a7a75e0ac 100644
 --- a/arch/loongarch/kernel/efi.c
 +++ b/arch/loongarch/kernel/efi.c
 @@ -25,6 +25,8 @@
@@ -73,7 +73,7 @@ index b4db71690c70e..999a7a75e0ace 100644
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
 new file mode 100644
-index 0000000000000..30c01c8b22a0a
+index 000000000000..30c01c8b22a0
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -0,0 +1,297 @@
@@ -376,7 +376,7 @@ index 0000000000000..30c01c8b22a0a
 +}
 diff --git a/arch/loongarch/kernel/legacy_boot.h b/arch/loongarch/kernel/legacy_boot.h
 new file mode 100644
-index 0000000000000..6d3a36ebaab71
+index 000000000000..6d3a36ebaab7
 --- /dev/null
 +++ b/arch/loongarch/kernel/legacy_boot.h
 @@ -0,0 +1,18 @@
@@ -399,7 +399,7 @@ index 0000000000000..6d3a36ebaab71
 +
 +#endif /* __LEGACY_BOOT_H_ */
 diff --git a/arch/loongarch/kernel/mem.c b/arch/loongarch/kernel/mem.c
-index d870e9e189736..86156ffdee5dc 100644
+index d870e9e18973..86156ffdee5d 100644
 --- a/arch/loongarch/kernel/mem.c
 +++ b/arch/loongarch/kernel/mem.c
 @@ -10,6 +10,8 @@
@@ -422,7 +422,7 @@ index d870e9e189736..86156ffdee5dc 100644
  
  	/* Reserve the first 2MB */
 diff --git a/arch/loongarch/kernel/numa.c b/arch/loongarch/kernel/numa.c
-index 3efd2b4fe37bb..38a10744e9a52 100644
+index 3efd2b4fe37b..38a10744e9a5 100644
 --- a/arch/loongarch/kernel/numa.c
 +++ b/arch/loongarch/kernel/numa.c
 @@ -27,6 +27,8 @@
@@ -450,7 +450,7 @@ index 3efd2b4fe37bb..38a10744e9a52 100644
  		return -EINVAL;
  
 diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
-index 2b260d15b2e25..1fe78a174f09d 100644
+index 2b260d15b2e2..1fe78a174f09 100644
 --- a/arch/loongarch/kernel/setup.c
 +++ b/arch/loongarch/kernel/setup.c
 @@ -49,6 +49,8 @@
@@ -471,7 +471,7 @@ index 2b260d15b2e25..1fe78a174f09d 100644
  	pagetable_init();
  	bootcmdline_init(cmdline_p);
 diff --git a/arch/loongarch/kernel/smp.c b/arch/loongarch/kernel/smp.c
-index 4513b15b72691..5805cce43ac73 100644
+index 4513b15b7269..5805cce43ac7 100644
 --- a/arch/loongarch/kernel/smp.c
 +++ b/arch/loongarch/kernel/smp.c
 @@ -36,6 +36,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From 7933bdecb519d2d3f39ed1d51a83db643d6c8084 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 303/449] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 303/450] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 321 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 7376840fa9f78..1f5905e0acffa 100644
+index 7376840fa9f7..1f5905e0acff 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -45,6 +45,11 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -39,7 +39,7 @@ index 7376840fa9f78..1f5905e0acffa 100644
  
  #define ACPI_TABLE_UPGRADE_MAX_PHYS ARCH_LOW_ADDRESS_LIMIT
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 30c01c8b22a0a..841d8db85a3cb 100644
+index 30c01c8b22a0..841d8db85a3c 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -1,7 +1,13 @@
@@ -383,7 +383,7 @@ index 30c01c8b22a0a..841d8db85a3cb 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/tables.c b/drivers/acpi/tables.c
-index 57fc8bc56166b..21e7555260f24 100644
+index 57fc8bc56166..21e7555260f2 100644
 --- a/drivers/acpi/tables.c
 +++ b/drivers/acpi/tables.c
 @@ -693,6 +693,7 @@ acpi_status acpi_os_table_override(struct acpi_table_header *existing_table,
@@ -403,7 +403,7 @@ index 57fc8bc56166b..21e7555260f24 100644
  
  int __init acpi_table_init(void)
 diff --git a/include/linux/acpi.h b/include/linux/acpi.h
-index 5ff5d99f6ead5..e8a9c6a5e6b58 100644
+index 5ff5d99f6ead..e8a9c6a5e6b5 100644
 --- a/include/linux/acpi.h
 +++ b/include/linux/acpi.h
 @@ -779,6 +779,16 @@ const char *acpi_get_subsystem_id(acpi_handle handle);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From df6e2e6bc10907454161da572d96f6955fd43201 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 304/449] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 304/450] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root
@@ -32,7 +32,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 29 insertions(+), 1 deletion(-)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index 1f5905e0acffa..fcf2cc1b37da1 100644
+index 1f5905e0acff..fcf2cc1b37da 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -49,6 +49,8 @@ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
@@ -45,7 +45,7 @@ index 1f5905e0acffa..fcf2cc1b37da1 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 841d8db85a3cb..7043bfd0399d6 100644
+index 841d8db85a3c..7043bfd0399d 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -60,7 +60,7 @@ struct loongarch_bpi_info __initdata loongarch_bpi_info = {
@@ -86,7 +86,7 @@ index 841d8db85a3cb..7043bfd0399d6 100644
  	return have_bpi;
  }
 diff --git a/drivers/acpi/pci_root.c b/drivers/acpi/pci_root.c
-index 961fdfd0e5a13..ac4531fba5710 100644
+index 961fdfd0e5a1..ac4531fba571 100644
 --- a/drivers/acpi/pci_root.c
 +++ b/drivers/acpi/pci_root.c
 @@ -917,6 +917,7 @@ int acpi_pci_probe_root_resources(struct acpi_pci_root_info *info)
@@ -98,7 +98,7 @@ index 961fdfd0e5a13..ac4531fba5710 100644
  				acpi_pci_root_remap_iospace(device,
  						entry);
 diff --git a/include/linux/pci-acpi.h b/include/linux/pci-acpi.h
-index 078225b514d48..1c22ca4ec794c 100644
+index 078225b514d4..1c22ca4ec794 100644
 --- a/include/linux/pci-acpi.h
 +++ b/include/linux/pci-acpi.h
 @@ -133,6 +133,10 @@ static inline void pci_acpi_remove_edr_notifier(struct pci_dev *pdev) { }

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From a0629d137233f49d7446846890c5c7d82303d018 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 305/449] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 305/450] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 49 insertions(+)
 
 diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
-index fcf2cc1b37da1..fa0202d02f97b 100644
+index fcf2cc1b37da..fa0202d02f97 100644
 --- a/arch/loongarch/include/asm/acpi.h
 +++ b/arch/loongarch/include/asm/acpi.h
 @@ -51,6 +51,8 @@ extern void acpi_arch_os_table_override (struct acpi_table_header *existing_tabl
@@ -43,7 +43,7 @@ index fcf2cc1b37da1..fa0202d02f97b 100644
  #endif /* !CONFIG_ACPI */
  
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 7043bfd0399d6..3ec69ffd8b942 100644
+index 7043bfd0399d..3ec69ffd8b94 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -617,6 +617,53 @@ void acpi_arch_pci_probe_root_dev_filter(struct resource_entry *entry)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From dc9ffdd81f6252c8d3cfaeb7dcd7a89775f0c573 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 306/449] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 306/450] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory
@@ -45,7 +45,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 27 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 3ec69ffd8b942..2888e2b9fb456 100644
+index 3ec69ffd8b94..2888e2b9fb45 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -46,6 +46,19 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From ed6976264dd72fd0b46354b3d5f9606399f41fe9 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 307/449] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 307/450] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+)
 
 diff --git a/arch/loongarch/kernel/legacy_boot.c b/arch/loongarch/kernel/legacy_boot.c
-index 2888e2b9fb456..204b33109f37d 100644
+index 2888e2b9fb45..204b33109f37 100644
 --- a/arch/loongarch/kernel/legacy_boot.c
 +++ b/arch/loongarch/kernel/legacy_boot.c
 @@ -59,6 +59,16 @@ enum bpi_mem_type {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From 51f21a5c558e116a62d3034c5fc2c529943c0c41 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 308/449] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 308/450] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/systable.h
 
 diff --git a/arch/loongarch/Kbuild b/arch/loongarch/Kbuild
-index beb8499dd8ed8..42a6b4c6adbe3 100644
+index beb8499dd8ed..42a6b4c6adbe 100644
 --- a/arch/loongarch/Kbuild
 +++ b/arch/loongarch/Kbuild
 @@ -7,3 +7,5 @@ obj-$(CONFIG_KVM) += kvm/
@@ -52,7 +52,7 @@ index beb8499dd8ed8..42a6b4c6adbe3 100644
 +obj-y += ow_syscall/
 diff --git a/arch/loongarch/ow_syscall/Kbuild b/arch/loongarch/ow_syscall/Kbuild
 new file mode 100644
-index 0000000000000..65cd78995176f
+index 000000000000..65cd78995176
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kbuild
 @@ -0,0 +1,38 @@
@@ -96,7 +96,7 @@ index 0000000000000..65cd78995176f
 +clean-files += kernel_feature.h feat_test.syms module_version.h
 diff --git a/arch/loongarch/ow_syscall/LICENSE b/arch/loongarch/ow_syscall/LICENSE
 new file mode 100644
-index 0000000000000..d159169d10508
+index 000000000000..d159169d1050
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/LICENSE
 @@ -0,0 +1,339 @@
@@ -441,7 +441,7 @@ index 0000000000000..d159169d10508
 +Public License instead of this License.
 diff --git a/arch/loongarch/ow_syscall/Makefile b/arch/loongarch/ow_syscall/Makefile
 new file mode 100644
-index 0000000000000..e975aa1cdb7af
+index 000000000000..e975aa1cdb7a
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Makefile
 @@ -0,0 +1,37 @@
@@ -484,7 +484,7 @@ index 0000000000000..e975aa1cdb7af
 +dev: modprobe-remove dkms-remove dkms-add dkms-build dkms-install modprobe-install
 diff --git a/arch/loongarch/ow_syscall/README.md b/arch/loongarch/ow_syscall/README.md
 new file mode 100644
-index 0000000000000..25c6757983896
+index 000000000000..25c675798389
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/README.md
 @@ -0,0 +1,77 @@
@@ -567,14 +567,14 @@ index 0000000000000..25c6757983896
 +```
 diff --git a/arch/loongarch/ow_syscall/VERSION b/arch/loongarch/ow_syscall/VERSION
 new file mode 100644
-index 0000000000000..17e51c385ea38
+index 000000000000..17e51c385ea3
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/VERSION
 @@ -0,0 +1 @@
 +0.1.1
 diff --git a/arch/loongarch/ow_syscall/dkms.conf.in b/arch/loongarch/ow_syscall/dkms.conf.in
 new file mode 100644
-index 0000000000000..ad9aec128e6f8
+index 000000000000..ad9aec128e6f
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/dkms.conf.in
 @@ -0,0 +1,11 @@
@@ -591,7 +591,7 @@ index 0000000000000..ad9aec128e6f8
 +DEST_MODULE_LOCATION[0]="/extra"
 diff --git a/arch/loongarch/ow_syscall/feat_test.c b/arch/loongarch/ow_syscall/feat_test.c
 new file mode 100644
-index 0000000000000..5fc3b8709364d
+index 000000000000..5fc3b8709364
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/feat_test.c
 @@ -0,0 +1,16 @@
@@ -613,7 +613,7 @@ index 0000000000000..5fc3b8709364d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.c b/arch/loongarch/ow_syscall/fsstat.c
 new file mode 100644
-index 0000000000000..1f5c336f52ec1
+index 000000000000..1f5c336f52ec
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.c
 @@ -0,0 +1,87 @@
@@ -706,7 +706,7 @@ index 0000000000000..1f5c336f52ec1
 +#endif
 diff --git a/arch/loongarch/ow_syscall/fsstat.h b/arch/loongarch/ow_syscall/fsstat.h
 new file mode 100644
-index 0000000000000..fa40914afa414
+index 000000000000..fa40914afa41
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/fsstat.h
 @@ -0,0 +1,4 @@
@@ -716,7 +716,7 @@ index 0000000000000..fa40914afa414
 +extern int (*p_vfs_fstat)(int fd, struct kstat *stat);
 diff --git a/arch/loongarch/ow_syscall/la_ow_syscall_main.c b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 new file mode 100644
-index 0000000000000..4ae3fc6d70785
+index 000000000000..4ae3fc6d7078
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/la_ow_syscall_main.c
 @@ -0,0 +1,274 @@
@@ -996,7 +996,7 @@ index 0000000000000..4ae3fc6d70785
 +MODULE_PARM_DESC(kallsyms_lookup_name_addr, "Address for kallsyms_lookup_name, provide this when unable to find using kprobe");
 diff --git a/arch/loongarch/ow_syscall/signal.c b/arch/loongarch/ow_syscall/signal.c
 new file mode 100644
-index 0000000000000..90eb34727680d
+index 000000000000..90eb34727680
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.c
 @@ -0,0 +1,239 @@
@@ -1241,7 +1241,7 @@ index 0000000000000..90eb34727680d
 +#endif
 diff --git a/arch/loongarch/ow_syscall/signal.h b/arch/loongarch/ow_syscall/signal.h
 new file mode 100644
-index 0000000000000..adcd53bedc662
+index 000000000000..adcd53bedc66
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/signal.h
 @@ -0,0 +1,44 @@
@@ -1291,7 +1291,7 @@ index 0000000000000..adcd53bedc662
 +#endif
 diff --git a/arch/loongarch/ow_syscall/systable.c b/arch/loongarch/ow_syscall/systable.c
 new file mode 100644
-index 0000000000000..8b311954d62ef
+index 000000000000..8b311954d62e
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.c
 @@ -0,0 +1,65 @@
@@ -1362,7 +1362,7 @@ index 0000000000000..8b311954d62ef
 +};
 diff --git a/arch/loongarch/ow_syscall/systable.h b/arch/loongarch/ow_syscall/systable.h
 new file mode 100644
-index 0000000000000..f2b6602cc7ef4
+index 000000000000..f2b6602cc7ef
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/systable.h
 @@ -0,0 +1,8 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 0ee0c5de5f7f5c5c59e3e332b81ba7e1f3f1fc87 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 309/449] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 309/450] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 [Xi Ruoyao: Select KALLSYMS and KPROBE]
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/loongarch/ow_syscall/Kconfig
 
 diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
-index 5b1116733d881..8bf1b0941a21d 100644
+index 5b1116733d88..8bf1b0941a21 100644
 --- a/arch/loongarch/Kconfig
 +++ b/arch/loongarch/Kconfig
 @@ -754,3 +754,5 @@ source "drivers/cpufreq/Kconfig"
@@ -26,7 +26,7 @@ index 5b1116733d881..8bf1b0941a21d 100644
 +source "arch/loongarch/ow_syscall/Kconfig"
 diff --git a/arch/loongarch/ow_syscall/Kconfig b/arch/loongarch/ow_syscall/Kconfig
 new file mode 100644
-index 0000000000000..8ef159cf10557
+index 000000000000..8ef159cf1055
 --- /dev/null
 +++ b/arch/loongarch/ow_syscall/Kconfig
 @@ -0,0 +1,17 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From 7f25237f15da1e0a469fcf3e27be202dc74444aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 310/449] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 310/450] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom
@@ -101,7 +101,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/kernel/rcu/tree.c b/kernel/rcu/tree.c
-index 8293bae1dec16..3be30131b1749 100644
+index 8293bae1dec1..3be30131b174 100644
 --- a/kernel/rcu/tree.c
 +++ b/kernel/rcu/tree.c
 @@ -4444,15 +4444,11 @@ void rcutree_migrate_callbacks(int cpu)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From 9d204420752032fbcd4ef2a4e819c64c55a1877d Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 311/449] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 311/450] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 deletions(-)
 
 diff --git a/arch/mips/Makefile.postlink b/arch/mips/Makefile.postlink
-index ea0add7d56b23..2543679da1492 100644
+index ea0add7d56b2..2543679da149 100644
 --- a/arch/mips/Makefile.postlink
 +++ b/arch/mips/Makefile.postlink
 @@ -24,9 +24,6 @@ quiet_cmd_relocs = RELOCS  $@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From d1503d83a088a0a2c78bbfab85a07ccfd606a5db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 312/449] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 312/450] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 13 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index d2a51bd395f6c..89915a33ec718 100644
+index d2a51bd395f6..89915a33ec71 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -17,6 +17,10 @@ int loongson_vblank = 1;
@@ -39,7 +39,7 @@ index d2a51bd395f6c..89915a33ec718 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 931c17521bf01..0dcc9646d2ff1 100644
+index 931c17521bf0..0dcc9646d2ff 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -7,6 +7,7 @@
@@ -51,7 +51,7 @@ index 931c17521bf01..0dcc9646d2ff1 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index 12193d2a301ac..ada66e809f364 100644
+index 12193d2a301a..ada66e809f36 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -265,6 +265,14 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From 0330de200f255990eafb4c6d548cf3e09d622b0c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 313/449] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 313/450] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/hp/hp-wmi.c b/drivers/platform/x86/hp/hp-wmi.c
-index dfe45692c956a..8736279e776fd 100644
+index dfe45692c956..8736279e776f 100644
 --- a/drivers/platform/x86/hp/hp-wmi.c
 +++ b/drivers/platform/x86/hp/hp-wmi.c
 @@ -128,7 +128,7 @@ static const char * const omen_thermal_profile_boards[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From 3537da5b0e0938ac2dee9b71c84510b80dd86ddb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 314/449] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 314/450] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index fa30523b1a7c4..bf2f922960416 100644
+index fa30523b1a7c..bf2f92296041 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -898,9 +898,9 @@ module_param_named(visualconfirm, amdgpu_dc_visual_confirm, uint, 0444);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From 1da40cbe563d7029506f11a3dd29bda826862801 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 315/449] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 315/450] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 28 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/unaligned.c b/arch/mips/kernel/unaligned.c
-index db652c99b72e3..4f2055afbd7e8 100644
+index db652c99b72e..4f2055afbd7e 100644
 --- a/arch/mips/kernel/unaligned.c
 +++ b/arch/mips/kernel/unaligned.c
 @@ -1514,14 +1514,37 @@ static void emulate_load_store_MIPS16e(struct pt_regs *regs, void __user * addr)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From a4c822ace38468e7d62ceeb69a7c829c878fcfbf Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 316/449] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 316/450] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 4 deletions(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index f06e97bc0c862..f7217c92f9d8a 100644
+index f06e97bc0c86..f7217c92f9d8 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -1746,7 +1746,6 @@ menu "PCI GPIO expanders"
@@ -29,7 +29,7 @@ index f06e97bc0c862..f7217c92f9d8a 100644
  	help
  	  Say yes here to support GPIO pins on Single Board Computers produced
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 8702e93e23c4b..742b9deba803f 100644
+index 8702e93e23c4..742b9deba803 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -41,7 +41,6 @@ comment "Native drivers"
@@ -41,7 +41,7 @@ index 8702e93e23c4b..742b9deba803f 100644
  	help
  	  This hwmon driver adds support for reporting temperature or fan
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index fe21092c09b08..ccab24a3b208c 100644
+index fe21092c09b0..ccab24a3b208 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -75,7 +75,6 @@ config LEDS_88PM860X
@@ -53,7 +53,7 @@ index fe21092c09b08..ccab24a3b208c 100644
  	help
  	  This led driver adds support for LED brightness control on Single
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 080607b313a74..f6af9be523dcf 100644
+index 080607b313a7..f6af9be523dc 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2396,7 +2396,6 @@ config MFD_QCOM_PM8008

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From e87cd9cd2c735612e66fcc2ef47d2b744558b687 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 317/449] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 317/450] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling
@@ -36,7 +36,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
-index 7fea6ba91c1ef..08da58fe6152b 100644
+index 7fea6ba91c1e..08da58fe6152 100644
 --- a/virt/kvm/kvm_main.c
 +++ b/virt/kvm/kvm_main.c
 @@ -5567,7 +5567,7 @@ static struct miscdevice kvm_dev = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 319c6058c3b072ba98228d5c3a9716d3d9a9b66e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 318/449] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 318/450] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 12 insertions(+)
 
 diff --git a/drivers/gpu/drm/loongson/loongson_module.c b/drivers/gpu/drm/loongson/loongson_module.c
-index 89915a33ec718..99e5fef3f2d9d 100644
+index 89915a33ec71..99e5fef3f2d9 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.c
 +++ b/drivers/gpu/drm/loongson/loongson_module.c
 @@ -21,6 +21,10 @@ int loongson_ls7a1000_support = 0;
@@ -42,7 +42,7 @@ index 89915a33ec718..99e5fef3f2d9d 100644
  {
  	if (!loongson_modeset || video_firmware_drivers_only())
 diff --git a/drivers/gpu/drm/loongson/loongson_module.h b/drivers/gpu/drm/loongson/loongson_module.h
-index 0dcc9646d2ff1..183a8a0586605 100644
+index 0dcc9646d2ff..183a8a058660 100644
 --- a/drivers/gpu/drm/loongson/loongson_module.h
 +++ b/drivers/gpu/drm/loongson/loongson_module.h
 @@ -8,6 +8,7 @@
@@ -54,7 +54,7 @@ index 0dcc9646d2ff1..183a8a0586605 100644
  
  #endif
 diff --git a/drivers/gpu/drm/loongson/lsdc_drv.c b/drivers/gpu/drm/loongson/lsdc_drv.c
-index ada66e809f364..31d187fe3d24f 100644
+index ada66e809f36..31d187fe3d24 100644
 --- a/drivers/gpu/drm/loongson/lsdc_drv.c
 +++ b/drivers/gpu/drm/loongson/lsdc_drv.c
 @@ -273,6 +273,13 @@ static int lsdc_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 352b25fc862cd268a58a3758445fefb4a917cb5a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 319/449] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 319/450] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 58f2089c1d91f..420c6f89ee7b9 100644
+index 58f2089c1d91..420c6f89ee7b 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -25,7 +25,7 @@ config MIPS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From 236e5eb27b868f4a04223b9d79dbcb2062485daf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 320/449] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 320/450] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/cpu_hwmon.c b/drivers/platform/mips/cpu_hwmon.c
-index 2ac2f31090f96..93619227f0396 100644
+index 2ac2f31090f9..93619227f039 100644
 --- a/drivers/platform/mips/cpu_hwmon.c
 +++ b/drivers/platform/mips/cpu_hwmon.c
 @@ -135,9 +135,22 @@ static int __init loongson_hwmon_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From d7ad39a261a74fcaecc9d666a50a151a04616e82 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 321/449] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 321/450] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:
@@ -40,7 +40,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_ring.c b/drivers/gpu/drm/radeon/radeon_ring.c
-index 346f0e49bb2ea..92aa8e1364c31 100644
+index 346f0e49bb2e..92aa8e1364c3 100644
 --- a/drivers/gpu/drm/radeon/radeon_ring.c
 +++ b/drivers/gpu/drm/radeon/radeon_ring.c
 @@ -185,7 +185,9 @@ void radeon_ring_commit(struct radeon_device *rdev, struct radeon_ring *ring,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 13be9f09b7e9ebd98c434b5b73c6237da03efff7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 322/449] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 322/450] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 390f82b4845df..5bf1bd87afff7 100644
+index 390f82b4845d..5bf1bd87afff 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -3522,7 +3522,9 @@ int usb_port_suspend(struct usb_device *udev, pm_message_t msg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From cd041a3ae5fe9a443ebc94e12368fefeab2fcba0 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 323/449] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 323/450] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -12,7 +12,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index 2a0caf15671d5..e7ce09d66adcd 100644
+index 2a0caf15671d..e7ce09d66adc 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -42,6 +42,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From 31fefd3a9d9b572521f1b7617af9098a13c8e6f8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 324/449] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 324/450] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/tools/bpf/bpftool/Makefile b/tools/bpf/bpftool/Makefile
-index fd43e5ea63f38..6226728ae471d 100644
+index fd43e5ea63f3..6226728ae471 100644
 --- a/tools/bpf/bpftool/Makefile
 +++ b/tools/bpf/bpftool/Makefile
 @@ -273,8 +273,8 @@ clean: $(LIBBPF)-clean $(LIBBPF_BOOTSTRAP)-clean feature-detect-clean

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
@@ -1,7 +1,7 @@
 From 431f520c70f0dc3635d5037e33b21eb1e2e28110 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 16:01:27 +0800
-Subject: [PATCH 325/449] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
+Subject: [PATCH 325/450] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
  support
 
 On IPASON NL38-N11 laptops, the touchpad device (a HID multitouch device
@@ -31,7 +31,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/gpio/gpio-loongson-64bit.c b/drivers/gpio/gpio-loongson-64bit.c
-index 0fdf15faa344d..6907347125685 100644
+index 0fdf15faa344..690734712568 100644
 --- a/drivers/gpio/gpio-loongson-64bit.c
 +++ b/drivers/gpio/gpio-loongson-64bit.c
 @@ -39,6 +39,7 @@ struct loongson_gpio_chip_data {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
@@ -1,7 +1,7 @@
 From 28bebe8f1912492ac0b022b4eef92a836c6ea16d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:36:15 +0800
-Subject: [PATCH 326/449] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
+Subject: [PATCH 326/450] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
  xdp_do_flush()
 
 Per 7f04bd109d4c ("net: Tree wide: Replace xdp_do_flush_map() with
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_main.c b/drivers/net/ethernet/phytium/phytmac_main.c
-index e7ce09d66adcd..03392c537666d 100644
+index e7ce09d66adc..03392c537666 100644
 --- a/drivers/net/ethernet/phytium/phytmac_main.c
 +++ b/drivers/net/ethernet/phytium/phytmac_main.c
 @@ -1247,7 +1247,7 @@ static int phytmac_rx(struct phytmac_queue *queue, struct napi_struct *napi,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
@@ -1,7 +1,7 @@
 From fd340232fc77f2802860bfa8a4b80f923dff9245 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:38:09 +0800
-Subject: [PATCH 327/449] AOSCOS: net/phytmac: Remove unnecessary
+Subject: [PATCH 327/450] AOSCOS: net/phytmac: Remove unnecessary
  pcim_iounmap_regions() call
 
 pcim_iounmap_regions() is removed in commit 855c634930f0 ("PCI: Remove
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/phytium/phytmac_pci.c b/drivers/net/ethernet/phytium/phytmac_pci.c
-index fac5d717ad766..69f34c2faaf5b 100644
+index fac5d717ad76..69f34c2faaf5 100644
 --- a/drivers/net/ethernet/phytium/phytmac_pci.c
 +++ b/drivers/net/ethernet/phytium/phytmac_pci.c
 @@ -177,7 +177,6 @@ static void phytmac_pci_remove(struct pci_dev *pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
@@ -1,7 +1,7 @@
 From f2acef049fb4b80973e18b22cfe6bc56b59856c0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 21:59:21 +0800
-Subject: [PATCH 328/449] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
+Subject: [PATCH 328/450] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
 
 The driver seems relying on ACPI to power up the device.  And the device
 is only available as a part of Phytium SoC.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/net/ethernet/phytium/Kconfig b/drivers/net/ethernet/phytium/Kconfig
-index 14a77adbfdc12..34cbb2a0ce82c 100644
+index 14a77adbfdc1..34cbb2a0ce82 100644
 --- a/drivers/net/ethernet/phytium/Kconfig
 +++ b/drivers/net/ethernet/phytium/Kconfig
 @@ -19,6 +19,8 @@ if NET_VENDOR_PHYTIUM

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-arm64-Disable-MPAM-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-arm64-Disable-MPAM-by-default.patch
@@ -1,7 +1,7 @@
 From a698f9a94be861f1bca9d465ff7fe3afacb16e5e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 14 Jul 2025 18:06:42 +0800
-Subject: [PATCH 329/449] AOSCOS: arm64: Disable MPAM by default
+Subject: [PATCH 329/450] AOSCOS: arm64: Disable MPAM by default
 
 We have to work OotB on W510, and ARM64 does not support extending the
 built-in command line with the one from the bootloader.  So only try
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 20 insertions(+)
 
 diff --git a/arch/arm64/kernel/pi/idreg-override.c b/arch/arm64/kernel/pi/idreg-override.c
-index bc57b290e5e7b..2d45dbb689476 100644
+index bc57b290e5e7..2d45dbb68947 100644
 --- a/arch/arm64/kernel/pi/idreg-override.c
 +++ b/arch/arm64/kernel/pi/idreg-override.c
 @@ -215,6 +215,17 @@ static const struct ftr_set_desc sw_features __prel64_initconst = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 1355236d3c9e53e4881936494408bab4486c3a76 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 330/449] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 330/450] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 420c6f89ee7b9..606f25c0d5bcc 100644
+index 420c6f89ee7b..606f25c0d5bc 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -548,6 +548,7 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From bf4325d3bffd7a57fbc821cc7f11dc64a8d2c313 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 331/449] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 331/450] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00.h b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
-index 09b9d1f9f793f..18bc1632a175b 100644
+index 09b9d1f9f793..18bc1632a175 100644
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00.h
 @@ -1167,23 +1167,27 @@ static inline bool rt2x00_intf(struct rt2x00_dev *rt2x00dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From cd6907982f7ed72ce41c455c367d97b25934e4ea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 332/449] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 332/450] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
-index 26db27d06a865..06d97f3f1087a 100644
+index 26db27d06a86..06d97f3f1087 100644
 --- a/drivers/tty/serial/serial_core.c
 +++ b/drivers/tty/serial/serial_core.c
 @@ -1952,6 +1952,8 @@ static int uart_open(struct tty_struct *tty, struct file *filp)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From c31c30e5de9fc2b7ff73b6c97787cda439375eea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 333/449] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 333/450] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").
@@ -41,7 +41,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/mips/loongson64/constant_timer.c
 
 diff --git a/arch/mips/include/asm/cpu-features.h b/arch/mips/include/asm/cpu-features.h
-index 404390bb87eaf..e522efa1b53d0 100644
+index 404390bb87ea..e522efa1b53d 100644
 --- a/arch/mips/include/asm/cpu-features.h
 +++ b/arch/mips/include/asm/cpu-features.h
 @@ -659,6 +659,10 @@
@@ -56,7 +56,7 @@ index 404390bb87eaf..e522efa1b53d0 100644
   * Guest capabilities
   */
 diff --git a/arch/mips/include/asm/cpu.h b/arch/mips/include/asm/cpu.h
-index 0fd9f9bbd21f1..05e6ce0bb3fb7 100644
+index 0fd9f9bbd21f..05e6ce0bb3fb 100644
 --- a/arch/mips/include/asm/cpu.h
 +++ b/arch/mips/include/asm/cpu.h
 @@ -420,6 +420,7 @@ enum cpu_type_enum {
@@ -68,7 +68,7 @@ index 0fd9f9bbd21f1..05e6ce0bb3fb7 100644
  /*
   * CPU ASE encodings
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_regs.h b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
-index fec7675076049..47294ab78a2cd 100644
+index fec767507604..47294ab78a2c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_regs.h
 @@ -131,6 +131,9 @@ static inline u32 read_cpucfg(u32 reg)
@@ -121,7 +121,7 @@ index fec7675076049..47294ab78a2cd 100644
 +
  #endif
 diff --git a/arch/mips/include/asm/mipsregs.h b/arch/mips/include/asm/mipsregs.h
-index f799c0d723dac..da710d7f35102 100644
+index f799c0d723da..da710d7f3510 100644
 --- a/arch/mips/include/asm/mipsregs.h
 +++ b/arch/mips/include/asm/mipsregs.h
 @@ -838,6 +838,7 @@
@@ -133,7 +133,7 @@ index f799c0d723dac..da710d7f35102 100644
  #define MTI_CONF6_FTLBEN	(_ULCAST_(1) << 15)
  /* Disable load/store bonding */
 diff --git a/arch/mips/include/asm/time.h b/arch/mips/include/asm/time.h
-index 93f8cd52e3d47..72fec943a9e44 100644
+index 93f8cd52e3d4..72fec943a9e4 100644
 --- a/arch/mips/include/asm/time.h
 +++ b/arch/mips/include/asm/time.h
 @@ -42,11 +42,19 @@ extern int __weak get_c0_perfcount_int(void);
@@ -179,7 +179,7 @@ index 93f8cd52e3d47..72fec943a9e44 100644
  	return 0;
  #endif
 diff --git a/arch/mips/include/asm/vdso/clocksource.h b/arch/mips/include/asm/vdso/clocksource.h
-index 510e1671d8985..7fd43ca06eb11 100644
+index 510e1671d898..7fd43ca06eb1 100644
 --- a/arch/mips/include/asm/vdso/clocksource.h
 +++ b/arch/mips/include/asm/vdso/clocksource.h
 @@ -4,6 +4,7 @@
@@ -192,7 +192,7 @@ index 510e1671d8985..7fd43ca06eb11 100644
  
  #endif /* __ASM_VDSOCLOCKSOURCE_H */
 diff --git a/arch/mips/include/asm/vdso/gettimeofday.h b/arch/mips/include/asm/vdso/gettimeofday.h
-index 32d2d173fdc0b..8cc0beef182d1 100644
+index 32d2d173fdc0..8cc0beef182d 100644
 --- a/arch/mips/include/asm/vdso/gettimeofday.h
 +++ b/arch/mips/include/asm/vdso/gettimeofday.h
 @@ -183,6 +183,22 @@ static __always_inline u64 read_gic_count(const struct vdso_time_data *data)
@@ -230,7 +230,7 @@ index 32d2d173fdc0b..8cc0beef182d1 100644
  	/*
  	 * Core checks mode already. So this raced against a concurrent
 diff --git a/arch/mips/kernel/cpu-probe.c b/arch/mips/kernel/cpu-probe.c
-index 12370ae3e4c5e..decfdb92ee8a1 100644
+index 12370ae3e4c5..decfdb92ee8a 100644
 --- a/arch/mips/kernel/cpu-probe.c
 +++ b/arch/mips/kernel/cpu-probe.c
 @@ -34,6 +34,10 @@
@@ -271,7 +271,7 @@ index 12370ae3e4c5e..decfdb92ee8a1 100644
  				  LOONGSON_CONF6_INTIMER);
  		break;
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index cbba30dfddf5d..ba083beb6ca81 100644
+index cbba30dfddf5..ba083beb6ca8 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,6 +4,7 @@
@@ -284,7 +284,7 @@ index cbba30dfddf5d..ba083beb6ca81 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
 new file mode 100644
-index 0000000000000..b8bdbb2c47b51
+index 000000000000..b8bdbb2c47b5
 --- /dev/null
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -0,0 +1,256 @@
@@ -545,7 +545,7 @@ index 0000000000000..b8bdbb2c47b51
 +	return res;
 +}
 diff --git a/arch/mips/loongson64/smp.c b/arch/mips/loongson64/smp.c
-index 69c1e77e6bfc7..f8e2fb4c7cd8c 100644
+index 69c1e77e6bfc..f8e2fb4c7cd8 100644
 --- a/arch/mips/loongson64/smp.c
 +++ b/arch/mips/loongson64/smp.c
 @@ -425,7 +425,9 @@ static void loongson3_smp_finish(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 1d1f1c1ed9542474ad9ce9a3fe827b1938da43cf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 334/449] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 334/450] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index b8bdbb2c47b51..975fb93c4efa2 100644
+index b8bdbb2c47b5..975fb93c4efa 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -42,12 +42,6 @@ static irqreturn_t constant_timer_interrupt(int irq, void *data)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From 3d0a24da1074a20edb99bb92cb119e88b32ac247 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 335/449] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 335/450] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/constant_timer.c b/arch/mips/loongson64/constant_timer.c
-index 975fb93c4efa2..c1fda4a3ae165 100644
+index 975fb93c4efa..c1fda4a3ae16 100644
 --- a/arch/mips/loongson64/constant_timer.c
 +++ b/arch/mips/loongson64/constant_timer.c
 @@ -252,7 +252,7 @@ int __init init_constant_clocksource(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 6d050464f4c77a47741d702f643c0a17e894effa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 336/449] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 336/450] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.
@@ -32,7 +32,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 new file mode 100644
-index 0000000000000..3d2ca3245a3e2
+index 000000000000..3d2ca3245a3e
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -0,0 +1,381 @@
@@ -418,7 +418,7 @@ index 0000000000000..3d2ca3245a3e2
 +
 +#endif /* __EC_WPCE775L_H__ */
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index ba083beb6ca81..0cb1654f346ab 100644
+index ba083beb6ca8..0cb1654f346a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -432,7 +432,7 @@ index ba083beb6ca81..0cb1654f346ab 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/ec_wpce775l.c b/arch/mips/loongson64/ec_wpce775l.c
 new file mode 100644
-index 0000000000000..f407ddbe933a1
+index 000000000000..f407ddbe933a
 --- /dev/null
 +++ b/arch/mips/loongson64/ec_wpce775l.c
 @@ -0,0 +1,249 @@
@@ -686,7 +686,7 @@ index 0000000000000..f407ddbe933a1
 +}
 +EXPORT_SYMBOL(ec_query_get_event_num);
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index c135254665b6b..1c602563b6a4d 100644
+index c135254665b6..1c602563b6a4 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -143,7 +143,7 @@ static struct fwnode_handle *i8042_kbd_fwnode;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From f39b8a9c1f9913e8cad5237e6f3635edda572b12 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 337/449] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 337/450] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index 3d2ca3245a3e2..fc60026bc6741 100644
+index 3d2ca3245a3e..fc60026bc674 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -374,6 +374,7 @@ extern int ec_write_noindex(unsigned char command, unsigned char data);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From e6b269589c95553b0d18c57497d6c55271ef66ca Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 338/449] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 338/450] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and
@@ -45,7 +45,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/mips/wpce_fan.c
 
 diff --git a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
-index 721eafc4644e5..071e8f445f5c9 100644
+index 721eafc4644e..071e8f445f5c 100644
 --- a/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 +++ b/arch/mips/include/asm/mach-loongson64/loongson_hwmon.h
 @@ -36,7 +36,7 @@ struct temp_range {
@@ -67,7 +67,7 @@ index 721eafc4644e5..071e8f445f5c9 100644
 +
  #endif /* __LOONGSON_HWMON_H_*/
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 0cb1654f346ab..16b0c555b52ae 100644
+index 0cb1654f346a..16b0c555b52a 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@
@@ -81,7 +81,7 @@ index 0cb1654f346ab..16b0c555b52ae 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/platform.c b/arch/mips/loongson64/platform.c
 new file mode 100644
-index 0000000000000..a447eab0218d2
+index 000000000000..a447eab0218d
 --- /dev/null
 +++ b/arch/mips/loongson64/platform.c
 @@ -0,0 +1,67 @@
@@ -153,7 +153,7 @@ index 0000000000000..a447eab0218d2
 +	.type = CONSTANT_SPEED_POLICY,
 +};
 diff --git a/drivers/hwmon/lm93.c b/drivers/hwmon/lm93.c
-index be4853fad80fd..649c5e1cf8200 100644
+index be4853fad80f..649c5e1cf820 100644
 --- a/drivers/hwmon/lm93.c
 +++ b/drivers/hwmon/lm93.c
 @@ -2497,8 +2497,9 @@ ATTRIBUTE_GROUPS(lm93);
@@ -195,7 +195,7 @@ index be4853fad80fd..649c5e1cf8200 100644
  	for (i = 0; i < 20; i++) {
  		msleep(10);
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index fb4ac4b08e891..59b6027eeadf5 100644
+index fb4ac4b08e89..59b6027eeadf 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -37,4 +37,20 @@ config LS2K_RESET
@@ -220,7 +220,7 @@ index fb4ac4b08e891..59b6027eeadf5 100644
 +
  endif # MIPS_PLATFORM_DEVICES
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4c71444e453a6..4dcbbcfcf7a1e 100644
+index 4c71444e453a..4dcbbcfcf7a1 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -2,3 +2,6 @@
@@ -232,7 +232,7 @@ index 4c71444e453a6..4dcbbcfcf7a1e 100644
 +obj-$(CONFIG_LEMOTE3A_LAPTOP) += lemote3a-laptop.o
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
 new file mode 100644
-index 0000000000000..02f2284743ed3
+index 000000000000..02f2284743ed
 --- /dev/null
 +++ b/drivers/platform/mips/emc1412.c
 @@ -0,0 +1,454 @@
@@ -692,7 +692,7 @@ index 0000000000000..02f2284743ed3
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
 new file mode 100644
-index 0000000000000..b06e7b6ae97c7
+index 000000000000..b06e7b6ae97c
 --- /dev/null
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -0,0 +1,1179 @@
@@ -1877,7 +1877,7 @@ index 0000000000000..b06e7b6ae97c7
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
 new file mode 100644
-index 0000000000000..6331e09722a1f
+index 000000000000..6331e09722a1
 --- /dev/null
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -0,0 +1,767 @@
@@ -2650,7 +2650,7 @@ index 0000000000000..6331e09722a1f
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
 new file mode 100644
-index 0000000000000..be42c58822901
+index 000000000000..be42c5882290
 --- /dev/null
 +++ b/drivers/platform/mips/sd5075.c
 @@ -0,0 +1,211 @@
@@ -2867,7 +2867,7 @@ index 0000000000000..be42c58822901
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/tmp75.c b/drivers/platform/mips/tmp75.c
 new file mode 100644
-index 0000000000000..0582c8fa2e2b2
+index 000000000000..0582c8fa2e2b
 --- /dev/null
 +++ b/drivers/platform/mips/tmp75.c
 @@ -0,0 +1,24 @@
@@ -2897,7 +2897,7 @@ index 0000000000000..0582c8fa2e2b2
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/mips/wpce_fan.c b/drivers/platform/mips/wpce_fan.c
 new file mode 100644
-index 0000000000000..ecef3158c59bc
+index 000000000000..ecef3158c59b
 --- /dev/null
 +++ b/drivers/platform/mips/wpce_fan.c
 @@ -0,0 +1,311 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 1c15f3d0b7299a383d043769076def0b4493f7f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 339/449] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 339/450] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 59b6027eeadf5..7ef9a47556d59 100644
+index 59b6027eeadf..7ef9a47556d5 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -39,7 +39,7 @@ config LS2K_RESET

--- a/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 6fe5eef86c10badc0b20cb57055a439761809ae0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 340/449] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 340/450] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index be42c58822901..02bb998210191 100644
+index be42c5882290..02bb99821019 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -93,7 +93,7 @@ static int sd5075_probe(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From d8946a7203199fcfc5f54d0c86523a7780d5cd52 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 341/449] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 341/450] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 02f2284743ed3..3fb2dcd600106 100644
+index 02f2284743ed..3fb2dcd60010 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -143,7 +143,7 @@ static int emc1412_probe(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From 54764018655e23894c4e79539021280088798acb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 342/449] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 342/450] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/sd5075.c b/drivers/platform/mips/sd5075.c
-index 02bb998210191..27e9fb359b9f6 100644
+index 02bb99821019..27e9fb359b9f 100644
 --- a/drivers/platform/mips/sd5075.c
 +++ b/drivers/platform/mips/sd5075.c
 @@ -128,7 +128,7 @@ static ssize_t get_sd5075_label(struct device *dev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From 5d1ecd74a5effca1cdfb60269b3e4bbd15e7e76b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 343/449] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 343/450] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 3fb2dcd600106..bf2fa4b815c8f 100644
+index 3fb2dcd60010..bf2fa4b815c8 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -182,7 +182,7 @@ static void emc1412_shutdown(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From b8c6b338744db126cbd9667239c524e04ce81739 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 344/449] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 344/450] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 60 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index bf2fa4b815c8f..6524baddd6ca2 100644
+index bf2fa4b815c8..6524baddd6ca 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -336,66 +336,6 @@ static void do_thermal_timer(struct work_struct *work)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From 0c6a0830e28ccde975e9a6ce02c0380855fedbe9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 345/449] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 345/450] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 deletions(-)
 
 diff --git a/drivers/platform/mips/emc1412.c b/drivers/platform/mips/emc1412.c
-index 6524baddd6ca2..fc1a26cd34fe0 100644
+index 6524baddd6ca..fc1a26cd34fe 100644
 --- a/drivers/platform/mips/emc1412.c
 +++ b/drivers/platform/mips/emc1412.c
 @@ -174,30 +174,6 @@ static void emc1412_shutdown(struct platform_device *dev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From 6fd85a9b03371a6398c712451cc30bd2048731fb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 346/449] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 346/450] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b06e7b6ae97c7..6e6b0c46aca4c 100644
+index b06e7b6ae97c..6e6b0c46aca4 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -625,9 +625,8 @@ static int lemote3a_set_brightness(struct backlight_device * pdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From 1690d5a7b1354e9484c66d61a020fd0281e75814 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 347/449] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 347/450] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index 6e6b0c46aca4c..a8d339a3e30b7 100644
+index 6e6b0c46aca4..a8d339a3e30b 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -542,10 +542,16 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s

--- a/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 093e7685bcfd1c377e9ba1e12e5400459373e5ba Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 348/449] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 348/450] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 38 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mips/sbx00_fan.c b/drivers/platform/mips/sbx00_fan.c
-index 6331e09722a1f..51c2017ebe1d6 100644
+index 6331e09722a1..51c2017ebe1d 100644
 --- a/drivers/platform/mips/sbx00_fan.c
 +++ b/drivers/platform/mips/sbx00_fan.c
 @@ -97,10 +97,44 @@ static struct loongson_fan_policy fan_policy[MAX_SBX00_FANS];

--- a/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From 68818aa4aec4489a197de018aa9af39b3ffc9331 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 349/449] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 349/450] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 73 insertions(+)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 5b8f9cc325893..35d2be41a54c4 100644
+index 5b8f9cc32589..35d2be41a54c 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -1,10 +1,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From ed68f078f42e94ba28d98deeb3cd0399d8987bcb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 350/449] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 350/450] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/rs780e-acpi.c b/drivers/platform/mips/rs780e-acpi.c
-index 35d2be41a54c4..6e53355be9d9f 100644
+index 35d2be41a54c..6e53355be9d9 100644
 --- a/drivers/platform/mips/rs780e-acpi.c
 +++ b/drivers/platform/mips/rs780e-acpi.c
 @@ -95,7 +95,7 @@ static int __init power_button_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From 23cf7b2cfa1d5b2a4dd3b21cf6283503efd13fd2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 351/449] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 351/450] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/input/keyboard/lmps2atkbd.h
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 2ff4fef322c24..109477ec6bbd0 100644
+index 2ff4fef322c2..109477ec6bbd 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -157,6 +157,17 @@ config KEYBOARD_ATKBD_RDI_KEYCODES
@@ -45,7 +45,7 @@ index 2ff4fef322c24..109477ec6bbd0 100644
  	tristate "Microchip AT42QT1050 Touch Sensor Chip"
  	depends on I2C
 diff --git a/drivers/input/keyboard/atkbd.c b/drivers/input/keyboard/atkbd.c
-index 4a08411348242..c437363cb550e 100644
+index 4a0841134824..c437363cb550 100644
 --- a/drivers/input/keyboard/atkbd.c
 +++ b/drivers/input/keyboard/atkbd.c
 @@ -77,7 +77,13 @@ MODULE_PARM_DESC(terminal, "Enable break codes on an IBM Terminal keyboard conne
@@ -99,7 +99,7 @@ index 4a08411348242..c437363cb550e 100644
  
 diff --git a/drivers/input/keyboard/lmps2atkbd.h b/drivers/input/keyboard/lmps2atkbd.h
 new file mode 100644
-index 0000000000000..95d4ac5365c0d
+index 000000000000..95d4ac5365c0
 --- /dev/null
 +++ b/drivers/input/keyboard/lmps2atkbd.h
 @@ -0,0 +1,32 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From e053542d2dd9114c598cc632ce91ca3d5b10dab3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 352/449] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 352/450] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index 109477ec6bbd0..c8baabe3423e2 100644
+index 109477ec6bbd..c8baabe3423e 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -159,7 +159,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES

--- a/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From 27e3e3cbab19ae6d1a0b1ae98d5e4d7305953aad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 353/449] AOSCOS: input: atkbd: disable
+Subject: [PATCH 353/450] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/input/keyboard/Kconfig b/drivers/input/keyboard/Kconfig
-index c8baabe3423e2..71331b85c2e8a 100644
+index c8baabe3423e..71331b85c2e8 100644
 --- a/drivers/input/keyboard/Kconfig
 +++ b/drivers/input/keyboard/Kconfig
 @@ -160,7 +160,7 @@ config KEYBOARD_ATKBD_RDI_KEYCODES

--- a/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 6aa0990016ddd8fff358721d4aa493c40595af16 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 354/449] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 354/450] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/mips/ec_rom.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
+index 4dcbbcfcf7a1..5929b5ad7b6c 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,3 +5,4 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -28,7 +28,7 @@ index 4dcbbcfcf7a1e..5929b5ad7b6cd 100644
 +obj-m += ec_rom.o
 diff --git a/drivers/platform/mips/ec_rom.c b/drivers/platform/mips/ec_rom.c
 new file mode 100644
-index 0000000000000..b7b1624191f7a
+index 000000000000..b7b1624191f7
 --- /dev/null
 +++ b/drivers/platform/mips/ec_rom.c
 @@ -0,0 +1,179 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From 02d0902d5bc4c19783157286a1e083d681b8d9fb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 355/449] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 355/450] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/mips/pmon_flash.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 5929b5ad7b6cd..98eef2e092264 100644
+index 5929b5ad7b6c..98eef2e09226 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -6,3 +6,7 @@ obj-$(CONFIG_I2C_PIIX4) += emc1412.o sd5075.o tmp75.o
@@ -39,7 +39,7 @@ index 5929b5ad7b6cd..98eef2e092264 100644
 +endif
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
 new file mode 100644
-index 0000000000000..8fd5f4bf8b1bb
+index 000000000000..8fd5f4bf8b1b
 --- /dev/null
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -0,0 +1,100 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 9208860b32609af14f1cdab2f15d30f6cfe1d122 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 356/449] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 356/450] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/mips/pmon_flash.c b/drivers/platform/mips/pmon_flash.c
-index 8fd5f4bf8b1bb..6c5a3c4342b29 100644
+index 8fd5f4bf8b1b..6c5a3c4342b2 100644
 --- a/drivers/platform/mips/pmon_flash.c
 +++ b/drivers/platform/mips/pmon_flash.c
 @@ -53,7 +53,7 @@ struct mtd_partition flash_parts[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 104858d55410a18e88d45e1b8ab3b34cb31b1def Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 357/449] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 357/450] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/mips/at24c04.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 98eef2e092264..4dde0988fdadb 100644
+index 98eef2e09226..4dde0988fdad 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -5,7 +5,7 @@ obj-$(CONFIG_LS2K_RESET) += ls2k-reset.o
@@ -31,7 +31,7 @@ index 98eef2e092264..4dde0988fdadb 100644
  obj-m += pmon_flash.o
 diff --git a/drivers/platform/mips/at24c04.c b/drivers/platform/mips/at24c04.c
 new file mode 100644
-index 0000000000000..7ba3d1c8692e1
+index 000000000000..7ba3d1c8692e
 --- /dev/null
 +++ b/drivers/platform/mips/at24c04.c
 @@ -0,0 +1,26 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From 2e558dc454c44ab3093aa5037ef91157cd2f109a Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 358/449] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 358/450] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ioremap.h b/arch/mips/include/asm/mach-loongson64/ioremap.h
 new file mode 100644
-index 0000000000000..155dafe2ef346
+index 000000000000..155dafe2ef34
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-loongson64/ioremap.h
 @@ -0,0 +1,44 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 061c98991e8dad27cf0c3f3445516dbc3de909a9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 359/449] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 359/450] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/input/mouse/sentelic.c b/drivers/input/mouse/sentelic.c
-index 44b136fc29aaf..6ccdec46e1f44 100644
+index 44b136fc29aa..6ccdec46e1f4 100644
 --- a/drivers/input/mouse/sentelic.c
 +++ b/drivers/input/mouse/sentelic.c
 @@ -899,8 +899,8 @@ static int fsp_activate_protocol(struct psmouse *psmouse)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 3e6bac1cef3bd1081449a7e3768924006579465d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 360/449] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 360/450] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3
@@ -48,7 +48,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 42 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_64xx.c b/drivers/scsi/mvsas/mv_64xx.c
-index 1f2b61de8c632..855d8465b30f2 100644
+index 1f2b61de8c63..855d8465b30f 100644
 --- a/drivers/scsi/mvsas/mv_64xx.c
 +++ b/drivers/scsi/mvsas/mv_64xx.c
 @@ -376,10 +376,14 @@ static int mvs_64xx_init(struct mvs_info *mvi)
@@ -82,7 +82,7 @@ index 1f2b61de8c632..855d8465b30f2 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_94xx.c b/drivers/scsi/mvsas/mv_94xx.c
-index fc0b8eb682045..1d1042ab82c8c 100644
+index fc0b8eb68204..1d1042ab82c8 100644
 --- a/drivers/scsi/mvsas/mv_94xx.c
 +++ b/drivers/scsi/mvsas/mv_94xx.c
 @@ -515,10 +515,14 @@ static int mvs_94xx_init(struct mvs_info *mvi)
@@ -116,7 +116,7 @@ index fc0b8eb682045..1d1042ab82c8c 100644
  		tmp = 0x10000 | time;
  		mw32(MVS_INT_COAL_TMOUT, tmp);
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 7f1ad305eee63..03a0ac5fab63f 100644
+index 7f1ad305eee6..03a0ac5fab63 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -10,7 +10,11 @@
@@ -140,7 +140,7 @@ index 7f1ad305eee63..03a0ac5fab63f 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index f2e7997d5b9d8..6a7ae6f410056 100644
+index f2e7997d5b9d..6a7ae6f41005 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -255,6 +255,20 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -206,7 +206,7 @@ index f2e7997d5b9d8..6a7ae6f410056 100644
  
  	case SAS_PROTOCOL_SATA:
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index 09ce3f2241f24..b6f5b739d67c9 100644
+index 09ce3f2241f2..b6f5b739d67c 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -429,6 +429,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From a1325dd13956850e750dfd2818f82eceb0b332f6 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 361/449] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 361/450] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/gpio/gpio-nct6102.c
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index f7217c92f9d8a..ff21d5881cf6b 100644
+index f7217c92f9d8..ff21d5881cf6 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -545,6 +545,13 @@ config GPIO_NPCM_SGPIO
@@ -38,7 +38,7 @@ index f7217c92f9d8a..ff21d5881cf6b 100644
  	tristate "Cavium OCTEON GPIO"
  	depends on CAVIUM_OCTEON_SOC
 diff --git a/drivers/gpio/Makefile b/drivers/gpio/Makefile
-index 3e59519667a6d..e5e14123997cb 100644
+index 3e59519667a6..e5e14123997c 100644
 --- a/drivers/gpio/Makefile
 +++ b/drivers/gpio/Makefile
 @@ -133,6 +133,7 @@ obj-$(CONFIG_GPIO_MXS)			+= gpio-mxs.o
@@ -51,7 +51,7 @@ index 3e59519667a6d..e5e14123997cb 100644
  obj-$(CONFIG_GPIO_PALMAS)		+= gpio-palmas.o
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
 new file mode 100644
-index 0000000000000..25efc588c7612
+index 000000000000..25efc588c761
 --- /dev/null
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -0,0 +1,191 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From 0f081e68ad7af345945a76d54634a2cb74f6aaf7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 362/449] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 362/450] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/Kconfig b/drivers/gpio/Kconfig
-index ff21d5881cf6b..2e7811768df28 100644
+index ff21d5881cf6..2e7811768df2 100644
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -548,7 +548,7 @@ config GPIO_NPCM_SGPIO

--- a/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From c5b659494a001af6a747ee772ba781d21150210b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 363/449] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 363/450] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 25efc588c7612..547b61008390d 100644
+index 25efc588c761..547b61008390 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -6,6 +6,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From 30f2e2770145f7b4c567f99a6d380c663da93538 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 364/449] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 364/450] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 deletions(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 547b61008390d..c376f9fd6d076 100644
+index 547b61008390..c376f9fd6d07 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -47,15 +47,6 @@ static unsigned char read_gbl(u8 gbl_reg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From d902b7944b12d20864a91b054d97574fc0e95fce Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 365/449] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 365/450] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index c376f9fd6d076..1bb29ea5f5f2d 100644
+index c376f9fd6d07..1bb29ea5f5f2 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -170,7 +170,6 @@ static struct gpio_chip nct6102_chip = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 3025e334120c7d3b2f63f3196d7311dd9b97a6dc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 366/449] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 366/450] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 1bb29ea5f5f2d..143f0a139e212 100644
+index 1bb29ea5f5f2..143f0a139e21 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -177,6 +177,6 @@ static int __init nct6102_gpio_setup(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From 54d0c1fbd411e7e6d1bf6f46d4dd3dc0e8ff8184 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 367/449] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 367/450] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/hwmon/nct7511.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 742b9deba803f..35215e4bcedfa 100644
+index 742b9deba803..35215e4bcedf 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -1785,6 +1785,17 @@ config SENSORS_NCT7363
@@ -45,7 +45,7 @@ index 742b9deba803f..35215e4bcedfa 100644
  	tristate "Nuvoton NCT7802Y"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index f0750b067db9a..16815d6a3bb2a 100644
+index f0750b067db9..16815d6a3bb2 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -182,6 +182,7 @@ nct6775-objs			:= nct6775-platform.o
@@ -58,7 +58,7 @@ index f0750b067db9a..16815d6a3bb2a 100644
  obj-$(CONFIG_SENSORS_NPCM7XX)	+= npcm750-pwm-fan.o
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
 new file mode 100644
-index 0000000000000..a945ffc2ab3d5
+index 000000000000..a945ffc2ab3d
 --- /dev/null
 +++ b/drivers/hwmon/nct7511.c
 @@ -0,0 +1,801 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0368-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0368-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From f954bb84f52611c06682144fb0d0fab378b54b87 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 368/449] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 368/450] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index a945ffc2ab3d5..e5006ecd83465 100644
+index a945ffc2ab3d..e5006ecd8346 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -709,7 +709,7 @@ static int nct7511_detect(struct i2c_client *client,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From b979ceb8101168fd6ebe3d88629d07c4d8007c8b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 369/449] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 369/450] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/hwmon/nct7511.c b/drivers/hwmon/nct7511.c
-index e5006ecd83465..808755e2c37d5 100644
+index e5006ecd8346..808755e2c37d 100644
 --- a/drivers/hwmon/nct7511.c
 +++ b/drivers/hwmon/nct7511.c
 @@ -744,8 +744,7 @@ static int nct7511_init_chip(struct nct7511_data *data)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From 4af3c2f1aeaa3b1224e08966c586b31c183944b6 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 370/449] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 370/450] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 
@@ -25,7 +25,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 74 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index f71123a475464..022bdf94ab37b 100644
+index f71123a47546..022bdf94ab37 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -1180,6 +1180,78 @@ static void add_cx5051_fake_mutes(struct hda_codec *codec)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 9cc3f4c0f0928cb7a71261bf876d9d79f73a1873 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 371/449] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 371/450] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 20 insertions(+)
 
 diff --git a/include/sound/hda_codec.h b/include/sound/hda_codec.h
-index 5d9f0ef228af1..9ca7a61eaed97 100644
+index 5d9f0ef228af..9ca7a61eaed9 100644
 --- a/include/sound/hda_codec.h
 +++ b/include/sound/hda_codec.h
 @@ -371,6 +371,8 @@ struct hda_verb {
@@ -32,7 +32,7 @@ index 5d9f0ef228af1..9ca7a61eaed97 100644
  			    const struct hda_verb *seq);
  
 diff --git a/sound/hda/common/codec.c b/sound/hda/common/codec.c
-index c6d44168c7f9d..e8ff6dfbec341 100644
+index c6d44168c7f9..e8ff6dfbec34 100644
 --- a/sound/hda/common/codec.c
 +++ b/sound/hda/common/codec.c
 @@ -77,6 +77,24 @@ static int codec_exec_verb(struct hdac_device *dev, unsigned int cmd,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0372-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0372-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From c5de6be5af2f442ac316492aebdb627e833fce88 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 372/449] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 372/450] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]
@@ -23,7 +23,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 9 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index 022bdf94ab37b..559d749be18ef 100644
+index 022bdf94ab37..559d749be18e 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -43,6 +43,9 @@ struct conexant_spec {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0373-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0373-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From a3a6e9530eba215bc41c243bb607324c2542e883 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 373/449] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 373/450] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 26 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index 559d749be18ef..d5cd101f6977e 100644
+index 559d749be18e..d5cd101f6977 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -285,6 +285,7 @@ enum {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0374-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0374-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From 850bf6e411526c805e728ee6a2de375d56f16a69 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 374/449] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 374/450] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/usb/serial/option.c b/drivers/usb/serial/option.c
-index d4505a4264460..47c1797fdca2e 100644
+index d4505a426446..47c1797fdca2 100644
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
 @@ -2141,6 +2141,7 @@ static const struct usb_device_id option_ids[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0375-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0375-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From 89844916aac413f43c5417fe6a0c519065306f9a Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 375/449] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 375/450] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 7 insertions(+)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index d5cd101f6977e..37b53bc33b0f6 100644
+index d5cd101f6977..37b53bc33b0f 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -1335,6 +1335,13 @@ static int cx_probe(struct hda_codec *codec, const struct hda_device_id *id)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0376-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0376-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From 54c328215363a8cc4cd1f2a17dab05546d4215fc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 376/449] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 376/450] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/sound/hda/codecs/conexant.c b/sound/hda/codecs/conexant.c
-index 37b53bc33b0f6..fad833acb715f 100644
+index 37b53bc33b0f..fad833acb715 100644
 --- a/sound/hda/codecs/conexant.c
 +++ b/sound/hda/codecs/conexant.c
 @@ -1335,8 +1335,9 @@ static int cx_probe(struct hda_codec *codec, const struct hda_device_id *id)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0377-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0377-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 9231fe1d9bf1f2853a4db4e16a4ad9ac3049ec99 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 377/449] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 377/450] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 82 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/e1000e/e1000.h b/drivers/net/ethernet/intel/e1000e/e1000.h
-index 018e61aea787d..495ff797eb588 100644
+index 018e61aea787..495ff797eb58 100644
 --- a/drivers/net/ethernet/intel/e1000e/e1000.h
 +++ b/drivers/net/ethernet/intel/e1000e/e1000.h
 @@ -228,6 +228,7 @@ struct e1000_adapter {
@@ -44,7 +44,7 @@ index 018e61aea787d..495ff797eb588 100644
  	u16 tx_ring_count;
  	u16 rx_ring_count;
 diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
-index 75896602e732c..7e93acdf16ed0 100644
+index 75896602e732..7e93acdf16ed 100644
 --- a/drivers/net/ethernet/intel/e1000e/netdev.c
 +++ b/drivers/net/ethernet/intel/e1000e/netdev.c
 @@ -637,6 +637,69 @@ static void e1000e_update_tdt_wa(struct e1000_ring *tx_ring, unsigned int i)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0378-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0378-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From 57d4ba18c7f7bf6192aefd26819fd32defce879b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 378/449] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 378/450] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/message.c b/drivers/usb/core/message.c
-index 6138468c67c47..59ea31d2d7a8f 100644
+index 6138468c67c4..59ea31d2d7a8 100644
 --- a/drivers/usb/core/message.c
 +++ b/drivers/usb/core/message.c
 @@ -1999,7 +1999,7 @@ int usb_set_configuration(struct usb_device *dev, int configuration)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0379-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0379-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From f9d2cbe99a4306a0d21ce77bd13ef19b51802910 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 379/449] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 379/450] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 52 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index fc60026bc6741..f1c686ef7a54b 100644
+index fc60026bc674..f1c686ef7a54 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -127,6 +127,13 @@ enum
@@ -37,7 +37,7 @@ index fc60026bc6741..f1c686ef7a54b 100644
  /*
   * The reported battery die temperature.
 diff --git a/drivers/platform/mips/Kconfig b/drivers/platform/mips/Kconfig
-index 7ef9a47556d59..a5a80e0a399ff 100644
+index 7ef9a47556d5..a5a80e0a399f 100644
 --- a/drivers/platform/mips/Kconfig
 +++ b/drivers/platform/mips/Kconfig
 @@ -49,6 +49,7 @@ config LEMOTE3A_LAPTOP
@@ -49,7 +49,7 @@ index 7ef9a47556d59..a5a80e0a399ff 100644
  	help
  	  Lemote Loongson-3A/2Gq family laptops driver.
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index a8d339a3e30b7..b6f585b0f7d35 100644
+index a8d339a3e30b..b6f585b0f7d3 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -19,12 +19,14 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0380-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0380-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From 1817232cce3e0a0e311af5ce03e417303bef1c8d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 380/449] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 380/450] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 61 insertions(+)
 
 diff --git a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
-index f1c686ef7a54b..e1f8577a6ed61 100644
+index f1c686ef7a54..e1f8577a6ed6 100644
 --- a/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 +++ b/arch/mips/include/asm/mach-loongson64/ec_wpce775l.h
 @@ -320,6 +320,17 @@ enum
@@ -37,7 +37,7 @@ index f1c686ef7a54b..e1f8577a6ed61 100644
  /* EC Status query, by direct read 66h port. */
  #define EC_SMI_EVT		(1 << 6)	/* 1 = SMI event padding */
 diff --git a/drivers/platform/mips/lemote3a-laptop.c b/drivers/platform/mips/lemote3a-laptop.c
-index b6f585b0f7d35..dbb37e376ee80 100644
+index b6f585b0f7d3..dbb37e376ee8 100644
 --- a/drivers/platform/mips/lemote3a-laptop.c
 +++ b/drivers/platform/mips/lemote3a-laptop.c
 @@ -160,6 +160,7 @@ static int lemote3a_laptop_suspend(struct platform_device * pdev, pm_message_t s

--- a/runtime-kernel/linux-kernel/autobuild/patches/0381-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0381-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 0b0362f9a2e70edb8580ecfc2b89ab03cc5e83f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 381/449] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 381/450] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/mips/kernel/audit-o32.h
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2248badc3acb6..2e9ac29588c81 100644
+index 2248badc3acb..2e9ac29588c8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -4,6 +4,7 @@
@@ -40,7 +40,7 @@ index 2248badc3acb6..2e9ac29588c81 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-n32.h b/arch/mips/kernel/audit-n32.h
 new file mode 100644
-index 0000000000000..781de2e9ad66b
+index 000000000000..781de2e9ad66
 --- /dev/null
 +++ b/arch/mips/kernel/audit-n32.h
 @@ -0,0 +1,5 @@
@@ -50,7 +50,7 @@ index 0000000000000..781de2e9ad66b
 +int audit_classify_syscall_n32(int abi, unsigned syscall);
 +#endif /* CONFIG_AUDITSYSCALL_N32 */
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 09ae3dbcfecbc..88e283f8df385 100644
+index 09ae3dbcfecb..88e283f8df38 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -2,6 +2,8 @@
@@ -73,7 +73,7 @@ index 09ae3dbcfecbc..88e283f8df385 100644
  {
  	int res;
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index e8b9b50f7d267..6bf302c04e5d3 100644
+index e8b9b50f7d26..6bf302c04e5d 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -4,6 +4,7 @@
@@ -86,7 +86,7 @@ index e8b9b50f7d267..6bf302c04e5d3 100644
  #include <asm-generic/audit_dir_write.h>
 diff --git a/arch/mips/kernel/audit-o32.h b/arch/mips/kernel/audit-o32.h
 new file mode 100644
-index 0000000000000..8a782fdd1c6e7
+index 000000000000..8a782fdd1c6e
 --- /dev/null
 +++ b/arch/mips/kernel/audit-o32.h
 @@ -0,0 +1,5 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0382-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0382-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From 9a27cacddf1e93c3754a88bba26ebdaafa17e1d7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 382/449] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 382/450] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 16 insertions(+), 13 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 2e9ac29588c81..8d114bf854254 100644
+index 2e9ac29588c8..8d114bf85425 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -35,11 +35,11 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -39,7 +39,7 @@ index 2e9ac29588c81..8d114bf854254 100644
  		return 0;
  	}
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 88e283f8df385..4a0fecd0e4867 100644
+index 88e283f8df38..4a0fecd0e486 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -45,20 +45,20 @@ int audit_classify_syscall(int abi, unsigned syscall)
@@ -68,7 +68,7 @@ index 88e283f8df385..4a0fecd0e4867 100644
  	default:
  #ifdef CONFIG_AUDITSYSCALL_O32
 diff --git a/arch/mips/kernel/audit-o32.c b/arch/mips/kernel/audit-o32.c
-index 6bf302c04e5d3..818f91ce14acf 100644
+index 6bf302c04e5d..818f91ce14ac 100644
 --- a/arch/mips/kernel/audit-o32.c
 +++ b/arch/mips/kernel/audit-o32.c
 @@ -35,15 +35,15 @@ int audit_classify_syscall_o32(int abi, unsigned syscall)
@@ -93,7 +93,7 @@ index 6bf302c04e5d3..818f91ce14acf 100644
  }
  
 diff --git a/include/linux/audit_arch.h b/include/linux/audit_arch.h
-index 2b8153791e6a5..2594c9b1c7891 100644
+index 2b8153791e6a..2594c9b1c789 100644
 --- a/include/linux/audit_arch.h
 +++ b/include/linux/audit_arch.h
 @@ -17,6 +17,9 @@ enum auditsc_class_t {
@@ -107,7 +107,7 @@ index 2b8153791e6a5..2594c9b1c7891 100644
  	AUDITSC_NVALS /* count */
  };
 diff --git a/kernel/auditsc.c b/kernel/auditsc.c
-index 6ba5cbd45d040..9dac09d44281c 100644
+index 6ba5cbd45d04..9dac09d44281 100644
 --- a/kernel/auditsc.c
 +++ b/kernel/auditsc.c
 @@ -190,7 +190,7 @@ static int audit_match_perm(struct audit_context *ctx, int mask)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0383-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0383-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From 0ba19f1b9fce1ec38075bbd888330e30d0706cb9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 383/449] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 383/450] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 8 insertions(+), 27 deletions(-)
 
 diff --git a/arch/mips/kernel/audit-n32.c b/arch/mips/kernel/audit-n32.c
-index 8d114bf854254..76c95ff924f83 100644
+index 8d114bf85425..76c95ff924f8 100644
 --- a/arch/mips/kernel/audit-n32.c
 +++ b/arch/mips/kernel/audit-n32.c
 @@ -41,7 +41,7 @@ int audit_classify_syscall_n32(int abi, unsigned syscall)
@@ -30,7 +30,7 @@ index 8d114bf854254..76c95ff924f83 100644
  }
  
 diff --git a/arch/mips/kernel/audit-native.c b/arch/mips/kernel/audit-native.c
-index 4a0fecd0e4867..763f0e6b3636a 100644
+index 4a0fecd0e486..763f0e6b3636 100644
 --- a/arch/mips/kernel/audit-native.c
 +++ b/arch/mips/kernel/audit-native.c
 @@ -41,45 +41,26 @@ int audit_classify_arch(int arch)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0384-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0384-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From f89eda9a9830ee969af068874f17d24e8d30865f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 384/449] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 384/450] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 37 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index 63c47585afbcf..371e6cd211453 100644
+index 63c47585afbc..371e6cd21145 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -2403,6 +2403,8 @@ struct radeon_device {
@@ -32,7 +32,7 @@ index 63c47585afbcf..371e6cd211453 100644
  	struct mutex dc_hw_i2c_mutex; /* display controller hw i2c mutex */
  	bool has_uvd;
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 92a3e3ee673c7..368221d175928 100644
+index 92a3e3ee673c..368221d17592 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1641,7 +1641,28 @@ int radeon_suspend_kms(struct drm_device *dev, bool suspend,
@@ -90,7 +90,7 @@ index 92a3e3ee673c7..368221d175928 100644
  }
  
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index 839d619e5602b..2f57feb4ca6cc 100644
+index 839d619e5602..2f57feb4ca6c 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -297,6 +297,8 @@ static bool radeon_msi_ok(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0385-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0385-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 68737419d8e7cf70a69b6942ff1977c509f258fa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 385/449] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 385/450] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.h b/drivers/gpu/drm/radeon/radeon_device.h
-index 31a0ae295cc8f..e7f6d468b5674 100644
+index 31a0ae295cc8..e7f6d468b567 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.h
 +++ b/drivers/gpu/drm/radeon/radeon_device.h
 @@ -29,4 +29,6 @@
@@ -29,7 +29,7 @@ index 31a0ae295cc8f..e7f6d468b5674 100644
 +
  #endif                         /* __RADEON_DEVICE_H__ */
 diff --git a/drivers/gpu/drm/radeon/radeon_irq_kms.c b/drivers/gpu/drm/radeon/radeon_irq_kms.c
-index 2f57feb4ca6cc..a995bf7c9f1e1 100644
+index 2f57feb4ca6c..a995bf7c9f1e 100644
 --- a/drivers/gpu/drm/radeon/radeon_irq_kms.c
 +++ b/drivers/gpu/drm/radeon/radeon_irq_kms.c
 @@ -40,6 +40,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0386-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0386-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From 770c35451b87f221bd455f028eb0d1f75a08eba1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 386/449] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 386/450] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.
@@ -26,7 +26,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  4 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index 368221d175928..e3be0c0aed5ae 100644
+index 368221d17592..e3be0c0aed5a 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1789,6 +1789,7 @@ int radeon_gpu_reset(struct radeon_device *rdev)
@@ -56,7 +56,7 @@ index 368221d175928..e3be0c0aed5ae 100644
  	rdev->needs_reset = false;
  
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index a855a96dd2ea9..ce8569bf0b04d 100644
+index a855a96dd2ea..ce8569bf0b04 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1853,10 +1853,11 @@ static bool radeon_pm_debug_check_in_vbl(struct radeon_device *rdev, bool finish
@@ -81,7 +81,7 @@ index a855a96dd2ea9..ce8569bf0b04d 100644
  
  /*
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index 29423ceeec5c7..e58f351f0119e 100644
+index 29423ceeec5c..e58f351f0119 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -331,6 +331,20 @@ void ttm_bo_put(struct ttm_buffer_object *bo)
@@ -106,7 +106,7 @@ index 29423ceeec5c7..e58f351f0119e 100644
  				     struct ttm_operation_ctx *ctx,
  				     struct ttm_place *hop)
 diff --git a/include/drm/ttm/ttm_bo.h b/include/drm/ttm/ttm_bo.h
-index e664a96540eb6..207e2fccb5ee9 100644
+index e664a96540eb..207e2fccb5ee 100644
 --- a/include/drm/ttm/ttm_bo.h
 +++ b/include/drm/ttm/ttm_bo.h
 @@ -355,6 +355,22 @@ static inline void ttm_bo_move_null(struct ttm_buffer_object *bo,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0387-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0387-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 40d92591e542f7de54f28c66c2bd60b436ed3c47 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 387/449] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 387/450] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_device.c b/drivers/gpu/drm/radeon/radeon_device.c
-index e3be0c0aed5ae..499a2bdf79bba 100644
+index e3be0c0aed5a..499a2bdf79bb 100644
 --- a/drivers/gpu/drm/radeon/radeon_device.c
 +++ b/drivers/gpu/drm/radeon/radeon_device.c
 @@ -1657,7 +1657,7 @@ void radeon_recover_callback(struct work_struct *work)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0388-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0388-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From aa1432527e58a6ba4563fb1d5773a72294d30ce6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 388/449] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 388/450] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/ttm/ttm_bo.c b/drivers/gpu/drm/ttm/ttm_bo.c
-index e58f351f0119e..af2022a241cb6 100644
+index e58f351f0119..af2022a241cb 100644
 --- a/drivers/gpu/drm/ttm/ttm_bo.c
 +++ b/drivers/gpu/drm/ttm/ttm_bo.c
 @@ -333,14 +333,14 @@ EXPORT_SYMBOL(ttm_bo_put);
@@ -48,7 +48,7 @@ index e58f351f0119e..af2022a241cb6 100644
  }
  EXPORT_SYMBOL(ttm_bo_unlock_delayed_workqueue);
 diff --git a/include/drm/ttm/ttm_device.h b/include/drm/ttm/ttm_device.h
-index c2e61312a43a2..de7195ef9b131 100644
+index c2e61312a43a..de7195ef9b13 100644
 --- a/include/drm/ttm/ttm_device.h
 +++ b/include/drm/ttm/ttm_device.h
 @@ -276,6 +276,11 @@ struct ttm_device {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0389-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0389-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 7d4e38beda103a02e2717f951476aa5c1cc65f1e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 389/449] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 389/450] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1ce165c627a6c..493022119c1a7 100644
+index 1ce165c627a6..493022119c1a 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,6 +1010,9 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -28,7 +28,7 @@ index 1ce165c627a6c..493022119c1a7 100644
  						 evergreen_golden_registers,
  						 (const u32)ARRAY_SIZE(evergreen_golden_registers));
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index ce8569bf0b04d..35e10f3db5f23 100644
+index ce8569bf0b04..35e10f3db5f2 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1519,6 +1519,7 @@ int radeon_pm_init(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0390-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0390-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From ad73e06906186cf9a376d9f483ab37e31a0a6cc9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 390/449] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 390/450] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 7 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 493022119c1a7..1a15f9264ead0 100644
+index 493022119c1a..1a15f9264ead 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -1010,8 +1010,10 @@ static void evergreen_init_golden_registers(struct radeon_device *rdev)
@@ -32,7 +32,7 @@ index 493022119c1a7..1a15f9264ead0 100644
  		radeon_program_register_sequence(rdev,
  						 evergreen_golden_registers,
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 35e10f3db5f23..280ef587a37f4 100644
+index 35e10f3db5f2..280ef587a37f 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1519,7 +1519,9 @@ int radeon_pm_init(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0391-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0391-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From 7a83c42a56e3687025bae50e1db532805cab9225 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 391/449] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 391/450] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
-index 280ef587a37f4..5ef222000ad5f 100644
+index 280ef587a37f..5ef222000ad5 100644
 --- a/drivers/gpu/drm/radeon/radeon_pm.c
 +++ b/drivers/gpu/drm/radeon/radeon_pm.c
 @@ -1353,7 +1353,7 @@ static int radeon_pm_init_old(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0392-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0392-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From 409da9e3489ef8a46696a3e5eb3920268ca5f1be Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 392/449] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 392/450] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do
@@ -28,7 +28,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  12 files changed, 35 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/cik.c b/drivers/gpu/drm/radeon/cik.c
-index 7e7f6248b63a6..170d54c4b5eb5 100644
+index 7e7f6248b63a..170d54c4b5eb 100644
 --- a/drivers/gpu/drm/radeon/cik.c
 +++ b/drivers/gpu/drm/radeon/cik.c
 @@ -5435,6 +5435,7 @@ static int cik_pcie_gart_enable(struct radeon_device *rdev)
@@ -40,7 +40,7 @@ index 7e7f6248b63a6..170d54c4b5eb5 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/evergreen.c b/drivers/gpu/drm/radeon/evergreen.c
-index 1a15f9264ead0..4a7774c35e850 100644
+index 1a15f9264ead..4a7774c35e85 100644
 --- a/drivers/gpu/drm/radeon/evergreen.c
 +++ b/drivers/gpu/drm/radeon/evergreen.c
 @@ -2414,6 +2414,7 @@ static int evergreen_pcie_gart_enable(struct radeon_device *rdev)
@@ -52,7 +52,7 @@ index 1a15f9264ead0..4a7774c35e850 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/ni.c b/drivers/gpu/drm/radeon/ni.c
-index 3890911fe693c..03335fa3367bb 100644
+index 3890911fe693..03335fa3367b 100644
 --- a/drivers/gpu/drm/radeon/ni.c
 +++ b/drivers/gpu/drm/radeon/ni.c
 @@ -1256,6 +1256,7 @@ static int cayman_pcie_gart_enable(struct radeon_device *rdev)
@@ -64,7 +64,7 @@ index 3890911fe693c..03335fa3367bb 100644
  	WREG32(MC_VM_MX_L1_TLB_CNTL,
  	       (0xA << 7) |
 diff --git a/drivers/gpu/drm/radeon/r100.c b/drivers/gpu/drm/radeon/r100.c
-index 07a9c523a17af..8d3c9653bdd58 100644
+index 07a9c523a17a..8d3c9653bdd5 100644
 --- a/drivers/gpu/drm/radeon/r100.c
 +++ b/drivers/gpu/drm/radeon/r100.c
 @@ -672,6 +672,7 @@ int r100_pci_gart_enable(struct radeon_device *rdev)
@@ -76,7 +76,7 @@ index 07a9c523a17af..8d3c9653bdd58 100644
  	tmp = RREG32(RADEON_AIC_CNTL) | RADEON_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32(RADEON_AIC_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r300.c b/drivers/gpu/drm/radeon/r300.c
-index d2ee6deec0397..ffc91b8f30b17 100644
+index d2ee6deec039..ffc91b8f30b1 100644
 --- a/drivers/gpu/drm/radeon/r300.c
 +++ b/drivers/gpu/drm/radeon/r300.c
 @@ -161,6 +161,7 @@ int rv370_pcie_gart_enable(struct radeon_device *rdev)
@@ -88,7 +88,7 @@ index d2ee6deec0397..ffc91b8f30b17 100644
  	tmp = RADEON_PCIE_TX_GART_UNMAPPED_ACCESS_DISCARD;
  	WREG32_PCIE(RADEON_PCIE_TX_GART_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
-index 88e38fb3f3476..4c57b429af216 100644
+index 88e38fb3f347..4c57b429af21 100644
 --- a/drivers/gpu/drm/radeon/r600.c
 +++ b/drivers/gpu/drm/radeon/r600.c
 @@ -1137,6 +1137,7 @@ static int r600_pcie_gart_enable(struct radeon_device *rdev)
@@ -100,7 +100,7 @@ index 88e38fb3f3476..4c57b429af216 100644
  	/* Setup L2 cache */
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
 diff --git a/drivers/gpu/drm/radeon/radeon.h b/drivers/gpu/drm/radeon/radeon.h
-index 371e6cd211453..cc0bc138f56b0 100644
+index 371e6cd21145..cc0bc138f56b 100644
 --- a/drivers/gpu/drm/radeon/radeon.h
 +++ b/drivers/gpu/drm/radeon/radeon.h
 @@ -625,6 +625,7 @@ void radeon_gart_unbind(struct radeon_device *rdev, unsigned offset,
@@ -112,7 +112,7 @@ index 371e6cd211453..cc0bc138f56b0 100644
  
  /*
 diff --git a/drivers/gpu/drm/radeon/radeon_gart.c b/drivers/gpu/drm/radeon/radeon_gart.c
-index acd89a20f2724..7b7ff74db6564 100644
+index acd89a20f272..7b7ff74db656 100644
 --- a/drivers/gpu/drm/radeon/radeon_gart.c
 +++ b/drivers/gpu/drm/radeon/radeon_gart.c
 @@ -317,6 +317,30 @@ int radeon_gart_bind(struct radeon_device *rdev, unsigned int offset,
@@ -147,7 +147,7 @@ index acd89a20f2724..7b7ff74db6564 100644
   * radeon_gart_init - init the driver info for managing the gart
   *
 diff --git a/drivers/gpu/drm/radeon/rs400.c b/drivers/gpu/drm/radeon/rs400.c
-index 13cd0a688a65c..6dad165e90fcc 100644
+index 13cd0a688a65..6dad165e90fc 100644
 --- a/drivers/gpu/drm/radeon/rs400.c
 +++ b/drivers/gpu/drm/radeon/rs400.c
 @@ -113,6 +113,7 @@ int rs400_gart_enable(struct radeon_device *rdev)
@@ -159,7 +159,7 @@ index 13cd0a688a65c..6dad165e90fcc 100644
  	tmp |= RS690_DIS_OUT_OF_PCI_GART_ACCESS;
  	WREG32_MC(RS690_AIC_CTRL_SCRATCH, tmp);
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 88c8e91ea6512..7cfe137d7dcdd 100644
+index 88c8e91ea651..7cfe137d7dcd 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -571,6 +571,7 @@ static int rs600_gart_enable(struct radeon_device *rdev)
@@ -171,7 +171,7 @@ index 88c8e91ea6512..7cfe137d7dcdd 100644
  	tmp = RREG32(RADEON_BUS_CNTL) & ~RS600_BUS_MASTER_DIS;
  	WREG32(RADEON_BUS_CNTL, tmp);
 diff --git a/drivers/gpu/drm/radeon/rv770.c b/drivers/gpu/drm/radeon/rv770.c
-index 7d4b0bf591090..c7317aff4cd64 100644
+index 7d4b0bf59109..c7317aff4cd6 100644
 --- a/drivers/gpu/drm/radeon/rv770.c
 +++ b/drivers/gpu/drm/radeon/rv770.c
 @@ -903,6 +903,7 @@ static int rv770_pcie_gart_enable(struct radeon_device *rdev)
@@ -183,7 +183,7 @@ index 7d4b0bf591090..c7317aff4cd64 100644
  	WREG32(VM_L2_CNTL, ENABLE_L2_CACHE | ENABLE_L2_FRAGMENT_PROCESSING |
  				ENABLE_L2_PTE_CACHE_LRU_UPDATE_BY_WRITE |
 diff --git a/drivers/gpu/drm/radeon/si.c b/drivers/gpu/drm/radeon/si.c
-index 2d7eeb781969d..8c66b602009e3 100644
+index 2d7eeb781969..8c66b602009e 100644
 --- a/drivers/gpu/drm/radeon/si.c
 +++ b/drivers/gpu/drm/radeon/si.c
 @@ -4273,6 +4273,7 @@ static int si_pcie_gart_enable(struct radeon_device *rdev)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0393-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0393-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From 1cf622b49e9023f192f7c8c7364dc870e2db079b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 393/449] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 393/450] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/gpu/drm/radeon/rs600.c b/drivers/gpu/drm/radeon/rs600.c
-index 7cfe137d7dcdd..8fb559af1a37f 100644
+index 7cfe137d7dcd..8fb559af1a37 100644
 --- a/drivers/gpu/drm/radeon/rs600.c
 +++ b/drivers/gpu/drm/radeon/rs600.c
 @@ -654,6 +654,9 @@ uint64_t rs600_gart_get_page_entry(uint64_t addr, uint32_t flags)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0394-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0394-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From e473b52bf99c8028340cab0647ce68c2968be402 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 394/449] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 394/450] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -12,7 +12,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index 3659af7e519db..ff7f6f278f8fa 100644
+index 3659af7e519d..ff7f6f278f8f 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -34,7 +34,7 @@ static int g_hwcursor = 1;

--- a/runtime-kernel/linux-kernel/autobuild/patches/0395-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0395-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From c0ffcebfe05724aa6e4930b8c70f11e4da089d86 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 395/449] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 395/450] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sm750fb/sm750.c b/drivers/staging/sm750fb/sm750.c
-index ff7f6f278f8fa..7add1b65932df 100644
+index ff7f6f278f8f..7add1b65932d 100644
 --- a/drivers/staging/sm750fb/sm750.c
 +++ b/drivers/staging/sm750fb/sm750.c
 @@ -30,7 +30,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0396-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0396-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 3d7305bd4cc8912851163458f92132df2410bf9f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 396/449] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 396/450] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
-index 1c602563b6a4d..12c4b1bca8f03 100644
+index 1c602563b6a4..12c4b1bca8f0 100644
 --- a/drivers/input/serio/i8042.c
 +++ b/drivers/input/serio/i8042.c
 @@ -132,7 +132,9 @@ MODULE_PARM_DESC(unmask_kbd_data, "Unconditional enable (may reveal sensitive da

--- a/runtime-kernel/linux-kernel/autobuild/patches/0397-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0397-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 9ee82fea715d4a1918dcbd9145e706fb7a73f110 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 397/449] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 397/450] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 76 insertions(+)
 
 diff --git a/drivers/net/ethernet/intel/igb/igb.h b/drivers/net/ethernet/intel/igb/igb.h
-index 0fff1df81b7bd..651a4328dbdec 100644
+index 0fff1df81b7b..651a4328dbde 100644
 --- a/drivers/net/ethernet/intel/igb/igb.h
 +++ b/drivers/net/ethernet/intel/igb/igb.h
 @@ -380,6 +380,13 @@ struct igb_q_vector {
@@ -31,7 +31,7 @@ index 0fff1df81b7bd..651a4328dbdec 100644
  	struct igb_ring ring[] ____cacheline_internodealigned_in_smp;
  };
 diff --git a/drivers/net/ethernet/intel/igb/igb_main.c b/drivers/net/ethernet/intel/igb/igb_main.c
-index dbea37269d2cd..369617994263a 100644
+index dbea37269d2c..369617994263 100644
 --- a/drivers/net/ethernet/intel/igb/igb_main.c
 +++ b/drivers/net/ethernet/intel/igb/igb_main.c
 @@ -4222,6 +4222,15 @@ static int __igb_open(struct net_device *netdev, bool resuming)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0398-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0398-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From 821542abe52b68042d209a2ae9eb37e338814328 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 398/449] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 398/450] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!
@@ -32,7 +32,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/staging/sb105x/sb_ser_core.h
 
 diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
-index 075e775d3868b..bd2999a91b31f 100644
+index 075e775d3868..bd2999a91b31 100644
 --- a/drivers/staging/Kconfig
 +++ b/drivers/staging/Kconfig
 @@ -36,6 +36,8 @@ source "drivers/staging/nvec/Kconfig"
@@ -45,7 +45,7 @@ index 075e775d3868b..bd2999a91b31f 100644
  
  source "drivers/staging/most/Kconfig"
 diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
-index e681e403509ce..7d80e07d27583 100644
+index e681e403509c..7d80e07d2758 100644
 --- a/drivers/staging/Makefile
 +++ b/drivers/staging/Makefile
 @@ -8,6 +8,7 @@ obj-$(CONFIG_VME_BUS)		+= vme_user/
@@ -58,7 +58,7 @@ index e681e403509ce..7d80e07d27583 100644
  obj-$(CONFIG_GREYBUS)		+= greybus/
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
 new file mode 100644
-index 0000000000000..245e7847a3542
+index 000000000000..245e7847a354
 --- /dev/null
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -0,0 +1,9 @@
@@ -73,7 +73,7 @@ index 0000000000000..245e7847a3542
 +	  will be called "sb105x".
 diff --git a/drivers/staging/sb105x/Makefile b/drivers/staging/sb105x/Makefile
 new file mode 100644
-index 0000000000000..b1bf3779acaed
+index 000000000000..b1bf3779acae
 --- /dev/null
 +++ b/drivers/staging/sb105x/Makefile
 @@ -0,0 +1,3 @@
@@ -82,7 +82,7 @@ index 0000000000000..b1bf3779acaed
 +sb105x-y :=  sb_pci_mp.o
 diff --git a/drivers/staging/sb105x/sb_mp_register.h b/drivers/staging/sb105x/sb_mp_register.h
 new file mode 100644
-index 0000000000000..276c1bbcc18dd
+index 000000000000..276c1bbcc18d
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_mp_register.h
 @@ -0,0 +1,295 @@
@@ -383,7 +383,7 @@ index 0000000000000..276c1bbcc18dd
 +#endif 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
 new file mode 100644
-index 0000000000000..c9d6ee3903adc
+index 000000000000..c9d6ee3903ad
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -0,0 +1,3189 @@
@@ -3578,7 +3578,7 @@ index 0000000000000..c9d6ee3903adc
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
 new file mode 100644
-index 0000000000000..80ae4ab046031
+index 000000000000..80ae4ab04603
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -0,0 +1,291 @@
@@ -3875,7 +3875,7 @@ index 0000000000000..80ae4ab046031
 +
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
 new file mode 100644
-index 0000000000000..c8fb991732997
+index 000000000000..c8fb99173299
 --- /dev/null
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -0,0 +1,368 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0399-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0399-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From fa2e15ff4e0b380a72a4c233c1c9df5eb9c52802 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 399/449] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 399/450] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
 new file mode 100644
-index 0000000000000..a780ee51a7188
+index 000000000000..a780ee51a718
 --- /dev/null
 +++ b/arch/mips/include/asm/serial.h
 @@ -0,0 +1,19 @@
@@ -46,7 +46,7 @@ index 0000000000000..a780ee51a7188
 +
 +#endif /* __ASM__SERIAL_H */
 diff --git a/drivers/staging/sb105x/Kconfig b/drivers/staging/sb105x/Kconfig
-index 245e7847a3542..c5f741e71c14b 100644
+index 245e7847a354..c5f741e71c14 100644
 --- a/drivers/staging/sb105x/Kconfig
 +++ b/drivers/staging/sb105x/Kconfig
 @@ -1,7 +1,7 @@
@@ -59,7 +59,7 @@ index 245e7847a3542..c5f741e71c14b 100644
  	  A driver for the SystemBase Multi-2/PCI serial card
  
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c9d6ee3903adc..18e91bc61ba16 100644
+index c9d6ee3903ad..18e91bc61ba1 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1,6 +1,7 @@
@@ -315,7 +315,7 @@ index c9d6ee3903adc..18e91bc61ba16 100644
              
  	   		     	if (status != 0)
 diff --git a/drivers/staging/sb105x/sb_pci_mp.h b/drivers/staging/sb105x/sb_pci_mp.h
-index 80ae4ab046031..0920beb31c15e 100644
+index 80ae4ab04603..0920beb31c15 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.h
 +++ b/drivers/staging/sb105x/sb_pci_mp.h
 @@ -287,5 +287,4 @@ static const struct sb105x_uart_config uart_config[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0400-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0400-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From 84883907b8f7a10739a06b63cfc47b14f6201712 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 400/449] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 400/450] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index c8fb991732997..8835415e1d3df 100644
+index c8fb99173299..8835415e1d3d 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -196,13 +196,13 @@ struct uart_driver {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0401-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0401-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From 4934b1fb503d28396a8aa8abb0e844e57377df31 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 401/449] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 401/450] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 18e91bc61ba16..e333245ec9c5d 100644
+index 18e91bc61ba1..e333245ec9c5 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -480,7 +480,7 @@ static void __mp_start(struct tty_struct *tty)
@@ -42,7 +42,7 @@ index 18e91bc61ba16..e333245ec9c5d 100644
  
  	return put_user(result, value);
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index 8835415e1d3df..d8664e723b4a3 100644
+index 8835415e1d3d..d8664e723b4a 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -52,7 +52,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0402-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0402-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From f5fa375aec5755e3636e03290573ca181f70aa1e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 402/449] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 402/450] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index e333245ec9c5d..963f3091a5c95 100644
+index e333245ec9c5..963f3091a5c9 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1051,7 +1051,7 @@ static int mp_wait_modem_status(struct sb_uart_state *state, unsigned long arg)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0403-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0403-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 27f4263e6eeea99f0ae99e1815a6eeacfa2ac6fb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 403/449] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 403/450] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 963f3091a5c95..cd98d3b0183da 100644
+index 963f3091a5c9..cd98d3b0183d 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1624,7 +1624,7 @@ static inline void mp_report_port(struct uart_driver *drv, struct sb_uart_port *

--- a/runtime-kernel/linux-kernel/autobuild/patches/0404-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0404-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From 27e9366592f97e748c587a8d92e426425edf7866 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 404/449] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 404/450] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all
@@ -22,7 +22,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index cd98d3b0183da..ccf02cfeb2fcc 100644
+index cd98d3b0183d..ccf02cfeb2fc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1728,12 +1728,10 @@ static int mp_register_driver(struct uart_driver *drv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0405-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0405-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From 8d16f18b156e55b946eac322d9ddb8ccfbafde2b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 405/449] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 405/450] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index ccf02cfeb2fcc..c5e1c39e7a7a2 100644
+index ccf02cfeb2fc..c5e1c39e7a7a 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1765,7 +1765,7 @@ for (i = 0; i < drv->nr; i++) {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0406-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0406-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From 67f1afe39738891f08d8e099a412ae59014350e7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 406/449] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 406/450] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/serial.h b/arch/mips/include/asm/serial.h
-index a780ee51a7188..2777148dbfc5a 100644
+index a780ee51a718..2777148dbfc5 100644
 --- a/arch/mips/include/asm/serial.h
 +++ b/arch/mips/include/asm/serial.h
 @@ -12,7 +12,6 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0407-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0407-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From 7aaa24699ca7eeede21bbbd72aeae0bb33b0f5af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 407/449] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 407/450] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index c5e1c39e7a7a2..32f60de269ccb 100644
+index c5e1c39e7a7a..32f60de269cc 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -2808,7 +2808,7 @@ static void __init multi_init_ports(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0408-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0408-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 1b8d74eb7c9f3f44d8b52500eab55a784ceec2c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 408/449] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 408/450] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 32f60de269ccb..841e9b15486b0 100644
+index 32f60de269cc..841e9b15486b 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -1736,7 +1736,6 @@ static int mp_register_driver(struct uart_driver *drv)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0409-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0409-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From e9093761f93447b341a622cc7b3c9f920e1d1ab4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 409/449] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 409/450] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 841e9b15486b0..0d7e216fad94a 100644
+index 841e9b15486b..0d7e216fad94 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -33,7 +33,7 @@ static void mp_tasklet_action(unsigned long data);
@@ -79,7 +79,7 @@ index 841e9b15486b0..0d7e216fad94a 100644
  	struct mp_port *mtpt = (struct mp_port *)port;
  	unsigned char cval, fcr = 0;
 diff --git a/drivers/staging/sb105x/sb_ser_core.h b/drivers/staging/sb105x/sb_ser_core.h
-index d8664e723b4a3..978b4b26ddbb1 100644
+index d8664e723b4a..978b4b26ddbb 100644
 --- a/drivers/staging/sb105x/sb_ser_core.h
 +++ b/drivers/staging/sb105x/sb_ser_core.h
 @@ -77,7 +77,7 @@ struct sb_uart_ops {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0410-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0410-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From 8af6767b220dc42595f19dc54ce14a020ebadaef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 410/449] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 410/450] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 0d7e216fad94a..f61451fabdcd0 100644
+index 0d7e216fad94..f61451fabdcd 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -39,7 +39,7 @@ static inline int __mp_put_char(struct sb_uart_port *port, struct circ_buf *circ

--- a/runtime-kernel/linux-kernel/autobuild/patches/0411-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0411-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From bb860b7cea7581c75ddb66c9018af05e66613772 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 411/449] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 411/450] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index f61451fabdcd0..593835f0ad11c 100644
+index f61451fabdcd..593835f0ad11 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -40,7 +40,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0412-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0412-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 6067846543aa885ca18ab51b2201f9880a1137ae Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 412/449] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 412/450] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 593835f0ad11c..8712e74230648 100644
+index 593835f0ad11..8712e7423064 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -41,7 +41,7 @@ static int mp_put_char(struct tty_struct *tty, unsigned char ch);

--- a/runtime-kernel/linux-kernel/autobuild/patches/0413-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0413-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 7c004062efe85b0c9038aa21bf86a7b496b7ce4b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 413/449] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 413/450] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 8712e74230648..19098bbfa113e 100644
+index 8712e7423064..19098bbfa113 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -43,7 +43,7 @@ static ssize_t mp_write(struct tty_struct *tty, const unsigned char *buf, long u

--- a/runtime-kernel/linux-kernel/autobuild/patches/0414-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0414-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From 1ff80710c680060913a8254e135fd882f01f46d9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 414/449] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 414/450] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 22 insertions(+)
 
 diff --git a/drivers/parport/parport_serial.c b/drivers/parport/parport_serial.c
-index 24d4f3a3ec3d0..9e1af7103d603 100644
+index 24d4f3a3ec3d..9e1af7103d60 100644
 --- a/drivers/parport/parport_serial.c
 +++ b/drivers/parport/parport_serial.c
 @@ -60,6 +60,7 @@ enum parport_pc_pci_cards {
@@ -64,7 +64,7 @@ index 24d4f3a3ec3d0..9e1af7103d603 100644
  		.flags		= FL_BASE2,
  		.num_ports	= 5,
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 79c3dca94b560..66a93629eb74a 100644
+index 79c3dca94b56..66a93629eb74 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,6 +74,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0415-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0415-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 569e49c9a7ef665059e00425deac8eb84605b738 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 415/449] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 415/450] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 25 insertions(+)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index 66a93629eb74a..f909bd51d88e6 100644
+index 66a93629eb74..f909bd51d88e 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -337,6 +337,12 @@ static int pci_plx9050_init(struct pci_dev *dev)
@@ -64,7 +64,7 @@ index 66a93629eb74a..f909bd51d88e6 100644
  		PCI_VENDOR_ID_PLX,
  		PCI_SUBDEVICE_ID_UNKNOWN_0x1588, 0, 0,
 diff --git a/drivers/tty/serial/8250/8250_pcilib.c b/drivers/tty/serial/8250/8250_pcilib.c
-index d8d0ae0d72387..cd70b62dbbb94 100644
+index d8d0ae0d7238..cd70b62dbbb9 100644
 --- a/drivers/tty/serial/8250/8250_pcilib.c
 +++ b/drivers/tty/serial/8250/8250_pcilib.c
 @@ -27,6 +27,12 @@ int serial8250_pci_setup_port(struct pci_dev *dev, struct uart_8250_port *port,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0416-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0416-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From 08c87d7226225e8ea15ac56df7a5782d963c1a3d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 416/449] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 416/450] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 52 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index f5715cf9468fc..2cb2765d2fd25 100644
+index f5715cf9468f..2cb2765d2fd2 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -684,7 +684,17 @@
@@ -37,7 +37,7 @@ index f5715cf9468fc..2cb2765d2fd25 100644
  #define USB_VENDOR_ID_INTEL_0		0x8086
  #define USB_VENDOR_ID_INTEL_1		0x8087
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 1d245e9986879..37095ae015d0b 100644
+index 1d245e998687..37095ae015d0 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -2483,7 +2483,47 @@ static const struct hid_device_id mt_devices[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0417-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0417-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From bec0457d04dff113ecb228d854d1c942c0e94aa2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 417/449] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 417/450] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt
@@ -24,7 +24,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/usb/host/ohci-hcd.c b/drivers/usb/host/ohci-hcd.c
-index 9c7f3008646ed..0d263f99f9154 100644
+index 9c7f3008646e..0d263f99f915 100644
 --- a/drivers/usb/host/ohci-hcd.c
 +++ b/drivers/usb/host/ohci-hcd.c
 @@ -1139,8 +1139,10 @@ int ohci_resume(struct usb_hcd *hcd, bool hibernated)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0418-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0418-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From 81b72a84d557b8f56b57485f5c61bb75577b90a7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 418/449] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 418/450] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/platform/mips/ls7a_fan.c
 
 diff --git a/drivers/platform/mips/Makefile b/drivers/platform/mips/Makefile
-index 4dde0988fdadb..a3e9e6b2f38fb 100644
+index 4dde0988fdad..a3e9e6b2f38f 100644
 --- a/drivers/platform/mips/Makefile
 +++ b/drivers/platform/mips/Makefile
 @@ -3,7 +3,7 @@ obj-$(CONFIG_CPU_HWMON) += cpu_hwmon.o
@@ -29,7 +29,7 @@ index 4dde0988fdadb..a3e9e6b2f38fb 100644
  
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
 new file mode 100644
-index 0000000000000..cc188d4d05762
+index 000000000000..cc188d4d0576
 --- /dev/null
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -0,0 +1,598 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0419-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0419-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From a64ca7a2b25094633ab52f5b5a766410cede5ab9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 419/449] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 419/450] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where
@@ -29,7 +29,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mips/ls7a_fan.c b/drivers/platform/mips/ls7a_fan.c
-index cc188d4d05762..e9cf2dded39e4 100644
+index cc188d4d0576..e9cf2dded39e 100644
 --- a/drivers/platform/mips/ls7a_fan.c
 +++ b/drivers/platform/mips/ls7a_fan.c
 @@ -9,10 +9,16 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0420-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0420-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From 45022c79b966f38423acdb8abb0e32a864f68689 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 420/449] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 420/450] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
-index cc0360e8dd62c..fc1d0c83b554a 100644
+index cc0360e8dd62..fc1d0c83b554 100644
 --- a/arch/mips/math-emu/cp1emu.c
 +++ b/arch/mips/math-emu/cp1emu.c
 @@ -1451,7 +1451,7 @@ static union ieee754sp fpemu_sp_rsqrt(union ieee754sp s)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0421-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0421-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From 8339ff3eb0f290547d17a8eba22365baf95a5fc2 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 421/449] AOSCOS: Optimize clear_page
+Subject: [PATCH 421/450] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  5 files changed, 56 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/uasm.h b/arch/mips/include/asm/uasm.h
-index b43bfd4452521..2573d559320e6 100644
+index b43bfd445252..2573d559320e 100644
 --- a/arch/mips/include/asm/uasm.h
 +++ b/arch/mips/include/asm/uasm.h
 @@ -42,6 +42,10 @@ void uasm_i##op(u32 **buf, unsigned int a, signed int b, unsigned int c)
@@ -38,7 +38,7 @@ index b43bfd4452521..2573d559320e6 100644
  Ip_u3u2u1(_sllv);
  Ip_s3s1s2(_slt);
 diff --git a/arch/mips/include/uapi/asm/inst.h b/arch/mips/include/uapi/asm/inst.h
-index c29dbc8c1d491..6d41c8bbbdec2 100644
+index c29dbc8c1d49..6d41c8bbbdec 100644
 --- a/arch/mips/include/uapi/asm/inst.h
 +++ b/arch/mips/include/uapi/asm/inst.h
 @@ -137,6 +137,13 @@ enum ddivu_op {
@@ -56,7 +56,7 @@ index c29dbc8c1d491..6d41c8bbbdec2 100644
   * rt field of bcond opcodes.
   */
 diff --git a/arch/mips/mm/page.c b/arch/mips/mm/page.c
-index 1df237bd4a72b..21c9d35ec25e8 100644
+index 1df237bd4a72..21c9d35ec25e 100644
 --- a/arch/mips/mm/page.c
 +++ b/arch/mips/mm/page.c
 @@ -206,6 +206,11 @@ static void set_prefetch_parameters(void)
@@ -88,7 +88,7 @@ index 1df237bd4a72b..21c9d35ec25e8 100644
  
  static inline void build_clear_pref(u32 **buf, int off)
 diff --git a/arch/mips/mm/uasm-mips.c b/arch/mips/mm/uasm-mips.c
-index e15c6700cd088..7e44ea365795b 100644
+index e15c6700cd08..7e44ea365795 100644
 --- a/arch/mips/mm/uasm-mips.c
 +++ b/arch/mips/mm/uasm-mips.c
 @@ -27,6 +27,10 @@
@@ -144,7 +144,7 @@ index e15c6700cd088..7e44ea365795b 100644
  		op |= build_simm(va_arg(ap, s32));
  	if (ip->fields & UIMM)
 diff --git a/arch/mips/mm/uasm.c b/arch/mips/mm/uasm.c
-index 125140979d62c..2a9ca7de43760 100644
+index 125140979d62..2a9ca7de4376 100644
 --- a/arch/mips/mm/uasm.c
 +++ b/arch/mips/mm/uasm.c
 @@ -26,6 +26,8 @@ enum fields {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0422-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0422-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From ac4f370af4d6e432a84b5c80ad641cee30cad5a2 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 422/449] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 422/450] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memset.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 16b0c555b52ae..f6a1fd6cb736e 100644
+index 16b0c555b52a..f6a1fd6cb736 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,6 +5,7 @@
@@ -31,7 +31,7 @@ index 16b0c555b52ae..f6a1fd6cb736e 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
 new file mode 100644
-index 0000000000000..227b2d67082e3
+index 000000000000..227b2d67082e
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -0,0 +1,206 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0423-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0423-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 8b4fc655d96a4e91da5db356a0946cc365046cc9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 423/449] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 423/450] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 227b2d67082e3..0a35c013f6df4 100644
+index 227b2d67082e..0a35c013f6df 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -8,9 +8,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0424-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0424-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 9a1083d7ac5302b5e5eb43f546f622cf2d78f86c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 424/449] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 424/450] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memset.S b/arch/mips/loongson64/loongson3-memset.S
-index 0a35c013f6df4..55c3b8d7bc458 100644
+index 0a35c013f6df..55c3b8d7bc45 100644
 --- a/arch/mips/loongson64/loongson3-memset.S
 +++ b/arch/mips/loongson64/loongson3-memset.S
 @@ -22,7 +22,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0425-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0425-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From 8191ea6c936c12c574082ada889a22d913f2365c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 425/449] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 425/450] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/lib/Makefile b/arch/mips/lib/Makefile
-index 5d5b993cbc2bf..b5532bab9337b 100644
+index 5d5b993cbc2b..b5532bab9337 100644
 --- a/arch/mips/lib/Makefile
 +++ b/arch/mips/lib/Makefile
 @@ -10,6 +10,7 @@ lib-y	+= bitops.o csum_partial.o delay.o memcpy.o memset.o \

--- a/runtime-kernel/linux-kernel/autobuild/patches/0426-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0426-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 283ca376f33418c90b1d3a7517ba98295d385d9b Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 426/449] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 426/450] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 arch/mips/loongson64/loongson3-memcpy.S
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index f6a1fd6cb736e..9783e54388902 100644
+index f6a1fd6cb736..9783e5438890 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -5,7 +5,7 @@
@@ -32,7 +32,7 @@ index f6a1fd6cb736e..9783e54388902 100644
  obj-$(CONFIG_NUMA)	+= numa.o
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
 new file mode 100644
-index 0000000000000..28b785363351c
+index 000000000000..28b785363351
 --- /dev/null
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -0,0 +1,506 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0427-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0427-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From ba80f41cc1d434ac03b6cc77ad7ecaf6beed44ed Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 427/449] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 427/450] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 28b785363351c..4c0b6b8474f04 100644
+index 28b785363351..4c0b6b8474f0 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -37,13 +37,13 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0428-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0428-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From dd698ffc265435205fcbd6a9fc6022eb0c940e73 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 428/449] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 428/450] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 4c0b6b8474f04..2021e75d5dd2e 100644
+index 4c0b6b8474f0..2021e75d5dd2 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -29,9 +29,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0429-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0429-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From 534bedcf5205e5b5acd16d32c46749aa9325b19f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 429/449] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 429/450] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 606f25c0d5bcc..1f35756d827ee 100644
+index 606f25c0d5bc..1f35756d827e 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -1385,6 +1385,7 @@ config CPU_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0430-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0430-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 1096ed4f69c475eb210b61e4b3258738aae0baa7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 430/449] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 430/450] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/loongson64/loongson3-memcpy.S b/arch/mips/loongson64/loongson3-memcpy.S
-index 2021e75d5dd2e..c5dd2e2866c3c 100644
+index 2021e75d5dd2..c5dd2e2866c3 100644
 --- a/arch/mips/loongson64/loongson3-memcpy.S
 +++ b/arch/mips/loongson64/loongson3-memcpy.S
 @@ -119,8 +119,10 @@ LEAF(memcpy)				/* a0=dst a1=src a2=len */

--- a/runtime-kernel/linux-kernel/autobuild/patches/0431-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0431-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From 7730adcc8ffd44a1942e4eb02e37de776d13cea9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 431/449] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 431/450] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index 1872f9d54a5cc..066611ec29dc1 100644
+index 1872f9d54a5c..066611ec29dc 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -588,12 +588,12 @@ config SPI_LM70_LLP

--- a/runtime-kernel/linux-kernel/autobuild/patches/0432-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0432-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 5ede5e743d072730b781ed074fbbb7a6e4901d7f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 432/449] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 432/450] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index 1f35756d827ee..a9f71bf344b05 100644
+index 1f35756d827e..a9f71bf344b0 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2139,9 +2139,9 @@ config ZBOOT_LOAD_ADDRESS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0433-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0433-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From 54b0566c1ec25d9e2a26aadea9458485e8a14571 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 433/449] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 433/450] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further
@@ -17,7 +17,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+)
 
 diff --git a/init/Kconfig b/init/Kconfig
-index cab3ad28ca49e..f260e92b27b89 100644
+index cab3ad28ca49..f260e92b27b8 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -976,6 +976,7 @@ config NUMA_BALANCING

--- a/runtime-kernel/linux-kernel/autobuild/patches/0434-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0434-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From c25602007ca19e26dc6f2bcb3b5971beea84a629 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 434/449] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 434/450] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/lib/audit.c b/lib/audit.c
-index 738bda22dd39b..5f68998fdaf60 100644
+index 738bda22dd39..5f68998fdaf6 100644
 --- a/lib/audit.c
 +++ b/lib/audit.c
 @@ -29,6 +29,7 @@ static unsigned signal_class[] = {

--- a/runtime-kernel/linux-kernel/autobuild/patches/0435-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0435-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From ab988cf916b09f8060009d94d306a9c59568e3c7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 435/449] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 435/450] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 10 deletions(-)
 
 diff --git a/arch/mips/include/asm/unistd.h b/arch/mips/include/asm/unistd.h
-index 91d0c7fd6d4b0..6a974b990f4b2 100644
+index 91d0c7fd6d4b..6a974b990f4b 100644
 --- a/arch/mips/include/asm/unistd.h
 +++ b/arch/mips/include/asm/unistd.h
 @@ -64,14 +64,4 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0436-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0436-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From 44a37900d02c36ae832efbad6be7ea279bc63e0a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 436/449] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 436/450] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/mips/include/uapi/asm/unistd.h b/arch/mips/include/uapi/asm/unistd.h
-index b501ea16ccd40..63bfa241b3aa5 100644
+index b501ea16ccd4..63bfa241b3aa 100644
 --- a/arch/mips/include/uapi/asm/unistd.h
 +++ b/arch/mips/include/uapi/asm/unistd.h
 @@ -6,6 +6,9 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0437-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0437-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From 6aa8bc827cf97bcc288e0504d8225220fc8120ca Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 437/449] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 437/450] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In
@@ -27,7 +27,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/arch/mips/kernel/setup.c b/arch/mips/kernel/setup.c
-index 22f4f9158413d..0f25914991f44 100644
+index 22f4f9158413..0f25914991f4 100644
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
 @@ -622,7 +622,9 @@ static void __init bootcmdline_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0438-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0438-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 2678e35934c65af7a8e951fb3890fa52e4b02f60 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 438/449] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 438/450] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>
@@ -12,7 +12,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/loongson64/Makefile b/arch/mips/loongson64/Makefile
-index 9783e54388902..04eba1ce8ff54 100644
+index 9783e5438890..04eba1ce8ff5 100644
 --- a/arch/mips/loongson64/Makefile
 +++ b/arch/mips/loongson64/Makefile
 @@ -4,7 +4,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0439-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0439-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From ca6851a1db12ccb1b2dba3dcba38c7a34d48b6ff Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 439/449] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 439/450] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes; Also move the struct domain_device
@@ -19,7 +19,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  3 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/mvsas/mv_init.c b/drivers/scsi/mvsas/mv_init.c
-index 03a0ac5fab63f..888e48cf71477 100644
+index 03a0ac5fab63..888e48cf7147 100644
 --- a/drivers/scsi/mvsas/mv_init.c
 +++ b/drivers/scsi/mvsas/mv_init.c
 @@ -36,7 +36,7 @@ static const struct attribute_group *mvst_sdev_groups[];
@@ -32,7 +32,7 @@ index 03a0ac5fab63f..888e48cf71477 100644
  	.scan_start		= mvs_scan_start,
  	.can_queue		= 1,
 diff --git a/drivers/scsi/mvsas/mv_sas.c b/drivers/scsi/mvsas/mv_sas.c
-index 6a7ae6f410056..1757f21d1312b 100644
+index 6a7ae6f41005..1757f21d1312 100644
 --- a/drivers/scsi/mvsas/mv_sas.c
 +++ b/drivers/scsi/mvsas/mv_sas.c
 @@ -255,13 +255,13 @@ static void mvs_bytes_dmaed(struct mvs_info *mvi, int i, gfp_t gfp_flags)
@@ -54,7 +54,7 @@ index 6a7ae6f410056..1757f21d1312b 100644
  		scsi_change_queue_depth(sdev, MVS_QUEUE_SIZE);
  #endif
 diff --git a/drivers/scsi/mvsas/mv_sas.h b/drivers/scsi/mvsas/mv_sas.h
-index b6f5b739d67c9..6d7831bd9c014 100644
+index b6f5b739d67c..6d7831bd9c01 100644
 --- a/drivers/scsi/mvsas/mv_sas.h
 +++ b/drivers/scsi/mvsas/mv_sas.h
 @@ -429,7 +429,7 @@ int mvs_phy_control(struct asd_sas_phy *sas_phy, enum phy_func func,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0440-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0440-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From 9e9146e26cd130ef32ff55917d6d3518710ab20e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 440/449] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 440/450] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.
@@ -16,7 +16,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  2 files changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/tty/serial/8250/8250_pci.c b/drivers/tty/serial/8250/8250_pci.c
-index f909bd51d88e6..d5021892cb001 100644
+index f909bd51d88e..d5021892cb00 100644
 --- a/drivers/tty/serial/8250/8250_pci.c
 +++ b/drivers/tty/serial/8250/8250_pci.c
 @@ -74,7 +74,6 @@
@@ -28,7 +28,7 @@ index f909bd51d88e6..d5021892cb001 100644
  
  #define PCI_DEVICE_ID_MOXA_CP102E	0x1024
 diff --git a/include/linux/pci_ids.h b/include/linux/pci_ids.h
-index 30598b776f0e6..1ada40ea37f61 100644
+index 30598b776f0e..1ada40ea37f6 100644
 --- a/include/linux/pci_ids.h
 +++ b/include/linux/pci_ids.h
 @@ -2599,6 +2599,7 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0441-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0441-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
@@ -1,7 +1,7 @@
 From e76dbb9e6f9ee4045d4a6ba06feaa90b0900ac6c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 22:05:56 +0800
-Subject: [PATCH 441/449] AOSCOS: sb105x: Adapt for timer related function
+Subject: [PATCH 441/450] AOSCOS: sb105x: Adapt for timer related function
  renames
 
 The upstream has renamed the timer related functions to have a strict
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/staging/sb105x/sb_pci_mp.c b/drivers/staging/sb105x/sb_pci_mp.c
-index 19098bbfa113e..416a0d30a40f6 100644
+index 19098bbfa113..416a0d30a40f 100644
 --- a/drivers/staging/sb105x/sb_pci_mp.c
 +++ b/drivers/staging/sb105x/sb_pci_mp.c
 @@ -2306,7 +2306,7 @@ static void serial_unlink_irq_chain(struct mp_port *mtpt)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0442-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0442-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 489e29c9c74d53caeaddc55a69c40696e8fd3fb5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 442/449] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 442/450] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
-index a9f71bf344b05..566dc6f029f7d 100644
+index a9f71bf344b0..566dc6f029f7 100644
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -548,7 +548,6 @@ config MACH_LOONGSON64

--- a/runtime-kernel/linux-kernel/autobuild/patches/0443-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0443-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
@@ -1,7 +1,7 @@
 From f493aea6884ba2368395d75d686d5f78ac8d6868 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 09:50:44 +0800
-Subject: [PATCH 443/449] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
+Subject: [PATCH 443/450] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
  LS7A
 
 On LoongArch laptops using LG110 GPU for display, LS7A PWM3 is used for
@@ -21,7 +21,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  create mode 100644 drivers/acpi/loongarch/acpi-ls7a-backlight.c
 
 diff --git a/drivers/acpi/Makefile b/drivers/acpi/Makefile
-index d1b0affb844f0..2148e6a5ebcca 100644
+index d1b0affb844f..2148e6a5ebcc 100644
 --- a/drivers/acpi/Makefile
 +++ b/drivers/acpi/Makefile
 @@ -134,3 +134,4 @@ obj-$(CONFIG_ACPI_VIOT)		+= viot.o
@@ -30,7 +30,7 @@ index d1b0affb844f0..2148e6a5ebcca 100644
  obj-$(CONFIG_X86)		+= x86/
 +obj-$(CONFIG_LOONGARCH)		+= loongarch/
 diff --git a/drivers/acpi/internal.h b/drivers/acpi/internal.h
-index 63354972ab0b8..2bf9a408e6ecc 100644
+index 63354972ab0b..2bf9a408e6ec 100644
 --- a/drivers/acpi/internal.h
 +++ b/drivers/acpi/internal.h
 @@ -76,6 +76,12 @@ void acpi_lpss_init(void);
@@ -48,7 +48,7 @@ index 63354972ab0b8..2bf9a408e6ecc 100644
  acpi_status acpi_hotplug_schedule(struct acpi_device *adev, u32 src);
 diff --git a/drivers/acpi/loongarch/Makefile b/drivers/acpi/loongarch/Makefile
 new file mode 100644
-index 0000000000000..25f207f841222
+index 000000000000..25f207f84122
 --- /dev/null
 +++ b/drivers/acpi/loongarch/Makefile
 @@ -0,0 +1,3 @@
@@ -57,7 +57,7 @@ index 0000000000000..25f207f841222
 +endif
 diff --git a/drivers/acpi/loongarch/acpi-ls7a-backlight.c b/drivers/acpi/loongarch/acpi-ls7a-backlight.c
 new file mode 100644
-index 0000000000000..5363747cd3a7f
+index 000000000000..5363747cd3a7
 --- /dev/null
 +++ b/drivers/acpi/loongarch/acpi-ls7a-backlight.c
 @@ -0,0 +1,42 @@
@@ -104,7 +104,7 @@ index 0000000000000..5363747cd3a7f
 +	acpi_scan_add_handler(&ls7a_pwm_handler);
 +}
 diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
-index a6bad2679a0c5..93e2b925430c8 100644
+index a6bad2679a0c..93e2b925430c 100644
 --- a/drivers/acpi/scan.c
 +++ b/drivers/acpi/scan.c
 @@ -2716,6 +2716,7 @@ void __init acpi_scan_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0444-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0444-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
@@ -1,7 +1,7 @@
 From 0bc589e4687d1088bf6b86f6f8b365ea11b140b9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:32:58 +0800
-Subject: [PATCH 444/449] AOSCOS: gpio: aaeon: use new GPIO line value setter
+Subject: [PATCH 444/450] AOSCOS: gpio: aaeon: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 10 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/gpio/gpio-aaeon.c b/drivers/gpio/gpio-aaeon.c
-index 3183c45dd1946..c723c59b5ea8b 100644
+index 3183c45dd194..c723c59b5ea8 100644
 --- a/drivers/gpio/gpio-aaeon.c
 +++ b/drivers/gpio/gpio-aaeon.c
 @@ -50,7 +50,7 @@ static int aaeon_gpio_input_set_direction(struct gpio_chip *chip,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0445-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0445-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
@@ -1,7 +1,7 @@
 From 96171a9d75a4ccac5bc529f5f433ba65799c0b0b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:36:16 +0800
-Subject: [PATCH 445/449] AOSCOS: gpio: nct6102: use new GPIO line value setter
+Subject: [PATCH 445/450] AOSCOS: gpio: nct6102: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpio/gpio-nct6102.c b/drivers/gpio/gpio-nct6102.c
-index 143f0a139e212..b79bd13e2c51e 100644
+index 143f0a139e21..b79bd13e2c51 100644
 --- a/drivers/gpio/gpio-nct6102.c
 +++ b/drivers/gpio/gpio-nct6102.c
 @@ -104,7 +104,7 @@ static int nct6102_gpio_get_value(struct gpio_chip *chip, unsigned offset)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0446-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0446-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
@@ -1,7 +1,7 @@
 From ff2493fa584d247df75026d6842f5f60027a42eb Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 10 Sep 2025 23:21:26 +0800
-Subject: [PATCH 446/449] AOSCOS: scsi: dc395x: correctly discard the return
+Subject: [PATCH 446/450] AOSCOS: scsi: dc395x: correctly discard the return
  value in certain reads
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -38,7 +38,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 12 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/scsi/dc395x.c b/drivers/scsi/dc395x.c
-index 386c8359e1cc8..137b7b3d1335b 100644
+index 386c8359e1cc..137b7b3d1335 100644
 --- a/drivers/scsi/dc395x.c
 +++ b/drivers/scsi/dc395x.c
 @@ -94,6 +94,12 @@

--- a/runtime-kernel/linux-kernel/autobuild/patches/0447-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0447-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
@@ -1,7 +1,7 @@
 From 2eab5747c68dff5b3f7e7f70740887b8eda51abe Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 12 Nov 2025 11:41:05 +0800
-Subject: [PATCH 447/449] AOSCOS: crypto: padlock-sha: return -ENODEV on
+Subject: [PATCH 447/450] AOSCOS: crypto: padlock-sha: return -ENODEV on
  Zhaoxin KaiXian KX-6000/6000G
 
 On Zhaoxin KaiXian KX-6000/6000G series of processors, this crypto module
@@ -20,7 +20,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/crypto/padlock-sha.c b/drivers/crypto/padlock-sha.c
-index 329f60ad422e6..10297ca54b760 100644
+index 329f60ad422e..10297ca54b76 100644
 --- a/drivers/crypto/padlock-sha.c
 +++ b/drivers/crypto/padlock-sha.c
 @@ -329,7 +329,17 @@ static int __init padlock_init(void)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0448-AOSCOS-Revert-FROMLIST-rust-generate-a-fatal-error-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0448-AOSCOS-Revert-FROMLIST-rust-generate-a-fatal-error-i.patch
@@ -1,7 +1,7 @@
 From 4ce774e437c7353f2706c82478f3a69aa8c4d13d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 23 Dec 2025 20:08:10 +0800
-Subject: [PATCH 448/449] AOSCOS: Revert "FROMLIST: rust: generate a fatal
+Subject: [PATCH 448/450] AOSCOS: Revert "FROMLIST: rust: generate a fatal
  error if BINDGEN_TARGET is undefined"
 
 This reverts "FROMLIST: rust: generate a fatal error if BINDGEN_TARGET is
@@ -14,7 +14,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 deletions(-)
 
 diff --git a/scripts/Makefile.rust b/scripts/Makefile.rust
-index cee28a6048302..bfdad4a0a3cee 100644
+index cee28a604830..bfdad4a0a3ce 100644
 --- a/scripts/Makefile.rust
 +++ b/scripts/Makefile.rust
 @@ -7,8 +7,4 @@ BINDGEN_TARGET_riscv	:= riscv64-linux-gnu

--- a/runtime-kernel/linux-kernel/autobuild/patches/0449-AOSCOS-MIPS-Loongson-Salvage-the-full-count-from-the.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0449-AOSCOS-MIPS-Loongson-Salvage-the-full-count-from-the.patch
@@ -1,7 +1,7 @@
 From 26de7f5531c7eb3b2eedcaa71927f3fd1f9f75bf Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Sun, 25 Jan 2026 00:54:35 +0800
-Subject: [PATCH 449/449] AOSCOS: MIPS: Loongson: Salvage the full count from
+Subject: [PATCH 449/450] AOSCOS: MIPS: Loongson: Salvage the full count from
  the constant timer
 
 HWR $30 (Loongson64 constant timer) is 64 bits wide. However, vDSO uses
@@ -30,7 +30,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 24 insertions(+), 1 deletion(-)
 
 diff --git a/arch/mips/include/asm/vdso/gettimeofday.h b/arch/mips/include/asm/vdso/gettimeofday.h
-index 8cc0beef182d1..2dba88c691edd 100644
+index 8cc0beef182d..2dba88c691ed 100644
 --- a/arch/mips/include/asm/vdso/gettimeofday.h
 +++ b/arch/mips/include/asm/vdso/gettimeofday.h
 @@ -183,17 +183,40 @@ static __always_inline u64 read_gic_count(const struct vdso_time_data *data)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0450-AOSCOS-drm-panel-orientation-quirks-Add-quirk-for-GP.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0450-AOSCOS-drm-panel-orientation-quirks-Add-quirk-for-GP.patch
@@ -1,0 +1,43 @@
+From 59ca2a97bc704d41c57c5b1ea3fd53e175af3391 Mon Sep 17 00:00:00 2001
+From: CyberNeko-AI <cyberneko.ai@aosc.io>
+Date: Thu, 26 Mar 2026 18:45:55 +0800
+Subject: [PATCH 450/450] AOSCOS: drm: panel-orientation-quirks: Add quirk for
+ GPD Pocket 4
+
+The GPD Pocket 4 is a mini laptop that features a natively portrait
+display panel (1600x2560) mounted in a landscape configuration.
+While the UEFI firmware correctly reports the native portrait resolution,
+the lack of orientation data causes the framebuffer console and
+desktop environments (e.g., KDE Plasma) to boot into a sideways
+portrait mode by default.
+
+Add a DMI quirk for the GPD Pocket 4 (matching "G1628-04") to
+provide the correct panel orientation. This allows DRM/KMS to
+automatically rotate the output, ensuring a seamless landscape
+experience out of the box for fbcon and Wayland/X11 compositors.
+
+Signed-off-by: CyberNeko-AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 3a218fb592ce..114dffaf6700 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -330,6 +330,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_BOARD_NAME, "Default string"),
+ 		},
+ 		.driver_data = (void *)&gpd_pocket2,
++	}, {	/* GPD Pocket 4 */
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "GPD"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "G1628-04"),
++		},
++		.driver_data = (void *)&lcd1600x2560_rightside_up,
+ 	}, {	/* GPD Win (same note on DMI match as GPD Pocket) */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_BOARD_VENDOR, "AMI Corporation"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.18.16
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=1
+REL=2
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: add panel orientation quirk for GPD Pocket 4

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.18.16-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
