### PR TITLE
chiron-sans-hk: update to 2.608

### DIFF
--- a/desktop-fonts/chiron-sans-hk/spec
+++ b/desktop-fonts/chiron-sans-hk/spec
@@ -1,4 +1,4 @@
-VER=2.046
+VER=2.608
 SRCS="git::commit=tags/v$VER::https://github.com/chiron-fonts/chiron-sans-hk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241426"


### PR DESCRIPTION
Topic Description
-----------------

- chiron-sans-hk: update to 2.608
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- chiron-sans-hk: 2.608

Security Update?
----------------

No

Build Order
-----------

```
#buildit chiron-sans-hk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
