### PR TITLE
pidgin: backport a patch to fix crash when removing gst dev

### DIFF
--- a/app-web/pidgin/01-libpurple/patches/0001-UPSTREAM-2.x.y-Fix-a-crash-in-the-media-manager.patch
+++ b/app-web/pidgin/01-libpurple/patches/0001-UPSTREAM-2.x.y-Fix-a-crash-in-the-media-manager.patch
@@ -1,0 +1,55 @@
+From d9a4a4da0d5e0e9ce2b2d25a5e830435892a2982 Mon Sep 17 00:00:00 2001
+From: Gary Kramlich <grim@reaperworld.com>
+Date: Tue, 3 Mar 2026 00:42:48 -0600
+Subject: [PATCH] UPSTREAM: 2.x.y: Fix a crash in the media manager
+
+This appears to be a race condition where somehow we get the unregister event
+for a device, but by the time we try to unregister it it's been deleted and
+we're left with a dangling pointer. To avoid this, we add a reference which
+solves the issue.
+
+Testing Done:
+Ran with the patch for awhile and no longer experienced any crashes.
+
+Bugs closed: PIDGIN-18142, PIDGIN-18148, PIDGIN-18155
+
+Reviewed at https://reviews.imfreedom.org/r/4404/
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ libpurple/mediamanager.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libpurple/mediamanager.c b/libpurple/mediamanager.c
+index 3ab3581ac1..234ff56849 100644
+--- a/libpurple/mediamanager.c
++++ b/libpurple/mediamanager.c
+@@ -2216,7 +2216,8 @@ purple_media_manager_register_gst_device(PurpleMediaManager *manager,
+ 			"create-cb", gst_device_create_cb,
+ 			NULL);
+ 
+-	g_object_set_data(G_OBJECT(info), "gst-device", device);
++	g_object_set_data_full(G_OBJECT(info), "gst-device", g_object_ref(device),
++	                       g_object_unref);
+ 
+ 	purple_media_manager_register_element(manager, info);
+ 
+@@ -2259,12 +2260,11 @@ purple_media_manager_unregister_gst_device(PurpleMediaManager *manager,
+ 				gchar *id;
+ 
+ 				id = purple_media_element_info_get_id(info);
+-				purple_media_manager_unregister_element(manager,
+-						id);
++				purple_media_manager_unregister_element(manager, id);
+ 
+ 				purple_debug_info("mediamanager",
+-						"Unregistered %s device %s",
+-						device_class, name);
++				                  "Unregistered %s device %s\n",
++				                  device_class, name);
+ 
+ 				g_free(id);
+ 
+-- 
+2.52.0
+

--- a/app-web/pidgin/spec
+++ b/app-web/pidgin/spec
@@ -1,5 +1,5 @@
 VER=2.14.14
-REL=1
+REL=2
 SRCS="https://downloads.sourceforge.net/project/pidgin/Pidgin/$VER/pidgin-$VER.tar.bz2"
 CHKSUMS="sha256::0ffc9994def10260f98a55cd132deefa8dc4a9835451cc0e982747bd458e2356"
 CHKUPDATE="anitya::id=3636"


### PR DESCRIPTION
Topic Description
-----------------

- pidgin: backport a patch to fix crash when removing gst dev
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- finch: 2.14.14-2
- libpurple: 2.14.14-2
- pidgin: 2.14.14-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pidgin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
