### PR TITLE
inotify-tools: update to 4.25.9.0

### DIFF
--- a/app-admin/inotify-tools/spec
+++ b/app-admin/inotify-tools/spec
@@ -1,4 +1,4 @@
-VER=4.23.9.0
-SRCS="https://github.com/rvoicilas/inotify-tools/archive/$VER.tar.gz"
-CHKSUMS="sha256::1dfa33f80b6797ce2f6c01f454fd486d30be4dca1b0c5c2ea9ba3c30a5c39855"
+VER=4.25.9.0
+SRCS="git::commit=tags/$VER::https://github.com/rvoicilas/inotify-tools"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8864"


### PR DESCRIPTION
Topic Description
-----------------

- inotify-tools: update to 4.25.9.0
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- inotify-tools: 4.25.9.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit inotify-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
