### PR TITLE
intel-oneapi-basekit: update to 2025.3.2

### DIFF
--- a/app-devel/intel-oneapi-basekit/spec
+++ b/app-devel/intel-oneapi-basekit/spec
@@ -1,6 +1,6 @@
-VER=2025.3.1
-PKG_URL=6caa93ca-e10a-4cc5-b210-68f385feea9e
-PKG_CODE=36
+VER=2025.3.2
+PKG_URL=99f4837a-25b7-425d-a897-60af022676ea
+PKG_CODE=21
 SRCS="file::rename=intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/"${PKG_URL}"/intel-oneapi-base-toolkit-"${VER}"."${PKG_CODE}"_offline.sh"
-CHKSUMS="sha384::5b496bad1bb5d3fc835722931035be83612aa04777c6f6388aaf657f96f3bc671d50a92998da9b0f0c120aeaf877071c"
+CHKSUMS="sha384::bf162da55cd5c71a750ab6cd6a0b0e6b1efc983839a32d3890e02fd0e606488e0a4229d6e741c0d3500c97c07ea355fb"
 CHKUPDATE="anitya::id=372585"


### PR DESCRIPTION
Topic Description
-----------------

- intel-oneapi-basekit: update to 2025.3.2

Package(s) Affected
-------------------

- intel-oneapi-basekit: 2025.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-oneapi-basekit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
