### PR TITLE
LoongArch 64K PageSize: rebuild due to compiler alignment configuration changes

### DIFF
--- a/app-admin/dbus/spec
+++ b/app-admin/dbus/spec
@@ -1,5 +1,5 @@
 VER=1.14.10
-REL=4
+REL=5
 SRCS="https://dbus.freedesktop.org/releases/dbus/dbus-$VER.tar.xz"
 CHKSUMS="sha256::ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f"
 CHKUPDATE="anitya::id=5356"

--- a/app-admin/kmod/spec
+++ b/app-admin/kmod/spec
@@ -2,3 +2,4 @@ VER=34.2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-$VER.tar.xz"
 CHKSUMS="sha256::5a5d5073070cc7e0c7a7a3c6ec2a0e1780850c8b47b3e3892226b93ffcb9cb54"
 CHKUPDATE="anitya::id=1517"
+REL="1"

--- a/app-admin/polkit/spec
+++ b/app-admin/polkit/spec
@@ -1,5 +1,5 @@
 VER=126
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/polkit-org/polkit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3682"

--- a/app-shells/bash/spec
+++ b/app-shells/bash/spec
@@ -1,5 +1,5 @@
 VER=5.2.37
-REL=1
+REL=2
 SRCS="https://ftp.gnu.org/gnu/bash/bash-${VER%.*}.tar.gz"
 CHKSUMS="sha256::a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb"
 CHKUPDATE="anitya::id=166"

--- a/app-utils/bzip2/spec
+++ b/app-utils/bzip2/spec
@@ -1,5 +1,5 @@
 VER=1.0.8
-REL=8
+REL=9
 SRCS="tbl::https://sourceware.org/pub/bzip2/bzip2-$VER.tar.gz"
 CHKSUMS="sha256::ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
 CHKUPDATE="anitya::id=237"

--- a/app-utils/kbd/spec
+++ b/app-utils/kbd/spec
@@ -2,3 +2,4 @@ VER=2.7.1
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/kbd/kbd-$VER.tar.gz"
 CHKSUMS="sha256::cc4ad92a5e41689589e0a35e1c339b210679bb744dcec1b4088842e331756577"
 CHKUPDATE="anitya::id=1492"
+REL="1"

--- a/app-utils/keyutils/spec
+++ b/app-utils/keyutils/spec
@@ -1,5 +1,5 @@
 VER=1.6.3
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17740"

--- a/core-libs/mpfr/spec
+++ b/core-libs/mpfr/spec
@@ -2,3 +2,4 @@ VER=4.2.2
 SRCS="tbl::https://ftp.gnu.org/gnu/mpfr/mpfr-$VER.tar.xz"
 CHKSUMS="sha256::b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
 CHKUPDATE="anitya::id=2019"
+REL="1"

--- a/lang-js/duktape/spec
+++ b/lang-js/duktape/spec
@@ -2,3 +2,4 @@ VER=2.7.0
 SRCS="tbl::https://duktape.org/duktape-$VER.tar.xz"
 CHKSUMS="sha256::90f8d2fa8b5567c6899830ddef2c03f3c27960b11aca222fa17aa7ac613c2890"
 CHKUPDATE="anitya::id=21345"
+REL="1"

--- a/runtime-admin/libgudev/spec
+++ b/runtime-admin/libgudev/spec
@@ -2,3 +2,4 @@ VER=238
 SRCS="tbl::https://download.gnome.org/sources/libgudev/$VER/libgudev-$VER.tar.xz"
 CHKSUMS="sha256::61266ab1afc9d73dbc60a8b2af73e99d2fdff47d99544d085760e4fa667b5dd1"
 CHKUPDATE="anitya::id=7735"
+REL=1

--- a/runtime-common/attr/spec
+++ b/runtime-common/attr/spec
@@ -1,5 +1,5 @@
 VER=2.4.48
-REL=2
+REL="3"
 SRCS="tbl::https://download.savannah.gnu.org/releases/attr/attr-$VER.tar.gz"
 CHKSUMS="sha256::5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7"
 CHKUPDATE="anitya::id=137"

--- a/runtime-common/libaio/spec
+++ b/runtime-common/libaio/spec
@@ -2,3 +2,4 @@ VER=0.3.113
 SRCS="git::commit=tags/libaio-${VER}::https://pagure.io/libaio.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1557"
+REL="1"

