### PR TITLE
nerdctl: update to 2.2.2

### DIFF
--- a/app-containers/nerdctl/spec
+++ b/app-containers/nerdctl/spec
@@ -1,5 +1,4 @@
-VER=2.2.1
-REL=2
+VER=2.2.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/nerdctl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="aniya::id=242901"


### PR DESCRIPTION
Topic Description
-----------------

- nerdctl: update to 2.2.2

Package(s) Affected
-------------------

- nerdctl: 2.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nerdctl
```

Test Build(s) Done
-----------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

