### PR TITLE
navidrome: update to 0.61.0

### DIFF
--- a/app-multimedia/navidrome/autobuild/defines
+++ b/app-multimedia/navidrome/autobuild/defines
@@ -6,7 +6,7 @@ BUILDDEP="nodejs go"
 
 ABTYPE=gomod
 GO_BUILD_AFTER=(
-    "-tags=netgo"
+    "-tags=netgo,sqlite_fts5"
 )
 
 # FIXME: Vite not supported on loongson3, riscv64.

--- a/app-multimedia/navidrome/spec
+++ b/app-multimedia/navidrome/spec
@@ -1,5 +1,4 @@
-VER=0.60.3
-REL=1
+VER=0.61.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/navidrome/navidrome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326646"


### PR DESCRIPTION
Topic Description
-----------------

- navidrome: update to 0.61.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- navidrome: 0.61.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit navidrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
