### PR TITLE
linux-kernel: add DRM panel orientation quirks for various handheld devices

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-net-stmmac-remove-xstats.pcs_-members.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0001-UPSTREAM-net-stmmac-remove-xstats.pcs_-members.patch
@@ -1,7 +1,7 @@
 From 85449c2681f7c5100d18254fdfa309735dd70646 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:51 +0100
-Subject: [PATCH 001/450] UPSTREAM: net: stmmac: remove xstats.pcs_* members
+Subject: [PATCH 001/463] UPSTREAM: net: stmmac: remove xstats.pcs_* members
 
 As a result of the previous commit, the pcs_link, pcs_duplex and
 pcs_speed members are not used outside of the interrupt handling code,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-net-stmmac-remove-SGMII-RGMII-SMII-interrup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0002-UPSTREAM-net-stmmac-remove-SGMII-RGMII-SMII-interrup.patch
@@ -1,7 +1,7 @@
 From 9378f32812afbef8db09920086e860b6f283e7f9 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:36:56 +0100
-Subject: [PATCH 002/450] UPSTREAM: net: stmmac: remove SGMII/RGMII/SMII
+Subject: [PATCH 002/463] UPSTREAM: net: stmmac: remove SGMII/RGMII/SMII
  interrupt handling
 
 Now that the only use for the interrupt is to clear it and increment a

--- a/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-net-stmmac-remove-PCS-mode-pause-handling.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0003-UPSTREAM-net-stmmac-remove-PCS-mode-pause-handling.patch
@@ -1,7 +1,7 @@
 From 624dde4cfbfdb6b0532f08d2b295ca9304e488cf Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:01 +0100
-Subject: [PATCH 003/450] UPSTREAM: net: stmmac: remove PCS "mode" pause
+Subject: [PATCH 003/463] UPSTREAM: net: stmmac: remove PCS "mode" pause
  handling
 
 Remove the "we always autoneg pause" forcing when the stmmac driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-net-stmmac-remove-unused-PCS-loopback-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0004-UPSTREAM-net-stmmac-remove-unused-PCS-loopback-suppo.patch
@@ -1,7 +1,7 @@
 From 589e4287a2a764c89dd1ef3e9deaec1006b915c2 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:06 +0100
-Subject: [PATCH 004/450] UPSTREAM: net: stmmac: remove unused PCS loopback
+Subject: [PATCH 004/463] UPSTREAM: net: stmmac: remove unused PCS loopback
  support
 
 Nothing calls stmmac_pcs_ctrl_ane() with the "loopback" argument set to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-net-stmmac-remove-hw-ps-xxx_core_init-hardw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0005-UPSTREAM-net-stmmac-remove-hw-ps-xxx_core_init-hardw.patch
@@ -1,7 +1,7 @@
 From a0ab5ac0f9d3eeb628758a9b7f64f39b05b845d3 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:11 +0100
-Subject: [PATCH 005/450] UPSTREAM: net: stmmac: remove hw->ps xxx_core_init()
+Subject: [PATCH 005/463] UPSTREAM: net: stmmac: remove hw->ps xxx_core_init()
  hardware setup
 
 After a lot of digging, it seems that the oddly named hw->ps member is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-net-stmmac-remove-RGMII-pcs-mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0006-UPSTREAM-net-stmmac-remove-RGMII-pcs-mode.patch
@@ -1,7 +1,7 @@
 From d55261cefdf2c86dc5c816d1440e1530652fe7d2 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:17 +0100
-Subject: [PATCH 006/450] UPSTREAM: net: stmmac: remove RGMII "pcs" mode
+Subject: [PATCH 006/463] UPSTREAM: net: stmmac: remove RGMII "pcs" mode
 
 Remove the RGMII "pcs" code in stmmac_check_pcs_mode() due to:
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-net-stmmac-move-reverse-pcs-mode-setup-to-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0007-UPSTREAM-net-stmmac-move-reverse-pcs-mode-setup-to-s.patch
@@ -1,7 +1,7 @@
 From 1e74c2e0748efd1f61f3a0a2a17a85de84230a18 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:22 +0100
-Subject: [PATCH 007/450] UPSTREAM: net: stmmac: move reverse-"pcs" mode setup
+Subject: [PATCH 007/463] UPSTREAM: net: stmmac: move reverse-"pcs" mode setup
  to stmmac_check_pcs_mode()
 
 The broken reverse-mode, selected by snps,ps-speed, is configured when

--- a/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-net-stmmac-simplify-stmmac_check_pcs_mode.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0008-UPSTREAM-net-stmmac-simplify-stmmac_check_pcs_mode.patch
@@ -1,7 +1,7 @@
 From ddf87955631c2a83a45a6de3fb93c87eac4d076d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:27 +0100
-Subject: [PATCH 008/450] UPSTREAM: net: stmmac: simplify
+Subject: [PATCH 008/463] UPSTREAM: net: stmmac: simplify
  stmmac_check_pcs_mode()
 
 Now that we only support one mode, simplify stmmac_check_pcs_mode().

--- a/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-net-stmmac-hw-ps-becomes-hw-reverse_sgmii_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0009-UPSTREAM-net-stmmac-hw-ps-becomes-hw-reverse_sgmii_e.patch
@@ -1,7 +1,7 @@
 From 98d2256ba05e0623059e17b240afed621c274dd3 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:32 +0100
-Subject: [PATCH 009/450] UPSTREAM: net: stmmac: hw->ps becomes
+Subject: [PATCH 009/463] UPSTREAM: net: stmmac: hw->ps becomes
  hw->reverse_sgmii_enable
 
 After a lot of digging, it seems that the oddly named hw->ps member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-net-stmmac-do-not-require-snps-ps-speed-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0010-UPSTREAM-net-stmmac-do-not-require-snps-ps-speed-for.patch
@@ -1,7 +1,7 @@
 From b9e6f7e93564cb45e68ca2669946e2f5ffe1ec19 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:37 +0100
-Subject: [PATCH 010/450] UPSTREAM: net: stmmac: do not require snps,ps-speed
+Subject: [PATCH 010/463] UPSTREAM: net: stmmac: do not require snps,ps-speed
  for SGMII
 
 SGMII mode does not require port-speed to be specified; this only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-net-stmmac-only-call-stmmac_pcs_ctrl_ane-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0011-UPSTREAM-net-stmmac-only-call-stmmac_pcs_ctrl_ane-fo.patch
@@ -1,7 +1,7 @@
 From a4883c5299983002de97810b0575da6a349309fb Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:42 +0100
-Subject: [PATCH 011/450] UPSTREAM: net: stmmac: only call
+Subject: [PATCH 011/463] UPSTREAM: net: stmmac: only call
  stmmac_pcs_ctrl_ane() for integrated SGMII PCS
 
 The internal PCS registers only exist if the core is synthesized with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-net-stmmac-provide-PCS-initialisation-hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0012-UPSTREAM-net-stmmac-provide-PCS-initialisation-hook.patch
@@ -1,7 +1,7 @@
 From ae37a76f2dabb82ef681d4a24807f13ae1587a11 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:47 +0100
-Subject: [PATCH 012/450] UPSTREAM: net: stmmac: provide PCS initialisation
+Subject: [PATCH 012/463] UPSTREAM: net: stmmac: provide PCS initialisation
  hook
 
 dwmac cores provide a feature bit to indicate when the PCS block is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-net-stmmac-convert-to-phylink-PCS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0013-UPSTREAM-net-stmmac-convert-to-phylink-PCS-support.patch
@@ -1,7 +1,7 @@
 From 036517b0dc2d8f71868cc6e6a991d7e5035e8bb4 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Thu, 16 Oct 2025 15:37:52 +0100
-Subject: [PATCH 013/450] UPSTREAM: net: stmmac: convert to phylink PCS support
+Subject: [PATCH 013/463] UPSTREAM: net: stmmac: convert to phylink PCS support
 
 Now that stmmac's PCS support is much more simple - just a matter of
 configuring the control register - the basic conversion to phylink PCS

--- a/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-net-stmmac-dwc-qos-eth-simplify-switch-in-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0014-UPSTREAM-net-stmmac-dwc-qos-eth-simplify-switch-in-d.patch
@@ -1,7 +1,7 @@
 From 397a48ee782ca94294c90f22f72ef88bd10ba4a5 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:14 +0000
-Subject: [PATCH 014/450] UPSTREAM: net: stmmac: dwc-qos-eth: simplify switch()
+Subject: [PATCH 014/463] UPSTREAM: net: stmmac: dwc-qos-eth: simplify switch()
  in dwc_eth_dwmac_config_dt()
 
 Simplify the switch() statement in dwc_eth_dwmac_config_dt().

--- a/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-net-stmmac-move-common-DMA-AXI-register-bit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0015-UPSTREAM-net-stmmac-move-common-DMA-AXI-register-bit.patch
@@ -1,7 +1,7 @@
 From f8100b489068e97933fed21648fab189564c432c Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:19 +0000
-Subject: [PATCH 015/450] UPSTREAM: net: stmmac: move common DMA AXI register
+Subject: [PATCH 015/463] UPSTREAM: net: stmmac: move common DMA AXI register
  bits to common.h
 
 Move the common DMA AXI register bits to common.h so they can be shared

--- a/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-net-stmmac-provide-common-stmmac_axi_blen_t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0016-UPSTREAM-net-stmmac-provide-common-stmmac_axi_blen_t.patch
@@ -1,7 +1,7 @@
 From 96a31e0107950ef0118c7f8f04c8c5442e123b8c Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:25 +0000
-Subject: [PATCH 016/450] UPSTREAM: net: stmmac: provide common
+Subject: [PATCH 016/463] UPSTREAM: net: stmmac: provide common
  stmmac_axi_blen_to_mask()
 
 Provide a common stmmac_axi_blen_to_mask() function to translate the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0017-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
@@ -1,7 +1,7 @@
 From 304bbfe86d96ebaca6e9e0e0d47d979f43618cdd Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:30 +0000
-Subject: [PATCH 017/450] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
+Subject: [PATCH 017/463] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
  to stmmac_main.c
 
 Move the call to stmmac_axi_blen_to_mask() out of the individual

--- a/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0018-UPSTREAM-net-stmmac-move-stmmac_axi_blen_to_mask-to-.patch
@@ -1,7 +1,7 @@
 From ca689fcb16d35cf794476969005f43b9c5ae9e07 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:35 +0000
-Subject: [PATCH 018/450] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
+Subject: [PATCH 018/463] UPSTREAM: net: stmmac: move stmmac_axi_blen_to_mask()
  to axi_blen init sites
 
 Move stmmac_axi_blen_to_mask() to the axi->axi_blen array init sites

--- a/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-net-stmmac-remove-axi_blen-array.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0019-UPSTREAM-net-stmmac-remove-axi_blen-array.patch
@@ -1,7 +1,7 @@
 From 06154539290aaa8448eade9d76b5f6a99c8cccd1 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Wed, 19 Nov 2025 10:23:40 +0000
-Subject: [PATCH 019/450] UPSTREAM: net: stmmac: remove axi_blen array
+Subject: [PATCH 019/463] UPSTREAM: net: stmmac: remove axi_blen array
 
 Remove the axi_blen array from struct stmmac_axi as we set this array,
 and then immediately convert it ot the register value, never looking at

--- a/runtime-kernel/linux-kernel/autobuild/patches/0020-BACKPORT-UPSTREAM-net-stmmac-add-stmmac_plat_dat_all.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0020-BACKPORT-UPSTREAM-net-stmmac-add-stmmac_plat_dat_all.patch
@@ -1,7 +1,7 @@
 From 2763592162b6c3e99497a1e81464013bce0e200d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:24 +0000
-Subject: [PATCH 020/450] BACKPORT: UPSTREAM: net: stmmac: add
+Subject: [PATCH 020/463] BACKPORT: UPSTREAM: net: stmmac: add
  stmmac_plat_dat_alloc()
 
 Add a function to allocate and initialise the plat_stmmacenet_data

--- a/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-net-stmmac-move-initialisation-of-phy_addr-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0021-UPSTREAM-net-stmmac-move-initialisation-of-phy_addr-.patch
@@ -1,7 +1,7 @@
 From a14ae458b5dac7712e9bbccca88e8333764fc189 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:29 +0000
-Subject: [PATCH 021/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 021/463] UPSTREAM: net: stmmac: move initialisation of
  phy_addr to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->phy_addr to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0022-UPSTREAM-net-stmmac-move-initialisation-of-clk_csr-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0022-UPSTREAM-net-stmmac-move-initialisation-of-clk_csr-t.patch
@@ -1,7 +1,7 @@
 From 046a9dd58bd7d3ebd31ea30d25408df89f00db94 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:34 +0000
-Subject: [PATCH 022/450] UPSTREAM: net: stmmac: move initialisation of clk_csr
+Subject: [PATCH 022/463] UPSTREAM: net: stmmac: move initialisation of clk_csr
  to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->clk_csr to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-move-initialisation-of-maxmtu-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0023-UPSTREAM-net-stmmac-move-initialisation-of-maxmtu-to.patch
@@ -1,7 +1,7 @@
 From ce9c62ef40bdd9b00dbd86b4585893e505b0a4e0 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:39 +0000
-Subject: [PATCH 023/450] UPSTREAM: net: stmmac: move initialisation of maxmtu
+Subject: [PATCH 023/463] UPSTREAM: net: stmmac: move initialisation of maxmtu
  to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->maxmtu to JUMBO_LEN to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-move-initialisation-of-multicast.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0024-UPSTREAM-net-stmmac-move-initialisation-of-multicast.patch
@@ -1,7 +1,7 @@
 From 80b2f808aba02dc96b99c11385ef81cc66c2724d Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:44 +0000
-Subject: [PATCH 024/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 024/463] UPSTREAM: net: stmmac: move initialisation of
  multicast_filter_bins to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->multicast_filter_bins to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-net-stmmac-move-initialisation-of-unicast_f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0025-UPSTREAM-net-stmmac-move-initialisation-of-unicast_f.patch
@@ -1,7 +1,7 @@
 From 632e2e37170c3427b22fcb6c74307c2bfe5ea822 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:49 +0000
-Subject: [PATCH 025/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 025/463] UPSTREAM: net: stmmac: move initialisation of
  unicast_filter_entries to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->unicast_filter_entries to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-net-stmmac-move-initialisation-of-queues_to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0026-UPSTREAM-net-stmmac-move-initialisation-of-queues_to.patch
@@ -1,7 +1,7 @@
 From c65ddf6c5664d9cab4fb91b5455038ada3122014 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:28:54 +0000
-Subject: [PATCH 026/450] UPSTREAM: net: stmmac: move initialisation of
+Subject: [PATCH 026/463] UPSTREAM: net: stmmac: move initialisation of
  queues_to_use to stmmac_plat_dat_alloc()
 
 Move the default initialisation of plat_dat->tx_queues_to_use and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-net-stmmac-setup-default-RX-channel-map-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0027-UPSTREAM-net-stmmac-setup-default-RX-channel-map-in-.patch
@@ -1,7 +1,7 @@
 From f6765935092892a902ae7a0b40d4812566e06d92 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:00 +0000
-Subject: [PATCH 027/450] UPSTREAM: net: stmmac: setup default RX channel map
+Subject: [PATCH 027/463] UPSTREAM: net: stmmac: setup default RX channel map
  in stmmac_plat_dat_alloc()
 
 Setup the default 1:1 RX channel map in stmmac_plat_dat_alloc() and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-net-stmmac-remove-unnecessary-.use_prio-que.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0028-UPSTREAM-net-stmmac-remove-unnecessary-.use_prio-que.patch
@@ -1,7 +1,7 @@
 From 2b4f5fc32c0ffa2bc67607abfeed27cb7b7834e0 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:05 +0000
-Subject: [PATCH 028/450] UPSTREAM: net: stmmac: remove unnecessary .use_prio
+Subject: [PATCH 028/463] UPSTREAM: net: stmmac: remove unnecessary .use_prio
  queue initialisation
 
 Several drivers (see below) explicitly set the queue .use_prio

--- a/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-net-stmmac-remove-unnecessary-.prio-queue-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0029-UPSTREAM-net-stmmac-remove-unnecessary-.prio-queue-i.patch
@@ -1,7 +1,7 @@
 From 1bfda16d34cede94991d2f381b1c4a9cc4594269 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:10 +0000
-Subject: [PATCH 029/450] UPSTREAM: net: stmmac: remove unnecessary .prio queue
+Subject: [PATCH 029/463] UPSTREAM: net: stmmac: remove unnecessary .prio queue
  initialisation
 
 stmmac_platform.c explicitly sets .prio to zero if the snps,priority

--- a/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-net-stmmac-remove-unnecessary-.pkt_route-qu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0030-UPSTREAM-net-stmmac-remove-unnecessary-.pkt_route-qu.patch
@@ -1,7 +1,7 @@
 From 21a42f526621fe5be224a374c50ec700d5ed3d10 Mon Sep 17 00:00:00 2001
 From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
 Date: Fri, 14 Nov 2025 15:29:15 +0000
-Subject: [PATCH 030/450] UPSTREAM: net: stmmac: remove unnecessary .pkt_route
+Subject: [PATCH 030/463] UPSTREAM: net: stmmac: remove unnecessary .pkt_route
  queue initialisation
 
 PCI drivers explicitly set .pkt_route to zero. However, as the struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-arm64-dts-cix-add-DT-nodes-for-SPI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0031-UPSTREAM-arm64-dts-cix-add-DT-nodes-for-SPI.patch
@@ -1,7 +1,7 @@
 From 9c42c395100b1829effd06afddfa6ab12b1ab56e Mon Sep 17 00:00:00 2001
 From: Jun Guo <jun.guo@cixtech.com>
 Date: Fri, 19 Sep 2025 09:31:18 +0800
-Subject: [PATCH 031/450] UPSTREAM: arm64: dts: cix: add DT nodes for SPI
+Subject: [PATCH 031/463] UPSTREAM: arm64: dts: cix: add DT nodes for SPI
 
 Add the device tree node for the spi controller of the CIX SKY1 SoC.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-dt-bindings-pinctrl-Add-cix-sky1-pinctrl.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0032-UPSTREAM-dt-bindings-pinctrl-Add-cix-sky1-pinctrl.patch
@@ -1,7 +1,7 @@
 From a0e530195b9b11464f763f4744dd5d93d654607c Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:08 +0800
-Subject: [PATCH 032/450] UPSTREAM: dt-bindings: pinctrl: Add cix,sky1-pinctrl
+Subject: [PATCH 032/463] UPSTREAM: dt-bindings: pinctrl: Add cix,sky1-pinctrl
 
 The pin-controller is used to control the Soc pins.
 There are two pin-controllers on Cix Sky1 platform.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-pinctrl-cix-Add-pin-controller-support-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0033-UPSTREAM-pinctrl-cix-Add-pin-controller-support-for-.patch
@@ -1,7 +1,7 @@
 From f59a9a48cbd6054d6ab8db87b5a02f07dacfa99a Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:09 +0800
-Subject: [PATCH 033/450] UPSTREAM: pinctrl: cix: Add pin-controller support
+Subject: [PATCH 033/463] UPSTREAM: pinctrl: cix: Add pin-controller support
  for sky1
 
 There are two pin-controllers on Cix Sky1 platform.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0034-UPSTREAM-arm64-dts-cix-Add-pinctrl-nodes-for-sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0034-UPSTREAM-arm64-dts-cix-Add-pinctrl-nodes-for-sky1.patch
@@ -1,7 +1,7 @@
 From 000a880f3f1fc79e9e9d7758822db934cff2f9ce Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 21 Oct 2025 15:04:10 +0800
-Subject: [PATCH 034/450] UPSTREAM: arm64: dts: cix: Add pinctrl nodes for sky1
+Subject: [PATCH 034/463] UPSTREAM: arm64: dts: cix: Add pinctrl nodes for sky1
 
 Add the pin-controller nodes for Sky1 platform.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0035-UPSTREAM-PCI-cadence-Add-module-support-for-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0035-UPSTREAM-PCI-cadence-Add-module-support-for-platform.patch
@@ -1,7 +1,7 @@
 From 03acefed1c23686dfcf08ffdd133bb3f9241edc3 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:56 +0800
-Subject: [PATCH 035/450] UPSTREAM: PCI: cadence: Add module support for
+Subject: [PATCH 035/463] UPSTREAM: PCI: cadence: Add module support for
  platform controller driver
 
 Add support for building PCI cadence platforms as a module.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0036-UPSTREAM-PCI-cadence-Split-PCIe-controller-header-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0036-UPSTREAM-PCI-cadence-Split-PCIe-controller-header-fi.patch
@@ -1,7 +1,7 @@
 From 4dc45d1b84f46e1ad1e1a6fcca59de592a4badb0 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:57 +0800
-Subject: [PATCH 036/450] UPSTREAM: PCI: cadence: Split PCIe controller header
+Subject: [PATCH 036/463] UPSTREAM: PCI: cadence: Split PCIe controller header
  file
 
 Split the Cadence PCIe header file by moving the Legacy (LGA) controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0037-UPSTREAM-PCI-cadence-Move-PCIe-RP-common-functions-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0037-UPSTREAM-PCI-cadence-Move-PCIe-RP-common-functions-t.patch
@@ -1,7 +1,7 @@
 From a29809323e87022d62aed51fa9e79811d98da727 Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:58 +0800
-Subject: [PATCH 037/450] UPSTREAM: PCI: cadence: Move PCIe RP common functions
+Subject: [PATCH 037/463] UPSTREAM: PCI: cadence: Move PCIe RP common functions
  to a separate file
 
 Move the Cadence PCIe controller RP common functions into a separate file.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0038-UPSTREAM-PCI-cadence-Add-support-for-High-Perf-Archi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0038-UPSTREAM-PCI-cadence-Add-support-for-High-Perf-Archi.patch
@@ -1,7 +1,7 @@
 From aeb68c4ca6e53d440a925eaec453762071d20a3c Mon Sep 17 00:00:00 2001
 From: Manikandan K Pillai <mpillai@cadence.com>
 Date: Sat, 8 Nov 2025 22:02:59 +0800
-Subject: [PATCH 038/450] UPSTREAM: PCI: cadence: Add support for High Perf
+Subject: [PATCH 038/463] UPSTREAM: PCI: cadence: Add support for High Perf
  Architecture (HPA) controller
 
 Add support for Cadence PCIe RP configuration for High Performance

--- a/runtime-kernel/linux-kernel/autobuild/patches/0039-UPSTREAM-dt-bindings-PCI-Add-CIX-Sky1-PCIe-Root-Comp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0039-UPSTREAM-dt-bindings-PCI-Add-CIX-Sky1-PCIe-Root-Comp.patch
@@ -1,7 +1,7 @@
 From 9d0d9e6096864951a4ddd4f42bbbcc8a0bc9c990 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:00 +0800
-Subject: [PATCH 039/450] UPSTREAM: dt-bindings: PCI: Add CIX Sky1 PCIe Root
+Subject: [PATCH 039/463] UPSTREAM: dt-bindings: PCI: Add CIX Sky1 PCIe Root
  Complex bindings
 
 Document the bindings for CIX Sky1 PCIe Controller configured in Root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0040-UPSTREAM-PCI-sky1-Add-PCIe-host-support-for-CIX-Sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0040-UPSTREAM-PCI-sky1-Add-PCIe-host-support-for-CIX-Sky1.patch
@@ -1,7 +1,7 @@
 From 20a6671973ff5c3507699d59fc9d1cfd95f3b7ed Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:02 +0800
-Subject: [PATCH 040/450] UPSTREAM: PCI: sky1: Add PCIe host support for CIX
+Subject: [PATCH 040/463] UPSTREAM: PCI: sky1: Add PCIe host support for CIX
  Sky1
 
 Add driver for the CIX Sky1 SoC PCIe Gen4 16 GT/s controller based on the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0041-UPSTREAM-arm64-dts-cix-Add-PCIe-Root-Complex-on-sky1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0041-UPSTREAM-arm64-dts-cix-Add-PCIe-Root-Complex-on-sky1.patch
@@ -1,7 +1,7 @@
 From d5aa7648ae70019530044e54fa3a8d7c10a79900 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:04 +0800
-Subject: [PATCH 041/450] UPSTREAM: arm64: dts: cix: Add PCIe Root Complex on
+Subject: [PATCH 041/463] UPSTREAM: arm64: dts: cix: Add PCIe Root Complex on
  sky1
 
 Add pcie_x*_rc node to support Sky1 PCIe driver based on the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0042-UPSTREAM-arm64-dts-cix-Enable-PCIe-on-the-Orion-O6-b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0042-UPSTREAM-arm64-dts-cix-Enable-PCIe-on-the-Orion-O6-b.patch
@@ -1,7 +1,7 @@
 From 740dfe4859e7b8f199b96c311a1f91b733e9cdd4 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Sat, 8 Nov 2025 22:03:05 +0800
-Subject: [PATCH 042/450] UPSTREAM: arm64: dts: cix: Enable PCIe on the Orion
+Subject: [PATCH 042/463] UPSTREAM: arm64: dts: cix: Enable PCIe on the Orion
  O6 board
 
 Add PCIe RC support on Orion O6 board.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0043-UPSTREAM-arm64-dts-cix-add-a-compatible-string-for-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0043-UPSTREAM-arm64-dts-cix-add-a-compatible-string-for-t.patch
@@ -1,7 +1,7 @@
 From 14e013f4f2aa9a228b0ef3862b060456a8a594f2 Mon Sep 17 00:00:00 2001
 From: Jun Guo <jun.guo@cixtech.com>
 Date: Fri, 31 Oct 2025 15:30:03 +0800
-Subject: [PATCH 043/450] UPSTREAM: arm64: dts: cix: add a compatible string
+Subject: [PATCH 043/463] UPSTREAM: arm64: dts: cix: add a compatible string
  for the cix sky1 SoC
 
 The SPI IP design for the cix sky1 SoC uses a FIFO with a data width

--- a/runtime-kernel/linux-kernel/autobuild/patches/0044-UPSTREAM-drm-ttm-add-pgprot-handling-for-RISC-V.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0044-UPSTREAM-drm-ttm-add-pgprot-handling-for-RISC-V.patch
@@ -1,7 +1,7 @@
 From 4c2ed69a025bd79717b542820cdc6150b9aa452e Mon Sep 17 00:00:00 2001
 From: Han Gao <gaohan@iscas.ac.cn>
 Date: Fri, 5 Dec 2025 10:42:07 +0800
-Subject: [PATCH 044/450] UPSTREAM: drm/ttm: add pgprot handling for RISC-V
+Subject: [PATCH 044/463] UPSTREAM: drm/ttm: add pgprot handling for RISC-V
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0045-UPSTREAM-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0045-UPSTREAM-riscv-sophgo-dts-add-PCIe-controllers-for-S.patch
@@ -1,7 +1,7 @@
 From 8458cddce1f6b842d5bc94436c5d912d759d6b6d Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:33:43 +0800
-Subject: [PATCH 045/450] UPSTREAM: riscv: sophgo: dts: add PCIe controllers
+Subject: [PATCH 045/463] UPSTREAM: riscv: sophgo: dts: add PCIe controllers
  for SG2042
 
 Add PCIe controller nodes in DTS for Sophgo SG2042.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0046-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0046-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-PioneerBox.patch
@@ -1,7 +1,7 @@
 From 71e256de362b232fa1edc737f9c5072232788b13 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:34:05 +0800
-Subject: [PATCH 046/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 046/463] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  PioneerBox
 
 Enable PCIe controllers for PioneerBox, which uses SG2042 SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0047-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0047-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 9cdba38d4e01bc9bbd095fd49cac4ea494c40dc2 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:39:22 +0800
-Subject: [PATCH 047/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 047/463] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V1.X
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V1.X board,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0048-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0048-UPSTREAM-riscv-sophgo-dts-enable-PCIe-for-SG2042_EVB.patch
@@ -1,7 +1,7 @@
 From 11ab32fd7c47907005b23057c1631e9deeabaf82 Mon Sep 17 00:00:00 2001
 From: Chen Wang <unicorn_wang@outlook.com>
 Date: Mon, 20 Oct 2025 11:40:09 +0800
-Subject: [PATCH 048/450] UPSTREAM: riscv: sophgo: dts: enable PCIe for
+Subject: [PATCH 048/463] UPSTREAM: riscv: sophgo: dts: enable PCIe for
  SG2042_EVB_V2.0
 
 Enable PCIe controllers for Sophgo SG2042_EVB_V2.0 board,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0049-UPSTREAM-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0049-UPSTREAM-riscv-dts-sophgo-Add-SPI-NOR-node-for-SG204.patch
@@ -1,7 +1,7 @@
 From aa1766dfeb33d4a7db4d96c32a13003bb94e9eb0 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:50 +0800
-Subject: [PATCH 049/450] UPSTREAM: riscv: dts: sophgo: Add SPI NOR node for
+Subject: [PATCH 049/463] UPSTREAM: riscv: dts: sophgo: Add SPI NOR node for
  SG2042
 
 Add SPI NOR controller node for SG2042

--- a/runtime-kernel/linux-kernel/autobuild/patches/0050-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0050-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-Pi.patch
@@ -1,7 +1,7 @@
 From 6a4df7e5a17240233159e0c3c8bf785f93dba400 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:51 +0800
-Subject: [PATCH 050/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 050/463] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  PioneerBox
 
 Enable SPI NOR node for PioneerBox device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0051-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0051-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 333c10aab0cf9c2d79d73c66f9e3ba97255e7358 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:52 +0800
-Subject: [PATCH 051/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 051/463] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V1
 
 Enable SPI NOR node for SG2042_EVB_V1 device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0052-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0052-UPSTREAM-riscv-dts-sophgo-Enable-SPI-NOR-node-for-SG.patch
@@ -1,7 +1,7 @@
 From 52330652a8789ec4f43bb63e1f76c91a606ec516 Mon Sep 17 00:00:00 2001
 From: Zixian Zeng <sycamoremoon376@gmail.com>
 Date: Tue, 16 Sep 2025 21:22:53 +0800
-Subject: [PATCH 052/450] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
+Subject: [PATCH 052/463] UPSTREAM: riscv: dts: sophgo: Enable SPI NOR node for
  SG2042_EVB_V2
 
 Enable SPI NOR node for SG2042_EVB_V2 device tree

--- a/runtime-kernel/linux-kernel/autobuild/patches/0053-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-add-phy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0053-UPSTREAM-dt-bindings-net-sophgo-sg2044-dwmac-add-phy.patch
@@ -1,7 +1,7 @@
 From 3951bb3466fb467be83f842acaf5631c52f08cec Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Fri, 14 Nov 2025 08:38:03 +0800
-Subject: [PATCH 053/450] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: add
+Subject: [PATCH 053/463] UPSTREAM: dt-bindings: net: sophgo,sg2044-dwmac: add
  phy mode restriction
 
 As the ethernet controller of SG2044 and SG2042 only supports

--- a/runtime-kernel/linux-kernel/autobuild/patches/0054-UPSTREAM-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0054-UPSTREAM-perf-vendor-events-riscv-add-T-HEAD-C920V2-.patch
@@ -1,7 +1,7 @@
 From 918463546746a417787db07316cd2db3cb0637e5 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Tue, 14 Oct 2025 09:48:29 +0800
-Subject: [PATCH 054/450] UPSTREAM: perf vendor events riscv: add T-HEAD C920V2
+Subject: [PATCH 054/463] UPSTREAM: perf vendor events riscv: add T-HEAD C920V2
  JSON support
 
 T-HEAD C920 has a V2 iteration, which supports Sscompmf. The V2

--- a/runtime-kernel/linux-kernel/autobuild/patches/0055-UPSTREAM-rust-macros-Add-support-for-imports_ns-to-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0055-UPSTREAM-rust-macros-Add-support-for-imports_ns-to-m.patch
@@ -1,7 +1,7 @@
 From 5a104d7d4185ebc565773566b3c3b7b3f0764055 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:32 +0100
-Subject: [PATCH 055/450] UPSTREAM: rust: macros: Add support for 'imports_ns'
+Subject: [PATCH 055/463] UPSTREAM: rust: macros: Add support for 'imports_ns'
  to module!
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0056-UPSTREAM-pwm-Export-pwmchip_release-for-external-use.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0056-UPSTREAM-pwm-Export-pwmchip_release-for-external-use.patch
@@ -1,7 +1,7 @@
 From 2dd835f59aed8b65bfee661797e6a5a7823a35b6 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:01 +0200
-Subject: [PATCH 056/450] UPSTREAM: pwm: Export `pwmchip_release` for external
+Subject: [PATCH 056/463] UPSTREAM: pwm: Export `pwmchip_release` for external
  use
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0057-UPSTREAM-rust-pwm-Add-Kconfig-and-basic-data-structu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0057-UPSTREAM-rust-pwm-Add-Kconfig-and-basic-data-structu.patch
@@ -1,7 +1,7 @@
 From b2e5d4a8a14a22c471f2ecf0884143bf45d96eb0 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:02 +0200
-Subject: [PATCH 057/450] UPSTREAM: rust: pwm: Add Kconfig and basic data
+Subject: [PATCH 057/463] UPSTREAM: rust: pwm: Add Kconfig and basic data
  structures
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0058-UPSTREAM-rust-pwm-Add-complete-abstraction-layer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0058-UPSTREAM-rust-pwm-Add-complete-abstraction-layer.patch
@@ -1,7 +1,7 @@
 From 41a346fc369e62cc8e5535be49b34a801794b16c Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:03 +0200
-Subject: [PATCH 058/450] UPSTREAM: rust: pwm: Add complete abstraction layer
+Subject: [PATCH 058/463] UPSTREAM: rust: pwm: Add complete abstraction layer
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0059-UPSTREAM-rust-pwm-Add-module_pwm_platform_driver-mac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0059-UPSTREAM-rust-pwm-Add-module_pwm_platform_driver-mac.patch
@@ -1,7 +1,7 @@
 From c55e51fc49dcbf3c33d420c7c1b91d1138cb2e29 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:33 +0100
