### PR TITLE
openjdk-25: new,25.0.2-ga

### DIFF
--- a/lang-java/openjdk-25/autobuild/beyond
+++ b/lang-java/openjdk-25/autobuild/beyond
@@ -1,0 +1,20 @@
+##### Control part variables
+OPENJDK_SUFFIX="-25"
+
+abinfo "Generating postinst scripts ..."
+printf 'update-alternatives --install /usr/lib/java java-home /usr/lib/java%s 50\n' "$OPENJDK_SUFFIX" >>"$SRCDIR/autobuild/postinst"
+printf 'update-alternatives --install /usr/bin/java java /usr/lib/java%s/bin/java 50' "$OPENJDK_SUFFIX" >> "$SRCDIR/autobuild/postinst"
+for i in "$PKGDIR"/usr/lib/java${OPENJDK_SUFFIX}/bin/*; do
+    BIN="$(basename $i)"
+    [ "$BIN" == 'java' ] || printf " --slave /usr/bin/$BIN $BIN /usr/lib/java%s/bin/$BIN" "$OPENJDK_SUFFIX" >> "$SRCDIR/autobuild/postinst"
+done
+
+cat <<EOF >"$SRCDIR/autobuild/postrm"
+if [ "\$1" != "upgrade" ]; then
+    update-alternatives --remove java-home /usr/lib/java$OPENJDK_SUFFIX || true
+    update-alternatives --remove java /usr/lib/java$OPENJDK_SUFFIX || true
+fi
+EOF
+
+abinfo "Final postinst script:"
+cat "$SRCDIR/autobuild/postinst"

--- a/lang-java/openjdk-25/autobuild/build
+++ b/lang-java/openjdk-25/autobuild/build
@@ -1,0 +1,112 @@
+##### Control part variables
+EXTRA_FEATURES=""
+OPENJDK_SUFFIX="-25"
+
+##### Archtecture mapping
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
+ab_match_arch "mipsel" && export ADOPTIUM_ARCH="mipsel"
+ab_match_arch "powerpc" && export ADOPTIUM_ARCH="ppc"
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+
+__JDK_CONFIGURE_AFTER=()
+if [[ -z "${JDK_HAS_JIT:-}" ]]; then
+    __JDK_CONFIGURE_AFTER+=(
+        "--with-jvm-variants=zero"
+        "--enable-precompiled-headers"
+    )
+    # FIXME: disable jfr in zero builds to fix:
+    # error: no matching function for call to ‘frame::frame(intptr_t* const&,
+    # intptr_t* const&, intptr_t* const&, address, nmethod* const&)’
+    EXTRA_FEATURES+=",-jfr"
+else
+    EXTRA_FEATURES+=",shenandoahgc,zgc,jfr"
+fi
+
+unset JAVA_HOME
+unset _JAVA_OPTIONS
+
+abinfo "Configuring OpenJDK ${PKGVER} ..."
+install -dv -m 755 "$SRCDIR"/image
+sh "$SRCDIR"/configure \
+    --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
+    --with-version-pre='' \
+    --with-version-opt="AOSC" \
+    --with-stdc++lib=dynamic \
+    --disable-warnings-as-errors \
+    --enable-unlimited-crypto \
+    --enable-linktime-gc \
+    --with-zlib=system \
+    --with-libpng=system \
+    --with-libjpeg=system \
+    --with-giflib=system \
+    "${__JDK_CONFIGURE_AFTER[@]}" \
+    --with-jvm-features="${EXTRA_FEATURES}" \
+    --enable-precompiled-headers \
+    --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
+    --with-extra-cflags="${EXTRA_CFLAGS}" \
+    --with-extra-ldflags="${LDFLAGS}" \
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
+
+abinfo "Building OpenJDK ..."
+make product-images docs JOBS="$(nproc)"
+
+mkdir -pv "$PKGDIR"/usr/lib/java
+mkdir -pv "$PKGDIR/etc/"
+# Not installing docs
+# mkdir -pv "$PKGDIR"/usr/share/doc
+
+IMAGE_FOLDER=build/aosc/images/
+abinfo "Copying JDK images ..."
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
+# Not installing docs
+# cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+# FIXME: no pandoc for other architecture for now
+if ab_match_arch amd64 || ab_match_arch arm64 ; then
+    mkdir -pv "$PKGDIR"/usr/share
+    abinfo "Installing man pages ..."
+    mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
+    ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
+    find "$PKGDIR"/usr/share/man -type l -delete
+fi
+find "$PKGDIR" -iname '*.diz' -exec rm -v {} \;
+find "$PKGDIR" -iname '*.debuginfo' -exec rm -v {} \;
+
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+
+abinfo "Linking system CA certificate store ..."
+rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+
+if [[ -n "$OPENJDK_SUFFIX" ]]; then
+    abinfo "Renaming for openjdk suffix ..."
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    done
+    if [[ -e "$PKGDIR"/usr/share/man/man1 ]]; then
+        mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    fi
+fi
+
+abinfo "Generating conffiles ..."
+pushd "$PKGDIR" || exit
+while read -r path; do
+    printf '/%s\n' "$path" >>"$SRCDIR"/autobuild/conffiles
+done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
+popd || exit
+
+unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-25/autobuild/build.stage2
+++ b/lang-java/openjdk-25/autobuild/build.stage2
@@ -1,0 +1,129 @@
+##### Control part variables
+EXTRA_FEATURES=""
+BOOTSTRAP_ADOPTIUM=24+37
+BOOTSTRAP_ALPINE="v3.20"
+BOOTSTRAP_DEBIAN="sid"
+# the current version of LoongArchLinux jre-openjdk package
+# https://loongarchlinux.org/package/?repo=extra&arch=loong64&name=jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk
+BOOTSTRAP_LOONGARCH64_SUF=""
+BOOTSTRAP_LOONGARCH64="20"
+OPENJDK_SUFFIX="-25"
+# set to /usr/lib/java to bootstrap from AOSC OS JDK
+JDKBOOTDIR="/usr/lib/java-24"
+
+##### Archtecture mapping
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+
+__JDK_CONFIGURE_AFTER=()
+if [[ -z "${JDK_HAS_JIT:-}" ]]; then
+    __JDK_CONFIGURE_AFTER+=(
+        "--with-jvm-variants=zero"
+        "--enable-precompiled-headers"
+        # Note: To address stack overflow when compiling on loongson3
+        "--with-boot-jdk-jvmargs=-Xss256M"
+    )
+    # FIXME: disable jfr in zero builds to fix:
+    # error: no matching function for call to ‘frame::frame(intptr_t* const&,
+    # intptr_t* const&, intptr_t* const&, address, nmethod* const&)’
+    EXTRA_FEATURES+=",-jfr"
+else
+    EXTRA_FEATURES+=",shenandoahgc,zgc,jfr"
+fi
+
+unset JAVA_HOME
+unset _JAVA_OPTIONS
+
+if [[ -z "$JDKBOOTDIR" ]]; then
+    abdie "Could not find a possible bootstrap JDK"
+fi
+
+export JDKBOOTDIR
+
+abinfo "Configuring OpenJDK ${PKGVER} ..."
+install -dv -m 755 "$SRCDIR"/image
+sh "$SRCDIR"/configure \
+    --with-boot-jdk="$JDKBOOTDIR" \
+    --prefix="$SRCDIR"/image \
+    --with-conf-name=aosc \
+    --with-version-pre='' \
+    --with-version-opt="AOSC" \
+    --with-stdc++lib=dynamic \
+    --disable-warnings-as-errors \
+    --enable-unlimited-crypto \
+    --enable-linktime-gc \
+    --with-zlib=system \
+    --with-libpng=system \
+    --with-libjpeg=system \
+    --with-giflib=system \
+    "${__JDK_CONFIGURE_AFTER[@]}" \
+    --with-jvm-features="${EXTRA_FEATURES}" \
+    --enable-precompiled-headers \
+    --with-extra-cxxflags="${EXTRA_CPP_FLAGS}" \
+    --with-extra-cflags="${EXTRA_CFLAGS}" \
+    --with-extra-ldflags="${LDFLAGS}" \
+    --with-vendor-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-vendor-vm-bug-url="https://github.com/AOSC-Dev/aosc-os-abbs/issues" \
+    --with-native-debug-symbols=zipped
+
+abinfo "Building OpenJDK ..."
+make product-images docs JOBS="$(nproc)"
+
+mkdir -pv "$PKGDIR"/usr/lib/java
+mkdir -pv "$PKGDIR/etc/"
+# disabling docs
+# mkdir -pv "$PKGDIR"/usr/share/doc
+
+IMAGE_FOLDER=build/aosc/images/
+abinfo "Copying JDK images ..."
+cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
+# disabling docs
+# cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+ln -sv ../../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+
+# FIXME: no pandoc for other architecture for now
+if ab_match_arch amd64 || ab_match_arch arm64 ; then
+    abinfo "Installing man pages ..."
+    mkdir -pv "$PKGDIR"/usr/share
+    mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
+    ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
+    find "$PKGDIR"/usr/share/man -type l -delete
+fi
+find "$PKGDIR" -iname '*.diz' -exec rm -v {} \;
+find "$PKGDIR" -iname '*.debuginfo' -exec rm -v {} \;
+
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../../usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+
+abinfo "Linking system CA certificate store ..."
+rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+
+if [[ -n "$OPENJDK_SUFFIX" ]]; then
+    abinfo "Renaming for openjdk suffix ..."
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    done
+    if [[ -e "$PKGDIR"/usr/share/man/man1 ]]; then
+        mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    fi
+fi
+
+abinfo "Generating conffiles ..."
+pushd "$PKGDIR" || exit
+while read -r path; do
+    printf '/%s\n' "$path" >>"$SRCDIR"/autobuild/conffiles
+done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
+popd || exit
+
+unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-25/autobuild/defines
+++ b/lang-java/openjdk-25/autobuild/defines
@@ -1,0 +1,20 @@
+PKGNAME=openjdk-25
+PKGSEC=java
+PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
+        cups fontconfig unzip zip cpio"
+BUILDDEP="openjdk-25"
+# FIXME: pandoc is only available on amd64 and arm64
+BUILDDEP__AMD64="${BUILDDEP} pandoc graphviz"
+BUILDDEP__ARM64="${BUILDDEP} pandoc graphviz"
+PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 25)"
+ABTYPE=self
+PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"
+AB_FLAGS_EXC=0
+# Note: openjdk uses "make JOBS=n"
+NOPARALLEL=1
+
+# FIXME: breaks binary.
+NOLTO=1
+
+# Note: No useful symbol can be split out.
+ABSPLITDBG=0

--- a/lang-java/openjdk-25/autobuild/defines.stage2
+++ b/lang-java/openjdk-25/autobuild/defines.stage2
@@ -1,0 +1,20 @@
+PKGNAME=openjdk-25
+PKGSEC=java
+PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
+        cups fontconfig unzip zip cpio"
+BUILDDEP="openjdk-24"
+# FIXME: pandoc is only available on amd64 and arm64
+BUILDDEP__AMD64="${BUILDDEP} pandoc graphviz"
+BUILDDEP__ARM64="${BUILDDEP} pandoc graphviz"
+PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 25)"
+
+PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"
+ABTYPE=self
+AB_FLAGS_EXC=0
+
+# Note: openjdk uses "make JOBS=n"
+NOPARALLEL=1
+
+# FIXME: breaks binary.
+NOLTO=1
+ABSPLITDBG=0

--- a/lang-java/openjdk-25/autobuild/postinst
+++ b/lang-java/openjdk-25/autobuild/postinst
@@ -1,0 +1,1 @@
+ldconfig

--- a/lang-java/openjdk-25/autobuild/prepare
+++ b/lang-java/openjdk-25/autobuild/prepare
@@ -1,0 +1,16 @@
+# Java version.
+_JAVA_VERSION=25
+
+abinfo "Replacing config.* ..."
+find "$SRCDIR" '(' -name config.guess -o -name config.sub ')' \
+    -execdir 'cp' '-v' '/usr/bin/{}' '{}' ';' \
+    || abdie "Failed to copy replacement: $?."
+
+abinfo "Setting compilation flags ..."
+export JAVA_HOME="/usr/lib/java-${_JAVA_VERSION}"
+
+abinfo "Setting OpenJDK to mainline version ..."
+update-alternatives --set java-home /usr/lib/java-${_JAVA_VERSION} || true
+update-alternatives --set java /usr/lib/java-${_JAVA_VERSION}/bin/java ||
+    update-alternatives --set java /usr/lib/java/bin/java || true
+java -version

--- a/lang-java/openjdk-25/autobuild/prepare.stage2
+++ b/lang-java/openjdk-25/autobuild/prepare.stage2
@@ -1,0 +1,6 @@
+# Java version.
+_JAVA_VERSION=24
+abinfo "Overriding GNU config files ..."
+cp -v /usr/bin/config.* "$SRCDIR"/make/autoconf/build-aux/
+abinfo "Setting compilation flags ..."
+export JAVA_HOME="/usr/lib/java-${_JAVA_VERSION}"

--- a/lang-java/openjdk-25/spec
+++ b/lang-java/openjdk-25/spec
@@ -1,0 +1,6 @@
+MAJOR_VER=25
+UPSTREAM_VER=25.0.2-ga
+VER=${UPSTREAM_VER/-/+}
+SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376246"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-25:new, 25.0.2-ga

Package(s) Affected
-------------------

- openjdk-25: 25.0.2+ga

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjdk-25:+stage2 openjdk-25
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
