### PR TITLE
openssh: fix bad signature errors on loongson3

### DIFF
--- a/app-network/openssh/autobuild/defines
+++ b/app-network/openssh/autobuild/defines
@@ -74,3 +74,6 @@ AUTOTOOLS_AFTER__POWERPC="$AUTOTOOLS_AFTER__RETRO"
 AUTOTOOLS_AFTER__PPC64="$AUTOTOOLS_AFTER__RETRO"
 
 PKGCONFL="openssh-hpn"
+
+# FIXME: ssh_dispatch_run_fatal: Connection to 127.0.0.1 port 22: incorrect signature
+NOLTO__LOONGSON3=1

--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -2,4 +2,4 @@ VER=10.2p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
 CHKSUMS="sha256::ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2"
 CHKUPDATE="anitya::id=2565"
-REL=3
+REL=4


### PR DESCRIPTION
Topic Description
-----------------

- openssh: fix bad signature errors on loongson3

Package(s) Affected
-------------------

- openssh: 10.2p1-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
