### PR TITLE
fastfetch: update to 2.61.0

### DIFF
--- a/app-utils/fastfetch/autobuild/defines
+++ b/app-utils/fastfetch/autobuild/defines
@@ -4,6 +4,6 @@ PKGSEC=utils
 PKGDEP="bash"
 BUILDDEP="libnma libpurple ddcutil gcc make xfconf imagemagick+7 libclc libcl \
           opencl-registry-api opencl-clang vulkan-headers dbus zlib pkgconf \
-          chafa directx-headers"
+          chafa"
 
 ABTYPE=cmakeninja

--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,4 +1,4 @@
-VER=2.60.0
+VER=2.61.0
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: update to 2.61.0
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- fastfetch: 2.61.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
