### PR TITLE
topics: rework for libpng-1.6.56.toml

### DIFF
--- a/topics/libpng-1.6.56.toml
+++ b/topics/libpng-1.6.56.toml
@@ -9,5 +9,5 @@ default = "Fixes a heap-based buffer overflow vulnerability (CVE-2026-3713, Seve
 zh_CN = "修复一个基于堆的缓冲区溢出漏洞（CVE-2026-3713，严重性：中）"
 
 [packages-v2]
-"libpng" = "1.6.56"
-"libpng+32" = "1.6.56"
+"libpng" = "< 1.6.56"
+"libpng+32" = "< 1.6.56"


### PR DESCRIPTION
Topic Description
-----------------

- topics: rework for libpng-1.6.56.toml
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
