### PR TITLE
depthcharge: add patch to support aosc os arm64 kernel dtbs

### DIFF
--- a/app-admin/depthcharge-tools/autobuild/patches/0003-AOSC-support-AOSC-OS-arm64-kernel-dtb-path.patch
+++ b/app-admin/depthcharge-tools/autobuild/patches/0003-AOSC-support-AOSC-OS-arm64-kernel-dtb-path.patch
@@ -1,0 +1,32 @@
+From 74e3cd131595606869642f99eccfd57edd883881 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Sun, 29 Mar 2026 14:20:37 +0800
+Subject: [PATCH] AOSC: support AOSC OS arm64 kernel dtb path
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ depthcharge_tools/utils/platform.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/depthcharge_tools/utils/platform.py b/depthcharge_tools/utils/platform.py
+index 9b30938..d03f6f8 100644
+--- a/depthcharge_tools/utils/platform.py
++++ b/depthcharge_tools/utils/platform.py
+@@ -339,6 +339,14 @@ def installed_kernels(root=None, boot=None):
+         _, _, release = d.name.partition("linux-image-")
+         fdtdirs[release] = d.resolve()
+ 
++    for d in (
++        *root.glob("usr/lib/aosc-os-arm64-boot/dtbs-kernel-*"),
++    ):
++        if not d.is_dir():
++            continue
++        _, _, release = d.name.partition("dtbs-kernel-")
++        fdtdirs[release] = d.resolve()
++
+     for d in (
+         *root.glob("lib/modules/*/dtb"),
+         *root.glob("lib/modules/*/dtbs"),
+-- 
+2.52.0
+

--- a/app-admin/depthcharge-tools/spec
+++ b/app-admin/depthcharge-tools/spec
@@ -1,5 +1,5 @@
 VER=0.6.2
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER}::https://github.com/alpernebbi/depthcharge-tools.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198825"


### PR DESCRIPTION
Topic Description
-----------------

- depthcharge-tools: add patch to support aosc os arm64 kernel dtbs
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- depthcharge-tools: 0.6.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit depthcharge-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