-Subject: [PATCH 059/450] UPSTREAM: rust: pwm: Add module_pwm_platform_driver!
+Subject: [PATCH 059/463] UPSTREAM: rust: pwm: Add module_pwm_platform_driver!
  macro
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0060-UPSTREAM-rust-pwm-Drop-wrapping-of-PWM-polarity-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0060-UPSTREAM-rust-pwm-Drop-wrapping-of-PWM-polarity-and-.patch
@@ -1,7 +1,7 @@
 From 4228cd8f92f41fc58735501c39fe0a87f5dbfa39 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Uwe=20Kleine-K=C3=B6nig?= <u.kleine-koenig@baylibre.com>
 Date: Sat, 25 Oct 2025 14:23:56 +0200
-Subject: [PATCH 060/450] UPSTREAM: rust: pwm: Drop wrapping of PWM polarity
+Subject: [PATCH 060/463] UPSTREAM: rust: pwm: Drop wrapping of PWM polarity
  and state
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0061-UPSTREAM-rust-pwm-Fix-broken-intra-doc-link.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0061-UPSTREAM-rust-pwm-Fix-broken-intra-doc-link.patch
@@ -1,7 +1,7 @@
 From 3b06c9f15400789feb8e6eb8d0ee76f0163d6efe Mon Sep 17 00:00:00 2001
 From: Miguel Ojeda <ojeda@kernel.org>
 Date: Wed, 29 Oct 2025 19:19:40 +0100
-Subject: [PATCH 061/450] UPSTREAM: rust: pwm: Fix broken intra-doc link
+Subject: [PATCH 061/463] UPSTREAM: rust: pwm: Fix broken intra-doc link
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0062-UPSTREAM-pwm-Add-Rust-driver-for-T-HEAD-TH1520-SoC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0062-UPSTREAM-pwm-Add-Rust-driver-for-T-HEAD-TH1520-SoC.patch
@@ -1,7 +1,7 @@
 From c2582f16a5082088746377ef449bb59e0c7ff056 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:04 +0200
-Subject: [PATCH 062/450] UPSTREAM: pwm: Add Rust driver for T-HEAD TH1520 SoC
+Subject: [PATCH 062/463] UPSTREAM: pwm: Add Rust driver for T-HEAD TH1520 SoC
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0063-UPSTREAM-dt-bindings-pwm-thead-Add-T-HEAD-TH1520-PWM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0063-UPSTREAM-dt-bindings-pwm-thead-Add-T-HEAD-TH1520-PWM.patch
@@ -1,7 +1,7 @@
 From 8283ee5ecefcf69dbc5814f19fea5ddbb40eabe1 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:05 +0200
-Subject: [PATCH 063/450] UPSTREAM: dt-bindings: pwm: thead: Add T-HEAD TH1520
+Subject: [PATCH 063/463] UPSTREAM: dt-bindings: pwm: thead: Add T-HEAD TH1520
  PWM controller
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0064-UPSTREAM-pwm-Fix-Rust-formatting.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0064-UPSTREAM-pwm-Fix-Rust-formatting.patch
@@ -1,7 +1,7 @@
 From 8b5ce0bf30be7a1c2587ed7bce623de58369f8cb Mon Sep 17 00:00:00 2001
 From: Miguel Ojeda <ojeda@kernel.org>
 Date: Wed, 29 Oct 2025 19:25:02 +0100
-Subject: [PATCH 064/450] UPSTREAM: pwm: Fix Rust formatting
+Subject: [PATCH 064/463] UPSTREAM: pwm: Fix Rust formatting
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0065-UPSTREAM-pwm-th1520-Fix-clippy-warning-for-redundant.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0065-UPSTREAM-pwm-th1520-Fix-clippy-warning-for-redundant.patch
@@ -1,7 +1,7 @@
 From dcf17cabf0991d77bec2464a5906e86f988eefcd Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:35 +0100
-Subject: [PATCH 065/450] UPSTREAM: pwm: th1520: Fix clippy warning for
+Subject: [PATCH 065/463] UPSTREAM: pwm: th1520: Fix clippy warning for
  redundant struct field init
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0066-UPSTREAM-pwm-th1520-Use-module_pwm_platform_driver-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0066-UPSTREAM-pwm-th1520-Use-module_pwm_platform_driver-m.patch
@@ -1,7 +1,7 @@
 From b3d894d8c9873aca53939042470f1d571a2724dd Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 28 Oct 2025 13:22:34 +0100
-Subject: [PATCH 066/450] UPSTREAM: pwm: th1520: Use
+Subject: [PATCH 066/463] UPSTREAM: pwm: th1520: Use
  module_pwm_platform_driver! macro
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0067-UPSTREAM-pwm-th1520-Fix-missing-Kconfig-dependencies.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0067-UPSTREAM-pwm-th1520-Fix-missing-Kconfig-dependencies.patch
@@ -1,7 +1,7 @@
 From f960d77dc0fd5f4a35b4351f1738afbf1b83c7c2 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Tue, 9 Dec 2025 21:06:03 +0100
-Subject: [PATCH 067/450] UPSTREAM: pwm: th1520: Fix missing Kconfig
+Subject: [PATCH 067/463] UPSTREAM: pwm: th1520: Fix missing Kconfig
  dependencies
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0068-UPSTREAM-riscv-dts-thead-add-xtheadvector-to-the-th1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0068-UPSTREAM-riscv-dts-thead-add-xtheadvector-to-the-th1.patch
@@ -1,7 +1,7 @@
 From a73b9042e40db073dd1d53d80a2e4ff1444be9a7 Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:47 +0800
-Subject: [PATCH 068/450] UPSTREAM: riscv: dts: thead: add xtheadvector to the
+Subject: [PATCH 068/463] UPSTREAM: riscv: dts: thead: add xtheadvector to the
  th1520 devicetree
 
 The th1520 support xtheadvector [1] so it can be included in the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0069-UPSTREAM-riscv-dts-thead-add-ziccrse-for-th1520.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0069-UPSTREAM-riscv-dts-thead-add-ziccrse-for-th1520.patch
@@ -1,7 +1,7 @@
 From 7cbe361278ca0bc45e3355490496a1c12c013aab Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:48 +0800
-Subject: [PATCH 069/450] UPSTREAM: riscv: dts: thead: add ziccrse for th1520
+Subject: [PATCH 069/463] UPSTREAM: riscv: dts: thead: add ziccrse for th1520
 
 Existing rv64 hardware conforms to the rva20 profile.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0070-UPSTREAM-riscv-dts-thead-add-zfh-for-th1520.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0070-UPSTREAM-riscv-dts-thead-add-zfh-for-th1520.patch
@@ -1,7 +1,7 @@
 From 1d43a8d03a459259b7b5ac5af5696b7f66836bce Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Fri, 19 Sep 2025 04:44:49 +0800
-Subject: [PATCH 070/450] UPSTREAM: riscv: dts: thead: add zfh for th1520
+Subject: [PATCH 070/463] UPSTREAM: riscv: dts: thead: add zfh for th1520
 
 th1520 support Zfh ISA extension.
 It supports the same RISC-V extensions as SG2042.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0071-UPSTREAM-riscv-dts-thead-Add-PWM-controller-node.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0071-UPSTREAM-riscv-dts-thead-Add-PWM-controller-node.patch
@@ -1,7 +1,7 @@
 From b38e3a2f07016fd655ad69d9f5da73ca7bff0d24 Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:06 +0200
-Subject: [PATCH 071/450] UPSTREAM: riscv: dts: thead: Add PWM controller node
+Subject: [PATCH 071/463] UPSTREAM: riscv: dts: thead: Add PWM controller node
 
 Add the Device Tree node for the T-HEAD TH1520 SoC's PWM controller.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0072-UPSTREAM-riscv-dts-thead-Add-PWM-fan-and-thermal-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0072-UPSTREAM-riscv-dts-thead-Add-PWM-fan-and-thermal-con.patch
@@ -1,7 +1,7 @@
 From 98b2c40eea6d1c0c831aeaed089e0005c93fc76b Mon Sep 17 00:00:00 2001
 From: Michal Wilczynski <m.wilczynski@samsung.com>
 Date: Thu, 16 Oct 2025 15:38:07 +0200
-Subject: [PATCH 072/450] UPSTREAM: riscv: dts: thead: Add PWM fan and thermal
+Subject: [PATCH 072/463] UPSTREAM: riscv: dts: thead: Add PWM fan and thermal
  control
 
 Add Device Tree nodes to enable a PWM controlled fan and it's associated

--- a/runtime-kernel/linux-kernel/autobuild/patches/0073-UPSTREAM-MIPS-Loongson64-dts-fix-phy-related-definit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0073-UPSTREAM-MIPS-Loongson64-dts-fix-phy-related-definit.patch
@@ -1,7 +1,7 @@
 From 50ead3569b57edcba557f0c9852651ad514eab1c Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 2 Jan 2026 23:52:43 +0800
-Subject: [PATCH 073/450] UPSTREAM: MIPS: Loongson64: dts: fix phy-related
+Subject: [PATCH 073/463] UPSTREAM: MIPS: Loongson64: dts: fix phy-related
  definition of LS7A GMAC
 
 Currently the LS7A GMAC device tree node lacks a proper phy-handle

--- a/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0074-FROMLIST-usb-phy-tegra-Add-38.4MHz-clock-table-entry.patch
@@ -1,7 +1,7 @@
 From 4755496d961f8ec89539f03ed19c5b0cb678201a Mon Sep 17 00:00:00 2001
 From: Hunter Laux <hunterlaux-Re5JQEeQqe8AvxtiuMwx3w@public.gmane.org>
 Date: Wed, 6 Apr 2016 00:54:05 -0700
-Subject: [PATCH 074/450] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
+Subject: [PATCH 074/463] FROMLIST: usb: phy: tegra: Add 38.4MHz clock table
  entry
 
 The Tegra210 uses a 38.4MHz OSC. This clock table entry is required to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0075-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0075-BACKPORT-FROMLIST-drm-Makefile-Move-tiny-drivers-bef.patch
@@ -1,7 +1,7 @@
 From 10bc21d227744cb4fa0ae929a7622debfc6f6a3d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 8 Nov 2023 10:46:13 +0800
