### PR TITLE
rclone: update to 1.73.3

### DIFF
--- a/app-web/rclone/autobuild/patches/0001-update-saferith-for-loongarch64.patch
+++ b/app-web/rclone/autobuild/patches/0001-update-saferith-for-loongarch64.patch
@@ -1,26 +1,26 @@
 diff --git a/go.mod b/go.mod
-index 3440bb78f..11b5fd423 100644
+index e0507c94f..4f8309c6c 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -152,7 +152,7 @@ require (
+@@ -156,7 +156,7 @@ require (
  	github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc // indirect
  	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
  	github.com/creasty/defaults v1.8.0 // indirect
 -	github.com/cronokirby/saferith v0.33.0 // indirect
 +	github.com/cronokirby/saferith v0.33.1-0.20250226174546-1f11f94ce488 // indirect
  	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+ 	github.com/dromara/dongle v1.0.1 // indirect
  	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
- 	github.com/dustin/go-humanize v1.0.1 // indirect
 diff --git a/go.sum b/go.sum
-index 30e0aa049..e019028fe 100644
+index 77ecc9498..51c78e67c 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -218,8 +218,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3
+@@ -220,8 +220,9 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3
  github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
  github.com/creasty/defaults v1.8.0 h1:z27FJxCAa0JKt3utc0sCImAEb+spPucmKoOdLHvHYKk=
  github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 -github.com/cronokirby/saferith v0.33.0 h1:TgoQlfsD4LIwx71+ChfRcIpjkw+RPOapDEVxa+LhwLo=
--github.com/cronokirby/saferith v0.33.0/go.mod h1:QKJhjoqUtBsXCAVEjw38mFqoi7DebT7kthcD7UzbnoA=
+ github.com/cronokirby/saferith v0.33.0/go.mod h1:QKJhjoqUtBsXCAVEjw38mFqoi7DebT7kthcD7UzbnoA=
 +github.com/cronokirby/saferith v0.33.1-0.20250226174546-1f11f94ce488 h1:tLWBZgPg6TV67oe76W4p+aUQEWIa52wbcuiz8GFd3vo=
 +github.com/cronokirby/saferith v0.33.1-0.20250226174546-1f11f94ce488/go.mod h1:QKJhjoqUtBsXCAVEjw38mFqoi7DebT7kthcD7UzbnoA=
  github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/app-web/rclone/spec
+++ b/app-web/rclone/spec
@@ -1,5 +1,4 @@
-VER=1.72.1
+VER=1.73.3
 SRCS="git::commit=tags/v$VER::https://github.com/rclone/rclone"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11750"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- rclone: update to 1.73.3
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- rclone: 1.73.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit rclone
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
