### PR TITLE
mercurial: update to 7.2.1

### DIFF
--- a/app-vcs/mercurial/spec
+++ b/app-vcs/mercurial/spec
@@ -1,5 +1,4 @@
-VER=7.0.2
+VER=7.2.1
 SRCS="tbl::https://www.mercurial-scm.org/release/mercurial-$VER.tar.gz"
-CHKSUMS="sha256::f7731f1b42acaeaacb8cf7e41c0a472a7aa31a8f47e518baea735f1cb2987e0c"
+CHKSUMS="sha256::f750f86c5734a8df776a003db45e9a9df4e398a770479ea4cc19b61e9f3acd17"
 CHKUPDATE="anitya::id=1969"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- mercurial: update to 7.2.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- mercurial: 7.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mercurial
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
