### PR TITLE
suitesparse: update to 7.12.2

### DIFF
--- a/runtime-scientific/suitesparse/spec
+++ b/runtime-scientific/suitesparse/spec
@@ -1,5 +1,4 @@
-VER=7.6.1
-REL=2
+VER=7.12.2
 SRCS="git::commit=tags/v$VER::https://github.com/DrTimothyAldenDavis/SuiteSparse"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4908"


### PR DESCRIPTION
Topic Description
-----------------

- suitesparse: update to 7.12.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- suitesparse: 7.12.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit suitesparse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
