### PR TITLE
clblast: update to 1.7.0

### DIFF
--- a/runtime-scientific/clblast/spec
+++ b/runtime-scientific/clblast/spec
@@ -1,4 +1,4 @@
-VER=1.6.3
+VER=1.7.0
 SRCS="git::commit=tags/$VER::https://github.com/CNugteren/CLBlast.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17818"


### PR DESCRIPTION
Topic Description
-----------------

- clblast: update to 1.7.0
    Co-authored-by: Anjia Wang \(@ouankou\) <anjia@ouankou.com>

Package(s) Affected
-------------------

- clblast: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit clblast
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
