### PR TITLE
copyq: update to 14.0.0

### DIFF
--- a/app-utils/copyq/autobuild/defines
+++ b/app-utils/copyq/autobuild/defines
@@ -1,9 +1,12 @@
 PKGNAME=copyq
 PKGSEC=utils
 BUILDDEP="extra-cmake-modules"
-PKGDEP="qt-5 gcc-runtime glibc knotifications wayland x11-lib"
+PKGDEP="qt-5 gcc-runtime glibc knotifications wayland x11-lib qca qtkeychain miniaudio"
 PKGDES="Clipboard manager with editing and scripting features"
 FAIL_ARCH="(loongarch64_nosimd)"
 
 ABTYPE="cmakeninja"
-CMAKE_AFTER=("-DWITH_QT6=OFF")
+CMAKE_AFTER=(
+	-DWITH_QT6=OFF
+	-DMINIAUDIO_INCLUDE_DIR=/usr/include/miniaudio
+)

--- a/app-utils/copyq/spec
+++ b/app-utils/copyq/spec
@@ -1,4 +1,4 @@
-VER=13.0.0
+VER=14.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/hluk/CopyQ"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6205"

--- a/runtime-multimedia/miniaudio/autobuild/defines
+++ b/runtime-multimedia/miniaudio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=miniaudio
+PKGSEC=sound
+PKGDEP="opusfile libvorbis"
+PKGDES="Single-file audio playback and capture library"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+	-DBUILD_SHARED_LIBS=ON
+)

--- a/runtime-multimedia/miniaudio/spec
+++ b/runtime-multimedia/miniaudio/spec
@@ -1,0 +1,4 @@
+VER=0.11.25
+SRCS="git::commit=tags/$VER::https://github.com/mackron/miniaudio"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=376647"


### PR DESCRIPTION
Topic Description
-----------------

- copyq: update to 14.0.0
- miniaudio: new, 0.11.25

Package(s) Affected
-------------------

- copyq: 14.0.0
- miniaudio: 0.11.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit miniaudio copyq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
