### PR TITLE
incus: security update to 6.23.0

### DIFF
--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,5 +1,4 @@
-VER=6.22.0
-REL=1
+VER=6.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"

--- a/topics/incus-6.23.0.toml
+++ b/topics/incus-6.23.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Incus 6.23.0"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (including 3 of critical severity and 1 of high severity)"
+zh_CN = "修复 6 个安全漏洞（含 3 个严重漏洞及 1 个高危漏洞）"
+
+[packages-v2]
+"incus" = "< 6.23.0"


### PR DESCRIPTION
Topic Description
-----------------

- incus: security update to 6.23.0
    Fix CVE-2026-33711, CVE-2026-33542, CVE-2026-33743, CVE-2026-33898,
    CVE-2026-33897, CVE-2026-33945
    CVE-2026-33711 URL:
    https://github.com/lxc/incus/security/advisories/GHSA-q9vp-3wcg-8p4x
    CVE-2026-33542 URL:
    https://github.com/lxc/incus/security/advisories/GHSA-p8mm-23gg-jc9r
    CVE-2026-33743 URL:
    https://github.com/lxc/incus/security/advisories/GHSA-vg76-xmhg-j5x3
    CVE-2026-33898 URL:
    https://github.com/lxc/incus/security/advisories/GHSA-453r-g2pg-cxxq
    CVE-2026-33897 URL:
    https://github.com/lxc/incus/security/advisories/GHSA-83xr-5xxr-mh92
    CVE-2026-33945 URL:
    https://github.com/lxc/incus/security/advisories/GHSA-q4q8-7f2j-9h9f

Package(s) Affected
-------------------

- incus: 6.23.0
- incus-agent: 6.23.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