-Subject: [PATCH 075/450] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
+Subject: [PATCH 075/463] BACKPORT: FROMLIST: drm/Makefile: Move tiny drivers
  before native drivers
 
 After commit 60aebc9559492cea ("drivers/firmware: Move sysfb_init() from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0076-FROMLIST-drm-radeon-Call-mmiowb-at-the-end-of-radeon.patch
@@ -1,7 +1,7 @@
 From d831ec2a8deb716bbf893e08dc172f2a7e5ea0c4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Tue, 20 Feb 2024 15:49:58 +0800
-Subject: [PATCH 076/450] FROMLIST: drm/radeon: Call mmiowb() at the end of
+Subject: [PATCH 076/463] FROMLIST: drm/radeon: Call mmiowb() at the end of
  radeon_ring_commit()
 
 Commit fb24ea52f78e0d595852e ("drivers: Remove explicit invocations of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0077-FROMLIST-LoongArch-Update-the-flush-cache-policy.patch
@@ -1,7 +1,7 @@
 From d148b9375c0b1d9fccc18ab94853c2c24591512e Mon Sep 17 00:00:00 2001
 From: Li Jun <lijun01@kylinos.cn>
 Date: Tue, 7 May 2024 15:43:57 +0800
-Subject: [PATCH 077/450] FROMLIST: LoongArch: Update the flush cache policy
+Subject: [PATCH 077/463] FROMLIST: LoongArch: Update the flush cache policy
 
 fix when LoongArch s3 resume, Can't find image information
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0078-FROMLIST-dt-bindings-serial-8250-Add-Loongson-uart-c.patch
@@ -1,7 +1,7 @@
 From 4924bfe3f94da1a96d1e81e4fea81fe471d12064 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:47 +0800
-Subject: [PATCH 078/450] FROMLIST: dt-bindings: serial: 8250: Add Loongson
+Subject: [PATCH 078/463] FROMLIST: dt-bindings: serial: 8250: Add Loongson
  uart compatible
 
 The Loongson family have a mostly NS16550A-compatible UART and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0079-FROMLIST-serial-8250-Add-Loongson-uart-driver-suppor.patch
@@ -1,7 +1,7 @@
 From 13c79907564c8be8ca562b8e0a2635d7505c4d09 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:48 +0800
-Subject: [PATCH 079/450] FROMLIST: serial: 8250: Add Loongson uart driver
+Subject: [PATCH 079/463] FROMLIST: serial: 8250: Add Loongson uart driver
  support
 
 Add the driver for on-chip UART used on Loongson family chips.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0080-FROMLIST-LoongArch-dts-Add-uart-new-compatible-strin.patch
@@ -1,7 +1,7 @@
 From 296b4e3f301ec3da7db1532c8c093c434c4db4b6 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 11 Oct 2025 15:16:49 +0800
-Subject: [PATCH 080/450] FROMLIST: LoongArch: dts: Add uart new compatible
+Subject: [PATCH 080/463] FROMLIST: LoongArch: dts: Add uart new compatible
  string
 
 Add loongson,ls2k*-uart compatible string on uarts.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0081-FROMLIST-mips-disable-CRASH_DUMP-by-default.patch
@@ -1,7 +1,7 @@
 From 11159bb264d2c4a9f912d23d239dfbe146219786 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Tue, 17 Dec 2024 01:35:14 +0800
-Subject: [PATCH 081/450] FROMLIST: mips: disable CRASH_DUMP by default
+Subject: [PATCH 081/463] FROMLIST: mips: disable CRASH_DUMP by default
 
 On MIPS, the space of a crash dump kernel needs to be manually specified
 by both the debugee and the crash dump kernel PHYSICAL_START config

--- a/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0082-FROMLIST-x86-fpu-Fix-the-os-panic-issue-caused-by-th.patch
@@ -1,7 +1,7 @@
 From 65deacfcad21cbebacbcdbee2052e89b1c267f03 Mon Sep 17 00:00:00 2001
 From: Lyle Li <LyleLi@zhaoxin.com>
 Date: Thu, 2 Jan 2025 15:54:19 +0800
-Subject: [PATCH 082/450] FROMLIST: x86/fpu: Fix the os panic issue caused by
+Subject: [PATCH 082/463] FROMLIST: x86/fpu: Fix the os panic issue caused by
  the XGETBV instruction
 
 The callers of the xfeatures_in_use function must ensure that the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0083-FROMLIST-USB-core-Enable-root_hub-s-remote-wakeup-fo.patch
@@ -1,7 +1,7 @@
 From a1c0d528a734fceb7283607e33cfe26c8a00e5f2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 31 Jan 2025 18:06:30 +0800
-Subject: [PATCH 083/450] FROMLIST: USB: core: Enable root_hub's remote wakeup
+Subject: [PATCH 083/463] FROMLIST: USB: core: Enable root_hub's remote wakeup
  for wakeup sources
 
 Now we only enable the remote wakeup function for the USB wakeup source

--- a/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0084-FROMLIST-scsi-Bypass-certain-SCSI-commands-on-disks-.patch
@@ -1,7 +1,7 @@
 From 7c42efd5afaedb28c50ed1a9fcc3178da7c9140a Mon Sep 17 00:00:00 2001
 From: WangYuli <wangyuli@uniontech.com>
 Date: Tue, 18 Mar 2025 14:11:25 +0800
-Subject: [PATCH 084/450] FROMLIST: scsi: Bypass certain SCSI commands on disks
+Subject: [PATCH 084/463] FROMLIST: scsi: Bypass certain SCSI commands on disks
  with "use_192_bytes_for_3f" attribute
 
 On some external USB hard drives, mounting can fail if "lshw" is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0085-FROMLIST-PCI-Use-local_pci_probe-when-best-selected-.patch
@@ -1,7 +1,7 @@
 From 65fc9d4103e7626442c8d4707b552ec6b21bbd8f Mon Sep 17 00:00:00 2001
 From: Hongchen Zhang <zhanghongchen@loongson.cn>
 Date: Sun, 11 May 2025 16:34:12 +0800
-Subject: [PATCH 085/450] FROMLIST: PCI: Use local_pci_probe() when best
+Subject: [PATCH 085/463] FROMLIST: PCI: Use local_pci_probe() when best
  selected cpu is offline
 
 When the best selected CPU is offline, work_on_cpu() will stuck forever.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0086-FROMLIST-PCI-Prevent-LS7A-Bus-Master-clearing-on-kex.patch
@@ -1,7 +1,7 @@
 From 9f49f0fadc057eacb2902931090e8e373b641307 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 11 May 2025 16:34:13 +0800
-Subject: [PATCH 086/450] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
+Subject: [PATCH 086/463] FROMLIST: PCI: Prevent LS7A Bus Master clearing on
  kexec
 
 This is similar to commit 62b6dee1b44a ("PCI/portdrv: Prevent LS7A Bus

--- a/runtime-kernel/linux-kernel/autobuild/patches/0087-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0087-REVERT-Revert-Mark-xe-driver-as-BROKEN-if-kernel-pag.patch
@@ -1,7 +1,7 @@
 From f7113b37a54fe540832b0e038fd663e98cc11ecf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 17 Aug 2025 22:19:09 +0800
-Subject: [PATCH 087/450] REVERT: Revert "Mark xe driver as BROKEN if kernel
+Subject: [PATCH 087/463] REVERT: Revert "Mark xe driver as BROKEN if kernel
  page size is not 4kB"
 
 This reverts commit 022906afdf90327bce33d52fb4fb41b6c7d618fb.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0088-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0088-BACKPORT-FROMLIST-drm-xe-bo-fix-alignment-with-non-4.patch
@@ -1,7 +1,7 @@
 From 1d94e0f218c3986c57c191949dcaa149a880b97f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:18 +0800
-Subject: [PATCH 088/450] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
+Subject: [PATCH 088/463] BACKPORT: FROMLIST: drm/xe/bo: fix alignment with
  non-4K kernel page sizes
 
 The bo/ttm interfaces with kernel memory mapping from dedicated GPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0089-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0089-BACKPORT-FROMLIST-drm-xe-guc-use-SZ_4K-for-alignment.patch
@@ -1,7 +1,7 @@
 From 6fb386d83f4424914e35ff5c7a2f86a52660ec75 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:19 +0800
-Subject: [PATCH 089/450] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
+Subject: [PATCH 089/463] BACKPORT: FROMLIST: drm/xe/guc: use SZ_4K for
  alignment
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0090-BACKPORT-FROMLIST-drm-xe-regs-fix-RING_CTL_SIZE-size.patch
@@ -1,7 +1,7 @@
 From f5885f2c98a81c005b04369d0f1571c314bfaac1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:20 +0800
-Subject: [PATCH 090/450] BACKPORT: FROMLIST: drm/xe/regs: fix
+Subject: [PATCH 090/463] BACKPORT: FROMLIST: drm/xe/regs: fix
  RING_CTL_SIZE(size) calculation
 
 Similar to the preceding patch for GuC (and with the same references),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0091-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0091-FROMLIST-drm-xe-use-4K-alignment-for-cursor-jumps.patch
@@ -1,7 +1,7 @@
 From d68f49d9e1d436aecd9593281da1bd2a0d798125 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:21 +0800
-Subject: [PATCH 091/450] FROMLIST: drm/xe: use 4K alignment for cursor jumps
+Subject: [PATCH 091/463] FROMLIST: drm/xe: use 4K alignment for cursor jumps
 
 It appears that the xe_res_cursor also assumes 4K alignment.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0092-FROMLIST-drm-xe-query-use-PAGE_SIZE-as-the-minimum-p.patch
@@ -1,7 +1,7 @@
 From ac7d3b7a639f521db34dd43e0601ce7f4ae02c7f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 10:00:22 +0800
-Subject: [PATCH 092/450] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
+Subject: [PATCH 092/463] FROMLIST: drm/xe/query: use PAGE_SIZE as the minimum
  page alignment
 
 As this component hooks into userspace API, it should be assumed that it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0093-FROMLIST-RFC-drm-amdkfd-disable-HSA_AMD_SVM-on-Loong.patch
@@ -1,7 +1,7 @@
 From 7f2bd85e5436a36b04a706fa90e2802bb717cfd4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 14 Aug 2025 11:21:36 +0800
-Subject: [PATCH 093/450] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
+Subject: [PATCH 093/463] FROMLIST: RFC: drm/amdkfd: disable HSA_AMD_SVM on
  LoongArch and AArch64
 
 While testing my ROCm port for LoongArch and AArch64 (patches pending) on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0094-BACKPORT-FROMLIST-drm-ttm-save-the-device-s-DMA-cohe.patch
@@ -1,7 +1,7 @@
 From 0fdadc3f08f3f3c5140d5c4201cd7e7cc9601bc2 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:46 +0800
-Subject: [PATCH 094/450] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
+Subject: [PATCH 094/463] BACKPORT: FROMLIST: drm/ttm: save the device's DMA
  coherency status in ttm_device
 
 Currently TTM utilizes cached memory regardless of whether the device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0095-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0095-BACKPORT-FROMLIST-drm-ttm-downgrade-cached-to-write_.patch
@@ -1,7 +1,7 @@
 From c2552bc229facfe6e3d66c62bb49d697967e2f5b Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sat, 29 Jun 2024 13:22:47 +0800
-Subject: [PATCH 095/450] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
+Subject: [PATCH 095/463] BACKPORT: FROMLIST: drm/ttm: downgrade cached to
  write_combined when snooping not available
 
 As we can now acquire the presence of the full DMA coherency (snooping

--- a/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0096-FROMLIST-riscv-errata-Add-ERRATA_THEAD_WRITE_ONCE-fi.patch
@@ -1,7 +1,7 @@
 From c5c2c88351392fea5d0b61d51087f74db83e551f Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sun, 13 Jul 2025 11:53:21 -0400
-Subject: [PATCH 096/450] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
+Subject: [PATCH 096/463] FROMLIST: riscv: errata: Add ERRATA_THEAD_WRITE_ONCE
  fixup
 
 The early version of XuanTie C910 core has a store merge buffer

--- a/runtime-kernel/linux-kernel/autobuild/patches/0097-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0097-FROMLIST-riscv-Add-pgprot_dmacoherent-definition.patch
@@ -1,7 +1,7 @@
 From be2778832c8d0b2fa778e40ad2f3fb5b9e2176d4 Mon Sep 17 00:00:00 2001
 From: "Guo Ren (Alibaba DAMO Academy)" <guoren@kernel.org>
 Date: Sat, 11 Oct 2025 11:57:46 -0400
-Subject: [PATCH 097/450] FROMLIST: riscv: Add pgprot_dmacoherent definition
+Subject: [PATCH 097/463] FROMLIST: riscv: Add pgprot_dmacoherent definition
 
 RISC-V Svpbmt Standard Extension for Page-Based Memory Types
 defines three modes:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0098-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0098-FROMLIST-PCI-Release-BAR0-of-an-integrated-bridge-to.patch
@@ -1,7 +1,7 @@
 From bc9ef7fad3dfd1f1495c58354718be69e48901a4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ilpo=20J=C3=A4rvinen?= <ilpo.jarvinen@linux.intel.com>
 Date: Thu, 18 Sep 2025 13:58:56 -0700
-Subject: [PATCH 098/450] FROMLIST: PCI: Release BAR0 of an integrated bridge
+Subject: [PATCH 098/463] FROMLIST: PCI: Release BAR0 of an integrated bridge
  to allow GPU BAR resize
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-LoongArch-KVM-Get-VM-PMU-capability-from-HW.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0099-FROMLIST-LoongArch-KVM-Get-VM-PMU-capability-from-HW.patch
@@ -1,7 +1,7 @@
 From c3d0a4af835249c7eb63378617d6509dd0165da1 Mon Sep 17 00:00:00 2001
 From: Bibo Mao <maobibo@loongson.cn>
 Date: Tue, 30 Sep 2025 17:37:41 +0800
-Subject: [PATCH 099/450] FROMLIST: LoongArch: KVM: Get VM PMU capability from
+Subject: [PATCH 099/463] FROMLIST: LoongArch: KVM: Get VM PMU capability from
  HW GCFG register
 
 Now VM PMU capability comes from host PMU capability directly, instead

--- a/runtime-kernel/linux-kernel/autobuild/patches/0100-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0100-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From 2c52cbc66d3b988b04d59caf71c33ab1e2b92a1a Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia.pukngae@linux.dev>
 Date: Wed, 22 Oct 2025 18:40:42 +0800
-Subject: [PATCH 100/450] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 100/463] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -

--- a/runtime-kernel/linux-kernel/autobuild/patches/0101-FROMLIST-gpio-loongson-64bit-Switch-to-dynamic-alloc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0101-FROMLIST-gpio-loongson-64bit-Switch-to-dynamic-alloc.patch
@@ -1,7 +1,7 @@
 From 6b4e80321278460fa2d13582663f7bb4a7ed42bb Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 23 Oct 2025 17:03:46 +0800
-Subject: [PATCH 101/450] FROMLIST: gpio: loongson-64bit: Switch to dynamic
+Subject: [PATCH 101/463] FROMLIST: gpio: loongson-64bit: Switch to dynamic
  allocate GPIO base in byte mode
 
 gpiolib want to get completely rid of static gpiobase allocation, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0102-FROMLIST-dt-bindings-clock-thead-th1520-clk-ap-Add-I.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0102-FROMLIST-dt-bindings-clock-thead-th1520-clk-ap-Add-I.patch
@@ -1,7 +1,7 @@
 From e2c1e4841bc00a3ad73be5b9664d50e3a1df558e Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:10 +0000
-Subject: [PATCH 102/450] FROMLIST: dt-bindings: clock: thead,th1520-clk-ap:
+Subject: [PATCH 102/463] FROMLIST: dt-bindings: clock: thead,th1520-clk-ap:
  Add ID for C910 bus clock
 
 Add binding ID for C910 bus clock, which takes CLK_C910 as parent and is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0103-FROMLIST-clk-thead-th1520-ap-Add-C910-bus-clock.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0103-FROMLIST-clk-thead-th1520-ap-Add-C910-bus-clock.patch
@@ -1,7 +1,7 @@
 From 9e3155346b730e9b6b73c12e0b7351fbc65d9a40 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:12 +0000
-Subject: [PATCH 103/450] FROMLIST: clk: thead: th1520-ap: Add C910 bus clock
+Subject: [PATCH 103/463] FROMLIST: clk: thead: th1520-ap: Add C910 bus clock
 
 This divider takes c910_clk as parent and is essential for the C910
 cluster to operate, thus is marked as CLK_IS_CRITICAL.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0104-FROMLIST-clk-thead-th1520-ap-Support-setting-PLL-rat.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0104-FROMLIST-clk-thead-th1520-ap-Support-setting-PLL-rat.patch
@@ -1,7 +1,7 @@
 From 0c650ed96b108e066b53ac62fe315e7c00930537 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:13 +0000
-Subject: [PATCH 104/450] FROMLIST: clk: thead: th1520-ap: Support setting PLL
+Subject: [PATCH 104/463] FROMLIST: clk: thead: th1520-ap: Support setting PLL
  rates
 
 TH1520 ships several PLLs that could operate in either integer or

--- a/runtime-kernel/linux-kernel/autobuild/patches/0105-FROMLIST-clk-thead-th1520-ap-Add-macro-to-define-mul.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0105-FROMLIST-clk-thead-th1520-ap-Add-macro-to-define-mul.patch
@@ -1,7 +1,7 @@
 From e0fefe0eef1a3c37c0881a874fab454b7bc6009f Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:14 +0000
-Subject: [PATCH 105/450] FROMLIST: clk: thead: th1520-ap: Add macro to define
+Subject: [PATCH 105/463] FROMLIST: clk: thead: th1520-ap: Add macro to define
  multiplexers with flags
 
 The new macro, TH_CCU_MUX_FLAGS, extends TH_CCU_MUX macro by adding two

--- a/runtime-kernel/linux-kernel/autobuild/patches/0106-FROMLIST-clk-thead-th1520-ap-Support-CPU-frequency-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0106-FROMLIST-clk-thead-th1520-ap-Support-CPU-frequency-s.patch
@@ -1,7 +1,7 @@
 From 4665f554b84bebb396c9193d7903aac809ef8a3f Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:15 +0000
-Subject: [PATCH 106/450] FROMLIST: clk: thead: th1520-ap: Support CPU
+Subject: [PATCH 106/463] FROMLIST: clk: thead: th1520-ap: Support CPU
  frequency scaling
 
 On TH1520 SoC, c910_clk feeds the CPU cluster. It could be glitchlessly

--- a/runtime-kernel/linux-kernel/autobuild/patches/0107-FROMLIST-NFU-riscv-dts-thead-Add-CPU-clock-and-OPP-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0107-FROMLIST-NFU-riscv-dts-thead-Add-CPU-clock-and-OPP-t.patch
@@ -1,7 +1,7 @@
 From 928a2cfe502724ad16f6603e08ee8b01e5f5cc8e Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Thu, 20 Nov 2025 13:14:16 +0000
-Subject: [PATCH 107/450] FROMLIST: NFU: riscv: dts: thead: Add CPU clock and
+Subject: [PATCH 107/463] FROMLIST: NFU: riscv: dts: thead: Add CPU clock and
  OPP table for TH1520
 
 Add operating point table for CPU cores, and wire up clocks for CPU

--- a/runtime-kernel/linux-kernel/autobuild/patches/0108-FROMLIST-dt-bindings-vendor-prefixes-add-verisilicon.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0108-FROMLIST-dt-bindings-vendor-prefixes-add-verisilicon.patch
@@ -1,7 +1,7 @@
 From 05ec845bd6e9f8ab089c46cbe180a6fb8e520e86 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:18 +0800
-Subject: [PATCH 108/450] FROMLIST: dt-bindings: vendor-prefixes: add
+Subject: [PATCH 108/463] FROMLIST: dt-bindings: vendor-prefixes: add
  verisilicon
 
 VeriSilicon is a Silicon IP vendor, which is the current owner of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0109-FROMLIST-dt-bindings-display-add-verisilicon-dc.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0109-FROMLIST-dt-bindings-display-add-verisilicon-dc.patch
@@ -1,7 +1,7 @@
 From 4dbf506b86915b3df03e913faf7f932ad941e5bf Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:19 +0800
-Subject: [PATCH 109/450] FROMLIST: dt-bindings: display: add verisilicon,dc
+Subject: [PATCH 109/463] FROMLIST: dt-bindings: display: add verisilicon,dc
 
 Verisilicon has a series of display controllers prefixed with DC and
 with self-identification facility like their GC series GPUs.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0110-FROMLIST-drm-verisilicon-add-a-driver-for-Verisilico.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0110-FROMLIST-drm-verisilicon-add-a-driver-for-Verisilico.patch
@@ -1,7 +1,7 @@
 From a7b8a9e7487b38325ee620340cf7129830a52bda Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:20 +0800
-Subject: [PATCH 110/450] FROMLIST: drm: verisilicon: add a driver for
+Subject: [PATCH 110/463] FROMLIST: drm: verisilicon: add a driver for
  Verisilicon display controllers
 
 This is a from-scratch driver targeting Verisilicon DC-series display

--- a/runtime-kernel/linux-kernel/autobuild/patches/0111-FROMLIST-dt-bindings-display-bridge-add-binding-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0111-FROMLIST-dt-bindings-display-bridge-add-binding-for-.patch
@@ -1,7 +1,7 @@
 From 7b45c024efccd9dbea4361942499d89982ae94cb Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:21 +0800
-Subject: [PATCH 111/450] FROMLIST: dt-bindings: display/bridge: add binding
+Subject: [PATCH 111/463] FROMLIST: dt-bindings: display/bridge: add binding
  for TH1520 HDMI controller
 
 T-Head TH1520 SoC contains a Synopsys DesignWare HDMI controller paired

--- a/runtime-kernel/linux-kernel/autobuild/patches/0112-FROMLIST-drm-bridge-add-a-driver-for-T-Head-TH1520-H.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0112-FROMLIST-drm-bridge-add-a-driver-for-T-Head-TH1520-H.patch
@@ -1,7 +1,7 @@
 From 2b59a9c322f8f64a1b4005f7db0df3476bb4cc41 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:22 +0800
-Subject: [PATCH 112/450] FROMLIST: drm/bridge: add a driver for T-Head TH1520
+Subject: [PATCH 112/463] FROMLIST: drm/bridge: add a driver for T-Head TH1520
  HDMI controller
 
 T-Head TH1520 SoC contains a Synopsys DesignWare HDMI controller (paired

--- a/runtime-kernel/linux-kernel/autobuild/patches/0113-FROMLIST-riscv-dts-thead-add-DPU-and-HDMI-device-tre.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0113-FROMLIST-riscv-dts-thead-add-DPU-and-HDMI-device-tre.patch
@@ -1,7 +1,7 @@
 From 864c15cc7a9292858f5ec0c3e231ff032e68aa97 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:23 +0800
-Subject: [PATCH 113/450] FROMLIST: riscv: dts: thead: add DPU and HDMI device
+Subject: [PATCH 113/463] FROMLIST: riscv: dts: thead: add DPU and HDMI device
  tree nodes
 
 T-Head TH1520 SoC contains a Verisilicon DC8200 display controller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0114-FROMLIST-MAINTAINERS-assign-myself-as-maintainer-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0114-FROMLIST-MAINTAINERS-assign-myself-as-maintainer-for.patch
@@ -1,7 +1,7 @@
 From e9682b01ace0b3171b0e97236b94b7b525b58a22 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:25 +0800
-Subject: [PATCH 114/450] FROMLIST: MAINTAINERS: assign myself as maintainer
+Subject: [PATCH 114/463] FROMLIST: MAINTAINERS: assign myself as maintainer
  for verisilicon DC driver
 
 As I am the author of this rewritten driver, it makes sense for me to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0115-FROMLIST-mailmap-map-all-Icenowy-Zheng-s-mail-addres.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0115-FROMLIST-mailmap-map-all-Icenowy-Zheng-s-mail-addres.patch
@@ -1,7 +1,7 @@
 From 62fd7a8a917d949b31a9100e1e9d00c02f645312 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:26 +0800
-Subject: [PATCH 115/450] FROMLIST: mailmap: map all Icenowy Zheng's mail
+Subject: [PATCH 115/463] FROMLIST: mailmap: map all Icenowy Zheng's mail
  addresses
 
 Map all mail addresses Icenowy Zheng had used to the personal mailbox

--- a/runtime-kernel/linux-kernel/autobuild/patches/0116-FROMLIST-dt-bindings-usb-Add-T-HEAD-TH1520-USB-contr.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0116-FROMLIST-dt-bindings-usb-Add-T-HEAD-TH1520-USB-contr.patch
@@ -1,7 +1,7 @@
 From 1ead46c043478ec3f017997f86188026ce8468f3 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 28 Sep 2023 00:42:21 +0800
-Subject: [PATCH 116/450] FROMLIST: dt-bindings: usb: Add T-HEAD TH1520 USB
+Subject: [PATCH 116/463] FROMLIST: dt-bindings: usb: Add T-HEAD TH1520 USB
  controller
 
 T-HEAD TH1520 platform's USB has a wrapper module around

--- a/runtime-kernel/linux-kernel/autobuild/patches/0117-FROMLIST-usb-dwc3-add-T-HEAD-TH1520-usb-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0117-FROMLIST-usb-dwc3-add-T-HEAD-TH1520-usb-driver.patch
@@ -1,7 +1,7 @@
 From 29cbc2ebf312468395c385a7c458851b41793024 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 28 Sep 2023 00:42:22 +0800
-Subject: [PATCH 117/450] FROMLIST: usb: dwc3: add T-HEAD TH1520 usb driver
+Subject: [PATCH 117/463] FROMLIST: usb: dwc3: add T-HEAD TH1520 usb driver
 
 Adds TH1520 Glue layer to support USB controller on T-HEAD TH1520 SoC.
 There is a DesignWare USB3 DRD core in TH1520 SoCs, the dwc3 core is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0118-FROMLIST-net-stmmac-Add-generic-suspend-resume-helpe.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0118-FROMLIST-net-stmmac-Add-generic-suspend-resume-helpe.patch
@@ -1,7 +1,7 @@
 From 68147a454238d58419ee1b8d277e040ec18c4878 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:15 +0000
-Subject: [PATCH 118/450] FROMLIST: net: stmmac: Add generic suspend/resume
+Subject: [PATCH 118/463] FROMLIST: net: stmmac: Add generic suspend/resume
  helper for PCI-based controllers
 
 Most glue driver for PCI-based DWMAC controllers utilize similar

--- a/runtime-kernel/linux-kernel/autobuild/patches/0119-FROMLIST-net-stmmac-loongson-Use-generic-PCI-suspend.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0119-FROMLIST-net-stmmac-loongson-Use-generic-PCI-suspend.patch
@@ -1,7 +1,7 @@
 From dcf348689ac2503f8bf17678e920415c8880223c Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:16 +0000
-Subject: [PATCH 119/450] FROMLIST: net: stmmac: loongson: Use generic PCI
+Subject: [PATCH 119/463] FROMLIST: net: stmmac: loongson: Use generic PCI
  suspend/resume routines
 
 Convert glue driver for Loongson DWMAC controller to use the generic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0120-FROMLIST-net-stmmac-pci-Use-generic-PCI-suspend-resu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0120-FROMLIST-net-stmmac-pci-Use-generic-PCI-suspend-resu.patch
@@ -1,7 +1,7 @@
 From fa960ccc1e8131791d106c04d6699f269e8cacb8 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:04:17 +0000
-Subject: [PATCH 120/450] FROMLIST: net: stmmac: pci: Use generic PCI
+Subject: [PATCH 120/463] FROMLIST: net: stmmac: pci: Use generic PCI
  suspend/resume routines
 
 Convert STMMAC PCI glue driver to use the generic platform

--- a/runtime-kernel/linux-kernel/autobuild/patches/0121-FROMLIST-net-phy-motorcomm-Support-YT8531S-PHY-in-YT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0121-FROMLIST-net-phy-motorcomm-Support-YT8531S-PHY-in-YT.patch
@@ -1,7 +1,7 @@
 From 0d986fa3bad422b7a200babf8a4b8286484dbf74 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:09 +0000
-Subject: [PATCH 121/450] FROMLIST: net: phy: motorcomm: Support YT8531S PHY in
+Subject: [PATCH 121/463] FROMLIST: net: phy: motorcomm: Support YT8531S PHY in
  YT6801 Ethernet controller
 
 YT6801's internal PHY is confirmed as a GMII-capable variant of YT8531S

--- a/runtime-kernel/linux-kernel/autobuild/patches/0122-FROMLIST-net-stmmac-Add-glue-driver-for-Motorcomm-YT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0122-FROMLIST-net-stmmac-Add-glue-driver-for-Motorcomm-YT.patch
@@ -1,7 +1,7 @@
 From b332249e0a27cb552c11be1071f711ef25b43483 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:10 +0000
-Subject: [PATCH 122/450] FROMLIST: net: stmmac: Add glue driver for Motorcomm
+Subject: [PATCH 122/463] FROMLIST: net: stmmac: Add glue driver for Motorcomm
  YT6801 ethernet controller
 
 Motorcomm YT6801 is a PCIe ethernet controller based on DWMAC4 IP. It

--- a/runtime-kernel/linux-kernel/autobuild/patches/0123-FROMLIST-MAINTAINERS-Assign-myself-as-maintainer-of-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0123-FROMLIST-MAINTAINERS-Assign-myself-as-maintainer-of-.patch
@@ -1,7 +1,7 @@
 From 2dfa2135f1965c614b53ae7fb0ec0356af8f76a4 Mon Sep 17 00:00:00 2001
 From: Yao Zi <ziyao@disroot.org>
 Date: Mon, 24 Nov 2025 16:32:11 +0000
-Subject: [PATCH 123/450] FROMLIST: MAINTAINERS: Assign myself as maintainer of
+Subject: [PATCH 123/463] FROMLIST: MAINTAINERS: Assign myself as maintainer of
  Motorcomm DWMAC glue driver
 
 I volunteer to maintain the DWMAC glue driver for Motorcomm ethernet

--- a/runtime-kernel/linux-kernel/autobuild/patches/0124-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0124-FROMLIST-Input-Add-driver-for-PixArt-PS-2-touchpad.patch
@@ -1,7 +1,7 @@
 From cf6278598eb66abb5885f74f14c1d9a9b45b0099 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 27 Nov 2025 16:02:03 +0800
-Subject: [PATCH 124/450] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
+Subject: [PATCH 124/463] FROMLIST: Input: Add driver for PixArt PS/2 touchpad
 
 This patch introduces a driver for the PixArt PS/2 touchpad, which
 supports both clickpad and touchpad types.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0125-FROMLIST-PCI-Add-Cix-Technology-Vendor-and-Device-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0125-FROMLIST-PCI-Add-Cix-Technology-Vendor-and-Device-ID.patch
@@ -1,7 +1,7 @@
 From 80a0583c00ef3dc1657416ed746675dfbf653d1d Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Mon, 20 Oct 2025 12:28:53 +0800
-Subject: [PATCH 125/450] FROMLIST: PCI: Add Cix Technology Vendor and Device
+Subject: [PATCH 125/463] FROMLIST: PCI: Add Cix Technology Vendor and Device
  ID
 
 Add CIX P1 (internal name sky1) as a vendor and device ID for PCI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0126-FROMLIST-MAINTAINERS-add-entry-for-CIX-Sky1-PCIe-dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0126-FROMLIST-MAINTAINERS-add-entry-for-CIX-Sky1-PCIe-dri.patch
@@ -1,7 +1,7 @@
 From 9f49f005db6937705f6e2f3c6a93629088d55b18 Mon Sep 17 00:00:00 2001
 From: Hans Zhang <hans.zhang@cixtech.com>
 Date: Mon, 20 Oct 2025 12:28:55 +0800
-Subject: [PATCH 126/450] FROMLIST: MAINTAINERS: add entry for CIX Sky1 PCIe
+Subject: [PATCH 126/463] FROMLIST: MAINTAINERS: add entry for CIX Sky1 PCIe
  driver
 
 Add myself as maintainer of Sky1 PCIe host driver

--- a/runtime-kernel/linux-kernel/autobuild/patches/0127-FROMLIST-dt-bindings-reset-add-sky1-reset-controller.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0127-FROMLIST-dt-bindings-reset-add-sky1-reset-controller.patch
@@ -1,7 +1,7 @@
 From bf2e557d2c357f59b2235f9e35a145bf6064909b Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Thu, 13 Nov 2025 15:59:33 +0800
-Subject: [PATCH 127/450] FROMLIST: dt-bindings: reset: add sky1 reset
+Subject: [PATCH 127/463] FROMLIST: dt-bindings: reset: add sky1 reset
  controller
 
 There are two reset controllers on Cix sky1 Soc.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0128-FROMLIST-reset-cix-add-support-for-cix-sky1-resets.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0128-FROMLIST-reset-cix-add-support-for-cix-sky1-resets.patch
@@ -1,7 +1,7 @@
 From 1fd219f301f77d852aef463ad4baf826c5c4adf7 Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Thu, 13 Nov 2025 15:59:34 +0800
-Subject: [PATCH 128/450] FROMLIST: reset: cix: add support for cix sky1 resets
+Subject: [PATCH 128/463] FROMLIST: reset: cix: add support for cix sky1 resets
 
 There are two reset controllers on Cix Sky1 Soc.
 One is located in S0 domain, and the other is located

--- a/runtime-kernel/linux-kernel/autobuild/patches/0129-FROMLIST-arm64-dts-cix-add-support-for-cix-sky1-rese.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0129-FROMLIST-arm64-dts-cix-add-support-for-cix-sky1-rese.patch
@@ -1,7 +1,7 @@
 From 460c09e66715abf8ad2ff7e37572765c027c15fe Mon Sep 17 00:00:00 2001
 From: Gary Yang <gary.yang@cixtech.com>
 Date: Tue, 2 Dec 2025 19:29:22 +0800
-Subject: [PATCH 129/450] FROMLIST: arm64: dts: cix: add support for cix sky1
+Subject: [PATCH 129/463] FROMLIST: arm64: dts: cix: add support for cix sky1
  resets
 
 There are two reset conctrollers on Cix Sky1 Soc.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0130-FROMLIST-ALSA-hda-dt-bindings-add-CIX-IPBLOQ-HDA-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0130-FROMLIST-ALSA-hda-dt-bindings-add-CIX-IPBLOQ-HDA-con.patch
@@ -1,7 +1,7 @@
 From 2aa958cdd3a9ebae168065cd5961e27f4e34a3b9 Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:56:58 +0800
-Subject: [PATCH 130/450] FROMLIST: ALSA: hda: dt-bindings: add CIX IPBLOQ HDA
+Subject: [PATCH 130/463] FROMLIST: ALSA: hda: dt-bindings: add CIX IPBLOQ HDA
  controller support
 
 Add CIX IPBLOQ HDA controller support, which integrated in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0131-FROMLIST-ALSA-hda-core-add-addr_offset-field-for-bus.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0131-FROMLIST-ALSA-hda-core-add-addr_offset-field-for-bus.patch
@@ -1,7 +1,7 @@
 From 4f53ce214ccaa6248bb924836dc821d19c45aa8b Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:56:59 +0800
-Subject: [PATCH 131/450] FROMLIST: ALSA: hda/core: add addr_offset field for
+Subject: [PATCH 131/463] FROMLIST: ALSA: hda/core: add addr_offset field for
  bus address translation
 
 Add bus addr_offset field for dma address translation,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0132-FROMLIST-ALSA-hda-add-CIX-IPBLOQ-HDA-controller-supp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0132-FROMLIST-ALSA-hda-add-CIX-IPBLOQ-HDA-controller-supp.patch
@@ -1,7 +1,7 @@
 From 86fe55a52e4f8061a7e46515c30a76fa2f1da02b Mon Sep 17 00:00:00 2001
 From: Joakim Zhang <joakim.zhang@cixtech.com>
 Date: Mon, 1 Dec 2025 18:57:00 +0800
-Subject: [PATCH 132/450] FROMLIST: ALSA: hda: add CIX IPBLOQ HDA controller
+Subject: [PATCH 132/463] FROMLIST: ALSA: hda: add CIX IPBLOQ HDA controller
  support
 
 Add CIX IPBLOQ HDA controller support, which integrated

--- a/runtime-kernel/linux-kernel/autobuild/patches/0133-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0133-FROMLIST-Input-atkbd-skip-deactivate-for-HONOR-FMB-P.patch
@@ -1,7 +1,7 @@
 From ef9ab18c1984eb06a82d8984633502f99ec8eb90 Mon Sep 17 00:00:00 2001
 From: Cryolitia PukNgae <cryolitia@aosc.io>
 Date: Wed, 22 Oct 2025 18:16:30 +0800
-Subject: [PATCH 133/450] FROMLIST: Input: atkbd - skip deactivate for HONOR
+Subject: [PATCH 133/463] FROMLIST: Input: atkbd - skip deactivate for HONOR
  FMB-P's internal keyboard
 
 After commit 9cf6e24c9fbf17e52de9fff07f12be7565ea6d61 ("Input: atkbd -

--- a/runtime-kernel/linux-kernel/autobuild/patches/0134-FROMLIST-rust-export-BINDGEN_TARGET-from-a-separate-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0134-FROMLIST-rust-export-BINDGEN_TARGET-from-a-separate-.patch
@@ -1,7 +1,7 @@
 From 009100641c69ecbf6651dd8a87814596ad568a74 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:51 +0100
-Subject: [PATCH 134/450] FROMLIST: rust: export BINDGEN_TARGET from a separate
+Subject: [PATCH 134/463] FROMLIST: rust: export BINDGEN_TARGET from a separate
  Makefile
 
 A subsequent commit will add a new function `bindgen-option` to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0135-FROMLIST-rust-generate-a-fatal-error-if-BINDGEN_TARG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0135-FROMLIST-rust-generate-a-fatal-error-if-BINDGEN_TARG.patch
@@ -1,7 +1,7 @@
 From 73686c35315e3d78f4d40874e6cf6fa2f1cf3e05 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:52 +0100
-Subject: [PATCH 135/450] FROMLIST: rust: generate a fatal error if
+Subject: [PATCH 135/463] FROMLIST: rust: generate a fatal error if
  BINDGEN_TARGET is undefined
 
 Generate a friendly fatal error if the target triplet is undefined for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0136-FROMLIST-rust-add-a-Kconfig-function-to-test-for-sup.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0136-FROMLIST-rust-add-a-Kconfig-function-to-test-for-sup.patch
@@ -1,7 +1,7 @@
 From 27ed6c2d09b39a9a1c8ebf97aa3fb9149116fbeb Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:53 +0100
-Subject: [PATCH 136/450] FROMLIST: rust: add a Kconfig function to test for
+Subject: [PATCH 136/463] FROMLIST: rust: add a Kconfig function to test for
  support of bindgen options
 
 Add a new `bindgen-backend-option` Kconfig function to test whether the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0137-FROMLIST-RISC-V-handle-extension-configs-for-bindgen.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0137-FROMLIST-RISC-V-handle-extension-configs-for-bindgen.patch
@@ -1,7 +1,7 @@
 From 5f25f46ab0dc40b49423185242a9be4fcb502fd8 Mon Sep 17 00:00:00 2001
 From: Asuna Yang <spriteovo@gmail.com>
 Date: Thu, 4 Dec 2025 08:54:54 +0100
-Subject: [PATCH 137/450] FROMLIST: RISC-V: handle extension configs for
+Subject: [PATCH 137/463] FROMLIST: RISC-V: handle extension configs for
  bindgen, re-enable gcc + rust builds
 
 Commit 33549fcf37ec ("RISC-V: disallow gcc + rust builds") disabled GCC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0138-FROMLIST-riscv-dts-thead-lichee-pi-4a-enable-HDMI.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0138-FROMLIST-riscv-dts-thead-lichee-pi-4a-enable-HDMI.patch
@@ -1,7 +1,7 @@
 From d32c7b395099d2d7a706add5c0e01f7bd0c6e551 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Mon, 24 Nov 2025 18:52:24 +0800
-Subject: [PATCH 138/450] FROMLIST: riscv: dts: thead: lichee-pi-4a: enable
+Subject: [PATCH 138/463] FROMLIST: riscv: dts: thead: lichee-pi-4a: enable
  HDMI
 
 Lichee Pi 4A board features a HDMI Type-A connector connected to the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0139-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2042-PC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0139-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2042-PC.patch
@@ -1,7 +1,7 @@
 From 15b02d728041ad78fef867dd34fbbc56e827311a Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 25 Dec 2025 18:05:28 +0800
-Subject: [PATCH 139/450] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2042
+Subject: [PATCH 139/463] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2042
  PCIe [1f1c:2042] Root Ports
 
 Since commit f3ac2ff14834 ("PCI/ASPM: Enable all ClockPM and ASPM

--- a/runtime-kernel/linux-kernel/autobuild/patches/0140-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2044-PC.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0140-FROMLIST-PCI-ASPM-Avoid-L0s-and-L1-on-Sophgo-2044-PC.patch
@@ -1,7 +1,7 @@
 From 43d659c92b74c287984ef97b35dfdc5d67b32ba2 Mon Sep 17 00:00:00 2001
 From: Inochi Amaoto <inochiama@gmail.com>
 Date: Thu, 25 Dec 2025 18:05:29 +0800
-Subject: [PATCH 140/450] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2044
+Subject: [PATCH 140/463] FROMLIST: PCI/ASPM: Avoid L0s and L1 on Sophgo 2044
  PCIe [1f1c:2044] Root Ports
 
 Since commit f3ac2ff14834 ("PCI/ASPM: Enable all ClockPM and ASPM

--- a/runtime-kernel/linux-kernel/autobuild/patches/0141-FROMLIST-PCI-loongson-Override-PCIe-bridge-supported.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0141-FROMLIST-PCI-loongson-Override-PCIe-bridge-supported.patch
@@ -1,7 +1,7 @@
 From 8b6b4b419eaebf0e8b3df138e2d90f383399736b Mon Sep 17 00:00:00 2001
 From: Ziyao Li <liziyao@uniontech.com>
 Date: Wed, 21 Jan 2026 16:22:40 +0800
-Subject: [PATCH 141/450] FROMLIST: PCI: loongson: Override PCIe bridge
+Subject: [PATCH 141/463] FROMLIST: PCI: loongson: Override PCIe bridge
  supported speeds for Loongson-3C6000 series
 
 Older steppings of the Loongson-3C6000 series incorrectly report the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-FROMLIST-loongarch-wire-up-memfd_secret-sys.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0142-BACKPORT-FROMLIST-loongarch-wire-up-memfd_secret-sys.patch
@@ -1,7 +1,7 @@
 From 2f932a963537c1772978400491e36f6a8b3f7fa4 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <fearyncess@aosc.io>
 Date: Fri, 9 Jan 2026 13:10:51 +0800
-Subject: [PATCH 142/450] BACKPORT: FROMLIST: loongarch: wire up memfd_secret
+Subject: [PATCH 142/463] BACKPORT: FROMLIST: loongarch: wire up memfd_secret
  system call
 
 LoongArch supports ARCH_HAS_SET_DIRECT_MAP, therefore wire up the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0143-FROMLIST-loongarch-retrieve-CPU-package-ID-from-PPTT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0143-FROMLIST-loongarch-retrieve-CPU-package-ID-from-PPTT.patch
@@ -1,7 +1,7 @@
 From e823a4c998fad1cad5f7a875581745f2c7450838 Mon Sep 17 00:00:00 2001
 From: Rong Bao <rong.bao@csmantle.top>
 Date: Fri, 23 Jan 2026 23:56:06 +0800
-Subject: [PATCH 143/450] FROMLIST: loongarch: retrieve CPU package ID from
+Subject: [PATCH 143/463] FROMLIST: loongarch: retrieve CPU package ID from
  PPTT when available
 
 Currently, the LoongArch CPU topology initialization code calculates

--- a/runtime-kernel/linux-kernel/autobuild/patches/0144-BACKPORT-FROMLIST-ACPI-PCI-check-if-the-root-io-spac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0144-BACKPORT-FROMLIST-ACPI-PCI-check-if-the-root-io-spac.patch
@@ -1,7 +1,7 @@
 From d8d17a65525f9737984599e4370fa38fdc896c90 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 14 Aug 2024 20:09:15 +0800
-Subject: [PATCH 144/450] BACKPORT: FROMLIST: ACPI: PCI: check if the root io
+Subject: [PATCH 144/463] BACKPORT: FROMLIST: ACPI: PCI: check if the root io
  space is page aligned
 
 When the IO resource given by _CRS method is not page aligned, especially

--- a/runtime-kernel/linux-kernel/autobuild/patches/0145-FROMLIST-PCI-MSI-Conservatively-generalize-no_64bit_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0145-FROMLIST-PCI-MSI-Conservatively-generalize-no_64bit_.patch
@@ -1,7 +1,7 @@
 From 889425bfad0c46d336f75e416a10e4e195b8e283 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:28 +0800
-Subject: [PATCH 145/450] FROMLIST: PCI/MSI: Conservatively generalize
+Subject: [PATCH 145/463] FROMLIST: PCI/MSI: Conservatively generalize
  no_64bit_msi into msi_addr_mask
 
 Some PCI devices have PCI_MSI_FLAGS_64BIT in the MSI capability, but

--- a/runtime-kernel/linux-kernel/autobuild/patches/0146-FROMLIST-PCI-MSI-Check-msi_addr_mask-in-msi_verify_e.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0146-FROMLIST-PCI-MSI-Check-msi_addr_mask-in-msi_verify_e.patch
@@ -1,7 +1,7 @@
 From 8f3730a4dd913859ed8cf531b554217b1d6e5a9a Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:29 +0800
-Subject: [PATCH 146/450] FROMLIST: PCI/MSI: Check msi_addr_mask in
+Subject: [PATCH 146/463] FROMLIST: PCI/MSI: Check msi_addr_mask in
  msi_verify_entries()
 
 Instead of a 32-bit/64-bit dichotomy, check the MSI address against

--- a/runtime-kernel/linux-kernel/autobuild/patches/0147-FROMLIST-drm-radeon-Raise-msi_addr_mask-to-dma_bits.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0147-FROMLIST-drm-radeon-Raise-msi_addr_mask-to-dma_bits.patch
@@ -1,7 +1,7 @@
 From 2a691419388ac2a0d7baa6905c6021d9ce935c25 Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:30 +0800
-Subject: [PATCH 147/450] FROMLIST: drm/radeon: Raise msi_addr_mask to dma_bits
+Subject: [PATCH 147/463] FROMLIST: drm/radeon: Raise msi_addr_mask to dma_bits
 
 The code was originally written using no_64bit_msi, which restricts the
 device to 32-bit MSI addresses.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0148-FROMLIST-ALSA-hda-intel-Raise-msi_addr_mask-to-dma_b.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0148-FROMLIST-ALSA-hda-intel-Raise-msi_addr_mask-to-dma_b.patch
@@ -1,7 +1,7 @@
 From 1e592fbc7c821efb437ffbdc64213696f12bb1ab Mon Sep 17 00:00:00 2001
 From: Vivian Wang <wangruikang@iscas.ac.cn>
 Date: Fri, 23 Jan 2026 14:07:31 +0800
-Subject: [PATCH 148/450] FROMLIST: ALSA: hda/intel: Raise msi_addr_mask to
+Subject: [PATCH 148/463] FROMLIST: ALSA: hda/intel: Raise msi_addr_mask to
  dma_bits
 
 The code was originally written using no_64bit_msi, which restricts the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0149-FROMLIST-genirq-reserve-NR_IRQS_LEGACY-IRQs-in-dynir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0149-FROMLIST-genirq-reserve-NR_IRQS_LEGACY-IRQs-in-dynir.patch
@@ -1,7 +1,7 @@
 From 679d1574c77e9a232f6975726f38082f3c553f9f Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Sat, 31 Jan 2026 16:51:42 +0800
-Subject: [PATCH 149/450] FROMLIST: genirq: reserve NR_IRQS_LEGACY IRQs in
+Subject: [PATCH 149/463] FROMLIST: genirq: reserve NR_IRQS_LEGACY IRQs in
  dynirq by default
 
 Several architectures define NR_IRQS_LEGACY to reserve a low range of IRQ

--- a/runtime-kernel/linux-kernel/autobuild/patches/0150-FROMLIST-dt-bindings-interrupt-controller-add-LS7A-P.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0150-FROMLIST-dt-bindings-interrupt-controller-add-LS7A-P.patch
@@ -1,7 +1,7 @@
 From 590eacf8ed5c67060158c02b949b61b6a08d4cc5 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:59:33 +0800
-Subject: [PATCH 150/450] FROMLIST: dt-bindings: interrupt-controller: add LS7A
+Subject: [PATCH 150/463] FROMLIST: dt-bindings: interrupt-controller: add LS7A
  PCH LPC
 
 Loongson 7A series PCH contains an LPC controller with an interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0151-BACKPORT-FROMLIST-irqchip-loongson-pch-lpc-extract-n.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0151-BACKPORT-FROMLIST-irqchip-loongson-pch-lpc-extract-n.patch
@@ -1,7 +1,7 @@
 From 8d70fcbb099d76ce36d66230e01619f8a4b479c9 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:22:40 +0800
-Subject: [PATCH 151/450] BACKPORT: FROMLIST: irqchip/loongson-pch-lpc: extract
+Subject: [PATCH 151/463] BACKPORT: FROMLIST: irqchip/loongson-pch-lpc: extract
  non-ACPI-related code from ACPI init
 
 A lot of code could be shared between the current ACPI init flow with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0152-FROMLIST-irqchip-loongson-pch-lpc-guard-ACPI-init-co.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0152-FROMLIST-irqchip-loongson-pch-lpc-guard-ACPI-init-co.patch
@@ -1,7 +1,7 @@
 From 7658b2ea790bf2f930aacea7970cf768828b9ea8 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:27:26 +0800
-Subject: [PATCH 152/450] FROMLIST: irqchip/loongson-pch-lpc: guard ACPI init
+Subject: [PATCH 152/463] FROMLIST: irqchip/loongson-pch-lpc: guard ACPI init
  code with CONFIG_ACPI
 
 As OF-based initialization is going to be added to the driver, guard the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0153-FROMLIST-irqchip-loongson-pch-lpc-add-OF-init-code.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0153-FROMLIST-irqchip-loongson-pch-lpc-add-OF-init-code.patch
@@ -1,7 +1,7 @@
 From 8f7b296b1a7836fdb9f13a9f3d5442449870a2f7 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:41:50 +0800
-Subject: [PATCH 153/450] FROMLIST: irqchip/loongson-pch-lpc: add OF init code
+Subject: [PATCH 153/463] FROMLIST: irqchip/loongson-pch-lpc: add OF init code
 
 As the (kernel-internally) OF-based MIPS Loongson-3 systems can also
 have PCH LPC interrupt controller, add OF-based initialization code for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0154-FROMLIST-irqchip-loongson-pch-lpc-enable-building-on.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0154-FROMLIST-irqchip-loongson-pch-lpc-enable-building-on.patch
@@ -1,7 +1,7 @@
 From 49ddcc79907984fb37932c8ca5ee8925089bd4f4 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:45:01 +0800
-Subject: [PATCH 154/450] FROMLIST: irqchip/loongson-pch-lpc: enable building
+Subject: [PATCH 154/463] FROMLIST: irqchip/loongson-pch-lpc: enable building
  on MIPS Loongson64
 
 As the driver can now support OF-based platforms, it's now possible to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0155-FROMLIST-MIPS-Loongson64-dts-sort-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0155-FROMLIST-MIPS-Loongson64-dts-sort-nodes.patch
@@ -1,7 +1,7 @@
 From f6c79561a103624f84ef7786345802557ace4ec4 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Thu, 15 Jan 2026 12:03:45 +0800
-Subject: [PATCH 155/450] FROMLIST: MIPS: Loongson64: dts: sort nodes
+Subject: [PATCH 155/463] FROMLIST: MIPS: Loongson64: dts: sort nodes
 
 The RTC's address is after UARTs, however the node is currently before
 them.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0156-FROMLIST-MIPS-Loongson64-dts-add-node-for-LS7A-PCH-L.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0156-FROMLIST-MIPS-Loongson64-dts-add-node-for-LS7A-PCH-L.patch
@@ -1,7 +1,7 @@
 From 4591dc8f1059ca71e66d1ebe472cde72125dd6e1 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Fri, 16 Jan 2026 01:48:34 +0800
-Subject: [PATCH 156/450] FROMLIST: MIPS: Loongson64: dts: add node for LS7A
+Subject: [PATCH 156/463] FROMLIST: MIPS: Loongson64: dts: add node for LS7A
  PCH LPC
 
 Loongson 7A series PCH contain a LPC IRQ controller.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0157-FROMLIST-kbuild-install-extmod-build-do-not-exclude-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0157-FROMLIST-kbuild-install-extmod-build-do-not-exclude-.patch
@@ -1,7 +1,7 @@
 From d3873e505585207fa850d640b98e15c515ffd2fd Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
 Date: Sun, 1 Feb 2026 20:39:30 +0800
-Subject: [PATCH 157/450] FROMLIST: kbuild: install-extmod-build: do not
+Subject: [PATCH 157/463] FROMLIST: kbuild: install-extmod-build: do not
  exclude scripts/dtc/libfdt/
 
 There exists a header file in include/linux/ called libfdt.h that is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0158-FROMLIST-x86-cpu-centaur-Disable-X86_FEATURE_FSGSBAS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0158-FROMLIST-x86-cpu-centaur-Disable-X86_FEATURE_FSGSBAS.patch
@@ -1,7 +1,7 @@
 From 728521c46ec93715bc0393de4b8783c55f9c6746 Mon Sep 17 00:00:00 2001
 From: Yao Zi <me@ziyao.cc>
 Date: Sat, 28 Feb 2026 17:37:04 +0000
-Subject: [PATCH 158/450] FROMLIST: x86/cpu/centaur: Disable
+Subject: [PATCH 158/463] FROMLIST: x86/cpu/centaur: Disable
  X86_FEATURE_FSGSBASE on Zhaoxin C4600
 
 Zhaoxin C4600, which names itself as CentaurHauls, claims

--- a/runtime-kernel/linux-kernel/autobuild/patches/0159-FROMLIST-drm-amd-display-Wrap-dcn32_override_min_req.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0159-FROMLIST-drm-amd-display-Wrap-dcn32_override_min_req.patch
@@ -1,7 +1,7 @@
 From c2f68795b759d998f764d2265235e7fceda5710a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 6 Mar 2026 14:28:03 +0800
-Subject: [PATCH 159/450] FROMLIST: drm/amd/display: Wrap
+Subject: [PATCH 159/463] FROMLIST: drm/amd/display: Wrap
  dcn32_override_min_req_memclk() in DC_FP_{START,END}
 
 [Why]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0160-MARKER-FROMLIST-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0160-MARKER-FROMLIST-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 1f9f66e3b1fe46628755808ec1509759504fa3ee Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:42:45 +0800
-Subject: [PATCH 160/450] MARKER: FROMLIST: Start of Lemote patches
+Subject: [PATCH 160/463] MARKER: FROMLIST: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0161-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0161-FROMLIST-scsi-lpfc-Switch-memcpy_fromio-to-__read32_.patch
@@ -1,7 +1,7 @@
 From 80a276fd838fc681761479af0e48aa6efd8aa116 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 19 Dec 2018 16:31:14 +0800
-Subject: [PATCH 161/450] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
+Subject: [PATCH 161/463] FROMLIST: scsi: lpfc: Switch memcpy_fromio() to
  __read32_copy()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0162-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0162-FROMLIST-MIPS-math-emu-Add-madd-msub-nmadd-nmsub-emu.patch
@@ -1,7 +1,7 @@
 From 5b222a8f51427ec9d4904799c4b1cf3b801d2cb6 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 6 Feb 2019 20:03:14 +0800
-Subject: [PATCH 162/450] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
+Subject: [PATCH 162/463] FROMLIST: MIPS: math-emu: Add madd/msub/nmadd/nmsub
  emulation for Loongson-3
 
 Add madd.s/madd.d/msub.s/msub.d/nmadd.s/nmadd.d/nmsub.s/nmsub.d

--- a/runtime-kernel/linux-kernel/autobuild/patches/0163-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0163-BACKPORT-FROMLIST-MIPS-Add-__cpu_full_name-to-make-C.patch
@@ -1,7 +1,7 @@
 From 8bb0c8c03ab6c117bb27db2780f9292e1f5901c1 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:40:53 +0800
-Subject: [PATCH 163/450] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
+Subject: [PATCH 163/463] BACKPORT: FROMLIST: MIPS: Add __cpu_full_name[] to
  make CPU names more human-readable
 
 In /proc/cpuinfo, we keep "cpu model" as is, since GCC should use it

--- a/runtime-kernel/linux-kernel/autobuild/patches/0164-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0164-BACKPORT-FROMLIST-MIPS-Add-syscall-auditing-support.patch
@@ -1,7 +1,7 @@
 From 2d9a0d26eac362086724b07b3a251661e5ea1055 Mon Sep 17 00:00:00 2001
 From: Ralf Baechle <ralf@linux-mips.org>
 Date: Thu, 12 Mar 2020 17:41:23 +0800
-Subject: [PATCH 164/450] BACKPORT: FROMLIST: MIPS: Add syscall auditing
+Subject: [PATCH 164/463] BACKPORT: FROMLIST: MIPS: Add syscall auditing
  support
 
 The original patch is from Ralf. I have maintained it for more than six

--- a/runtime-kernel/linux-kernel/autobuild/patches/0165-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0165-FROMLIST-MIPS-Loongson-Add-board_ebase_setup-support.patch
@@ -1,7 +1,7 @@
 From 81e38cd2f0dc338951591eefb2e72773a2fbb7fa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 12 Mar 2020 17:41:57 +0800
-Subject: [PATCH 165/450] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
+Subject: [PATCH 165/463] FROMLIST: MIPS: Loongson: Add board_ebase_setup()
  support
 
 The EBase registers of old Loongson processor models before 3A2000 are

--- a/runtime-kernel/linux-kernel/autobuild/patches/0166-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0166-FROMLIST-MIPS-Crash-kernel-should-be-able-to-see-old.patch
@@ -1,7 +1,7 @@
 From de15f6d65e5a9b0f0f0d187ce13d90cfa61b3c79 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:57 +0800
-Subject: [PATCH 166/450] FROMLIST: MIPS: Crash kernel should be able to see
+Subject: [PATCH 166/463] FROMLIST: MIPS: Crash kernel should be able to see
  old memories
 
 Kexec-tools use mem=X@Y to pass usable memories to crash kernel, but in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0167-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0167-BACKPORT-FROMLIST-MIPS-Reserve-extra-memory-for-cras.patch
@@ -1,7 +1,7 @@
 From 6bebf19585da2ca27658173e493161d1cad10d81 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 24 Sep 2020 18:07:58 +0800
-Subject: [PATCH 167/450] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
+Subject: [PATCH 167/463] BACKPORT: FROMLIST: MIPS: Reserve extra memory for
  crash dump
 
 Traditionally, MIPS's contiguous low memory can be as less as 256M, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0168-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0168-BACKPORT-FROMLIST-mips-mm-Add-NUMA-balancing-support.patch
@@ -1,7 +1,7 @@
 From 30a568f290cb54e695a32bcee6cc3857e7208be4 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:56 +0800
-Subject: [PATCH 168/450] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
+Subject: [PATCH 168/463] BACKPORT: FROMLIST: mips/mm: Add NUMA balancing
  support
 
 NUMA balancing is available on nearly all architectures, but MIPS lacks

--- a/runtime-kernel/linux-kernel/autobuild/patches/0169-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0169-FROMLIST-MIPS-Loongson64-Enlarge-cross-package-node-.patch
@@ -1,7 +1,7 @@
 From ea9457d0bcaf4495bede2a7ebfcec4bf47dc1f1d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 1 Nov 2020 11:33:58 +0800
-Subject: [PATCH 169/450] FROMLIST: MIPS: Loongson64: Enlarge cross-package
+Subject: [PATCH 169/463] FROMLIST: MIPS: Loongson64: Enlarge cross-package
  node distance
 
 NUMA node distances affect the NUMA balancing behaviors. The cost of

--- a/runtime-kernel/linux-kernel/autobuild/patches/0170-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0170-BACKPORT-FROMLIST-MIPS-tlbex-Avoid-access-invalid-ad.patch
@@ -1,7 +1,7 @@
 From 921a74ce2c5ee160d99714f4968d5d3f4bc736b1 Mon Sep 17 00:00:00 2001
 From: wangrui <wangrui@loongson.cn>
 Date: Thu, 8 Apr 2021 19:30:59 +0800
-Subject: [PATCH 170/450] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
+Subject: [PATCH 170/463] BACKPORT: FROMLIST: MIPS: tlbex: Avoid access invalid
  address when pmd is modifying
 
 When user-space program accessing a virtual address and falls into TLB invalid

--- a/runtime-kernel/linux-kernel/autobuild/patches/0171-MARKER-FROMLIST-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0171-MARKER-FROMLIST-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 05ee466ba0f4f1a4edf97bb9b1da39e2df3efa2b Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:01 +0800
-Subject: [PATCH 171/450] MARKER: FROMLIST: End of Lemote patches
+Subject: [PATCH 171/463] MARKER: FROMLIST: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0172-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0172-LOONGSON-irqchip-loongson-eiointc-Improve-IRQ-affini.patch
@@ -1,7 +1,7 @@
 From ae08d68869165be8d73c43151a2ff65fe68bd88d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Wed, 9 Nov 2022 17:24:11 +0800
-Subject: [PATCH 172/450] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
+Subject: [PATCH 172/463] LOONGSON: irqchip/loongson-eiointc: Improve IRQ
  affinity setting
 
 On multiple bridge platform, a MSIX vector is often affinitive with only

--- a/runtime-kernel/linux-kernel/autobuild/patches/0173-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0173-LOONGSON-LoongArch-Add-CPU-HWMon-platform-driver.patch
@@ -1,7 +1,7 @@
 From 832c8e683f568d10c02697981a29d0cbea79b15d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 Oct 2020 16:29:11 +0800
-Subject: [PATCH 173/450] LOONGSON: LoongArch: Add CPU HWMon platform driver
+Subject: [PATCH 173/463] LOONGSON: LoongArch: Add CPU HWMon platform driver
 
 This add CPU HWMon (temperature sensor) platform driver for Loongson-3.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0174-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0174-LOONGSON-drivers-firmware-Move-sysfb_init-from-devic.patch
@@ -1,7 +1,7 @@
 From 4f21230c07c14d51d46112d189ed85eeac143dd2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Sun, 28 Jan 2024 14:07:46 +0800
-Subject: [PATCH 174/450] LOONGSON: drivers/firmware: Move sysfb_init() from
+Subject: [PATCH 174/463] LOONGSON: drivers/firmware: Move sysfb_init() from
  device_initcall to fs_initcall
 
 Consider a configuration like this:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0175-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0175-LOONGSON-drm-radeon-Workaround-radeon-driver-bug-for.patch
@@ -1,7 +1,7 @@
 From 732ab0b8c397c4687cf57d677c893f7f7254ff0c Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Mon, 22 Feb 2021 10:53:47 +0800
-Subject: [PATCH 175/450] LOONGSON: drm/radeon: Workaround radeon driver bug
+Subject: [PATCH 175/463] LOONGSON: drm/radeon: Workaround radeon driver bug
  for Loongson
 
 Radeon driver can not handle the interrupt is faster than DMA data, so

--- a/runtime-kernel/linux-kernel/autobuild/patches/0176-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0176-LOONGSON-drm-ast-Restore-vaddr-field-to-struct-ast_p.patch
@@ -1,7 +1,7 @@
 From c33c915f988f39156525006ed42e59b662dcea11 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Thu, 29 May 2025 20:08:26 +0800
-Subject: [PATCH 176/450] LOONGSON: drm/ast: Restore vaddr field to struct
+Subject: [PATCH 176/463] LOONGSON: drm/ast: Restore vaddr field to struct
  ast_plane
 
 Revert "drm/ast: Remove vaddr field from struct ast_plane".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0177-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0177-LOONGSON-drm-ast-Support-both-SHMEM-helper-and-VRAM-.patch
@@ -1,7 +1,7 @@
 From 63486419b7bf40bc35ac873d60a3c8407da11e37 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhuacai@loongson.cn>
 Date: Fri, 28 Feb 2025 20:28:08 +0800
-Subject: [PATCH 177/450] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
+Subject: [PATCH 177/463] LOONGSON: drm/ast: Support both SHMEM helper and VRAM
  helper
 
 Commit f2fa5a99ca81ce105653 ("drm/ast: Convert ast to SHMEM") converts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0178-AOSCOS-ast-Drop-drm_gem_vram_-un-pin-calls.patch
@@ -1,7 +1,7 @@
 From 8223e1a017593e1945f72b15ec17b0623c5639a7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 26 Aug 2025 19:01:09 +0800
-Subject: [PATCH 178/450] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
+Subject: [PATCH 178/463] AOSCOS: ast: Drop drm_gem_vram_{,un}pin calls
 
 If I read the upstream commit 62e1e11a4916
 ("drm/client: Do not pin in drm_client_buffer_vmap()") correctly, we

--- a/runtime-kernel/linux-kernel/autobuild/patches/0179-LOONGSON-dt-bindings-dmaengine-Add-Loongson-Multi-Ch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0179-LOONGSON-dt-bindings-dmaengine-Add-Loongson-Multi-Ch.patch
@@ -1,7 +1,7 @@
 From 642c4f41442dc3216dc40ad754063d53b862d69e Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Thu, 23 Oct 2025 20:27:08 +0800
-Subject: [PATCH 179/450] LOONGSON: dt-bindings: dmaengine: Add Loongson
+Subject: [PATCH 179/463] LOONGSON: dt-bindings: dmaengine: Add Loongson
  Multi-Channel DMA controller
 
 The Loongson-2K0300/Loongson-2K3000 have built-in multi-channel DMA

--- a/runtime-kernel/linux-kernel/autobuild/patches/0180-LOONGSON-dmaengine-loongson2-mcdma-New-driver-for-th.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0180-LOONGSON-dmaengine-loongson2-mcdma-New-driver-for-th.patch
@@ -1,7 +1,7 @@
 From 56e230baed51f5d9ee79ab1b09b93a462ca55086 Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Sat, 18 Oct 2025 12:46:21 +0800
-Subject: [PATCH 180/450] LOONGSON: dmaengine: loongson2-mcdma: New driver for
+Subject: [PATCH 180/463] LOONGSON: dmaengine: loongson2-mcdma: New driver for
  the Loongson Multi-Channel DMA controller
 
 This DMA controller appears in Loongson-2K0300 and Loongson-2K3000.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0181-LOONGSON-LoongArch-Add-canfd-support-for-ls2k3000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0181-LOONGSON-LoongArch-Add-canfd-support-for-ls2k3000.patch
@@ -1,7 +1,7 @@
 From 81b71150774d38f74c67c822173a1b9ef5fea259 Mon Sep 17 00:00:00 2001
 From: libingxiong <libingxiong@loongson.cn>
 Date: Fri, 30 May 2025 14:22:46 +0800
-Subject: [PATCH 181/450] LOONGSON: LoongArch: Add canfd support for ls2k3000
+Subject: [PATCH 181/463] LOONGSON: LoongArch: Add canfd support for ls2k3000
 
 Add new canfd controller and dma controller driver support for ls2k3000
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0182-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0182-BACKPORT-PHYTIUM-arm64-phytium-Add-support-for-Phyti.patch
@@ -1,7 +1,7 @@
 From 315ef8fc81ab6f98652aa1ba337e4c16d62f8965 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:58 +0800
-Subject: [PATCH 182/450] BACKPORT: PHYTIUM: arm64: phytium: Add support for
+Subject: [PATCH 182/463] BACKPORT: PHYTIUM: arm64: phytium: Add support for
  Phytium SoC family
 
 This patch adds supoort for the Phytium SoC family.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0183-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0183-PHYTIUM-PCI-Add-Phytium-vendor-ID.patch
@@ -1,7 +1,7 @@
 From ed1d00bf91be0cad94208d7f1fdcf3f26eed524a Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:33:59 +0800
-Subject: [PATCH 183/450] PHYTIUM: PCI: Add Phytium vendor ID
+Subject: [PATCH 183/463] PHYTIUM: PCI: Add Phytium vendor ID
 
 Update pci_ids.h with the vendor ID for Phytium.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0184-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0184-BACKPORT-PHYTIUM-net-stmmac-Add-Phytium-GMAC-glue-la.patch
@@ -1,7 +1,7 @@
 From b4f641cb86f8a88b4a962b4dd8cd7630c170aca5 Mon Sep 17 00:00:00 2001
 From: Chen Baozi <chenbaozi@phytium.com.cn>
 Date: Fri, 14 Jul 2023 08:34:22 +0800
-Subject: [PATCH 184/450] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
+Subject: [PATCH 184/463] BACKPORT: PHYTIUM: net: stmmac: Add Phytium GMAC glue
  layer
 
 This patch adds support for Phytium GMAC controller which derived from

--- a/runtime-kernel/linux-kernel/autobuild/patches/0185-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0185-PHYTIUM-net-stmmac-Add-a-barrier-to-make-sure-all-ac.patch
@@ -1,7 +1,7 @@
 From 3ed0bde5831b54bbc1fda55e9663173e34b61f37 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 20 Oct 2023 18:55:20 +0800
-Subject: [PATCH 185/450] PHYTIUM: net: stmmac: Add a barrier to make sure all
+Subject: [PATCH 185/463] PHYTIUM: net: stmmac: Add a barrier to make sure all
  access coherent
 
 Add a memory barrier to sync TX descriptor to avoid data error.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0186-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0186-BACKPORT-PHYTIUM-drivers-fix-build-errors.patch
@@ -1,7 +1,7 @@
 From 9faae736f4fb500222a4b029203e6201eae87ac4 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Tue, 23 Jan 2024 09:24:03 +0800
-Subject: [PATCH 186/450] BACKPORT: PHYTIUM: drivers: fix build errors
+Subject: [PATCH 186/463] BACKPORT: PHYTIUM: drivers: fix build errors
 
 1. spi: Rename SPI_MASTER_GPIO_SS to SPI_CONTROLLER_GPIO_SS 82238
 2. net: stmmac: clarify difference between "interface" and "phy_interface"  a014c3555

--- a/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0187-BACKPORT-PHYTIUM-Update-phytium-copyright-info-to-20.patch
@@ -1,7 +1,7 @@
 From 6807726267bb86a6fb05a78b1337e36ab032748a Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Mon, 5 Feb 2024 09:52:51 +0800
-Subject: [PATCH 187/450] BACKPORT: PHYTIUM: Update phytium copyright info to
+Subject: [PATCH 187/463] BACKPORT: PHYTIUM: Update phytium copyright info to
  2024
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0188-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0188-BACKPORT-PHYTIUM-edac-Phytium-Add-edac-driver-to-rec.patch
@@ -1,7 +1,7 @@
 From adb47c21fd92ae97750bd982d964f96fc63289e2 Mon Sep 17 00:00:00 2001
 From: Zhu Honglei <zhuhonglei1714@phytium.com.cn>
 Date: Wed, 20 Mar 2024 14:53:55 +0800
-Subject: [PATCH 188/450] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
+Subject: [PATCH 188/463] BACKPORT: PHYTIUM: edac: Phytium: Add edac driver to
  receive RAS error
 
 Support for error detection and correction on the Phytium

--- a/runtime-kernel/linux-kernel/autobuild/patches/0189-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0189-BACKPORT-PHYTIUM-net-stmmac-Add-phytium-DWMAC-driver.patch
@@ -1,7 +1,7 @@
 From b4651b53389f8f622dce9764db7dca9a55845571 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 25 Mar 2024 17:38:27 +0800
-Subject: [PATCH 189/450] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
+Subject: [PATCH 189/463] BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC
  driver support v2
 
 Modify stmmmac driver to support phytium DWMAC controler.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0190-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0190-PHYTIUM-net-stmmac-phytium-driver-add-pm-support.patch
@@ -1,7 +1,7 @@
 From 5875561679067e912c6ef3ca7aca28348659ce0b Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Thu, 13 Jun 2024 17:50:28 +0800
-Subject: [PATCH 190/450] PHYTIUM: net: stmmac: phytium driver add pm support
+Subject: [PATCH 190/463] PHYTIUM: net: stmmac: phytium driver add pm support
 
 Test S3 with net device open will got this cut log.
 ...

--- a/runtime-kernel/linux-kernel/autobuild/patches/0191-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0191-BACKPORT-PHYTIUM-net-phytium-Add-support-for-phytium.patch
@@ -1,7 +1,7 @@
 From 671ad72f97ef07a1326c8548a836675a9376cfaf Mon Sep 17 00:00:00 2001
 From: Song Wenting <songwenting@phytium.com.cn>
 Date: Mon, 25 Mar 2024 13:55:20 +0800
-Subject: [PATCH 191/450] BACKPORT: PHYTIUM: net: phytium: Add support for
+Subject: [PATCH 191/463] BACKPORT: PHYTIUM: net: phytium: Add support for
  phytium GMAC
 
 This patch provides support for Phytium GMAC controller driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0192-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0192-PHYTIUM-net-phytmac-Bugfixed-the-MDIO-registration-f.patch
@@ -1,7 +1,7 @@
 From d9748446416887f064bf0e021ec7a50b6fcee721 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:45:04 +0800
-Subject: [PATCH 192/450] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
+Subject: [PATCH 192/463] PHYTIUM: net/phytmac: Bugfixed the MDIO registration
  failures
 
 When MDIO registration fails, it will double free netdev,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0193-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0193-PHYTIUM-net-phytmac-Fixed-the-issue-of-pxe-startup-f.patch
@@ -1,7 +1,7 @@
 From c3d3cea66a58dda1f8e3c8e75cf5c5e129f6dcb6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:46:54 +0800
-Subject: [PATCH 193/450] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
+Subject: [PATCH 193/463] PHYTIUM: net/phytmac: Fixed the issue of pxe startup
  failure.
 
 When network driver supports broadcast mode, no_broadcast bit of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0194-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0194-PHYTIUM-net-phytmac-Adapt-interface-type-1000BASE-x.patch
@@ -1,7 +1,7 @@
 From d8c52bf95911c9ca29dbb2c7162ecc94ae02b7bf Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 29 Mar 2024 16:49:17 +0800
-Subject: [PATCH 194/450] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
+Subject: [PATCH 194/463] PHYTIUM: net/phytmac: Adapt interface type 1000BASE-x
 
 Added 1000BASE-x interface type support for phymac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0195-PHYTIUM-net-phytmac-Added-high-address-check.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0195-PHYTIUM-net-phytmac-Added-high-address-check.patch
@@ -1,7 +1,7 @@
 From aab92932271974f145b023ebeecaa36e5b57a951 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:33:32 +0800
-Subject: [PATCH 195/450] PHYTIUM: net/phytmac:Added high address check
+Subject: [PATCH 195/463] PHYTIUM: net/phytmac:Added high address check
 
 A maximum of three DMA ring addresses can be allocated,
 and check whether the high addresses in multiple queues

--- a/runtime-kernel/linux-kernel/autobuild/patches/0196-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0196-PHYTIUM-net-phytmac-Adjust-the-code-style.patch
@@ -1,7 +1,7 @@
 From 4fb857515ed1cbe3405654defcb40bd778df5873 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:52:58 +0800
-Subject: [PATCH 196/450] PHYTIUM: net/phytmac: Adjust the code style
+Subject: [PATCH 196/463] PHYTIUM: net/phytmac: Adjust the code style
 
 Fix spelling mistakes and replace the default value
 with a macro definition.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0197-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0197-PHYTIUM-net-phytmac-Get-device-type-error-fixed.patch
@@ -1,7 +1,7 @@
 From 75a507aebfae9562e7d93cc37df44b20bc666199 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:55:39 +0800
-Subject: [PATCH 197/450] PHYTIUM: net/phytmac: Get device type error fixed
+Subject: [PATCH 197/463] PHYTIUM: net/phytmac: Get device type error fixed
 
 We should return -EOPNOTSUPP to the unsupported device types,
 otherwise the wireless attribute will be added by default.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0198-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0198-PHYTIUM-net-phytmac-Modify-the-method-of-obtaining-t.patch
@@ -1,7 +1,7 @@
 From f3c3ce6b49ed0f4d4e71775218bc04bfc9f1d2d2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 14:57:15 +0800
-Subject: [PATCH 198/450] PHYTIUM: net/phytmac: Modify the method of obtaining
+Subject: [PATCH 198/463] PHYTIUM: net/phytmac: Modify the method of obtaining
  the link status
 
 Firstly, modify the state of pdata->speed and pdata->duplex to be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0199-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0199-PHYTIUM-net-phytmac-Support-usxgmii-wol-feature.patch
@@ -1,7 +1,7 @@
 From 930b892d79e544a3ac372db28a34da2f708d86f5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:02:13 +0800
-Subject: [PATCH 199/450] PHYTIUM: net/phytmac: Support usxgmii wol feature
+Subject: [PATCH 199/463] PHYTIUM: net/phytmac: Support usxgmii wol feature
 
 Support usxgmii wol by change the value of registers,
 including  wol register, int register, net config register

--- a/runtime-kernel/linux-kernel/autobuild/patches/0200-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0200-PHYTIUM-net-phytmac-Roll-back-rx_clean-version.patch
@@ -1,7 +1,7 @@
 From 9d6a074b6e73f31f974a569bea96448503a9b3e5 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:04:49 +0800
-Subject: [PATCH 200/450] PHYTIUM: net/phytmac: Roll back rx_clean version
+Subject: [PATCH 200/463] PHYTIUM: net/phytmac: Roll back rx_clean version
 
 Roll back rx_clean version to not use batching.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0201-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0201-PHYTIUM-net-phytmac-Override-rx_skb-allocation-funct.patch
@@ -1,7 +1,7 @@
 From 78d095c3897378f78f0a54c4386ee2a8879d0b9d Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:09:08 +0800
-Subject: [PATCH 201/450] PHYTIUM: net/phytmac: Override rx_skb allocation
+Subject: [PATCH 201/463] PHYTIUM: net/phytmac: Override rx_skb allocation
  function
 
 Changing the way netdev_alloc_skb function assigns SKB directly,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0202-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0202-PHYTIUM-net-phytmac-Round-down-rx_buf_len-to-64-byte.patch
@@ -1,7 +1,7 @@
 From 790f15c8b534410cfd8d9715cc8f2055f2539bd2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:10:12 +0800
-Subject: [PATCH 202/450] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
+Subject: [PATCH 202/463] PHYTIUM: net/phytmac: Round down rx_buf_len to 64
  bytes
 
 DMA config register needs the rx_buf_len to be aligned to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0203-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0203-PHYTIUM-net-phytmac-Add-version-display-for-phytmac-.patch
@@ -1,7 +1,7 @@
 From 531e270d9a6eb172f4a828b2b43baa5d4423169a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Fri, 26 Apr 2024 15:11:35 +0800
-Subject: [PATCH 203/450] PHYTIUM: net/phytmac: Add version display for phytmac
+Subject: [PATCH 203/463] PHYTIUM: net/phytmac: Add version display for phytmac
  driver
 
 Add support for Using the ethtool -i interface or modinfo

--- a/runtime-kernel/linux-kernel/autobuild/patches/0204-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0204-PHYTIUM-net-phytmac-Bugfix-about-dma-conflict-proble.patch
@@ -1,7 +1,7 @@
 From 5dda99021f9f0c180b99576bb0cbdea449a446b9 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 10:47:47 +0800
-Subject: [PATCH 204/450] PHYTIUM: net/phytmac: Bugfix about dma conflict
+Subject: [PATCH 204/463] PHYTIUM: net/phytmac: Bugfix about dma conflict
  problem
 
 When setting RX_USED bit of the last descriptor for rx ring to 1,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0205-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0205-PHYTIUM-net-phytmac-Bugfix-MAC-address-change-when-r.patch
@@ -1,7 +1,7 @@
 From 38ae43f4ab57e1eb6faeaf8adbb79c599f75c128 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Mon, 29 Apr 2024 18:23:45 +0800
-Subject: [PATCH 205/450] PHYTIUM: net/phytmac: Bugfix MAC address change when
+Subject: [PATCH 205/463] PHYTIUM: net/phytmac: Bugfix MAC address change when
  rmmod and insmod module
 
 The eth_hw_addr_random function cause systemd-udevd to generate

--- a/runtime-kernel/linux-kernel/autobuild/patches/0206-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0206-PHYTIUM-net-phytmac-Bugfix-MAC-10-100M-speed-does-t-.patch
@@ -1,7 +1,7 @@
 From 4425c6f402cb0ff5b66dc9de6ba56765a22df449 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Tue, 21 May 2024 14:20:05 +0800
-Subject: [PATCH 206/450] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
+Subject: [PATCH 206/463] PHYTIUM: net/phytmac: Bugfix MAC 10/100M speed does't
  work problem
 
 Gigabit_mode_enable bit should be clear when the speed is switched

--- a/runtime-kernel/linux-kernel/autobuild/patches/0207-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0207-PHYTIUM-net-phytmac-Adapt-interface-type-2500BASE-x.patch
@@ -1,7 +1,7 @@
 From 6320a21fb54266d1272cfc1733281edfc2801124 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:09:53 +0800
-Subject: [PATCH 207/450] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
+Subject: [PATCH 207/463] PHYTIUM: net/phytmac: Adapt interface type 2500BASE-x
 
 Add 2500BASE-x interface type support for phytmac driver.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0208-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0208-PHYTIUM-net-phytmac-Support-WOL-interaction-with-BIO.patch
@@ -1,7 +1,7 @@
 From 1f3d9c7d7793487cc6738dde586985acf23a8423 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 27 Jun 2024 10:15:06 +0800
-Subject: [PATCH 208/450] PHYTIUM: net/phytmac: Support WOL interaction with
+Subject: [PATCH 208/463] PHYTIUM: net/phytmac: Support WOL interaction with
  BIOS
 
 It should notify the BIOS to enable or disable the WOL function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0209-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0209-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 60ab990ddc7707455c9284e9206080cbd3c2a29b Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Wed, 26 Feb 2025 03:50:13 +0000
-Subject: [PATCH 209/450] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 209/463] PHYTIUM: net: phytmac: Manage WOL on MAC if PHY
  supports WOL
 
 Signed-off-by: zuoqian <zuoqian2032@phytium.com.cn>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0210-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0210-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From ae73cc7be37950e6e2bc97b20d76cb76686cdcc2 Mon Sep 17 00:00:00 2001
 From: zuoqian <zuoqian2032@phytium.com.cn>
 Date: Thu, 27 Feb 2025 05:44:58 +0000
-Subject: [PATCH 210/450] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 210/463] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0211-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0211-PHYTIUM-net-phytmac-Add-support-for-phytmac-v2.0.patch
@@ -1,7 +1,7 @@
 From 6aab08ebe5994b45f398548851136e58f03fce20 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Thu, 15 Aug 2024 17:06:59 +0800
-Subject: [PATCH 211/450] PHYTIUM: net/phytmac: Add support for phytmac v2.0
+Subject: [PATCH 211/463] PHYTIUM: net/phytmac: Add support for phytmac v2.0
 
 This patch Adds support for phtymac v2.0,including acpi description,
 rx tail pointer supporting, power management and other functions.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0212-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0212-PHYTIUM-net-phytmac-Slove-left-shift-out-of-bound-is.patch
@@ -1,7 +1,7 @@
 From 333705d20ad2d9484fca74435c9cd96fead85b18 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 212/450] PHYTIUM: net/phytmac: Slove left-shift out of bound
+Subject: [PATCH 212/463] PHYTIUM: net/phytmac: Slove left-shift out of bound
  issue
 
 When the value of the bd_prefetch is equal to 0, subtracting 1 and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0213-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0213-PHYTIUM-Revert-net-phytmac-Manage-WOL-on-MAC-if-PHY-.patch
@@ -1,7 +1,7 @@
 From fe3a8ced305072d20a38fb6f7660d1043297a34b Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:29:38 +0800
-Subject: [PATCH 213/450] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
+Subject: [PATCH 213/463] PHYTIUM: Revert "net: phytmac: Manage WOL on MAC if
  PHY supports WOL"
 
 This reverts commit 94967211afe596a9e9c5d80ca9d54e915de3a335.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0214-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0214-PHYTIUM-Revert-net-phytmac-Bugfix-set-WOL-failed-iss.patch
@@ -1,7 +1,7 @@
 From a5df6aec6237478de2830c435b960391efb8e2a0 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 10:36:36 +0800
-Subject: [PATCH 214/450] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
+Subject: [PATCH 214/463] PHYTIUM: Revert "net/phytmac: Bugfix set WOL failed
  issue"
 
 This reverts commit 3161ed880479e35c7759e127c62c37d2d722edee.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0215-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0215-PHYTIUM-net-phytmac-Manage-WOL-on-MAC-if-PHY-support.patch
@@ -1,7 +1,7 @@
 From 806578981cddc957c9b4f833f01e956948351be0 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 215/450] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
+Subject: [PATCH 215/463] PHYTIUM: net/phytmac: Manage WOL on MAC if PHY
  supports WOL feature
 
 Don't manage WoL on MAC, if PHY sets wol fails, So modify if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0216-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0216-PHYTIUM-net-phytmac-Fixed-the-PTP-test-failure-issue.patch
@@ -1,7 +1,7 @@
 From 2cac519dd74e51d0cbb32461906fc624ed1843a2 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 216/450] PHYTIUM: net/phytmac: Fixed the PTP test failure
+Subject: [PATCH 216/463] PHYTIUM: net/phytmac: Fixed the PTP test failure
  issue
 
 The bit of RX_TS_VALID should be retained in the process of zero RX

--- a/runtime-kernel/linux-kernel/autobuild/patches/0217-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0217-PHYTIUM-net-phytmac-Cancels-the-power-on-off-capabil.patch
@@ -1,7 +1,7 @@
 From a6abc4e7cec4e0245a81608249369712ac96ed45 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 217/450] PHYTIUM: net/phytmac: Cancels the power-on/off
+Subject: [PATCH 217/463] PHYTIUM: net/phytmac: Cancels the power-on/off
  capability
 
 The MAC register is powered on by default in the firmware

--- a/runtime-kernel/linux-kernel/autobuild/patches/0218-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0218-PHYTIUM-net-phytmac-Exit-probe-when-MDIO-times-out.patch
@@ -1,7 +1,7 @@
 From 87dea9f50950a684fa916c79e55dce413555b1b6 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 218/450] PHYTIUM: net/phytmac: Exit probe when MDIO times out
