### PR TITLE
cryptography: update to 46.0.7

### DIFF
--- a/lang-python/cryptography/spec
+++ b/lang-python/cryptography/spec
@@ -1,4 +1,4 @@
-VER=46.0.6
+VER=46.0.7
 SRCS="pypi::version=$VER::cryptography"
-CHKSUMS="sha256::27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759"
+CHKSUMS="sha256::e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"
 CHKUPDATE="anitya::id=5532"

--- a/topics/cryptography-46.0.7.toml
+++ b/topics/cryptography-46.0.7.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PyCA cryptography 46.0.7"
+
+[caution]
+default = "Fixes a Buffer Overflow vulnerability - CVE-2026-39892 (Severity: High)"
+zh_CN = "修复一个缓冲区溢出漏洞，漏洞编号 CVE-2026-39892（严重性：高）"
+
+[packages-v2]
+"cryptography" = "< 46.0.7"


### PR DESCRIPTION
Topic Description
-----------------

- cryptography: update to 46.0.7
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- cryptography: 46.0.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit cryptography
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
