### PR TITLE
lxgwcleargothic-font: update to 0.527

### DIFF
--- a/desktop-fonts/lxgwcleargothic-font/spec
+++ b/desktop-fonts/lxgwcleargothic-font/spec
@@ -1,8 +1,8 @@
-VER=0.508
+VER=0.527
 SRCS="file::rename=LXGWXiHeiCL.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiCL.ttf \
       file::rename=LXGWXiHeiMN.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiMN.ttf
       file::rename=LICENSE.md::https://raw.githubusercontent.com/lxgw/LxgwXiHei/v$VER/LICENSE.md"
-CHKSUMS="sha256::9e46fb41dad3e94a289a706d9899e6c554e822ace24aa8648f169a86d8967c16 \
-         sha256::b2ce4b7cf1f4f0121719e039abc79888ac0582ba6bbace3f7c2cb55757ab4531 \
+CHKSUMS="sha256::eea8fb5cbad591269b0d07d413c91b0afaf7601d608d97d51cc04187b77c2742 \
+         sha256::d5c3094004e3e8b19ec0f926db5221ff86125832e7393558458ec10cb0475357 \
          sha256::a186b1f3ad4b8d56a43dc96637ce55f5aa4f4446025d6247641d4ef13c4bb29b"
 CHKUPDATE="anitya::id=234782"


### PR DESCRIPTION
Topic Description
-----------------

- lxgwcleargothic-font: update to 0.527
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lxgwcleargothic-font: 0.527

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxgwcleargothic-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