+Subject: [PATCH 218/463] PHYTIUM: net/phytmac: Exit probe when MDIO times out
 
 Exit early to avoid system stuck due to MDIO timeout.
 We have added a callback function for mdio_idle and improved

--- a/runtime-kernel/linux-kernel/autobuild/patches/0219-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0219-PHYTIUM-net-phytmac-Add-XDP-feature-support.patch
@@ -1,7 +1,7 @@
 From 58c9b8a059250bd848281bf233fc33b2fcb2ca2b Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 219/450] PHYTIUM: net/phytmac: Add XDP feature support
+Subject: [PATCH 219/463] PHYTIUM: net/phytmac: Add XDP feature support
 
 Add XDP feature support to the phytmac driver.XDP by optimizing
 the data processing flow provided significant performance improvements

--- a/runtime-kernel/linux-kernel/autobuild/patches/0220-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0220-PHYTIUM-net-phytmac-Clear-RX-descriptor-address-afte.patch
@@ -1,7 +1,7 @@
 From d4dc42f7260d6a7c15b6bf0d61f1ea49a9d742cb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 220/450] PHYTIUM: net/phytmac: Clear RX descriptor address
+Subject: [PATCH 220/463] PHYTIUM: net/phytmac: Clear RX descriptor address
  after the skb construction
 
 If the skb build failed, the descriptor address has been cleared,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0221-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0221-PHYTIUM-net-phytmac-Enable-the-tail-pointer-by-the-d.patch
@@ -1,7 +1,7 @@
 From 6518854ae051842745d779c740a5a26f5ff7f425 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 221/450] PHYTIUM: net/phytmac: Enable the tail pointer by the
+Subject: [PATCH 221/463] PHYTIUM: net/phytmac: Enable the tail pointer by the
  driver
 
 It is need to enable the RX/TX tail pointer to ensure the NIC

--- a/runtime-kernel/linux-kernel/autobuild/patches/0222-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0222-PHYTIUM-net-phytmac-Modify-cmd-processing-function.patch
@@ -1,7 +1,7 @@
 From 0c5c1e381031d8bea6ef19ee6446700ed158cdcb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 222/450] PHYTIUM: net/phytmac: Modify cmd processing function
+Subject: [PATCH 222/463] PHYTIUM: net/phytmac: Modify cmd processing function
 
 Change the para size in the msg struct from 64 to 56
 and add mutux to avoid race.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0223-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0223-PHYTIUM-net-phytmac-Bugfix-set-WOL-failed-issue.patch
@@ -1,7 +1,7 @@
 From 7229900aaa54842d0dd35672b91104586bb730ea Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:12 +0800
-Subject: [PATCH 223/450] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
+Subject: [PATCH 223/463] PHYTIUM: net/phytmac: Bugfix set WOL failed issue
 
 Before configuring WOL, we need to obtain the packet types
 that WOL supports.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0224-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0224-PHYTIUM-net-phytmac-Bugfix-invalid-wait-context.patch
@@ -1,7 +1,7 @@
 From b3c7872e7fd9e75e3bc48fc96679f631e548b70a Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 224/450] PHYTIUM: net/phytmac: Bugfix invalid wait context
+Subject: [PATCH 224/463] PHYTIUM: net/phytmac: Bugfix invalid wait context
 
 After the spinlock is called, the mutex should no longer to be
 invoked, which will lead to unnecessary sleep.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0225-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0225-PHYTIUM-net-phytmac-Change-the-requested-resource-ty.patch
@@ -1,7 +1,7 @@
 From b4804c5556de3cc7ffd584fc89ed66ecbff12760 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 225/450] PHYTIUM: net/phytmac: Change the requested resource
+Subject: [PATCH 225/463] PHYTIUM: net/phytmac: Change the requested resource
  type from nRE to nRnE
 
 The resource type is changed from nRE to nRnE to avoid interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0226-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0226-PHYTIUM-net-phytmac-BugFix-Memory-leak-when-releasin.patch
@@ -1,7 +1,7 @@
 From d4321c9453b14af6d1a0ee9cd6874ce9c313bcbb Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 226/450] PHYTIUM: net/phytmac: BugFix Memory leak when
+Subject: [PATCH 226/463] PHYTIUM: net/phytmac: BugFix Memory leak when
  releasing resource
 
 The size of the memory released in the dma_free_coherent is smaller

--- a/runtime-kernel/linux-kernel/autobuild/patches/0227-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0227-PHYTIUM-net-phytmac-Limit-the-number-of-retries-to-a.patch
@@ -1,7 +1,7 @@
 From c9fa7554b8e1b3d0f622e18a308db43f7f2349d7 Mon Sep 17 00:00:00 2001
 From: Li Wencheng <liwencheng@phytium.com.cn>
 Date: Wed, 7 May 2025 17:22:13 +0800
