### PR TITLE
flatpak: update to 1.17.5

### DIFF
--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,5 +1,4 @@
-VER=1.17.2
-REL=1
+VER=1.17.5
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak.git \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \

--- a/topics/flatpak-1.17.5.toml
+++ b/topics/flatpak-1.17.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Flatpak 1.17.5"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (including 1 of Critical and 1 of High severity)"
+zh_CN = "修复 4 个安全漏洞（含 1 个严重漏洞和 1 个高危漏洞）"
+
+[packages-v2]
+"flatpak" = "< 1.17.5"


### PR DESCRIPTION
Topic Description
-----------------

- flatpak: update to 1.17.5
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- flatpak: 1.17.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatpak
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
