### PR TITLE
linyaps-web-store-installer: drop, orphaned

### DIFF
--- a/app-admin/linyaps-web-store-installer/autobuild/defines
+++ b/app-admin/linyaps-web-store-installer/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=linyaps-web-store-installer
-PKGSEC=admin
-PKGDEP="qt-5"
-PKGDES="Package installer for Linyaps (Linglong) Web store"

--- a/app-admin/linyaps-web-store-installer/spec
+++ b/app-admin/linyaps-web-store-installer/spec
@@ -1,5 +1,0 @@
-VER=1.6.3
-# FIXME: A new tag needs to be made to reflect ll-installer sync.
-SRCS="git::commit=tags/v$VER::https://github.com/OpenAtom-Linyaps/linyaps-web-store-installer"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=374940"


### PR DESCRIPTION
Topic Description
-----------------

- linyaps-web-store-installer: drop, orphaned

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
