### PR TITLE
telegram-desktop: update to 6.7.2

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=telegram-desktop
 PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
-        openal-soft openssl lz4 qt-5 xxhash hunspell libdispatch \
+        openal-soft openssl lz4 qt-6 xxhash hunspell libdispatch \
         libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons \
         glibmm-2.68 fmt ada crc32c"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm gperf \
@@ -21,7 +21,7 @@ CMAKE_AFTER=(
     '-DDESKTOP_APP_DISABLE_X11_INTEGRATION=OFF'
     '-DDESKTOP_APP_USE_PACKAGED=OFF'
     '-DDESKTOP_APP_USE_PACKAGED_FONTS=OFF'
-    '-DQT_VERSION_MAJOR=5'
+    '-DQT_VERSION_MAJOR=6'
 )
 
 # FIXME: relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'

--- a/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-fix-window.style-set-default-window-width-to-360px.patch
@@ -1,4 +1,4 @@
-From 8979e3fa60751846879cf4510de4ae2f65dabf51 Mon Sep 17 00:00:00 2001
+From bf1d5da40741241d4c84fba5d8479f1ff5ad98ad Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
 Subject: [PATCH 01/15] fix(window.style): set default window width to 360px
@@ -9,7 +9,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index b56f520d61..37d3d1a113 100644
+index 4d6ee0ce..e39c47a2 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";

--- a/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-fix-core_settings.h-use-system-window-decoration-by-.patch
@@ -1,4 +1,4 @@
-From 8ab6b5aceba5a9dab7654e9d2d95dc1e0cb12bac Mon Sep 17 00:00:00 2001
+From d5269a8a8262c8ec9eefc44d3caeb4ba99156d72 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
 Subject: [PATCH 02/15] fix(core_settings.h): use system window decoration by
@@ -9,10 +9,10 @@ Subject: [PATCH 02/15] fix(core_settings.h): use system window decoration by
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 0a78d2c22c..2e59e02c6f 100644
+index 26da92fd..ddfc116d 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1051,7 +1051,7 @@ private:
+@@ -1140,7 +1140,7 @@ private:
  	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
  	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
  	bool _notifyFromAll = true;
@@ -20,7 +20,7 @@ index 0a78d2c22c..2e59e02c6f 100644
 +	rpl::variable<bool> _nativeWindowFrame = true;
  	rpl::variable<std::optional<bool>> _systemDarkMode = std::nullopt;
  	rpl::variable<bool> _systemDarkModeEnabled = true;
- 	rpl::variable<WindowTitleContent> _windowTitleContent;
+ 	bool _systemAccentColorEnabled = false;
 -- 
 2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-fix-ui-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From 98da6dd7843d421cc18c426d748dfcc4f7cebf63 Mon Sep 17 00:00:00 2001
+From adac2243f12b0825db2d18f961b46aec3356df2e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:02:32 +0800
 Subject: [PATCH 03/15] fix(ui): fix build with Qt 5
@@ -12,10 +12,10 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  4 files changed, 8 insertions(+)
 
 diff --git a/Telegram/lib_ui/ui/text/text_entity.cpp b/Telegram/lib_ui/ui/text/text_entity.cpp
-index 810f5764ef..cd6200f555 100644
+index dd1fa5fc..d4172d60 100644
 --- a/Telegram/lib_ui/ui/text/text_entity.cpp
 +++ b/Telegram/lib_ui/ui/text/text_entity.cpp
