### PR TITLE
ansible: update to 2.20.4

### DIFF
--- a/app-admin/ansible/spec
+++ b/app-admin/ansible/spec
@@ -1,5 +1,4 @@
-VER=2.12.1
+VER=2.20.4
 SRCS="tbl::https://github.com/ansible/ansible/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::69b3cdeb56513fffad95bee5323f4f96a04d5bcc9236d9897cf603eb2a50959c"
+CHKSUMS="sha256::253c90c6cacf95b3ee04ca8401805170562e2b72294454ccb97468a205990781"
 CHKUPDATE="anitya::id=6097"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- ansible: update to 2.20.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ansible: 2.20.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ansible
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