--- a/runtime-common/libassuan/spec
+++ b/runtime-common/libassuan/spec
@@ -2,3 +2,4 @@ VER=3.0.2
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/libassuan/libassuan-$VER.tar.bz2"
 CHKSUMS="sha256::d2931cdad266e633510f9970e1a2f346055e351bb19f9b78912475b8074c36f6"
 CHKUPDATE="anitya::id=1559"
+REL="1"

--- a/runtime-common/libdaemon/spec
+++ b/runtime-common/libdaemon/spec
@@ -1,5 +1,5 @@
 VER=0.14
-REL=4
-SRCS="tbl::http://0pointer.de/lennart/projects/libdaemon/libdaemon-$VER.tar.gz"
+REL=5
+SRCS="tbl::https://repo.aosc.io/aosc-repacks/libdaemon-$VER.tar.gz"
 CHKSUMS="sha256::fd23eb5f6f986dcc7e708307355ba3289abe03cc381fc47a80bca4a50aa6b834"
 CHKUPDATE="anitya::id=13299"

--- a/runtime-common/libffi/spec
+++ b/runtime-common/libffi/spec
@@ -2,4 +2,4 @@ VER=3.4.8
 SRCS="tbl::https://github.com/libffi/libffi/releases/download/v${VER}/libffi-${VER}.tar.gz"
 CHKSUMS="sha256::bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b"
 CHKUPDATE="anitya::id=1611"
-REL=1
+REL=2

--- a/runtime-common/nspr/spec
+++ b/runtime-common/nspr/spec
@@ -1,5 +1,5 @@
 VER=4.35
-REL=1
+REL=2
 SRCS="tbl::https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$VER/src/nspr-$VER.tar.gz"
 CHKSUMS="sha256::7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f"
 SUBDIR="nspr-$VER/nspr"

--- a/runtime-devices/libatasmart/spec
+++ b/runtime-devices/libatasmart/spec
@@ -1,5 +1,5 @@
 VER=0.19
-REL=2
+REL=3
 SRCS="tbl::http://0pointer.de/public/libatasmart-$VER.tar.xz"
 CHKSUMS="sha256::61f0ea345f63d28ab2ff0dc352c22271661b66bf09642db3a4049ac9dbdb0f8d"
 CHKUPDATE="anitya::id=14599"

--- a/runtime-devices/libusb-compat/spec
+++ b/runtime-devices/libusb-compat/spec
@@ -1,5 +1,5 @@
 VER=0.1.5
-REL=2
+REL="3"
 SRCS="tbl::https://downloads.sourceforge.net/libusb/libusb-compat-$VER.tar.bz2"
 CHKSUMS="sha256::404ef4b6b324be79ac1bfb3d839eac860fbc929e6acb1ef88793a6ea328bc55a"
 CHKUPDATE="anitya::id=1750"

--- a/runtime-network/libndp/spec
+++ b/runtime-network/libndp/spec
@@ -1,5 +1,5 @@
 VER=1.7
-REL=1
+REL=2
 SRCS="tbl::http://libndp.org/files/libndp-$VER.tar.gz"
 CHKSUMS="sha256::2c480afbffb02792dbae3c13bbfb71d89f735562f2795cca0640ed3428b491b6"
 CHKUPDATE="anitya::id=14944"


### PR DESCRIPTION
Topic Description
-----------------

- libassuan: bump REL to trigger rebuild
- libatasmart: bump REL to trigger rebuild
- mpfr: bump REL to trigger rebuild
- nspr: bump REL to trigger rebuild
- libusb-compat: bump REL to trigger rebuild
- attr: bump REL to trigger rebuild
- libndp: bump REL to trigger rebuild
- duktape: bump REL to trigger rebuild
- libgudev: bump REL to trigger rebuild
- bzip2: bump REL to trigger rebuild

... and 9 more commits

Package(s) Affected
-------------------

- attr: 2.4.48-3
- bash: 5.2.37-2
- bzip2: 1.0.8-9
- dbus: 2:1.14.10-5
- duktape: 2.7.0-1
- kbd: 2.7.1-1
- keyutils: 1.6.3-3
- kmod: 34.2-1
- libaio: 0.3.113-1
- libassuan: 3.0.2-1
- libatasmart: 0.19-3
- libdaemon: 0.14-5
- libffi: 3.4.8-2
- libgudev: 238-1
- libndp: 1.7-2
- libusb-compat: 1:0.1.5-3
- mpfr: 4.2.2-1
- nspr: 4.35-2
- polkit: 1:126-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kmod bash polkit libaio kbd keyutils dbus libffi libdaemon bzip2 libgudev duktape libndp attr libusb-compat nspr mpfr libatasmart libassuan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