-@@ -2417,6 +2417,8 @@ EntityInText::EntityInText(
+@@ -2443,6 +2443,8 @@ EntityInText::EntityInText(
  , _data(data) {
  }
  
@@ -25,10 +25,10 @@ index 810f5764ef..cd6200f555 100644
  		const EntitiesInText &entities,
  		int textLength) {
 diff --git a/Telegram/lib_ui/ui/text/text_entity.h b/Telegram/lib_ui/ui/text/text_entity.h
-index 2fba82e0da..0538f8d7e7 100644
+index 0781d03e..0d59a338 100644
 --- a/Telegram/lib_ui/ui/text/text_entity.h
 +++ b/Telegram/lib_ui/ui/text/text_entity.h
-@@ -84,6 +84,8 @@ public:
+@@ -103,6 +103,8 @@ public:
  		int length,
  		const QString &data = QString());
  
@@ -38,7 +38,7 @@ index 2fba82e0da..0538f8d7e7 100644
  		return _type;
  	}
 diff --git a/Telegram/lib_webview/CMakeLists.txt b/Telegram/lib_webview/CMakeLists.txt
-index 4b9450934b..522208bd89 100644
+index 4b945093..522208bd 100644
 --- a/Telegram/lib_webview/CMakeLists.txt
 +++ b/Telegram/lib_webview/CMakeLists.txt
 @@ -7,6 +7,7 @@
@@ -50,7 +50,7 @@ index 4b9450934b..522208bd89 100644
  get_filename_component(src_loc . REALPATH)
  
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
-index 24274c3794..a57c4fab1f 100644
+index a04e4225..bd87377c 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_compositor.cpp
 @@ -54,6 +54,7 @@ private:

--- a/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-fix-core-launcher.cpp-revert-to-old-HiDPI-handling-b.patch
@@ -1,4 +1,4 @@
-From 6a82cef02c72aeb0660c4e7eef080a6bc57a10d9 Mon Sep 17 00:00:00 2001
+From ffe3ed743116d3bad0205b5742c7d9496e93e9b5 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 22:04:57 +0800
 Subject: [PATCH 04/15] fix(core/launcher.cpp): revert to old HiDPI handling
@@ -13,10 +13,10 @@ Co-authored-by: Henry Chen <chenx97@aosc.io>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
-index a5e98dc11e..0675ee1605 100644
+index d56d1d50..eed8ba6d 100644
 --- a/Telegram/SourceFiles/core/launcher.cpp
 +++ b/Telegram/SourceFiles/core/launcher.cpp
