### PR TITLE
openssl: update to 3.6.2

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.6.1
-SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
+VER=3.6.2
+SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
+CHKSUMS="sha256::aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.6.1
-SRCS="tbl::https://github.com/openssl/openssl/releases/download/openssl-$VER/openssl-$VER.tar.gz"
-CHKSUMS="sha256::b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
+VER=3.6.2
+SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
+CHKSUMS="sha256::aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f"
 CHKUPDATE="anitya::id=2566"

--- a/topics/openssl-3.6.2.toml
+++ b/topics/openssl-3.6.2.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 3.6.2"
+
+[caution]
+default = "Fixes 8 security vulnerabilities disclosed in OpenSSL Security Advisory on March 13, 2026 and April 7, 2026 (2 of high severity)"
+zh_CN = "修复 OpenSSL 在 2026 年 3 月 13 日和 2026 年 4 月 7 日发布的安全公告中披露的 8 个安全漏洞（含 2 个高危漏洞）"
+
+[packages-v2]
+"openssl" = "< 3.6.2"
+"openssl+32" = "< 3.6.2"


### PR DESCRIPTION
Topic Description
-----------------

- openssl: update to 3.6.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- openssl: 3.6.2
- openssl-static: 3.6.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
