### PR TITLE
readline: fix a typo in inputrc

### DIFF
--- a/runtime-common/readline/autobuild/overrides/etc/inputrc
+++ b/runtime-common/readline/autobuild/overrides/etc/inputrc
@@ -31,7 +31,7 @@ $if mode=emacs
 "\e[1;5C": forward-word
 "\e[1;5D": backward-word
 
-# for enable history search mode
+# for history search mode
 "\e[A": history-search-backward
 "\e[B": history-search-forward
 

--- a/runtime-common/readline/spec
+++ b/runtime-common/readline/spec
@@ -1,4 +1,5 @@
 VER=8.3
+REL=1
 SRCS="https://ftp.gnu.org/gnu/readline/readline-${VER:0:3}.tar.gz"
 CHKSUMS="sha256::fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc"
 CHKUPDATE="anitya::id=4173"


### PR DESCRIPTION
Topic Description
-----------------

- readline: fix a typo in inputrc

Package(s) Affected
-------------------

- readline: 8.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit readline
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
