### PR TITLE
partclone: update to 0.3.47

### DIFF
--- a/app-admin/partclone/spec
+++ b/app-admin/partclone/spec
@@ -1,4 +1,4 @@
-VER=0.3.38
+VER=0.3.47
 SRCS="tbl::https://github.com/Thomas-Tsai/partclone/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::5afd6f558e83026e9270396394bc95308fbe1543f8b963a4fb5331bc7b0ed9d9"
+CHKSUMS="sha256::8215844d14737d8fbb09fe1b1eafe688a8c790eafc8413a26c08e5795ac9ccd3"
 CHKUPDATE="anitya::id=141535"


### PR DESCRIPTION
Topic Description
-----------------

- partclone: update to 0.3.47
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- partclone: 0.3.47

Security Update?
----------------

No

Build Order
-----------

```
#buildit partclone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