-Subject: [PATCH 227/450] PHYTIUM: net/phytmac: Limit the number of retries to
+Subject: [PATCH 227/463] PHYTIUM: net/phytmac: Limit the number of retries to
  avoid deadlock
 
 It is need to limit retries that messages are processed

--- a/runtime-kernel/linux-kernel/autobuild/patches/0228-PHYTIUM-net-phytmac-update-to-1.0.47.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0228-PHYTIUM-net-phytmac-update-to-1.0.47.patch
@@ -1,7 +1,7 @@
 From a772f0e5ff16d5b03d7c2ed5b51da8be35ae23f9 Mon Sep 17 00:00:00 2001
 From: liutianyu1250 <liutianyu1250@phytium.com.cn>
 Date: Fri, 30 May 2025 11:41:46 +0800
-Subject: [PATCH 228/450] PHYTIUM: net: phytmac: update to 1.0.47
+Subject: [PATCH 228/463] PHYTIUM: net: phytmac: update to 1.0.47
 
 Signed-off-by: liutianyu1250 <liutianyu1250@phytium.com.cn>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0229-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0229-DEBIAN-Use-RELAXED-ieee754-mode-for-Loongson-3-as-3A.patch
@@ -1,7 +1,7 @@
 From 74c122fef80ebefe004496f163cc718d5cf10949 Mon Sep 17 00:00:00 2001
 From: YunQiang Su <syq@debian.org>
 Date: Mon, 16 Nov 2020 09:11:00 +0800
-Subject: [PATCH 229/450] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
+Subject: [PATCH 229/463] DEBIAN: Use RELAXED ieee754 mode for Loongson-3 as 3A
  4000 is 2008-only
 
 There are 2 mode of value of IEEE NaN hardcoded by CPU.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0230-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0230-UBUNTU-ODM-hwmon-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From d12c6e902caedbfda6b98249d5d4f3885173e956 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:01 +0800
-Subject: [PATCH 230/450] UBUNTU: ODM: hwmon: add driver for AAEON devices
+Subject: [PATCH 230/463] UBUNTU: ODM: hwmon: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0231-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0231-UBUNTU-ODM-leds-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From 4fa9949befbddff329acb6904723dadc85fe40a3 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:57:02 +0800
-Subject: [PATCH 231/450] UBUNTU: ODM: leds: add driver for AAEON devices
+Subject: [PATCH 231/463] UBUNTU: ODM: leds: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0232-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0232-UBUNTU-ODM-gpio-add-driver-for-AAEON-devices.patch
@@ -1,7 +1,7 @@
 From f55f1d1bbcfcd0a6093c92158cf04db751c2821f Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:59 +0800
-Subject: [PATCH 232/450] UBUNTU: ODM: gpio: add driver for AAEON devices
+Subject: [PATCH 232/463] UBUNTU: ODM: gpio: add driver for AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0233-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0233-UBUNTU-ODM-mfd-Add-support-for-IO-functions-of-AAEON.patch
@@ -1,7 +1,7 @@
 From 82fc28c2d0bd5fe9740feb4a0023b52a6ce5ac36 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Wed, 16 Jun 2021 13:56:58 +0800
-Subject: [PATCH 233/450] UBUNTU: ODM: mfd: Add support for IO functions of
+Subject: [PATCH 233/463] UBUNTU: ODM: mfd: Add support for IO functions of
  AAEON devices
 
 BugLink: https://bugs.launchpad.net/bugs/1929504

--- a/runtime-kernel/linux-kernel/autobuild/patches/0234-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0234-UBUNTU-ODM-mfd-Check-AAEON-BFPI-version-before-addin.patch
@@ -1,7 +1,7 @@
 From ea6456c1399199efe1412c02ee5df771b6d09727 Mon Sep 17 00:00:00 2001
 From: Kunyang_Fan <kunyang_fan@asus.com>
 Date: Tue, 24 Aug 2021 15:26:59 +0800
-Subject: [PATCH 234/450] UBUNTU: ODM: mfd: Check AAEON BFPI version before
+Subject: [PATCH 234/463] UBUNTU: ODM: mfd: Check AAEON BFPI version before
  adding device
 
 BugLink: https://bugs.launchpad.net/bugs/1937897

--- a/runtime-kernel/linux-kernel/autobuild/patches/0235-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0235-UBUNTU-SAUCE-hwmon-Fix-aaeon-driver-for-6.11.patch
@@ -1,7 +1,7 @@
 From 1c66a8558ec732dab7c135e193a3c4b80d9ab6ca Mon Sep 17 00:00:00 2001
 From: Timo Aaltonen <timo.aaltonen@canonical.com>
 Date: Mon, 5 Aug 2024 14:48:08 +0300
-Subject: [PATCH 235/450] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
+Subject: [PATCH 235/463] UBUNTU: SAUCE: hwmon: Fix aaeon driver for 6.11.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0236-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0236-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-S.patch
@@ -1,7 +1,7 @@
 From 93790f59aa53ae8ea2c79933260cbf3df87455bc Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 12 Aug 2024 14:28:31 +0800
-Subject: [PATCH 236/450] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 236/463] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for SKL integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2062951

--- a/runtime-kernel/linux-kernel/autobuild/patches/0237-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0237-BACKPORT-UBUNTU-SAUCE-iommu-intel-disable-DMAR-for-K.patch
@@ -1,7 +1,7 @@
 From 2703984340a62ab4710186e6326eaa5cb929e36d Mon Sep 17 00:00:00 2001
 From: "Chia-Lin Kao (AceLan)" <acelan.kao@canonical.com>
 Date: Mon, 18 Nov 2024 09:28:40 +0800
-Subject: [PATCH 237/450] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
+Subject: [PATCH 237/463] BACKPORT: UBUNTU: SAUCE: iommu/intel: disable DMAR
  for KBL and CML integrated gfx
 
 BugLink: https://bugs.launchpad.net/bugs/2086587

--- a/runtime-kernel/linux-kernel/autobuild/patches/0238-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0238-DEEPIN-net-stmmac-Add-phytium-old-dwmac-acpi_device_.patch
@@ -1,7 +1,7 @@
 From a508280f5ed15d0474f66f49aa8e5421044c714b Mon Sep 17 00:00:00 2001
 From: Wentao Guan <guanwentao@uniontech.com>
 Date: Wed, 8 May 2024 18:11:37 +0800
-Subject: [PATCH 238/450] DEEPIN: net: stmmac: Add phytium old dwmac
+Subject: [PATCH 238/463] DEEPIN: net: stmmac: Add phytium old dwmac
  acpi_device_id
 
 As Phytium ACPI Description Specification document v1.2 p13

--- a/runtime-kernel/linux-kernel/autobuild/patches/0239-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0239-DEEPIN-net-stmmac-fix-potential-double-free-of-dma-d.patch
@@ -1,7 +1,7 @@
 From cf44686438f5c2b774dfb49e0c2b5b0bf0985713 Mon Sep 17 00:00:00 2001
 From: Yanteng Si <siyanteng@loongson.cn>
 Date: Mon, 27 May 2024 10:20:21 +0800
-Subject: [PATCH 239/450] DEEPIN: net: stmmac: fix potential double free of dma
+Subject: [PATCH 239/463] DEEPIN: net: stmmac: fix potential double free of dma
  descriptor resources
 
 reset the dma descriptor related resource's pointer to NULL,otherwise

--- a/runtime-kernel/linux-kernel/autobuild/patches/0240-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0240-DEEPIN-net-stmmac-dwmac-phytium-compat-some-FT2000.patch
@@ -1,7 +1,7 @@
 From 4785bc6a77fe218be926d46f6d1c0a1080eb253f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <guanwentao@uniontech.com>
 Date: Tue, 9 Jul 2024 17:17:48 +0800
-Subject: [PATCH 240/450] DEEPIN: net: stmmac: dwmac-phytium: compat some
+Subject: [PATCH 240/463] DEEPIN: net: stmmac: dwmac-phytium: compat some
  FT2000
 
 Compat with some quirk platform FT2000/4 as id "FTGM0001",

--- a/runtime-kernel/linux-kernel/autobuild/patches/0241-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0241-BACKPORT-DEEPIN-pci-quirks-LS7A2000-Fix-pm-transitio.patch
@@ -1,7 +1,7 @@
 From 5ac6fa96de1a257b9ea530dfe24581c67e80c33f Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubinbin@loongson.cn>
 Date: Fri, 14 Feb 2025 17:48:41 +0800
-Subject: [PATCH 241/450] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
+Subject: [PATCH 241/463] BACKPORT: DEEPIN: pci/quirks: LS7A2000: Fix pm
  transition of devices under pcie port
 
 The CPU may not be able to access the PCI header of the device if

--- a/runtime-kernel/linux-kernel/autobuild/patches/0242-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0242-DEEPIN-net-stmmac-fix-dwmac-phytium-build-on-6.9.patch
@@ -1,7 +1,7 @@
 From cd9115f3e36d211b41258433080764acb5fa292e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Thu, 27 Jun 2024 14:37:53 +0800
-Subject: [PATCH 242/450] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
+Subject: [PATCH 242/463] DEEPIN: net: stmmac: fix dwmac-phytium build on 6.9
 
 Declare phytium_dwmac_remove() as a static function to resolve a missing
 prototype warning.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0243-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0243-DEEPIN-net-ethernet-phytium-fix-phytmac_platform-on-.patch
@@ -1,7 +1,7 @@
 From 3d1f89016a8d67ab6cd810c1b3f443622212234d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 11:45:05 +0800
-Subject: [PATCH 243/450] DEEPIN: net: ethernet: phytium: fix phytmac_platform
+Subject: [PATCH 243/463] DEEPIN: net: ethernet: phytium: fix phytmac_platform
  on 6.9
 
 Add missing <linux/platform_device.h> include.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0244-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0244-BACKPORT-DEEPIN-net-ethernet-fix-phytmac-on-6.9.patch
@@ -1,7 +1,7 @@
 From 185d5475752b175b59f83708e00d79066821b019 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 14:08:40 +0800
-Subject: [PATCH 244/450] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
+Subject: [PATCH 244/463] BACKPORT: DEEPIN: net: ethernet: fix phytmac on 6.9
 
 Declare multiple functions as static functions to suppress warnings about
 missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0245-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0245-DEEPIN-net-ethernet-phytium-add-a-missing-declaratio.patch
@@ -1,7 +1,7 @@
 From 3eb6960d4c3cacfe476b3d7b26040c1a77f0a120 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Fri, 28 Jun 2024 16:23:20 +0800
-Subject: [PATCH 245/450] DEEPIN: net: ethernet: phytium: add a missing
+Subject: [PATCH 245/463] DEEPIN: net: ethernet: phytium: add a missing
  declaration for *np
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0246-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0246-BACKPORT-DEEPIN-net-phytium-convert-and-remove-valid.patch
@@ -1,7 +1,7 @@
 From ced4f073673ef245bcf90cfc25993ee4e6ced2b9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=E5=BF=98=E6=80=80?= <otgwt@outlook.com>
 Date: Wed, 3 Jul 2024 03:13:45 +0000
-Subject: [PATCH 246/450] BACKPORT: DEEPIN: net: phytium: convert and remove
+Subject: [PATCH 246/463] BACKPORT: DEEPIN: net: phytium: convert and remove
  validate() references
 
 Populate the supported interfaces bitmap and MAC capabilities mask for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0247-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0247-ARMBIAN-ayufan-dts-rockpro64-change-rx_delay-for-gma.patch
@@ -1,7 +1,7 @@
 From c51e63c5cb7ef9df2b09de4f30d53211fc684dcc Mon Sep 17 00:00:00 2001
 From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH 247/450] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
+Subject: [PATCH 247/463] ARMBIAN: ayufan: dts: rockpro64: change rx_delay for
  gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07

--- a/runtime-kernel/linux-kernel/autobuild/patches/0248-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0248-SURFACE-surface3-oemb-add-DMI-matches-for-Surface-3-.patch
@@ -1,7 +1,7 @@
 From d0d50c7f515549bd864dede400fd0b795d21114e Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
-Subject: [PATCH 248/450] SURFACE: (surface3-oemb) add DMI matches for Surface
+Subject: [PATCH 248/463] SURFACE: (surface3-oemb) add DMI matches for Surface
  3 with broken DMI table
 
 On some Surface 3, the DMI table gets corrupted for unknown reasons

--- a/runtime-kernel/linux-kernel/autobuild/patches/0249-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0249-SURFACE-surface3-spi-workaround-disable-DMA-mode-to-.patch
@@ -1,7 +1,7 @@
 From a6a4afc54a6b23dbbd7b1d1ca452f7ad28c5e5d8 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
-Subject: [PATCH 249/450] SURFACE: surface3-spi: workaround: disable DMA mode
+Subject: [PATCH 249/463] SURFACE: surface3-spi: workaround: disable DMA mode
  to avoid crash by default
 
 On Arch Linux kernel at least after 4.19, touch input is broken after suspend

--- a/runtime-kernel/linux-kernel/autobuild/patches/0250-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0250-SURFACE-mwifiex-Add-quirk-resetting-the-PCI-bridge-o.patch
@@ -1,7 +1,7 @@
 From c877183ade142e1b73f1cee60c5d64462e26485f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
-Subject: [PATCH 250/450] SURFACE: mwifiex: Add quirk resetting the PCI bridge
+Subject: [PATCH 250/463] SURFACE: mwifiex: Add quirk resetting the PCI bridge
  on MS Surface devices
 
 The most recent firmware of the 88W8897 card reports a hardcoded LTR

--- a/runtime-kernel/linux-kernel/autobuild/patches/0251-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0251-SURFACE-mwifiex-pcie-disable-bridge_d3-for-Surface-g.patch
@@ -1,7 +1,7 @@
 From 23c7ca8fecb5046f808caaa504935106fcf7e720 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
-Subject: [PATCH 251/450] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
+Subject: [PATCH 251/463] SURFACE: mwifiex: pcie: disable bridge_d3 for Surface
  gen4+
 
 Currently, mwifiex fw will crash after suspend on recent kernel series.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0252-BACKPORT-SURFACE-Bluetooth-btusb-Lower-passive-lesca.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0252-BACKPORT-SURFACE-Bluetooth-btusb-Lower-passive-lesca.patch
@@ -1,7 +1,7 @@
 From b2236eb29f028d200a245ece1ef545f7a52fb0bd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
-Subject: [PATCH 252/450] BACKPORT: SURFACE: Bluetooth: btusb: Lower passive
+Subject: [PATCH 252/463] BACKPORT: SURFACE: Bluetooth: btusb: Lower passive
  lescan interval on Marvell 88W8897
 
 The Marvell 88W8897 combined wifi and bluetooth card (pcie+usb version)

--- a/runtime-kernel/linux-kernel/autobuild/patches/0253-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0253-SURFACE-ath10k-Add-module-parameters-to-override-boa.patch
@@ -1,7 +1,7 @@
 From 31efd02fad063acc3c9a0a0008abc2e03adccf03 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
-Subject: [PATCH 253/450] SURFACE: ath10k: Add module parameters to override
+Subject: [PATCH 253/463] SURFACE: ath10k: Add module parameters to override
  board files
 
 Some Surface devices, specifically the Surface Go and AMD version of the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0254-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0254-SURFACE-mei-me-Add-Icelake-device-ID-for-iTouch.patch
@@ -1,7 +1,7 @@
 From 4241b8562f1ec9b7b79f9969fe53dafa430508b8 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
-Subject: [PATCH 254/450] SURFACE: mei: me: Add Icelake device ID for iTouch
+Subject: [PATCH 254/463] SURFACE: mei: me: Add Icelake device ID for iTouch
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
 Patchset: ipts

--- a/runtime-kernel/linux-kernel/autobuild/patches/0255-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0255-BACKPORT-SURFACE-iommu-Use-IOMMU-passthrough-mode-fo.patch
@@ -1,7 +1,7 @@
 From fd8b0d2b3fbe11efeaa0f49a59f27495c30bcc39 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
-Subject: [PATCH 255/450] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
+Subject: [PATCH 255/463] BACKPORT: SURFACE: iommu: Use IOMMU passthrough mode
  for IPTS
 
 Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0256-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0256-SURFACE-hid-Add-support-for-Intel-Precise-Touch-and-.patch
@@ -1,7 +1,7 @@
 From f737c5be0b3e7dc16b394a0dcf54dcd6ed62215f Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
-Subject: [PATCH 256/450] SURFACE: hid: Add support for Intel Precise Touch and
+Subject: [PATCH 256/463] SURFACE: hid: Add support for Intel Precise Touch and
  Stylus
 
 Based on linux-surface/intel-precise-touch@8abe268

--- a/runtime-kernel/linux-kernel/autobuild/patches/0257-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0257-SURFACE-iommu-intel-Disable-source-id-verification-f.patch
@@ -1,7 +1,7 @@
 From fb9f863716e68ca64eb953e6e9414fb4fe86e911 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
-Subject: [PATCH 257/450] SURFACE: iommu: intel: Disable source id verification
+Subject: [PATCH 257/463] SURFACE: iommu: intel: Disable source id verification
  for ITHC
 
 Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0258-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0258-SURFACE-hid-Add-support-for-Intel-Touch-Host-Control.patch
@@ -1,7 +1,7 @@
 From 891a44d86f046faa0e12d27abd26aa7a1799a3d5 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
-Subject: [PATCH 258/450] SURFACE: hid: Add support for Intel Touch Host
+Subject: [PATCH 258/463] SURFACE: hid: Add support for Intel Touch Host
  Controller
 
 Based on quo/ithc-linux@34539af4726d.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0259-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0259-SURFACE-rtc-Add-basic-support-for-RTC-via-Surface-Sy.patch
@@ -1,7 +1,7 @@
 From 709259d6d7f40ab55160b4f71db081bc155de92e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
-Subject: [PATCH 259/450] SURFACE: rtc: Add basic support for RTC via Surface
+Subject: [PATCH 259/463] SURFACE: rtc: Add basic support for RTC via Surface
  System Aggregator Module
 
 Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0260-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0260-SURFACE-platform-surface-aggregator_registry-Add-Sur.patch
@@ -1,7 +1,7 @@
 From aa93c1208cfd82b5bea46773d7f254acb0b93161 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
-Subject: [PATCH 260/450] SURFACE: platform/surface: aggregator_registry: Add
+Subject: [PATCH 260/463] SURFACE: platform/surface: aggregator_registry: Add
  Surface Laptop 7 (ACPI)
 
 Patchset: surface-sam

--- a/runtime-kernel/linux-kernel/autobuild/patches/0261-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0261-SURFACE-i2c-acpi-Implement-RawBytes-read-access.patch
@@ -1,7 +1,7 @@
 From b77289658fad0233987b0a25b74cd49cfbee59ba Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
-Subject: [PATCH 261/450] SURFACE: i2c: acpi: Implement RawBytes read access
+Subject: [PATCH 261/463] SURFACE: i2c: acpi: Implement RawBytes read access
 
 Microsoft Surface Pro 4 and Book 1 devices access the MSHW0030 I2C
 device via a generic serial bus operation region and RawBytes read

--- a/runtime-kernel/linux-kernel/autobuild/patches/0262-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0262-SURFACE-platform-surface-Add-driver-for-Surface-Book.patch
@@ -1,7 +1,7 @@
 From 47b375f1a8697c576b90fd2f979fd0ed5ed13e6c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
-Subject: [PATCH 262/450] SURFACE: platform/surface: Add driver for Surface
+Subject: [PATCH 262/463] SURFACE: platform/surface: Add driver for Surface
  Book 1 dGPU switch
 
 Add driver exposing the discrete GPU power-switch of the  Microsoft

--- a/runtime-kernel/linux-kernel/autobuild/patches/0263-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0263-SURFACE-Input-soc_button_array-support-AMD-variant-S.patch
@@ -1,7 +1,7 @@
 From 9057b820fc7dc213d07a8b6d327e1e1c68633a5f Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
-Subject: [PATCH 263/450] SURFACE: Input: soc_button_array - support AMD
+Subject: [PATCH 263/463] SURFACE: Input: soc_button_array - support AMD
  variant Surface devices
 
 The power button on the AMD variant of the Surface Laptop uses the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0264-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0264-SURFACE-platform-surface-surfacepro3_button-don-t-lo.patch
@@ -1,7 +1,7 @@
 From a547c8cb49464a0b9fecbd60cd77746484935257 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
-Subject: [PATCH 264/450] SURFACE: platform/surface: surfacepro3_button: don't
+Subject: [PATCH 264/463] SURFACE: platform/surface: surfacepro3_button: don't
  load on amd variant
 
 The AMD variant of the Surface Laptop report 0 for their OEM platform

--- a/runtime-kernel/linux-kernel/autobuild/patches/0265-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0265-SURFACE-USB-quirks-Add-USB_QUIRK_DELAY_INIT-for-Surf.patch
@@ -1,7 +1,7 @@
 From 7b0832499e64cee4cd12c6204b5ecc26a31e5757 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
-Subject: [PATCH 265/450] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
+Subject: [PATCH 265/463] SURFACE: USB: quirks: Add USB_QUIRK_DELAY_INIT for
  Surface Go 3 Type-Cover
 
 The touchpad on the Type-Cover of the Surface Go 3 is sometimes not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0266-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0266-SURFACE-hid-multitouch-Turn-off-Type-Cover-keyboard-.patch
@@ -1,7 +1,7 @@
 From 6a684ca4abd51f9093fef9529a0bcca1bd8aad77 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
-Subject: [PATCH 266/450] SURFACE: hid/multitouch: Turn off Type Cover keyboard
+Subject: [PATCH 266/463] SURFACE: hid/multitouch: Turn off Type Cover keyboard
  backlight when suspending
 
 The Type Cover for Microsoft Surface devices supports a special usb

--- a/runtime-kernel/linux-kernel/autobuild/patches/0267-BACKPORT-SURFACE-hid-multitouch-Add-support-for-surf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0267-BACKPORT-SURFACE-hid-multitouch-Add-support-for-surf.patch
@@ -1,7 +1,7 @@
 From 9e6ee7586c050213e93c81062135144e62c1e586 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
-Subject: [PATCH 267/450] BACKPORT: SURFACE: hid/multitouch: Add support for
+Subject: [PATCH 267/463] BACKPORT: SURFACE: hid/multitouch: Add support for
  surface pro type cover tablet switch
 
 The Surface Pro Type Cover has several non standard HID usages in it's

--- a/runtime-kernel/linux-kernel/autobuild/patches/0268-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0268-BACKPORT-SURFACE-PCI-Add-quirk-to-prevent-calling-sh.patch
@@ -1,7 +1,7 @@
 From 338c1feda509da0b5ad92ccbf98d67a64d32577d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH 268/450] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
+Subject: [PATCH 268/463] BACKPORT: SURFACE: PCI: Add quirk to prevent calling
  shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0269-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0269-SURFACE-platform-surface-gpe-Add-support-for-Surface.patch
@@ -1,7 +1,7 @@
 From a767dfa17d478fe69f09b3dae70569f9937720b2 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
-Subject: [PATCH 269/450] SURFACE: platform/surface: gpe: Add support for
+Subject: [PATCH 269/463] SURFACE: platform/surface: gpe: Add support for
  Surface Pro 9
 
 Add the lid GPE used by the Surface Pro 9.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0270-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0270-SURFACE-ACPI-delay-enumeration-of-devices-with-a-_DE.patch
@@ -1,7 +1,7 @@
 From 23fd4dd3d86c127050b9d51d3347dc7126d90b25 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
-Subject: [PATCH 270/450] SURFACE: ACPI: delay enumeration of devices with a
+Subject: [PATCH 270/463] SURFACE: ACPI: delay enumeration of devices with a
  _DEP pointing to an INT3472 device
 
 The clk and regulator frameworks expect clk/regulator consumer-devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0271-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0271-BACKPORT-SURFACE-iommu-intel-ipu-use-IOMMU-passthrou.patch
@@ -1,7 +1,7 @@
 From a6063ea18b67a0bfddab7c12c0a0978f7e04ce40 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
-Subject: [PATCH 271/450] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
+Subject: [PATCH 271/463] BACKPORT: SURFACE: iommu: intel-ipu: use IOMMU
  passthrough mode for Intel IPUs
 
 Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0272-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0272-SURFACE-platform-x86-int3472-Enable-I2c-daisy-chain.patch
@@ -1,7 +1,7 @@
 From 955d8c6c36e05884ff162e0004db5418fadc8b71 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
-Subject: [PATCH 272/450] SURFACE: platform/x86: int3472: Enable I2c daisy
+Subject: [PATCH 272/463] SURFACE: platform/x86: int3472: Enable I2c daisy
  chain
 
 The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic

--- a/runtime-kernel/linux-kernel/autobuild/patches/0273-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0273-SURFACE-media-i2c-Clarify-that-gain-is-Analogue-gain.patch
@@ -1,7 +1,7 @@
 From 9ec4aeed3f7800f8d2c14135c8c7c6aa707e38d9 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
-Subject: [PATCH 273/450] SURFACE: media: i2c: Clarify that gain is Analogue
+Subject: [PATCH 273/463] SURFACE: media: i2c: Clarify that gain is Analogue
  gain in OV7251
 
 Update the control ID for the gain control in the ov7251 driver to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0274-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0274-SURFACE-media-v4l2-core-Acquire-privacy-led-in-v4l2_.patch
@@ -1,7 +1,7 @@
 From 99e8efdef65492e79854d86924677d60557a7e3c Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
-Subject: [PATCH 274/450] SURFACE: media: v4l2-core: Acquire privacy led in
+Subject: [PATCH 274/463] SURFACE: media: v4l2-core: Acquire privacy led in
  v4l2_async_register_subdev()
 
 The current call to v4l2_subdev_get_privacy_led() is contained in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0275-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0275-SURFACE-platform-x86-int3472-Add-MFD-cell-for-tps684.patch
@@ -1,7 +1,7 @@
 From 0ef6f1d99a19b1e6c70831028cf68c2e7417f5d9 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
-Subject: [PATCH 275/450] SURFACE: platform: x86: int3472: Add MFD cell for
+Subject: [PATCH 275/463] SURFACE: platform: x86: int3472: Add MFD cell for
  tps68470 LED
 
 Add MFD cell for tps68470-led.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0276-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0276-SURFACE-include-mfd-tps68470-Add-masks-for-LEDA-and-.patch
@@ -1,7 +1,7 @@
 From 0d7b9b3d3827e79fe53d798375ff98237e36792b Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
-Subject: [PATCH 276/450] SURFACE: include: mfd: tps68470: Add masks for LEDA
+Subject: [PATCH 276/463] SURFACE: include: mfd: tps68470: Add masks for LEDA
  and LEDB
 
 Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB

--- a/runtime-kernel/linux-kernel/autobuild/patches/0277-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0277-SURFACE-leds-tps68470-Add-LED-control-for-tps68470.patch
@@ -1,7 +1,7 @@
 From 36f2d3f1b3d76a110a136bb5869bfff64163eadd Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
-Subject: [PATCH 277/450] SURFACE: leds: tps68470: Add LED control for tps68470
+Subject: [PATCH 277/463] SURFACE: leds: tps68470: Add LED control for tps68470
 
 There are two LED controllers, LEDA indicator LED and LEDB flash LED for
 tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0278-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0278-SURFACE-media-i2c-dw9719-fix-probe-error-on-surface-.patch
@@ -1,7 +1,7 @@
 From 6d3ac4de40d057d6471d6cd701fb9cf3359ef496 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
-Subject: [PATCH 278/450] SURFACE: media: i2c: dw9719: fix probe error on
+Subject: [PATCH 278/463] SURFACE: media: i2c: dw9719: fix probe error on
  surface go 2
 
 On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".

--- a/runtime-kernel/linux-kernel/autobuild/patches/0279-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0279-SURFACE-ACPI-Add-quirk-for-Surface-Laptop-4-AMD-miss.patch
@@ -1,7 +1,7 @@
 From 0ef2abe9b2779b8f2f4f27325246bd23d7cd67e0 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
-Subject: [PATCH 279/450] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
+Subject: [PATCH 279/463] SURFACE: ACPI: Add quirk for Surface Laptop 4 AMD
  missing irq 7 override
 
 This patch is the work of Thomas Gleixner <tglx@linutronix.de> and is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0280-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0280-SURFACE-ACPI-Add-AMD-13-Surface-Laptop-4-model-to-ir.patch
@@ -1,7 +1,7 @@
 From 5a5c235bac8d7ec6c6981994fea02acd345a1fe5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
-Subject: [PATCH 280/450] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
+Subject: [PATCH 280/463] SURFACE: ACPI: Add AMD 13" Surface Laptop 4 model to
  irq 7 override quirk
 
 The 13" version of the Surface Laptop 4 has the same problem as the 15"

--- a/runtime-kernel/linux-kernel/autobuild/patches/0281-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0281-BACKPORT-SURFACE-acpi-allow-usage-of-acpi_tad-on-HW-.patch
@@ -1,7 +1,7 @@
 From fedbb34be9e93cf7832de4c4659f728aafad28bd Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
-Subject: [PATCH 281/450] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
+Subject: [PATCH 281/463] BACKPORT: SURFACE: acpi: allow usage of acpi_tad on
  HW-reduced platforms
 
 The specification [1] allows so-called HW-reduced platforms,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0282-XUANTIE-riscv-dts-th1520-add-licheepi4a-16g-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0282-XUANTIE-riscv-dts-th1520-add-licheepi4a-16g-support.patch
@@ -1,7 +1,7 @@
 From b1e1fbbc678399af7322690a23f15c4a13423c05 Mon Sep 17 00:00:00 2001
 From: Han Gao <gaohan@iscas.ac.cn>
 Date: Mon, 24 Nov 2025 20:38:44 +0800
-Subject: [PATCH 282/450] XUANTIE: riscv: dts: th1520: add licheepi4a 16g
+Subject: [PATCH 282/463] XUANTIE: riscv: dts: th1520: add licheepi4a 16g
  support
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/01a510898e41e704bee1fe58a2c0c0a29cb96548

--- a/runtime-kernel/linux-kernel/autobuild/patches/0283-XUANTIE-riscv-dts-thead-Add-TH1520-USB-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0283-XUANTIE-riscv-dts-thead-Add-TH1520-USB-nodes.patch
@@ -1,7 +1,7 @@
 From 869af198b42e3140933fb3b296922b75cf1f72fe Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:51:56 +0800
-Subject: [PATCH 283/450] XUANTIE: riscv: dts: thead: Add TH1520 USB nodes
+Subject: [PATCH 283/463] XUANTIE: riscv: dts: thead: Add TH1520 USB nodes
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/2bd78742752e4f0eb07b421c3b3fc662c953aff0
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0284-XUANTIE-riscv-dts-thead-Add-TH1520-I2C-nodes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0284-XUANTIE-riscv-dts-thead-Add-TH1520-I2C-nodes.patch
@@ -1,7 +1,7 @@
 From ce5f87adae5bf8908ccb085008b8bbece9af40f8 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:50:07 +0800
-Subject: [PATCH 284/450] XUANTIE: riscv: dts: thead: Add TH1520 I2C nodes
+Subject: [PATCH 284/463] XUANTIE: riscv: dts: thead: Add TH1520 I2C nodes
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/ef4ac920a874b013f7609fb1f88fa08bcd445a01
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0285-XUANTIE-riscv-dts-thead-Add-Lichee-Pi-4A-IO-expansio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0285-XUANTIE-riscv-dts-thead-Add-Lichee-Pi-4A-IO-expansio.patch
@@ -1,7 +1,7 @@
 From 1bfe23ac5d531bc26d0d4f6222cb79d98f922fd0 Mon Sep 17 00:00:00 2001
 From: Emil Renner Berthing <emil.renner.berthing@canonical.com>
 Date: Wed, 13 Dec 2023 01:58:00 +0100
-Subject: [PATCH 285/450] XUANTIE: riscv: dts: thead: Add Lichee Pi 4A IO
+Subject: [PATCH 285/463] XUANTIE: riscv: dts: thead: Add Lichee Pi 4A IO
  expansions
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/b41720b46f4b203f7935d7cf5613c1782949774b

--- a/runtime-kernel/linux-kernel/autobuild/patches/0286-XUANTIE-riscv-dts-thead-Enable-Lichee-Pi-4A-USB.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0286-XUANTIE-riscv-dts-thead-Enable-Lichee-Pi-4A-USB.patch
@@ -1,7 +1,7 @@
 From 120ed48efda7f7e335e0e6debece1103de3231c4 Mon Sep 17 00:00:00 2001
 From: Jisheng Zhang <jszhang@kernel.org>
 Date: Thu, 21 Sep 2023 13:56:37 +0800
-Subject: [PATCH 286/450] XUANTIE: riscv: dts: thead: Enable Lichee Pi 4A USB
+Subject: [PATCH 286/463] XUANTIE: riscv: dts: thead: Enable Lichee Pi 4A USB
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/9f2a969ac4596062d55412ee6b7f25a6774b5358
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0287-REVYOS-HACK-riscv-dts-th1520-rename-thead-to-xuantie.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0287-REVYOS-HACK-riscv-dts-th1520-rename-thead-to-xuantie.patch
@@ -1,7 +1,7 @@
 From fa162a733e1f2a34f699a8feb9f67b08feb7b81d Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 14 May 2025 08:16:15 +0800
-Subject: [PATCH 287/450] REVYOS: HACK: riscv: dts: th1520: rename thead to
+Subject: [PATCH 287/463] REVYOS: HACK: riscv: dts: th1520: rename thead to
  xuantie
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/fe55f7b77b81749bfd2a5eac9328e016f299d7a6

--- a/runtime-kernel/linux-kernel/autobuild/patches/0288-REVYOS-HACK-riscv-dts-th1520-add-xuantie-th1520-mbox.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0288-REVYOS-HACK-riscv-dts-th1520-add-xuantie-th1520-mbox.patch
@@ -1,7 +1,7 @@
 From d240ca25329c75269b839e2ab6d110506a11287a Mon Sep 17 00:00:00 2001
 From: Han Gao <rabenda.cn@gmail.com>
 Date: Wed, 14 May 2025 08:27:18 +0800
