### PR TITLE
deno: update to 2.7.9

### DIFF
--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From 084161a50b4c171faf1add4e60f487c2fbda79f3 Mon Sep 17 00:00:00 2001
+From a06fec63128b2a23c471481dab4d271a8c7b9ef6 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 4 Mar 2026 20:16:58 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
@@ -9,23 +9,23 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index c7e80d3b9..9baed9a62 100644
+index 3b7c5bccc..d16844c88 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -11173,8 +11173,6 @@ dependencies = [
+@@ -11195,8 +11195,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "146.8.0"
+ version = "147.0.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "67519d234f7bc5a54a71f7fbc52258b0f3a7e9c11f365213d49016a59207ec10"
+-checksum = "a98a7a54a2cbb941924658340efeff052840ab2dcb925c34260142ba85310023"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index 4017762d8..894d8376b 100644
+index d1878f148..2865d7de0 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -602,3 +602,6 @@ opt-level = 3
+@@ -604,3 +604,6 @@ opt-level = 3
  opt-level = 3
  [profile.release.package.twox-hash]
  opt-level = 3

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-loong64-support.patch.loongarch64
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-loong64-support.patch.loongarch64
@@ -1,4 +1,4 @@
-From baf4d2c4e67af192c42e389aed1ff0863571be09 Mon Sep 17 00:00:00 2001
+From 68381ca9186fbafb8b6403055f26d2690d539365 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 20 Mar 2026 09:45:58 +0800
 Subject: [PATCH 2/2] AOSCOS: add loong64 support
@@ -10,10 +10,10 @@ Subject: [PATCH 2/2] AOSCOS: add loong64 support
  3 files changed, 46 insertions(+), 27 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 9baed9a62..6bf8fbd11 100644
+index d16844c88..9554f7faa 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1296,37 +1296,53 @@ dependencies = [
+@@ -1308,37 +1308,53 @@ dependencies = [
  
  [[package]]
  name = "cranelift"
@@ -75,7 +75,7 @@ index 9baed9a62..6bf8fbd11 100644
   "cranelift-bforest",
   "cranelift-bitset",
   "cranelift-codegen-meta",
-@@ -1335,7 +1351,7 @@ dependencies = [
+@@ -1347,7 +1363,7 @@ dependencies = [
   "cranelift-entity",
   "cranelift-isle",
   "gimli",
@@ -84,7 +84,7 @@ index 9baed9a62..6bf8fbd11 100644
   "log",
   "regalloc2",
   "rustc-hash 2.1.1",
-@@ -1346,42 +1362,43 @@ dependencies = [
+@@ -1358,42 +1374,43 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen-meta"
@@ -138,7 +138,7 @@ index 9baed9a62..6bf8fbd11 100644
  dependencies = [
   "cranelift-codegen",
   "log",
-@@ -1391,15 +1408,15 @@ dependencies = [
+@@ -1403,15 +1420,15 @@ dependencies = [
  
  [[package]]
  name = "cranelift-isle"
@@ -158,7 +158,7 @@ index 9baed9a62..6bf8fbd11 100644
  dependencies = [
   "anyhow",
   "cranelift-codegen",
-@@ -1408,9 +1425,9 @@ dependencies = [
+@@ -1420,9 +1437,9 @@ dependencies = [
  
  [[package]]
  name = "cranelift-native"
@@ -171,10 +171,10 @@ index 9baed9a62..6bf8fbd11 100644
   "cranelift-codegen",
   "libc",
 diff --git a/Cargo.toml b/Cargo.toml
-index 894d8376b..91ae52fe6 100644
+index 2865d7de0..a44a66cdd 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -420,8 +420,8 @@ x25519-dalek = "2.0.0"
+@@ -422,8 +422,8 @@ x25519-dalek = "2.0.0"
  x509-parser = "0.15.0"
  
  # ffi
@@ -186,7 +186,7 @@ index 894d8376b..91ae52fe6 100644
  libffi = "=5.1.0"
  libffi-sys = "=4.1.0"
 diff --git a/ext/node/polyfills/_process/process.ts b/ext/node/polyfills/_process/process.ts
-index 5dcbf5fbc..afb43bbc7 100644
+index 6dd071a90..5dfa47412 100644
 --- a/ext/node/polyfills/_process/process.ts
 +++ b/ext/node/polyfills/_process/process.ts
 @@ -37,6 +37,8 @@ export function arch(): string {

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,7 +1,7 @@
-From 2d7e26cefe9682334b98e4e5a23936e4502678cc Mon Sep 17 00:00:00 2001
+From 703913fd88c8f95823bf06bc925df2f2136e6725 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Thu, 29 Jan 2026 23:09:43 +0800
-Subject: [PATCH 3/4] AOSCOS: Disable cross-compilation setup on arm64
+Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup on arm64
 
 Because we have native linux arm64 CI :)
 ---

--- a/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,7 +1,7 @@
-From bd6d2f6a9c2a57a2dbc59b2af79b56d931fb19f5 Mon Sep 17 00:00:00 2001
+From e6ec6e15dce4650a6daee885fa4de9c69ad78b08 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
-Subject: [PATCH 4/4] AOSCOS: build: correct Clang builtins path
+Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
 
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 
@@ -11,10 +11,10 @@ Correct the builtins path accordingly.
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index 5031ea2..b1c78e8 100644
+index e05032c..6709252 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -182,22 +182,23 @@ template("clang_lib") {
+@@ -185,22 +185,23 @@ template("clang_lib") {
        } else if (is_apple) {
          _dir = "darwin"
        } else if (is_linux || is_chromeos) {
@@ -46,7 +46,7 @@ index 5031ea2..b1c78e8 100644
          } else {
            assert(false)  # Unhandled cpu type
          }
-@@ -228,7 +229,7 @@ template("clang_lib") {
+@@ -231,7 +232,7 @@ template("clang_lib") {
          assert(false)  # Unhandled target platform
        }
  

--- a/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,0 +1,49 @@
+From 0d8db76403b3c726b89b0a17624b80585ca73d22 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 29 Mar 2026 18:50:37 +0800
+Subject: [PATCH 5/5] AOSCOS: drop unknown argument
+
+---
+ build/config/compiler/BUILD.gn | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index ff8022f..9721cdd 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -625,13 +625,6 @@ config("compiler") {
+       ]
+     }
+ 
+-    # The performance improvement does not seem worth the risk. See
+-    # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
+-    # for discussion.
+-    if (!is_wasm) {
+-      cflags += [ "-fno-lifetime-dse" ]
+-    }
+-
+     # TODO(hans): Remove this once Clang generates better optimized debug info
+     # by default. https://crbug.com/765793
+     cflags += [
+@@ -1892,18 +1885,6 @@ config("sanitize_c_array_bounds") {
+     cflags = [
+       "-fsanitize=array-bounds",
+       "-fsanitize-trap=array-bounds",
+-
+-      # Some code users feature detection to determine if UBSAN (or any
+-      # sanitizer) is enabled, they then do expensive debug like operations. We
+-      # want to suppress this behaviour since we want to keep performance costs
+-      # as low as possible while having these checks.
+-      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
+-
+-      # Because we've enabled array-bounds sanitizing we also want to suppress
+-      # the related warning about "unsafe-buffer-usage-in-static-sized-array",
+-      # since we know that the array bounds sanitizing will catch any out-of-
+-      # bounds accesses.
+-      "-Wno-unsafe-buffer-usage-in-static-sized-array",
+     ]
+   }
+ }
+-- 
+2.53.0
+

--- a/lang-js/deno/autobuild/prepare
+++ b/lang-js/deno/autobuild/prepare
@@ -1,19 +1,11 @@
+# Note: Build V8 from source as the upstream does not provide enough
+# binaries for the architectures we support.
 abinfo "Patching rusty_v8 ..."
 pushd "$SRCDIR"/../rusty_v8
 ab_apply_patches "$SRCDIR"/autobuild/patches/*.deferred
 popd
 
-abinfo "Setting up build environment ..."
-# FIXME: Deno's build system does not set these automatically.
-export AR="/usr/bin/llvm-ar"
-export NM="/usr/bin/llvm-nm"
-
-# Use system gn and ninja (for v8).
-export GN="/usr/bin/gn"
-export NINJA="/usr/bin/ninja"
-
-# Note: Build V8 from source as the upstream does not provide enough
-# binaries for the architectures we support.
+abinfo "Setting up environment for rusty_v8 ..."
 CLANG_VERSION=$(clang --version | sed -n 's/clang version //p' | cut -d. -f1)
 
 # Flags for building v8; inspired by app-web/chromium.
@@ -24,14 +16,17 @@ __GN_ARGS=(
     'v8_enable_temporal_support=false'
     'is_debug=false'
     'use_sysroot=false'
-    'use_system_libffi=true'
-    'system_zlib=true'
     "clang_version=\"${CLANG_VERSION}\""
     'clang_base_path="/usr"'
     "custom_toolchain=\"//build/toolchain/linux/unbundle:default\""
     "host_toolchain=\"//build/toolchain/linux/unbundle:default\""
 )
 
-export V8_FROM_SOURCE=1
 export GN_ARGS="${__GN_ARGS[@]}"
+export GN="/usr/bin/gn"
+export AR="/usr/bin/llvm-ar"
+export NM="/usr/bin/llvm-nm"
+export NINJA="/usr/bin/ninja"
+export PYTHON="/usr/bin/python3"
 export CLANG_BASE_PATH="/usr"
+export V8_FROM_SOURCE=1

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.7.7
+VER=2.7.9
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=146.8.0
+RUSTY_V8_VER=147.0.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::8786a1cb51d93275da845be33e0199a7a63c6ecc7839b8feec548097288c16ac \
+CHKSUMS="sha256::46c3aa21851ea9579c3ce8dfcc393ec4de5c405360be742ee02dab5ef5b4e48a \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.7.9

Package(s) Affected
-------------------

- deno: 2.7.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
