### PR TITLE
Address UAF in libibus

### DIFF
--- a/app-i18n/ibus/01-libibus/patches/0002-libibus-make-an-IBusText-own-an-updated-IBusAttrList.patch
+++ b/app-i18n/ibus/01-libibus/patches/0002-libibus-make-an-IBusText-own-an-updated-IBusAttrList.patch
@@ -1,0 +1,90 @@
+From b52b51b23e68843ad983f3c211a0703b6cfe323e Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Thu, 26 Mar 2026 20:43:47 -0400
+Subject: [PATCH] libibus: make an IBusText own an updated IBusAttrList
+ reference
+
+For all usages of IBusAttrList, the list is an owned reference within a
+IBusText struct.
+
+ibus_panel_convert_text() and ibus_input_context_convert_text() violate
+the invarient by assigning a **floating** IBusAttrList reference to an
+IBusText without sinking it.
+
+Through interactions I don't completely understand, GJS can somehow obtain
+a strong owning reference to the IBusAttrList and can end up freeing a
+`IBusAttrList` with a valid (albeit floating) reference somewhere else.
+Using the other reference constitutes a use-after-free.
+
+We already have a `ibus_text_set_attributes()` that does the intended
+ref sinking, so just use that instead of manually assigning pointers.
+---
+ src/ibusinputcontext.c | 6 ++----
+ src/ibuspanelservice.c | 6 ++----
+ src/ibustext.h         | 2 +-
+ 3 files changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/src/ibusinputcontext.c b/src/ibusinputcontext.c
+index 68d12fb5..235a2f1f 100644
+--- a/src/ibusinputcontext.c
++++ b/src/ibusinputcontext.c
+@@ -570,8 +570,7 @@ ibus_input_context_convert_text (IBusInputContext *context,
+             g_error_free (error);
+         }
+         if (new_attrs) {
+-            g_object_unref (text->attrs);
+-            text->attrs = new_attrs;
++            ibus_text_set_attributes (text, new_attrs);
+         }
+         break;
+     case IBUS_PREEDIT_FORMAT_HINT:
+@@ -582,8 +581,7 @@ ibus_input_context_convert_text (IBusInputContext *context,
+             g_error_free (error);
+         }
+         if (new_attrs) {
+-            g_object_unref (text->attrs);
+-            text->attrs = new_attrs;
++            ibus_text_set_attributes (text, new_attrs);
+         }
+         break;
+     default:
+diff --git a/src/ibuspanelservice.c b/src/ibuspanelservice.c
+index 16229822..fb0cc64f 100644
+--- a/src/ibuspanelservice.c
++++ b/src/ibuspanelservice.c
+@@ -1204,8 +1204,7 @@ ibus_panel_convert_text (IBusPanelService *panel,
+             g_error_free (error);
+         }
+         if (new_attrs) {
+-            g_object_unref (text->attrs);
+-            text->attrs = new_attrs;
++            ibus_text_set_attributes (text, new_attrs);
+         }
+         break;
+     case IBUS_PREEDIT_FORMAT_HINT:
+@@ -1216,8 +1215,7 @@ ibus_panel_convert_text (IBusPanelService *panel,
+             g_error_free (error);
+         }
+         if (new_attrs) {
+-            g_object_unref (text->attrs);
+-            text->attrs = new_attrs;
++            ibus_text_set_attributes (text, new_attrs);
+         }
+         break;
+     default:
+diff --git a/src/ibustext.h b/src/ibustext.h
+index e5e3c4a9..e5319b4b 100644
+--- a/src/ibustext.h
++++ b/src/ibustext.h
+@@ -209,7 +209,7 @@ IBusAttrList *   ibus_text_get_attributes           (IBusText       *text);
+ /**
+  * ibus_text_set_attributes:
+  * @text: An IBusText.
+- * @attrs: An IBusAttrList
++ * @attrs: (transfer full): An IBusAttrList
+  */
+ void             ibus_text_set_attributes           (IBusText       *text,
+                                                      IBusAttrList   *attrs);
+-- 
+2.52.0
+

--- a/app-i18n/ibus/spec
+++ b/app-i18n/ibus/spec
@@ -1,5 +1,5 @@
 VER=1.5.33
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/ibus/ibus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1352"


### PR DESCRIPTION
Topic Description
-----------------

- ibus: fix segmentation fault under active IME in gnome-shell

Package(s) Affected
-------------------

- ibus: 1.5.33-2
- libibus: 1.5.33-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ibus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