-Subject: [PATCH 288/450] REVYOS: HACK: riscv: dts: th1520: add
+Subject: [PATCH 288/463] REVYOS: HACK: riscv: dts: th1520: add
  xuantie,th1520-mbox-r
 
 From: https://github.com/revyos/th1520-linux-kernel/commit/1e57185ba18320bb4fb747a6089f9404f970964c

--- a/runtime-kernel/linux-kernel/autobuild/patches/0289-FROMEXT-cjktty-6.16.patch.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0289-FROMEXT-cjktty-6.16.patch.patch
@@ -1,7 +1,7 @@
 From a12f580095203f065051704f30f197abf6330e31 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 3 Nov 2025 17:49:44 +0800
-Subject: [PATCH 289/450] FROMEXT: cjktty-6.16.patch
+Subject: [PATCH 289/463] FROMEXT: cjktty-6.16.patch
 
 Co-developed-by: microcai <microcaicai@gmail.com>
 Signed-off-by: microcai <microcaicai@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0291-AOSCOS-drm-amdgpu-use-amdgpu-by-default-for-si-cik-d.patch
@@ -1,7 +1,7 @@
 From f7082f60edff70614e0cad6b4de3299290bb09da Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 22 Sep 2024 00:57:24 +0800
-Subject: [PATCH 291/450] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
+Subject: [PATCH 291/463] AOSCOS: drm: amdgpu: use amdgpu by default for si/cik
  devices
 
 On LoongArch, radeon causes a memory read violation that crashes

--- a/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0292-AOSCOS-drm-amdgpu-radeon-disable-cache-flush-workaro.patch
@@ -1,7 +1,7 @@
 From 14837632938715bd6d9402127225a86874f724e2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <baimingcong@uniontech.com>
 Date: Sun, 22 Sep 2024 01:07:11 +0800
-Subject: [PATCH 292/450] AOSCOS: drm: amdgpu: radeon: disable cache flush
+Subject: [PATCH 292/463] AOSCOS: drm: amdgpu: radeon: disable cache flush
  workaround for LoongArch and Loongson64
 
 This workaround causes instability for LoongArch/Loongson (MIPS) devices

--- a/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0293-AOSCOS-net-stmmac-Make-phytium_dwmac_remove-return-v.patch
@@ -1,7 +1,7 @@
 From 7e0823bdcdba4ce1675c6afc0f074b0769f1d77c Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:19:19 +0800
-Subject: [PATCH 293/450] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
+Subject: [PATCH 293/463] AOSCOS: net: stmmac: Make phytium_dwmac_remove()
  return void
 
 Fixes: 731b13ef92e8 ("BACKPORT: PHYTIUM: net/stmmac: Add phytium DWMAC driver support v2")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0294-AOSCOS-net-phytium-Adapt-struct-kernel_ethtool_ts_in.patch
@@ -1,7 +1,7 @@
 From 982ef4645f08e775dd01cef31f3485a9aa205539 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:42:30 +0800
-Subject: [PATCH 294/450] AOSCOS: net: phytium: Adapt struct
+Subject: [PATCH 294/463] AOSCOS: net: phytium: Adapt struct
  kernel_ethtool_ts_info
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0295-AOSCOS-net-ethernet-phytium-Make-phytmac_plat_remove.patch
@@ -1,7 +1,7 @@
 From 7571feb141142ad27f7105df6365b7dabe7468a0 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 22 Sep 2024 03:57:43 +0800
-Subject: [PATCH 295/450] AOSCOS: net: ethernet: phytium: Make
+Subject: [PATCH 295/463] AOSCOS: net: ethernet: phytium: Make
  phytmac_plat_remove() return void
 
 Fixes: 53f8c475850d ("BACKPORT: PHYTIUM: net: phytium: Add support for phytium GMAC")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-net-stmmac-dwmac-phytium-convert-to-use-phy_i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0296-AOSCOS-net-stmmac-dwmac-phytium-convert-to-use-phy_i.patch
@@ -1,7 +1,7 @@
 From 3aa3bcb5d87d9d80e3523d8274ee5ae91aac59e6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 15 Oct 2025 16:26:32 +0800
-Subject: [PATCH 296/450] AOSCOS: net: stmmac: dwmac-phytium: convert to use
+Subject: [PATCH 296/463] AOSCOS: net: stmmac: dwmac-phytium: convert to use
  phy_interface
 
 Follow upstream changes post-6.17 and replace mac_interface with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-stmmac-stmmac-phytium-fix-build-against-post-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0297-AOSCOS-stmmac-stmmac-phytium-fix-build-against-post-.patch
@@ -1,7 +1,7 @@
 From ba76228e3e94b69481d8f37994d3ae50c3d68774 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 5 Nov 2025 10:58:36 +0800
-Subject: [PATCH 297/450] AOSCOS: stmmac: stmmac-phytium: fix build against
+Subject: [PATCH 297/463] AOSCOS: stmmac: stmmac-phytium: fix build against
  post-6.18 net-next
 
 Since commit "net: stmmac: replace has_xxxx with core_type" from post-

--- a/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0298-AOSCOS-arm64-dts-rockchip-disable-usb3-on-quartz64.patch
@@ -1,7 +1,7 @@
 From b56b4f17fca5d3dd795b8ab25766d4f835e77038 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Sun, 22 Sep 2024 04:13:54 +0800
-Subject: [PATCH 298/450] AOSCOS: arm64: dts: rockchip: disable usb3 on
+Subject: [PATCH 298/463] AOSCOS: arm64: dts: rockchip: disable usb3 on
  quartz64
 
 USB 3 ports on Quartz64 is of bad quality as it shares lines with SATA.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0299-AOSCOS-arm64-drop-hisi_ddrc_pmu-driver.patch
@@ -1,7 +1,7 @@
 From 91ff0eb854d87f2b26ef8d7e43224da5e78ffa90 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Sun, 22 Sep 2024 04:18:12 +0800
-Subject: [PATCH 299/450] AOSCOS: arm64: drop hisi_ddrc_pmu driver
+Subject: [PATCH 299/463] AOSCOS: arm64: drop hisi_ddrc_pmu driver
 
 hisi_ddrc_pmu is broken and causes Kunpeng 920-based desktop systems to freeze
 during boot-up. Disable this driver to workaround this issue.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-loongarch-re-introduce-add_numamem_region-ini.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0300-AOSCOS-loongarch-re-introduce-add_numamem_region-ini.patch
@@ -1,7 +1,7 @@
 From e9483bbfe1623961e54dbe1a19ce809646a45a6a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Nov 2025 22:21:05 +0800
-Subject: [PATCH 300/450] AOSCOS: loongarch: re-introduce add_numamem_region(),
+Subject: [PATCH 300/463] AOSCOS: loongarch: re-introduce add_numamem_region(),
  init_node_memblock()
 
 This is a partial revert for commit acf5de1b23b0 ("LoongArch: Fix NUMA

--- a/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0301-AOSCOS-loongarch-basic-boot-support-for-legacy-firmw.patch
@@ -1,7 +1,7 @@
 From 8623655790be5adb3d61181088f211cf92f6166e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 17 Jul 2024 09:03:32 +0800
-Subject: [PATCH 301/450] AOSCOS: loongarch: basic boot support for legacy
+Subject: [PATCH 301/463] AOSCOS: loongarch: basic boot support for legacy
  firmware
 
 The addresses passed from legacy firmware in efi system tables, the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0302-AOSCOS-loongarch-parse-BPI-data-and-add-memory-mappi.patch
@@ -1,7 +1,7 @@
 From 68ba575229c0eb4d56f247aaaf5368f172b4381e Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 18 Jul 2024 18:55:59 +0800
-Subject: [PATCH 302/450] AOSCOS: loongarch: parse BPI data and add memory
+Subject: [PATCH 302/463] AOSCOS: loongarch: parse BPI data and add memory
  mapping
 
 On legacy firmwares, the memory mapping information passed in the EFI

--- a/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0303-AOSCOS-loongarch-add-MADT-ACPI-table-conversion.patch
@@ -1,7 +1,7 @@
 From 7933bdecb519d2d3f39ed1d51a83db643d6c8084 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Sat, 20 Jul 2024 06:32:15 +0800
-Subject: [PATCH 303/450] AOSCOS: loongarch: add MADT ACPI table conversion
+Subject: [PATCH 303/463] AOSCOS: loongarch: add MADT ACPI table conversion
 
 On machines with legacy firmware with BPI version BPI01000, i.e. the
 older version, the content of the MADT ACPI table is not following the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0304-AOSCOS-loongarch-correct-missing-offset-of-PCI-root-.patch
@@ -1,7 +1,7 @@
 From df6e2e6bc10907454161da572d96f6955fd43201 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 24 Jul 2024 09:06:27 +0800
-Subject: [PATCH 304/450] AOSCOS: loongarch: correct missing offset of PCI root
+Subject: [PATCH 304/463] AOSCOS: loongarch: correct missing offset of PCI root
  controller in DSDT table
 
 On machines with legacy firmware with BPI version BPI01000, the PCI root

--- a/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0305-AOSCOS-loongarch-fix-missing-dependency-info-in-DSDT.patch
@@ -1,7 +1,7 @@
 From a0629d137233f49d7446846890c5c7d82303d018 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Thu, 25 Jul 2024 16:09:19 +0800
-Subject: [PATCH 305/450] AOSCOS: loongarch: fix missing dependency info in
+Subject: [PATCH 305/463] AOSCOS: loongarch: fix missing dependency info in
  DSDT
 
 On machines with legacy firmware with BPI01000 version, the devices on

--- a/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-loongarch-fix-DMA-address-offset.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0306-AOSCOS-loongarch-fix-DMA-address-offset.patch
@@ -1,7 +1,7 @@
 From dc9ffdd81f6252c8d3cfaeb7dcd7a89775f0c573 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 16:05:28 +0800
-Subject: [PATCH 306/450] AOSCOS: loongarch: fix DMA address offset
+Subject: [PATCH 306/463] AOSCOS: loongarch: fix DMA address offset
 
 Loongarch CPUs are using HT bus interface, which is only 40-bit wide,
 to communicate with the bridge chipset. However, the actual memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0307-AOSCOS-loongarch-fix-HT_RX_INT_TRANS-register.patch
@@ -1,7 +1,7 @@
 From ed6976264dd72fd0b46354b3d5f9606399f41fe9 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Tue, 13 Aug 2024 22:33:01 +0800
-Subject: [PATCH 307/450] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
+Subject: [PATCH 307/463] AOSCOS: loongarch: fix HT_RX_INT_TRANS register
 
 On machines with legacy firmware with BPI01000 version, the
 HT_RX_INT_TRANS register on the node 5, i.e. the node connected with the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0308-AOSCOS-arch-loongarch-add-la_ow_syscall-as-in-tree-m.patch
@@ -1,7 +1,7 @@
 From 51f21a5c558e116a62d3034c5fc2c529943c0c41 Mon Sep 17 00:00:00 2001
 From: Miao Wang <shankerwangmiao@gmail.com>
 Date: Wed, 28 Aug 2024 03:09:24 +0800
-Subject: [PATCH 308/450] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
+Subject: [PATCH 308/463] AOSCOS: arch/loongarch: add la_ow_syscall as in-tree
  module
 
 Signed-off-by: Miao Wang <shankerwangmiao@gmail.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0309-AOSCOS-la_ow_syscall-add-kconfig-for-module.patch
@@ -1,7 +1,7 @@
 From 0ee0c5de5f7f5c5c59e3e332b81ba7e1f3f1fc87 Mon Sep 17 00:00:00 2001
 From: Tianhao Chai <cth451@gmail.com>
 Date: Thu, 18 Jan 2024 18:07:58 -0500
-Subject: [PATCH 309/450] AOSCOS: la_ow_syscall: add kconfig for module
+Subject: [PATCH 309/463] AOSCOS: la_ow_syscall: add kconfig for module
 
 Signed-off-by: Tianhao Chai <cth451@gmail.com>
 [Xi Ruoyao: Select KALLSYMS and KPROBE]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0310-AOSCOS-Revert-rcu-Fix-rcu_barrier-VS-post-CPUHP_TEAR.patch
@@ -1,7 +1,7 @@
 From 7f25237f15da1e0a469fcf3e27be202dc74444aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 15 Oct 2024 20:32:21 +0800
-Subject: [PATCH 310/450] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
+Subject: [PATCH 310/463] AOSCOS: Revert "rcu: Fix rcu_barrier() VS post
  CPUHP_TEARDOWN_CPU invocation"
 
 When this change was introduced between v6.10.4 and v6.10.5, the Broadcom

--- a/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0311-AOSCOS-MIPS-Temporarily-disable-Loongson3-LL-SC-erra.patch
@@ -1,7 +1,7 @@
 From 9d204420752032fbcd4ef2a4e819c64c55a1877d Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Fri, 18 Oct 2024 20:51:39 +0800
-Subject: [PATCH 311/450] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
+Subject: [PATCH 311/463] AOSCOS: MIPS: Temporarily disable Loongson3 LL/SC
  errata check
 
 To workaround the following errors:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0312-AOSCOS-drm-loongson-add-ls7a1000_support-module-para.patch
@@ -1,7 +1,7 @@
 From d1503d83a088a0a2c78bbfab85a07ccfd606a5db Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 29 Oct 2024 23:17:28 +0800
-Subject: [PATCH 312/450] AOSCOS: drm: loongson: add ls7a1000_support module
+Subject: [PATCH 312/463] AOSCOS: drm: loongson: add ls7a1000_support module
  parameter
 
 The loongson DRM driver is known to cause boot failure or hang on certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0313-AOSCOS-platform-x86-hp-wmi-Mark-8BAB-board-for-OMEN-.patch
@@ -1,7 +1,7 @@
 From 0330de200f255990eafb4c6d548cf3e09d622b0c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 2 Nov 2024 22:25:37 +0800
-Subject: [PATCH 313/450] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
+Subject: [PATCH 313/463] AOSCOS: platform/x86: hp-wmi: Mark 8BAB board for
  OMEN thermal profile
 
 Similar to 3a057bf30e044a51af8e6a8fe8cbfac49e2b9bc5 ("platform/x86:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0314-AOSCOS-drm-amdgpu-disable-ABM-Adaptive-Backlight-Man.patch
@@ -1,7 +1,7 @@
 From 3537da5b0e0938ac2dee9b71c84510b80dd86ddb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 24 Oct 2024 20:53:23 +0800
-Subject: [PATCH 314/450] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
+Subject: [PATCH 314/463] AOSCOS: drm: amdgpu: disable ABM (Adaptive Backlight
  Management) by default
 
 Per report from a contributor, since v6.9, ABM was set to be automatically

--- a/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-Check-address-space-in-ADE.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0315-AOSCOS-MIPS-Check-address-space-in-ADE.patch
@@ -1,7 +1,7 @@
 From 1da40cbe563d7029506f11a3dd29bda826862801 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Tue, 22 Oct 2024 12:55:46 +0100
-Subject: [PATCH 315/450] AOSCOS: MIPS: Check address space in ADE
+Subject: [PATCH 315/463] AOSCOS: MIPS: Check address space in ADE
 
 Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0316-AOSCOS-remove-dependencies-on-UBUNTU_ODM_DRIVERS.patch
@@ -1,7 +1,7 @@
 From a4c822ace38468e7d62ceeb69a7c829c878fcfbf Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 21 Nov 2024 18:53:37 +0800
-Subject: [PATCH 316/450] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
+Subject: [PATCH 316/463] AOSCOS: remove dependencies on UBUNTU_ODM_DRIVERS
 
 That specific config option doesn't exist in AOSC OS.
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0317-AOSCOS-kvm-disable-enable_virt_at_load-by-default.patch
@@ -1,7 +1,7 @@
 From e87cd9cd2c735612e66fcc2ef47d2b744558b687 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 12 Jan 2025 15:43:08 +0800
-Subject: [PATCH 317/450] AOSCOS: kvm: disable enable_virt_at_load by default
+Subject: [PATCH 317/463] AOSCOS: kvm: disable enable_virt_at_load by default
 
 Disable enable_virt_at_load, a >= 6.12 on-by-default parameter introduced
 with commit b4886fab6fb6 ("KVM: Add a module param to allow enabling

--- a/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0318-AOSCOS-drm-loongson-add-ls7a2000_support-module-para.patch
@@ -1,7 +1,7 @@
 From 319c6058c3b072ba98228d5c3a9716d3d9a9b66e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 19 Jan 2025 12:53:05 +0800
-Subject: [PATCH 318/450] AOSCOS: drm: loongson: add ls7a2000_support module
+Subject: [PATCH 318/463] AOSCOS: drm: loongson: add ls7a2000_support module
  parameter
 
 The loongson DRM driver does not implement userspace acceleration,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0319-AOSCOS-MIPS-loongson64-deselect-ARCH_SUPPORTS_HUGETL.patch
@@ -1,7 +1,7 @@
 From 352b25fc862cd268a58a3758445fefb4a917cb5a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 03:03:03 +0800
-Subject: [PATCH 319/450] AOSCOS: MIPS: loongson64: deselect
+Subject: [PATCH 319/463] AOSCOS: MIPS: loongson64: deselect
  ARCH_SUPPORTS_HUGETLBFS
 
 Disable HugeTLB support as it causes TLB exceptions and illegal memory

--- a/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0320-AOSCOS-MIPS-platform-disable-unreliable-CSR-based-te.patch
@@ -1,7 +1,7 @@
 From 236e5eb27b868f4a04223b9d79dbcb2062485daf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 25 Jan 2025 13:00:30 +0800
-Subject: [PATCH 320/450] AOSCOS: MIPS: platform: disable unreliable CSR-based
+Subject: [PATCH 320/463] AOSCOS: MIPS: platform: disable unreliable CSR-based
  temperature reading
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0321-AOSCOS-drm-radeon-limit-mmiowb-hack-for-radeon_ring_.patch
@@ -1,7 +1,7 @@
 From d7ad39a261a74fcaecc9d666a50a151a04616e82 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 24 Feb 2025 14:01:03 +0800
-Subject: [PATCH 321/450] AOSCOS: drm/radeon: limit mmiowb() hack for
+Subject: [PATCH 321/463] AOSCOS: drm/radeon: limit mmiowb() hack for
  radeon_ring_commit() to MACH_LOONGSON64
 
 As mentioned in the previous patch ("LOONGARCH64: FROMLIST: drm/radeon:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0322-AOSCOS-USB-core-only-enable-root_hub-wakeup-on-MACH_.patch
@@ -1,7 +1,7 @@
 From 13be9f09b7e9ebd98c434b5b73c6237da03efff7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 26 Feb 2025 11:43:02 +0800
-Subject: [PATCH 322/450] AOSCOS: USB: core: only enable root_hub wakeup on
+Subject: [PATCH 322/463] AOSCOS: USB: core: only enable root_hub wakeup on
  MACH_LOONGSON64
 
 The previous attempt to fix USB remote wake on Loongson 7A platforms broke

--- a/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0323-AOSCOS-net-phytmac-include-linux-vmalloc.h-to-fix-bu.patch
@@ -1,7 +1,7 @@
 From cd041a3ae5fe9a443ebc94e12368fefeab2fcba0 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Thu, 27 Mar 2025 13:53:42 +0800
-Subject: [PATCH 323/450] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
+Subject: [PATCH 323/463] AOSCOS: net/phytmac: include linux/vmalloc.h to fix
  build errors
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0324-AOSCOS-bpftool-install-into-bin-instead-of-sbin.patch
@@ -1,7 +1,7 @@
 From 31fefd3a9d9b572521f1b7617af9098a13c8e6f8 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 9 Apr 2025 00:10:16 +0800
-Subject: [PATCH 324/450] AOSCOS: bpftool: install into bin instead of sbin
+Subject: [PATCH 324/463] AOSCOS: bpftool: install into bin instead of sbin
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0325-AOSCOS-gpio-loongson-64bit-Add-LS7A-GPIO-interrupt-s.patch
@@ -1,7 +1,7 @@
 From 431f520c70f0dc3635d5037e33b21eb1e2e28110 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 21 Jun 2025 16:01:27 +0800
-Subject: [PATCH 325/450] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
+Subject: [PATCH 325/463] AOSCOS: gpio: loongson-64bit: Add LS7A GPIO interrupt
  support
 
 On IPASON NL38-N11 laptops, the touchpad device (a HID multitouch device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0326-AOSCOS-net-phytmac-Replace-xdp_do_flush_map-with-xdp.patch
@@ -1,7 +1,7 @@
 From 28bebe8f1912492ac0b022b4eef92a836c6ea16d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:36:15 +0800
-Subject: [PATCH 326/450] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
+Subject: [PATCH 326/463] AOSCOS: net/phytmac: Replace xdp_do_flush_map() with
  xdp_do_flush()
 
 Per 7f04bd109d4c ("net: Tree wide: Replace xdp_do_flush_map() with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0327-AOSCOS-net-phytmac-Remove-unnecessary-pcim_iounmap_r.patch
@@ -1,7 +1,7 @@
 From fd340232fc77f2802860bfa8a4b80f923dff9245 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 12 Jul 2025 19:38:09 +0800
-Subject: [PATCH 327/450] AOSCOS: net/phytmac: Remove unnecessary
+Subject: [PATCH 327/463] AOSCOS: net/phytmac: Remove unnecessary
  pcim_iounmap_regions() call
 
 pcim_iounmap_regions() is removed in commit 855c634930f0 ("PCI: Remove

--- a/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0328-AOSCOS-net-phytium-Depends-on-ACPI-and-ARCH_PHYTIUM.patch
@@ -1,7 +1,7 @@
 From f2acef049fb4b80973e18b22cfe6bc56b59856c0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 21:59:21 +0800
-Subject: [PATCH 328/450] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
+Subject: [PATCH 328/463] AOSCOS: net/phytium: Depends on ACPI and ARCH_PHYTIUM
 
 The driver seems relying on ACPI to power up the device.  And the device
 is only available as a part of Phytium SoC.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-arm64-Disable-MPAM-by-default.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0329-AOSCOS-arm64-Disable-MPAM-by-default.patch
@@ -1,7 +1,7 @@
 From a698f9a94be861f1bca9d465ff7fe3afacb16e5e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 14 Jul 2025 18:06:42 +0800
-Subject: [PATCH 329/450] AOSCOS: arm64: Disable MPAM by default
+Subject: [PATCH 329/463] AOSCOS: arm64: Disable MPAM by default
 
 We have to work OotB on W510, and ARM64 does not support extending the
 built-in command line with the one from the bootloader.  So only try

--- a/runtime-kernel/linux-kernel/autobuild/patches/0330-MARKER-AOSCOS-Start-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0330-MARKER-AOSCOS-Start-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 1355236d3c9e53e4881936494408bab4486c3a76 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:43:40 +0800
-Subject: [PATCH 330/450] MARKER: AOSCOS: Start of Lemote patches
+Subject: [PATCH 330/463] MARKER: AOSCOS: Start of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0331-AOSCOS-wifi-rt2x00-Condition-interface-type-getters-.patch
@@ -1,7 +1,7 @@
 From bf4325d3bffd7a57fbc821cc7f11dc64a8d2c313 Mon Sep 17 00:00:00 2001
 From: Jiaxun Yang <jiaxun.yang@flygoat.com>
 Date: Thu, 19 Jan 2023 20:42:56 +0000
-Subject: [PATCH 331/450] AOSCOS: wifi: rt2x00: Condition interface type
+Subject: [PATCH 331/463] AOSCOS: wifi: rt2x00: Condition interface type
  getters with config options
 
 When compiling this driver for platforms with partial clk

--- a/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0332-AOSCOS-tty-serial_core-Clear-TTY_IO_ERROR-if-tty_por.patch
@@ -1,7 +1,7 @@
 From cd6907982f7ed72ce41c455c367d97b25934e4ea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 332/450] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
+Subject: [PATCH 332/463] AOSCOS: tty: serial_core: Clear TTY_IO_ERROR if
  tty_port_open() return 0
 
 After commit b3b57646186400d4f ("tty: serial_core: convert uart_open

--- a/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0333-AOSCOS-MIPS-Loongson-Add-constant-timer-support.patch
@@ -1,7 +1,7 @@
 From c31c30e5de9fc2b7ff73b6c97787cda439375eea Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 29 Nov 2019 09:11:38 +0800
-Subject: [PATCH 333/450] AOSCOS: MIPS: Loongson: Add constant timer support
+Subject: [PATCH 333/463] AOSCOS: MIPS: Loongson: Add constant timer support
 
 Partially implemented by commit 8267e78f020a ("MIPS: Tidy up CP0.Config6
 bits definition").

--- a/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0334-AOSCOS-MIPS-loongson64-fix-constant-timer-build-on-k.patch
@@ -1,7 +1,7 @@
 From 1d1f1c1ed9542474ad9ce9a3fe827b1938da43cf Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:52:14 +0800
-Subject: [PATCH 334/450] AOSCOS: MIPS: loongson64: fix constant timer build on
+Subject: [PATCH 334/463] AOSCOS: MIPS: loongson64: fix constant timer build on
  kernel versions >= v5.7-rc2
 
 With commit 07d8350ede4c ("genirq: Remove setup_irq() and remove_irq()"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0335-AOSCOS-MIPS-loongson64-use-generic-vDSO-clock-mode-s.patch
@@ -1,7 +1,7 @@
 From 3d0a24da1074a20edb99bb92cb119e88b32ac247 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 3 Dec 2024 16:56:36 +0800
-Subject: [PATCH 335/450] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
+Subject: [PATCH 335/463] AOSCOS: MIPS: loongson64: use generic vDSO clock mode
  storage for constant_timer
 
 Follow commit e1bdb22ebe53 ("mips: vdso: Use generic VDSO clock mode

--- a/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0336-AOSCOS-MIPS-Loongson-3-Add-basic-EC-operations.patch
@@ -1,7 +1,7 @@
 From 6d050464f4c77a47741d702f643c0a17e894effa Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 336/450] AOSCOS: MIPS: Loongson 3: Add basic EC operations
+Subject: [PATCH 336/463] AOSCOS: MIPS: Loongson 3: Add basic EC operations
 
 Loongson-3 based laptops has a WPCE775L embedded controller. Add
 basic operations for future related drivers and board support.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0337-AOSCOS-MIPS-ec_wpce775l-add-a-missing-prototype-for-.patch
@@ -1,7 +1,7 @@
 From f39b8a9c1f9913e8cad5237e6f3635edda572b12 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:00:14 +0800
-Subject: [PATCH 337/450] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
+Subject: [PATCH 337/463] AOSCOS: MIPS: ec_wpce775l: add a missing prototype
  for ec_query_get_event_num()
 
 Add missing prototype for ec_query_get_event_num() to suppress a -Werror

--- a/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0338-AOSCOS-MIPS-Loongson-3-Add-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From e6b269589c95553b0d18c57497d6c55271ef66ca Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 338/450] AOSCOS: MIPS: Loongson 3: Add platform device drivers
+Subject: [PATCH 338/463] AOSCOS: MIPS: Loongson 3: Add platform device drivers
 
 Platform device drivers include temperature sensor (EMC1412, TMP75,
 LM93), fan controllers (SB700/SB710/SB800 chipset, WPCE775L EC) and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0339-AOSCOS-platform-mips-rename-dependency-for-LEMOTE3A_.patch
@@ -1,7 +1,7 @@
 From 1c15f3d0b7299a383d043769076def0b4493f7f1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:16:04 +0800
-Subject: [PATCH 339/450] AOSCOS: platform: mips: rename dependency for
+Subject: [PATCH 339/463] AOSCOS: platform: mips: rename dependency for
  LEMOTE3A_LAPTOP
 
 Rename LOONGSON_MACH3X => MACH_LOONGSON64 per commit 6fbde6b492df ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0340-AOSCOS-platform-sd5075-convert-to-i2c_new_client_dev.patch
@@ -1,7 +1,7 @@
 From 6fe5eef86c10badc0b20cb57055a439761809ae0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:42:39 +0800
-Subject: [PATCH 340/450] AOSCOS: platform: sd5075: convert to
+Subject: [PATCH 340/463] AOSCOS: platform: sd5075: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0341-AOSCOS-platform-emc1412-convert-to-i2c_new_client_de.patch
@@ -1,7 +1,7 @@
 From d8946a7203199fcfc5f54d0c86523a7780d5cd52 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:46:26 +0800
-Subject: [PATCH 341/450] AOSCOS: platform: emc1412: convert to
+Subject: [PATCH 341/463] AOSCOS: platform: emc1412: convert to
  i2c_new_client_device() function
 
 Follow commit 390fd0475af5 ("i2c: remove deprecated i2c_new_device API")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0342-AOSCOS-platform-sd5075-mark-non-prototyped-functions.patch
@@ -1,7 +1,7 @@
 From 54764018655e23894c4e79539021280088798acb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:47:29 +0800
-Subject: [PATCH 342/450] AOSCOS: platform: sd5075: mark non-prototyped
+Subject: [PATCH 342/463] AOSCOS: platform: sd5075: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0343-AOSCOS-platform-emc1412-mark-non-prototyped-function.patch
@@ -1,7 +1,7 @@
 From 5d1ecd74a5effca1cdfb60269b3e4bbd15e7e76b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:04 +0800
-Subject: [PATCH 343/450] AOSCOS: platform: emc1412: mark non-prototyped
+Subject: [PATCH 343/463] AOSCOS: platform: emc1412: mark non-prototyped
  functions as static
 
 Fix build error with -Werror due to missing prototypes.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0344-AOSCOS-platform-emc1412-drop-unused-fixup_cpu_temp-f.patch
@@ -1,7 +1,7 @@
 From b8c6b338744db126cbd9667239c524e04ce81739 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:49:40 +0800
-Subject: [PATCH 344/450] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 344/463] AOSCOS: platform: emc1412: drop unused
  fixup_cpu_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0345-AOSCOS-platform-emc1412-drop-unused-emc1412_internal.patch
@@ -1,7 +1,7 @@
 From 0c6a0830e28ccde975e9a6ce02c0380855fedbe9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 15:56:33 +0800
-Subject: [PATCH 345/450] AOSCOS: platform: emc1412: drop unused
+Subject: [PATCH 345/463] AOSCOS: platform: emc1412: drop unused
  emc1412_internal_temp() function
 
 This function was not used anywhere and triggered -Werror=unused-function.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0346-AOSCOS-platform-lemote3a-laptop-drop-fb_blank-state-.patch
@@ -1,7 +1,7 @@
 From 6fd85a9b03371a6398c712451cc30bd2048731fb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:14:17 +0800
-Subject: [PATCH 346/450] AOSCOS: platform: lemote3a-laptop: drop fb_blank
+Subject: [PATCH 346/463] AOSCOS: platform: lemote3a-laptop: drop fb_blank
  state from backlight restoration logic
 
 Follow commit 4551978bb50a ("backlight: Remove fb_blank from struct

--- a/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0347-AOSCOS-platform-lemote3a-laptop-fix-pci_enable_devic.patch
@@ -1,7 +1,7 @@
 From 1690d5a7b1354e9484c66d61a020fd0281e75814 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:45:30 +0800
-Subject: [PATCH 347/450] AOSCOS: platform: lemote3a-laptop: fix
+Subject: [PATCH 347/463] AOSCOS: platform: lemote3a-laptop: fix
  pci_enable_device() usage
 
 pci_enable_device() ignores return values.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0348-AOSCOS-platform-sbx00_fan-add-missing-definitions-fo.patch
@@ -1,7 +1,7 @@
 From 093e7685bcfd1c377e9ba1e12e5400459373e5ba Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 16:47:07 +0800
-Subject: [PATCH 348/450] AOSCOS: platform: sbx00_fan: add missing definitions
+Subject: [PATCH 348/463] AOSCOS: platform: sbx00_fan: add missing definitions
  for pm{,2}_* functions
 
 These functions were declared as prototypes but were never defined, copy

--- a/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0349-AOSCOS-MIPS-Loongson-Add-ACPI-Power-Button-driver.patch
@@ -1,7 +1,7 @@
 From 68818aa4aec4489a197de018aa9af39b3ffc9331 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 9 Nov 2017 10:31:55 +0800
-Subject: [PATCH 349/450] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
+Subject: [PATCH 349/463] AOSCOS: MIPS: Loongson: Add ACPI Power Button driver
 
 [Mingcong Bai: arch/mips/loongson64/loongson-3/acpi_init.c was moved to
 drivers/platform/mips/rs780e-acpi.c with commit 0cfd2440aa03 ("MIPS:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0350-AOSCOS-platform-rs780e-acpi-deprecate-pci_get_bus_an.patch
@@ -1,7 +1,7 @@
 From ed68f078f42e94ba28d98deeb3cd0399d8987bcb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:36:26 +0800
-Subject: [PATCH 350/450] AOSCOS: platform: rs780e-acpi: deprecate
+Subject: [PATCH 350/463] AOSCOS: platform: rs780e-acpi: deprecate
  pci_get_bus_and_slot()
 
 The commit 5cf0c37a71da ("PCI: Remove pci_get_bus_and_slot() function")

--- a/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0351-AOSCOS-MIPS-Loongson-Add-the-multifunction-keys-Fnke.patch
@@ -1,7 +1,7 @@
 From 23cf7b2cfa1d5b2a4dd3b21cf6283503efd13fd2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 351/450] AOSCOS: MIPS: Loongson: Add the multifunction keys
+Subject: [PATCH 351/463] AOSCOS: MIPS: Loongson: Add the multifunction keys
  (Fnkey) support.
 
 1, Add special function keys keycode to keycode mapping table.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0352-AOSCOS-input-atkbd-correct-dependency-for-KEYBOARD_A.patch
@@ -1,7 +1,7 @@
 From e053542d2dd9114c598cc632ce91ca3d5b10dab3 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:18 +0800
-Subject: [PATCH 352/450] AOSCOS: input: atkbd: correct dependency for
+Subject: [PATCH 352/463] AOSCOS: input: atkbd: correct dependency for
  KEYBOARD_ATKBD_LEMOTE_KEYCODES
 
 Rename dependency MACH_LOONGSON => MACH_LOONGSON64 per commit

--- a/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0353-AOSCOS-input-atkbd-disable-KEYBOARD_ATKBD_LEMOTE_KEY.patch
@@ -1,7 +1,7 @@
 From 27e3e3cbab19ae6d1a0b1ae98d5e4d7305953aad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 4 Dec 2024 17:54:37 +0800
-Subject: [PATCH 353/450] AOSCOS: input: atkbd: disable
+Subject: [PATCH 353/463] AOSCOS: input: atkbd: disable
  KEYBOARD_ATKBD_LEMOTE_KEYCODES by default
 
 This option sets a special keycode to workaround issues with certain

--- a/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0354-AOSCOS-MIPS-Loongson-3-Add-EC-resources-accessing-an.patch
@@ -1,7 +1,7 @@
 From 6aa0990016ddd8fff358721d4aa493c40595af16 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 354/450] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
+Subject: [PATCH 354/463] AOSCOS: MIPS: Loongson 3: Add EC resources accessing
  and programming support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0355-AOSCOS-MIPS-Loongson-Add-PMON-read-write-in-OS-suppo.patch
@@ -1,7 +1,7 @@
 From 02d0902d5bc4c19783157286a1e083d681b8d9fb Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 355/450] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
+Subject: [PATCH 355/463] AOSCOS: MIPS: Loongson: Add PMON read/write in OS
  support
 
 PMON is the firmware(BIOS) of Loongson.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0356-AOSCOS-platform-pmon_flash-mark-init_flash-function-.patch
@@ -1,7 +1,7 @@
 From 9208860b32609af14f1cdab2f15d30f6cfe1d122 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 5 Dec 2024 16:19:39 +0800
-Subject: [PATCH 356/450] AOSCOS: platform: pmon_flash: mark init_flash()
+Subject: [PATCH 356/463] AOSCOS: platform: pmon_flash: mark init_flash()
  function as static
 
 Suppress a missing prototypes warning during build.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0357-AOSCOS-MIPS-Loongson-AT24c04-support-for-Loongson-3.patch
@@ -1,7 +1,7 @@
 From 104858d55410a18e88d45e1b8ab3b34cb31b1def Mon Sep 17 00:00:00 2001
 From: Binbin Zhou <zhoubb@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 357/450] AOSCOS: MIPS: Loongson: AT24c04 support for
+Subject: [PATCH 357/463] AOSCOS: MIPS: Loongson: AT24c04 support for
  Loongson-3
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0358-AOSCOS-Add-ioremap.h-for-loongson-platform.patch
@@ -1,7 +1,7 @@
 From 2e558dc454c44ab3093aa5037ef91157cd2f109a Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 358/450] AOSCOS: Add ioremap.h for loongson platform
+Subject: [PATCH 358/463] AOSCOS: Add ioremap.h for loongson platform
 
 Add loongson specific plat_ioremap to utilize uncached acceleration
 feature.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0359-AOSCOS-Fix-touchpad-status-error-after-STR-STD.patch
@@ -1,7 +1,7 @@
 From 061c98991e8dad27cf0c3f3445516dbc3de909a9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 359/450] AOSCOS: Fix touchpad status error after STR/STD
+Subject: [PATCH 359/463] AOSCOS: Fix touchpad status error after STR/STD
 
 Signed-off-by: Rui Wang <wangr@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0360-AOSCOS-mvsas-Optimise-performance-and-stability-on-C.patch
@@ -1,7 +1,7 @@
 From 3e6bac1cef3bd1081449a7e3768924006579465d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 10:35:39 +0800
-Subject: [PATCH 360/450] AOSCOS: mvsas: Optimise performance and stability on
+Subject: [PATCH 360/463] AOSCOS: mvsas: Optimise performance and stability on
  CPU_LOONGSON64
 
 Optimize this driver conditionally for MIPS-based Loongson 3

--- a/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0361-AOSCOS-GPIO-Add-NCT6102-GPIO-driver-support.patch
@@ -1,7 +1,7 @@
 From a1325dd13956850e750dfd2818f82eceb0b332f6 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 5 Jan 2018 11:28:18 +0800
-Subject: [PATCH 361/450] AOSCOS: GPIO: Add NCT6102 GPIO driver support
+Subject: [PATCH 361/463] AOSCOS: GPIO: Add NCT6102 GPIO driver support
 
 [Mingcong Bai: Resolved minor merge conflicts in drivers/gpio/Kconfig and
 drivers/gpio/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0362-AOSCOS-gpio-use-CPU_LOONGSON64-for-GPIO_NCT6102.patch
@@ -1,7 +1,7 @@
 From 0f081e68ad7af345945a76d54634a2cb74f6aaf7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:24:26 +0800
-Subject: [PATCH 362/450] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
+Subject: [PATCH 362/463] AOSCOS: gpio: use CPU_LOONGSON64 for GPIO_NCT6102
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and
 rework"), rename the CPU_LOONGSON3 dependency as CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0363-AOSCOS-gpio-gpio-nct6102-add-a-missing-include-to-li.patch
@@ -1,7 +1,7 @@
 From c5b659494a001af6a747ee772ba781d21150210b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:25:34 +0800
-Subject: [PATCH 363/450] AOSCOS: gpio: gpio-nct6102: add a missing include to
+Subject: [PATCH 363/463] AOSCOS: gpio: gpio-nct6102: add a missing include to
  <linux/gpio/driver.h>
 
 This driver was missing an include to <linux/gpio/driver.h>, the reference

--- a/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0364-AOSCOS-gpio-gpio-nct6102-remove-unused-write_gbl-fun.patch
@@ -1,7 +1,7 @@
 From 30f2e2770145f7b4c567f99a6d380c663da93538 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:30:53 +0800
-Subject: [PATCH 364/450] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
+Subject: [PATCH 364/463] AOSCOS: gpio: gpio-nct6102: remove unused write_gbl()
  function
 
 Fix an error thrown by `-Werror=unused-function'.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0365-AOSCOS-gpio-gpio-nct6102-drop-an-unused-variable-in-.patch
@@ -1,7 +1,7 @@
 From d902b7944b12d20864a91b054d97574fc0e95fce Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:31:56 +0800
-Subject: [PATCH 365/450] AOSCOS: gpio: gpio-nct6102: drop an unused variable
+Subject: [PATCH 365/463] AOSCOS: gpio: gpio-nct6102: drop an unused variable
  in nct6102_gpio_setup()
 
 The integer-type variable `ret' was never used in the function, causing an

--- a/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0366-AOSCOS-gpio-gpio-nct6102-revise-gpiochip_add-as-gpio.patch
@@ -1,7 +1,7 @@
 From 3025e334120c7d3b2f63f3196d7311dd9b97a6dc Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:34:17 +0800
-Subject: [PATCH 366/450] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
+Subject: [PATCH 366/463] AOSCOS: gpio: gpio-nct6102: revise gpiochip_add() as
  gpiochip_add_data()
 
 Per commit 3ff1180a39fb ("gpiolib: Remove data-less gpiochip_add()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0367-AOSCOS-hwmon-Add-NCT7511-driver-support.patch
@@ -1,7 +1,7 @@
 From 54d0c1fbd411e7e6d1bf6f46d4dd3dc0e8ff8184 Mon Sep 17 00:00:00 2001
 From: Yao Wang <wangyao@lemote.com>
 Date: Fri, 22 Nov 2019 19:21:01 +0800
-Subject: [PATCH 367/450] AOSCOS: hwmon: Add NCT7511 driver support
+Subject: [PATCH 367/463] AOSCOS: hwmon: Add NCT7511 driver support
 
 This driver is base on nct7802y. The nct7802y driver is incompatible
 with nct7511y, so add a nct7511 driver.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0368-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0368-AOSCOS-hwmon-nct7511-replace-deprecated-strlcpy-with.patch
@@ -1,7 +1,7 @@
 From f954bb84f52611c06682144fb0d0fab378b54b87 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 17:58:37 +0800
-Subject: [PATCH 368/450] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
+Subject: [PATCH 368/463] AOSCOS: hwmon: nct7511: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0369-AOSCOS-hwmon-nct7511-revise-.probe-in-struct-i2c_dri.patch
@@ -1,7 +1,7 @@
 From b979ceb8101168fd6ebe3d88629d07c4d8007c8b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 9 Dec 2024 18:04:57 +0800
-Subject: [PATCH 369/450] AOSCOS: hwmon: nct7511: revise .probe() in struct
+Subject: [PATCH 369/463] AOSCOS: hwmon: nct7511: revise .probe() in struct
  i2c_driver
 
 Since commit 03c835f498b5 ("i2c: Switch .probe() to not take an id

--- a/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0370-AOSCOS-snd-hda-patch_conexant-add-proc_widget_hook.patch
@@ -1,7 +1,7 @@
 From 4af3c2f1aeaa3b1224e08966c586b31c183944b6 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 370/450] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
+Subject: [PATCH 370/463] AOSCOS: snd/hda/patch_conexant: add proc_widget_hook
 
 Export non-std/vendor defined node 0x27
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0371-AOSCOS-snd-hda-codec-new-symbol-snd_hda_codec_exec_v.patch
@@ -1,7 +1,7 @@
 From 9cc3f4c0f0928cb7a71261bf876d9d79f73a1873 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 371/450] AOSCOS: snd-hda-codec: new symbol
+Subject: [PATCH 371/463] AOSCOS: snd-hda-codec: new symbol
  snd_hda_codec_exec_verb
 
 snd_hda_codec_exec_verb() wraps&exports codec_exec_verb()

--- a/runtime-kernel/linux-kernel/autobuild/patches/0372-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0372-AOSCOS-snd-hda-conexant-add-support-for-raw-verbs.patch
@@ -1,7 +1,7 @@
 From c5de6be5af2f442ac316492aebdb627e833fce88 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 372/450] AOSCOS: snd/hda/conexant: add support for raw verbs
+Subject: [PATCH 372/463] AOSCOS: snd/hda/conexant: add support for raw verbs
 
 [Mingcong Bai: Resolved a minor merge conflict in
 sound/pci/hda/patch_conexant.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0373-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0373-AOSCOS-snd-hda-conexant-Add-support-for-lemote-A1205.patch
@@ -1,7 +1,7 @@
 From a3a6e9530eba215bc41c243bb607324c2542e883 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 373/450] AOSCOS: snd/hda/conexant: Add support for lemote
+Subject: [PATCH 373/463] AOSCOS: snd/hda/conexant: Add support for lemote
  A1205
 
 Lemote A1205 is a all in one product.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0374-AOSCOS-add-3g-support-and-ppp-config-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0374-AOSCOS-add-3g-support-and-ppp-config-support.patch
@@ -1,7 +1,7 @@
 From 850bf6e411526c805e728ee6a2de375d56f16a69 Mon Sep 17 00:00:00 2001
 From: xiangy <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 374/450] AOSCOS: add 3g support and ppp config support
+Subject: [PATCH 374/463] AOSCOS: add 3g support and ppp config support
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 Signed-off-by: Hongliang Tao <taohl@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0375-AOSCOS-add-rear-mic-support-for-CX20631.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0375-AOSCOS-add-rear-mic-support-for-CX20631.patch
@@ -1,7 +1,7 @@
 From 89844916aac413f43c5417fe6a0c519065306f9a Mon Sep 17 00:00:00 2001
 From: Xiang Yu <xiangy@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 375/450] AOSCOS: add rear mic support for CX20631
+Subject: [PATCH 375/463] AOSCOS: add rear mic support for CX20631
 
 CX20631 Node1b's default config value should be 0x01A190F0 according to CX20631
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0376-AOSCOS-add-rear-mic-support-for-CX20641.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0376-AOSCOS-add-rear-mic-support-for-CX20641.patch
@@ -1,7 +1,7 @@
 From 54c328215363a8cc4cd1f2a17dab05546d4215fc Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 376/450] AOSCOS: add rear mic support for CX20641
+Subject: [PATCH 376/463] AOSCOS: add rear mic support for CX20641
 
 CX20641 Node1b's default config value should be 0x01A190F0 according to CX20641
 datesheet, but the true value is 0x018xxxxx, this cause PortC can't work as rear

--- a/runtime-kernel/linux-kernel/autobuild/patches/0377-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0377-AOSCOS-E1000E-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 9231fe1d9bf1f2853a4db4e16a4ad9ac3049ec99 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 377/450] AOSCOS: E1000E: Detect and recover weird rx hang bug
+Subject: [PATCH 377/463] AOSCOS: E1000E: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0378-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0378-AOSCOS-Retry-to-configure-USB-device-if-needed.patch
@@ -1,7 +1,7 @@
 From 57d4ba18c7f7bf6192aefd26819fd32defce879b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 378/450] AOSCOS: Retry to configure USB device if needed
