### PR TITLE
zutils: update to 1.16

### DIFF
--- a/app-utils/zutils/spec
+++ b/app-utils/zutils/spec
@@ -1,5 +1,4 @@
-VER=1.7
-REL=5
+VER=1.16
 SRCS="tbl::https://download.savannah.gnu.org/releases/zutils/zutils-$VER.tar.lz"
-CHKSUMS="sha256::c4ffadab70458fab8f1fe51b003f953c590d95e060658105622144bdd93ba650"
+CHKSUMS="sha256::5bb953700e72e7088e2fce13c6224b8ee478bd6ac90197183f85f544189eb37d"
 CHKUPDATE="anitya::id=231686"


### PR DESCRIPTION
Topic Description
-----------------

- zutils: update to 1.16
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- zutils: 1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit zutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
