### PR TITLE
rocm-llama-cpp: update to 8547

### DIFF
--- a/runtime-rocm/rocm-llama-cpp/spec
+++ b/runtime-rocm/rocm-llama-cpp/spec
@@ -1,4 +1,4 @@
 VER=7.0.1
-SRCS="git::commit=b6558::https://github.com/ggml-org/llama.cpp.git"
+SRCS="git::commit=b8558::https://github.com/ggml-org/llama.cpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328681"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-llama-cpp: update to 8547
    Co-authored-by: nyovelt \(@Nyovelt\) <canarypwn@aosc.io>

Package(s) Affected
-------------------

- rocm-llama-cpp: 8547

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-llama-cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
