### PR TITLE
breezy: update to 3.3.21

### DIFF
--- a/app-vcs/breezy/autobuild/defines
+++ b/app-vcs/breezy/autobuild/defines
@@ -1,10 +1,13 @@
 PKGNAME=breezy
 PKGPROV="brz bzr"
 PKGSEC=vcs
-PKGDEP="python-3 configobj dulwich urllib3 pyyaml patiencediff merge3 tzlocal fastbencode"
+PKGDEP="python-3 configobj dulwich urllib3 pyyaml patiencediff merge3 \
+        tzlocal fastbencode launchpadlib"
 PKGSUG="fastimport dulwich"
-BUILDDEP="python-build python-installer wheel setuptools-python3 setuptools-rust setuptools-gettext llvm-20 cython"
+BUILDDEP="python-build python-installer wheel setuptools-python3 \
+          setuptools-rust setuptools-gettext llvm-20 cython"
 PKGDES="Command line tools for the Breezy distributed version control system"
+
 PKGREP="bzr<=2.7.0-2"
 PKGBREAK="bzr<=2.7.0-2"
 

--- a/app-vcs/breezy/spec
+++ b/app-vcs/breezy/spec
@@ -1,5 +1,4 @@
-VER=3.3.12
-REL="3"
+VER=3.3.21
 SRCS="tbl::https://github.com/breezy-team/breezy/archive/refs/tags/brz-$VER.tar.gz"
-CHKSUMS="sha256::9ce8a3af9f45ea85761bf8a924e719cb5b20dff3e3edb1220b5c99bb37a3e46f"
+CHKSUMS="sha256::86b34450e167f96208a19260d5c981046690097815cdf4bb56b3c9f299c9f8b8"
 CHKUPDATE="anitya::id=235155"

--- a/lang-python/launchpadlib/autobuild/defines
+++ b/lang-python/launchpadlib/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=launchpadlib
+PKGSEC=python
+PKGDEP="httplib2 lazr.restfulclient lazr.uri pysocks"
+BUILDDEP="setuptools-python3"
+PKGDES="Python interface to Launchpad"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/launchpadlib/spec
+++ b/lang-python/launchpadlib/spec
@@ -1,0 +1,4 @@
+VER=2.1.0
+SRCS="pypi::version=$VER::launchpadlib"
+CHKSUMS="sha256::b4c25890bb75050d54c08123d2733156b78a59a2555f5461f69b0e44cd91242f"
+CHKUPDATE="anitya::id=48821"

--- a/lang-python/lazr.restfulclient/autobuild/defines
+++ b/lang-python/lazr.restfulclient/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=lazr.restfulclient
+PKGSEC=python
+PKGDEP="distro httplib2 oauthlib wadllib"
+BUILDDEP="setuptools-python3"
+PKGDES="Python client library to extend wadllib with RESTful functionalities"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/lazr.restfulclient/spec
+++ b/lang-python/lazr.restfulclient/spec
@@ -1,0 +1,4 @@
+VER=0.14.6
+SRCS="pypi::version=$VER::lazr.restfulclient"
+CHKSUMS="sha256::43f12a1d3948463b1462038c47b429dcb5e42e0ba7f2e16511b02ba5d2adffdb"
+CHKUPDATE="anitya::id=298202"

--- a/lang-python/lazr.uri/autobuild/defines
+++ b/lang-python/lazr.uri/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=lazr.uri
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools-python3"
+PKGDES="Python module to parse, manipulate, and generate URIs"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/lazr.uri/spec
+++ b/lang-python/lazr.uri/spec
@@ -1,0 +1,4 @@
+VER=1.0.7
+SRCS="pypi::version=$VER::lazr.uri"
+CHKSUMS="sha256::ed0cf6f333e450114752afb1ce0c299c36ac4b109063eb50354c4f87f825a3ee"
+CHKUPDATE="anitya::id=99682"

--- a/lang-python/wadllib/autobuild/defines
+++ b/lang-python/wadllib/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=wadllib
+PKGSEC=python
+PKGDEP="lazr.uri"
+BUILDDEP="setuptools-python3"
+PKGDES="Python module to navigate HTTP resources using WADL files as guides"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/wadllib/spec
+++ b/lang-python/wadllib/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="pypi::version=$VER::wadllib"
+CHKSUMS="sha256::1edbaf23e4fa34fea70c9b380baa2a139b1086ae489ebcccc4b3b65fc9737427"
+CHKUPDATE="anitya::id=69576"


### PR DESCRIPTION
Topic Description
-----------------

- breezy: update to 3.3.21
    Add launchpadlib dep.
- launchpadlib: new, 2.1.0
- lazr.restfulclient: new, 0.14.6
- wadllib: new, 2.0.0
- lazr.uri: new, 1.0.7

Package(s) Affected
-------------------

- breezy: 3.3.21
- launchpadlib: 2.1.0
- lazr.restfulclient: 0.14.6
- lazr.uri: 1.0.7
- wadllib: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lazr.uri wadllib lazr.restfulclient launchpadlib breezy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
