### PR TITLE
postgresql-18-pgvector: new, 0.8.2

### DIFF
--- a/app-database/postgresql-18-pgvector/autobuild/build
+++ b/app-database/postgresql-18-pgvector/autobuild/build
@@ -1,0 +1,7 @@
+export PG_CONFIG=/usr/bin/pg_config-18
+
+abinfo "Building pgvector..."
+make OPTFLAGS=""
+abinfo "Installing pgvector..."
+make install \
+     DESTDIR="$PKGDIR"

--- a/app-database/postgresql-18-pgvector/autobuild/defines
+++ b/app-database/postgresql-18-pgvector/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=postgresql-18-pgvector
+PKGSEC=database
+BUILDDEP="llvm"
+PKGDEP="llvm-runtime postgresql-18"
+PKGDES="Open-source vector similarity search for Postgres"

--- a/app-database/postgresql-18-pgvector/spec
+++ b/app-database/postgresql-18-pgvector/spec
@@ -1,0 +1,4 @@
+VER=0.8.2
+SRCS="git::commit=tags/v$VER::https://github.com/pgvector/pgvector.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379418"


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-18-pgvector: new, 0.8.2
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- postgresql-18-pgvector: 0.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit postgresql-18-pgvector
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
