### PR TITLE
librepods: new, 0.1.0~rc.4

### DIFF
--- a/app-devices/librepods/autobuild/beyond
+++ b/app-devices/librepods/autobuild/beyond
@@ -1,3 +1,0 @@
-abinfo "Rename applinux to librepods ..."
-mv "$PKGDIR"/usr/bin/applinux \
-   "$PKGDIR"/usr/bin/librepods

--- a/app-devices/librepods/autobuild/beyond
+++ b/app-devices/librepods/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Rename applinux to librepods ..."
+mv "$PKGDIR"/usr/bin/applinux \
+   "$PKGDIR"/usr/bin/librepods

--- a/app-devices/librepods/autobuild/defines
+++ b/app-devices/librepods/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME="librepods"
+PKGDES="Utility to work with Apple AirPods"
+PKGDEP="gcc-runtime glibc openssl pulseaudio qt-6 wireplumber"
+PKGSEC="util"
+
+ABTYPE="cmakeninja"

--- a/app-devices/librepods/autobuild/overrides/usr/share/wireplumber/wireplumber.conf.d/51-bluez-avrcp.conf
+++ b/app-devices/librepods/autobuild/overrides/usr/share/wireplumber/wireplumber.conf.d/51-bluez-avrcp.conf
@@ -1,0 +1,5 @@
+monitor.bluez.properties = {
+  # Enable dummy AVRCP player for proper media control support
+  # This is required for AirPods and other devices to send play/pause/skip commands
+  bluez5.dummy-avrcp-player = true
+}

--- a/app-devices/librepods/spec
+++ b/app-devices/librepods/spec
@@ -1,0 +1,5 @@
+VER=0.1.0~rc.4
+SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/kavishdevar/librepods"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=389460"
+SUBDIR="librepods/linux"

--- a/app-devices/librepods/spec
+++ b/app-devices/librepods/spec
@@ -1,4 +1,4 @@
-VER=0.1.0~rc.4
+VER=0.2.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/kavishdevar/librepods"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=389460"


### PR DESCRIPTION
Topic Description
-----------------

- librepods: new, 0.1.0\~rc.4

Package(s) Affected
-------------------

- librepods: 0.1.0~rc.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit librepods
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
