### PR TITLE
libgnt: update to 2.14.4

### DIFF
--- a/runtime-common/libgnt/spec
+++ b/runtime-common/libgnt/spec
@@ -1,5 +1,4 @@
-VER=2.14.3
-REL="2"
-SRCS="https://downloads.sourceforge.net/project/pidgin/libgnt/${VER}/libgnt-${VER}.tar.xz"
-CHKSUMS="sha256::57f5457f72999d0bb1a139a37f2746ec1b5a02c094f2710a339d8bcea4236123"
+VER=2.14.4
+SRCS="https://downloads.sourceforge.net/project/pidgin/libgnt/${VER}/libgnt-${VER}-dev.tar.xz"
+CHKSUMS="sha256::195933a9a731d3575791b881ba5cc0ad2a715e1e9c4c23ccaaa2a17e164c96ec"
 CHKUPDATE="anitya::id=112663"


### PR DESCRIPTION
Topic Description
-----------------

- libgnt: update to 2.14.4

Package(s) Affected
-------------------

- libgnt: 2.14.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgnt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
