### PR TITLE
tigervnc: update to 1.16.2+xserver21.1.21

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.16.0
+UPSTREAM_VER=1.16.2
 XORG_VER=21.1.21
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \

--- a/topics/tigervnc-1.16.2-xserver21.1.21.toml
+++ b/topics/tigervnc-1.16.2-xserver21.1.21.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "TigerVNC 1.16.2"
+
+[caution]
+default = "Fixes a Denial-of-Service vulnerability - CVE-2026-34352 (Severity: High)"
+zh_CN = "修复一个拒绝服务漏洞，漏洞编号 CVE-2026-34352（严重性：高）"
+
+[packages-v2]
+"tigervnc" = "< 1.16.2+xserver21.1.21"


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update to 1.16.2+xserver21.1.21
    Co-authored-by: multimode_Liu \(@Dustymind\) <dustymind@foxmail.com>

Package(s) Affected
-------------------

- tigervnc: 1.16.2+xserver21.1.21

Security Update?
----------------

Yes, #15395

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
