### PR TITLE
noctalia-qs: update to 0.0.12

### DIFF
--- a/runtime-desktop/noctalia-qs/spec
+++ b/runtime-desktop/noctalia-qs/spec
@@ -1,4 +1,4 @@
-VER=0.0.11
+VER=0.0.12
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/noctalia-dev/noctalia-qs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388550"


### PR DESCRIPTION
Topic Description
-----------------

- noctalia-qs: update to 0.0.12
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- noctalia-qs: 0.0.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit noctalia-qs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
