### PR TITLE
lcms2 Rework 20260328

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -2,3 +2,4 @@ VER=5.2.15
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
 CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
 CHKUPDATE="anitya::id=10918"
+REL=1

--- a/app-doc/pstoedit/spec
+++ b/app-doc/pstoedit/spec
@@ -2,3 +2,4 @@ VER=4.02
 SRCS="tbl::https://sourceforge.net/projects/pstoedit/files/pstoedit/$VER/pstoedit-$VER.tar.gz/download"
 CHKSUMS="sha256::5588b432d2c6b2ad9828b44915ea5813ff9a3a3312a41fa0de4c38ddac9df72f"
 CHKUPDATE="anitya::id=12920"
+REL=1

--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -1,5 +1,5 @@
 VER=10.3.0
-REL=3
+REL=4
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
 CHKSUMS="sha256::68bc82885a3ae67a806debb14eb229506d2fe398c969dd42e2e38cc1c35f2aff"
 CHKUPDATE="anitya::id=2528"

--- a/app-utils/imagemagick+7/spec
+++ b/app-utils/imagemagick+7/spec
@@ -1,5 +1,5 @@
 VER=7.1.1+32
-REL=1
+REL=2
 SRCS="git::commit=tags/${VER/+/-}::https://github.com/imagemagick/imagemagick"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1372"

--- a/app-utils/imagemagick/spec
+++ b/app-utils/imagemagick/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=6.9.13-37
 VER=${UPSTREAM_VER/\-/+}
-REL=1
+REL=2
 SRCS="git::commit=tags/${UPSTREAM_VER}::https://github.com/ImageMagick/ImageMagick6.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16253"

--- a/desktop-mate/eom/spec
+++ b/desktop-mate/eom/spec
@@ -2,3 +2,4 @@ VER=1.28.1
 SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/eom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198704"
+REL=1

--- a/runtime-desktop/qt-5/spec
+++ b/runtime-desktop/qt-5/spec
@@ -12,3 +12,4 @@ ENVREQ="total_mem=60"
 ENVREQ__ARM64="total_mem_per_core=1.5"
 # Note: Prefer 3C5000 (or faster) build hosts.
 ENVREQ__LOONGARCH64="core=16"
+REL=1

--- a/runtime-doc/libcupsfilters/spec
+++ b/runtime-doc/libcupsfilters/spec
@@ -1,5 +1,5 @@
 VER=2.1.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/libcupsfilters"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=327181"

--- a/runtime-imaging/libcdr/spec
+++ b/runtime-imaging/libcdr/spec
@@ -2,3 +2,4 @@ VER=0.1.8
 SRCS="tbl::https://dev-www.libreoffice.org/src/libcdr/libcdr-$VER.tar.xz"
 CHKSUMS="sha256::ced677c8300b29c91d3004bb1dddf0b99761bf5544991c26c2ee8f427e87193c"
 CHKUPDATE="anitya::id=1574"
+REL=1

--- a/runtime-imaging/libfreehand/spec
+++ b/runtime-imaging/libfreehand/spec
@@ -1,5 +1,5 @@
 VER=0.1.2
-REL=3
+REL=4
 SRCS="tbl::https://dev-www.libreoffice.org/src/libfreehand/libfreehand-$VER.tar.xz"
 CHKSUMS="sha256::0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac"
 CHKUPDATE="anitya::id=1616"

--- a/runtime-imaging/libraw/spec
+++ b/runtime-imaging/libraw/spec
@@ -2,3 +2,4 @@ VER=0.20.0
 SRCS="tbl::https://github.com/LibRaw/LibRaw/archive/$VER.tar.gz"
 CHKSUMS="sha256::f38cd2620d5adc32d2c9f51cd0dc66d72c75671f1c81dfd13d30c45c6be80d40"
 CHKUPDATE="anitya::id=1709"
+REL=1

--- a/runtime-multimedia/xine-lib/spec
+++ b/runtime-multimedia/xine-lib/spec
@@ -1,5 +1,5 @@
 VER=1.2.13
-REL=8
+REL=9
 SRCS="tbl::https://sourceforge.net/projects/xine/files/xine-lib/$VER/xine-lib-$VER.tar.xz"
 CHKSUMS="sha256::5f10d6d718a4a51c17ed1b32b031d4f9b80b061e8276535b2be31e5ac4b75e6f"
 CHKUPDATE="anitya::id=5543"

