### PR TITLE
miniaudio: new, 0.11.25

### DIFF
--- a/runtime-multimedia/miniaudio/autobuild/defines
+++ b/runtime-multimedia/miniaudio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=miniaudio
+PKGSEC=sound
+PKGDEP="opusfile libvorbis"
+PKGDES="Single-file audio playback and capture library"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+	-DBUILD_SHARED_LIBS=ON
+)

--- a/runtime-multimedia/miniaudio/spec
+++ b/runtime-multimedia/miniaudio/spec
@@ -1,0 +1,4 @@
+VER=0.11.25
+SRCS="git::commit=tags/$VER::https://github.com/mackron/miniaudio"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376647"


### PR DESCRIPTION
Topic Description
-----------------

- miniaudio: new, 0.11.25

Package(s) Affected
-------------------

- miniaudio: 0.11.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit miniaudio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
