### PR TITLE
sing-box: update to 1.13.6

### DIFF
--- a/app-proxy/sing-box/spec
+++ b/app-proxy/sing-box/spec
@@ -1,4 +1,4 @@
-VER=1.13.5
+VER=1.13.6
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/SagerNet/sing-box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372359"


### PR DESCRIPTION
Topic Description
-----------------

- sing-box: update to 1.13.6
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- sing-box: 1.13.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit sing-box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
