### PR TITLE
openjpeg: update to 2.5.4

### DIFF
--- a/runtime-imaging/openjpeg/spec
+++ b/runtime-imaging/openjpeg/spec
@@ -1,5 +1,4 @@
-VER=2.5.2
-REL=1
-SRCS="tbl::https://github.com/uclouvain/openjpeg/archive/v$VER.tar.gz"
-CHKSUMS="sha256::90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a"
+VER=2.5.4
+SRCS="git::commit=tags/v$VER::https://github.com/uclouvain/openjpeg"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2550"

--- a/topics/openjpeg-2.5.4.toml
+++ b/topics/openjpeg-2.5.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "OpenJPEG 2.5.4"
+
+[caution]
+default = "Fixes an Out-of-Bounds Heap Memory Write vulnerability (CVE-2025-54874, Severity: High) and 2 Heap-based Buffer Overflow vulnerabilities (CVE-2024-56826 and CVE-2024-56827, Severity: Medium)"
+zh_CN = "修复 1 个越界堆内存写入漏洞（CVE-2025-54874，严重性：高）和 2 个堆缓冲区溢出漏洞（CVE-2024-56826 和 CVE-2024-56827，严重性：中）"
+
+[packages-v2]
+"openjpeg" = "< 2.5.4"


### PR DESCRIPTION
Topic Description
-----------------

- openjpeg: update to 2.5.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- openjpeg: 2.5.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
