### PR TITLE
libmicrohttpd: update to 1.0.3

### DIFF
--- a/runtime-web/libmicrohttpd/spec
+++ b/runtime-web/libmicrohttpd/spec
@@ -1,4 +1,4 @@
-VER=1.0.2
+VER=1.0.3
 SRCS="tbl::https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-$VER.tar.gz"
-CHKSUMS="sha256::df324fcd0834175dab07483133902d9774a605bfa298025f69883288fd20a8c7"
+CHKSUMS="sha256::7816b57aae199cf5c3645e8770e1be5f0a4dfafbcb24b3772173dc4ee634126a"
 CHKUPDATE="anitya::id=1658"


### PR DESCRIPTION
Topic Description
-----------------

- libmicrohttpd: update to 1.0.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- libmicrohttpd: 1.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmicrohttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
