### PR TITLE
i2pd: update to 2.59.0

### DIFF
--- a/app-web/i2pd/spec
+++ b/app-web/i2pd/spec
@@ -1,5 +1,5 @@
-VER=2.57.0
+VER=2.59.0
 SRCS="tbl::https://github.com/PurpleI2P/i2pd/archive/$VER.tar.gz"
-CHKSUMS="sha256::e2327f816d92a369eaaf9fd1661bc8b350495199e2f2cb4bfd4680107cd1d4b4"
+CHKSUMS="sha256::0ebeb05e4f36ab3809449561a095dc767ad821ac6a61c95623ab49be4ffd398b"
 SUBDIR="i2pd-$VER/build"
 CHKUPDATE="anitya::id=21355"


### PR DESCRIPTION
Topic Description
-----------------

- i2pd: update to 2.59.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- i2pd: 2.59.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit i2pd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
