### PR TITLE
lemonlime:new, 0.3.6.1

### DIFF
--- a/app-scientific/lemonlime/autobuild/defines
+++ b/app-scientific/lemonlime/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=lemonlime
+PKGSEC=science
+PKGDEP="qt-6"
+PKGDES="Offline judge environment for competitive progamming contest"
+
+ABTYPE=cmakeninja

--- a/app-scientific/lemonlime/autobuild/patches/0001-AOSCOS-change-executable-file-name-to-lemonlime.patch
+++ b/app-scientific/lemonlime/autobuild/patches/0001-AOSCOS-change-executable-file-name-to-lemonlime.patch
@@ -1,0 +1,53 @@
+From 603f475cdf6375492f6ac24b478b6ff6106a55b0 Mon Sep 17 00:00:00 2001
+From: BillZhou233 <46444349+BillZhou233@users.noreply.github.com>
+Date: Sat, 4 Apr 2026 16:43:45 +0800
+Subject: [PATCH] AOSCOS: change executable file name to lemonlime
+
+---
+ CMakeLists.txt                    | 3 +++
+ assets/lemon-lime.desktop.in      | 2 +-
+ assets/lemon-lime.metainfo.xml.in | 2 +-
+ 3 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f0dba81..5369a68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -285,6 +285,9 @@ else()
+     add_dependencies(lemon watcher_unix)
+ endif()
+ 
++# Rename output filename to lemonlime
++set_target_properties(lemon PROPERTIES OUTPUT_NAME "lemonlime")
++
+ target_include_directories(lemon PUBLIC ${CMAKE_SOURCE_DIR}/src)
+ 
+ if(WIN32 AND ENABLE_XLS_EXPORT)
+diff --git a/assets/lemon-lime.desktop.in b/assets/lemon-lime.desktop.in
+index b0eb349..69c0bc3 100755
+--- a/assets/lemon-lime.desktop.in
++++ b/assets/lemon-lime.desktop.in
+@@ -18,6 +18,6 @@ Keywords[ja]=OI;Qt;評価;
+ Categories=Utility;Education;Competition;
+ Terminal=false
+ Path=/usr/bin
+-Exec=lemon
++Exec=lemonlime
+ Icon=lemon-lime
+ MimeType=application/x-lemon-contest;
+diff --git a/assets/lemon-lime.metainfo.xml.in b/assets/lemon-lime.metainfo.xml.in
+index 73dbc92..46efa15 100644
+--- a/assets/lemon-lime.metainfo.xml.in
++++ b/assets/lemon-lime.metainfo.xml.in
+@@ -23,7 +23,7 @@
+     </screenshot>
+   </screenshots>
+   <provides>
+-    <binary>lemon</binary>
++    <binary>lemonlime</binary>
+   </provides>
+   <releases>
+     <release version="0.3.5" date="2024-7-15"/>
+-- 
+2.50.1 (Apple Git-155)
+

--- a/app-scientific/lemonlime/autobuild/patches/0002-AOSCOS-fix-mime-xml-path.patch
+++ b/app-scientific/lemonlime/autobuild/patches/0002-AOSCOS-fix-mime-xml-path.patch
@@ -1,0 +1,25 @@
+From c3ecdcb1dc676c88f2b6167d4a25a9196d60b633 Mon Sep 17 00:00:00 2001
+From: BillZhou233 <46444349+BillZhou233@users.noreply.github.com>
+Date: Sat, 4 Apr 2026 19:41:21 +0800
+Subject: [PATCH 2/2] AOSCOS: fix mime xml path
+
+---
+ cmake/platforms/linux.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/platforms/linux.cmake b/cmake/platforms/linux.cmake
+index 0f2f4e4..1c23c28 100644
+--- a/cmake/platforms/linux.cmake
++++ b/cmake/platforms/linux.cmake
+@@ -4,7 +4,7 @@ include(GNUInstallDirs)
+ 
+ set(LEMON_LINUX_ICON_DIMENSIONS 16 22 24 32 36 44 48 64 72 96 128 150 192 256 310 512 1024)
+ install(FILES assets/lemon-lime.metainfo.xml.in DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo" RENAME lemon-lime.metainfo.xml)
+-install(FILES assets/x-lemon-contest.xml.in DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/application" RENAME x-lemon-contest.xml)
++install(FILES assets/x-lemon-contest.xml.in DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages" RENAME x-lemon-contest.xml)
+ install(FILES assets/lemon-lime.desktop.in DESTINATION "${CMAKE_INSTALL_DATADIR}/applications" RENAME lemon-lime.desktop)
+ #install(FILES assets/icons/lemon-lime.svg DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps")
+ foreach(LEMON_LINUX_ICON_DIMENSION ${LEMON_LINUX_ICON_DIMENSIONS})
+-- 
+2.50.1 (Apple Git-155)
+

--- a/app-scientific/lemonlime/spec
+++ b/app-scientific/lemonlime/spec
@@ -1,0 +1,5 @@
+VER=0.3.6.1
+
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/Project-LemonLime/Project_LemonLime"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=389463"


### PR DESCRIPTION
Topic Description
-----------------

- lemonlime: new, 0.3.6.1

Package(s) Affected
-------------------

- lemonlime: 0.3.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lemonlime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
