### PR TITLE
mesa: enable legacy EGL_WL_bind_wayland_display functionality

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -94,6 +94,7 @@ MESON_AFTER=(
     '-Dprecomp-compiler=enabled'
     '-Dvirtgpu_kumquat=true'
     '-Dwrap_mode=default'
+    '-Dlegacy-wayland=bind-wayland-display'
 )
 
 MESON_AFTER__X86=(

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,5 +1,6 @@
 UPSTREAM_VER=25.3.5
 VER=${UPSTREAM_VER//-/~}
+REL=1
 SRCS="tbl::https://archive.mesa3d.org/mesa-${VER}.tar.xz"
 CHKSUMS="sha256::be472413475082df945e0f9be34f5af008baa03eb357e067ce5a611a2d44c44b"
 CHKUPDATE="anitya::id=1970"


### PR DESCRIPTION
Topic Description
-----------------

- mesa: enable legacy EGL_WL_bind_wayland_display functionality
    Unfortunately we're still stuck at KDE5 and this is needed for
    propagating acceleration on KWin 5.x \(at least for some devices\).
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mesa: 1:25.3.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
