### PR TITLE
libcap: update to 2.78

### DIFF
--- a/runtime-common/libcap/spec
+++ b/runtime-common/libcap/spec
@@ -1,4 +1,4 @@
-VER=2.77
+VER=2.78
 SRCS="tbl::https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-$VER.tar.xz"
-CHKSUMS="sha256::897bc18b44afc26c70e78cead3dbb31e154acc24bee085a5a09079a88dbf6f52"
+CHKSUMS="sha256::0d621e562fd932ccf67b9660fb018e468a683d7b827541df27813228c996bb11"
 CHKUPDATE="anitya::id=1569"

--- a/runtime-optenv32/libcap+32/spec
+++ b/runtime-optenv32/libcap+32/spec
@@ -1,4 +1,4 @@
-VER=2.73
+VER=2.78
 SRCS="tbl::https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-$VER.tar.xz"
-CHKSUMS="sha256::6405f6089cf4cdd8c271540cd990654d78dd0b1989b2d9bda20f933a75a795a5"
+CHKSUMS="sha256::0d621e562fd932ccf67b9660fb018e468a683d7b827541df27813228c996bb11"
 CHKUPDATE="anitya::id=1569"

--- a/topics/libcap-2.78.toml
+++ b/topics/libcap-2.78.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libcap 2.78"
+
+[caution]
+default = "Fixes a TOCTOU (Time-Of-Check to Time-of-Use) race condition vulnerability - CVE-2026-4878 (severity: High)"
+zh_CN = "修复一处 TOCTOU（检查到使用时间）竞态条件漏洞，漏洞编号 CVE-2026-4878（严重性：高）"
+
+[packages-v2]
+"libcap" = "< 2.78"
+"libcap+32" = "< 2.78"


### PR DESCRIPTION
Topic Description
-----------------

- libcap: update to 2.78
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libcap: 2.78

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
