### PR TITLE
uv: update to 0.11.3

### DIFF
--- a/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
+++ b/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
@@ -1,4 +1,4 @@
-From 588f908c973cdefa3be17469a6f9744ba1a50ab6 Mon Sep 17 00:00:00 2001
+From 64cf284f0b8fb83475cebdb1c040b38e690fcedb Mon Sep 17 00:00:00 2001
 From: Rong Bao <rong.bao@csmantle.top>
 Date: Sat, 28 Feb 2026 13:11:54 +0800
 Subject: [PATCH] AOSCOS: Relax ELF parsing mode
@@ -23,18 +23,18 @@ Signed-off-by: Rong Bao <rong.bao@csmantle.top>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/crates/uv-platform/src/libc.rs b/crates/uv-platform/src/libc.rs
-index edf05255e..015be4b1f 100644
+index 3a4e13343..0e49b4995 100644
 --- a/crates/uv-platform/src/libc.rs
 +++ b/crates/uv-platform/src/libc.rs
 @@ -6,6 +6,7 @@
- use crate::cpuinfo::detect_hardware_floating_point_support;
+ use crate::{Arch, cpuinfo::detect_hardware_floating_point_support};
  use fs_err as fs;
  use goblin::elf::Elf;
 +use goblin::options::ParseOptions as ElfParseOptions;
  use regex::Regex;
  use std::fmt::Display;
  use std::io;
-@@ -319,7 +320,7 @@ fn find_ld_path_at(path: impl AsRef<Path>) -> Option<PathBuf> {
+@@ -432,7 +433,7 @@ fn find_ld_path_at(path: impl AsRef<Path>) -> Option<PathBuf> {
      let path = path.as_ref();
      // Not all linux distributions have all of these paths.
      let buffer = fs::read(path).ok()?;
@@ -44,5 +44,5 @@ index edf05255e..015be4b1f 100644
          Err(err) => {
              trace!(
 -- 
-2.53.0.windows.1
+2.52.0
 

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.10.10
+VER=0.11.3
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.11.3
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.11.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
