### PR TITLE
deskflow: update to 1.26.0

### DIFF
--- a/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
+++ b/app-utils/deskflow/autobuild/patches/0001-AOSCOS-fix-neuter-version-checking-functionalities.patch
@@ -1,4 +1,4 @@
-From 2cb7a54e3106dae7d90af28a7115a7692f446a96 Mon Sep 17 00:00:00 2001
+From 42e3bc3146545bf9706b7cab40c549a8cde1216d Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Fri, 24 Oct 2025 09:49:02 +0800
 Subject: [PATCH] AOSCOS: fix: neuter version checking functionalities
@@ -7,82 +7,68 @@ Subject: [PATCH] AOSCOS: fix: neuter version checking functionalities
  src/lib/common/Settings.cpp            |  3 ---
  src/lib/common/Settings.h              |  4 ----
  src/lib/gui/CMakeLists.txt             |  2 --
- src/lib/gui/MainWindow.cpp             | 18 ------------------
+ src/lib/gui/MainWindow.cpp             | 19 -------------------
  src/lib/gui/MainWindow.h               |  3 ---
  src/lib/gui/Messages.cpp               | 18 ------------------
  src/lib/gui/Messages.h                 |  2 --
  src/lib/gui/dialogs/SettingsDialog.cpp |  3 ---
- src/lib/gui/dialogs/SettingsDialog.ui  |  8 --------
- 9 files changed, 61 deletions(-)
+ src/lib/gui/dialogs/SettingsDialog.ui  | 25 ++++++++++++++++++-------
+ 9 files changed, 18 insertions(+), 61 deletions(-)
 
 diff --git a/src/lib/common/Settings.cpp b/src/lib/common/Settings.cpp
-index 66fdd8443..c0a1e0d93 100644
+index 742ba998cc..2aeb480611 100644
 --- a/src/lib/common/Settings.cpp
 +++ b/src/lib/common/Settings.cpp
-@@ -203,9 +203,6 @@ QVariant Settings::defaultValue(const QString &key)
+@@ -184,9 +184,6 @@ QVariant Settings::defaultValue(const QString &key)
    if (key == Daemon::Elevate)
      return !Settings::isPortableMode();
  
--  if (key == Core::UpdateUrl)
+-  if (key == Gui::UpdateCheckUrl)
 -    return kUrlUpdateCheck;
 -
    if (key == Server::ExternalConfigFile)
      return QStringLiteral("%1/%2-server.conf").arg(Settings::settingsPath(), kAppId);
  
 diff --git a/src/lib/common/Settings.h b/src/lib/common/Settings.h
-index e816b69a6..d613d4ecf 100644
+index 8c7ee80791..6678e8164d 100644
 --- a/src/lib/common/Settings.h
 +++ b/src/lib/common/Settings.h