--- a/runtime-scientific/suitesparse/autobuild/patches/0001-UPSTREAM-avoid-including-headers-in-extern-C-block.patch
+++ b/runtime-scientific/suitesparse/autobuild/patches/0001-UPSTREAM-avoid-including-headers-in-extern-C-block.patch
@@ -1,0 +1,71 @@
+From 84fdcc9a5a25d80cb8895bcb90d0a2565f672967 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markus=20M=C3=BCtzel?= <markus.muetzel@gmx.de>
+Date: Thu, 6 Jun 2024 09:28:19 +0200
+Subject: [PATCH] SuiteSparse_config: Avoid including headers in extern "C"
+ block.
+
+Including headers (from the standard library) in extern "C" blocks can be
+problematic.
+
+Use extern "C" block only around function declarations.
+---
+ SuiteSparse_config/Config/SuiteSparse_config.h.in | 10 +++++-----
+ SuiteSparse_config/SuiteSparse_config.h           | 10 +++++-----
+ 2 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/SuiteSparse_config/Config/SuiteSparse_config.h.in b/SuiteSparse_config/Config/SuiteSparse_config.h.in
+index 147f51db17..8f50ad005e 100644
+--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
++++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
+@@ -19,11 +19,6 @@
+ #ifndef SUITESPARSE_CONFIG_H
+ #define SUITESPARSE_CONFIG_H
+ 
+-#ifdef __cplusplus
+-extern "C"
+-{
+-#endif
+-
+ //------------------------------------------------------------------------------
+ // SuiteSparse-wide ANSI C11 #include files
+ //------------------------------------------------------------------------------
+@@ -263,6 +258,11 @@ extern "C"
+ 
+ #endif
+ 
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
+ //==============================================================================
+ // SuiteSparse_config parameters and functions
+ //==============================================================================
+diff --git a/SuiteSparse_config/SuiteSparse_config.h b/SuiteSparse_config/SuiteSparse_config.h
+index ea74cea254..c8b6d420f8 100644
+--- a/SuiteSparse_config/SuiteSparse_config.h
++++ b/SuiteSparse_config/SuiteSparse_config.h
+@@ -19,11 +19,6 @@
+ #ifndef SUITESPARSE_CONFIG_H
+ #define SUITESPARSE_CONFIG_H
+ 
+-#ifdef __cplusplus
+-extern "C"
+-{
+-#endif
+-
+ //------------------------------------------------------------------------------
+ // SuiteSparse-wide ANSI C11 #include files
+ //------------------------------------------------------------------------------
+@@ -263,6 +258,11 @@ extern "C"
+ 
+ #endif
+ 
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
+ //==============================================================================
+ // SuiteSparse_config parameters and functions
+ //==============================================================================

--- a/runtime-scientific/suitesparse/spec
+++ b/runtime-scientific/suitesparse/spec
@@ -1,5 +1,5 @@
 VER=7.6.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/DrTimothyAldenDavis/SuiteSparse"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4908"


### PR DESCRIPTION
Topic Description
-----------------

- suitesparse: \(upstream patch\) fix FTBFS
- xine-lib: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- qt-5: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- pstoedit: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- octave: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- libraw: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- libfreehand: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- libcupsfilters: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- libcdr: rebuild for liblcms2_fast_float.so.2 \(lcms2\)
- krita: rebuild for liblcms2_fast_float.so.2 \(lcms2\)

... and 3 more commits

Package(s) Affected
-------------------

- eom: 1:1.28.1-1
- imagemagick: 6.9.13+37-2
- imagemagick+7: 7.1.1+32-2
- krita: 5.2.15-1
- libcdr: 0.1.8-1
- libcupsfilters: 2.1.1-2
- libfreehand: 0.1.2-4
- libraw: 0.20.0-1
- octave: 10.3.0-4
- pstoedit: 4.02-1
- qt-5: 1:5.15.18+webengine5.15.19+webkit5.212.0+kde20251209-1
- suitesparse: 7.6.1-2
- xine-lib: 1.2.13-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit eom imagemagick imagemagick+7 krita libcdr libcupsfilters libfreehand libraw suitesparse octave pstoedit qt-5 xine-lib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
