### PR TITLE
wine: update to 11.6+gecko2.47.4+mono11.0.0

### DIFF
--- a/app-emulation/wine/autobuild/build
+++ b/app-emulation/wine/autobuild/build
@@ -1,8 +1,15 @@
 abinfo "Applying Wine Staging patches ..."
 ln -sv "$SRCDIR" \
     "$SRCDIR"/../wine-staging/patches/wine
-"$SRCDIR"/../wine-staging/staging/patchinstall.py \
-    DESTDIR="$SRCDIR" --all
+# FIXME: ../dlls/dcomp/tests/dcomp.c:56:2: error: "Unsupported architecture"
+# Link: https://bugs.winehq.org/show_bug.cgi?id=59665
+if ab_match_arch arm64; then
+    "$SRCDIR"/../wine-staging/staging/patchinstall.py \
+        DESTDIR="$SRCDIR" --all -W dcomp-DCompositionCreateDevice2
+else
+    "$SRCDIR"/../wine-staging/staging/patchinstall.py \
+        DESTDIR="$SRCDIR" --all
+fi
 
 abinfo "Preparing to build Wine runtime ..."
 mkdir -pv "$SRCDIR"/wine

--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -95,9 +95,12 @@ AUTOTOOLS_AFTER__AMD64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-archs=x86_64,i386'
 )
+# FIXME: ../dlls/dcomp/tests/dcomp.c:56:2: error: "Unsupported architecture"
+# Link: https://bugs.winehq.org/show_bug.cgi?id=59665
 AUTOTOOLS_AFTER__ARM64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-archs=arm64ec,aarch64,x86_64,i386'
+    '--disable-dcomp'
 )
 AUTOTOOLS_AFTER__I486=(
     "${AUTOTOOLS_AFTER[@]}"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=11.0.0
-UPSTREAM_VER=11.5
+UPSTREAM_VER=11.6
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::11370b57ea5d548a54d92c9cd65d0ba635f4f1c3eadace09ed1c419f705e19d1 \
+CHKSUMS="sha256::d49d166975478f609e6a9cdbda0a07c65a3b795e061fc454d3f1034c828d19e0 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 11.6+gecko2.47.4+mono11.0.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wine: 3:11.6+gecko2.47.4+mono11.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
