### PR TITLE
tpm2-tss: Set the correct runtime state path to /run

### DIFF
--- a/runtime-devices/tpm2-tss/autobuild/beyond
+++ b/runtime-devices/tpm2-tss/autobuild/beyond
@@ -1,0 +1,6 @@
+# NOTE: /run is mounted as tmpfs.
+# No files should exist here during packaging.
+if [ -d "$PKGDIR"/run ] ; then
+	abinfo "Removing /run ..."
+	rm -rv "$PKGDIR"/run
+fi

--- a/runtime-devices/tpm2-tss/autobuild/defines
+++ b/runtime-devices/tpm2-tss/autobuild/defines
@@ -5,6 +5,7 @@ BUILDDEP="autoconf-archive"
 PKGDES="Implementation of the TCG Trusted Platform Module 2.0 Software Stack (TSS2)"
 
 AUTOTOOLS_AFTER=(
+	"--with-runstatedir=/run"
 	"--with-sysusersdir=/usr/lib/sysusers.d"
 	"--with-tmpfilesdir=/usr/lib/tmpfiles.d"
 	"--with-udevrulesprefix=60-"

--- a/runtime-devices/tpm2-tss/spec
+++ b/runtime-devices/tpm2-tss/spec
@@ -1,5 +1,5 @@
 VER=4.1.3
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/tpm2-software/tpm2-tss"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12683"


### PR DESCRIPTION
Topic Description
-----------------

- tpm2-tss: set runtime state dir to /run
    It was /var/run previously. And since we have /var/run -> ../run, no
    actual directories should be present as or under /var/run.
    This causes a problem with recently updated aoscbootstrap which contains
    mitigations of a symlink-directory collision chmod attack \[1\], which
    prevents any file or directory being extracted onto symlinks with the
    same path.

Package(s) Affected
-------------------

- tpm2-tss: 4.1.3-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tpm2-tss
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
