### PR TITLE
postfix: update to 3.11.1

### DIFF
--- a/app-web/postfix/spec
+++ b/app-web/postfix/spec
@@ -1,4 +1,4 @@
-VER=3.10.7
+VER=3.11.1
 SRCS="tbl::https://postfix.mirrors.ovh.net/postfix-release/official/postfix-${VER}.tar.gz"
-CHKSUMS="sha256::fcd3ff70806ae7f0a82e7b5c301e2f4fcfa6a689a2dbb3b3f1b5e5208115788a"
+CHKSUMS="sha256::659265606ed9b6242964b6d44a2aaf5e607d8fb9ad2541027a4a320ddfb89dc1"
 CHKUPDATE="anitya::id=3693"


### PR DESCRIPTION
Topic Description
-----------------

- postfix: update to 3.11.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- postfix: 3.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit postfix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
