### PR TITLE
apache-arrow: update to 23.0.1

### DIFF
--- a/runtime-database/apache-arrow/autobuild/defines
+++ b/runtime-database/apache-arrow/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=apache-arrow
 PKGSEC=libs
-PKGDES="A language-independent columnar memory format for flat and nested data"
+PKGDES="Universal columnar format and multi-language toolbox for data interchange and in-memory analytics"
 PKGDEP="abseil-cpp boost gcc-runtime glibc grpc libutf8proc openssl protobuf re2 zlib"
 BUILDDEP="gtest llvm"
 

--- a/runtime-database/apache-arrow/spec
+++ b/runtime-database/apache-arrow/spec
@@ -1,4 +1,4 @@
-VER=23.0.0
+VER=23.0.1
 SRCS="git::commit=tags/apache-arrow-$VER::https://github.com/apache/arrow"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20697"

--- a/topics/apache-arrow-23.0.1.toml
+++ b/topics/apache-arrow-23.0.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Apache Arrow 23.0.1"
+
+[caution]
+default = "Fixes a Use-After-Free vulnerability - CVE-2026-25087 (Severity: High)"
+zh_CN = "修复一个释放后使用 (Use-After-Free) 漏洞，漏洞编号 CVE-2026-25087（严重性：高）"
+
+[packages-v2]
+"apache-arrow" = "< 23.0.1"


### PR DESCRIPTION
Topic Description
-----------------

- apache-arrow: update to 23.0.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- apache-arrow: 23.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit apache-arrow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
