### PR TITLE
PULL_REQUEST_TEMPLATE: drop the Security Update section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -11,20 +11,6 @@ Package(s) Affected
 
 <!-- Please list all package(s) affected by this topic here. -->
 
-Security Update?
-----------------
-
-<!-- If this topic contains security update(s), please uncomment "Yes,"
-     mark with the `security` label and make sure to mark your commits to
-     relevant issue numbers.
-
-     Please see GitHub's documentation on "Linking a pull request to an issue":
-
-     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
-
-<!-- Yes, #ISSUENUMBER -->
-<!-- No -->
-
 Build Order
 -----------
 


### PR DESCRIPTION
Apparently nobody wants to care this now as we already have TUM.