### PR TITLE
[WIP] aoscbootstrap: fix WSL timeout

### DIFF
--- a/app-utils/aoscbootstrap/spec
+++ b/app-utils/aoscbootstrap/spec
@@ -1,4 +1,5 @@
 VER=0.10.4
-SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aoscbootstrap"
+REL=1
+SRCS="git::commit=510598a8e3889143ade0936e8baba03db77f5d90::https://github.com/AOSC-Dev/aoscbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231687"


### PR DESCRIPTION
Topic Description
-----------------

- try

Package(s) Affected
-------------------

- aoscbootstrap: 0.10.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aoscbootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
