### PR TITLE
jeepney: update to 0.9.0

### DIFF
--- a/lang-python/jeepney/autobuild/defines
+++ b/lang-python/jeepney/autobuild/defines
@@ -3,6 +3,6 @@ PKGSEC=python
 PKGDES="Low-level, pure Python DBus protocol wrapper"
 PKGDEP="python-3 dbus"
 
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1
 ABHOST=noarch

--- a/lang-python/jeepney/spec
+++ b/lang-python/jeepney/spec
@@ -1,5 +1,4 @@
-VER=0.6.0
-SRCS="https://pypi.io/packages/source/j/jeepney/jeepney-${VER}.tar.gz"
-CHKSUMS="sha256::7d59b6622675ca9e993a6bd38de845051d315f8b0c72cca3aef733a20b648657"
+VER=0.9.0
+SRCS="pypi::version=$VER::jeepney"
+CHKSUMS="sha256::cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"
 CHKUPDATE="anitya::id=19564"
-REL="2"

--- a/lang-python/secretstorage/autobuild/defines
+++ b/lang-python/secretstorage/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=secretstorage
 PKGSEC=python
-PKGDEP="python-3 dbus-python pycryptodome cryptography jeepney"
+PKGDEP="python-3 cryptography jeepney"
+BUILDDEP="setuptools"
 PKGDES="Securely store passwords and other private data using the SecretService DBus API"
 
 ABHOST=noarch

--- a/lang-python/secretstorage/spec
+++ b/lang-python/secretstorage/spec
@@ -1,5 +1,4 @@
-VER=3.3.3
-SRCS="https://pypi.io/packages/source/S/SecretStorage/SecretStorage-$VER.tar.gz"
-CHKSUMS="sha256::2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"
+VER=3.5.0
+SRCS="pypi::version=$VER::SecretStorage"
+CHKSUMS="sha256::f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"
 CHKUPDATE="anitya::id=4020"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- secretstorage: update to 3.5.0
- jeepney: update to 0.9.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit jeepney secretstorage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
