### PR TITLE
krita: update to 6.0.1

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,5 +1,4 @@
-VER=5.2.15
+VER=6.0.1
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
-CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
+CHKSUMS="sha256::aeaab7959b610eca5025af81eb54db2ce5985f98208d4390b08ee4ceb969c1f5"
 CHKUPDATE="anitya::id=10918"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- krita: update to 6.0.1
    Co-authored-by: Lumiere \(@atlarator\) <vzstless@qq.com>

Package(s) Affected
-------------------

- krita: 6.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit krita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
