### PR TITLE
kdeconnect: add sshfs dependency

### DIFF
--- a/desktop-kde/kdeconnect/autobuild/defines
+++ b/desktop-kde/kdeconnect/autobuild/defines
@@ -4,7 +4,7 @@ PKGDEP="fontconfig freetype fontconfig freetype kcmutils kcodecs kconfig \
         kcoreaddons kdbusaddons kguiaddons ki18n kiconthemes kio kirigami2 \
         kjobwidgets knotifications kpackage kpeople kpeoplevcard kservice \
         kwayland kwindowsystem libfakekey pulseaudio-qt qca \
-        qqc2-desktop-style solid"
+        qqc2-desktop-style solid sshfs"
 BUILDDEP="extra-cmake-modules kdoctools plasma-wayland-protocols"
 PKGDES="Applications suite for communication between KDE and other mobile devices"
 

--- a/desktop-kde/kdeconnect/spec
+++ b/desktop-kde/kdeconnect/spec
@@ -1,4 +1,5 @@
 VER=23.08.5
+REL=1
 SRCS="tbl::https://download.kde.org/stable/release-service/${VER}/src/kdeconnect-kde-${VER}.tar.xz"
 CHKSUMS="sha256::4b42cd66f824b9ba2ddd09c7147b2abe6107ac866104033a78c0c46909300d64"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

- kdeconnect: add sshfs dependency (Because KDE Connect uses SSHFS for file sharing)
- kdeconnect: dump REL

Package(s) Affected
-------------------

- kdeconnect: 23.08.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit kdeconnect
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
