### PR TITLE
vim: update to 9.2.0280

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0277
+VER=9.2.0280
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0280.toml
+++ b/topics/vim-9.2.0280.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0280"
+
+[caution]
+default = "Fixes a Improper Limitation of a Pathname to a Restricted Directory (Path Traversal) vulnerability (Severity: Low)"
+zh_CN = "修复一个对路径名的限制不恰当（路径遍历）漏洞（严重性：低）"
+
+[packages-v2]
+"vim" = "< 9.2.0280"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add vim-9.2.0280.toml
- vim: update to 9.2.0280

Package(s) Affected
-------------------

- gvim: 9.2.0280
- vim: 9.2.0280

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
