### PR TITLE
parallel: update to 20260322

### DIFF
--- a/app-utils/parallel/spec
+++ b/app-utils/parallel/spec
@@ -1,4 +1,4 @@
-VER=20250422
+VER=20260322
 SRCS="tbl::https://ftp.gnu.org/gnu/parallel/parallel-$VER.tar.bz2"
-CHKSUMS="sha256::10f0a7b7fbed87edcbd63a403fdc0ee1a1f86c241a3605f33162b4b9aff248dd"
+CHKSUMS="sha256::764680e932f4d0d21cf0329bd9f9eed659895de16836001f6491533b822befe0"
 CHKUPDATE="anitya::id=5448"


### PR DESCRIPTION
Topic Description
-----------------

- parallel: update to 20260322
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- parallel: 20260322

Security Update?
----------------

No

Build Order
-----------

```
#buildit parallel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