+Subject: [PATCH 378/463] AOSCOS: Retry to configure USB device if needed
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/usb/core/message.c.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0379-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0379-AOSCOS-platform-export-psmouse-touchpad-led-device.patch
@@ -1,7 +1,7 @@
 From f9d2cbe99a4306a0d21ce77bd13ef19b51802910 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 379/450] AOSCOS: platform: export psmouse::touchpad led device
+Subject: [PATCH 379/463] AOSCOS: platform: export psmouse::touchpad led device
 
 [Mingcong Bai: Resolved a minor merge conflict in
 drivers/platform/mips/Kconfig.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0380-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0380-AOSCOS-Loongson-Add-data-destory-and-healthy-led-con.patch
@@ -1,7 +1,7 @@
 From 1817232cce3e0a0e311af5ce03e417303bef1c8d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 21 Apr 2017 15:38:39 +0800
-Subject: [PATCH 380/450] AOSCOS: Loongson: Add data destory and healthy led
+Subject: [PATCH 380/463] AOSCOS: Loongson: Add data destory and healthy led
  control
 
 Signed-off-by: Binbin Zhou <zhoubb@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0381-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0381-AOSCOS-MIPS-audit-declare-function-prototypes-for-au.patch
@@ -1,7 +1,7 @@
 From 0b0362f9a2e70edb8580ecfc2b89ab03cc5e83f0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:36:25 +0800
-Subject: [PATCH 381/450] AOSCOS: MIPS: audit: declare function prototypes for
+Subject: [PATCH 381/463] AOSCOS: MIPS: audit: declare function prototypes for
  audit_classify_syscall_*()
 
 Functions `audit_classify_syscall_n32()', `audit_classify_syscall_o32()`

--- a/runtime-kernel/linux-kernel/autobuild/patches/0382-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0382-AOSCOS-MIPS-audit-replace-magic-audit-syscall-class-.patch
@@ -1,7 +1,7 @@
 From 9a27cacddf1e93c3754a88bba26ebdaafa17e1d7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 16:39:13 +0800
-Subject: [PATCH 382/450] AOSCOS: MIPS: audit: replace magic audit syscall
+Subject: [PATCH 382/463] AOSCOS: MIPS: audit: replace magic audit syscall
  class numbers with macros
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0383-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0383-AOSCOS-MIPS-audit-clean-up-the-last-remnants-of-magi.patch
@@ -1,7 +1,7 @@
 From 0ba19f1b9fce1ec38075bbd888330e30d0706cb9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 17 Dec 2024 02:00:03 +0800
-Subject: [PATCH 383/450] AOSCOS: MIPS: audit: clean up the last remnants of
+Subject: [PATCH 383/463] AOSCOS: MIPS: audit: clean up the last remnants of
  magic numbers
 
 Follow commit 42f355ef59a2 ("audit: replace magic audit syscall class

--- a/runtime-kernel/linux-kernel/autobuild/patches/0384-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0384-AOSCOS-drm-radeon-recover-the-GPU-if-it-fails-at-res.patch
@@ -1,7 +1,7 @@
 From f89eda9a9830ee969af068874f17d24e8d30865f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 384/450] AOSCOS: drm/radeon: recover the GPU if it fails at
+Subject: [PATCH 384/463] AOSCOS: drm/radeon: recover the GPU if it fails at
  resume
 
 [Mingcong Bai: Resolved a minor merge conflict in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0385-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0385-AOSCOS-drm-radeon-declare-prototype-for-radeon_recov.patch
@@ -1,7 +1,7 @@
 From 68737419d8e7cf70a69b6942ff1977c509f258fa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 17:55:36 +0800
-Subject: [PATCH 385/450] AOSCOS: drm: radeon: declare prototype for
+Subject: [PATCH 385/463] AOSCOS: drm: radeon: declare prototype for
  radeon_recover_callback()
 
 Declare radeon_recover_callback() in radeon_device.h to clean up function

--- a/runtime-kernel/linux-kernel/autobuild/patches/0386-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0386-AOSCOS-Revert-drm-ttm-remove-ttm_bo_-un-lock_delayed.patch
@@ -1,7 +1,7 @@
 From 770c35451b87f221bd455f028eb0d1f75a08eba1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 10 Dec 2024 18:06:52 +0800
-Subject: [PATCH 386/450] AOSCOS: Revert "drm/ttm: remove
+Subject: [PATCH 386/463] AOSCOS: Revert "drm/ttm: remove
  ttm_bo_(un)lock_delayed_workqueue"
 
 This reverts commit cd3a8a596214e6a338a22104936c40e62bdea2b6.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0387-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0387-AOSCOS-drm-radeon-use-rdev_to_drm-rdev.patch
@@ -1,7 +1,7 @@
 From 40d92591e542f7de54f28c66c2bd60b436ed3c47 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:31:17 +0800
-Subject: [PATCH 387/450] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
+Subject: [PATCH 387/463] AOSCOS: drm: radeon: use rdev_to_drm(rdev)
 
 Per commit fb1b5e1dd53f ("drm/radeon: change rdev->ddev to
 rdev_to_drm(rdev)"), members of the struct `rdev' is now accessed with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0388-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0388-AOSCOS-drm-ttm-introduce-struct-delayed_work-member-.patch
@@ -1,7 +1,7 @@
 From aa1432527e58a6ba4563fb1d5773a72294d30ce6 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 10:36:24 +0800
-Subject: [PATCH 388/450] AOSCOS: drm: ttm: introduce struct delayed_work
+Subject: [PATCH 388/463] AOSCOS: drm: ttm: introduce struct delayed_work
  member dwork to struct ttm_device
 
 Commit 9bff18d13473 ("drm/ttm: use per BO cleanup workers") revised the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0389-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0389-AOSCOS-drm-radeon-Fix-hibernation-for-JUNIPER-on-Loo.patch
@@ -1,7 +1,7 @@
 From 7d4e38beda103a02e2717f951476aa5c1cc65f1e Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 389/450] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
+Subject: [PATCH 389/463] AOSCOS: drm/radeon: Fix hibernation for JUNIPER on
  Loongson
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0390-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0390-AOSCOS-drm-radeon-limit-MIPS-Loongson-3-workarounds-.patch
@@ -1,7 +1,7 @@
 From ad73e06906186cf9a376d9f483ab37e31a0a6cc9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 11:20:38 +0800
-Subject: [PATCH 390/450] AOSCOS: drm: radeon: limit MIPS Loongson-3
+Subject: [PATCH 390/463] AOSCOS: drm: radeon: limit MIPS Loongson-3
  workarounds for Juniper
 
 Guard MIPS Loongson-3 specific hacks around CONFIG_MACH_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0391-AOSCOS-drm-radeon-Use-high-performance-profile.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0391-AOSCOS-drm-radeon-Use-high-performance-profile.patch
@@ -1,7 +1,7 @@
 From 7a83c42a56e3687025bae50e1db532805cab9225 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 6 May 2017 09:28:30 +0800
-Subject: [PATCH 391/450] AOSCOS: drm/radeon: Use high performance profile
+Subject: [PATCH 391/463] AOSCOS: drm/radeon: Use high performance profile
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0392-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0392-AOSCOS-drm-radeon-Reintroduce-radeon_gart_restore.patch
@@ -1,7 +1,7 @@
 From 409da9e3489ef8a46696a3e5eb3920268ca5f1be Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:31:19 +0800
-Subject: [PATCH 392/450] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
+Subject: [PATCH 392/463] AOSCOS: drm/radeon: Reintroduce radeon_gart_restore()
 
 This revert commit a3eb06dbca08e3fdad7039021ae0 ("drm/radeon: Remove
 radeon_gart_restore()") and update code for the latest kernel. We do

--- a/runtime-kernel/linux-kernel/autobuild/patches/0393-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0393-AOSCOS-drm-radeon-Modify-GART-TLB-setting-to-fix-kdu.patch
@@ -1,7 +1,7 @@
 From 1cf622b49e9023f192f7c8c7364dc870e2db079b Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Wed, 1 Aug 2018 14:39:20 +0800
-Subject: [PATCH 393/450] AOSCOS: drm/radeon: Modify GART TLB setting to fix
+Subject: [PATCH 393/463] AOSCOS: drm/radeon: Modify GART TLB setting to fix
  kdump failure
 
 After commit 0986c1a55ca64b44ee12 ("drm/radeon: stop poisoning the GART

--- a/runtime-kernel/linux-kernel/autobuild/patches/0394-AOSCOS-sm750fb-change-default-screen-resolution.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0394-AOSCOS-sm750fb-change-default-screen-resolution.patch
@@ -1,7 +1,7 @@
 From e473b52bf99c8028340cab0647ce68c2968be402 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Fri, 3 Nov 2017 09:15:11 +0800
-Subject: [PATCH 394/450] AOSCOS: sm750fb: change default screen resolution
+Subject: [PATCH 394/463] AOSCOS: sm750fb: change default screen resolution
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0395-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0395-AOSCOS-sm750fb-Disable-hw_cursor-to-avoid-screen-cor.patch
@@ -1,7 +1,7 @@
 From c0ffcebfe05724aa6e4930b8c70f11e4da089d86 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 395/450] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
+Subject: [PATCH 395/463] AOSCOS: sm750fb: Disable hw_cursor to avoid screen
  corruption
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0396-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0396-AOSCOS-Input-i8042-Make-i8042_bypass_aux_irq_test-as.patch
@@ -1,7 +1,7 @@
 From 3d7305bd4cc8912851163458f92132df2410bf9f Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 396/450] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
+Subject: [PATCH 396/463] AOSCOS: Input: i8042 - Make i8042_bypass_aux_irq_test
  as a module parameter
 
 The original i8042_bypass_aux_irq_test is a variable which cannot be

--- a/runtime-kernel/linux-kernel/autobuild/patches/0397-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0397-AOSCOS-IGB-Detect-and-recover-weird-rx-hang-bug.patch
@@ -1,7 +1,7 @@
 From 9ee82fea715d4a1918dcbd9145e706fb7a73f110 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 397/450] AOSCOS: IGB: Detect and recover weird rx hang bug
+Subject: [PATCH 397/463] AOSCOS: IGB: Detect and recover weird rx hang bug
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>
 

--- a/runtime-kernel/linux-kernel/autobuild/patches/0398-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0398-AOSCOS-Revert-staging-sb105x-delete-the-driver.patch
@@ -1,7 +1,7 @@
 From 821542abe52b68042d209a2ae9eb37e338814328 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 398/450] AOSCOS: Revert "staging: sb105x: delete the driver"
+Subject: [PATCH 398/463] AOSCOS: Revert "staging: sb105x: delete the driver"
 
 This reverts commit aa98b772b7d32d91ec2a7f8779adfc31f0aaaf24.
 Lemote use this driver for MIPS/Loongson, so let me maintain it!

--- a/runtime-kernel/linux-kernel/autobuild/patches/0399-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0399-AOSCOS-Staging-sb105x-Fix-build-and-add-MIPS-support.patch
@@ -1,7 +1,7 @@
 From fa2e15ff4e0b380a72a4c233c1c9df5eb9c52802 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 399/450] AOSCOS: Staging: sb105x: Fix build and add MIPS
