### PR TITLE
systemd: add -noawait in daemon-reload trigger

### DIFF
--- a/app-admin/systemd/autobuild/triggers
+++ b/app-admin/systemd/autobuild/triggers
@@ -1,6 +1,8 @@
 interest /etc/binfmt.d
 interest /usr/lib/binfmt.d
 interest systemd-binfmt
-interest /etc/systemd/system
-interest /usr/lib/systemd/system
-interest daemon-reload
+# Note: await tigger cause a dpkg trigger cycle in systemd
+# systemd -> systemd
+interest-noawait /etc/systemd/system
+interest-noawait /usr/lib/systemd/system
+interest-noawait daemon-reload

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=259
 
 # Use this for stable/main branch releases.
-REL=3
+REL=4
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- systemd: add -noawait in daemon-reload trigger
    fix dpkg trigger cycle in systemd

Package(s) Affected
-------------------

- systemd: 1:259-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
