### PR TITLE
autobuild4: update to 4.17.0

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.16.1
+VER=4.17.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.17.0
    \* Add IA-64 and Alpha support.
    \* Fix issues with parallel ELF stripping on 32-bit targets.

Package(s) Affected
-------------------

- autobuild4: 4.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
