### PR TITLE
gimp: update to 3.2.2

### DIFF
--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,4 +1,4 @@
-VER=3.2.0
+VER=3.2.2
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:3}/gimp-${VER/~rc/-RC}.tar.xz"
-CHKSUMS="sha256::2618391416e51be3c693df9ef90e3860ed72ab3d36363ea1f196e30b75b2e083"
+CHKSUMS="sha256::6c5f8cbabe081f405633a2d32b79a08166aeb7b43c7f548391608dc0d0de71be"
 CHKUPDATE="anitya::id=1161"


### PR DESCRIPTION
Topic Description
-----------------

- gimp: update to 3.2.2
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- gimp: 3.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gimp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
