### PR TITLE
clash-verge-rev: fix build

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/build
+++ b/app-proxy/clash-verge-rev/autobuild/build
@@ -1,20 +1,11 @@
 abinfo "Fetching dependencies and assets ..."
-pnpm approve-builds --all
-if ab_match_arch amd64 ; then
-	export ARCH_STR=x64
-elif ab_match_arch arm64 ; then
-	export ARCH_STR=arm64
-elif ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd ; then
-	export ARCH_STR=loong64
-elif ab_match_arch loongson3 ; then
-	export ARCH_STR=mips64el
-elif ab_match_arch riscv64 ; then
-	export ARCH_STR=riscv64
-elif ab_match_arch ppc64el ; then
-	export ARCH_STR=ppc64
-fi
-pnpm i @esbuild/linux-"$ARCH_STR"
 pnpm install
+pnpm approve-builds --all
+# FIXME: upstream pnpm-lock.yaml specified esbuild ^0.27.0, but Clash
+# Verge Rev 2.4.7 failed to build with > 0.27.4:
+#
+# assets/editor.worker-!~{001}~.js:48:18: ERROR: Transforming destructuring to the configured target environment ("edge109", "safari14" + 2 overrides) is not supported yet
+pnpm install esbuild@0.27.4
 pnpm run prebuild
 
 abinfo "Building Clash Verge ..."

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
@@ -1,4 +1,4 @@
-From d2131456ccd52babf3da4bd86739e6f80c0c6075 Mon Sep 17 00:00:00 2001
+From 0dacaf31cf8f9a6e2601fbed9dca624b75fcc19b Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Sun, 9 Nov 2025 19:15:18 +0800
 Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
@@ -7,11 +7,9 @@ Signed-off-by: stydxm <stydxm@outlook.com>
 ---
  Cargo.lock           | 11 -----------
  package.json         |  9 ++++++++-
- pnpm-workspace.yaml  |  5 +++++
  scripts/prebuild.mjs |  6 ++++--
  src-tauri/Cargo.toml |  2 +-
- 5 files changed, 18 insertions(+), 15 deletions(-)
- create mode 100644 pnpm-workspace.yaml
+ 4 files changed, 13 insertions(+), 15 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
 index d0669022..f6a840ad 100644
@@ -61,17 +59,6 @@ index 9ac6a4e3..bbce755b 100644
 +    }
    }
  }
-diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
-new file mode 100644
-index 00000000..3c58f6d7
---- /dev/null
-+++ b/pnpm-workspace.yaml
-@@ -0,0 +1,5 @@
-+supportedArchitectures:
-+  os:
-+    - wasip1-threads
-+  cpu:
-+    - wasm32
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
 index 3254a1c4..1cfcc7ed 100644
 --- a/scripts/prebuild.mjs

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,4 +1,5 @@
 VER=2.4.7
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: fix build
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- clash-verge-rev: 1:2.4.7-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
