### PR TITLE
libpng: update to 1.6.57

### DIFF
--- a/runtime-imaging/libpng/spec
+++ b/runtime-imaging/libpng/spec
@@ -1,4 +1,4 @@
-VER=1.6.56
+VER=1.6.57
 SRCS="git::commit=tags/v$VER::https://github.com/pnggroup/libpng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1705"

--- a/runtime-optenv32/libpng+32/spec
+++ b/runtime-optenv32/libpng+32/spec
@@ -1,4 +1,4 @@
-VER=1.6.56
+VER=1.6.57
 EPOCH=2
 SRCS="git::commit=tags/v$VER::https://github.com/pnggroup/libpng"
 CHKSUMS="SKIP"

--- a/topics/libpng-1.6.57.toml
+++ b/topics/libpng-1.6.57.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libpng 1.6.57"
+
+[caution]
+default = "Fixes a Use-After-Free vulnerability - CVE-2026-34757 (Severity: Medium)"
+zh_CN = "修复一个释放后使用 (Use-After-Free) 漏洞（CVE-2026-34757，严重性：中）"
+
+[packages-v2]
+"libpng" = "< 1.6.57"
+"libpng+32" = "< 2:1.6.57"


### PR DESCRIPTION
Topic Description
-----------------

- libpng: update to 1.6.57
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libpng: 1.6.57

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
