### PR TITLE
vim: update to 9.2.0271

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0209
+VER=9.2.0271
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0271
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gvim: 9.2.0271
- vim: 9.2.0271

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
