### PR TITLE
mimalloc: update to 3.2.8

### DIFF
--- a/app-devel/mold/autobuild/defines
+++ b/app-devel/mold/autobuild/defines
@@ -1,7 +1,11 @@
 PKGNAME=mold
 PKGDES="A drop-in replacement for existing Unix linkers"
 PKGSEC=devel
-PKGDEP="zlib gcc-runtime glibc mimalloc"
+PKGDEP="gcc-runtime glibc mimalloc tbb zlib zstd"
 
-# -DMOLD_USE_SYSTEM_TBB=ON is disabled for now until we have recent enough TBB
-CMAKE_AFTER="-DMOLD_LTO=ON -DMOLD_USE_SYSTEM_MIMALLOC=ON"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DMOLD_LTO=ON'
+    '-DMOLD_USE_SYSTEM_MIMALLOC=ON'
+    '-DMOLD_USE_SYSTEM_TBB=ON'
+)

--- a/app-devel/mold/spec
+++ b/app-devel/mold/spec
@@ -1,4 +1,5 @@
 VER=2.40.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/rui314/mold"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241732"

--- a/runtime-common/mimalloc/autobuild/defines
+++ b/runtime-common/mimalloc/autobuild/defines
@@ -11,4 +11,12 @@ PKGDEP="glibc"
 # to turn it off.
 # Building object file will put the object file in /usr/lib which
 # is unnecessary. Use -DMI_BUILD_OBJECT=OFF to turn it off.
-CMAKE_AFTER="-DMI_INSTALL_TOPLEVEL=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DMI_INSTALL_TOPLEVEL=ON'
+    '-DMI_BUILD_STATIC=OFF'
+    '-DMI_BUILD_OBJECT=OFF'
+    '-DMI_BUILD_TESTS=OFF'
+)
+
+PKGBREAK="mold<=2.40.4"

--- a/runtime-common/mimalloc/spec
+++ b/runtime-common/mimalloc/spec
@@ -1,4 +1,4 @@
-VER=2.2.4
+VER=3.2.8
 SRCS="git::commit=tags/v$VER::https://github.com/microsoft/mimalloc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=233872"


### PR DESCRIPTION
Topic Description
-----------------

- mold: bump REL due to mimalloc update to 3.2.8
- mimalloc: update to 3.2.8
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- mimalloc: 3.2.8
- mold: 2.40.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mimalloc:-pkgbreak mold mimalloc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
