### PR TITLE
vim: update to 9.2.0277

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0272
+VER=9.2.0277
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0277.toml
+++ b/topics/vim-9.2.0277.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0277"
+
+[caution]
+default = "Fixes a remote code execution vulnerability (CVE-2026-34982, Severity: High)"
+zh_CN = "修复一个远程代码执行漏洞（漏洞编号 CVE-2026-34982，严重性：高）"
+
+[packages-v2]
+"vim" = "< 9.2.0277"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0277
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.0277
- vim: 9.2.0277

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
