### PR TITLE
dnscrypt: update to 2.1.15

### DIFF
--- a/app-network/dnscrypt/spec
+++ b/app-network/dnscrypt/spec
@@ -1,5 +1,4 @@
-VER=2.1.7
-REL=4
+VER=2.1.15
 SRCS="git::commit=tags/$VER::https://github.com/DNSCrypt/dnscrypt-proxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15546"


### PR DESCRIPTION
Topic Description
-----------------

- dnscrypt: update to 2.1.15
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- dnscrypt: 2.1.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnscrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
