### PR TITLE
hysteria: update to 2.8.1

### DIFF
--- a/app-proxy/hysteria/spec
+++ b/app-proxy/hysteria/spec
@@ -1,5 +1,4 @@
-VER=2.6.3
-REL=3
+VER=2.8.1
 SRCS="git::commit=tags/app/v$VER::https://github.com/apernet/hysteria"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371975"


### PR DESCRIPTION
Topic Description
-----------------

- hysteria: update to 2.8.1
    Co-authored-by: Lain Yang \(@Fearyncess\) <fsf@live.com>

Package(s) Affected
-------------------

- hysteria: 2.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hysteria
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
