### PR TITLE
Bootstrap Survey Wave 0: riscv64 fixup

### DIFF
--- a/runtime-network/ldns/autobuild/defines
+++ b/runtime-network/ldns/autobuild/defines
@@ -24,5 +24,11 @@ AUTOTOOLS_AFTER=(
     '--with-ca-file=/etc/ssl/certs/ca-certificates.crt'
     '--with-ca-path=/etc/ssl/certs/'
 )
+# FIXME:
+# Can't link/include C library 'ldns', 'ldns', aborting.
+# cd /var/cache/acbs/build/acbs.ruw_9t9h/ldns-1.8.4/contrib/DNS-LDNS; make
+# make[1]: Entering directory '/var/cache/acbs/build/acbs.ruw_9t9h/ldns-1.8.4/contrib/DNS-LDNS'
+# make[1]: *** No targets specified and no makefile found.  Stop.
+NOPARALLEL__RISCV64=1
 
 PKGBREAK="dnscrypt<=2.0.39-1 openssh<=8.1p1 openssh-hpn<=7.8p1"


### PR DESCRIPTION
Topic Description
-----------------

- ldns: disable parallel building for riscv64

Package(s) Affected
-------------------

- automake: 2:1.18.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit automake  avahi  bash  cpio  cyrus-sasl  db  dbus-glib  dbus-python  dhcp  ding-libs  dnsmasq  dnspython  docbook-dtd  docbook-sgml31  dpkg  ethtool  expect  f2fs-tools  ffcall  giflib  gmp  gpm  gssproxy  guile  guile-2.2  harfbuzz  jack  json-c  ldns  libevdev  libftdi  libgcrypt  libsigsegv  libuv  lrzip  lshw  lsof  lvm2  lxml  netcat  opensp  openssh  pango  parted  perl-tk  postfix  ppp  protobuf-c  t1lib  tk  tpm2-tools  tpm2-tss  usb-modeswitch  w3m  wayland  x11-lib  yasm  gcc-15
```

Test Build(s) Done
------------------

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
