### PR TITLE
units: update to 2.27

### DIFF
--- a/app-utils/units/spec
+++ b/app-utils/units/spec
@@ -1,4 +1,4 @@
-VER=2.23
+VER=2.27
 SRCS="tbl::https://ftp.gnu.org/gnu/units/units-$VER.tar.gz"
-CHKSUMS="sha256::d957b451245925c9e614c4513397449630eaf92bd62b8495ba09bbe351a17370"
+CHKSUMS="sha256::e1bbdb09672e7c08eee986749e7a1629eb84a6bdf41f5a2a79d6804444abbe10"
 CHKUPDATE="anitya::id=5048"


### PR DESCRIPTION
Topic Description
-----------------

- units: update to 2.27
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- units: 2.27

Security Update?
----------------

No

Build Order
-----------

```
#buildit units
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
