### PR TITLE
openssl-1.1: update to 1.1.1zg

### DIFF
--- a/runtime-cryptography/openssl-1.1/spec
+++ b/runtime-cryptography/openssl-1.1/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.1.1ze
+UPSTREAM_VER=1.1.1zg
 VER=${UPSTREAM_VER/_/+}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/kzalewski/openssl-1.1.1.git"
 CHKSUMS="SKIP"

--- a/runtime-optenv32/openssl-1.1+32/spec
+++ b/runtime-optenv32/openssl-1.1+32/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.1.1ze
+UPSTREAM_VER=1.1.1zg
 VER=${UPSTREAM_VER/_/+}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/kzalewski/openssl-1.1.1.git"
 CHKSUMS="SKIP"

--- a/topics/openssl-1.1.1zg.toml
+++ b/topics/openssl-1.1.1zg.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 1.1.1zg"
+
+[caution]
+default = "Fixes 4 security vulnerabilities disclosed in OpenSSL Security Advisory on April 7, 2026"
+zh_CN = "修复 OpenSSL 在 2026 年 4 月 7 日发布的安全公告中披露的 4 个安全漏洞"
+
+[packages-v2]
+"openssl-1.1" = "< 1.1.1zg"
+"openssl-1.1+32" = "< 1.1.1zg"


### PR DESCRIPTION
Topic Description
-----------------

- openssl-1.1: update to 1.1.1zg

Package(s) Affected
-------------------

- openssl-1.1: 1.1.1zg

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl-1.1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