-@@ -342,7 +342,9 @@ void Launcher::initHighDpi() {
+@@ -356,7 +356,9 @@ void Launcher::initHighDpi() {
  #endif // Qt < 6.2.0
  
  #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -26,7 +26,7 @@ index a5e98dc11e..0675ee1605 100644
 +		Qt::HighDpiScaleFactorRoundingPolicy::Floor);
  #endif // Qt < 6.0.0
  
- 	if (OptionFractionalScalingEnabled.value()) {
+ 	if (OptionHighDpiDownscale.value()) {
 -- 
 2.52.0
 

--- a/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-fix-settings-use-system-fonts-by-default.patch
@@ -1,4 +1,4 @@
-From 7126598f074e8123c462ef68665b3a71edc46a3a Mon Sep 17 00:00:00 2001
+From 1be24d070f63ff3c2ef906f5e1f846cd7c643512 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
 Subject: [PATCH 05/15] fix(settings): use system fonts by default
@@ -8,7 +8,7 @@ Subject: [PATCH 05/15] fix(settings): use system fonts by default
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 2e59e02c6f..1331b60ceb 100644
+index ddfc116d..6f03522b 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
 @@ -12,6 +12,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -19,10 +19,10 @@ index 2e59e02c6f..1331b60ceb 100644
  #include "base/flags.h"
  #include "emoji.h"
  
-@@ -1085,7 +1086,7 @@ private:
- 	rpl::variable<bool> _storiesClickTooltipHidden = false;
+@@ -1177,7 +1178,7 @@ private:
  	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
  	WindowPosition _ivPosition;
+ 	WindowPosition _callPanelPosition;
 -	QString _customFontFamily;
 +	QString _customFontFamily = style::SystemFontTag();
  	bool _systemUnlockEnabled = false;

--- a/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0006-Remove-the-confusing-Default-option-from-selectable-.patch
@@ -1,4 +1,4 @@
-From 5b5181e610d44c85339ce66c05911b257e14f2df Mon Sep 17 00:00:00 2001
+From 71570d470e27c173fee634322f746a609c80f067 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
 Subject: [PATCH 06/15] Remove the confusing "Default" option from selectable
@@ -9,7 +9,7 @@ Subject: [PATCH 06/15] Remove the confusing "Default" option from selectable
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
-index a891c422f1..585c3a7934 100644
+index aa750570..3de85967 100644
 --- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 +++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 @@ -532,7 +532,7 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {

--- a/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0007-fix-lib_tl-add-missing-cstring-include.patch
@@ -1,4 +1,4 @@
-From 5cf367a8de78f83ac32997ea406faaba7d45698b Mon Sep 17 00:00:00 2001
+From b56155b371ee472d5097e3c5e46661a1f30c63f3 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:15:07 -0700
 Subject: [PATCH 07/15] fix(lib_tl): add missing cstring include
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/lib_tl/tl/tl_basic_types.h b/Telegram/lib_tl/tl/tl_basic_types.h
-index 5eadf62a93..961f7febe0 100644
+index 5eadf62a..961f7feb 100644
 --- a/Telegram/lib_tl/tl/tl_basic_types.h
 +++ b/Telegram/lib_tl/tl/tl_basic_types.h
 @@ -10,6 +10,7 @@

--- a/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0008-fix-lib_webview-add-missing-cstdint-include.patch
@@ -1,4 +1,4 @@
-From 1c0ed089e514fecf325e0b3b1e89b0c114c00c07 Mon Sep 17 00:00:00 2001
+From 3e65e16ccd84bacefbedbb484f2082094217db39 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Fri, 1 Nov 2024 23:28:52 -0700
 Subject: [PATCH 08/15] fix(lib_webview): add missing cstdint include
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/lib_webview/webview/webview_interface.h b/Telegram/lib_webview/webview/webview_interface.h
-index 7477811ad4..a175bd69aa 100644
+index 4d0fc0ce..2b1bb084 100644
 --- a/Telegram/lib_webview/webview/webview_interface.h
 +++ b/Telegram/lib_webview/webview/webview_interface.h
 @@ -12,6 +12,7 @@

--- a/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0009-fix-current_geo_location_linux-add-missing-QGuiAppli.patch
@@ -1,4 +1,4 @@
-From 0393c3defe28ce83b17f4b8280830119a72449bd Mon Sep 17 00:00:00 2001
+From 8c59b3990ffb0deefebc6ae1a7060e79994e859e Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Thu, 13 Feb 2025 22:30:40 -0800
 Subject: [PATCH 09/15] fix(current_geo_location_linux): add missing
@@ -10,7 +10,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp b/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
-index 7015af7398..d48fc7025a 100644
+index fe26b13d..eda595b0 100644
 --- a/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
 @@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL

--- a/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0010-fix-core_settings.h-enable-video-hardware-accelerati.patch
@@ -1,4 +1,4 @@
-From b48ee65dc78b6068799f82900b546a8e52bd3599 Mon Sep 17 00:00:00 2001
+From cfb672839d872ed52d57b00989edebe7f7c53c72 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Wed, 19 Mar 2025 21:30:27 -0700
 Subject: [PATCH 10/15] fix(core_settings.h): enable video hardware
@@ -10,10 +10,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
-index 1331b60ceb..7b1d6dc3a0 100644
+index 6f03522b..7623c421 100644
 --- a/Telegram/SourceFiles/core/core_settings.h
 +++ b/Telegram/SourceFiles/core/core_settings.h
-@@ -1067,11 +1067,7 @@ private:
+@@ -1157,11 +1157,7 @@ private:
  	rpl::variable<Media::OrderMode> _playerOrderMode;
  	bool _macWarnBeforeQuit = true;
  	std::vector<uint64> _accountsOrder;

--- a/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0011-fix-cmake-disable-CMP0160-to-workaround-KF5-cmake-er.patch
@@ -1,4 +1,4 @@
-From ce670f7600f77437a26617e308542b1ae401d982 Mon Sep 17 00:00:00 2001
+From e4ef9c8f0d63f4b4bca6645a3120abed3cdecfb4 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 10 May 2025 16:24:38 -0700
 Subject: [PATCH 11/15] fix(cmake): disable CMP0160 to workaround KF5 cmake
@@ -10,7 +10,7 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fc7b239b03..d9f278a357 100644
+index e762a3cd..ee1ab366 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -6,6 +6,12 @@

--- a/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0012-fix-credits_amount.h-include-cmath-for-std-floor.patch
@@ -1,4 +1,4 @@
-From f81c30c19ef812aa4ecd900177aab8a616c2eef8 Mon Sep 17 00:00:00 2001
+From 22920be289ba5084e92c950d045f4da20f514e79 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 3 Jul 2025 19:04:36 -0700
 Subject: [PATCH 12/15] fix(credits_amount.h): include cmath for std::floor
@@ -9,7 +9,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/Telegram/SourceFiles/core/credits_amount.h b/Telegram/SourceFiles/core/credits_amount.h
-index 098266d887..a5d329c417 100644
+index 42bf1a52..5eb2b7d0 100644
 --- a/Telegram/SourceFiles/core/credits_amount.h
 +++ b/Telegram/SourceFiles/core/credits_amount.h
 @@ -7,6 +7,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL

--- a/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0013-fix-lib_webview-fix-build-with-Qt-5.patch
@@ -1,4 +1,4 @@
-From bfe151bf126c0a7f91e6c6c1ab01bbfe83399bc0 Mon Sep 17 00:00:00 2001
+From 18175e716772a3e60d8fdbe45d272ff0a3efced2 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 28 Aug 2025 02:08:09 -0700
 Subject: [PATCH 13/15] fix(lib_webview): fix build with Qt 5
@@ -10,7 +10,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  2 files changed, 41 insertions(+)
 
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
-index 5439d2bb42..038d64a22b 100644
+index 5439d2bb..038d64a2 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_http_server.cpp
 @@ -128,8 +128,18 @@ bool HttpServer::Private::processRedirect(
@@ -66,10 +66,10 @@ index 5439d2bb42..038d64a22b 100644
  	});
  }
 diff --git a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
-index 7f88a2a21d..776eefce6b 100644
+index c0fc13e8..eab09ba0 100644
 --- a/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
 +++ b/Telegram/lib_webview/webview/platform/linux/webview_linux_webkitgtk.cpp
-@@ -751,21 +751,37 @@ void Instance::dataRequest(
+@@ -837,21 +837,37 @@ void Instance::dataRequest(
  		socket->write("HTTP/1.1 ");
  		socket->write(partial ? "206 Partial Content\r\n" : "200 OK\r\n");
  

--- a/app-web/telegram-desktop/autobuild/patches/0014-Fix-desktop-file-name-on-Qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0014-Fix-desktop-file-name-on-Qt-5.patch
@@ -1,4 +1,4 @@
-From 056e8434e4c57cc788881d532aeb528e063fa0a1 Mon Sep 17 00:00:00 2001
+From 75ce8fc62dfbbc052130b569ed13e4cc11e6ffcb Mon Sep 17 00:00:00 2001
 From: Kirikaze Chiyuki <me@chyk.ink>
 Date: Mon, 4 Aug 2025 09:53:59 +0800
 Subject: [PATCH 14/15] Fix desktop file name on Qt 5
@@ -12,18 +12,18 @@ The target Qt version of Telegram Desktop code is Qt 6. commit 0534a2f aligns th
  4 files changed, 54 insertions(+)
 
 diff --git a/Telegram/SourceFiles/platform/linux/integration_linux.cpp b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
-index 9ea29d6ba8..c39ddf5fd1 100644
+index f5d9473a..734323f6 100644
 --- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
-@@ -17,6 +17,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
- #endif
+@@ -18,6 +18,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
  #include "base/random.h"
+ #include "base/qt_connection.h"
  
 +#include <QtGlobal>
  #include <QtCore/QAbstractEventDispatcher>
  
  #include <gio/gio.hpp>
-@@ -86,7 +87,11 @@ public:
+@@ -87,7 +88,11 @@ public:
  
  Application::Application()
  : Gio::impl::ApplicationImpl(this) {
@@ -36,7 +36,7 @@ index 9ea29d6ba8..c39ddf5fd1 100644
  		set_application_id(appId);
  	}
 diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
-index 77f668fc71..7ad50f1135 100644
+index 3bee37bf..51e4950c 100644
 --- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
 @@ -35,6 +35,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -63,7 +63,7 @@ index 77f668fc71..7ad50f1135 100644
  	const auto counterSlice = std::min(Core::App().unreadBadge(), 9999);
  
 diff --git a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
-index 176eb1de43..ff493c960c 100644
+index 409659fc..b3a82fd6 100644
 --- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
 @@ -25,6 +25,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
@@ -74,7 +74,7 @@ index 176eb1de43..ff493c960c 100644
  #include <QtCore/QBuffer>
  #include <QtCore/QVersionNumber>
  #include <QtGui/QGuiApplication>
-@@ -680,8 +681,13 @@ void Manager::Private::showNotification(
+@@ -676,8 +677,13 @@ void Manager::Private::showNotification(
  			"category",
  			GLib::Variant::new_string("im.received"));
  
@@ -89,7 +89,7 @@ index 176eb1de43..ff493c960c 100644
  
  	const auto imageKey = GetImageKey();
 diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
-index cc9e032979..275f906995 100644
+index cc9e0329..275f9069 100644
 --- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
 @@ -26,6 +26,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL

--- a/app-web/telegram-desktop/autobuild/patches/0015-fix-main_window_linux-include-QScreen-for-qt-5.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0015-fix-main_window_linux-include-QScreen-for-qt-5.patch
@@ -1,4 +1,4 @@
-From a3de6b504b6afd4d12546f2389c184d6b4967840 Mon Sep 17 00:00:00 2001
+From cdf7191f9684c774620a562b486b0c1de8538b9c Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Tue, 2 Dec 2025 16:46:34 +0800
 Subject: [PATCH 15/15] fix(main_window_linux): include QScreen for qt-5
@@ -8,7 +8,7 @@ Subject: [PATCH 15/15] fix(main_window_linux): include QScreen for qt-5
  1 file changed, 1 insertion(+)
 
 diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
-index 7ad50f1135..b303a1b191 100644
+index 51e4950c..0afdb5b5 100644
 --- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
 +++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
 @@ -39,6 +39,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,12 +1,11 @@
-VER=6.3.6
-REL=3
+VER=6.7.2
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
-OWTVER=d888bc3f79b4aa80333d8903410fa439db5f6696
-TDLIBVER=889bdf06029f98f3d04cac874dafab6f4f847c47
+OWTVER=26068e29bfa8d74a9dc9c8f7f94172fafbc262b8
+TDLIBVER=1677a0c77f30bbb337f91cf6627d62b2a62a8f87
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::e2cb4d726f8ce9a268ce903317b02b17a3b8486372e3e121dd57c130e7b55498 \
+CHKSUMS="sha256::b9e0c5fc1ec48debf2522b00a047d60e4f14167c646700ffb931f5fa766884d3 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.7.2
    Track patches at AOSC-Tracking/telegram-desktop @ aosc/v6.7.2
    \(HEAD: cdf7191f9684c774620a562b486b0c1de8538b9c\).

Package(s) Affected
-------------------

- telegram-desktop: 6.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
