### PR TITLE
coreboot-utils: update to 26.03

### DIFF
--- a/app-admin/coreboot-utils/spec
+++ b/app-admin/coreboot-utils/spec
@@ -1,4 +1,4 @@
-VER=24.08
+VER=26.03
 SRCS="https://www.coreboot.org/releases/coreboot-$VER.tar.xz"
-CHKSUMS="sha256::1fc9a997d497539f915dc6498e4aca4bf049955d4db9a17a85454ad6b342710c"
+CHKSUMS="sha256::ee6e13c454175c5e1d8615877467d25171ee8958a2e6a4ffe87d91e7c78b20d4"
 CHKUPDATE="anitya::id=10128"


### PR DESCRIPTION
Topic Description
-----------------

- coreboot-utils: update to 26.03
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- coreboot-utils: 26.03

Security Update?
----------------

No

Build Order
-----------

```
#buildit coreboot-utils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