+Subject: [PATCH 399/463] AOSCOS: Staging: sb105x: Fix build and add MIPS
  support
 
 [Mingcong Bai: Resolved merge conflicts in arch/mips/include/asm/serial.h

--- a/runtime-kernel/linux-kernel/autobuild/patches/0400-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0400-AOSCOS-staging-sb105x-add-missing-function-prototype.patch
@@ -1,7 +1,7 @@
 From 84883907b8f7a10739a06b63cfc47b14f6201712 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 13:49:12 +0800
-Subject: [PATCH 400/450] AOSCOS: staging: sb105x: add missing function
+Subject: [PATCH 400/463] AOSCOS: staging: sb105x: add missing function
  prototypes
 
 A few functions in drivers/staging/sb105x/sb_ser_core.h were missing

--- a/runtime-kernel/linux-kernel/autobuild/patches/0401-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0401-AOSCOS-staging-sb105x-adapt-to-tty_struct-changes.patch
@@ -1,7 +1,7 @@
 From 4934b1fb503d28396a8aa8abb0e844e57377df31 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:44:52 +0800
-Subject: [PATCH 401/450] AOSCOS: staging: sb105x: adapt to tty_struct changes
+Subject: [PATCH 401/463] AOSCOS: staging: sb105x: adapt to tty_struct changes
 
 Per commit 6e94dbc7a4e4 ("tty: cumulate and document tty_struct::flow*
 members"), struct members `stopped' and `tco_stopped' were grouped under

--- a/runtime-kernel/linux-kernel/autobuild/patches/0402-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0402-AOSCOS-staging-sb105x-rename-state-to-__state-in-tas.patch
@@ -1,7 +1,7 @@
 From f5fa375aec5755e3636e03290573ca181f70aa1e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:52:57 +0800
-Subject: [PATCH 402/450] AOSCOS: staging: sb105x: rename state to __state in
+Subject: [PATCH 402/463] AOSCOS: staging: sb105x: rename state to __state in
  task_struct
 
 Per commit 2f064a59a11f ("sched: Change task_struct::state"), the member

--- a/runtime-kernel/linux-kernel/autobuild/patches/0403-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0403-AOSCOS-staging-sb105x-replace-deprecated-strlcpy-wit.patch
@@ -1,7 +1,7 @@
 From 27f4263e6eeea99f0ae99e1815a6eeacfa2ac6fb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 14:58:57 +0800
-Subject: [PATCH 403/450] AOSCOS: staging: sb105x: replace deprecated strlcpy()
+Subject: [PATCH 403/463] AOSCOS: staging: sb105x: replace deprecated strlcpy()
  with strscpy()
 
 The string function strlcpy() was removed in commit d26270061ae6 ("string:

--- a/runtime-kernel/linux-kernel/autobuild/patches/0404-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0404-AOSCOS-staging-sb105x-replace-alloc_tty_driver-with-.patch
@@ -1,7 +1,7 @@
 From 27e9366592f97e748c587a8d92e426425edf7866 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:21:26 +0800
-Subject: [PATCH 404/450] AOSCOS: staging: sb105x: replace alloc_tty_driver()
+Subject: [PATCH 404/463] AOSCOS: staging: sb105x: replace alloc_tty_driver()
  with tty_alloc_driver()
 
 Per commit 39b7b42be4a8 ("tty: stop using alloc_tty_driver"), all

--- a/runtime-kernel/linux-kernel/autobuild/patches/0405-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0405-AOSCOS-staging-sb105x-replace-put_tty_driver-with-tt.patch
@@ -1,7 +1,7 @@
 From 8d16f18b156e55b946eac322d9ddb8ccfbafde2b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:37:23 +0800
-Subject: [PATCH 405/450] AOSCOS: staging: sb105x: replace put_tty_driver()
+Subject: [PATCH 405/463] AOSCOS: staging: sb105x: replace put_tty_driver()
  with tty_driver_kref_put()
 
 Per commit 9f90a4ddef4e ("tty: drop put_tty_driver"), "put_tty_driver() is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0406-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0406-AOSCOS-MIPS-serial-drop-STD_FLAGS.patch
@@ -1,7 +1,7 @@
 From 67f1afe39738891f08d8e099a412ae59014350e7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 15:47:49 +0800
-Subject: [PATCH 406/450] AOSCOS: MIPS: serial: drop STD_FLAGS
+Subject: [PATCH 406/463] AOSCOS: MIPS: serial: drop STD_FLAGS
 
 Per commit b1d984cf7d6b ("crisv10: use flags from tty_port"), the flags
 defined in STD_FLAGS (ASYNC_BOOT_AUTOCONF | ASYNC_SKIP_TEST) were not

--- a/runtime-kernel/linux-kernel/autobuild/patches/0407-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0407-AOSCOS-staging-sb105x-drop-upstream-removed-STD_COM_.patch
@@ -1,7 +1,7 @@
 From 7aaa24699ca7eeede21bbbd72aeae0bb33b0f5af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:02:01 +0800
-Subject: [PATCH 407/450] AOSCOS: staging: sb105x: drop upstream-removed
+Subject: [PATCH 407/463] AOSCOS: staging: sb105x: drop upstream-removed
  STD_COM_FLAGS
 
 Per commit 5691e03593cb ("tty: frv, remove unused serial macros"), the

--- a/runtime-kernel/linux-kernel/autobuild/patches/0408-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0408-AOSCOS-staging-sb105x-drop-TTY_DRIVER_MAGIC-assignme.patch
@@ -1,7 +1,7 @@
 From 1b8d74eb7c9f3f44d8b52500eab55a784ceec2c2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:19:05 +0800
-Subject: [PATCH 408/450] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
+Subject: [PATCH 408/463] AOSCOS: staging: sb105x: drop TTY_DRIVER_MAGIC
  assignment
 
 Per commit 5052df99d3bc ("tty: remove TTY_DRIVER_MAGIC"), the magic number

--- a/runtime-kernel/linux-kernel/autobuild/patches/0409-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0409-AOSCOS-staging-sb105x-convert-old-ktermios-to-a-cons.patch
@@ -1,7 +1,7 @@
 From e9093761f93447b341a622cc7b3c9f920e1d1ab4 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 16:58:16 +0800
-Subject: [PATCH 409/450] AOSCOS: staging: sb105x: convert old ktermios to a
+Subject: [PATCH 409/463] AOSCOS: staging: sb105x: convert old ktermios to a
  const
 
 Per commit a8c11c152034 ("tty: Make ->set_termios() old ktermios const"),

--- a/runtime-kernel/linux-kernel/autobuild/patches/0410-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0410-AOSCOS-staging-sb105x-revise-type-of-mp_write-as-ssi.patch
@@ -1,7 +1,7 @@
 From 8af6767b220dc42595f19dc54ce14a020ebadaef Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:16:44 +0800
-Subject: [PATCH 410/450] AOSCOS: staging: sb105x: revise type of mp_write() as
+Subject: [PATCH 410/463] AOSCOS: staging: sb105x: revise type of mp_write() as
  ssize_t
 
 Per commit 95713967ba52 ("tty: make tty_operations::write()'s count

--- a/runtime-kernel/linux-kernel/autobuild/patches/0411-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0411-AOSCOS-staging-sb105x-revise-type-of-mp_write_room-a.patch
@@ -1,7 +1,7 @@
 From bb860b7cea7581c75ddb66c9018af05e66613772 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:20:33 +0800
-Subject: [PATCH 411/450] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 411/463] AOSCOS: staging: sb105x: revise type of
  mp_write_room() as unsigned int
 
 Per commit 03b3b1a2405c ("tty: make tty_operations::write_room return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0412-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0412-AOSCOS-staging-sb105x-revise-type-of-mp_chars_in_buf.patch
@@ -1,7 +1,7 @@
 From 6067846543aa885ca18ab51b2201f9880a1137ae Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:22:27 +0800
-Subject: [PATCH 412/450] AOSCOS: staging: sb105x: revise type of
+Subject: [PATCH 412/463] AOSCOS: staging: sb105x: revise type of
  mp_chars_in_buffer() as unsigned int
 
 Per commit fff4ef17a940 ("tty: make tty_operations::chars_in_buffer return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0413-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0413-AOSCOS-staging-sb105x-revise-type-of-second-argument.patch
@@ -1,7 +1,7 @@
 From 7c004062efe85b0c9038aa21bf86a7b496b7ce4b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 17:25:55 +0800
-Subject: [PATCH 413/450] AOSCOS: staging: sb105x: revise type of second
+Subject: [PATCH 413/463] AOSCOS: staging: sb105x: revise type of second
  argument of mp_send_xchar() as u8
 
 Per commit 3a00da027946 ("tty: make tty_operations::send_xchar accept u8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0414-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0414-AOSCOS-parport-Add-support-for-the-WCH384-4S-1P-mult.patch
@@ -1,7 +1,7 @@
 From 1ff80710c680060913a8254e135fd882f01f46d9 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 23 Jun 2018 14:14:24 +0800
-Subject: [PATCH 414/450] AOSCOS: parport: Add support for the WCH384 4S/1P
+Subject: [PATCH 414/463] AOSCOS: parport: Add support for the WCH384 4S/1P
  multi-IO card
 
 WCH384 4S/1P is a PCI-E card with 1 LPT and 4 DB9 COM ports detected as

--- a/runtime-kernel/linux-kernel/autobuild/patches/0415-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0415-AOSCOS-8250_pci-Add-a-new-PLX9050-serial-port-card-s.patch
@@ -1,7 +1,7 @@
 From 569e49c9a7ef665059e00425deac8eb84605b738 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sun, 28 May 2017 09:29:33 +0800
-Subject: [PATCH 415/450] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
+Subject: [PATCH 415/463] AOSCOS: 8250_pci: Add a new PLX9050 serial port card
  support
 
 [Mingcong Bai: Resolved merge conflicts in

--- a/runtime-kernel/linux-kernel/autobuild/patches/0416-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0416-AOSCOS-HID-Add-some-usb-ids-ILITEK-touch-screen-driv.patch
@@ -1,7 +1,7 @@
 From 08c87d7226225e8ea15ac56df7a5782d963c1a3d Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Tue, 18 Jul 2017 16:41:48 +0800
-Subject: [PATCH 416/450] AOSCOS: HID: Add some usb-ids ILITEK touch screen
+Subject: [PATCH 416/463] AOSCOS: HID: Add some usb-ids ILITEK touch screen
  driver
 
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0417-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0417-AOSCOS-USB-OHCI-Fix-ohci_resume-for-hibernation.patch
@@ -1,7 +1,7 @@
 From bec0457d04dff113ecb228d854d1c942c0e94aa2 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Sat, 24 Nov 2018 15:28:13 +0800
-Subject: [PATCH 417/450] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
+Subject: [PATCH 417/463] AOSCOS: USB: OHCI: Fix ohci_resume() for hibernation
 
 During hibernation restore, some OHCI controllers (such as in AMD RS780
 and Loongson LS7A) may generate RHSC interrupt. Once RHSC interrupt

--- a/runtime-kernel/linux-kernel/autobuild/patches/0418-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0418-AOSCOS-Loongson-Add-LS7A-pwm-driver-support.patch
@@ -1,7 +1,7 @@
 From 81b72a84d557b8f56b57485f5c61bb75577b90a7 Mon Sep 17 00:00:00 2001
 From: Huacai Chen <chenhc@lemote.com>
 Date: Mon, 16 Apr 2018 15:13:09 +0800
-Subject: [PATCH 418/450] AOSCOS: Loongson: Add LS7A pwm driver support
+Subject: [PATCH 418/463] AOSCOS: Loongson: Add LS7A pwm driver support
 
 Signed-off-by: Ce Sun <sunc@lemote.com>
 Signed-off-by: Huacai Chen <chenhc@lemote.com>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0419-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0419-AOSCOS-MIPS-ls7a_fan-use-register-addresses-in-loong.patch
@@ -1,7 +1,7 @@
 From a64ca7a2b25094633ab52f5b5a766410cede5ab9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 11 Dec 2024 23:29:38 +0800
-Subject: [PATCH 419/450] AOSCOS: MIPS: ls7a_fan: use register addresses in
+Subject: [PATCH 419/463] AOSCOS: MIPS: ls7a_fan: use register addresses in
  loongson.h
 
 Original driver code expects register definition in loongson-pch.h (where

--- a/runtime-kernel/linux-kernel/autobuild/patches/0420-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0420-AOSCOS-MIPS-math-emu-replace-CPU_LOONGSON3-condition.patch
@@ -1,7 +1,7 @@
 From 45022c79b966f38423acdb8abb0e32a864f68689 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 00:29:07 +0800
-Subject: [PATCH 420/450] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
+Subject: [PATCH 420/463] AOSCOS: MIPS: math-emu: replace CPU_LOONGSON3
  conditions with CPU_LOONGSON64
 
 Per commit 30ad29bb4888 ("MIPS: Loongson: Naming style cleanup and

--- a/runtime-kernel/linux-kernel/autobuild/patches/0421-AOSCOS-Optimize-clear_page.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0421-AOSCOS-Optimize-clear_page.patch
@@ -1,7 +1,7 @@
 From 8339ff3eb0f290547d17a8eba22365baf95a5fc2 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 421/450] AOSCOS: Optimize clear_page
+Subject: [PATCH 421/463] AOSCOS: Optimize clear_page
 
 Signed-off-by: chenj <chenj@lemote.com>
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0422-AOSCOS-memset-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0422-AOSCOS-memset-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From ac4f370af4d6e432a84b5c80ad641cee30cad5a2 Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 422/450] AOSCOS: memset optimization for loongson-3
+Subject: [PATCH 422/463] AOSCOS: memset optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0423-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0423-AOSCOS-MIPS-loongson3-memset-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From 8b4fc655d96a4e91da5db356a0946cc365046cc9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 01:27:08 +0800
-Subject: [PATCH 423/450] AOSCOS: MIPS: loongson3-memset: replace
+Subject: [PATCH 423/463] AOSCOS: MIPS: loongson3-memset: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0424-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0424-AOSCOS-MIPS-loongson3-memset-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From 9a1083d7ac5302b5e5eb43f546f622cf2d78f86c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:30:55 +0800
-Subject: [PATCH 424/450] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
+Subject: [PATCH 424/463] AOSCOS: MIPS: loongson3-memset: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0425-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0425-AOSCOS-MIPS-lib-exclude-generic-memset.o-if-CPU_LOON.patch
@@ -1,7 +1,7 @@
 From 8191ea6c936c12c574082ada889a22d913f2365c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 13:33:50 +0800
-Subject: [PATCH 425/450] AOSCOS: MIPS: lib: exclude generic memset.o if
+Subject: [PATCH 425/463] AOSCOS: MIPS: lib: exclude generic memset.o if
  CPU_LOONGSON64 is set
 
 In "AOSCOS: memset optimization for loongson-3", a Loongson-3-specific

--- a/runtime-kernel/linux-kernel/autobuild/patches/0426-AOSCOS-memcpy-optimization-for-loongson-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0426-AOSCOS-memcpy-optimization-for-loongson-3.patch
@@ -1,7 +1,7 @@
 From 283ca376f33418c90b1d3a7517ba98295d385d9b Mon Sep 17 00:00:00 2001
 From: chenj <chenj@lemote.com>
 Date: Thu, 1 Dec 2016 09:51:35 +0800
-Subject: [PATCH 426/450] AOSCOS: memcpy optimization for loongson-3
+Subject: [PATCH 426/463] AOSCOS: memcpy optimization for loongson-3
 
 [Mingcong Bai: Resolved a minor merge conflict in
 arch/mips/loongson64/Makefile.]

--- a/runtime-kernel/linux-kernel/autobuild/patches/0427-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0427-AOSCOS-MIPS-loongson3-memcpy-use-PTR_WD-to-fix-build.patch
@@ -1,7 +1,7 @@
 From ba80f41cc1d434ac03b6cc77ad7ecaf6beed44ed Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:03:01 +0800
-Subject: [PATCH 427/450] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
+Subject: [PATCH 427/463] AOSCOS: MIPS: loongson3-memcpy: use PTR_WD to fix
  build
 
 Per commit fa62f39dc7e2 ("MIPS: Fix build error due to PTR used in more

--- a/runtime-kernel/linux-kernel/autobuild/patches/0428-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0428-AOSCOS-MIPS-loongson3-memcpy-replace-asm-export.h-wi.patch
@@ -1,7 +1,7 @@
 From dd698ffc265435205fcbd6a9fc6022eb0c940e73 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:04:20 +0800
-Subject: [PATCH 428/450] AOSCOS: MIPS: loongson3-memcpy: replace
+Subject: [PATCH 428/463] AOSCOS: MIPS: loongson3-memcpy: replace
  <asm/export.h> with <linux/export.h>
 
 Per commit 9259e15b3f27 ("mips: replace #include <asm/export.h> with

--- a/runtime-kernel/linux-kernel/autobuild/patches/0429-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0429-AOSCOS-MIPS-mark-CPU_LOONGSON64-as-HAVE_PLAT_MEMCPY.patch
@@ -1,7 +1,7 @@
 From 534bedcf5205e5b5acd16d32c46749aa9325b19f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:09:34 +0800
-Subject: [PATCH 429/450] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
+Subject: [PATCH 429/463] AOSCOS: MIPS: mark CPU_LOONGSON64 as HAVE_PLAT_MEMCPY
 
 loongson3-memcpy is a platform-specific memcpy implementation, add
 HAVE_PLAT_MEMCPY under CPU_LOONGSON64.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0430-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0430-AOSCOS-MIPS-loongson3-memcpy-adapt-to-RAW_COPY_USER.patch
@@ -1,7 +1,7 @@
 From 1096ed4f69c475eb210b61e4b3258738aae0baa7 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:10:57 +0800
-Subject: [PATCH 430/450] AOSCOS: MIPS: loongson3-memcpy: adapt to
+Subject: [PATCH 430/463] AOSCOS: MIPS: loongson3-memcpy: adapt to
  RAW_COPY_USER
 
 Since commit 2260ea86c0e7 ("mips: switch to RAW_COPY_USER"), it is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0431-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0431-AOSCOS-spi-spi-loongson-allow-building-on-MACH_LOONG.patch
@@ -1,7 +1,7 @@
 From 7730adcc8ffd44a1942e4eb02e37de776d13cea9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 14:45:22 +0800
-Subject: [PATCH 431/450] AOSCOS: spi: spi-loongson: allow building on
+Subject: [PATCH 431/463] AOSCOS: spi: spi-loongson: allow building on
  MACH_LOONGSON32/64
 
 LS2K/LS7A chipsets are also found on some MIPS-based Loongson hardware,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0432-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0432-AOSCOS-MIPS-select-ARCH_FORCE_MAX_ORDER-11-if-NUMA_B.patch
@@ -1,7 +1,7 @@
 From 5ede5e743d072730b781ed074fbbb7a6e4901d7f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:05:51 +0800
-Subject: [PATCH 432/450] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
+Subject: [PATCH 432/463] AOSCOS: MIPS: select ARCH_FORCE_MAX_ORDER >= 11 if
  NUMA_BALANCING is selected
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0433-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0433-AOSCOS-init-make-NUMA_BALANCING-depend-on-TRANSPAREN.patch
@@ -1,7 +1,7 @@
 From 54b0566c1ec25d9e2a26aadea9458485e8a14571 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 12 Dec 2024 16:07:57 +0800
-Subject: [PATCH 433/450] AOSCOS: init: make NUMA_BALANCING depend on
+Subject: [PATCH 433/463] AOSCOS: init: make NUMA_BALANCING depend on
  TRANSPARENT_HUGEPAGE if MIPS
 
 This should suppress an assertion failure during build. Further

--- a/runtime-kernel/linux-kernel/autobuild/patches/0434-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0434-AOSCOS-audit-remove-duplicate-functions-for-MIPS.patch
@@ -1,7 +1,7 @@
 From c25602007ca19e26dc6f2bcb3b5971beea84a629 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sun, 15 Dec 2024 11:21:54 +0800
-Subject: [PATCH 434/450] AOSCOS: audit: remove duplicate functions for MIPS
+Subject: [PATCH 434/463] AOSCOS: audit: remove duplicate functions for MIPS
 
 audit_classify_arch() and audit_classify_syscall() are already defined
 in arch/mips/kernel/audit-native.c, adding preprocessor directives to

--- a/runtime-kernel/linux-kernel/autobuild/patches/0435-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0435-AOSCOS-MIPS-remove-duplicate-defines-of-NR_syscalls.patch
@@ -1,7 +1,7 @@
 From ab988cf916b09f8060009d94d306a9c59568e3c7 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:38:26 +0800
-Subject: [PATCH 435/450] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
+Subject: [PATCH 435/463] AOSCOS: MIPS: remove duplicate defines of NR_syscalls
 
 In "FROMLIST: MIPS: Add syscall auditing support", some duplicate
 defines of NR_syscalls were added to arch/mips/include/asm/unistd.h,

--- a/runtime-kernel/linux-kernel/autobuild/patches/0436-AOSCOS-MIPS-add-copyright-headers-back.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0436-AOSCOS-MIPS-add-copyright-headers-back.patch
@@ -1,7 +1,7 @@
 From 44a37900d02c36ae832efbad6be7ea279bc63e0a Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 17 Dec 2024 05:45:49 +0800
-Subject: [PATCH 436/450] AOSCOS: MIPS: add copyright headers back
+Subject: [PATCH 436/463] AOSCOS: MIPS: add copyright headers back
 
 In "FROMLIST: MIPS: Add syscall auditing support", a copyright header
 was removed from arch/mips/include/uapi/asm/unistd.h with no proper

--- a/runtime-kernel/linux-kernel/autobuild/patches/0437-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0437-AOSCOS-mips-crash-wrap-more-crash-dumping-code-into-.patch
@@ -1,7 +1,7 @@
 From 6aa8bc827cf97bcc288e0504d8225220fc8120ca Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Mon, 23 Dec 2024 19:06:09 +0800
-Subject: [PATCH 437/450] AOSCOS: mips, crash: wrap more crash dumping code
+Subject: [PATCH 437/463] AOSCOS: mips, crash: wrap more crash dumping code
  into crash related ifdefs
 
 In

--- a/runtime-kernel/linux-kernel/autobuild/patches/0438-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0438-AOSCOS-MIPS-Loongson-3-build-platform-device-drivers.patch
@@ -1,7 +1,7 @@
 From 2678e35934c65af7a8e951fb3890fa52e4b02f60 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Sat, 25 Jan 2025 04:22:54 +0800
-Subject: [PATCH 438/450] AOSCOS: MIPS: Loongson 3: build platform device
+Subject: [PATCH 438/463] AOSCOS: MIPS: Loongson 3: build platform device
  drivers with CPU_HWMON only
 
 Suggested-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0439-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0439-AOSCOS-mvsas-Rename-.device_configure-into-.sdev_con.patch
@@ -1,7 +1,7 @@
 From ca6851a1db12ccb1b2dba3dcba38c7a34d48b6ff Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 12:31:07 +0800
-Subject: [PATCH 439/450] AOSCOS: mvsas: Rename .device_configure() into
+Subject: [PATCH 439/463] AOSCOS: mvsas: Rename .device_configure() into
  .sdev_configure()
 
 Following upstream name changes; Also move the struct domain_device

--- a/runtime-kernel/linux-kernel/autobuild/patches/0440-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0440-AOSCOS-serial-8250_pci-Move-WCH-CH384-4S1P-card-ID-i.patch
@@ -1,7 +1,7 @@
 From 9e9146e26cd130ef32ff55917d6d3518710ab20e Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 4 Feb 2025 14:14:35 +0800
-Subject: [PATCH 440/450] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
+Subject: [PATCH 440/463] AOSCOS: serial: 8250_pci: Move WCH CH384 4S1P card ID
  into pci_ids.h
 
 Fix incomplete port of the previous patch mentioned below.

--- a/runtime-kernel/linux-kernel/autobuild/patches/0441-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0441-AOSCOS-sb105x-Adapt-for-timer-related-function-renam.patch
@@ -1,7 +1,7 @@
 From e76dbb9e6f9ee4045d4a6ba06feaa90b0900ac6c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 13 Jul 2025 22:05:56 +0800
-Subject: [PATCH 441/450] AOSCOS: sb105x: Adapt for timer related function
+Subject: [PATCH 441/463] AOSCOS: sb105x: Adapt for timer related function
  renames
 
 The upstream has renamed the timer related functions to have a strict

--- a/runtime-kernel/linux-kernel/autobuild/patches/0442-MARKER-AOSCOS-End-of-Lemote-patches.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0442-MARKER-AOSCOS-End-of-Lemote-patches.patch
@@ -1,7 +1,7 @@
 From 489e29c9c74d53caeaddc55a69c40696e8fd3fb5 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Tue, 25 Feb 2025 17:45:08 +0800
-Subject: [PATCH 442/450] MARKER: AOSCOS: End of Lemote patches
+Subject: [PATCH 442/463] MARKER: AOSCOS: End of Lemote patches
 
 Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>

--- a/runtime-kernel/linux-kernel/autobuild/patches/0443-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0443-AOSCOS-ACPI-scan-Add-pwm_lookup_entry-for-PWM3-on-LS.patch
@@ -1,7 +1,7 @@
 From f493aea6884ba2368395d75d686d5f78ac8d6868 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 16 Aug 2025 09:50:44 +0800
-Subject: [PATCH 443/450] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
+Subject: [PATCH 443/463] AOSCOS: ACPI / scan: Add pwm_lookup_entry for PWM3 on
  LS7A
 
 On LoongArch laptops using LG110 GPU for display, LS7A PWM3 is used for

--- a/runtime-kernel/linux-kernel/autobuild/patches/0444-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0444-AOSCOS-gpio-aaeon-use-new-GPIO-line-value-setter-cal.patch
@@ -1,7 +1,7 @@
 From 0bc589e4687d1088bf6b86f6f8b365ea11b140b9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:32:58 +0800
-Subject: [PATCH 444/450] AOSCOS: gpio: aaeon: use new GPIO line value setter
+Subject: [PATCH 444/463] AOSCOS: gpio: aaeon: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0445-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0445-AOSCOS-gpio-nct6102-use-new-GPIO-line-value-setter-c.patch
@@ -1,7 +1,7 @@
 From 96171a9d75a4ccac5bc529f5f433ba65799c0b0b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 30 Aug 2025 22:36:16 +0800
-Subject: [PATCH 445/450] AOSCOS: gpio: nct6102: use new GPIO line value setter
+Subject: [PATCH 445/463] AOSCOS: gpio: nct6102: use new GPIO line value setter
  callbacks
 
 struct gpio_chip now has callbacks for setting line values that return

--- a/runtime-kernel/linux-kernel/autobuild/patches/0446-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0446-AOSCOS-scsi-dc395x-correctly-discard-the-return-valu.patch
@@ -1,7 +1,7 @@
 From ff2493fa584d247df75026d6842f5f60027a42eb Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Wed, 10 Sep 2025 23:21:26 +0800
-Subject: [PATCH 446/450] AOSCOS: scsi: dc395x: correctly discard the return
+Subject: [PATCH 446/463] AOSCOS: scsi: dc395x: correctly discard the return
  value in certain reads
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/runtime-kernel/linux-kernel/autobuild/patches/0447-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0447-AOSCOS-crypto-padlock-sha-return-ENODEV-on-Zhaoxin-K.patch
@@ -1,7 +1,7 @@
 From 2eab5747c68dff5b3f7e7f70740887b8eda51abe Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Wed, 12 Nov 2025 11:41:05 +0800
-Subject: [PATCH 447/450] AOSCOS: crypto: padlock-sha: return -ENODEV on
+Subject: [PATCH 447/463] AOSCOS: crypto: padlock-sha: return -ENODEV on
  Zhaoxin KaiXian KX-6000/6000G
 
 On Zhaoxin KaiXian KX-6000/6000G series of processors, this crypto module

--- a/runtime-kernel/linux-kernel/autobuild/patches/0448-AOSCOS-Revert-FROMLIST-rust-generate-a-fatal-error-i.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0448-AOSCOS-Revert-FROMLIST-rust-generate-a-fatal-error-i.patch
@@ -1,7 +1,7 @@
 From 4ce774e437c7353f2706c82478f3a69aa8c4d13d Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 23 Dec 2025 20:08:10 +0800
-Subject: [PATCH 448/450] AOSCOS: Revert "FROMLIST: rust: generate a fatal
+Subject: [PATCH 448/463] AOSCOS: Revert "FROMLIST: rust: generate a fatal
  error if BINDGEN_TARGET is undefined"
 
 This reverts "FROMLIST: rust: generate a fatal error if BINDGEN_TARGET is

--- a/runtime-kernel/linux-kernel/autobuild/patches/0449-AOSCOS-MIPS-Loongson-Salvage-the-full-count-from-the.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0449-AOSCOS-MIPS-Loongson-Salvage-the-full-count-from-the.patch
@@ -1,7 +1,7 @@
 From 26de7f5531c7eb3b2eedcaa71927f3fd1f9f75bf Mon Sep 17 00:00:00 2001
 From: Rong Zhang <i@rong.moe>
 Date: Sun, 25 Jan 2026 00:54:35 +0800
-Subject: [PATCH 449/450] AOSCOS: MIPS: Loongson: Salvage the full count from
+Subject: [PATCH 449/463] AOSCOS: MIPS: Loongson: Salvage the full count from
  the constant timer
 
 HWR $30 (Loongson64 constant timer) is 64 bits wide. However, vDSO uses

--- a/runtime-kernel/linux-kernel/autobuild/patches/0450-FROMLIST-drm-panel-orientation-quirks-Add-AOKZOE-A1-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0450-FROMLIST-drm-panel-orientation-quirks-Add-AOKZOE-A1-.patch
@@ -1,0 +1,40 @@
+From 7aaf9ead8a5a6696c268ed6519802a7568bf361f Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:34 +0100
+Subject: [PATCH 450/463] FROMLIST: drm: panel-orientation-quirks: Add AOKZOE
+ A1 Pro
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The AOKZOE A1 Pro has a portrait 16:10 panel, add a quirk for it.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 3a218fb592ce..736280302f76 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -179,6 +179,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Win600"),
+ 		},
+ 		.driver_data = (void *)&lcd720x1280_rightside_up,
++	}, {	/* AOKZOE A1 Pro */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AOKZOE"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "AOKZOE A1 Pro"),
++		},
++		.driver_data = (void *)&lcd1200x1920_leftside_up,
+ 	}, {	/* Asus T100HA */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0451-FROMLIST-drm-panel-orientation-quirks-Add-additional.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0451-FROMLIST-drm-panel-orientation-quirks-Add-additional.patch
@@ -1,0 +1,41 @@
+From c7107272b85600bc878e7e4df0ba44332b0b92d8 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:35 +0100
+Subject: [PATCH 451/463] FROMLIST: drm: panel-orientation-quirks: Add
+ additional ID for Ayaneo 2021
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Ayaneo 2021 has an alternate variant that skips AYA in the
+beginning. Add that as well.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 736280302f76..23e736469aab 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -215,6 +215,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "AYA NEO 2021"),
+ 		},
+ 		.driver_data = (void *)&lcd800x1280_rightside_up,
++	}, {	/* AYA NEO 2021 */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AYANEO"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "NEO 2021"),
++		},
++		.driver_data = (void *)&lcd800x1280_rightside_up,
+ 	}, {	/* AYA NEO AIR */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AYANEO"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0452-FROMLIST-drm-panel-orientation-quirks-Add-Ayaneo-3.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0452-FROMLIST-drm-panel-orientation-quirks-Add-Ayaneo-3.patch
@@ -1,0 +1,45 @@
+From bb00672eeed9a457d092dc211b7c5531e36897a6 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:36 +0100
+Subject: [PATCH 452/463] FROMLIST: drm: panel-orientation-quirks: Add Ayaneo 3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Ayaneo 3 comes with two panels, an OLED right side up 1080p panel
+and an IPS landscape 1080p panel. However, both have the same DMI data.
+This quirk adds support for the portrait OLED panel.
+
+As the landscape panel is 1920x1080 and the right side up panel is
+1080x1920, the width and height arguments are used to differentiate
+the panels.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 23e736469aab..f745db95c394 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -209,6 +209,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_MATCH(DMI_PRODUCT_NAME, "AYANEO 2"),
+ 		},
+ 		.driver_data = (void *)&lcd1200x1920_rightside_up,
++	}, {	/* AYANEO 3 */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AYANEO"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "AYANEO 3"),
++		},
++		.driver_data = (void *)&lcd1080x1920_rightside_up,
+ 	}, {	/* AYA NEO 2021 */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AYADEVICE"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0453-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0453-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
@@ -1,0 +1,60 @@
+From 501efd9a8ef55279d0fc002909a357e7b95e844c Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:37 +0100
+Subject: [PATCH 453/463] FROMLIST: drm: panel-orientation-quirks: Add
+ OneXPlayer X1 variants
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The OneXPlayer X1 series features a 2k 10.95 display with a portrait
+orientation. Add quirks to set the panel orientation to portrait mode
+to the Intel, AMD, and EVA-02 variants.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ .../gpu/drm/drm_panel_orientation_quirks.c    | 24 +++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index f745db95c394..2efffe962460 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -504,6 +504,30 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONE XPLAYER"),
+ 		},
+ 		.driver_data = (void *)&lcd1200x1920_leftside_up,
++	}, {	/* OneXPlayer X1 AMD */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1 A"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1 Intel */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1 i"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1 AMD Strix Point */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1Pro"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1Pro EVA variant with Intel */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1Pro EVA-02"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
+ 	}, {	/* OrangePi Neo */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "OrangePi"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0454-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0454-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
@@ -1,0 +1,48 @@
+From 2cb263157c7b2bb4e584e3c1a890dd42ec54d26a Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:38 +0100
+Subject: [PATCH 454/463] FROMLIST: drm: panel-orientation-quirks: Add
+ OneXPlayer X1 Mini variants
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The OneXPlayer X1 mini features a 2k 8.8 display with a portrait
+orientation. The Pro is a CPU refresh. Add quirks to set the panel
+orientation to portrait mode. There is no Intel variant.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 2efffe962460..1ee66e4db0e9 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -516,6 +516,18 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1 i"),
+ 		},
+ 		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1 mini (AMD) */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1 mini"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1 mini pro (AMD Strix Point) */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1Mini Pro"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
+ 	}, {	/* OneXPlayer X1 AMD Strix Point */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0455-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0455-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
@@ -1,0 +1,55 @@
+From ae22a7cfbc6af3dc73d92ca4cd2c21d51033cdc1 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:39 +0100
+Subject: [PATCH 455/463] FROMLIST: drm: panel-orientation-quirks: Add
+ OneXPlayer F1 variants
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The OneXPlayer F1Pro has a 144hz 1920x1080 portrait OLED panel.
+Add a quirk to correct the panel portrait orientation. In addition,
+it comes with a red limited edition variant in the Chinese market,
+so add that as well. Then, add the 8840U non-pro variant as well.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 1ee66e4db0e9..af45d79622b5 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -540,6 +540,24 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1Pro EVA-02"),
+ 		},
+ 		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer OneXFly F1 Pro (OLED) LE Red variant */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER F1 EVA-02"),
++		},
++		.driver_data = (void *)&lcd1080x1920_leftside_up,
++	}, {	/* OneXPlayer OneXFly F1 Pro (OLED) Hawk Point */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER F1 OLED"),
++		},
++		.driver_data = (void *)&lcd1080x1920_leftside_up,
++	}, {	/* OneXPlayer OneXFly F1 Pro (OLED) Strix Point */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER F1Pro"),
++		},
++		.driver_data = (void *)&lcd1080x1920_leftside_up,
+ 	}, {	/* OrangePi Neo */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "OrangePi"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0456-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0456-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
@@ -1,0 +1,47 @@
+From c815c3c31baa50a61b8d53ce39106ffc9d17968d Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:40 +0100
+Subject: [PATCH 456/463] FROMLIST: drm: panel-orientation-quirks: Add
+ OneXPlayer G1 variants
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add quirks for the new clamshell device OneXPlayer G1 for both AMD
+and Intel. The device has a 1600x2560p 144hz LCD panel.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index af45d79622b5..675a0aeb750e 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -558,6 +558,18 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER F1Pro"),
+ 		},
+ 		.driver_data = (void *)&lcd1080x1920_leftside_up,
++	}, {	/* OneXPlayer OneXFly G1 AMD */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER G1 A"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer OneXFly G1 Intel */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER G1 i"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
+ 	}, {	/* OrangePi Neo */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "OrangePi"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0457-FROMLIST-drm-panel-orientation-quirks-Add-GPD-Win-Ma.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0457-FROMLIST-drm-panel-orientation-quirks-Add-GPD-Win-Ma.patch
@@ -1,0 +1,40 @@
+From 42eb05d6a5661904484d61fd6a5a06df51b1bedd Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:41 +0100
+Subject: [PATCH 457/463] FROMLIST: drm: panel-orientation-quirks: Add GPD Win
+ Max (2021)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Right side up, DSI-1, 800x1280 screen.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 675a0aeb750e..21ae8a811e2b 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -327,6 +327,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "G1619-01"),
+ 		},
+ 		.driver_data = (void *)&lcd800x1280_rightside_up,
++	}, {	/* GPD Win Max (2021) */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "GPD"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "G1619-03"),
++		},
++		.driver_data = (void *)&lcd800x1280_rightside_up,
+ 	}, {	/*
+ 		 * GPD Pocket, note that the DMI data is less generic then
+ 		 * it seems, devices with a board-vendor of "AMI Corporation"
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0458-FROMLIST-drm-panel-orientation-quirks-Add-GPD-Pocket.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0458-FROMLIST-drm-panel-orientation-quirks-Add-GPD-Pocket.patch
@@ -1,0 +1,41 @@
+From 6461bbcbec4215b0c3278dc62be6e8cf1ce31550 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:42 +0100
+Subject: [PATCH 458/463] FROMLIST: drm: panel-orientation-quirks: Add GPD
+ Pocket 4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The GPD Pocket 4 is a mini laptop replacement with a portrait
+2k panel. Add a quirk for it.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 21ae8a811e2b..8475811df890 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -388,6 +388,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "G1617-01")
+ 		},
+ 		.driver_data = (void *)&lcd1080x1920_rightside_up,
++	}, {	/* GPD Pocket 4 */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "GPD"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "G1628-04"),
++		},
++		.driver_data = (void *)&lcd1600x2560_rightside_up,
+ 	}, {	/* I.T.Works TW891 */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "To be filled by O.E.M."),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0459-FROMLIST-drm-panel-orientation-quirks-Add-Zeenix-Lit.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0459-FROMLIST-drm-panel-orientation-quirks-Add-Zeenix-Lit.patch
@@ -1,0 +1,47 @@
+From 6a46a3768c174aa083b38231b5d29ecb09dc3780 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:43 +0100
+Subject: [PATCH 459/463] FROMLIST: drm: panel-orientation-quirks: Add Zeenix
+ Lite and Pro
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add quirks for two Zeenix handhelds, the Lite and the Pro.
+They are identical to the Ayn Loki and the Ayn Loki Pro respectively.
+
+Reviewed-by: Philip Müller <philm@manjaro.org>
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 8475811df890..c055be8d8b25 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -594,6 +594,18 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Galaxy Book 10.6"),
+ 		},
+ 		.driver_data = (void *)&lcd1280x1920_rightside_up,
++	}, {    /* Tectoy Zeenix Lite */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Tectoy"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Zeenix Lite"),
++		},
++		.driver_data = (void *)&lcd1080x1920_leftside_up,
++	}, {    /* Tectoy Zeenix Pro */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Tectoy"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Zeenix Pro"),
++		},
++		.driver_data = (void *)&lcd1080x1920_leftside_up,
+ 	}, {	/* Valve Steam Deck (Jupiter) */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Valve"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0460-FROMLIST-drm-panel-orientation-quirks-add-SuiPlay0X1.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0460-FROMLIST-drm-panel-orientation-quirks-add-SuiPlay0X1.patch
@@ -1,0 +1,38 @@
+From db9574ec242740680e767c2d9133d31d9cd4c67e Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:44 +0100
+Subject: [PATCH 460/463] FROMLIST: drm: panel-orientation-quirks: add
+ SuiPlay0X1
+
+Very similar to the AYANEO 2S, the Mysten SuiPlay0X1 is a handheld
+gaming device with a 1200x1920 display that is mounted in a
+right-side-up orientation. Add a quirk for it.
+
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index c055be8d8b25..857fbc1ba4dc 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -491,6 +491,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		 DMI_MATCH(DMI_PRODUCT_VERSION, "Blade3-10A-001"),
+ 		},
+ 		.driver_data = (void *)&lcd1600x2560_rightside_up,
++	}, {	/* Mysten SuiPlay0X1 */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Mysten Labs, Inc."),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "SuiPlay0X1"),
++		},
++		.driver_data = (void *)&lcd1200x1920_rightside_up,
+ 	}, {	/* Nanote UMPC-01 */
+ 		.matches = {
+ 		 DMI_MATCH(DMI_SYS_VENDOR, "RWC CO.,LTD"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0461-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0461-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
@@ -1,0 +1,36 @@
+From 667f7f115ca071434e0472cab251d99077faac9a Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:45 +0100
+Subject: [PATCH 461/463] FROMLIST: drm: panel-orientation-quirks: Add
+ OneXPlayer X1z
+
+Different variant of the OneXPlayer X1 AMD edition with an 8840U.
+
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 857fbc1ba4dc..96c910d4524e 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -546,6 +546,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1Mini Pro"),
+ 		},
+ 		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1 AMD second variant */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1z"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
+ 	}, {	/* OneXPlayer X1 AMD Strix Point */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0462-FROMLIST-drm-panel-orientation-quirks-Add-AOKZOE-A2-.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0462-FROMLIST-drm-panel-orientation-quirks-Add-AOKZOE-A2-.patch
@@ -1,0 +1,36 @@
+From 283ea3ad5f020f9a76ecfb2f69e4ccf34710469c Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:46 +0100
+Subject: [PATCH 462/463] FROMLIST: drm: panel-orientation-quirks: Add AOKZOE
+ A2 Pro
+
+We are missing a quirk for this older device, so add it.
+
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 96c910d4524e..6de137b5e777 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -185,6 +185,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "AOKZOE A1 Pro"),
+ 		},
+ 		.driver_data = (void *)&lcd1200x1920_leftside_up,
++	}, {	/* AOKZOE A2 Pro */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AOKZOE"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "AOKZOE A2 Pro"),
++		},
++		.driver_data = (void *)&lcd1200x1920_leftside_up,
+ 	}, {	/* Asus T100HA */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/autobuild/patches/0463-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0463-FROMLIST-drm-panel-orientation-quirks-Add-OneXPlayer.patch
@@ -1,0 +1,36 @@
+From 79c99c8c5ef782ed14aa598b2caae98437773d54 Mon Sep 17 00:00:00 2001
+From: Antheas Kapenekakis <lkml@antheas.dev>
+Date: Mon, 16 Feb 2026 21:45:47 +0100
+Subject: [PATCH 463/463] FROMLIST: drm: panel-orientation-quirks: Add
+ OneXPlayer X1 Air
+
+Special edition of the X1 with a new Intel chipset.
+
+Signed-off-by: Antheas Kapenekakis <lkml@antheas.dev>
+
+Link: https://lore.kernel.org/all/20260216204547.293291-1-lkml@antheas.dev/
+Signed-off-by: CyberNeko.AI <cyberneko.ai@aosc.io>
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index 6de137b5e777..b1915c1f92da 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -546,6 +546,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1 mini"),
+ 		},
+ 		.driver_data = (void *)&lcd1600x2560_leftside_up,
++	}, {	/* OneXPlayer X1 Intel */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER X1Air"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
+ 	}, {	/* OneXPlayer X1 mini pro (AMD Strix Point) */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
+-- 
+2.52.0
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=6.18.16
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=2
+REL=3
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: add DRM panel orientation quirks for various handheld devices

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 6.18.16-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
