### PR TITLE
tree-sitter: update to 0.26.8

### DIFF
--- a/app-devel/tree-sitter/spec
+++ b/app-devel/tree-sitter/spec
@@ -1,5 +1,4 @@
-VER=0.25.3
-REL=1
+VER=0.26.8
 SRCS="git::commit=tags/v$VER::https://github.com/tree-sitter/tree-sitter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=142464"


### PR DESCRIPTION
Topic Description
-----------------

- tree-sitter: update to 0.26.8
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- tree-sitter: 0.26.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit tree-sitter
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
