### PR TITLE
halloy: update to 2026.5

### DIFF
--- a/app-web/halloy/autobuild/defines
+++ b/app-web/halloy/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=halloy
 PKGSEC=web
 PKGDEP="alsa-lib hicolor-icon-theme openssl glibc"
-BUILDDEP="cargo git llvm-20"
+BUILDDEP="rustc llvm"
 PKGDES="Graphical IRC client with support for multiple tiled chat panels"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_*

--- a/app-web/halloy/spec
+++ b/app-web/halloy/spec
@@ -1,4 +1,4 @@
-VER=2025.8
+VER=2026.5
 SRCS="git::commit=tags/$VER::https://github.com/squidowl/halloy.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373405"

--- a/topics/halloy-2026.5.toml
+++ b/topics/halloy-2026.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Halloy 2026.5"
+
+[caution]
+default = "Fixes a path traversal vulnerabilities (CVE-2026-32733, Severity: High) and a credentials leak vulnerability (CVE-2026-32810, Severity: Medium)"
+zh_CN = "修复一个路径穿越漏洞（漏洞编号 CVE-2026-32733，严重性：高）和一个凭据泄漏漏洞（漏洞编号 CVE-2026-32810，严重性：中等）"
+
+[packages-v2]
+"halloy" = "< 2026.5"


### PR DESCRIPTION
Topic Description
-----------------

- halloy: update to 2026.5
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- halloy: 2026.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit halloy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
