### PR TITLE
suitesparse: fix tls relocation failure on loongson3

### DIFF
--- a/runtime-scientific/suitesparse/autobuild/defines
+++ b/runtime-scientific/suitesparse/autobuild/defines
@@ -29,3 +29,7 @@ CMAKE_AFTER__AMD64="${CMAKE_AFTER__CUDA[@]}"
 CMAKE_AFTER__ARM64="${CMAKE_AFTER__CUDA[@]}"
 
 PKGBREAK="clp<=1.17.6-1 gegl-0.4<=0.4.48 octave<=6.4.0-2 scikit-sparse<=0.4.6"
+
+# FIXME: relocation truncated to fit: R_MIPS_TLS_GD against `GB_CONTEXT_THREAD'
+# By not using LTO, we have access to other TLS models
+NOLTO__LOONGSON3=1


### PR DESCRIPTION
Topic Description
-----------------

- suitesparse: fix linker failure on loongson3

Package(s) Affected
-------------------

- eom: 1:1.28.1-1
- imagemagick: 6.9.13+37-2
- imagemagick+7: 7.1.1+32-2
- krita: 5.2.15-1
- libcdr: 0.1.8-1
- libcupsfilters: 2.1.1-2
- libfreehand: 0.1.2-4
- libraw: 0.20.0-1
- octave: 10.3.0-4
- pstoedit: 4.02-1
- qt-5: 1:5.15.18+webengine5.15.19+webkit5.212.0+kde20251209-1
- suitesparse: 7.6.1-2
- xine-lib: 1.2.13-9

Security Update?
----------------

No

Build Order
-----------

```
#buildit eom imagemagick imagemagick+7 krita libcdr libcupsfilters libfreehand libraw suitesparse octave pstoedit qt-5 xine-lib
```

Test Build(s) Done
------------------

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
