### PR TITLE
lvm2: update to 2.03.39

### DIFF
--- a/app-admin/lvm2/spec
+++ b/app-admin/lvm2/spec
@@ -1,5 +1,4 @@
-VER=2.03.31
+VER=2.03.39
 SRCS="tbl::https://gcc.gnu.org/pub/lvm2/LVM2.$VER.tgz"
-CHKSUMS="sha256::5db2956a00fbf87d92274cccc92436387ec0c3faadece7413ece1ba1c10c98ff"
+CHKSUMS="sha256::23bc9067e28fe0d37b3cc441f2865b9e022ce3c624babe22918b8dd90c031ee8"
 CHKUPDATE="anitya::id=5354"
-REL="2"


### PR DESCRIPTION
Topic Description
-----------------

- lvm2: update to 2.03.39
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lvm2: 2.03.39

Security Update?
----------------

No

Build Order
-----------

```
#buildit lvm2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
