### PR TITLE
vim: update to 9.2.0272

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0209
+VER=9.2.0272
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0272.toml
+++ b/topics/vim-9.2.0272.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0272"
+
+[caution]
+default = "Fixes an arbitrary OS command execution vulnerability (severity: High)"
+zh_CN = "修复一个任意操作系统命令执行 (Arbitrary OS Command Execution) 漏洞（严重性：高）"
+
+[packages-v2]
+"vim" = "< 9.2.0272"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0272
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gvim: 9.2.0272
- vim: 9.2.0272

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
