### PR TITLE
libplacebo: update to 7.360.1

### DIFF
--- a/app-multimedia/mpv/spec
+++ b/app-multimedia/mpv/spec
@@ -1,5 +1,5 @@
 VER=0.41.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/mpv-player/mpv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5348"

--- a/runtime-multimedia/libplacebo/autobuild/defines
+++ b/runtime-multimedia/libplacebo/autobuild/defines
@@ -1,8 +1,13 @@
 PKGNAME=libplacebo
 PKGDES="Core rendering algorithms of mpv as a library"
 PKGSEC=video
-PKGDEP="ffmpeg gcc-runtime glfw glibc lcms2 libunwind sdl2 shaderc \
-        vulkan-loader"
+PKGDEP="ffmpeg gcc-runtime glfw glibc lcms2 libunwind sdl2-compat \
+        shaderc vulkan-loader"
 BUILDDEP="sdl2-image spirv-headers spirv-tools vulkan-headers xz zlib"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Ddemos=false'
+)
+
+PKGBREAK="mpv<=0.41.0-1"

--- a/runtime-multimedia/libplacebo/spec
+++ b/runtime-multimedia/libplacebo/spec
@@ -1,4 +1,4 @@
-VER=7.351.0
+VER=7.360.1
 SRCS="git::commit=tags/v$VER::https://github.com/haasn/libplacebo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20101"


### PR DESCRIPTION
Topic Description
-----------------

- mpv: bump REL due to libplacebo update to 7.360.1
- libplacebo: update to 7.360.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- libplacebo: 7.360.1
- mpv: 0.41.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libplacebo:-pkgbreak mpv libplacebo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