-@@ -50,7 +50,6 @@ public:
-     inline static const auto ProcessMode = QStringLiteral("core/processMode");
-     inline static const auto ScreenName = QStringLiteral("core/screenName");
-     inline static const auto StartedBefore = QStringLiteral("core/startedBefore");
--    inline static const auto UpdateUrl = QStringLiteral("core/updateUrl");
-     inline static const auto Display = QStringLiteral("core/display");
-     inline static const auto UseHooks = QStringLiteral("core/useHooks");
-     inline static const auto Language = QStringLiteral("core/language");
-@@ -66,7 +65,6 @@ public:
-   struct Gui
+@@ -70,8 +70,6 @@ public:
    {
      inline static const auto Autohide = QStringLiteral("gui/autoHide");
+     inline static const auto AutoStartCore = QStringLiteral("gui/startCoreWithGui");
 -    inline static const auto AutoUpdateCheck = QStringLiteral("gui/enableUpdateCheck");
+-    inline static const auto UpdateCheckUrl = QStringLiteral("gui/updateCheckUrl");
      inline static const auto CloseReminder = QStringLiteral("gui/closeReminder");
      inline static const auto CloseToTray = QStringLiteral("gui/closeToTray");
      inline static const auto LogExpanded = QStringLiteral("gui/logExpanded");
-@@ -192,7 +190,6 @@ private:
-     , Settings::Core::ProcessMode
-     , Settings::Core::ScreenName
-     , Settings::Core::StartedBefore
--    , Settings::Core::UpdateUrl
-     , Settings::Core::Display
-     , Settings::Core::UseHooks
-     , Settings::Core::UseWlClipboard
-@@ -205,7 +202,6 @@ private:
-     , Settings::Log::ToFile
+@@ -221,8 +219,6 @@ private:
      , Settings::Log::GuiDebug
      , Settings::Gui::Autohide
+     , Settings::Gui::AutoStartCore
 -    , Settings::Gui::AutoUpdateCheck
+-    , Settings::Gui::UpdateCheckUrl
      , Settings::Gui::CloseReminder
      , Settings::Gui::CloseToTray
      , Settings::Gui::LogExpanded
 diff --git a/src/lib/gui/CMakeLists.txt b/src/lib/gui/CMakeLists.txt
-index 10d1a88be..4795b66b6 100644
+index e4388cde41..908036215b 100644
 --- a/src/lib/gui/CMakeLists.txt
 +++ b/src/lib/gui/CMakeLists.txt
-@@ -36,8 +36,6 @@ add_library(${target} STATIC
-   ScreenSetupModel.h
-   Styles.h
+@@ -37,8 +37,6 @@ add_library(${target} STATIC
    StyleUtils.h
+   TlsUtility.cpp
+   TlsUtility.h
 -  VersionChecker.cpp
 -  VersionChecker.h
    config/IServerConfig.h
    config/Screen.cpp
    config/Screen.h
 diff --git a/src/lib/gui/MainWindow.cpp b/src/lib/gui/MainWindow.cpp
-index 12b03df80..9439fb69d 100644
+index 91dff167e4..5aa4038c18 100644
 --- a/src/lib/gui/MainWindow.cpp
 +++ b/src/lib/gui/MainWindow.cpp
-@@ -291,8 +291,6 @@ void MainWindow::connectSlots()
+@@ -290,8 +290,6 @@ void MainWindow::connectSlots()
    connect(m_actionRestartCore, &QAction::triggered, this, &MainWindow::resetCore);
    connect(m_actionStopCore, &QAction::triggered, this, &MainWindow::stopCore);
  
@@ -91,7 +77,7 @@ index 12b03df80..9439fb69d 100644
    // Mac os tray will only show a menu
    if (!deskflow::platform::isMac())
      connect(m_trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated);
-@@ -391,12 +389,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
+@@ -401,12 +399,6 @@ void MainWindow::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
    isVisible() ? hide() : showAndActivate();
  }
  
@@ -104,7 +90,15 @@ index 12b03df80..9439fb69d 100644
  void MainWindow::coreProcessError(CoreProcess::Error error)
  {
    if (error == CoreProcess::Error::AddressMissing) {
-@@ -660,16 +652,6 @@ void MainWindow::open()
+@@ -457,7 +449,6 @@ void MainWindow::clearSettings()
+   disconnect(&m_coreProcess, nullptr, this, nullptr);
+   disconnect(&m_serverConnection, nullptr, this, nullptr);
+   disconnect(&m_clientConnection, nullptr, this, nullptr);
+-  disconnect(&m_versionChecker, nullptr, this, nullptr);
+   disconnect(m_guiDupeChecker, nullptr, this, nullptr);
+   disconnect(m_trayIcon, nullptr, this, nullptr);
+   disconnect(m_logDock->toggleViewAction(), nullptr, this, nullptr);
+@@ -657,16 +648,6 @@ void MainWindow::open()
    const auto kCriticalDialogDelay = 100;
    QTimer::singleShot(kCriticalDialogDelay, this, &messages::raiseCriticalDialog);
  
@@ -115,17 +109,17 @@ index 12b03df80..9439fb69d 100644
 -  if (Settings::value(Settings::Gui::AutoUpdateCheck).toBool()) {
 -    m_versionChecker.checkLatest();
 -  } else {
--    qDebug() << "update check disabled";
+-    qDebug() << "skipping check for new version, disabled";
 -  }
 -
-   if (Settings::value(Settings::Core::StartedBefore).toBool()) {
+   if (Settings::value(Settings::Gui::AutoStartCore).toBool()) {
      if (ui->rbModeClient->isChecked() && ui->lineHostname->text().isEmpty())
        return;
 diff --git a/src/lib/gui/MainWindow.h b/src/lib/gui/MainWindow.h
-index 63db153dc..91df18373 100644
+index 8327de8c8e..f696039e48 100644
 --- a/src/lib/gui/MainWindow.h
 +++ b/src/lib/gui/MainWindow.h
-@@ -16,7 +16,6 @@
+@@ -18,7 +18,6 @@
  #include <QSystemTrayIcon>
  #include <QThread>
  
@@ -133,7 +127,7 @@ index 63db153dc..91df18373 100644
  #include "config/ServerConfig.h"
  #include "gui/core/ClientConnection.h"
  #include "gui/core/CoreProcess.h"
-@@ -103,7 +102,6 @@ private:
+@@ -106,7 +105,6 @@ private:
    void coreProcessError(CoreProcess::Error error);
    void coreConnectionStateChanged(CoreProcess::ConnectionState state);
    void coreProcessStateChanged(CoreProcess::ProcessState state);
@@ -141,19 +135,19 @@ index 63db153dc..91df18373 100644
    void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
    void serverConnectionConfigureClient(const QString &clientName);
  
-@@ -172,7 +170,6 @@ private:
+@@ -185,7 +183,6 @@ private:
    inline static const auto m_guiSocketName = QStringLiteral("deskflow-gui");
    inline static const auto m_nameRegEx = QRegularExpression(QStringLiteral("^[\\w\\-_\\.]{0,255}$"));
  
 -  VersionChecker m_versionChecker;
    bool m_secureSocket = false;
    bool m_saveOnExit = true;
-   deskflow::gui::core::WaylandWarnings m_waylandWarnings;
+   bool m_clientErrorVisible = false;
 diff --git a/src/lib/gui/Messages.cpp b/src/lib/gui/Messages.cpp
-index f41dda93a..e4a0ba451 100644
+index ca396f3f32..6fa30f5b2b 100644
 --- a/src/lib/gui/Messages.cpp
 +++ b/src/lib/gui/Messages.cpp
-@@ -309,24 +309,6 @@ void showWaylandLibraryError(QWidget *parent)
+@@ -298,24 +298,6 @@ void showWaylandLibraryError(QWidget *parent)
    );
  }
  
@@ -168,7 +162,7 @@ index f41dda93a..e4a0ba451 100644
 -          "<p>Checking for updates requires an Internet connection.</p>"
 -          "<p>URL: <pre>%2</pre></p>"
 -      )
--          .arg(kAppName, Settings::value(Settings::Core::UpdateUrl).toString())
+-          .arg(kAppName, Settings::value(Settings::Gui::UpdateCheckUrl).toString())
 -  );
 -
 -  message.exec();
@@ -179,10 +173,10 @@ index f41dda93a..e4a0ba451 100644
  {
    QMessageBox message(parent);
 diff --git a/src/lib/gui/Messages.h b/src/lib/gui/Messages.h
-index f035e2092..339eb8dfb 100644
+index 7e27392c96..e36f4fe0e5 100644
 --- a/src/lib/gui/Messages.h
 +++ b/src/lib/gui/Messages.h
-@@ -47,8 +47,6 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
+@@ -35,8 +35,6 @@ void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
  
  void showWaylandLibraryError(QWidget *parent);
  
@@ -192,10 +186,10 @@ index f035e2092..339eb8dfb 100644
  
  } // namespace deskflow::gui::messages
 diff --git a/src/lib/gui/dialogs/SettingsDialog.cpp b/src/lib/gui/dialogs/SettingsDialog.cpp
-index 4e0ebb774..18041ec10 100644
+index 5c0514b0c2..470f32ede0 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.cpp
 +++ b/src/lib/gui/dialogs/SettingsDialog.cpp
-@@ -165,7 +165,6 @@ void SettingsDialog::accept()
+@@ -176,7 +176,6 @@ void SettingsDialog::accept()
    Settings::setValue(Settings::Log::File, ui->lineLogFilename->text());
    Settings::setValue(Settings::Daemon::Elevate, ui->cbElevateDaemon->isChecked());
    Settings::setValue(Settings::Gui::Autohide, ui->cbAutoHide->isChecked());
@@ -203,15 +197,15 @@ index 4e0ebb774..18041ec10 100644
    Settings::setValue(Settings::Core::PreventSleep, ui->cbPreventSleep->isChecked());
    Settings::setValue(Settings::Security::Certificate, ui->lineTlsCertPath->text());
    Settings::setValue(Settings::Security::KeySize, ui->comboTlsKeyLength->currentText().toInt());
-@@ -203,7 +202,6 @@ void SettingsDialog::loadFromConfig()
-   ui->cbScrollDirection->setChecked(Settings::value(Settings::Client::InvertScrollDirection).toBool());
+@@ -209,7 +208,6 @@ void SettingsDialog::loadFromConfig()
+   ui->cbPreventSleep->setChecked(Settings::value(Settings::Core::PreventSleep).toBool());
    ui->cbCloseToTray->setChecked(Settings::value(Settings::Gui::CloseToTray).toBool());
    ui->cbElevateDaemon->setChecked(Settings::value(Settings::Daemon::Elevate).toBool());
 -  ui->cbAutoUpdate->setChecked(Settings::value(Settings::Gui::AutoUpdateCheck).toBool());
-   ui->sbScrollSpeed->setValue(Settings::value(Settings::Client::ScrollSpeed).toInt());
    ui->cbGuiDebug->setChecked(Settings::value(Settings::Log::GuiDebug).toBool());
    ui->cbUseWlClipboard->setChecked(Settings::value(Settings::Core::UseWlClipboard).toBool());
-@@ -295,7 +293,6 @@ void SettingsDialog::updateControls()
+   ui->cbShowVersion->setChecked(Settings::value(Settings::Gui::ShowVersionInTitle).toBool());
+@@ -302,7 +300,6 @@ void SettingsDialog::updateControls()
    ui->comboLogLevel->setEnabled(writable);
    ui->cbLogToFile->setEnabled(writable);
    ui->cbAutoHide->setEnabled(writable);
@@ -220,10 +214,10 @@ index 4e0ebb774..18041ec10 100644
    ui->lineTlsCertPath->setEnabled(writable);
    ui->comboTlsKeyLength->setEnabled(writable);
 diff --git a/src/lib/gui/dialogs/SettingsDialog.ui b/src/lib/gui/dialogs/SettingsDialog.ui
-index 8bce0d9a4..adffd664b 100644
+index 187eedafab..74c1c2d8c0 100644
 --- a/src/lib/gui/dialogs/SettingsDialog.ui
 +++ b/src/lib/gui/dialogs/SettingsDialog.ui
-@@ -104,13 +104,6 @@
+@@ -45,13 +45,6 @@
            <string>App</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -235,16 +229,33 @@ index 8bce0d9a4..adffd664b 100644
 -           </widget>
 -          </item>
            <item>
-            <widget class="QCheckBox" name="cbAutoHide">
+            <widget class="QCheckBox" name="cbShowVersion">
              <property name="text">
-@@ -722,7 +715,6 @@
-  <tabstops>
-   <tabstop>cbLanguageSync</tabstop>
-   <tabstop>cbScrollDirection</tabstop>
--  <tabstop>cbAutoUpdate</tabstop>
-   <tabstop>cbCloseToTray</tabstop>
-   <tabstop>rbIconColorful</tabstop>
-   <tabstop>rbIconMono</tabstop>
+@@ -717,6 +710,24 @@
+    </item>
+   </layout>
+  </widget>
++ <tabstops>
++  <tabstop>cbLanguageSync</tabstop>
++  <tabstop>cbScrollDirection</tabstop>
++  <tabstop>cbCloseToTray</tabstop>
++  <tabstop>rbIconColorful</tabstop>
++  <tabstop>rbIconMono</tabstop>
++  <tabstop>groupSecurity</tabstop>
++  <tabstop>lineTlsCertPath</tabstop>
++  <tabstop>btnTlsCertPath</tabstop>
++  <tabstop>comboTlsKeyLength</tabstop>
++  <tabstop>btnTlsRegenCert</tabstop>
++  <tabstop>cbRequireClientCert</tabstop>
++  <tabstop>sbPort</tabstop>
++  <tabstop>lineInterface</tabstop>
++  <tabstop>cbLogToFile</tabstop>
++  <tabstop>lineLogFilename</tabstop>
++  <tabstop>btnBrowseLog</tabstop>
++ </tabstops>
+  <resources/>
+  <connections/>
+ </ui>
 -- 
 2.52.0
 

--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -1,4 +1,4 @@
-VER=1.25.0
+VER=1.26.0
 SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375452"


### PR DESCRIPTION
Topic Description
-----------------

- deskflow: update to 1.26.0
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- deskflow: 1.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit deskflow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
