### PR TITLE
Libiscsi survey 20260402

### DIFF
--- a/app-virtualization/libvirt/spec
+++ b/app-virtualization/libvirt/spec
@@ -1,4 +1,5 @@
 VER=12.1.0
+REL=1
 SRCS="tbl::https://libvirt.org/sources/libvirt-$VER.tar.xz"
 CHKSUMS="sha256::3b60040a3670ec014d058ed021ae641e9fa6d3b5c4b56e63e8928f1804ef4b9b"
 CHKUPDATE="anitya::id=13830"

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=10.2.2
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
 CHKSUMS="sha256::784b296ff29c1417aa72323abcb2d2ea9ab9771724f577dcd785c3b04f21e176"
 CHKUPDATE="anitya::id=13607"

--- a/runtime-network/libiscsi/spec
+++ b/runtime-network/libiscsi/spec
@@ -1,5 +1,4 @@
-VER=1.18.0
-REL=1
-SRCS="tbl::https://github.com/sahlberg/libiscsi/archive/$VER.tar.gz"
-CHKSUMS="sha256::464d104e12533dc11f0dd7662cbc2f01c132f94aa4f5bd519e3413ef485830e8"
+VER=1.20.3
+SRCS="git::commit=tags/$VER::https://github.com/sahlberg/libiscsi"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10862"


### PR DESCRIPTION
Topic Description
-----------------

- libvirt: bump REL due to libiscsi update
- qemu: bump REL due to libiscsi update
- libiscsi: update to 1.20.3

Package(s) Affected
-------------------

- libiscsi: 1.20.3
- libvirt: 12.1.0-1
- qemu: 10.2.2-1
- qemu-aarch64-static: 10.2.2-1
- qemu-alpha-static: 10.2.2-1
- qemu-arm-static: 10.2.2-1
- qemu-armeb-static: 10.2.2-1
- qemu-guest-agent: 10.2.2-1
- qemu-i386-static: 10.2.2-1
- qemu-loongarch64-static: 10.2.2-1
- qemu-m68k-static: 10.2.2-1
- qemu-microblaze-static: 10.2.2-1
- qemu-microblazeel-static: 10.2.2-1
- qemu-mips-static: 10.2.2-1
- qemu-mips64-static: 10.2.2-1
- qemu-mips64el-static: 10.2.2-1
- qemu-mipsel-static: 10.2.2-1
- qemu-mipsn32-static: 10.2.2-1
- qemu-mipsn32el-static: 10.2.2-1
- qemu-or32-static: 10.2.2-1
- qemu-ppc-static: 10.2.2-1
- qemu-ppc64-static: 10.2.2-1
- qemu-ppc64le-static: 10.2.2-1
- qemu-riscv32-static: 10.2.2-1
- qemu-riscv64-static: 10.2.2-1
- qemu-s390x-static: 10.2.2-1
- qemu-sh4-static: 10.2.2-1
- qemu-sh4eb-static: 10.2.2-1
- qemu-sparc-static: 10.2.2-1
- qemu-sparc32plus-static: 10.2.2-1
- qemu-sparc64-static: 10.2.2-1
- qemu-user-static: 10.2.2-1
- qemu-x86-64-static: 10.2.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libiscsi qemu libvirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
