### PR TITLE
dtc: fix dependency of yaml

### DIFF
--- a/app-devel/dtc/autobuild/defines
+++ b/app-devel/dtc/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=dtc
 PKGSEC=devel
-PKGDEP="glibc"
+PKGDEP="yaml"
 PKGDES="Device Tree Compiler"

--- a/app-devel/dtc/spec
+++ b/app-devel/dtc/spec
@@ -1,4 +1,5 @@
 VER=1.7.0
+REL=1
 SRCS="tbl::https://www.kernel.org/pub/software/utils/dtc/dtc-$VER.tar.xz"
 CHKSUMS="sha256::29edce3d302a15563d8663198bbc398c5a0554765c83830d0d4c0409d21a16c4"
 CHKUPDATE="anitya::id=16911"


### PR DESCRIPTION
Topic Description
-----------------

- dtc: add yaml dependency

Package(s) Affected
-------------------

- dtc: 1.7.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit dtc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
