### PR TITLE
snapd-glib: drop unneeded snapd dep

### DIFF
--- a/runtime-admin/snapd-glib/autobuild/defines
+++ b/runtime-admin/snapd-glib/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=snapd-glib
 PKGSEC=libs
-PKGDEP="glib json-glib libsoup-3 snapd"
+PKGDEP="glib json-glib libsoup-3"
 BUILDDEP="gobject-introspection qt-5 vala"
 PKGDES="GLib library to communicate with Snapd"
 

--- a/runtime-admin/snapd-glib/spec
+++ b/runtime-admin/snapd-glib/spec
@@ -1,4 +1,5 @@
 VER=1.70
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/snapcore/snapd-glib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13996"


### PR DESCRIPTION
Topic Description
-----------------

- snapd-glib: drop unneeded snapd dep

Package(s) Affected
-------------------

- snapd-glib: 1.70-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit snapd-glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
