### PR TITLE
neovim: update to 0.12.1

### DIFF
--- a/app-editors/neovim/spec
+++ b/app-editors/neovim/spec
@@ -1,4 +1,4 @@
-VER=0.11.6
+VER=0.12.1
 SRCS="git::commit=tags/v$VER::https://github.com/neovim/neovim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9037"


### PR DESCRIPTION
Topic Description
-----------------

- neovim: update to 0.12.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- neovim: 1:0.12.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit neovim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
