### PR TITLE
flameshot: update v14

### DIFF
--- a/app-utils/flameshot/autobuild/beyond
+++ b/app-utils/flameshot/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Deleting bundled QtColorWidgets header files..."
+
+rm -rv "${PKGDIR}"/usr/include/QtColorWidgets
+rm -rv "${PKGDIR}"/usr/lib/cmake/QtColorWidgets
+rm -rv "${PKGDIR}"/usr/lib/pkgconfig/QtColorWidgets.pc

--- a/app-utils/flameshot/autobuild/defines
+++ b/app-utils/flameshot/autobuild/defines
@@ -1,6 +1,11 @@
 PKGNAME=flameshot
 PKGSEC=utils
-PKGDEP="qt-5"
+PKGDEP="qt-6 kdsingleapplication"
 PKGDES="Powerful yet simple to use screenshot software"
 PKGBREAK="zsh-completions<=0.32.0"
 PKGREP="zsh-completions<=0.32.0"
+
+CMAKE_AFTER=(
+	"-DUSE_BUNDLED_KDSINGLEAPPLICATION=OFF"
+	"-DDISABLE_UPDATE_CHECKER=ON"
+)

--- a/app-utils/flameshot/spec
+++ b/app-utils/flameshot/spec
@@ -1,5 +1,4 @@
-VER=12.1.0
-REL=5
-SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c82c05d554e7a6d810aca8417ca12b21e4f74864455ab4ac94602668f85ac22a"
+VER=14.0.0
+SRCS="git::commit=tags/v${VER/\0~/}::https://github.com/flameshot-org/flameshot"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16948"


### PR DESCRIPTION
Topic Description
-----------------

- flameshot: update to 14.0.0\~rc1

Package(s) Affected
-------------------

- flameshot: 14.0.0~rc1

Security Update?
----------------

No

Build Order
-----------

```
#buildit flameshot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
