### PR TITLE
oma: update to 1.25.2

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.25.1
+VER=1.25.2
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.25.2.toml
+++ b/topics/oma-1.25.2.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "oma 1.25.2"
+zh_CN = "小熊猫包管理 (oma) 1.25.2"
+
+[caution]
+default = "Fixes a Improper Neutralization of CRLF Sequences vulnerability (Severity: Low)"
+zh_CN = "修复一个 CRLF 序列处理不当漏洞（严重性：低）"
+
+[packages-v2]
+"oma" = "< 1.25.2"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.25.2

Package(s) Affected
-------------------

- oma: 1.25.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`



